### PR TITLE
feat(enterprise): harden supply-chain security and observability

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,43 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Daily at midnight
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  audit:
+    name: Dependency & License Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit and cargo-deny
+        run: |
+          cargo install cargo-audit
+          cargo install cargo-deny
+
+      - name: Run cargo audit
+        working-directory: rust_core
+        run: cargo audit
+
+      - name: Run cargo deny
+        working-directory: rust_core
+        run: cargo deny check
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8
+
+      - name: Setup Python
+        run: uv python install 3.12
+
+      - name: Install pip-audit
+        run: uv pip install pip-audit
+
+      - name: Run pip-audit
+        run: uv run pip-audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo deny check
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install ripgrep
@@ -68,7 +68,7 @@ jobs:
       - name: Throughput smoke benchmark
         run: uv run pytest tests/e2e/test_throughput.py -v --tb=short
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-artifacts
           path: artifacts/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.0.0
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate PR title for semantic release
         run: python scripts/validate_pr_title_semver.py
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         run: python -m pip install uv
@@ -61,13 +61,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -111,7 +111,7 @@ jobs:
         run: uv run python scripts/smoke_test_package_manager_bundle.py --bundle-dir artifacts/package-manager-bundle
 
       - name: Upload package-manager bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-manager-bundle-${{ matrix.os }}
           path: artifacts/package-manager-bundle/
@@ -122,7 +122,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Repo Hygiene Guard
         shell: bash
@@ -153,7 +153,7 @@ jobs:
         run: python -m pip install uv
         
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           
@@ -190,7 +190,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install uv
         run: python -m pip install uv
@@ -254,7 +254,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         rust_channel: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Setup Rust ${{ matrix.rust_channel }}
         shell: bash
@@ -273,7 +273,7 @@ jobs:
           cargo --version
           
       - name: Setup Python for PyO3 Linker
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           
@@ -297,13 +297,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Python for PyO3 Linker
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -327,13 +327,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Python for PyO3 Linker
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -380,13 +380,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install uv
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
         
@@ -430,7 +430,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         run: python -m pip install uv
@@ -480,7 +480,7 @@ jobs:
           cat artifacts/benchmark_summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-artifacts-ci
           path: artifacts/
@@ -497,7 +497,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -547,7 +547,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
       - uses: PyO3/maturin-action@v1
@@ -557,7 +557,7 @@ jobs:
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pypi-wheels-${{ matrix.os }}
           path: dist
@@ -570,7 +570,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
       - uses: PyO3/maturin-action@v1
@@ -580,7 +580,7 @@ jobs:
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pypi-sdist
           path: dist
@@ -593,9 +593,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download all distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pypi-*
           path: dist
@@ -625,12 +625,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
 
       - name: Download all distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pypi-*
           path: dist
@@ -663,14 +663,14 @@ jobs:
         run: |
           echo "No semantic-release version for this commit; skipping publish parity gate."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.release.outputs.release_version != ''
         with:
           ref: v${{ needs.release.outputs.release_version }}
 
       - name: Download all distributions
         if: needs.release.outputs.release_version != '' && needs.release.outputs.publish_pypi == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: pypi-*
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
       - name: Setup Python
         run: uv python install 3.12
       - name: Validate release/package asset consistency
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Validate Homebrew formula syntax
         if: runner.os == 'Linux'
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -181,7 +181,7 @@ jobs:
           path: artifacts
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -276,7 +276,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -318,7 +318,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
       - name: Setup Python
         run: uv python install 3.12
       - name: Validate release/package asset consistency
@@ -30,10 +30,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Validate Homebrew formula syntax
         if: runner.os == 'Linux'
@@ -103,10 +103,10 @@ jobs:
             gpu: cpu
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
         run: uv python install 3.12
@@ -160,7 +160,7 @@ jobs:
           ./tg-macos-amd64-${{ matrix.gpu }} --version
         
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ runner.os }}-${{ matrix.gpu }}
           path: tg-*
@@ -170,16 +170,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
+
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Setup Python
         run: uv python install 3.12
@@ -210,7 +212,35 @@ jobs:
           uv run python scripts/smoke_verify_release_binary.py \
             --artifacts-dir artifacts \
             --expected-version "${GITHUB_REF#refs/tags/v}"
-          
+
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@cargo-cyclonedx
+
+      - name: Generate Rust SBOM
+        working-directory: rust_core
+        run: cargo cyclonedx --format json --all-features
+
+      - name: Move Rust SBOM
+        run: mv rust_core/bom.json artifacts/sbom-rust.json
+
+      - name: Generate Python SBOM
+        run: |
+          uv pip install cyclonedx-bom
+          uv run cyclonedx-py environment --outfile artifacts/sbom-python.json
+
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            artifacts/**/tg-*
+            artifacts/CHECKSUMS.txt
+            artifacts/sbom-*.json
+
+      - name: Generate SLSA Provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/**
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -218,15 +248,17 @@ jobs:
             artifacts/**/tg-*
             artifacts/CHECKSUMS.txt
             artifacts/package-manager-bundle/**
+            artifacts/sbom-*.json
+            artifacts/**/*.sig
+            artifacts/**/*.crt
           generate_release_notes: true
-
   verify-release-assets:
     needs: create-release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify uploaded release assets and checksum coverage
         run: |
@@ -241,10 +273,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Setup Python
         run: uv python install 3.12
@@ -262,12 +294,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify Version Match
@@ -286,7 +318,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Setup Python
         run: uv python install 3.12
@@ -306,10 +338,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           
@@ -328,10 +360,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Setup Python
         run: uv python install 3.12

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,0 +1,20 @@
+# API and Data Contracts
+
+This document defines the backward-compatibility guarantees for internal structures and CLI outputs used by enterprise integrations, IDEs, and editor-plane agents.
+
+## 1. Configuration (`sgconfig.yml`)
+The root-level keys and structure of `sgconfig.yml` are guaranteed to be stable within a major version. Unrecognized keys will be ignored rather than causing fatal errors to allow progressive rollout of new configurations.
+
+## 2. AST Cache (`project_data_v6.json`)
+The schema of the `.tg_cache/ast/project_data_v6.json` cache is versioned within its filename.
+- Backward compatibility is NOT guaranteed across major/minor versions.
+- If the schema changes (e.g., to `v7`), `tensor-grep` will automatically invalidate older cache files and rebuild them transparently.
+
+## 3. CLI Output (`--json` and `--ndjson`)
+The JSON schemas emitted by `tensor-grep search --json` and related commands are considered public APIs.
+- Existing fields (e.g., `file`, `line`, `match`, `context`) will not be renamed or removed without a major version bump.
+- New fields may be added in minor versions.
+- Consumers should ignore unrecognized JSON fields.
+
+## 4. Python Library API
+Classes and functions exposed in `tensor_grep.api` are stable. Internal modules (prefixed with `_` or deep inside `tensor_grep.core` or `backends`) are subject to change without notice.

