### PR TITLE
ci: split benchmark gate into base-compare and baseline-drift reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         run: python -m pip install uv
@@ -448,42 +450,126 @@ jobs:
           uv venv --python 3.12
           uv pip install -e ".[bench,dev]"
 
+      - name: Determine benchmark base revision
+        if: github.event_name != 'schedule'
+        id: benchmark-base
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout base revision for same-runner benchmark comparison
+        if: github.event_name != 'schedule'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.benchmark-base.outputs.base_sha }}
+          path: base-revision
+          fetch-depth: 0
+
+      - name: Install base benchmark dependencies
+        if: github.event_name != 'schedule'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd base-revision
+          uv venv --python 3.12
+          uv pip install -e ".[bench,dev]"
+
       - name: Run core benchmark suite
         shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           mkdir -p artifacts
-          uv run python benchmarks/run_benchmarks.py | tee artifacts/bench_run_benchmarks.txt
+          uv run python benchmarks/run_benchmarks.py \
+            --output artifacts/bench_run_benchmarks.head.json \
+            | tee artifacts/bench_run_benchmarks.head.txt
+
+      - name: Run base benchmark suite
+        if: github.event_name != 'schedule'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p base-revision/artifacts
+          (
+            cd base-revision
+            uv run python benchmarks/run_benchmarks.py \
+              --output artifacts/bench_run_benchmarks.base.json
+          ) | tee base-revision/artifacts/bench_run_benchmarks.base.txt
 
       - name: Run hot-query benchmark suite
         shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           uv run python benchmarks/run_hot_query_benchmarks.py | tee artifacts/bench_hot_query_benchmarks.txt
 
       - name: Enforce benchmark regression gate
+        if: github.event_name != 'schedule'
         run: |
           uv run python benchmarks/check_regression.py \
-            --baseline auto \
-            --current artifacts/bench_run_benchmarks.json \
+            --baseline base-revision/artifacts/bench_run_benchmarks.base.json \
+            --current artifacts/bench_run_benchmarks.head.json \
             --max-regression-pct 20.0 \
             --min-baseline-time-s 0.2
 
-      - name: Build benchmark markdown summary
+      - name: Report accepted benchmark baseline drift
+        continue-on-error: true
+        shell: bash
         run: |
+          set -euo pipefail
+          uv run python benchmarks/check_regression.py \
+            --baseline auto \
+            --current artifacts/bench_run_benchmarks.head.json \
+            --max-regression-pct 20.0 \
+            --min-baseline-time-s 0.2 \
+            | tee artifacts/bench_run_benchmarks.accepted_drift.txt
+
+      - name: Build benchmark markdown summary
+        shell: bash
+        run: |
+          set -euo pipefail
           uv run python benchmarks/summarize_benchmarks.py \
             --baseline auto \
-            --current artifacts/bench_run_benchmarks.json \
+            --current artifacts/bench_run_benchmarks.head.json \
             --max-regression-pct 20.0 \
             --min-baseline-time-s 0.2 \
             --output artifacts/benchmark_summary.md
-          cat artifacts/benchmark_summary.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Same-runner benchmark gate"
+            echo ""
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              echo "Scheduled runs skip the base-vs-head blocking comparison."
+            else
+              echo "Blocking comparison uses:"
+              echo "- baseline: \`base-revision/artifacts/bench_run_benchmarks.base.json\`"
+              echo "- current: \`artifacts/bench_run_benchmarks.head.json\`"
+            fi
+            echo ""
+            echo "## Accepted baseline drift report"
+            echo ""
+            if [ -f artifacts/bench_run_benchmarks.accepted_drift.txt ]; then
+              cat artifacts/bench_run_benchmarks.accepted_drift.txt
+            else
+              echo "No accepted-baseline drift output was captured."
+            fi
+            echo ""
+            cat artifacts/benchmark_summary.md
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark artifacts
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-artifacts-ci
-          path: artifacts/
+          path: |
+            artifacts/
+            base-revision/artifacts/
 
   release:
     name: Semantic Release

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -17,7 +17,7 @@ Primary responsibilities:
 - `search-golden-parity`: Windows routing parity guard
 - `native-build-smoke`: native binary smoke tests across platforms
 - `package-manager-readiness`: Homebrew/Winget/package-manager bundle validation
