### PR TITLE
docs: mention lexical repo-map retrieval in tg help

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -52,6 +52,7 @@ persisted repeated-query acceleration, and optional GPU routing.
 - Bare patterns are treated as `tg search`.
 - Use `tg search --help` for ripgrep-compatible flags.
 - `tg run --help` for AST rewrite flags.
+- Lexical repo-map retrieval bridges camelCase, snake_case, and source-term planning queries.
 - Use `tg doctor --json` for system, GPU, cache, and daemon diagnostics.
 - Use `tg session --help` for cached edit-loop and daemon commands.""",
     no_args_is_help=True,

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -4212,6 +4212,11 @@ def test_app_help_should_list_upgrade_update_checkpoint_and_symbol_commands():
     assert "tg blast-radius-render PATH --symbol" in result.stdout
     assert "tg session open PATH" in result.stdout
     assert "tg session daemon start PATH" in result.stdout
+    normalized_help = re.sub(r"\s+", " ", result.stdout)
+    assert (
+        "Lexical repo-map retrieval bridges camelCase, snake_case, and source-term planning queries."
+        in normalized_help
+    )
     assert "tg doctor --with-lsp" in result.stdout
     assert "upgrade" in result.stdout
     assert "doctor" in result.stdout


### PR DESCRIPTION
## Summary
- mention the lexical repo-map retrieval behavior in top-level \	g --help\
- lock the help output with a CLI contract assertion

## Verification
- uv run ruff check .
- uv run mypy src/tensor_grep
- uv run pytest -q
- uv run tg --help