### PR TITLE
fix: harden search against binary reads and invalid input paths

### DIFF
--- a/docs/superpowers/plans/2026-04-19-search-cli-bug-bundle-plan.md
+++ b/docs/superpowers/plans/2026-04-19-search-cli-bug-bundle-plan.md
@@ -1,0 +1,115 @@
+# Search CLI Bug Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the reproducible `tg search` correctness bugs around binary fixed-string reads, empty patterns, and missing paths, while adding a non-hanging structured-output regression contract.
+
+**Architecture:** Keep the change set small. Add one shared text-loading helper in `StringZillaBackend`, add early argument/path validation in `search_command()`, and cover each behavior with focused tests before changing production code.
+
+**Tech Stack:** Typer CLI, Python backends, pytest, subprocess-based CLI regression tests.
+
+---
+
+### Task 1: Add the failing backend safety tests
+
+**Files:**
+- Modify: `tests/unit/test_stringzilla_backend.py`
+- Modify: `src/tensor_grep/backends/stringzilla_backend.py`
+
+- [ ] **Step 1: Write the failing binary-safety tests**
+
+Add tests covering:
+- a fixed-string search over a binary/invalid-UTF8 file returns an empty result instead of raising
+- `--text` / binary-opt-in behavior still allows the backend to search replacement-decoded content
+
+- [ ] **Step 2: Run the focused test file to verify the new test fails**
+
+Run: `uv run pytest tests/unit/test_stringzilla_backend.py -q`
+
+- [ ] **Step 3: Implement the minimal shared text-loading helper**
+
+Use one helper in `StringZillaBackend` for both `_search_with_index()` and `search()` so strict UTF-8 decode failures and obvious binary files return an empty `SearchResult` unless binary/text mode is explicitly enabled.
+
+- [ ] **Step 4: Re-run the focused backend tests**
+
+Run: `uv run pytest tests/unit/test_stringzilla_backend.py -q`
+
+- [ ] **Step 5: Keep the helper scoped**
+
+Do not redesign encoding support beyond the documented skip-or-replace behavior.
+
+### Task 2: Add the failing CLI argument-validation tests
+
+**Files:**
+- Modify: `tests/unit/test_cli_modes.py`
+- Modify: `src/tensor_grep/cli/main.py`
+
+- [ ] **Step 1: Write the failing empty-pattern and missing-path tests**
+
+Add tests covering:
+- `tg search "" file.py` exits `2` and prints a usage-style error
+- `tg search foo missing-path` exits `2` and prints a clear missing-path error
+
+- [ ] **Step 2: Run only the new CLI tests to verify they fail**
+
+Run the specific pytest node ids for the new tests.
+
+- [ ] **Step 3: Add early validation in `search_command()`**
+
+Validate:
+- empty `pattern`
+- nonexistent `paths_to_search`
+
+Return clear errors before scanner/pipeline setup.
+
+- [ ] **Step 4: Re-run the focused CLI tests**
+
+Run the same node ids and verify green.
+
+### Task 3: Add the structured-output non-hang regression contract
+
+**Files:**
+- Modify: `tests/e2e/test_routing_parity.py` or `tests/unit/test_cli_modes.py`
+
+- [ ] **Step 1: Add a subprocess contract test for `--json`**
+
+The test should run `tg search ... --json` with a short timeout and assert:
+- the process exits before timeout
+- `stdout` is non-empty structured output
+
+- [ ] **Step 2: Run that focused test**
+
+Run only the new node id and verify it passes on current behavior.
+
+- [ ] **Step 3: Avoid speculative production changes**
+
+If the regression contract passes, do not edit serializer/flush code in this task bundle.
+
+### Task 4: Full validation and benchmarks
+
+**Files:**
+- No new code expected unless validation exposes a real issue
+
+- [ ] **Step 1: Run lint**
+
+Run: `uv run ruff check .`
+
+- [ ] **Step 2: Run typing**
+
+Run: `uv run mypy src/tensor_grep`
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `uv run pytest -q`
+
+- [ ] **Step 4: Run the CLI benchmark**
+
+Run: `python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.search_cli_bug_bundle.json`
+
+- [ ] **Step 5: Check benchmark regression**
+
+Run: `python benchmarks/check_regression.py --baseline auto --current artifacts/bench_run_benchmarks.search_cli_bug_bundle.json`
+
+- [ ] **Step 6: Update docs only if user-facing behavior changed materially**
+
+If the CLI error behavior warrants it, update the relevant docs/help text. Do not add performance claims.

