### PR TITLE
fix: correct Windows installer pinned extras

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -74,15 +74,19 @@ try {
         & $uvPath pip install torch torchvision torchaudio $indexArg $indexUrl --python "$installDir\.venv\Scripts\python.exe"
         $pkgRequirement = if ($installChannel -eq "main") {
             "tensor-grep[gpu-win,nlp,ast] @ $pkgSpec"
+        } elseif ($requestedVersion) {
+            "tensor-grep[gpu-win,nlp,ast]==$requestedVersion"
         } else {
-            "$pkgSpec[gpu-win,nlp,ast]"
+            "tensor-grep[gpu-win,nlp,ast]"
         }
         & $uvPath pip install $pkgRequirement --python "$installDir\.venv\Scripts\python.exe"
     } else {
         $pkgRequirement = if ($installChannel -eq "main") {
             "tensor-grep[ast,nlp] @ $pkgSpec"
+        } elseif ($requestedVersion) {
+            "tensor-grep[ast,nlp]==$requestedVersion"
         } else {
-            "$pkgSpec[ast,nlp]"
+            "tensor-grep[ast,nlp]"
         }
         & $uvPath pip install $pkgRequirement --python "$installDir\.venv\Scripts\python.exe"
     }

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -67,6 +67,15 @@ def test_install_ps1_should_remove_stale_same_dir_tg_launchers_before_cmd_shim()
     )
 
 
+def test_install_ps1_should_place_extras_before_pinned_version_specifier():
+    content = _read_script("scripts/install.ps1")
+
+    assert '"tensor-grep[gpu-win,nlp,ast]==$requestedVersion"' in content
+    assert '"tensor-grep[ast,nlp]==$requestedVersion"' in content
+    assert '"$pkgSpec[gpu-win,nlp,ast]"' not in content
+    assert '"$pkgSpec[ast,nlp]"' not in content
+
+
 def test_install_sh_should_target_native_frontdoor_instead_of_venv_console_script():
     content = _read_script("scripts/install.sh")
 


### PR DESCRIPTION
## Summary
- fix Windows install.ps1 pinned extras requirements so version constraints come after extras
- add installer regression coverage for GPU and CPU pinned package specs

## Local validation
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest tests/unit/test_install_scripts.py tests/unit/test_public_docs_governance.py -q
- uv run pytest -q (1825 passed, 16 skipped)
- git diff --check
- local fixed install.ps1 with TENSOR_GREP_VERSION=1.8.13 installed tensor-grep==1.8.13 and fresh PATH tg --version returned 1.8.13