--- a/docs/HOTFIX_PROCEDURE.md
+++ b/docs/HOTFIX_PROCEDURE.md
@@ -1,0 +1,54 @@
+# Hotfix & Rollback Procedure
+
+This document outlines the operational procedures for addressing critical bugs or security vulnerabilities in `tensor-grep` production releases.
+
+## 1. Hotfix Release Procedure
+
+When a critical issue requires an immediate patch without including unreleased features from `main`:
+
+1. **Branching:**
+   Create a hotfix branch from the affected stable tag.
+   ```bash
+   git checkout -b hotfix/v1.0.1 v1.0.0
+   ```
+
+2. **Patching:**
+   Cherry-pick the specific bugfix commits from `main`, or implement the minimal required fix directly on the hotfix branch.
+
+3. **Validation:**
+   Run the full local test suite and ensure no regressions are introduced.
+   ```bash
+   uv run pytest
+   cargo test
+   ```
+
+4. **Tagging & Releasing:**
+   Push the branch and create a new patch tag.
+   ```bash
+   git tag -a v1.0.1 -m "Hotfix for critical issue"
+   git push origin v1.0.1
+   ```
+   The `.github/workflows/release.yml` will automatically trigger, build the binaries, generate SBOMs, sign artifacts, and publish the release.
+
+## 2. Rollback Procedure
+
+If a deployed version causes severe regressions, administrators must roll back to the previous stable version.
+
+### Winget (Windows)
+```powershell
+winget install oimiragieo.tensor-grep --version 1.0.0
+```
+
+### pip (Python)
+```bash
+pip install tensor-grep==1.0.0
+```
+
+### Homebrew (macOS)
+Homebrew users should use the exact URL to the previous formula commit or download the binary directly from the GitHub Releases page.
+
+## 3. Reproducible Release Verification
+To verify that a published binary matches the source code:
+1. Clone the repository and checkout the exact tag (e.g., `v1.0.0`).
+2. Execute the build scripts in `scripts/build_binaries.py` using the exact Rust/Python toolchains specified in `.github/workflows/release.yml`.
+3. Compare the SHA256 hashes of the generated binaries against the `CHECKSUMS.txt` provided in the GitHub Release assets.

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,0 +1,26 @@
+# Support Matrix
+
+This document defines the officially supported operating systems, runtime environments, and distribution channels for `tensor-grep`.
+
+## Operating Systems
+- **Linux:** Ubuntu 20.04+, Debian 11+, RHEL 11+. (glibc 2.31+)
+- **Windows:** Windows 10, Windows 11, Windows Server 2019+. (amd64)
+- **macOS:** macOS 12+ (Apple Silicon and Intel).
+
+## Python Versions
+- **Supported:** Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14.
+- Python < 3.9 is completely unsupported and untested.
+
+## Rust Toolchain
+- **Supported:** Stable Rust (1.75+).
+
+## Package Managers
+- **pip:** Official distribution channel for Python integration.
+- **winget:** Official distribution for Windows standalone binaries.
+- **Homebrew:** Official distribution for macOS standalone binaries.
+
+## Semantic Versioning & Deprecation
+`tensor-grep` follows Semantic Versioning (SemVer) 2.0.0.
+- **Major versions** may introduce breaking changes to CLI flags, `sgconfig.yml` schemas, or JSON outputs.
+- **Minor versions** add features in a backward-compatible manner.
+- **Deprecation Policy:** Features, flags, or fields scheduled for removal will be marked as `DEPRECATED` for at least 2 minor versions before removal.

--- a/docs/runbooks/cache-management.md
+++ b/docs/runbooks/cache-management.md
@@ -1,0 +1,23 @@
+# Cache Management Runbook
+
+tensor-grep maintains internal caches to accelerate searches. This runbook explains how to inspect and clear them.
+
+## Cache Location
+Caches are typically stored in `.tg_cache/` at the project root.
+- **AST Cache:** `.tg_cache/ast/project_data_v6.json`
+- **Trigram Index:** `.tg_cache/trigrams/`
+
+## Diagnosing Stale Caches
+Run `tg doctor` to see the size, modification time, and staleness of the AST cache. If the cache is unusually large or out of sync with recent file changes, it may need to be rebuilt.
+
+## Safely Invalidating Caches
+To clear all caches and force a full rebuild on the next search:
+```bash
+rm -rf .tg_cache/
+```
+
+## Rebuilding Indexes
+After clearing the cache, you can pre-warm it by running a dummy search or using `tg calibrate`.
+```bash
+tg calibrate
+```

--- a/docs/runbooks/gpu-troubleshooting.md
+++ b/docs/runbooks/gpu-troubleshooting.md
@@ -1,0 +1,27 @@
+# GPU Troubleshooting Runbook
+
+This guide helps administrators diagnose and resolve GPU-related issues in tensor-grep.
+
+## Common Issues
+
+### 1. CUDA Out of Memory (OOM)
+- **Symptom:** Searches fail with `CUDA out of memory` errors.
+- **Diagnosis:** Run `tg doctor` to check VRAM utilization and available memory.
+- **Resolution:**
+  - Reduce batch size or thread concurrency in `sgconfig.yml`.
+  - Force CPU fallback by setting `TG_FORCE_CPU=1`.
+  - Ensure no other heavy ML workloads are consuming VRAM on the same device.
+
+### 2. Driver Mismatch
+- **Symptom:** CUDA driver version is insufficient for the compiled PyTorch bindings.
+- **Diagnosis:** Run `tg doctor` to verify the driver version against the required CUDA version (e.g., CUDA 12.x).
+- **Resolution:**
+  - Update NVIDIA drivers on the host.
+  - Alternatively, use the CPU-only binary.
+
+### 3. Forcing CPU Fallback
+To bypass GPU acceleration entirely for a session or globally:
+```bash
+export TG_FORCE_CPU=1
+tg search "pattern"
+```

--- a/docs/runbooks/resident-worker.md
+++ b/docs/runbooks/resident-worker.md
@@ -1,0 +1,23 @@
+# Resident AST Worker Runbook
+
+The Resident AST Worker keeps the AST metadata warm in memory, achieving extremely low latency for repeated searches. It communicates via TCP IPC.
+
+## Experimental Status
+This feature is currently experimental and must be explicitly opted into by setting:
+`TG_RESIDENT_AST=1`
+
+## Troubleshooting
+
+### 1. IPC Port Conflicts
+- **Symptom:** The worker fails to start or claims the port is in use.
+- **Diagnosis:** `tg doctor` will report if the TCP port file exists and if the socket is responding.
+- **Resolution:**
+  - Check `.tg_cache/ast/worker_port.txt` to find the active port.
+  - Kill any orphaned worker processes holding that port.
+
+### 2. Orphaned Worker Processes
+- **Symptom:** High background CPU/memory usage when `tg` is not actively running.
+- **Diagnosis:** Look for lingering `tg worker` processes.
+- **Resolution:**
+  - Send a termination signal to the orphaned process: `kill <pid>` (Linux/macOS) or `Stop-Process -Id <pid>` (Windows).
+  - Delete `.tg_cache/ast/worker_port.txt`.

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -108,6 +108,10 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
         "Skip publish parity gate when semantic-release produced no version",
         "Verify release version parity across tag/assets/PyPI",
         "scripts/validate_release_version_parity.py",
+        "uses: actions/checkout@v6",
+        "uses: actions/setup-python@v6",
+        "uses: actions/upload-artifact@v7",
+        "uses: actions/download-artifact@v8",
     ):
         if expected not in ci_workflow:
             errors.append(
@@ -1100,6 +1104,10 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             "Verify package-manager bundle checksums",
             "Smoke-test package-manager bundle contracts",
             "Smoke-verify Linux release binary version",
+            "Generate Rust SBOM",
+            "Generate Python SBOM",
+            "Sign artifacts with Sigstore",
+            "Generate SLSA Provenance",
         ):
             if required_step not in create_release_step_names:
                 errors.append(
@@ -1128,6 +1136,15 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                 "--artifacts-dir",
                 "--expected-version",
             ),
+            "Generate Rust SBOM": (
+                "cargo cyclonedx",
+                "--format json",
+                "--all-features",
+            ),
+            "Generate Python SBOM": (
+                "cyclonedx-py environment",
+                "--outfile artifacts/sbom-python.json",
+            ),
         }
         for step_name, required_contract_tokens in create_release_step_contracts.items():
             run_script = create_release_run_by_name.get(step_name)
@@ -1145,6 +1162,22 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                         "Release workflow create-release "
                         f"`{step_name}` step must pass `{required_flag}`"
                     )
+        
+        sigstore_step = create_release_steps_by_name.get("Sign artifacts with Sigstore")
+        if sigstore_step is not None:
+            uses_value = sigstore_step.get("uses", "")
+            if "sigstore/gh-action-sigstore-python" not in str(uses_value):
+                errors.append(
+                    "Release workflow create-release `Sign artifacts with Sigstore` step must use `sigstore/gh-action-sigstore-python`"
+                )
+                
+        slsa_step = create_release_steps_by_name.get("Generate SLSA Provenance")
+        if slsa_step is not None:
+            uses_value = slsa_step.get("uses", "")
+            if "actions/attest-build-provenance" not in str(uses_value):
+                errors.append(
+                    "Release workflow create-release `Generate SLSA Provenance` step must use `actions/attest-build-provenance`"
+                )
         github_release_step = create_release_steps_by_name.get("Create GitHub Release")
         if github_release_step is None:
             errors.append(

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -1180,7 +1180,7 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                         "Release workflow create-release "
                         f"`{step_name}` step must pass `{required_flag}`"
                     )
-        
+
         sigstore_step = create_release_steps_by_name.get("Sign artifacts with Sigstore")
         if sigstore_step is not None:
             uses_value = sigstore_step.get("uses", "")
@@ -1188,7 +1188,7 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                 errors.append(
                     "Release workflow create-release `Sign artifacts with Sigstore` step must use `sigstore/gh-action-sigstore-python`"
                 )