-- `benchmark-regression`: benchmark gate for accepted performance lines
+- `benchmark-regression`: blocking same-runner base-vs-head regression gate plus accepted-baseline drift reporting
 - `Semantic Release`: semantic-release on `main`
 - PyPI build, validation, and publish jobs when semantic-release emits a new version
 
@@ -28,6 +28,13 @@ Release behavior:
 - `fix:` / `perf:` => patch
 - `feat!:` / `fix!:` => major
 - `docs:` / `test:` / `ci:` / `chore:` / `build:` => no package release
+
+Benchmark behavior:
+
+- Pull requests benchmark the candidate checkout and the PR base revision in the same runner job; the explicit base-vs-head comparison is the blocking regression gate.
+- Pushes to `main` benchmark the current checkout and `${{ github.event.before }}` in the same runner job; that explicit comparison is the blocking regression gate before semantic-release.
+- Scheduled runs keep accepted-baseline drift reporting and summary generation, but do not block on a synthetic base-vs-head comparison.
+- Accepted baseline JSONs remain the public benchmark truth surface, but drift against them is reported separately from the release-blocking same-runner comparison.
 
 ### `release.yml`
 

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -226,10 +226,13 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                         )
 
             benchmark_job = jobs.get("benchmark-regression")
-            if isinstance(benchmark_job, dict):
+            if not isinstance(benchmark_job, dict):
+                errors.append("CI workflow must define benchmark-regression job when release depends on it")
+            else:
                 benchmark_steps = benchmark_job.get("steps", [])
                 benchmark_run_by_name: dict[str, str] = {}
                 benchmark_step_names: set[str] = set()
+                benchmark_step_by_name: dict[str, dict[str, object]] = {}
                 if isinstance(benchmark_steps, list):
                     for step in benchmark_steps:
                         if not isinstance(step, dict):
@@ -237,6 +240,7 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                         name = step.get("name")
                         if isinstance(name, str):
                             benchmark_step_names.add(name)
+                            benchmark_step_by_name[name] = step
                         run = step.get("run")
                         if isinstance(name, str) and isinstance(run, str):
                             benchmark_run_by_name[name] = run
@@ -251,32 +255,186 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                         "CI workflow benchmark-regression `Install benchmark dependencies` step "
                         "must install `.[bench,dev]`"
                     )
-                required_benchmark_step_names = {"Run hot-query benchmark suite"}
+                required_benchmark_step_names = {
+                    "Run hot-query benchmark suite",
+                    "Determine benchmark base revision",
+                    "Checkout base revision for same-runner benchmark comparison",
+                    "Install base benchmark dependencies",
+                    "Run base benchmark suite",
+                    "Report accepted benchmark baseline drift",
+                }
                 for step_name in required_benchmark_step_names:
                     if step_name not in benchmark_step_names:
                         errors.append(
                             f"CI workflow benchmark-regression job must include step `{step_name}`"
                         )
