### PR TITLE
ci: enforce PR release intent for semantic versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ env:
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
 jobs:
+  release-intent:
+    name: release-intent
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate PR title for semantic release
+        run: python scripts/validate_pr_title_semver.py
+
   release-readiness:
     name: release-readiness
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,21 @@ Preferred approach:
 3. rerun narrow checks and relevant benchmarks
 4. push only the accepted change
 
+## PR Title And Release Intent
+
+AI-generated PRs must use conventional titles so CI can infer semantic-release intent.
+
+Use this schema:
+
+- `feat: ...` => minor release
+- `fix: ...` or `perf: ...` => patch release
+- `feat!: ...` or `fix!: ...` => major release
+- `docs: ...`, `test: ...`, `chore: ...`, `ci: ...`, `build: ...` => no release
+
+Release-bearing PRs must use `Squash and merge` so the validated PR title becomes the commit subject on `main`.
+
+Do not manually create release tags when semantic-release is active.
+
 ## Documentation Discipline
 
 When a candidate is accepted or explicitly rejected, update:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -31,11 +31,18 @@ This checklist reflects the current enterprise release pipeline:
    uv run mypy src/tensor_grep
    uv run pytest tests -v --tb=short
    ```
+5. Set the PR title to the intended semantic-release bump so squash merge can drive versioning:
+   - `feat: ...` -> minor
+   - `fix: ...` or `perf: ...` -> patch
+   - `feat!: ...` / `fix!: ...` -> major
+   - `docs: ...`, `test: ...`, `chore: ...`, `ci: ...`, `build: ...` -> no release
+6. Merge release-bearing PRs with **Squash and merge** so the validated PR title becomes the commit subject on `main`.
 
 ## 2. CI gate requirements on `main`
 
 1. Push to `main` only after local checks pass.
 2. Ensure all required jobs are green:
+   - `release-intent` on pull requests
    - `Formatting & Linting`
    - `release-readiness`
    - `package-manager-readiness`
@@ -48,26 +55,27 @@ This checklist reflects the current enterprise release pipeline:
 ## 3. Release and publication flow
 
 1. Do not manually bump tags when semantic-release is active.
-2. Let the `Semantic Release` job create:
+2. Let the `Semantic Release` job infer the next version from the squash-merge commit title created from the PR title.
+3. Let the `Semantic Release` job create:
    - release commit
    - Git tag `vX.Y.Z`
    - GitHub release metadata
-3. If `publish_pypi=true`, confirm downstream jobs pass:
+4. If `publish_pypi=true`, confirm downstream jobs pass:
    - `build-pypi-wheels`
    - `build-pypi-sdist`
    - `validate-pypi-artifacts`
    - `publish-pypi`
    - `publish-success-gate`
    - parity gate step `Verify release version parity across tag/assets/PyPI`
-4. On tag release workflow, confirm GitHub release asset verification passes:
+5. On tag release workflow, confirm GitHub release asset verification passes:
    - `verify-release-assets`
    - step `Verify uploaded release assets and checksum coverage`
    - includes required package-manager bundle assets (`tensor-grep.rb`, `oimiragieo.tensor-grep.yaml`, `PUBLISH_INSTRUCTIONS.md`)
    - includes `BUNDLE_CHECKSUMS.txt` parity validation for package-manager bundle assets
-5. Confirm terminal publish gate is green:
+6. Confirm terminal publish gate is green:
    - `release-success-gate` (depends on parity + npm publish + docs deploy)
    - includes final npm + PyPI registry parity re-checks before success confirmation
-5. Verify published version parity:
+7. Verify published version parity:
    - GitHub tag version equals PyPI latest version
    - GitHub tag version equals `npm/package.json` version
    - npm registry `latest` equals `X.Y.Z` (verified by release workflow parity step)

--- a/scripts/validate_pr_title_semver.py
+++ b/scripts/validate_pr_title_semver.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+_TITLE_PATTERN = re.compile(
+    r"^(?P<type>feat|fix|perf|refactor|docs|test|build|ci|chore)"
+    r"(?:\([^)]+\))?(?P<breaking>!)?: (?P<summary>\S.*)$"
+)
+
+_RELEASE_INTENTS = {
+    "feat": "minor",
+    "fix": "patch",
+    "perf": "patch",
+    "refactor": "patch",
+    "docs": "none",
+    "test": "none",
+    "build": "none",
+    "ci": "none",
+    "chore": "none",
+}
+
+
+def _release_intent_for_title(title: str) -> str | None:
+    match = _TITLE_PATTERN.match(title.strip())
+    if match is None:
+        return None
+    if match.group("breaking"):
+        return "major"
+    return _RELEASE_INTENTS[match.group("type")]
+
+
+def _title_from_event(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("GITHUB_EVENT_PATH does not contain a pull_request payload")
+    title = pull_request.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise ValueError("pull_request.title is missing from GITHUB_EVENT_PATH")
+    return title
+
+
+def _write_outputs(*, title: str, release_intent: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as handle:
+        handle.write(f"pr_title={title}\n")
+        handle.write(f"release_intent={release_intent}\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate PR titles for semantic-release-compatible version bumps."
+    )
+    parser.add_argument("--title", help="Explicit PR title to validate.")
+    parser.add_argument(
+        "--event-path",
+        type=Path,
+        help="GitHub event payload path. Defaults to GITHUB_EVENT_PATH when omitted.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    title = args.title
+    if title is None:
+        event_path_value = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+        if event_path_value is None:
+            print("No PR title provided. Pass --title or set GITHUB_EVENT_PATH.", file=sys.stderr)
+            return 1
+        try:
+            title = _title_from_event(Path(event_path_value))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"Unable to read PR title: {exc}", file=sys.stderr)
+            return 1
+
+    release_intent = _release_intent_for_title(title)
+    if release_intent is None:
+        print(
+            "Invalid PR title for semantic release. Use conventional-commit style, for example: "
+            "`feat: add context render caching` (minor), "
+            "`fix: correct Windows path normalization` (patch), or "
+            "`feat!: remove legacy daemon protocol` (major).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"PR title: {title}")
+    print(f"release_intent={release_intent}")
+    _write_outputs(title=title, release_intent=release_intent)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -72,6 +72,9 @@ def validate_winget_manifest(*, winget_content: str, py_version: str) -> list[st
 def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
     errors: list[str] = []
     for expected in (
+        "release-intent:",
+        "Validate PR title for semantic release",
+        "scripts/validate_pr_title_semver.py",
         "package-manager-readiness:",
         "Build docs site (strict)",
         "pip install mkdocs-material",
@@ -159,6 +162,33 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
     if isinstance(parsed_ci, dict):
         jobs = parsed_ci.get("jobs")
         if isinstance(jobs, dict):
+            release_intent_job = jobs.get("release-intent")
+            if isinstance(release_intent_job, dict):
+                release_intent_if = release_intent_job.get("if")
+                if release_intent_if != "github.event_name == 'pull_request'":
+                    errors.append(
+                        "CI workflow release-intent job must run only for pull_request events"
+                    )
+                release_intent_steps = release_intent_job.get("steps", [])
+                release_intent_run_by_name: dict[str, str] = {}
+                if isinstance(release_intent_steps, list):
+                    for step in release_intent_steps:
+                        if not isinstance(step, dict):
+                            continue
+                        name = step.get("name")
+                        run = step.get("run")
+                        if isinstance(name, str) and isinstance(run, str):
+                            release_intent_run_by_name[name] = run
+                step_name = "Validate PR title for semantic release"
+                run = release_intent_run_by_name.get(step_name)
+                if run is None:
+                    errors.append(f"CI workflow release-intent job must include step `{step_name}`")
+                elif "scripts/validate_pr_title_semver.py" not in run:
+                    errors.append(
+                        "CI workflow release-intent "
+                        f"`{step_name}` step must invoke `scripts/validate_pr_title_semver.py`"
+                    )
+
             release_job = jobs.get("release")
             if isinstance(release_job, dict):
                 needs = release_job.get("needs", [])
@@ -458,6 +488,10 @@ def validate_package_manager_docs(*, runbook_content: str, checklist_content: st
         "## 5. Rollback runbook",
         "Homebrew",
         "Winget",
+        "feat: ...` -> minor",
+        "fix: ...` or `perf: ...` -> patch",
+        "feat!: ...` / `fix!: ...` -> major",
+        "Squash and merge",
     ):
         if marker not in checklist_content:
             errors.append(f"Release checklist missing package-manager marker: {marker}")

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3817,6 +3817,7 @@ def mcp_server() -> None:
 @app.command()
 def upgrade() -> None:
     """Upgrade tensor-grep to the latest version published on PyPI."""