-                
+
         slsa_step = create_release_steps_by_name.get("Generate SLSA Provenance")
         if slsa_step is not None:
             uses_value = slsa_step.get("uses", "")

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -125,7 +125,7 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
             "publish-pypi must depend on validate-pypi-artifacts before uploading to PyPI"
         )
 
-    uv_bootstrap_count = ci_workflow.count("uses: astral-sh/setup-uv@v5") + ci_workflow.count(
+    uv_bootstrap_count = ci_workflow.count("uses: astral-sh/setup-uv@v8") + ci_workflow.count(
         "python -m pip install uv"
     )
     if uv_bootstrap_count < 2:
@@ -718,6 +718,12 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
         "Preflight smoke-test package-manager bundle contracts",
         "scripts/prepare_package_manager_release.py --check",
         "Confirm release publication gates",
+        "Generate Rust SBOM",
+        "Generate Python SBOM",
+        "Sign artifacts with Sigstore",
+        "gh-action-sigstore-python",
+        "Generate SLSA Provenance",
+        "attest-build-provenance",
     ):
         if expected not in release_workflow:
             errors.append(f"Release workflow missing expected job block: {expected.rstrip(':')}")
@@ -769,9 +775,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow build-binaries job must include step `Install uv`")
         else:
             uses_value = build_install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v5":
+            if uses_value != "astral-sh/setup-uv@v8":
                 errors.append(
-                    "Release workflow build-binaries `Install uv` step must use `astral-sh/setup-uv@v5`"
+                    "Release workflow build-binaries `Install uv` step must use `astral-sh/setup-uv@v8`"
                 )
         build_setup_python_run = build_run_by_name.get("Set up Python")
         if build_setup_python_run is None:
@@ -819,9 +825,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow build-binaries job must include step `Upload Artifact`")
         else:
             uses_value = upload_step.get("uses")
-            if uses_value != "actions/upload-artifact@v4":
+            if uses_value != "actions/upload-artifact@v7":
                 errors.append(
-                    "Release workflow build-binaries `Upload Artifact` step must use `actions/upload-artifact@v4`"
+                    "Release workflow build-binaries `Upload Artifact` step must use `actions/upload-artifact@v7`"
                 )
             with_block = upload_step.get("with")
             if not isinstance(with_block, dict):
@@ -894,16 +900,16 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                     docs_steps_by_name[name] = step
                     if isinstance(run, str):
                         docs_run_by_name[name] = run
-        if "actions/checkout@v4" not in docs_uses_values:
-            errors.append("Release workflow publish-docs job must include `actions/checkout@v4`")
+        if "actions/checkout@v6" not in docs_uses_values:
+            errors.append("Release workflow publish-docs job must include `actions/checkout@v6`")
         setup_python_step = docs_steps_by_name.get("Set up Python")
         if setup_python_step is None:
             errors.append("Release workflow publish-docs job must include step `Set up Python`")
         else:
             uses_value = setup_python_step.get("uses")
-            if uses_value != "actions/setup-python@v5":
+            if uses_value != "actions/setup-python@v6":
                 errors.append(
-                    "Release workflow publish-docs `Set up Python` step must use `actions/setup-python@v5`"
+                    "Release workflow publish-docs `Set up Python` step must use `actions/setup-python@v6`"
                 )
             with_block = setup_python_step.get("with")
             if not isinstance(with_block, dict):
@@ -1057,9 +1063,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow create-release job must include step `Install uv`")
         else:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v5":
+            if uses_value != "astral-sh/setup-uv@v8":
                 errors.append(
-                    "Release workflow create-release `Install uv` step must use `astral-sh/setup-uv@v5`"
+                    "Release workflow create-release `Install uv` step must use `astral-sh/setup-uv@v8`"
                 )
         setup_python_run = create_release_run_by_name.get("Setup Python")
         if setup_python_run is None:
@@ -1075,9 +1081,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             )
         else:
             uses_value = download_artifacts_step.get("uses")
-            if uses_value != "actions/download-artifact@v4":
+            if uses_value != "actions/download-artifact@v8":
                 errors.append(
-                    "Release workflow create-release `Download Artifacts` step must use `actions/download-artifact@v4`"
+                    "Release workflow create-release `Download Artifacts` step must use `actions/download-artifact@v8`"
                 )
             with_block = download_artifacts_step.get("with")
             if not isinstance(with_block, dict):
@@ -1194,9 +1200,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                     tag_steps_by_name[name] = step
                     if isinstance(run, str):
                         tag_run_by_name[name] = run
-        if "actions/checkout@v4" not in tag_uses_values:
+        if "actions/checkout@v6" not in tag_uses_values:
             errors.append(
-                "Release workflow validate-tag-version-parity job must include `actions/checkout@v4`"
+                "Release workflow validate-tag-version-parity job must include `actions/checkout@v6`"
             )
         for required_step in ("Install uv", "Setup Python"):
             if required_step not in tag_step_names:
@@ -1207,10 +1213,10 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
         install_uv_step = tag_steps_by_name.get("Install uv")
         if install_uv_step is not None:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v5":
+            if uses_value != "astral-sh/setup-uv@v8":
                 errors.append(
                     "Release workflow validate-tag-version-parity "
-                    "`Install uv` step must use `astral-sh/setup-uv@v5`"
+                    "`Install uv` step must use `astral-sh/setup-uv@v8`"
                 )
         setup_python_run = tag_run_by_name.get("Setup Python")
         if setup_python_run is not None and "uv python install 3.12" not in setup_python_run:
@@ -1275,9 +1281,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                 uses_value = step.get("uses")
                 if isinstance(uses_value, str):
                     checkout_uses_values.append(uses_value)
-        if "actions/checkout@v4" not in checkout_uses_values:
+        if "actions/checkout@v6" not in checkout_uses_values:
             errors.append(
-                "Release workflow verify-release-assets job must include `actions/checkout@v4`"
+                "Release workflow verify-release-assets job must include `actions/checkout@v6`"
             )
     verify_assets_step = "Verify uploaded release assets and checksum coverage"
     verify_assets_run = verify_release_assets_runs.get(verify_assets_step)
@@ -1321,16 +1327,16 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                     npm_uses_values.append(uses_value)
                 if isinstance(name, str):
                     npm_steps_by_name[name] = step
-        if "actions/checkout@v4" not in npm_uses_values:
-            errors.append("Release workflow publish-npm job must include `actions/checkout@v4`")
+        if "actions/checkout@v6" not in npm_uses_values:
+            errors.append("Release workflow publish-npm job must include `actions/checkout@v6`")
         setup_node_step = npm_steps_by_name.get("Setup Node.js")
         if setup_node_step is None:
             errors.append("Release workflow publish-npm job must include step `Setup Node.js`")
         else:
             uses_value = setup_node_step.get("uses")
-            if uses_value != "actions/setup-node@v4":
+            if uses_value != "actions/setup-node@v6":
                 errors.append(
-                    "Release workflow publish-npm `Setup Node.js` step must use `actions/setup-node@v4`"
+                    "Release workflow publish-npm `Setup Node.js` step must use `actions/setup-node@v6`"
                 )
             with_block = setup_node_step.get("with")
             if not isinstance(with_block, dict):
@@ -1338,9 +1344,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                     "Release workflow publish-npm `Setup Node.js` step must define a `with` mapping"
                 )
             else:
-                if str(with_block.get("node-version")) != "20":
+                if str(with_block.get("node-version")) != "22":
                     errors.append(
-                        "Release workflow publish-npm `Setup Node.js` step must include `node-version: 20`"
+                        "Release workflow publish-npm `Setup Node.js` step must include `node-version: 22`"
                     )
                 if str(with_block.get("registry-url")) != "https://registry.npmjs.org":
                     errors.append(
@@ -1351,9 +1357,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow publish-npm job must include step `Install uv`")
         else:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v5":
+            if uses_value != "astral-sh/setup-uv@v8":
                 errors.append(
-                    "Release workflow publish-npm `Install uv` step must use `astral-sh/setup-uv@v5`"
+                    "Release workflow publish-npm `Install uv` step must use `astral-sh/setup-uv@v8`"
                 )
         setup_python_run = publish_npm_runs.get("Setup Python")
         if setup_python_run is None:
@@ -1467,9 +1473,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
                 name = step.get("name")
                 if isinstance(name, str):
                     release_gate_steps_by_name[name] = step
-        if "actions/checkout@v4" not in release_gate_uses_values:
+        if "actions/checkout@v6" not in release_gate_uses_values:
             errors.append(
-                "Release workflow release-success-gate job must include `actions/checkout@v4`"
+                "Release workflow release-success-gate job must include `actions/checkout@v6`"
             )
         install_uv_step = release_gate_steps_by_name.get("Install uv")
         if install_uv_step is None:
@@ -1478,9 +1484,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             )
         else:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v5":
