### PR TITLE
fix: remove stale Windows tg launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Installer defaults and channels:
 - Set `TENSOR_GREP_VERSION` to pin a specific stable version (example: `TENSOR_GREP_VERSION=1.1.3`).
 - Set `TENSOR_GREP_CHANNEL=main` to install directly from the GitHub `main` branch.
 - At completion, the installer prints `tg --version` and returns to the directory where you started the script.
-- Windows installer now installs `tg.cmd` shims in `~/.local/bin` and `~/bin`, moves those shim directories ahead of stale Python `Scripts` launchers on User PATH, updates both PowerShell 7 and Windows PowerShell profiles, and replaces stale aliases.
+- Windows installer now installs `tg.cmd` shims in `~/.local/bin` and `~/bin`, removes stale same-directory `tg.exe`/`tg.bat` launchers that would shadow the shim, moves those shim directories ahead of stale Python `Scripts` launchers on User PATH, updates both PowerShell 7 and Windows PowerShell profiles, and replaces stale aliases.
 
 If `tg --version` still reports an older version, check command resolution:
 ```powershell

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@ The install scripts create an isolated environment, print `tg --version` at the 
 
 They also run `tg lsp-setup --json` after creating the front-door `tg` command. That attempts the safe default managed provider setup under `~/.tensor-grep/providers` for pinned Node-backed providers and warns without failing the core install if optional provider setup is unavailable. If you install through `pip`, `uv`, or a package-manager channel and need provider-backed planning, run `tg lsp-setup` manually. Use `tg lsp-setup --include-toolchain-providers` only when you want tensor-grep to copy or install Rust, Go, and C# provider binaries through local toolchains.
 
-On Windows, the install script puts the managed `tg.cmd` shim directories ahead of stale Python `Scripts` launchers on User PATH. If a profile-free shell still reports an older `tg`, run `where.exe tg` and `tg doctor --json` to see which launcher is winning.
+On Windows, the install script removes stale same-directory `tg.exe`/`tg.bat` launchers from the managed shim directories, then puts those directories ahead of stale Python `Scripts` launchers on User PATH. If a profile-free shell still reports an older `tg`, run `where.exe tg` and `tg doctor --json` to see which launcher is winning.
 
 **Windows (PowerShell):**
 ```powershell

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -121,6 +121,13 @@ try {
         if (!(Test-Path $shimDir)) {
             New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
         }
+        foreach ($staleShimName in @("tg.com", "tg.exe", "tg.bat", "tg.ps1")) {
+            $staleShimPath = Join-Path $shimDir $staleShimName
+            if (Test-Path -LiteralPath $staleShimPath) {
+                Remove-Item -LiteralPath $staleShimPath -Force
+                Write-Host "Removed stale tg launcher shadowing managed shim: $staleShimPath"
+            }
+        }
         $cmdShimPath = "$shimDir\tg.cmd"
         Set-Content -Path $cmdShimPath -Value $cmdShimContent -Encoding ascii
         $installedShimPaths += $cmdShimPath

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -56,6 +56,17 @@ def test_install_ps1_should_prepend_shim_dirs_ahead_of_stale_python_scripts():
     assert '"$env:Path;$shimDir"' not in content
 
 
+def test_install_ps1_should_remove_stale_same_dir_tg_launchers_before_cmd_shim():
+    content = _read_script("scripts/install.ps1")
+
+    assert '"tg.com", "tg.exe", "tg.bat", "tg.ps1"' in content
+    assert "Remove-Item -LiteralPath $staleShimPath -Force" in content
+    assert "Removed stale tg launcher shadowing managed shim" in content
+    assert content.index("Remove-Item -LiteralPath $staleShimPath -Force") < content.index(
+        "Set-Content -Path $cmdShimPath"
+    )
+
+
 def test_install_sh_should_target_native_frontdoor_instead_of_venv_console_script():
     content = _read_script("scripts/install.sh")
 


### PR DESCRIPTION
## Summary

- remove stale `tg.com`, `tg.exe`, `tg.bat`, and `tg.ps1` launchers from managed Windows shim directories before writing `tg.cmd`
- document that same-directory stale launchers can shadow the managed shim
- add an installer regression test for the same-directory `tg.exe` shadowing case

## Root Cause

The previous PATH-order fix moved `~/.local/bin` and `~/bin` ahead of stale Python `Scripts` directories, but Windows resolves `.exe` before `.cmd` within the same directory. On this dogfood host, `C:\Users\oimir\.local\bin\tg.exe` reported `tensor-grep 0.32.0`, so it still shadowed the newly installed `tg.cmd` reporting `1.8.12`.

## Validation

- `uv run pytest tests/unit/test_install_scripts.py -q` -> `8 passed`
- `uv run pytest tests/unit/test_public_docs_governance.py tests/unit/test_install_scripts.py -q` -> `31 passed`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `git diff --check`