### PR TITLE
ci: fix preview formatter drift in benchmark validator follow-up

### DIFF
--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -227,7 +227,9 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
 
             benchmark_job = jobs.get("benchmark-regression")
             if not isinstance(benchmark_job, dict):
-                errors.append("CI workflow must define benchmark-regression job when release depends on it")
+                errors.append(
+                    "CI workflow must define benchmark-regression job when release depends on it"
+                )
             else:
                 benchmark_steps = benchmark_job.get("steps", [])
                 benchmark_run_by_name: dict[str, str] = {}
@@ -326,7 +328,10 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                             "CI workflow benchmark-regression "
                             "`Run core benchmark suite` step must invoke `benchmarks/run_benchmarks.py`"
                         )
-                    if "--output artifacts/bench_run_benchmarks.head.json" not in run_core_benchmark:
+                    if (
+                        "--output artifacts/bench_run_benchmarks.head.json"
+                        not in run_core_benchmark
+                    ):
                         errors.append(
                             "CI workflow benchmark-regression "
                             "`Run core benchmark suite` step must emit `artifacts/bench_run_benchmarks.head.json`"
@@ -339,7 +344,10 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                             "CI workflow benchmark-regression "
                             "`Run base benchmark suite` step must invoke `benchmarks/run_benchmarks.py`"
                         )
-                    if "--output artifacts/bench_run_benchmarks.base.json" not in run_base_benchmark:
+                    if (
+                        "--output artifacts/bench_run_benchmarks.base.json"
+                        not in run_base_benchmark
+                    ):
                         errors.append(
                             "CI workflow benchmark-regression "
                             "`Run base benchmark suite` step must emit `artifacts/bench_run_benchmarks.base.json`"
@@ -369,7 +377,10 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                             "`Enforce benchmark regression gate` step must compare against "
                             "`base-revision/artifacts/bench_run_benchmarks.base.json`"
                         )
-                    if "--current artifacts/bench_run_benchmarks.head.json" not in enforce_benchmark_gate_run:
+                    if (
+                        "--current artifacts/bench_run_benchmarks.head.json"
+                        not in enforce_benchmark_gate_run
+                    ):
                         errors.append(
                             "CI workflow benchmark-regression "
                             "`Enforce benchmark regression gate` step must compare current artifact "

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -3369,12 +3369,10 @@ def test_check_regression_should_allow_same_environment_explicit_baseline_for_ca
     }
     baseline_path.write_text(json.dumps(payload), encoding="utf-8")
     current_path.write_text(
-        json.dumps(
-            {
-                **payload,
-                "rows": [{"name": "x", "tg_time_s": 1.03, "rg_time_s": 0.81}],
-            }
-        ),
+        json.dumps({
+            **payload,
+            "rows": [{"name": "x", "tg_time_s": 1.03, "rg_time_s": 0.81}],
+        }),
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- apply the `ruff format --preview` canonical rewrite to the two files introduced by the benchmark-governance CI change
- restore `main` to a green `Formatting & Linting` state without changing behavior

## Why
PR #15 merged before the full Actions matrix completed, and the remote `Python Ruff Formatter` step later failed on these two files even though `ruff check` passed locally.

## Validation
- `uvx ruff format --check --preview scripts/validate_release_assets.py tests/unit/test_benchmark_scripts.py`
- `uv run ruff check .`
- `uv run python scripts/validate_release_assets.py`
- `uv run mypy src/tensor_grep`
- `uv run pytest tests/unit/test_benchmark_scripts.py -q`
- `uv run pytest -q`