-                required_benchmark_steps = {
-                    "Enforce benchmark regression gate": "benchmarks/check_regression.py",
-                    "Build benchmark markdown summary": "benchmarks/summarize_benchmarks.py",
-                }
-                for step_name, command in required_benchmark_steps.items():
-                    run_script = benchmark_run_by_name.get(step_name)
-                    if run_script is None:
-                        errors.append(
-                            f"CI workflow benchmark-regression job must include step `{step_name}`"
-                        )
-                        continue
-                    if command not in run_script:
-                        errors.append(
-                            "CI workflow benchmark-regression "
-                            f"`{step_name}` step must invoke `{command}`"
-                        )
-                    if "--baseline auto" not in run_script:
+                base_revision_run = benchmark_run_by_name.get("Determine benchmark base revision")
+                if base_revision_run is not None:
+                    for expected in ("github.event.pull_request.base.sha", "github.event.before"):
+                        if expected not in base_revision_run:
+                            errors.append(
+                                "CI workflow benchmark-regression "
+                                "`Determine benchmark base revision` step must inspect "
+                                f"`{expected}`"
+                            )
+
+                checkout_base_step = benchmark_step_by_name.get(
+                    "Checkout base revision for same-runner benchmark comparison"
+                )
+                if checkout_base_step is not None:
+                    if checkout_base_step.get("uses") != "actions/checkout@v6":
                         errors.append(
                             "CI workflow benchmark-regression "
-                            f"`{step_name}` step must pass `--baseline auto`"
+                            "`Checkout base revision for same-runner benchmark comparison` "
+                            "step must use `actions/checkout@v6`"
+                        )
+                    with_block = checkout_base_step.get("with", {})
+                    if not isinstance(with_block, dict):
+                        with_block = {}
+                    if str(with_block.get("path")) != "base-revision":
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Checkout base revision for same-runner benchmark comparison` "
+                            "step must set `path: base-revision`"
+                        )
+                    if str(with_block.get("ref")) != "${{ steps.benchmark-base.outputs.base_sha }}":
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Checkout base revision for same-runner benchmark comparison` "
+                            "step must checkout `${{ steps.benchmark-base.outputs.base_sha }}`"
+                        )
+
+                install_base_benchmark_run = benchmark_run_by_name.get(
+                    "Install base benchmark dependencies"
+                )
+                if install_base_benchmark_run is not None:
+                    if '".[bench,dev]"' not in install_base_benchmark_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Install base benchmark dependencies` step must install `.[bench,dev]`"
+                        )
+                    if "base-revision" not in install_base_benchmark_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Install base benchmark dependencies` step must operate inside `base-revision`"
+                        )
+
+                run_core_benchmark = benchmark_run_by_name.get("Run core benchmark suite")
+                if run_core_benchmark is not None:
+                    if "benchmarks/run_benchmarks.py" not in run_core_benchmark:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Run core benchmark suite` step must invoke `benchmarks/run_benchmarks.py`"
+                        )
+                    if "--output artifacts/bench_run_benchmarks.head.json" not in run_core_benchmark:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Run core benchmark suite` step must emit `artifacts/bench_run_benchmarks.head.json`"
+                        )
+
+                run_base_benchmark = benchmark_run_by_name.get("Run base benchmark suite")
+                if run_base_benchmark is not None:
+                    if "benchmarks/run_benchmarks.py" not in run_base_benchmark:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Run base benchmark suite` step must invoke `benchmarks/run_benchmarks.py`"
+                        )
+                    if "--output artifacts/bench_run_benchmarks.base.json" not in run_base_benchmark:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Run base benchmark suite` step must emit `artifacts/bench_run_benchmarks.base.json`"
+                        )
+
+                enforce_benchmark_gate_run = benchmark_run_by_name.get(
+                    "Enforce benchmark regression gate"
+                )
+                if enforce_benchmark_gate_run is None:
+                    errors.append(
+                        "CI workflow benchmark-regression job must include step "
+                        "`Enforce benchmark regression gate`"
+                    )
+                else:
+                    if "benchmarks/check_regression.py" not in enforce_benchmark_gate_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Enforce benchmark regression gate` step must invoke "
+                            "`benchmarks/check_regression.py`"
+                        )
+                    if (
+                        "--baseline base-revision/artifacts/bench_run_benchmarks.base.json"
+                        not in enforce_benchmark_gate_run
+                    ):
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Enforce benchmark regression gate` step must compare against "
+                            "`base-revision/artifacts/bench_run_benchmarks.base.json`"
+                        )
+                    if "--current artifacts/bench_run_benchmarks.head.json" not in enforce_benchmark_gate_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Enforce benchmark regression gate` step must compare current artifact "
+                            "`artifacts/bench_run_benchmarks.head.json`"
+                        )
+                    if "--baseline auto" in enforce_benchmark_gate_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Enforce benchmark regression gate` step must not use `--baseline auto`"
+                        )
+
+                drift_report_run = benchmark_run_by_name.get(
+                    "Report accepted benchmark baseline drift"
+                )
+                drift_report_step = benchmark_step_by_name.get(
+                    "Report accepted benchmark baseline drift"
+                )
+                if drift_report_run is not None:
+                    if "benchmarks/check_regression.py" not in drift_report_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Report accepted benchmark baseline drift` step must invoke "
+                            "`benchmarks/check_regression.py`"
+                        )
+                    if "--baseline auto" not in drift_report_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Report accepted benchmark baseline drift` step must pass `--baseline auto`"
+                        )
+                    if "--current artifacts/bench_run_benchmarks.head.json" not in drift_report_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Report accepted benchmark baseline drift` step must compare current artifact "
+                            "`artifacts/bench_run_benchmarks.head.json`"
+                        )
+                if isinstance(drift_report_step, dict):
+                    if drift_report_step.get("continue-on-error") is not True:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Report accepted benchmark baseline drift` step must set `continue-on-error: true`"
+                        )
+
+                summary_run = benchmark_run_by_name.get("Build benchmark markdown summary")
+                if summary_run is None:
+                    errors.append(
+                        "CI workflow benchmark-regression job must include step "
+                        "`Build benchmark markdown summary`"
+                    )
+                else:
+                    if "benchmarks/summarize_benchmarks.py" not in summary_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Build benchmark markdown summary` step must invoke "
+                            "`benchmarks/summarize_benchmarks.py`"
+                        )
+                    if "--baseline auto" not in summary_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Build benchmark markdown summary` step must pass `--baseline auto`"
+                        )
+                    if "--current artifacts/bench_run_benchmarks.head.json" not in summary_run:
+                        errors.append(
+                            "CI workflow benchmark-regression "
+                            "`Build benchmark markdown summary` step must summarize "
+                            "`artifacts/bench_run_benchmarks.head.json`"
                         )
 
             publish_pypi_job = jobs.get("publish-pypi")
