### PR TITLE
test: strip ANSI styling from tg help assertion

### DIFF
--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -4212,7 +4212,7 @@ def test_app_help_should_list_upgrade_update_checkpoint_and_symbol_commands():
     assert "tg blast-radius-render PATH --symbol" in result.stdout
     assert "tg session open PATH" in result.stdout
     assert "tg session daemon start PATH" in result.stdout
-    normalized_help = re.sub(r"\s+", " ", result.stdout)
+    normalized_help = re.sub(r"\s+", " ", _strip_ansi(result.stdout))
     assert (
         "Lexical repo-map retrieval bridges camelCase, snake_case, and source-term planning queries."
         in normalized_help


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences before matching the new top-level help note
- keep the cross-platform help assertion stable across styled and plain CLI output

## Verification
- uv run ruff check .
- uvx ruff@0.15.11 format --check --preview C:/wt/tghelp-lexical/tests/unit/test_cli_modes.py
- uv run mypy src/tensor_grep
- uv run pytest tests/unit/test_cli_modes.py -q -k app_help_should_list_upgrade_update_checkpoint_and_symbol_commands
- uv run pytest -q