### PR TITLE
fix: write WSL bash shims with LF newlines

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -29,6 +29,26 @@ function Convert-ToWslPath {
     return $normalizedPath
 }
 
+function Write-AsciiFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    [System.IO.File]::WriteAllText($Path, $Value, [System.Text.Encoding]::ASCII)
+}
+
+function Write-BashFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    # WSL bash treats CR in shebangs or final "$@" lines as syntax or argv bytes.
+    $lfValue = ($Value -replace "`r`n", "`n") -replace "`r", "`n"
+    Write-AsciiFile -Path $Path -Value $lfValue
+}
+
 function Remove-StalePythonPackageLauncher {
     param(
         [Parameter(Mandatory = $true)][string]$candidatePath,
@@ -290,10 +310,10 @@ export PYTHONUTF8=1
 export PYTHONIOENCODING=utf-8
 exec "`$TG_PYTHON" -X utf8 -m tensor_grep "`$@"
 "@
-    Set-Content -Path $frontdoorCmdPath -Value $frontdoorCmdContent -Encoding ascii
-    Set-Content -Path $frontdoorArgBridgePath -Value $cmdArgvBridgeContent -Encoding ascii
-    Set-Content -Path $frontdoorPs1Path -Value $frontdoorPs1Content -Encoding ascii
-    Set-Content -Path $frontdoorBashPath -Value $frontdoorBashContent -Encoding ascii
+    Write-AsciiFile -Path $frontdoorCmdPath -Value $frontdoorCmdContent
+    Write-AsciiFile -Path $frontdoorArgBridgePath -Value $cmdArgvBridgeContent
+    Write-AsciiFile -Path $frontdoorPs1Path -Value $frontdoorPs1Content
+    Write-BashFile -Path $frontdoorBashPath -Value $frontdoorBashContent
 
     Write-Host "      Installing managed external LSP providers..."
     try {
@@ -354,9 +374,9 @@ exec "`$TG_FRONTDOOR" "`$@"
         $cmdShimPath = "$shimDir\tg.cmd"
         $ps1ShimPath = "$shimDir\tg.ps1"
         $bashShimPath = "$shimDir\tg"
-        Set-Content -Path $cmdShimPath -Value $cmdShimContent -Encoding ascii
-        Set-Content -Path $ps1ShimPath -Value $ps1ShimContent -Encoding ascii
-        Set-Content -Path $bashShimPath -Value $bashShimContent -Encoding ascii
+        Write-AsciiFile -Path $cmdShimPath -Value $cmdShimContent
+        Write-AsciiFile -Path $ps1ShimPath -Value $ps1ShimContent
+        Write-BashFile -Path $bashShimPath -Value $bashShimContent
         $installedShimPaths += $cmdShimPath
         $installedShimPaths += $ps1ShimPath
         $installedShimPaths += $bashShimPath

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -97,7 +97,7 @@ def test_install_ps1_should_remove_stale_same_dir_tg_launchers_before_cmd_shim()
     assert "Remove-Item -LiteralPath $staleShimPath -Force" in content
     assert "Removed stale tg launcher shadowing managed shim" in content
     assert content.index("Remove-Item -LiteralPath $staleShimPath -Force") < content.index(
-        "Set-Content -Path $cmdShimPath"
+        "Write-AsciiFile -Path $cmdShimPath"
     )
 
 
@@ -145,6 +145,20 @@ def test_install_ps1_should_create_wsl_aware_bash_shims():
     assert "grep -qi microsoft /proc/version" in content
     assert 'TG_PYTHON="$wslInstallDir/.venv/Scripts/python.exe"' in content
     assert 'TG_FRONTDOOR="$wslFrontdoorPath"' in content
+
+
+def test_install_ps1_should_write_bash_shims_without_windows_newline_append():
+    content = _read_script("scripts/install.ps1")
+
+    assert "function Write-AsciiFile" in content
+    assert "function Write-BashFile" in content
+    assert "[System.IO.File]::WriteAllText" in content
+    assert "WSL bash treats CR in shebangs" in content
+    assert '$lfValue = ($Value -replace "`r`n", "`n") -replace "`r", "`n"' in content
+    assert "Set-Content -Path $frontdoorBashPath" not in content
+    assert "Set-Content -Path $bashShimPath" not in content
+    assert "Write-BashFile -Path $frontdoorBashPath -Value $frontdoorBashContent" in content
+    assert "Write-BashFile -Path $bashShimPath -Value $bashShimContent" in content
 
 
 def test_install_ps1_should_place_extras_before_pinned_version_specifier():


### PR DESCRIPTION
## Summary
- write generated Windows installer files through direct ASCII writes instead of Set-Content
- normalize generated bash shims to LF so WSL does not see bash\r or pass carriage returns through "$@"
- add installer regression coverage for the WSL-safe bash shim writer

## Validation
- uv run pytest tests/unit/test_install_scripts.py -q
- pwsh/powershell parser checks for scripts/install.ps1
- patched local installer dogfood pinned to tensor-grep==1.8.18
- WSL: tg --version resolves tensor-grep 1.8.18 through /mnt/c/Users/oimir/bin/tg
- WSL: tg search "class|def" works from /mnt/c/dev/projects/tensor-grep
- PowerShell/cmd regex alternation smoke tests pass with the supported quoting forms
- git diff --check
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q: 1840 passed, 16 skipped