@@ -460,37 +618,6 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
     if "uv run ruff format --check --preview ." not in ci_workflow:
         errors.append(
             "CI workflow must run formatter with `ruff format --check --preview .` to keep local/CI formatting semantics aligned"
-        )
-
-    def _command_invocations_have_flag(command: str, required: str) -> bool:
-        command_indexes = [m.start() for m in re.finditer(re.escape(command), ci_workflow)]
-        if not command_indexes:
-            return False
-
-        for idx in command_indexes:
-            # Restrict inspection to the current YAML step block; do not confuse
-            # command flags like `--baseline` with a new `- <step>` entry.
-            next_step_match = re.search(
-                r"\n\s{6,}-\s+(?:name|run|uses|if|with|env|id|working-directory|shell)\s*:",
-                ci_workflow[idx + len(command) :],
-            )
-            if next_step_match:
-                next_step_idx = idx + len(command) + next_step_match.start()
-            else:
-                next_step_idx = len(ci_workflow)
-            block = ci_workflow[idx:next_step_idx]
-            if required not in block:
-                return False
-        return True
-
-    if not _command_invocations_have_flag("benchmarks/check_regression.py", "--baseline auto"):
-        errors.append(
-            "CI workflow benchmark regression gate must pass `--baseline auto` to check_regression.py"
-        )
-
-    if not _command_invocations_have_flag("benchmarks/summarize_benchmarks.py", "--baseline auto"):
-        errors.append(
-            "CI workflow benchmark summary generation must pass `--baseline auto` to summarize_benchmarks.py"
         )
 
     action_versions = {

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -3350,6 +3350,50 @@ def test_check_regression_should_resolve_auto_baseline_for_windows_platform(monk
     assert exit_code == 0
 
 
+def test_check_regression_should_allow_same_environment_explicit_baseline_for_candidate_gate(
+    monkeypatch, tmp_path
+):
+    module = _load_script_module(
+        "check_regression_script_same_env_candidate", "benchmarks/check_regression.py"
+    )
+    baseline_path = tmp_path / "base.json"
+    current_path = tmp_path / "head.json"
+    payload = {
+        "suite": "run_benchmarks",
+        "environment": {
+            "platform": "windows",
+            "machine": "amd64",
+            "python_version": "3.12.12",
+        },
+        "rows": [{"name": "x", "tg_time_s": 1.00, "rg_time_s": 0.80}],
+    }
+    baseline_path.write_text(json.dumps(payload), encoding="utf-8")
+    current_path.write_text(
+        json.dumps(
+            {
+                **payload,
+                "rows": [{"name": "x", "tg_time_s": 1.03, "rg_time_s": 0.81}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_regression.py",
+            "--baseline",
+            str(baseline_path),
+            "--current",
+            str(current_path),
+            "--max-regression-pct",
+            "5",
+        ],
+    )
+
+    assert module.main() == 0
+
+
 def test_check_regression_should_resolve_auto_milestone_baseline(monkeypatch, tmp_path):
     module = _load_script_module(
         "check_regression_script_auto_milestone", "benchmarks/check_regression.py"

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -497,7 +497,7 @@ def test_should_require_release_intent_job_to_be_pull_request_only():
     assert any("release-intent job must run only for pull_request events" in err for err in errors)
 
 
-def test_should_require_ci_benchmark_jobs_to_use_auto_baseline_resolution():
+def test_should_require_ci_benchmark_jobs_to_split_base_compare_and_drift_reporting():
     root = Path(__file__).resolve().parents[2]
     script_path = root / "scripts" / "validate_release_assets.py"
     spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
@@ -510,46 +510,113 @@ def test_should_require_ci_benchmark_jobs_to_use_auto_baseline_resolution():
     jobs:
       benchmark-regression:
         steps:
+          - name: Install benchmark dependencies
+            run: |
+              uv venv --python 3.12
+              uv pip install -e ".[bench,dev]"
+          - name: Run core benchmark suite
+            run: uv run python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.head.json
+          - name: Run hot-query benchmark suite
+            run: uv run python benchmarks/run_hot_query_benchmarks.py
           - run: |
               uv run python benchmarks/check_regression.py \
-                --baseline benchmarks/baselines/run_benchmarks.ubuntu.json \
-                --current artifacts/bench_run_benchmarks.json
-          - run: |
-              uv run python benchmarks/summarize_benchmarks.py \
-                --baseline benchmarks/baselines/run_benchmarks.ubuntu.json \
-                --current artifacts/bench_run_benchmarks.json \
-                --output artifacts/benchmark_summary.md
-    """
-    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
-    assert any("check_regression.py" in err and "--baseline auto" in err for err in errors)
-    assert any("summarize_benchmarks.py" in err and "--baseline auto" in err for err in errors)
-
-
-def test_should_require_auto_baseline_per_benchmark_command_invocation():
-    root = Path(__file__).resolve().parents[2]
-    script_path = root / "scripts" / "validate_release_assets.py"
-    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
-    assert spec is not None and spec.loader is not None
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    ci_workflow = """
-    jobs:
-      benchmark-regression:
-        steps:
-          - run: |
-              uv run python benchmarks/check_regression.py \
-                --current artifacts/bench_run_benchmarks.json
+                --baseline base-revision/artifacts/bench_run_benchmarks.base.json \
+                --current artifacts/bench_run_benchmarks.head.json
           - run: |
               uv run python benchmarks/summarize_benchmarks.py \
                 --baseline auto \
-                --current artifacts/bench_run_benchmarks.json \
+                --current artifacts/bench_run_benchmarks.head.json \
                 --output artifacts/benchmark_summary.md
     """
     errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
-    assert any("check_regression.py" in err and "--baseline auto" in err for err in errors)
-    assert not any("summarize_benchmarks.py" in err and "--baseline auto" in err for err in errors)
+    assert any(
+        "benchmark-regression job must include step `Determine benchmark base revision`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Checkout base revision for same-runner benchmark comparison`"
+        in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Install base benchmark dependencies`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Run base benchmark suite`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Report accepted benchmark baseline drift`"
+        in err
+        for err in errors
+    )
+
+
+def test_should_require_explicit_base_artifact_for_blocking_benchmark_gate():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      benchmark-regression:
+        steps:
+          - name: Install benchmark dependencies
+            run: |
+              uv venv --python 3.12
+              uv pip install -e ".[bench,dev]"
+          - name: Determine benchmark base revision
+            run: echo "base_sha=deadbeef" >> "$GITHUB_OUTPUT"
+          - name: Checkout base revision for same-runner benchmark comparison
+            uses: actions/checkout@v6
+            with:
+              ref: deadbeef
+              path: base-revision
+          - name: Install base benchmark dependencies
+            run: |
+              cd base-revision
+              uv venv --python 3.12
+              uv pip install -e ".[bench,dev]"
+          - name: Run core benchmark suite
+            run: uv run python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.head.json
+          - name: Run base benchmark suite
+            run: |
+              cd base-revision
+              uv run python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.base.json
+          - name: Run hot-query benchmark suite
+            run: uv run python benchmarks/run_hot_query_benchmarks.py
+          - name: Enforce benchmark regression gate
+            run: |
+              uv run python benchmarks/check_regression.py \
+                --baseline auto \
+                --current artifacts/bench_run_benchmarks.head.json
+          - name: Report accepted benchmark baseline drift
+            run: |
+              uv run python benchmarks/check_regression.py \
+                --current artifacts/bench_run_benchmarks.json
+          - name: Build benchmark markdown summary
+            run: |
+              uv run python benchmarks/summarize_benchmarks.py \
+                --baseline auto \
+                --current artifacts/bench_run_benchmarks.head.json \
+                --output artifacts/benchmark_summary.md
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert any(
+        "benchmark-regression `Enforce benchmark regression gate` step must compare against "
+        "`base-revision/artifacts/bench_run_benchmarks.base.json`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression `Report accepted benchmark baseline drift` step must pass `--baseline auto`"
+        in err
+        for err in errors
+    )
 
 
 def test_should_require_structural_gpu_ci_steps_for_retry_and_gpu_pytest():
@@ -580,7 +647,7 @@ def test_should_require_structural_gpu_ci_steps_for_retry_and_gpu_pytest():
     )
 
 
-def test_should_require_structural_benchmark_regression_steps_with_auto_baseline():
+def test_should_require_structural_benchmark_regression_steps_for_base_compare_and_drift_reporting():
     root = Path(__file__).resolve().parents[2]
     script_path = root / "scripts" / "validate_release_assets.py"
     spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
@@ -596,19 +663,31 @@ def test_should_require_structural_benchmark_regression_steps_with_auto_baseline
         steps:
           - name: Enforce benchmark regression gate
             run: |
-              uv run python benchmarks/check_regression.py --current artifacts/bench_run_benchmarks.json
+              uv run python benchmarks/check_regression.py --current artifacts/bench_run_benchmarks.head.json
           - name: Build benchmark markdown summary
             run: |
-              uv run python benchmarks/summarize_benchmarks.py --current artifacts/bench_run_benchmarks.json
+              uv run python benchmarks/summarize_benchmarks.py --baseline auto --current artifacts/bench_run_benchmarks.head.json
     """
     errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
     assert any(
-        "benchmark-regression `Enforce benchmark regression gate` step must pass `--baseline auto`"
+        "benchmark-regression job must include step `Determine benchmark base revision`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Checkout base revision for same-runner benchmark comparison`"
         in err
         for err in errors
     )
     assert any(
-        "benchmark-regression `Build benchmark markdown summary` step must pass `--baseline auto`"
+        "benchmark-regression job must include step `Install base benchmark dependencies`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Run base benchmark suite`" in err
+        for err in errors
+    )
+    assert any(
+        "benchmark-regression job must include step `Report accepted benchmark baseline drift`"
         in err
         for err in errors
     )
@@ -675,6 +754,27 @@ def test_should_require_benchmark_regression_to_install_bench_and_dev_extras():
     errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
     assert any(
         "Install benchmark dependencies` step must install `.[bench,dev]`" in err for err in errors
+    )
+
+
+def test_should_require_benchmark_regression_job_to_exist_when_release_depends_on_it():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      release:
+        needs: [benchmark-regression]
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert any(
+        "CI workflow must define benchmark-regression job when release depends on it" in err
+        for err in errors
     )
 
 


### PR DESCRIPTION
## Summary
- split benchmark validation into a blocking same-runner base-vs-head comparison and a non-blocking accepted-baseline drift report
- update the release asset validator and CI contract docs to match the new benchmark governance model
- add validator-backed regression coverage for the revised workflow behavior

## Why
The accepted baseline was drifting on `origin/main`, which made release branches fail the benchmark gate even when they did not regress relative to the branch base. This change keeps branch regression detection strict while reporting baseline drift separately.

## Validation
- `uv run ruff check .`
- `uv run mypy src/tensor_grep`
- `uv run python scripts/validate_release_assets.py`
- `uv run pytest -q`