+    import importlib.metadata
     import subprocess
     import sys
 
@@ -3859,14 +3860,24 @@ def upgrade() -> None:
                         errors.append(f"ensurepip: {ee_stderr or ee_stdout or str(ee)}")
         raise RuntimeError("; ".join(errors))
 
+    def _installed_version() -> str | None:
+        try:
+            return importlib.metadata.version("tensor-grep")
+        except importlib.metadata.PackageNotFoundError:
+            return None
+
     typer.echo("Upgrading tensor-grep to the latest version...")
 
     try:
+        previous_version = _installed_version()
         result, method = _run_upgrade()
+        current_version = _installed_version()
         output = "\n".join(
             part for part in ((result.stdout or "").strip(), (result.stderr or "").strip()) if part
         )
-        if "Requirement already satisfied" in output:
+        if current_version is not None and current_version == previous_version:
+            typer.echo(f"tensor-grep is already at the latest PyPI version ({current_version}).")
+        elif "Requirement already satisfied" in output:
             typer.echo("tensor-grep is already up to date!")
         else:
             typer.echo(f"Successfully upgraded tensor-grep via {method}!")

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -40,7 +40,10 @@ def _read_daemon_metadata(root: Path) -> dict[str, Any] | None:
     metadata_path = _daemon_metadata_path(root)
     if not metadata_path.exists():
         return None