+            if uses_value != "astral-sh/setup-uv@v8":
                 errors.append(
-                    "Release workflow release-success-gate `Install uv` step must use `astral-sh/setup-uv@v5`"
+                    "Release workflow release-success-gate `Install uv` step must use `astral-sh/setup-uv@v8`"
                 )
         setup_python_run = release_gate_runs.get("Setup Python")
         if setup_python_run is None:
@@ -1549,7 +1555,7 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             '`echo "Release publication gates passed: parity, npm, docs."`'
         )
 
-    if "uses: astral-sh/setup-uv@v5" not in release_workflow:
+    if "uses: astral-sh/setup-uv@v8" not in release_workflow:
         errors.append(
             "Release workflow package-manager validation must install uv before fallback checks"
         )

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -493,6 +493,24 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
             "CI workflow benchmark summary generation must pass `--baseline auto` to summarize_benchmarks.py"
         )
 
+    action_versions = {
+        "actions/checkout": "v6",
+        "actions/setup-python": "v6",
+        "actions/setup-node": "v6",
+        "actions/upload-artifact": "v7",
+        "actions/download-artifact": "v8",
+        "astral-sh/setup-uv": "v8",
+    }
+    for match in re.finditer(r"uses:\s+([^@\s\n]+)@([^\s\n]+)", ci_workflow):
+        action = match.group(1)
+        version = match.group(2)
+        if action in action_versions:
+            expected_version = action_versions[action]
+            if version != expected_version:
+                errors.append(
+                    f"CI workflow must use {action}@{expected_version}, found @{version}"
+                )
+
     return errors
 
 

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -129,7 +129,7 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
             "publish-pypi must depend on validate-pypi-artifacts before uploading to PyPI"
         )
 
-    uv_bootstrap_count = ci_workflow.count("uses: astral-sh/setup-uv@v8") + ci_workflow.count(
+    uv_bootstrap_count = ci_workflow.count("uses: astral-sh/setup-uv@v8.0.0") + ci_workflow.count(
         "python -m pip install uv"
     )
     if uv_bootstrap_count < 2:
@@ -499,7 +499,7 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
         "actions/setup-node": "v6",
         "actions/upload-artifact": "v7",
         "actions/download-artifact": "v8",
-        "astral-sh/setup-uv": "v8",
+        "astral-sh/setup-uv": "v8.0.0",
     }
     for match in re.finditer(r"uses:\s+([^@\s\n]+)@([^\s\n]+)", ci_workflow):
         action = match.group(1)
@@ -797,9 +797,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow build-binaries job must include step `Install uv`")
         else:
             uses_value = build_install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v8":
+            if uses_value != "astral-sh/setup-uv@v8.0.0":
                 errors.append(
-                    "Release workflow build-binaries `Install uv` step must use `astral-sh/setup-uv@v8`"
+                    "Release workflow build-binaries `Install uv` step must use `astral-sh/setup-uv@v8.0.0`"
                 )
         build_setup_python_run = build_run_by_name.get("Set up Python")
         if build_setup_python_run is None:
@@ -1085,9 +1085,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow create-release job must include step `Install uv`")
         else:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v8":
+            if uses_value != "astral-sh/setup-uv@v8.0.0":
                 errors.append(
-                    "Release workflow create-release `Install uv` step must use `astral-sh/setup-uv@v8`"
+                    "Release workflow create-release `Install uv` step must use `astral-sh/setup-uv@v8.0.0`"
                 )
         setup_python_run = create_release_run_by_name.get("Setup Python")
         if setup_python_run is None:
@@ -1264,10 +1264,10 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
         install_uv_step = tag_steps_by_name.get("Install uv")
         if install_uv_step is not None:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v8":
+            if uses_value != "astral-sh/setup-uv@v8.0.0":
                 errors.append(
                     "Release workflow validate-tag-version-parity "
-                    "`Install uv` step must use `astral-sh/setup-uv@v8`"
+                    "`Install uv` step must use `astral-sh/setup-uv@v8.0.0`"
                 )
         setup_python_run = tag_run_by_name.get("Setup Python")
         if setup_python_run is not None and "uv python install 3.12" not in setup_python_run:
@@ -1408,9 +1408,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             errors.append("Release workflow publish-npm job must include step `Install uv`")
         else:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v8":
+            if uses_value != "astral-sh/setup-uv@v8.0.0":
                 errors.append(
-                    "Release workflow publish-npm `Install uv` step must use `astral-sh/setup-uv@v8`"
+                    "Release workflow publish-npm `Install uv` step must use `astral-sh/setup-uv@v8.0.0`"
                 )
         setup_python_run = publish_npm_runs.get("Setup Python")
         if setup_python_run is None:
@@ -1535,9 +1535,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             )
         else:
             uses_value = install_uv_step.get("uses")
-            if uses_value != "astral-sh/setup-uv@v8":
+            if uses_value != "astral-sh/setup-uv@v8.0.0":
                 errors.append(
-                    "Release workflow release-success-gate `Install uv` step must use `astral-sh/setup-uv@v8`"
+                    "Release workflow release-success-gate `Install uv` step must use `astral-sh/setup-uv@v8.0.0`"
                 )
         setup_python_run = release_gate_runs.get("Setup Python")
         if setup_python_run is None:
@@ -1606,7 +1606,7 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             '`echo "Release publication gates passed: parity, npm, docs."`'
         )
 
-    if "uses: astral-sh/setup-uv@v8" not in release_workflow:
+    if "uses: astral-sh/setup-uv@v8.0.0" not in release_workflow:
         errors.append(
             "Release workflow package-manager validation must install uv before fallback checks"
         )

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -297,9 +297,9 @@ def _doctor_ast_cache_status(path: str) -> dict[str, Any]:
                     data = json.load(f)
                 val_meta = data.get("validation_metadata", {})
                 for field in ("rule_files", "test_files", "tree_dirs"):
-                    for file_path_str in val_meta.get(field, {}):
+                    for file_path_str, recorded_mtime_ns in val_meta.get(field, {}).items():
                         p = Path(file_path_str)
-                        if not p.exists() or p.stat().st_mtime > cache_mtime:
+                        if not p.exists() or p.stat().st_mtime_ns > recorded_mtime_ns:
                             stale = True
                             break
                     if stale:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -276,8 +276,8 @@ def _doctor_gpu_status() -> dict[str, Any]:
         status["error"] = str(e)
     return status
 
-def _doctor_ast_cache_status(path: str) -> dict[str, Any]:
-    root = Path(path).resolve()
+def _doctor_ast_cache_status(root_path: str, config_path: str) -> dict[str, Any]:
+    root = Path(root_path).resolve()
     cache_file = root / ".tg_cache" / "ast" / "project_data_v6.json"
     status: dict[str, Any] = {"exists": False}
     if cache_file.exists():
@@ -288,7 +288,7 @@ def _doctor_ast_cache_status(path: str) -> dict[str, Any]:
         stale = False
         try:
             cache_mtime = stat.st_mtime
-            sgconfig = root / "sgconfig.yml"
+            sgconfig = Path(config_path).resolve()
             if sgconfig.exists() and sgconfig.stat().st_mtime > cache_mtime:
                 stale = True
             if not stale:
@@ -309,6 +309,7 @@ def _doctor_ast_cache_status(path: str) -> dict[str, Any]:
         status["stale"] = stale
     return status
 
+
 def _doctor_resident_worker_status(path: str) -> dict[str, Any]:
     import socket
     root = Path(path).resolve()
@@ -328,8 +329,14 @@ def _doctor_resident_worker_status(path: str) -> dict[str, Any]:
     return status
 
 
-def _build_doctor_payload(path: str, *, with_lsp: bool) -> dict[str, Any]:
+def _build_doctor_payload(path: str, config: str | None = None, *, with_lsp: bool) -> dict[str, Any]:
     root = Path(path).resolve()
