### PR TITLE
fix: polish CLI version help and doctor diagnostics

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -44,9 +44,11 @@ Agent automation contracts:
 - Invalid regex syntax exits as an error distinct from no-match and emits a diagnostic that recommends `--fixed-strings` for literal searches.
 - `tg search --json` emits a valid aggregate JSON object even when there are zero matches.
 - `tg search --files-with-matches` stays root-based on the ripgrep path instead of expanding large candidate-file lists into the Windows process argument vector, and plain path-list output emits one trailing line separator only.
+- Default output ordering for root-scale `--files-with-matches`, `--count`, and `--force-cpu` is a semantic result parity contract, not a golden stdout ordering contract. Use `--sort path` when automation needs deterministic path ordering across backends.
 - Broad generated roots such as `.claude` are routed through Python guardrails instead of rust-first/native passthrough so generated `.claude/context` snapshots can be pruned by default.
 - `tg search --type-list` prints a built-in fallback list when no ripgrep or standalone native binary is available. `--pcre2-version` follows ripgrep semantics and exits with an error when no PCRE2-capable backend is available.
 - `tg ast-info --json` exposes AST language identifiers via `{"languages": [...]}` for agent discovery without help-text scraping.
+- On Windows, PowerShell automation should invoke `tg` or `tg.ps1` for regex metacharacters. Direct `.cmd` invocation from PowerShell is not a safe argv-preserving contract for unescaped metacharacters such as `|` because `cmd.exe` parses the line before the batch wrapper receives arguments; `tg.cmd` is for `cmd.exe`.
 
 Known current limitations:
 - Broad plain path-list output from `tg search --files ...` over generated artifact trees can still be expensive. The Python path-list output path and managed Windows launchers force UTF-8, but scope file-list commands to the smallest useful root.

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -154,12 +154,13 @@ def _print_version() -> None:
         pkg_version = _read_project_version_fallback()
 
     print(f"tensor-grep {pkg_version}")
-    print()
-    print("features:+gpu-cudf,+gpu-torch,+rust-core")
-    print("simd(compile):+SSE2,-SSSE3,-AVX2")
-    print("simd(runtime):+SSE2,+SSSE3,+AVX2")
-    print()
-    print("Arrow Zero-Copy IPC is available")
+    if any(arg in {"--verbose", "-v"} for arg in sys.argv[2:]):
+        print()
+        print("features:+gpu-cudf,+gpu-torch,+rust-core")
+        print("simd(compile):+SSE2,-SSSE3,-AVX2")
+        print("simd(runtime):+SSE2,+SSSE3,+AVX2")
+        print()
+        print("Arrow Zero-Copy IPC is available")
 
 
 def _normalize_search_invocation(argv: list[str]) -> list[str] | None:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -147,6 +147,33 @@ def _read_project_version_fallback() -> str:
     return "0.0.0"
 
 
+def _cli_package_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("tensor-grep")
+    except Exception:
+        return _read_project_version_fallback()
+
+
+def _version_detail_lines() -> tuple[str, ...]:
+    return (
+        "",
+        "features:+gpu-cudf,+gpu-torch,+rust-core",
+        "simd(compile):+SSE2,-SSSE3,-AVX2",
+        "simd(runtime):+SSE2,+SSSE3,+AVX2",
+        "",
+        "Arrow Zero-Copy IPC is available",
+    )
+
+
+def _print_version(*, verbose: bool = False) -> None:
+    print(f"tensor-grep {_cli_package_version()}")
+    if verbose:
+        for line in _version_detail_lines():
+            print(line)
+
+
 @lru_cache(maxsize=1)
 def _json_output_version() -> int:
     try:
@@ -250,12 +277,7 @@ _NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS = (
 
 
 def _doctor_installed_version() -> str:
-    try:
-        from importlib.metadata import version
-
-        return version("tensor-grep")
-    except Exception:
-        return _read_project_version_fallback()
+    return _cli_package_version()
 
 
 def _doctor_session_daemon_status(path: str) -> dict[str, Any]:
@@ -309,6 +331,76 @@ def _doctor_rust_binary_version_matches(
     if rust_binary_version is None:
         return None
     return bool(re.search(rf"\b{re.escape(expected_version)}\b", rust_binary_version))
+
+
+def _doctor_native_tg_binary_kind(native_tg_binary: Path | None) -> str:
+    if native_tg_binary is None:
+        return "missing"
+
+    repo_root = Path(__file__).resolve().parents[3]
+    try:
+        relative = native_tg_binary.resolve().relative_to(repo_root.resolve())
+    except (OSError, ValueError):
+        return "standalone-executable"
+
+    parts = tuple(part.lower() for part in relative.parts)
+    if len(parts) >= 4 and parts[:2] == ("rust_core", "target"):
+        if parts[2] == "debug":
+            return "in-tree-debug"
+        if parts[2] == "release":
+            return "in-tree-release"
+        return "in-tree-target"
+    return "standalone-executable"
+
+
+def _doctor_rust_binary_version_status(
+    *,
+    native_tg_binary_kind: str,
+    rust_binary_version: str | None,
+    rust_binary_version_matches: bool | None,
+) -> str:
+    if rust_binary_version is None:
+        return "missing"
+    if rust_binary_version_matches is True:
+        return "matches"
+    if native_tg_binary_kind.startswith("in-tree-"):
+        return "stale"
+    return "mismatch"
+
+
+def _doctor_rust_binary_remediation(
+    *,
+    rust_binary_version_status: str,
+    native_tg_binary_kind: str,
+) -> str | None:
+    if rust_binary_version_status == "stale" and native_tg_binary_kind.startswith("in-tree-"):
+        return (
+            "Rebuild the in-tree native tg binary, for example "
+            "`C:/Users/oimir/.cargo/bin/cargo.exe build --manifest-path rust_core/Cargo.toml "
+            "--release`, or set TG_NATIVE_TG_BINARY to the intended release binary."
+        )
+    if rust_binary_version_status == "mismatch":
+        return "Set TG_NATIVE_TG_BINARY to the intended release binary or refresh the tg install."
+    return None
+
+
+def _doctor_rust_binary_warning(
+    *,
+    expected_version: str,
+    rust_binary_version: str | None,
+    rust_binary_version_status: str,
+) -> str | None:
+    if rust_binary_version_status == "stale":
+        return (
+            "in-tree native tg binary is stale: "
+            f"expected {expected_version}, found {rust_binary_version or 'unknown'}"
+        )
+    if rust_binary_version_status == "mismatch":
+        return (
+            "native tg binary version mismatch: "
+            f"expected {expected_version}, found {rust_binary_version or 'unknown'}"
+        )
+    return None
 
 
 def _doctor_tg_candidate_version(candidate: Path) -> str | None:
@@ -464,6 +556,16 @@ def _build_doctor_payload(
     ]
     installed_version = _doctor_installed_version()
     rust_binary_version = _doctor_rust_binary_version(native_tg_binary)
+    native_tg_binary_kind = _doctor_native_tg_binary_kind(native_tg_binary)
+    rust_binary_version_matches = _doctor_rust_binary_version_matches(
+        installed_version,
+        rust_binary_version,
+    )
+    rust_binary_version_status = _doctor_rust_binary_version_status(
+        native_tg_binary_kind=native_tg_binary_kind,
+        rust_binary_version=rust_binary_version,
+        rust_binary_version_matches=rust_binary_version_matches,
+    )
     rust_core_extension_available = _doctor_rust_core_extension_available()
     path_tg_candidates = _doctor_path_tg_candidates()
     path_tg_first_version = (
@@ -479,9 +581,7 @@ def _build_doctor_payload(
         "config": str(resolved_config),
         "native_tg_binary": str(native_tg_binary) if native_tg_binary is not None else None,
         "native_tg_binary_exists": native_tg_binary is not None,
-        "native_tg_binary_kind": (
-            "standalone-executable" if native_tg_binary is not None else "missing"
-        ),
+        "native_tg_binary_kind": native_tg_binary_kind,
         "rust_core_extension_available": rust_core_extension_available,
         "search_acceleration_backend": (
             "standalone-native-tg"
@@ -492,9 +592,16 @@ def _build_doctor_payload(
         ),
         "rust_binary_version": rust_binary_version,
         "rust_binary_expected_version": installed_version,
-        "rust_binary_version_matches": _doctor_rust_binary_version_matches(
-            installed_version,
-            rust_binary_version,
+        "rust_binary_version_matches": rust_binary_version_matches,
+        "rust_binary_version_status": rust_binary_version_status,
+        "rust_binary_version_warning": _doctor_rust_binary_warning(
+            expected_version=installed_version,
+            rust_binary_version=rust_binary_version,
+            rust_binary_version_status=rust_binary_version_status,
+        ),
+        "rust_binary_remediation": _doctor_rust_binary_remediation(
+            rust_binary_version_status=rust_binary_version_status,
+            native_tg_binary_kind=native_tg_binary_kind,
         ),
         "path_tg_candidates": path_tg_candidates,
         "path_tg_first_version": path_tg_first_version,
@@ -529,15 +636,16 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
     ]
     native_tg_binary = payload.get("native_tg_binary")
     lines.append(f"native_tg_binary: {native_tg_binary or 'missing'}")
+    lines.append(f"native_tg_binary_kind: {payload.get('native_tg_binary_kind', 'unknown')}")
     lines.append(
         f"search_acceleration_backend: {payload.get('search_acceleration_backend', 'unknown')}"
     )
     if rust_version := payload.get("rust_binary_version"):
         lines.append(f"rust_binary_version:\n  {rust_version.replace(chr(10), chr(10) + '  ')}")
-    if payload.get("rust_binary_version_matches") is False:
-        lines.append(
-            f"rust_binary_version_warning: expected {payload.get('rust_binary_expected_version')}"
-        )
+    if rust_binary_warning := payload.get("rust_binary_version_warning"):
+        lines.append(f"rust_binary_version_warning: {rust_binary_warning}")
+    if rust_binary_remediation := payload.get("rust_binary_remediation"):
+        lines.append(f"rust_binary_remediation: {rust_binary_remediation}")
     path_tg_candidates = cast(list[dict[str, str | None]], payload.get("path_tg_candidates", []))
     if path_tg_candidates:
         lines.append("path_tg_candidates:")
@@ -5582,13 +5690,6 @@ def main_entry() -> None:
     if len(sys.argv) > 1 and sys.argv[1] in ("--version", "-V", "--pcre2-version"):
         first_arg = sys.argv[1]
 
-        try:
-            from importlib.metadata import version
-
-            pkg_version = version("tensor-grep")
-        except Exception:
-            pkg_version = _read_project_version_fallback()
-
         if first_arg == "--pcre2-version":
             candidates = [resolve_native_tg_binary(), resolve_ripgrep_binary()]
             last_completed: subprocess.CompletedProcess[str] | None = None
@@ -5613,13 +5714,7 @@ def main_entry() -> None:
             )
             sys.exit(1)
 
-        print(f"tensor-grep {pkg_version}")
-        print()
-        print("features:+gpu-cudf,+gpu-torch,+rust-core")
-        print("simd(compile):+SSE2,-SSSE3,-AVX2")
-        print("simd(runtime):+SSE2,+SSSE3,+AVX2")
-        print()
-        print("Arrow Zero-Copy IPC is available")
+        _print_version(verbose=any(arg in {"--verbose", "-v"} for arg in sys.argv[2:]))
         sys.exit(0)
 
     from tensor_grep.cli.commands import KNOWN_COMMANDS as _KNOWN_COMMANDS
@@ -5627,7 +5722,7 @@ def main_entry() -> None:
     known_commands = _KNOWN_COMMANDS
 
     if len(sys.argv) == 1:
-        app(args=["--help"], windows_expand_args=False)
+        app(args=["--help"], prog_name="tg", windows_expand_args=False)
         return
 
     if len(sys.argv) > 1:
@@ -5639,7 +5734,7 @@ def main_entry() -> None:
         ):
             sys.argv.insert(1, "search")
 
-    app(windows_expand_args=False)
+    app(prog_name="tg", windows_expand_args=False)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.metadata as importlib_metadata
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -691,4 +693,43 @@ def test_main_entry_should_print_version_without_loading_full_cli(monkeypatch, c
         bootstrap.main_entry()
 
     assert excinfo.value.code == 0
-    assert "tensor-grep 9.9.9" in capsys.readouterr().out
+    assert capsys.readouterr().out == "tensor-grep 9.9.9\n"
+
+
+def test_main_entry_should_keep_verbose_version_details_without_loading_full_cli(
+    monkeypatch,
+    capsys,
+):
+    def _raise_version(_dist_name: str) -> str:
+        raise RuntimeError("metadata unavailable")
+
+    monkeypatch.setattr(sys, "argv", ["tg", "--version", "--verbose"])
+    monkeypatch.setattr(importlib_metadata, "version", _raise_version)
+    monkeypatch.setattr(bootstrap, "_read_project_version_fallback", lambda: "9.9.9")
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    output = capsys.readouterr().out
+    assert excinfo.value.code == 0
+    assert output.startswith("tensor-grep 9.9.9\n\n")
+    assert "features:+gpu-cudf,+gpu-torch,+rust-core" in output
+    assert "Arrow Zero-Copy IPC is available" in output
+
+
+def test_python_module_help_should_use_public_tg_program_name() -> None:
+    env = dict(os.environ)
+    env["TYPER_USE_RICH"] = "0"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_grep", "--help"],
+        capture_output=True,
+        env=env,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Usage: tg " in result.stdout
+    assert "python -m tensor_grep" not in result.stdout

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -707,6 +707,36 @@ def test_doctor_json_reports_native_version_mismatch(monkeypatch, tmp_path: Path
     assert payload["rust_binary_expected_version"] == "1.8.1"
 
 
+def test_doctor_json_labels_stale_in_tree_native_binary(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    native_binary = repo_root / "rust_core" / "target" / "debug" / "tg.exe"
+
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.8.19")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_binary)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_binary_version",
+        lambda _binary: "tg 1.8.14",
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["native_tg_binary_kind"] == "in-tree-debug"
+    assert payload["rust_binary_version_matches"] is False
+    assert payload["rust_binary_version_status"] == "stale"
+    assert "in-tree native tg binary is stale" in payload["rust_binary_version_warning"]
+    assert "TG_NATIVE_TG_BINARY" in payload["rust_binary_remediation"]
+
+
 def test_doctor_json_reports_path_tg_candidates(monkeypatch, tmp_path: Path) -> None:
     stale_tg = tmp_path / "Python314" / "Scripts" / "tg.exe"
     current_tg = tmp_path / "bin" / "tg.cmd"
@@ -6126,6 +6156,7 @@ def test_main_entry_should_disable_click_windows_arg_expansion_for_globs(monkeyp
         ".",
     ]
     assert seen["kwargs"]["windows_expand_args"] is False
+    assert seen["kwargs"]["prog_name"] == "tg"
 
 
 def test_main_entry_should_not_rewrite_map_subcommand(monkeypatch):
@@ -6696,7 +6727,29 @@ def test_main_entry_should_fallback_to_pyproject_version_when_metadata_missing(m
         cli_main.main_entry()
 
     assert excinfo.value.code == 0
-    assert "tensor-grep 0.31.4" in capsys.readouterr().out
+    assert capsys.readouterr().out == "tensor-grep 0.31.4\n"
+
+
+def test_main_entry_should_keep_verbose_version_details_when_requested(monkeypatch, capsys):
+    import importlib.metadata as importlib_metadata
+
+    from tensor_grep.cli import main as cli_main
+
+    def _raise_version(_dist_name: str) -> str:
+        raise RuntimeError("metadata unavailable")
+
+    monkeypatch.setattr(sys, "argv", ["tg", "--version", "--verbose"])
+    monkeypatch.setattr(importlib_metadata, "version", _raise_version)
+    monkeypatch.setattr(cli_main, "_read_project_version_fallback", lambda: "0.31.4")
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main.main_entry()
+
+    output = capsys.readouterr().out
+    assert excinfo.value.code == 0
+    assert output.startswith("tensor-grep 0.31.4\n\n")
+    assert "features:+gpu-cudf,+gpu-torch,+rust-core" in output
+    assert "Arrow Zero-Copy IPC is available" in output
 
 
 def test_main_entry_should_delegate_top_level_pcre2_version_to_native_binary(

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -10,6 +10,7 @@ AGENTS_DOC_PATH = Path("AGENTS.md")
 SKILL_DOC_PATH = Path("SKILL.md")
 SESSION_HANDOFF_PATH = Path("docs/SESSION_HANDOFF.md")
 CONTINUATION_PLAN_PATH = Path("docs/CONTINUATION_PLAN.md")
+CONTRACTS_DOC_PATH = Path("docs/CONTRACTS.md")
 
 
 def test_readme_should_point_to_canonical_public_docs() -> None:
@@ -31,6 +32,14 @@ def test_readme_should_point_to_canonical_public_docs() -> None:
     assert "tg run --rewrite" in readme
     assert "--apply" in readme
     assert "atomic temp-file rename contract" in readme
+
+
+def test_contracts_should_record_windows_shell_and_ordering_limits() -> None:
+    contracts = CONTRACTS_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "Direct `.cmd` invocation from PowerShell" in contracts
+    assert "semantic result parity" in contracts
+    assert "`--sort path`" in contracts
 
 
 def test_routing_policy_should_describe_current_native_and_fallback_routes() -> None:


### PR DESCRIPTION
## Summary
- make default tg --version output script-friendly while keeping verbose details behind --verbose
- force Python-module help rendering to use the public tg program name
- label stale in-tree native tg doctor findings with status, warning, and remediation
- document Windows direct .cmd PowerShell limits and semantic ordering parity

## Root Cause
The CLI still treated human detail output as the default version contract, Typer inherited the python -m tensor_grep invocation name for module help, and doctor flattened in-tree native binaries into generic standalone diagnostics.

## Validation
- uv run pytest tests/unit/test_cli_bootstrap.py tests/unit/test_cli_modes.py tests/unit/test_public_docs_governance.py -q
- git diff --check
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q
- uv run tg --version
- uv run tg --version --verbose
- uv run python -m tensor_grep --help
- uv run tg search --help
- uv run tg doctor --json