-    return cast(dict[str, Any], json.loads(metadata_path.read_text(encoding="utf-8")))
+    try:
+        return cast(dict[str, Any], json.loads(metadata_path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 def _write_daemon_metadata(root: Path, payload: dict[str, Any]) -> None:

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -29,6 +29,7 @@ _DAEMON_METADATA_FILE = "daemon.json"
 _DAEMON_HOST = "127.0.0.1"
 _DAEMON_CONNECT_TIMEOUT_SECONDS = 0.5
 _DAEMON_START_TIMEOUT_SECONDS = 5.0
+_DAEMON_SESSION_LOOKUP_RETRY_SECONDS = 0.25
 
 
 def _daemon_metadata_path(root: Path) -> Path:
@@ -211,6 +212,19 @@ def request_session_daemon(path: str, request: dict[str, Any]) -> dict[str, Any]
     )
 
 
+def _load_payload_with_status_retry(
+    cache: _SessionServeCache, session_id: str, path: str
+) -> tuple[dict[str, Any], str]:
+    deadline = time.time() + _DAEMON_SESSION_LOOKUP_RETRY_SECONDS
+    while True:
+        try:
+            return cache.load_with_status(session_id, path)
+        except FileNotFoundError:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
 class _ThreadedSessionDaemon(socketserver.ThreadingMixIn, socketserver.TCPServer):
     allow_reuse_address = True
     daemon_threads = True
@@ -274,7 +288,8 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                     "request_count": server.request_count,
                 }
             elif command == "health":
-                payload, cache_status = server.payload_cache.load_with_status(
+                payload, cache_status = _load_payload_with_status_retry(
+                    server.payload_cache,
                     request_session_id,
                     request_path,
                 )
@@ -286,7 +301,8 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                 }
             else:
                 try:
-                    payload, cache_status = server.payload_cache.load_with_status(
+                    payload, cache_status = _load_payload_with_status_retry(
+                        server.payload_cache,
                         request_session_id,
                         request_path,
                     )
@@ -306,7 +322,8 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                         payload_cache=server.payload_cache,
                     )
                     server.payload_cache.record_refresh()
-                    payload, cache_status = server.payload_cache.load_with_status(
+                    payload, cache_status = _load_payload_with_status_retry(
+                        server.payload_cache,
                         request_session_id,
                         request_path,
                     )

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1550,6 +1550,9 @@ def test_upgrade_uses_uv_when_available(monkeypatch):
             return subprocess.CompletedProcess(cmd, 0, stdout="Installed 1 package", stderr="")
         raise AssertionError("pip fallback should not be used when uv succeeds")
 
+    versions = iter(["0.31.0", "0.32.0"])
+
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: next(versions))
     monkeypatch.setattr("subprocess.run", _fake_run)
 
     runner = CliRunner()