+    if config:
+        config_p = Path(config)
+        resolved_config = config_p if config_p.is_absolute() else Path.cwd() / config_p
+        root = resolved_config.parent
+    else:
+        resolved_config = root / "sgconfig.yml"
     native_tg_binary = _resolve_native_tg_binary()
     env_keys = [
         "TG_NATIVE_TG_BINARY",
@@ -346,11 +353,12 @@ def _build_doctor_payload(path: str, *, with_lsp: bool) -> dict[str, Any]:
         "python_version": ".".join([str(x) for x in sys.version_info[:3]]),
         "invoked_as": sys.argv[0] if sys.argv else "tg",
         "root": str(root),
+        "config": str(resolved_config),
         "native_tg_binary": str(native_tg_binary) if native_tg_binary is not None else None,
         "native_tg_binary_exists": native_tg_binary is not None,
         "rust_binary_version": _doctor_rust_binary_version(native_tg_binary),
         "gpu": _doctor_gpu_status(),
-        "ast_cache": _doctor_ast_cache_status(str(root)),
+        "ast_cache": _doctor_ast_cache_status(str(root), str(resolved_config)),
         "resident_worker": _doctor_resident_worker_status(str(root)),
         "env": {key: os.environ[key] for key in env_keys if os.environ.get(key)},
         "session_daemon": _doctor_session_daemon_status(str(root)),

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -246,6 +246,88 @@ def _doctor_lsp_provider_statuses(path: str) -> list[dict[str, Any]]:
     ]
 
 
+def _doctor_rust_binary_version(native_tg_binary: Path | None) -> str | None:
+    if not native_tg_binary:
+        return None
+    try:
+        import subprocess
+        res = subprocess.run([str(native_tg_binary), "--version"], capture_output=True, text=True, timeout=2)
+        if res.returncode == 0:
+            return res.stdout.strip()
+        return None
+    except Exception:
+        return None
+
+def _doctor_gpu_status() -> dict[str, Any]:
+    status: dict[str, Any] = {"available": False, "devices": [], "error": None}
+    try:
+        from tensor_grep.core.hardware.device_detect import DeviceDetector
+        detector = DeviceDetector()
+        status["available"] = detector.has_gpu()
+        status["device_count"] = detector.get_device_count()
+        for device in detector.list_devices():
+            status["devices"].append({
+                "id": device.device_id,
+                "vram_total_mb": device.vram_capacity_mb
+            })
+    except ImportError:
+        status["error"] = "PyTorch/cuDF not installed"
+    except Exception as e:
+        status["error"] = str(e)
+    return status
+
+def _doctor_ast_cache_status(path: str) -> dict[str, Any]:
+    root = Path(path).resolve()
+    cache_file = root / ".tg_cache" / "ast" / "project_data_v6.json"
+    status: dict[str, Any] = {"exists": False}
+    if cache_file.exists():
+        stat = cache_file.stat()
+        status["exists"] = True
+        status["size_bytes"] = stat.st_size
+        status["mtime"] = stat.st_mtime
+        stale = False
+        try:
+            cache_mtime = stat.st_mtime
+            sgconfig = root / "sgconfig.yml"
+            if sgconfig.exists() and sgconfig.stat().st_mtime > cache_mtime:
+                stale = True
+            if not stale:
+                with cache_file.open("r", encoding="utf-8") as f:
+                    import json
+                    data = json.load(f)
+                val_meta = data.get("validation_metadata", {})
+                for field in ("rule_files", "test_files", "tree_dirs"):
+                    for file_path_str in val_meta.get(field, {}):
+                        p = Path(file_path_str)
+                        if not p.exists() or p.stat().st_mtime > cache_mtime:
+                            stale = True
+                            break
+                    if stale:
+                        break
+        except Exception:
+            pass
+        status["stale"] = stale
+    return status
+
+def _doctor_resident_worker_status(path: str) -> dict[str, Any]:
+    import socket
+    root = Path(path).resolve()
+    port_file = root / ".tg_cache" / "ast" / "worker_port.txt"
+    status: dict[str, Any] = {"port_file_exists": False, "port": None, "responding": False}
+    if port_file.exists():
+        status["port_file_exists"] = True
+        try:
+            port = int(port_file.read_text(encoding="utf-8").strip())
+            status["port"] = port
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.1)
+                s.connect(("127.0.0.1", port))
+                status["responding"] = True
+        except Exception:
+            status["responding"] = False
+    return status
+
+
 def _build_doctor_payload(path: str, *, with_lsp: bool) -> dict[str, Any]:
     root = Path(path).resolve()
     native_tg_binary = _resolve_native_tg_binary()
@@ -261,10 +343,15 @@ def _build_doctor_payload(path: str, *, with_lsp: bool) -> dict[str, Any]:
         "version": _doctor_installed_version(),
         "platform": sys.platform,
         "python_executable": sys.executable,
+        "python_version": ".".join([str(x) for x in sys.version_info[:3]]),
         "invoked_as": sys.argv[0] if sys.argv else "tg",
         "root": str(root),
         "native_tg_binary": str(native_tg_binary) if native_tg_binary is not None else None,
         "native_tg_binary_exists": native_tg_binary is not None,
+        "rust_binary_version": _doctor_rust_binary_version(native_tg_binary),
+        "gpu": _doctor_gpu_status(),
+        "ast_cache": _doctor_ast_cache_status(str(root)),
+        "resident_worker": _doctor_resident_worker_status(str(root)),
         "env": {key: os.environ[key] for key in env_keys if os.environ.get(key)},
         "session_daemon": _doctor_session_daemon_status(str(root)),
     }
@@ -283,12 +370,34 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
         "tensor-grep doctor",
         f"version: {payload['version']}",
         f"platform: {payload['platform']}",
-        f"python: {payload['python_executable']}",
+        f"python: {payload['python_executable']} ({payload.get('python_version', 'unknown')})",
         f"invoked_as: {payload['invoked_as']}",
         f"root: {payload['root']}",
     ]
     native_tg_binary = payload.get("native_tg_binary")
     lines.append(f"native_tg_binary: {native_tg_binary or 'missing'}")
