### PR TITLE
fix: honor ignore rules in files-without-match candidate collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ Force all matches to be surrounded by word boundaries with `-w`:
 $ tg -w foobar
 ```
 
+List files that do not contain a match while still honoring ignore rules by default:
+
+```bash
+$ tg search foobar . --files-without-match
+```
+
+Add `--no-ignore` when you want ignored files and directories included in the candidate set for this mode.
+
 Search only Python and Javascript files:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "typer>=0.12",
     "rich>=13.0",
     "mcp>=1.2.0",
+    "pathspec>=1.0.4",
     "pyyaml>=6.0",
     "pyarrow>=14.0.0",
     "opentelemetry-api>=1.27.0",

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -3,8 +3,12 @@ import os
 import sys
 from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from tensor_grep.core.config import SearchConfig
+
+if TYPE_CHECKING:
+    import pathspec
 
 # Attempt to load the blazing fast Rust PyO3 gitignore scanner
 try:
@@ -22,6 +26,19 @@ except (ImportError, ModuleNotFoundError):
 class DirectoryScanner:
     def __init__(self, config: SearchConfig | None = None):
         self.config = config or SearchConfig()
+
+    def _load_ignore_spec(self, base_path: Path) -> "pathspec.PathSpec | None":
+        if self.config.no_ignore or self.config.no_ignore_vcs or self.config.no_ignore_files:
+            return None
+
+        gitignore = base_path / ".gitignore"
+        if not gitignore.exists():
+            return None
+
+        import pathspec
+
+        patterns = gitignore.read_text(encoding="utf-8").splitlines()
+        return pathspec.GitIgnoreSpec.from_lines(patterns)
 
     def walk(self, path_str: str) -> Iterator[str]:
         base_path = Path(path_str)
@@ -54,6 +71,10 @@ class DirectoryScanner:
         # Python Fallback Path
         max_depth = self.config.max_depth
         base_depth = len(base_path.parts)
+        ignore_spec = self._load_ignore_spec(base_path)
+
+        def _relative_posix(path: Path) -> str:
+            return path.relative_to(base_path).as_posix()
 
         for root, dirs, files in os.walk(base_path):
             current_depth = len(Path(root).parts) - base_depth
@@ -66,12 +87,21 @@ class DirectoryScanner:
             if not self.config.hidden:
                 dirs[:] = [d for d in dirs if not d.startswith(".")]
 
+            if ignore_spec is not None:
+                dirs[:] = [
+                    directory
+                    for directory in dirs
+                    if not ignore_spec.match_file(f"{_relative_posix(Path(root) / directory)}/")
+                ]
+
             for file_name in files:
                 # Filter hidden files
                 if not self.config.hidden and file_name.startswith("."):
                     continue
 
                 file_path = Path(root) / file_name
+                if ignore_spec is not None and ignore_spec.match_file(_relative_posix(file_path)):
+                    continue
                 if self._should_include_file(file_path):
                     yield str(file_path)
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1759,8 +1759,41 @@ def test_files_without_match_respects_scanned_candidates_for_hidden_relative_roo
             check=False,
         )
 
-        assert result.returncode == 0
-        assert result.stdout.strip() == str(Path(hidden_root.name) / "empty.txt")
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(Path(hidden_root.name) / "empty.txt")
+
+
+def test_files_without_match_skips_gitignored_directories(tmp_path: Path):
+    (tmp_path / ".gitignore").write_text("build/\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "build").mkdir()
+
+    kept = tmp_path / "src" / "empty.txt"
+    ignored = tmp_path / "build" / "ignored.txt"
+    matched = tmp_path / "src" / "matched.txt"
+
+    kept.write_text("other\n", encoding="utf-8")
+    ignored.write_text("other\n", encoding="utf-8")
+    matched.write_text("NEEDLE\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.main",
+            "search",
+            "NEEDLE",
+            str(tmp_path),
+            "--files-without-match",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert str(kept) in result.stdout
+    assert str(ignored) not in result.stdout
 
 
 def test_files_with_matches_null_outputs_nul_separator(tmp_path: Path):

--- a/tests/unit/test_directory_scanner.py
+++ b/tests/unit/test_directory_scanner.py
@@ -3,6 +3,43 @@ from tensor_grep.io.directory_scanner import DirectoryScanner
 
 
 class TestDirectoryScanner:
+    def test_should_skip_gitignored_directories_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tensor_grep.io.directory_scanner.HAS_RUST_SCANNER", False)
+
+        (tmp_path / ".gitignore").write_text("build/\nnode_modules/\n", encoding="utf-8")
+        src_dir = tmp_path / "src"
+        build_dir = tmp_path / "build"
+        node_dir = tmp_path / "node_modules"
+        src_dir.mkdir()
+        build_dir.mkdir()
+        node_dir.mkdir()
+
+        kept = src_dir / "keep.py"
+        ignored_build = build_dir / "ignored.py"
+        ignored_node = node_dir / "ignored.js"
+        kept.write_text("ok", encoding="utf-8")
+        ignored_build.write_text("ignore", encoding="utf-8")
+        ignored_node.write_text("ignore", encoding="utf-8")
+
+        files = list(DirectoryScanner(SearchConfig()).walk(str(tmp_path)))
+
+        assert files == [str(kept)]
+
+    def test_should_include_gitignored_directories_when_no_ignore_is_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("tensor_grep.io.directory_scanner.HAS_RUST_SCANNER", False)
+
+        (tmp_path / ".gitignore").write_text("build/\n", encoding="utf-8")
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        ignored_file = build_dir / "ignored.py"
+        ignored_file.write_text("ignore", encoding="utf-8")
+
+        files = list(DirectoryScanner(SearchConfig(no_ignore=True)).walk(str(tmp_path)))
+
+        assert str(ignored_file) in files
+
     def test_should_filterGlob_when_dashG_provided(self, tmp_path):
         import os
 

--- a/uv.lock
+++ b/uv.lock
@@ -3659,7 +3659,7 @@ wheels = [
 
 [[package]]
 name = "tensor-grep"
-version = "1.2.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "importlib-metadata", version = "8.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -3667,6 +3667,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+    { name = "pathspec" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -3742,6 +3743,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
+    { name = "pathspec", specifier = ">=1.0.4" },
     { name = "psutil", marker = "extra == 'dev'" },
     { name = "pyarrow", specifier = ">=14.0.0" },
     { name = "pygls", marker = "extra == 'ast'", specifier = ">=1.3.0" },


### PR DESCRIPTION
## Summary
- make the Python fallback directory scanner honor root `.gitignore` rules during candidate-file collection for `--files-without-match`
- keep `--no-ignore` behavior intact while pruning ignored directories and files before the existing include filters run
- add scanner and CLI regression coverage, declare the `pathspec` runtime dependency, and document the default ignore-aware behavior in the README

## Why
`--files-without-match` still used the Python candidate walker in production fallback paths, and that walker could include files that should have been ignored by default. This closes the remaining confirmed parity gap for the v1.3.2 safe release.

## Validation
- `uv run ruff check .`
- `uv run mypy src/tensor_grep`
- `uv run python scripts/validate_release_assets.py`
- `uv run pytest tests/unit/test_directory_scanner.py -q`
- `uv run pytest tests/unit/test_cli_modes.py -k "gitignored_directories or files_without_match or null_outputs_nul_separator" -q`
- `uv run pytest -q`
- `uv run python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.base.v132.json` on the repaired base tree
- `uv run python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.head.v132.json`
- `uv run python benchmarks/check_regression.py --baseline C:/wt/tgci132fmt/artifacts/bench_run_benchmarks.base.v132.json --current artifacts/bench_run_benchmarks.head.v132.json --max-regression-pct 20.0 --min-baseline-time-s 0.2`

## Benchmark note
The same-runner base-vs-head comparison reported `No benchmark regressions detected.` The accepted checked-in `--baseline auto` comparison still reports historical baseline drift, which is expected under the repaired benchmark-governance model and is no longer treated as a branch-only regression signal.