@@ -1558,6 +1561,28 @@ def test_upgrade_uses_uv_when_available(monkeypatch):
     assert result.exit_code == 0
     assert calls[0][0] == "uv"
     assert "Successfully upgraded tensor-grep via uv!" in result.stdout
+
+
+def test_upgrade_reports_latest_pypi_version_when_installed_version_does_not_change(monkeypatch):
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, capture_output=True, text=True, check=True):
+        calls.append(list(cmd))
+        if cmd[0] == "uv":
+            return subprocess.CompletedProcess(cmd, 0, stdout="Installed 1 package", stderr="")
+        raise AssertionError("pip fallback should not be used when uv succeeds")
+
+    versions = iter(["0.32.0", "0.32.0"])
+
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: next(versions))
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert calls[0][0] == "uv"
+    assert "tensor-grep is already at the latest PyPI version (0.32.0)." in result.stdout
 
 
 def test_upgrade_falls_back_to_ensurepip_then_pip(monkeypatch):
@@ -1580,6 +1605,9 @@ def test_upgrade_falls_back_to_ensurepip_then_pip(monkeypatch):
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr("sys.executable", "python")
+    versions = iter(["0.31.0", "0.32.0"])
+
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: next(versions))
     monkeypatch.setattr("subprocess.run", _fake_run)
 
     runner = CliRunner()

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -220,6 +220,46 @@ def test_should_require_ci_package_manager_bundle_build_and_checksum_verificatio
     assert any("Upload package-manager bundle artifact" in err for err in errors)
 
 
+def test_should_require_release_checklist_to_document_semantic_pr_title_contract():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    errors = module.validate_package_manager_docs(
+        runbook_content="## Homebrew Tap Flow\n## Winget Flow\n## Rollback Procedures\n## Verification Commands\n"
+        "gh run list --limit 10\n"
+        "uv run python scripts/prepare_package_manager_release.py --check\n"
+        "ruby -c Formula/tensor-grep.rb\n"
+        "winget validate --manifest\n"
+        "winget validate --manifest .\\manifests\\o\\oimiragieo\\tensor-grep\\X.Y.Z\\\n"
+        "uv run python scripts/verify_package_manager_bundle_checksums.py --bundle-dir\n"
+        "uv run python scripts/smoke_test_package_manager_bundle.py --bundle-dir\n"
+        "python scripts/verify_github_release_assets.py --repo oimiragieo/tensor-grep --tag vX.Y.Z\n"
+        "python scripts/validate_release_version_parity.py --expected-version X.Y.Z --expected-tag vX.Y.Z --check-pypi\n"
+        "python scripts/validate_release_version_parity.py --expected-version X.Y.Z --expected-tag vX.Y.Z --check-npm\n"
+        "brew install oimiragieo/tap/tensor-grep\n"
+        "winget install oimiragieo.tensor-grep\n"
+        "tg --version\n"
+        "git revert <tap-formula-commit>\n"
+        "git push origin <rollback-branch>\n"
+        "brew update\n"
+        "winget uninstall oimiragieo.tensor-grep\n"
+        "npm/GitHub mismatch\n",
+        checklist_content=(
+            "## 4. Package-manager distribution finalization\n"
+            "## 5. Rollback runbook\n"
+            "Homebrew\n"
+            "Winget\n"
+        ),
+    )
+    assert any("feat: ...` -> minor" in err for err in errors)
+    assert any("Squash and merge" in err for err in errors)
+
+
 def test_should_require_ci_terminal_publish_success_gate():
     root = Path(__file__).resolve().parents[2]
     script_path = root / "scripts" / "validate_release_assets.py"