+    if rust_version := payload.get("rust_binary_version"):
+        lines.append(f"rust_binary_version:\n  {rust_version.replace(chr(10), chr(10) + '  ')}")
+
+    gpu_payload = cast(dict[str, Any], payload.get("gpu", {}))
+    lines.append(f"gpu: available={gpu_payload.get('available', False)}")
+    if gpu_payload.get("error"):
+        lines.append(f"  error: {gpu_payload['error']}")
+    for dev in gpu_payload.get("devices", []):
+        lines.append(f"  device {dev.get('id')}: {dev.get('vram_total_mb')} MB VRAM")
+
+    ast_payload = cast(dict[str, Any], payload.get("ast_cache", {}))
+    lines.append(f"ast_cache: exists={ast_payload.get('exists', False)}")
+    if ast_payload.get("exists"):
+        lines.append(f"  size: {ast_payload.get('size_bytes')} bytes")
+        lines.append(f"  mtime: {ast_payload.get('mtime')}")
+        lines.append(f"  stale: {ast_payload.get('stale')}")
+
+    worker_payload = cast(dict[str, Any], payload.get("resident_worker", {}))
+    lines.append(
+        f"resident_worker: port_file_exists={worker_payload.get('port_file_exists', False)} "
+        f"port={worker_payload.get('port')} responding={worker_payload.get('responding', False)}"
+    )
 
     env_payload = cast(dict[str, str], payload.get("env", {}))
     if env_payload:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -333,7 +333,7 @@ def _build_doctor_payload(path: str, config: str | None = None, *, with_lsp: boo
     root = Path(path).resolve()
     if config:
         config_p = Path(config)
-        resolved_config = config_p if config_p.is_absolute() else Path.cwd() / config_p
+        resolved_config = config_p if config_p.is_absolute() else (root / config_p).resolve()
         root = resolved_config.parent
     else:
         resolved_config = root / "sgconfig.yml"
@@ -4053,6 +4053,9 @@ def mcp_server() -> None:
 @app.command()
 def doctor(
     path: str = typer.Argument(".", help="Workspace root to inspect."),
+    config: str | None = typer.Option(
+        "sgconfig.yml", "--config", "-c", help="Path to ast-grep root config."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
     with_lsp: bool = typer.Option(
         True,
@@ -4061,7 +4064,7 @@ def doctor(
     ),
 ) -> None:
     """Print runtime, daemon, and optional LSP diagnostics for AI troubleshooting."""
-    payload = _build_doctor_payload(path, with_lsp=with_lsp)
+    payload = _build_doctor_payload(path, config=config, with_lsp=with_lsp)
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
         return

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1861,6 +1861,89 @@ def test_upgrade_schedules_windows_helper_when_tg_exe_is_locked(monkeypatch, tmp
     assert "Upgrade log:" in result.output
 
 
+def test_upgrade_schedules_windows_helper_for_realworld_uv_pip_ensurepip_lock(
+    monkeypatch, tmp_path
+):
+    calls: list[list[str]] = []
+    popen_calls: list[list[str]] = []
+
+    uv_locked_error = (
+        "uv: Using Python 3.12.12 environment at: .tensor-grep\\.venv\n"
+        "Resolved 57 packages in 3.09s\n"
+        "Downloading tensor-grep (3.1MiB)\n"
+        "Downloading cryptography (3.3MiB)\n"
+        " Downloaded tensor-grep\n"
+        " Downloaded cryptography\n"
+        "Prepared 14 packages in 1.00s\n"
+        "error: failed to remove file "
+        "`C:\\Users\\oimir\\.tensor-grep\\.venv\\Lib\\site-packages\\../../Scripts\\tg.exe`: "
+        "The process cannot access the file because it is being used by another process. "
+        "(os error 32)"
+    )
+    pip_missing_error = (
+        "C:\\Users\\oimir\\.tensor-grep\\.venv\\Scripts\\python.exe: No module named pip"
+    )
+    ensurepip_locked_error = (
+        "ERROR: Could not install packages due to an OSError: [WinError 32] "
+        "The process cannot access the file because it is being used by another process: "
+        "'c:\\users\\oimir\\.tensor-grep\\.venv\\scripts\\tg.exe'\n"
+        "Check the permissions."
+    )
+
+    def _fake_run(cmd, capture_output=True, text=True, check=True):
+        command = list(cmd)
+        calls.append(command)
+        if command[0] == "uv":
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=command,
+                stderr=uv_locked_error,
+            )
+        if command[:3] == ["python", "-m", "pip"]:
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=command,
+                stderr=pip_missing_error,
+            )
+        if command[:3] == ["python", "-m", "ensurepip"]:
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=command,
+                stderr=ensurepip_locked_error,
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    class _FakePopen:
+        def __init__(
+            self,
+            cmd,
+            stdout=None,
+            stderr=None,
+            stdin=None,
+            close_fds=None,
+            creationflags=0,
+        ):
+            popen_calls.append(list(cmd))
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    monkeypatch.setattr("sys.executable", "python")
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert calls[0][0] == "uv"
+    assert any(cmd[:3] == ["python", "-m", "pip"] for cmd in calls)
+    assert any(cmd[:3] == ["python", "-m", "ensurepip"] for cmd in calls)
+    assert popen_calls
+    assert "Windows is still using tg.exe" in result.output
+    assert "Wait a few seconds, then run `tg --version` again." in result.output
+    assert "Upgrade log:" in result.output
+
+
 def test_cli_debug_prints_pipeline_routing_reason(monkeypatch):
     global _FAKE_WALK, _FAKE_BACKEND
     _FAKE_WALK = {".": ["a.log"]}

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -1613,12 +1613,10 @@ def test_should_require_create_release_sbom_slsa_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "Generate Rust SBOM" in joined_errors
-    assert "Generate Python SBOM" in joined_errors
-    assert "Sign artifacts with Sigstore" in joined_errors
-    assert "gh-action-sigstore-python" in joined_errors
-    assert "Generate SLSA Provenance" in joined_errors
-    assert "attest-build-provenance" in joined_errors
+    assert "Release workflow create-release job must include step `Generate Rust SBOM`" in joined_errors
+    assert "Release workflow create-release job must include step `Generate Python SBOM`" in joined_errors
+    assert "Release workflow create-release job must include step `Sign artifacts with Sigstore`" in joined_errors
+    assert "Release workflow create-release job must include step `Generate SLSA Provenance`" in joined_errors
 
 
 def test_should_require_release_binary_artifact_validation_flags():

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -189,8 +189,8 @@ def test_should_require_ci_pypi_parity_retry_arguments():
     publish-pypi:
       needs: [release, build-wheels-pypi, build-sdist-pypi, validate-pypi-artifacts]
       steps:
-        - uses: astral-sh/setup-uv@v8
-        - uses: astral-sh/setup-uv@v8
+        - uses: astral-sh/setup-uv@v8.0.0
+        - uses: astral-sh/setup-uv@v8.0.0
         - run: |
             python scripts/validate_release_version_parity.py
     """
@@ -273,8 +273,8 @@ def test_should_require_ci_terminal_publish_success_gate():
     publish-pypi:
       needs: [release, build-wheels-pypi, build-sdist-pypi, validate-pypi-artifacts]
       steps:
-        - uses: astral-sh/setup-uv@v8
-        - uses: astral-sh/setup-uv@v8
+        - uses: astral-sh/setup-uv@v8.0.0
+        - uses: astral-sh/setup-uv@v8.0.0
         - run: |
             python scripts/validate_release_version_parity.py \
               --pypi-wait-seconds 180 \
@@ -2363,7 +2363,7 @@ def test_should_require_release_publish_npm_setup_node_contract():
         needs: verify-release-assets
         steps:
           - name: Install uv
-            uses: astral-sh/setup-uv@v8
+            uses: astral-sh/setup-uv@v8.0.0
           - name: Setup Python
             run: uv python install 3.12
           - name: Validate release tag/version parity across package metadata
@@ -2420,8 +2420,8 @@ def test_should_require_release_build_binaries_step_contracts():
     build_binaries_prefix, build_binaries_rest = release_workflow.split("  build-binaries:", 1)
     build_binaries_section, remainder = build_binaries_rest.split("  create-release:", 1)
     build_binaries_section = build_binaries_section.replace(
-        "astral-sh/setup-uv@v8",
-        "astral-sh/setup-uv@v4",
+        "astral-sh/setup-uv@v8.0.0",
+        "astral-sh/setup-uv@v4.0.0",
         1,
     )
     build_binaries_section = build_binaries_section.replace(
@@ -2494,7 +2494,7 @@ def test_should_require_release_build_binaries_step_contracts():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "build-binaries `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
+    assert "build-binaries `Install uv` step must use `astral-sh/setup-uv@v8.0.0`" in joined_errors
     assert (
         "build-binaries `Set up Python` step must invoke `uv python install 3.12`" in joined_errors
     )
@@ -2586,8 +2586,8 @@ def test_should_require_create_release_setup_contract():
     create_release_prefix, create_release_rest = release_workflow.split("  create-release:", 1)
     create_release_section, remainder = create_release_rest.split("  verify-release-assets:", 1)
     create_release_section = create_release_section.replace(
-        "astral-sh/setup-uv@v8",
-        "astral-sh/setup-uv@v4",
+        "astral-sh/setup-uv@v8.0.0",
+        "astral-sh/setup-uv@v4.0.0",
         1,
     )
     create_release_section = create_release_section.replace(
@@ -2606,7 +2606,7 @@ def test_should_require_create_release_setup_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "create-release `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
+    assert "create-release `Install uv` step must use `astral-sh/setup-uv@v8.0.0`" in joined_errors
     assert (
         "create-release `Setup Python` step must invoke `uv python install 3.12`" in joined_errors
     )
@@ -2729,7 +2729,7 @@ def test_should_require_validate_tag_version_parity_setup_contract():
     tag_prefix, tag_rest = release_workflow.split("  validate-tag-version-parity:", 1)
     tag_section, remainder = tag_rest.split("  publish-npm:", 1)
     tag_section = tag_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
-    tag_section = tag_section.replace("astral-sh/setup-uv@v8", "astral-sh/setup-uv@v4", 1)
+    tag_section = tag_section.replace("astral-sh/setup-uv@v8.0.0", "astral-sh/setup-uv@v4.0.0", 1)
     tag_section = tag_section.replace("uv python install 3.12", "python -V", 1)
     release_workflow = (
         tag_prefix + "  validate-tag-version-parity:" + tag_section + "  publish-npm:" + remainder
@@ -2740,7 +2740,7 @@ def test_should_require_validate_tag_version_parity_setup_contract():
     joined_errors = "\n".join(errors)
     assert "validate-tag-version-parity job must include `actions/checkout@v6`" in joined_errors
     assert (
-        "validate-tag-version-parity `Install uv` step must use `astral-sh/setup-uv@v8`"
+        "validate-tag-version-parity `Install uv` step must use `astral-sh/setup-uv@v8.0.0`"
         in joined_errors
     )
     assert (
@@ -2812,14 +2812,14 @@ def test_should_require_publish_npm_uv_python_setup_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
-    npm_section = npm_section.replace("astral-sh/setup-uv@v8", "astral-sh/setup-uv@v4", 1)
+    npm_section = npm_section.replace("astral-sh/setup-uv@v8.0.0", "astral-sh/setup-uv@v4.0.0", 1)
     npm_section = npm_section.replace("uv python install 3.12", "python -V", 1)
     release_workflow = npm_prefix + "  publish-npm:" + npm_section + "  publish-docs:" + remainder
     errors = module.validate_release_workflow_content(
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "publish-npm `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
+    assert "publish-npm `Install uv` step must use `astral-sh/setup-uv@v8.0.0`" in joined_errors
     assert "publish-npm `Setup Python` step must invoke `uv python install 3.12`" in joined_errors
 
 
@@ -3148,7 +3148,7 @@ def test_should_require_release_success_gate_setup_contract():
     gate_prefix, gate_rest = release_workflow.split("  release-success-gate:", 1)
     gate_section = gate_rest
     gate_section = gate_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
-    gate_section = gate_section.replace("astral-sh/setup-uv@v8", "astral-sh/setup-uv@v4", 1)
+    gate_section = gate_section.replace("astral-sh/setup-uv@v8.0.0", "astral-sh/setup-uv@v4.0.0", 1)
     gate_section = gate_section.replace("uv python install 3.12", "python -V", 1)
     release_workflow = gate_prefix + "  release-success-gate:" + gate_section
     errors = module.validate_release_workflow_content(
@@ -3157,7 +3157,7 @@ def test_should_require_release_success_gate_setup_contract():
     joined_errors = "\n".join(errors)
     assert "release-success-gate job must include `actions/checkout@v6`" in joined_errors
     assert (
-        "release-success-gate `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
+        "release-success-gate `Install uv` step must use `astral-sh/setup-uv@v8.0.0`" in joined_errors
     )
     assert (
         "release-success-gate `Setup Python` step must invoke `uv python install 3.12`"

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -189,8 +189,8 @@ def test_should_require_ci_pypi_parity_retry_arguments():
     publish-pypi:
       needs: [release, build-wheels-pypi, build-sdist-pypi, validate-pypi-artifacts]
       steps:
-        - uses: astral-sh/setup-uv@v5
-        - uses: astral-sh/setup-uv@v5
+        - uses: astral-sh/setup-uv@v8
+        - uses: astral-sh/setup-uv@v8
         - run: |
             python scripts/validate_release_version_parity.py
     """
@@ -273,8 +273,8 @@ def test_should_require_ci_terminal_publish_success_gate():
     publish-pypi:
       needs: [release, build-wheels-pypi, build-sdist-pypi, validate-pypi-artifacts]
       steps:
-        - uses: astral-sh/setup-uv@v5
-        - uses: astral-sh/setup-uv@v5
+        - uses: astral-sh/setup-uv@v8
+        - uses: astral-sh/setup-uv@v8
         - run: |
             python scripts/validate_release_version_parity.py \
               --pypi-wait-seconds 180 \
@@ -770,11 +770,11 @@ def test_should_require_publish_success_gate_dist_branch_and_download_guard():
         if: always()
         needs: [release, publish-pypi]
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v6
             if: needs.release.outputs.release_version != ''
           - name: Download all distributions
             if: needs.release.outputs.release_version != ''
-            uses: actions/download-artifact@v4
+            uses: actions/download-artifact@v8
             with:
               pattern: pypi-*
               path: dist
@@ -1593,6 +1593,34 @@ def test_should_require_release_binary_smoke_verify_expected_version_flag():
     )
 
 
+def test_should_require_create_release_sbom_slsa_contract():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    release_workflow = """
+    jobs:
+      create-release:
+        steps:
+          - name: Build stuff
+            run: echo "building"
+    """
+    errors = module.validate_release_workflow_content(
+        release_workflow=textwrap.dedent(release_workflow)
+    )
+    joined_errors = "\n".join(errors)
+    assert "Generate Rust SBOM" in joined_errors
+    assert "Generate Python SBOM" in joined_errors
+    assert "Sign artifacts with Sigstore" in joined_errors
+    assert "gh-action-sigstore-python" in joined_errors
+    assert "Generate SLSA Provenance" in joined_errors
+    assert "attest-build-provenance" in joined_errors
+
+
 def test_should_require_release_binary_artifact_validation_flags():
     root = Path(__file__).resolve().parents[2]
     script_path = root / "scripts" / "validate_release_assets.py"
@@ -1807,7 +1835,7 @@ def test_should_require_validate_pypi_artifacts_job_step_flags():
       validate-pypi-artifacts:
         steps:
           - name: Download all distributions
-            uses: actions/download-artifact@v4
+            uses: actions/download-artifact@v8
             with:
               pattern: pypi-*
               path: dist
@@ -2337,7 +2365,7 @@ def test_should_require_release_publish_npm_setup_node_contract():
         needs: verify-release-assets
         steps:
           - name: Install uv
-            uses: astral-sh/setup-uv@v5
+            uses: astral-sh/setup-uv@v8
           - name: Setup Python
             run: uv python install 3.12
           - name: Validate release tag/version parity across package metadata
@@ -2355,7 +2383,7 @@ def test_should_require_release_publish_npm_setup_node_contract():
           - name: Setup Node.js
             uses: actions/setup-node@v3
             with:
-              node-version: '20'
+              node-version: '22'
           - name: Verify Version Match
             run: |
               TAG_VERSION=${GITHUB_REF#refs/tags/v}
@@ -2372,7 +2400,7 @@ def test_should_require_release_publish_npm_setup_node_contract():
     """
     errors = module.validate_release_workflow_content(release_workflow=release_workflow)
     assert any(
-        "publish-npm `Setup Node.js` step must use `actions/setup-node@v4`" in err for err in errors
+        "publish-npm `Setup Node.js` step must use `actions/setup-node@v6`" in err for err in errors
     )
     assert any(
         "publish-npm `Setup Node.js` step must include `registry-url: https://registry.npmjs.org`"
@@ -2394,7 +2422,7 @@ def test_should_require_release_build_binaries_step_contracts():
     build_binaries_prefix, build_binaries_rest = release_workflow.split("  build-binaries:", 1)
     build_binaries_section, remainder = build_binaries_rest.split("  create-release:", 1)
     build_binaries_section = build_binaries_section.replace(
-        "astral-sh/setup-uv@v5",
+        "astral-sh/setup-uv@v8",
         "astral-sh/setup-uv@v4",
         1,
     )
@@ -2461,14 +2489,14 @@ def test_should_require_release_build_binaries_step_contracts():
         1,
     )
     release_workflow = release_workflow.replace(
-        "actions/upload-artifact@v4", "actions/upload-artifact@v3", 1
+        "actions/upload-artifact@v7", "actions/upload-artifact@v3", 1
     )
     release_workflow = release_workflow.replace("path: tg-*", "path: dist/*", 1)
     errors = module.validate_release_workflow_content(
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "build-binaries `Install uv` step must use `astral-sh/setup-uv@v5`" in joined_errors
+    assert "build-binaries `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
     assert (
         "build-binaries `Set up Python` step must invoke `uv python install 3.12`" in joined_errors
     )
@@ -2490,7 +2518,7 @@ def test_should_require_release_build_binaries_step_contracts():
         in joined_errors
     )
     assert (
-        "build-binaries `Upload Artifact` step must use `actions/upload-artifact@v4`"
+        "build-binaries `Upload Artifact` step must use `actions/upload-artifact@v7`"
         in joined_errors
     )
     assert "build-binaries `Upload Artifact` step must include `path: tg-*`" in joined_errors
@@ -2529,7 +2557,7 @@ def test_should_require_create_release_download_artifacts_contract():
 
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     release_workflow = release_workflow.replace(
-        "actions/download-artifact@v4",
+        "actions/download-artifact@v8",
         "actions/download-artifact@v3",
         1,
     )
@@ -2539,7 +2567,7 @@ def test_should_require_create_release_download_artifacts_contract():
     )
     joined_errors = "\n".join(errors)
     assert (
-        "create-release `Download Artifacts` step must use `actions/download-artifact@v4`"
+        "create-release `Download Artifacts` step must use `actions/download-artifact@v8`"
         in joined_errors
     )
     assert (
@@ -2560,7 +2588,7 @@ def test_should_require_create_release_setup_contract():
     create_release_prefix, create_release_rest = release_workflow.split("  create-release:", 1)
     create_release_section, remainder = create_release_rest.split("  verify-release-assets:", 1)
     create_release_section = create_release_section.replace(
-        "astral-sh/setup-uv@v5",
+        "astral-sh/setup-uv@v8",
         "astral-sh/setup-uv@v4",
         1,
     )
@@ -2580,7 +2608,7 @@ def test_should_require_create_release_setup_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "create-release `Install uv` step must use `astral-sh/setup-uv@v5`" in joined_errors
+    assert "create-release `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
     assert (
         "create-release `Setup Python` step must invoke `uv python install 3.12`" in joined_errors
     )
@@ -2641,7 +2669,7 @@ def test_should_require_verify_release_assets_checkout_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     verify_prefix, verify_rest = release_workflow.split("  verify-release-assets:", 1)
     verify_section, remainder = verify_rest.split("  validate-tag-version-parity:", 1)
-    verify_section = verify_section.replace("actions/checkout@v4", "actions/checkout@v3", 1)
+    verify_section = verify_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
     release_workflow = (
         verify_prefix
         + "  verify-release-assets:"
@@ -2653,7 +2681,7 @@ def test_should_require_verify_release_assets_checkout_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "verify-release-assets job must include `actions/checkout@v4`" in joined_errors
+    assert "verify-release-assets job must include `actions/checkout@v6`" in joined_errors
 
 
 def test_should_require_verify_release_assets_python_entrypoint_contract():
@@ -2702,8 +2730,8 @@ def test_should_require_validate_tag_version_parity_setup_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     tag_prefix, tag_rest = release_workflow.split("  validate-tag-version-parity:", 1)
     tag_section, remainder = tag_rest.split("  publish-npm:", 1)
-    tag_section = tag_section.replace("actions/checkout@v4", "actions/checkout@v3", 1)
-    tag_section = tag_section.replace("astral-sh/setup-uv@v5", "astral-sh/setup-uv@v4", 1)
+    tag_section = tag_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
+    tag_section = tag_section.replace("astral-sh/setup-uv@v8", "astral-sh/setup-uv@v4", 1)
     tag_section = tag_section.replace("uv python install 3.12", "python -V", 1)
     release_workflow = (
         tag_prefix + "  validate-tag-version-parity:" + tag_section + "  publish-npm:" + remainder
@@ -2712,9 +2740,9 @@ def test_should_require_validate_tag_version_parity_setup_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "validate-tag-version-parity job must include `actions/checkout@v4`" in joined_errors
+    assert "validate-tag-version-parity job must include `actions/checkout@v6`" in joined_errors
     assert (
-        "validate-tag-version-parity `Install uv` step must use `astral-sh/setup-uv@v5`"
+        "validate-tag-version-parity `Install uv` step must use `astral-sh/setup-uv@v8`"
         in joined_errors
     )
     assert (
@@ -2765,13 +2793,13 @@ def test_should_require_publish_npm_checkout_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
-    npm_section = npm_section.replace("actions/checkout@v4", "actions/checkout@v3", 1)
+    npm_section = npm_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
     release_workflow = npm_prefix + "  publish-npm:" + npm_section + "  publish-docs:" + remainder
     errors = module.validate_release_workflow_content(
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "publish-npm job must include `actions/checkout@v4`" in joined_errors
+    assert "publish-npm job must include `actions/checkout@v6`" in joined_errors
 
 
 def test_should_require_publish_npm_uv_python_setup_contract():
@@ -2786,14 +2814,14 @@ def test_should_require_publish_npm_uv_python_setup_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
-    npm_section = npm_section.replace("astral-sh/setup-uv@v5", "astral-sh/setup-uv@v4", 1)
+    npm_section = npm_section.replace("astral-sh/setup-uv@v8", "astral-sh/setup-uv@v4", 1)
     npm_section = npm_section.replace("uv python install 3.12", "python -V", 1)
     release_workflow = npm_prefix + "  publish-npm:" + npm_section + "  publish-docs:" + remainder
     errors = module.validate_release_workflow_content(
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "publish-npm `Install uv` step must use `astral-sh/setup-uv@v5`" in joined_errors
+    assert "publish-npm `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
     assert "publish-npm `Setup Python` step must invoke `uv python install 3.12`" in joined_errors
 
 
@@ -2809,13 +2837,13 @@ def test_should_require_publish_npm_node_version_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
-    npm_section = npm_section.replace("node-version: '20'", "node-version: '18'", 1)
+    npm_section = npm_section.replace("node-version: '22'", "node-version: '18'", 1)
     release_workflow = npm_prefix + "  publish-npm:" + npm_section + "  publish-docs:" + remainder
     errors = module.validate_release_workflow_content(
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "publish-npm `Setup Node.js` step must include `node-version: 20`" in joined_errors
+    assert "publish-npm `Setup Node.js` step must include `node-version: 22`" in joined_errors
 
 
 def test_should_require_publish_npm_version_check_entrypoint_contract():
@@ -2938,7 +2966,7 @@ def test_should_require_publish_docs_checkout_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
-    docs_section = docs_section.replace("actions/checkout@v4", "actions/checkout@v3", 1)
+    docs_section = docs_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
     release_workflow = (
         docs_prefix + "  publish-docs:" + docs_section + "  release-success-gate:" + remainder
     )
@@ -2946,7 +2974,7 @@ def test_should_require_publish_docs_checkout_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "publish-docs job must include `actions/checkout@v4`" in joined_errors
+    assert "publish-docs job must include `actions/checkout@v6`" in joined_errors
 
 
 def test_should_require_publish_docs_python_setup_contract():
@@ -2961,7 +2989,7 @@ def test_should_require_publish_docs_python_setup_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
-    docs_section = docs_section.replace("actions/setup-python@v5", "actions/setup-python@v4", 1)
+    docs_section = docs_section.replace("actions/setup-python@v6", "actions/setup-python@v4", 1)
     docs_section = docs_section.replace("python-version: '3.11'", "python-version: '3.10'", 1)
     release_workflow = (
         docs_prefix + "  publish-docs:" + docs_section + "  release-success-gate:" + remainder
@@ -2970,7 +2998,7 @@ def test_should_require_publish_docs_python_setup_contract():
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "publish-docs `Set up Python` step must use `actions/setup-python@v5`" in joined_errors
+    assert "publish-docs `Set up Python` step must use `actions/setup-python@v6`" in joined_errors
     assert "publish-docs `Set up Python` step must include `python-version: 3.11`" in joined_errors
 
 
@@ -3121,17 +3149,17 @@ def test_should_require_release_success_gate_setup_contract():
     release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     gate_prefix, gate_rest = release_workflow.split("  release-success-gate:", 1)
     gate_section = gate_rest
-    gate_section = gate_section.replace("actions/checkout@v4", "actions/checkout@v3", 1)
-    gate_section = gate_section.replace("astral-sh/setup-uv@v5", "astral-sh/setup-uv@v4", 1)
+    gate_section = gate_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
+    gate_section = gate_section.replace("astral-sh/setup-uv@v8", "astral-sh/setup-uv@v4", 1)
     gate_section = gate_section.replace("uv python install 3.12", "python -V", 1)
     release_workflow = gate_prefix + "  release-success-gate:" + gate_section
     errors = module.validate_release_workflow_content(
         release_workflow=textwrap.dedent(release_workflow)
     )
     joined_errors = "\n".join(errors)
-    assert "release-success-gate job must include `actions/checkout@v4`" in joined_errors
+    assert "release-success-gate job must include `actions/checkout@v6`" in joined_errors
     assert (
-        "release-success-gate `Install uv` step must use `astral-sh/setup-uv@v5`" in joined_errors
+        "release-success-gate `Install uv` step must use `astral-sh/setup-uv@v8`" in joined_errors
     )
     assert (
         "release-success-gate `Setup Python` step must invoke `uv python install 3.12`"


### PR DESCRIPTION
## What changed
- harden the release pipeline with SBOM generation, provenance/signing hooks, and stricter validator-backed workflow contracts
- expand `tg doctor` into a real diagnostic surface, including config-aware AST cache staleness and runtime/worker visibility
- add enterprise-facing governance docs and runbooks for support matrix, contracts, hotfixes, cache, GPU, and resident worker operations

## Why
- move the project from feature-complete to operationally supportable
- prevent CI/release workflow drift from silently weakening the supply-chain posture
- make runtime health and troubleshooting explicit for production users

## Impact
- introduces a minor release surface because it adds new CLI diagnostics and enterprise documentation/contracts
- keeps the resident worker experimental and non-default
- preserves existing hot paths while strengthening release and observability discipline

## Validation
- `uv run ruff check .`
- `uv run mypy src/tensor_grep`
- `uv run pytest -q`
