### PR TITLE
fix: harden Windows and WSL installer shims

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -19,6 +19,16 @@ function Convert-ToMsysPath {
     return $normalizedPath
 }
 
+function Convert-ToWslPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $normalizedPath = $Path -replace '\\', '/'
+    if ($normalizedPath -match '^([A-Za-z]):/(.*)$') {
+        return "/mnt/$($Matches[1].ToLowerInvariant())/$($Matches[2])"
+    }
+    return $normalizedPath
+}
+
 function Remove-StalePythonPackageLauncher {
     param(
         [Parameter(Mandatory = $true)][string]$candidatePath,
@@ -224,11 +234,24 @@ try {
     $frontdoorPs1Path = Join-Path $frontdoorDir "tg.ps1"
     $frontdoorBashPath = Join-Path $frontdoorDir "tg"
     $msysInstallDir = Convert-ToMsysPath $installDir
+    $frontdoorArgBridgePath = Join-Path $frontdoorDir "tg-cmd-bridge.py"
+    $wslInstallDir = Convert-ToWslPath $installDir
+    $msysFrontdoorPath = Convert-ToMsysPath $frontdoorBashPath
+    $wslFrontdoorPath = Convert-ToWslPath $frontdoorBashPath
     $frontdoorCmdContent = (
         "@echo off`r`n" +
+        "setlocal`r`n" +
         "set PYTHONUTF8=1`r`n" +
         "set PYTHONIOENCODING=utf-8`r`n" +
-        "`"$installDir\.venv\Scripts\python.exe`" -X utf8 -m tensor_grep %*`r`n"
+        "set /a TG_CMD_SHIM_ARGC=0`r`n" +
+        ":tg_arg_loop`r`n" +
+        'if "%~1"=="" goto tg_arg_done' + "`r`n" +
+        "set /a TG_CMD_SHIM_ARGC+=1`r`n" +
+        'set "TG_CMD_SHIM_ARG_%TG_CMD_SHIM_ARGC%=%~1"' + "`r`n" +
+        "shift`r`n" +
+        "goto tg_arg_loop`r`n" +
+        ":tg_arg_done`r`n" +
+        "`"$installDir\.venv\Scripts\python.exe`" -X utf8 `"$frontdoorArgBridgePath`"`r`n"
     )
     $frontdoorPs1Content = @"
 `$env:PYTHONUTF8 = "1"
@@ -236,13 +259,39 @@ try {
 & "$installDir\.venv\Scripts\python.exe" -X utf8 -m tensor_grep @args
 exit `$LASTEXITCODE
 "@
+    $cmdArgvBridgeContent = @'
+import os
+import runpy
+import sys
+
+try:
+    argc = int(os.environ.get("TG_CMD_SHIM_ARGC", "0") or "0")
+except ValueError:
+    argc = 0
+
+argv = [
+    os.environ.get(f"TG_CMD_SHIM_ARG_{index}", "")
+    for index in range(1, argc + 1)
+]
+
+os.environ["PYTHONUTF8"] = "1"
+os.environ["PYTHONIOENCODING"] = "utf-8"
+sys.argv = ["tensor-grep"] + argv
+runpy.run_module("tensor_grep", run_name="__main__")
+'@
     $frontdoorBashContent = @"
 #!/usr/bin/env bash
+if grep -qi microsoft /proc/version 2>/dev/null; then
+    TG_PYTHON="$wslInstallDir/.venv/Scripts/python.exe"
+else
+    TG_PYTHON="$msysInstallDir/.venv/Scripts/python.exe"
+fi
 export PYTHONUTF8=1
 export PYTHONIOENCODING=utf-8
-"$msysInstallDir/.venv/Scripts/python.exe" -X utf8 -m tensor_grep "$@"
+exec "`$TG_PYTHON" -X utf8 -m tensor_grep "`$@"
 "@
     Set-Content -Path $frontdoorCmdPath -Value $frontdoorCmdContent -Encoding ascii
+    Set-Content -Path $frontdoorArgBridgePath -Value $cmdArgvBridgeContent -Encoding ascii
     Set-Content -Path $frontdoorPs1Path -Value $frontdoorPs1Content -Encoding ascii
     Set-Content -Path $frontdoorBashPath -Value $frontdoorBashContent -Encoding ascii
 
@@ -264,18 +313,31 @@ export PYTHONIOENCODING=utf-8
     )
     $cmdShimContent = (
         "@echo off`r`n" +
+        "setlocal`r`n" +
         "set PYTHONUTF8=1`r`n" +
         "set PYTHONIOENCODING=utf-8`r`n" +
-        "`"$frontdoorCmdPath`" %*`r`n"
+        "set /a TG_CMD_SHIM_ARGC=0`r`n" +
+        ":tg_arg_loop`r`n" +
+        'if "%~1"=="" goto tg_arg_done' + "`r`n" +
+        "set /a TG_CMD_SHIM_ARGC+=1`r`n" +
+        'set "TG_CMD_SHIM_ARG_%TG_CMD_SHIM_ARGC%=%~1"' + "`r`n" +
+        "shift`r`n" +
+        "goto tg_arg_loop`r`n" +
+        ":tg_arg_done`r`n" +
+        "`"$installDir\.venv\Scripts\python.exe`" -X utf8 `"$frontdoorArgBridgePath`"`r`n"
     )
     $ps1ShimContent = @"
 & "$frontdoorPs1Path" @args
 exit `$LASTEXITCODE
 "@
-    $msysFrontdoorPath = Convert-ToMsysPath $frontdoorBashPath
     $bashShimContent = @"
 #!/usr/bin/env bash
-"$msysFrontdoorPath" "$@"
+if grep -qi microsoft /proc/version 2>/dev/null; then
+    TG_FRONTDOOR="$wslFrontdoorPath"
+else
+    TG_FRONTDOOR="$msysFrontdoorPath"
+fi
+exec "`$TG_FRONTDOOR" "`$@"
 "@
     $installedShimPaths = @()
     foreach ($shimDir in $shimDirs) {

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -113,13 +113,38 @@ def test_install_ps1_should_create_argv_safe_utf8_powershell_shims():
     assert 'Set-Alias -Name tg -Value `"$frontdoorCmdPath`"' not in content
 
 
+def test_install_ps1_should_create_cmd_shims_without_child_command_percent_star_expansion():
+    content = _read_script("scripts/install.ps1")
+
+    assert "$cmdArgvBridgeContent" in content
+    assert "TG_CMD_SHIM_ARGC" in content
+    assert "TG_CMD_SHIM_ARG_%TG_CMD_SHIM_ARGC%=%~1" in content
+    assert 'runpy.run_module("tensor_grep", run_name="__main__")' in content
+    assert "%*" not in content
+    assert " -m tensor_grep %*" not in content
+    assert '`"$frontdoorCmdPath`" %*' not in content
+
+
 def test_install_ps1_should_create_git_bash_shims_without_pathext():
     content = _read_script("scripts/install.ps1")
 
     assert "$frontdoorBashPath" in content
     assert "$msysInstallDir" in content
-    assert '"$msysInstallDir/.venv/Scripts/python.exe" -X utf8 -m tensor_grep "$@"' in content
-    assert '"$msysFrontdoorPath" "$@"' in content
+    assert 'TG_PYTHON="$msysInstallDir/.venv/Scripts/python.exe"' in content
+    assert 'exec "`$TG_PYTHON" -X utf8 -m tensor_grep "`$@"' in content
+    assert 'TG_FRONTDOOR="$msysFrontdoorPath"' in content
+    assert 'exec "`$TG_FRONTDOOR" "`$@"' in content
+
+
+def test_install_ps1_should_create_wsl_aware_bash_shims():
+    content = _read_script("scripts/install.ps1")
+
+    assert "function Convert-ToWslPath" in content
+    assert "$wslInstallDir = Convert-ToWslPath $installDir" in content
+    assert "$wslFrontdoorPath = Convert-ToWslPath $frontdoorBashPath" in content
+    assert "grep -qi microsoft /proc/version" in content
+    assert 'TG_PYTHON="$wslInstallDir/.venv/Scripts/python.exe"' in content
+    assert 'TG_FRONTDOOR="$wslFrontdoorPath"' in content
 
 
 def test_install_ps1_should_place_extras_before_pinned_version_specifier():


### PR DESCRIPTION
## Summary
- Add a Windows installer `.cmd` argv bridge so generated batch launchers no longer expand `%*` into another child command line.
- Add WSL-aware path conversion for generated Bash shims, using `/mnt/<drive>/...` under WSL and `/c/...` under Git Bash/MSYS.
- Extend installer-contract tests for the cmd bridge and WSL shim generation.

## Root Cause
- The Windows installer chained user `tg.cmd` through another `.cmd %*` invocation, adding an extra batch reparse point for shell metacharacters.
- The no-extension Bash shim always emitted MSYS-style `/c/...` paths, which Git Bash understands but WSL does not.

## Validation
- `git diff --check`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `uv run pytest tests/unit/test_install_scripts.py -q`
- `pwsh -NoProfile` PowerShell parser check for `scripts/install.ps1`
- temp `.cmd` bridge smoke preserving quoted `class|def` argv from PowerShell and `cmd.exe`
- `uv run pytest -q` (`1839 passed, 16 skipped`)

## Caveat
An explicit PowerShell invocation of a `.cmd` file with an unescaped pipe, such as `tg.cmd search 'class|def' ...`, is split by the outer `cmd.exe` before batch code can inspect argv. The PowerShell-safe public path remains `tg`/`tg.ps1`; quoted cmd-style alternation is preserved by the new bridge.
