### PR TITLE
feat: surface AI workflows in top-level help

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -38,10 +38,19 @@ persisted repeated-query acceleration, and optional GPU routing.
 - `tg scan --config sgconfig.yml`
 - `tg mcp`
 
+**AI workflows**
+- `tg map PATH`
+- `tg context-render PATH --query "invoice flow"`
+- `tg edit-plan PATH --query "add retry with tests"`
+- `tg blast-radius-render PATH --symbol create_invoice`
+- `tg session open PATH`
+- `tg session daemon start PATH`
+
 **Notes**
 - Bare patterns are treated as `tg search`.
 - Use `tg search --help` for ripgrep-compatible flags.
-- Use `tg run --help` for AST rewrite flags.""",
+- Use `tg run --help` for AST rewrite flags.
+- Use `tg session --help` for cached edit-loop and daemon commands.""",
     no_args_is_help=True,
     add_completion=False,
     rich_markup_mode="markdown",

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -3386,6 +3386,13 @@ def test_app_help_should_list_upgrade_update_checkpoint_and_symbol_commands():
     assert "Fast text, AST, indexed, and GPU-aware search CLI" in result.stdout
     assert "Common usage" in result.stdout
     assert "tg PATTERN [PATH ...]" in result.stdout
+    assert "AI workflows" in result.stdout
+    assert "tg map PATH" in result.stdout
+    assert "tg context-render PATH --query" in result.stdout
+    assert "tg edit-plan PATH --query" in result.stdout
+    assert "tg blast-radius-render PATH --symbol" in result.stdout
+    assert "tg session open PATH" in result.stdout
+    assert "tg session daemon start PATH" in result.stdout
     assert "upgrade" in result.stdout
     assert "update" in result.stdout
     assert "checkpoint" in result.stdout


### PR DESCRIPTION
## Summary
- make top-level `tg --help` surface AI/edit workflows explicitly
- add a focused help-text regression for the new examples
- keep the change scoped so merging this PR triggers the semantic-release version bump

## Validation
- `uv run pytest tests/unit/test_cli_modes.py -q -k "test_app_help_should_list_upgrade_update_checkpoint_and_symbol_commands"`
- `uv run ruff check src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py`
- `uv run ruff format --check --preview src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py`