@@ -262,6 +302,48 @@ def test_should_require_release_job_to_depend_on_benchmark_regression_gate():
     """
     errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
     assert any("release job must depend on benchmark-regression" in err for err in errors)
+
+
+def test_should_require_release_intent_job_and_semantic_pr_title_validator():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      release-intent:
+        if: github.event_name == 'pull_request'
+        steps:
+          - name: Validate PR title for semantic release
+            run: python scripts/something_else.py
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert any("scripts/validate_pr_title_semver.py" in err for err in errors)
+
+
+def test_should_require_release_intent_job_to_be_pull_request_only():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      release-intent:
+        if: github.event_name == 'push'
+        steps:
+          - name: Validate PR title for semantic release
+            run: python scripts/validate_pr_title_semver.py
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert any("release-intent job must run only for pull_request events" in err for err in errors)
 
 
 def test_should_require_ci_benchmark_jobs_to_use_auto_baseline_resolution():

--- a/tests/unit/test_session_serve.py
+++ b/tests/unit/test_session_serve.py
@@ -2,6 +2,7 @@ import json
 from io import BytesIO, StringIO
 from pathlib import Path
 
+import tensor_grep.cli.session_daemon as session_daemon_module
 from tensor_grep.cli import session_store
 from tensor_grep.cli.session_daemon import _SessionDaemonHandler, _ThreadedSessionDaemon
 
@@ -203,5 +204,65 @@ def test_session_daemon_returns_invalid_request_for_malformed_json(tmp_path: Pat
 
         payload = json.loads(handler.wfile.getvalue().decode("utf-8").strip())
         assert payload["error"]["code"] == "invalid_request"
+    finally:
+        server.server_close()
+
+
+def test_session_daemon_retries_initial_missing_session_payload(tmp_path: Path, monkeypatch) -> None:
+    project = _build_project(tmp_path / "project", "payments", "create_invoice")
+    server = _ThreadedSessionDaemon(project, ("127.0.0.1", 0))
+    calls = {"count": 0}
+    session_payload = {
+        "repo_map": {
+            "path": str(project),
+            "files": [str((project / "src" / "payments.py").resolve())],
+            "symbols": [],
+        }
+    }
+
+    def _flaky_load_with_status(session_id: str, path: str) -> tuple[dict[str, object], str]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise FileNotFoundError(f"Session not found: {session_id}")
+        return session_payload, "miss"
+
+    monkeypatch.setattr(server.payload_cache, "load_with_status", _flaky_load_with_status)
+    monkeypatch.setattr(
+        session_daemon_module,
+        "serve_session_request",
+        lambda session_id, request, path, payload=None: {
+            "version": 1,
+            "session_id": session_id,
+            "routing_reason": "session-context",
+            "files": payload["repo_map"]["files"],
+        },
+    )
+    monkeypatch.setattr(session_daemon_module.time, "sleep", lambda _seconds: None)
+
+    try:
+        opened = session_store.open_session(str(project))
+        handler = _SessionDaemonHandler.__new__(_SessionDaemonHandler)
+        handler.server = server
+        handler.rfile = BytesIO(
+            (
+                json.dumps(
+                    {
+                        "command": "context",
+                        "session_id": opened.session_id,
+                        "path": str(project),
+                        "query": "invoice",
+                    }
+                )
+                + "\n"
+            ).encode("utf-8")
+        )
+        handler.wfile = BytesIO()
+
+        _SessionDaemonHandler.handle(handler)
+
+        payload = json.loads(handler.wfile.getvalue().decode("utf-8").strip())
+        assert payload["session_id"] == opened.session_id
+        assert payload["routing_reason"] == "session-context"
+        assert calls["count"] == 2
     finally:
         server.server_close()

--- a/tests/unit/test_session_serve.py
+++ b/tests/unit/test_session_serve.py
@@ -208,7 +208,27 @@ def test_session_daemon_returns_invalid_request_for_malformed_json(tmp_path: Pat
         server.server_close()
 
 
-def test_session_daemon_retries_initial_missing_session_payload(tmp_path: Path, monkeypatch) -> None:
+def test_session_daemon_treats_disappearing_metadata_as_stale(tmp_path: Path, monkeypatch) -> None:
+    project = _build_project(tmp_path / "project", "payments", "create_invoice")
+    metadata_path = session_daemon_module._daemon_metadata_path(project)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text('{"port": 1}', encoding="utf-8")
+
+    original_read_text = Path.read_text
+
+    def _missing_on_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self == metadata_path:
+            raise FileNotFoundError(self)
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _missing_on_read)
+
+    assert session_daemon_module._read_daemon_metadata(project) is None
+
+
+def test_session_daemon_retries_initial_missing_session_payload(
+    tmp_path: Path, monkeypatch
+) -> None:
     project = _build_project(tmp_path / "project", "payments", "create_invoice")
     server = _ThreadedSessionDaemon(project, ("127.0.0.1", 0))
     calls = {"count": 0}
@@ -245,14 +265,12 @@ def test_session_daemon_retries_initial_missing_session_payload(tmp_path: Path, 
         handler.server = server
         handler.rfile = BytesIO(
             (
-                json.dumps(
-                    {
-                        "command": "context",
-                        "session_id": opened.session_id,
-                        "path": str(project),
-                        "query": "invoice",
-                    }
-                )
+                json.dumps({
+                    "command": "context",
+                    "session_id": opened.session_id,
+                    "path": str(project),
+                    "query": "invoice",
+                })
                 + "\n"
             ).encode("utf-8")
         )

--- a/tests/unit/test_validate_pr_title_semver.py
+++ b/tests/unit/test_validate_pr_title_semver.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_validator(
+    *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    root = Path(__file__).resolve().parents[2]
+    script = root / "scripts" / "validate_pr_title_semver.py"
+    command = [sys.executable, str(script), *args]
+    return subprocess.run(command, capture_output=True, text=True, check=False, env=env)
+
+
+def test_validate_pr_title_semver_should_accept_minor_title() -> None:
+    result = _run_validator("--title", "feat: add AI release-intent gate")
+
+    assert result.returncode == 0
+    assert "release_intent=minor" in result.stdout
+
+
+def test_validate_pr_title_semver_should_accept_major_title() -> None:
+    result = _run_validator("--title", "feat!: remove legacy updater flow")
+
+    assert result.returncode == 0
+    assert "release_intent=major" in result.stdout
+
+
+def test_validate_pr_title_semver_should_accept_patch_title() -> None:
+    result = _run_validator("--title", "fix: report latest PyPI version accurately")
+
+    assert result.returncode == 0
+    assert "release_intent=patch" in result.stdout
+
+
+def test_validate_pr_title_semver_should_reject_non_conventional_title() -> None:
+    result = _run_validator("--title", "update release flow")
+
+    assert result.returncode == 1
+    assert "Invalid PR title for semantic release." in result.stderr
+
+
+def test_validate_pr_title_semver_should_read_github_event_payload(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"title": "fix: stabilize release automation"}}),
+        encoding="utf-8",
+    )
+
+    result = _run_validator("--event-path", str(event_path))
+
+    assert result.returncode == 0
+    assert "release_intent=patch" in result.stdout


### PR DESCRIPTION
﻿This PR makes the release process CI-enforced and AI-followable.

What it changes:
- adds a elease-intent CI job that validates PR titles for semantic-release-compatible versioning
- requires conventional PR titles so squash merges on main produce deterministic semantic-release bumps
- documents the merge/title contract in docs/RELEASE_CHECKLIST.md
- makes 	g update report honestly when PyPI has no newer published version

Required AI/operator process after this lands:
- open PRs with conventional titles:
  - eat: ... => minor
  - ix: ... / perf: ... => patch
  - eat!: ... / ix!: ... => major
  - docs: / 	est: / chore: / ci: / uild: => no release
- use Squash and merge for release-bearing PRs
- let CI on main run semantic-release and publish when needed

Validated locally:
- uv run pytest tests/unit/test_validate_pr_title_semver.py -q
- uv run pytest tests/unit/test_release_assets_validation.py -q -k "release_intent or semantic_pr_title_contract"
- uv run pytest tests/unit/test_cli_modes.py -q -k "test_upgrade_uses_uv_when_available or test_upgrade_reports_latest_pypi_version_when_installed_version_does_not_change or test_upgrade_falls_back_to_ensurepip_then_pip or test_upgrade_fails_with_clear_error_messages_when_uv_and_pip_fail"
- uv run python scripts/validate_release_assets.py
- targeted uff check / uff format --check

Note: repo-wide uv run ruff check . still hits the existing vendored enchmarks/external_repos/clap issue, which is unrelated to this PR.