--- a/docs/superpowers/specs/2026-04-19-search-cli-bug-bundle-design.md
+++ b/docs/superpowers/specs/2026-04-19-search-cli-bug-bundle-design.md
@@ -1,0 +1,93 @@
+# Search CLI Bug Bundle Design
+
+## Goal
+
+Fix the currently reproducible `tg search` correctness bugs in the Python search path without widening scope beyond search safety and CLI contract parity.
+
+## Scope
+
+This design covers four reported upstream symptoms:
+
+1. `B1`: fixed-string directory search can crash when the `StringZillaBackend` reads invalid UTF-8 or binary content.
+2. `B2`: structured output (`--json` / `--ndjson`) reportedly hangs.
+3. `B3`: empty search patterns are accepted and behave like match-everything instead of being rejected as invalid input.
+4. `B4`: nonexistent paths fall through as a silent search miss instead of a clear path error.
+
+## Current Read
+
+Local reproduction on `origin/main` shows:
+
+- `B1` is real at the backend level. `StringZillaBackend.search()` and `_search_with_index()` open files with strict UTF-8 decoding and can raise `UnicodeDecodeError`.
+- `B3` is real. `search_command()` accepts `""` as the positional pattern and proceeds with a match-everything search.
+- `B4` is real in effect, but the exact symptom has drifted. Current behavior is a silent nonzero exit (`1`), not the reported silent `0`. It is still missing a useful path error and ripgrep-like usage distinction.
+- `B2` does not reproduce on this branch. `tg search ... --json` returns immediately with structured output, and `tg search ... --ndjson` fails quickly with the existing native-binary requirement message. No code change should be made for `B2` without a failing reproduction.
+
+## Design Decisions
+
+### 1. Fixed-string binary handling should fail soft, not crash
+
+`StringZillaBackend` will gain a small shared text-loading helper used by both the direct search path and the index-building path.
+
+Behavior:
+
+- If the file contains obvious binary data (NUL bytes) and neither `--text` nor `--binary` is active, skip it and return an empty `SearchResult`.
+- If strict UTF-8 decoding fails and neither `--text` nor `--binary` is active, skip it and return an empty `SearchResult`.
+- If `--text` or `--binary` is active, decode with replacement so the search can proceed without crashing.
+
+This keeps the default behavior aligned with ripgrep’s “do not crash on binary” posture while preserving an explicit opt-in to search binary-like content.
+
+### 2. Empty patterns are invalid input
+
+`search_command()` will reject an empty positional pattern before pipeline setup and scanning.
+
+Behavior:
+
+- Print a concise error to `stderr`.
+- Exit with code `2` to mark an invocation/usage error.
+
+This prevents the current accidental match-everything behavior and makes the failure scriptable.
+
+### 3. Missing paths should be reported before scanning
+
+`search_command()` will validate every input path after argument parsing and before candidate collection.
+
+Behavior:
+
+- If any path does not exist, print a path-specific error to `stderr`.
+- Exit with code `2`.
+
+This keeps the difference between “no matches found” and “invalid invocation/input path” explicit.
+
+### 4. Structured output gets a regression contract, not a speculative fix
+
+Because `B2` does not currently reproduce, the safe action is a focused regression test that exercises `tg search --json` in a subprocess with a timeout and proves the command returns data promptly.
+
+No serializer or flush changes should be made unless that test fails first.
+
+## Non-Goals
+
+- No native `tg` CLI protocol changes.
+- No search output format redesign.
+- No benchmark-claim changes in docs or paper.
+- No broad encoding-system redesign beyond the minimum fixed-string safety fix.
+
+## Verification
+
+Required local gates:
+
+- `uv run ruff check .`
+- `uv run mypy src/tensor_grep`
+- `uv run pytest -q`
+
+Because this touches search behavior in a hot path, also run:
+
+- `python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.search_cli_bug_bundle.json`
+- `python benchmarks/check_regression.py --baseline auto --current artifacts/bench_run_benchmarks.search_cli_bug_bundle.json`
+
+## Files Expected To Change
+
+- `src/tensor_grep/backends/stringzilla_backend.py`
+- `src/tensor_grep/cli/main.py`
+- `tests/unit/test_stringzilla_backend.py`
+- `tests/unit/test_cli_modes.py`
+- `tests/e2e/test_routing_parity.py` or another focused subprocess CLI contract test if needed for `B2`

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -17,7 +17,7 @@ class StringZillaBackend(ComputeBackend):
     """
 
     _shared_index_cache: ClassVar[
-        dict[tuple[str, bool], tuple[tuple[int, int], list[str], dict[str, list[int]]]]
+        dict[tuple[str, bool, bool], tuple[tuple[int, int], list[str], dict[str, list[int]]]]
     ] = {}
 
     @classmethod
@@ -57,9 +57,31 @@ class StringZillaBackend(ComputeBackend):
             return Path(xdg_cache_home) / "tensor-grep" / "string-index"
         return Path.home() / ".cache" / "tensor-grep" / "string-index"
 
-    def _get_index_cache_path(self, file_path: str, ignore_case: bool) -> Path:
+    @staticmethod
+    def _should_search_binary_as_text(config: SearchConfig | None) -> bool:
+        return bool(config and (config.text or config.binary))
+
+    @staticmethod
+    def _load_searchable_text(file_path: str, *, treat_binary_as_text: bool) -> str | None:
+        if treat_binary_as_text:
+            raw = Path(file_path).read_bytes()
+            return raw.decode("utf-8", errors="replace")
+
+        with open(file_path, "rb") as binary_handle:
+            if b"\x00" in binary_handle.read(4096):
+                return None
+
+        try:
+            with open(file_path, encoding="utf-8") as text_handle:
+                return text_handle.read()
+        except UnicodeDecodeError:
+            return None
+
+    def _get_index_cache_path(
+        self, file_path: str, ignore_case: bool, treat_binary_as_text: bool
+    ) -> Path:
         digest = hashlib.sha256(
-            f"{Path(file_path).resolve()}::{int(ignore_case)}".encode()
+            f"{Path(file_path).resolve()}::{int(ignore_case)}::{int(treat_binary_as_text)}".encode()
         ).hexdigest()
         return self._get_index_cache_dir() / f"{digest}.json"
 
@@ -127,9 +149,9 @@ class StringZillaBackend(ComputeBackend):
         return [pattern[i : i + 3] for i in range(len(pattern) - 2)]
 
     def _load_cached_index(
-        self, file_path: str, ignore_case: bool
+        self, file_path: str, ignore_case: bool, treat_binary_as_text: bool
     ) -> tuple[list[str], dict[str, list[int]]] | None:
-        cache_key = (file_path, ignore_case)
+        cache_key = (file_path, ignore_case, treat_binary_as_text)
         cache_signature = self._build_file_signature(file_path)
         cached = self._shared_index_cache.get(cache_key)
         if cached and cached[0] == cache_signature:
@@ -138,7 +160,7 @@ class StringZillaBackend(ComputeBackend):
         if not self._is_index_enabled():
             return None
 
-        cache_path = self._get_index_cache_path(file_path, ignore_case)
+        cache_path = self._get_index_cache_path(file_path, ignore_case, treat_binary_as_text)
         if not cache_path.exists():
             return None
 
@@ -169,15 +191,20 @@ class StringZillaBackend(ComputeBackend):
         self,
         file_path: str,
         ignore_case: bool,
+        treat_binary_as_text: bool,
         lines: list[str],
         trigram_index: dict[str, list[int]],
     ) -> None:
         cache_signature = self._build_file_signature(file_path)
-        self._shared_index_cache[(file_path, ignore_case)] = (cache_signature, lines, trigram_index)
+        self._shared_index_cache[(file_path, ignore_case, treat_binary_as_text)] = (
+            cache_signature,
+            lines,
+            trigram_index,
+        )
         if not self._is_index_enabled():
             return
 
-        cache_path = self._get_index_cache_path(file_path, ignore_case)
+        cache_path = self._get_index_cache_path(file_path, ignore_case, treat_binary_as_text)
         payload = {
             "file_signature": list(cache_signature),
             "lines": lines,
@@ -190,21 +217,40 @@ class StringZillaBackend(ComputeBackend):
             return
 
     def _search_with_index(
-        self, file_path: str, pattern: str, ignore_case: bool
+        self, file_path: str, pattern: str, config: SearchConfig | None, ignore_case: bool
     ) -> SearchResult | None:
         if len(pattern) < 3:
             return None
 
-        cached = self._load_cached_index(file_path, ignore_case)
+        treat_binary_as_text = self._should_search_binary_as_text(config)
+        cached = self._load_cached_index(file_path, ignore_case, treat_binary_as_text)
         routing_reason = "stringzilla_fixed_strings_index_cache"
         if cached is None:
-            with open(file_path, encoding="utf-8") as f_obj:
-                source_lines = f_obj.read().splitlines()
+            content = self._load_searchable_text(
+                file_path, treat_binary_as_text=treat_binary_as_text
+            )
+            if content is None:
+                return SearchResult(
+                    matches=[],
+                    total_files=0,
+                    total_matches=0,
+                    routing_backend="StringZillaBackend",
+                    routing_reason="stringzilla_fixed_strings_skipped_binary",
+                    routing_distributed=False,
+                    routing_worker_count=1,
+                )
+            source_lines = content.splitlines()
             normalized_lines = (
                 [line.lower() for line in source_lines] if ignore_case else source_lines
             )
             trigram_index = self._build_line_trigram_index(normalized_lines)
-            self._persist_index(file_path, ignore_case, source_lines, trigram_index)
+            self._persist_index(
+                file_path,
+                ignore_case,
+                treat_binary_as_text,
+                source_lines,
+                trigram_index,
+            )
             routing_reason = "stringzilla_fixed_strings_index"
         else:
             source_lines, trigram_index = cached
@@ -251,14 +297,24 @@ class StringZillaBackend(ComputeBackend):
         try:
             ignore_case = bool(config and config.ignore_case)
             if config and config.fixed_strings:
-                indexed = self._search_with_index(file_path, pattern, ignore_case)
+                indexed = self._search_with_index(file_path, pattern, config, ignore_case)
                 if indexed is not None:
                     return indexed
 
-            # Read file via normal python IO for now, wrap in sz.Str
-            # In a real implementation we might memory-map directly.
-            with open(file_path, encoding="utf-8") as f_obj:
-                content = f_obj.read()
+            content = self._load_searchable_text(
+                file_path,
+                treat_binary_as_text=self._should_search_binary_as_text(config),
+            )
+            if content is None:
+                return SearchResult(
+                    matches=[],
+                    total_files=0,
+                    total_matches=0,
+                    routing_backend="StringZillaBackend",
+                    routing_reason="stringzilla_fixed_strings_skipped_binary",
+                    routing_distributed=False,
+                    routing_worker_count=1,
+                )
 
             sz_str = sz.Str(content)
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -2046,10 +2046,20 @@ def search_command(
             typer.echo("Error: Please provide a PATTERN to search.", err=True)
             sys.exit(1)
         pattern = args[0]
+        if pattern == "":
+            typer.echo("Error: PATTERN must not be empty.", err=True)
+            sys.exit(2)
         paths_to_search = args[1:]
         if not paths_to_search:
             typer.echo("Error: Please provide at least one PATH to search.", err=True)
             sys.exit(1)
+
+    if not files:
+        missing_paths = [path for path in paths_to_search if path != "-" and not Path(path).exists()]
+        if missing_paths:
+            for missing_path in missing_paths:
+                typer.echo(f"Error: search path does not exist: {missing_path}", err=True)
+            sys.exit(2)
 
     if line_number is None:
         line_number = sys.stdout.isatty()

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -2055,7 +2055,9 @@ def search_command(
             sys.exit(1)
 
     if not files:
-        missing_paths = [path for path in paths_to_search if path != "-" and not Path(path).exists()]
+        missing_paths = [
+            path for path in paths_to_search if path != "-" and not Path(path).exists()
+        ]
         if missing_paths:
             for missing_path in missing_paths:
                 typer.echo(f"Error: search path does not exist: {missing_path}", err=True)

--- a/tests/e2e/test_cli_search.py
+++ b/tests/e2e/test_cli_search.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 
@@ -32,3 +33,23 @@ class TestCLISearch:
             text=True,
         )
         assert result.returncode == 1
+
+    def test_should_emit_json_without_hanging(self, sample_log_file):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tensor_grep.cli.main",
+                "search",
+                "ERROR",
+                str(sample_log_file),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert payload["total_matches"] == 2

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1796,6 +1796,28 @@ def test_files_without_match_skips_gitignored_directories(tmp_path: Path):
     assert str(ignored) not in result.stdout
 
 
+def test_search_rejects_empty_pattern(tmp_path: Path):
+    target = tmp_path / "sample.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["search", "", str(target)])
+
+    assert result.exit_code == 2
+    assert "PATTERN must not be empty" in result.output
+
+
+def test_search_reports_missing_input_paths(tmp_path: Path):
+    missing = tmp_path / "missing.py"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["search", "hello", str(missing)])
+
+    assert result.exit_code == 2
+    assert str(missing) in result.output
+    assert "does not exist" in result.output
+
+
 def test_files_with_matches_null_outputs_nul_separator(tmp_path: Path):
     target = tmp_path / "sample.txt"
     target.write_text("hello\n", encoding="utf-8")

--- a/tests/unit/test_stringzilla_backend.py
+++ b/tests/unit/test_stringzilla_backend.py
@@ -57,6 +57,33 @@ def test_stringzilla_no_matches(backend, tmp_path):
     assert len(result.matches) == 0
 
 
+def test_stringzilla_skips_invalid_utf8_by_default(backend, tmp_path):
+    binary_file = tmp_path / "compiled.pyc"
+    binary_file.write_bytes(b"\x80\x81\x82needle\xff\xfe")
+
+    result = backend.search(str(binary_file), "needle", config=SearchConfig(fixed_strings=True))
+
+    assert result.total_matches == 0
+    assert result.matches == []
+    assert result.routing_backend == "StringZillaBackend"
+
+
+def test_stringzilla_can_search_binary_like_content_when_text_mode_enabled(backend, tmp_path):
+    binary_file = tmp_path / "compiled.pyc"
+    binary_file.write_bytes(b"\x80\x81needle\x00tail\xff")
+
+    result = backend.search(
+        str(binary_file),
+        "needle",
+        config=SearchConfig(fixed_strings=True, text=True),
+    )
+
+    assert result.total_matches == 1
+    assert len(result.matches) == 1
+    assert result.matches[0].line_number == 1
+    assert result.matches[0].file == str(binary_file)
+
+
 def test_stringzilla_reuses_persistent_trigram_index_across_instances(tmp_path, monkeypatch):
     cache_dir = tmp_path / "sz-cache"
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX_DIR", str(cache_dir))


### PR DESCRIPTION
## Summary
- prevent fixed-string StringZilla searches from crashing on binary or invalid UTF-8 files, while still honoring `--text` and `--binary` opt-in behavior
- reject empty search patterns and missing input paths with explicit exit code `2` errors, without breaking the existing `--files` compatibility contract
- add regression coverage for the binary-read bug, CLI validation paths, and a subprocess `--json` non-hang contract

## Root Cause
- `StringZillaBackend` opened files with strict UTF-8 decoding in both direct and indexed search paths, so invalid bytes could raise `UnicodeDecodeError`
- `search_command()` accepted `""` as a valid pattern and let nonexistent paths fall through into the normal search/no-match path instead of treating them as invocation errors

## Validation
- `uv run ruff check .`
- `uv run mypy src/tensor_grep`
- `uv run pytest -q`
- `uv run python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.search_cli_bug_bundle.json`
- `uv run python benchmarks/check_regression.py --baseline auto --current artifacts/bench_run_benchmarks.search_cli_bug_bundle.json` (noisy / inconclusive on this runner)

## Benchmark Note
The accepted-baseline benchmark check was noisy on this host. I also ran same-machine control samples against fresh `origin/main`; they showed substantial cross-run drift, so this PR should be treated as a correctness fix with benchmark ambiguity, not as a performance claim.