### PR TITLE
test: add fast agent readiness gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ The repo should be treated as a benchmark-governed, contract-heavy codebase. Do 
 
 ## Current Handoff
 
-As of 2026-05-06, the current released state is `v1.8.21`.
+As of 2026-05-07, the current released state is `v1.8.22`.
 
-- Release commit: `4e83e6d chore(release): v1.8.21 [skip ci]`
+- Release commit: `5a0d6d9 chore(release): v1.8.22 [skip ci]`
 - Recent fix commits:
+  - `8a061ee fix: improve agent context trust and rg parity`
   - `1bf2c76 fix: ignore stale native binaries in dev resolution`
   - `10cac14 fix: polish CLI version help and doctor diagnostics`
   - `a5fa279 fix: write WSL bash shims with LF newlines`
@@ -30,20 +31,21 @@ As of 2026-05-06, the current released state is `v1.8.21`.
   - `f98a6e4 fix: correct Windows installer pinned extras`
   - `1a06cba fix: remove stale Windows tg launchers`
   - `379b22f fix: harden tg resolution and rg path parity`
-- Main CI run `25414052583`: passed through `publish-success-gate`
-- Main CodeQL run `25414051923`: passed
-- Release-commit CodeQL run `25414407901`: passed
-- PyPI latest and pinned install: `tensor-grep==1.8.21` resolves from PyPI
-- Public installer dogfood: pinned `1.8.21` verified profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, WSL, regex alternation in normal shell entrypoints, one-line `tg --version`, `tg --version --verbose`, `Usage: tg` help, and public `tg doctor --json` PATH-version parity
-- Repo dev dogfood: `uv run tg doctor --json --no-lsp` reported stale in-tree standalone binaries as `stale-skipped`, left `native_tg_binary` unset, and kept `search_acceleration_backend = rust-core-extension`; repo JSON search routed through `RipgrepBackend` instead of a stale standalone native binary.
-- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.8.21>
+- Main CI run `25469910767`: passed through `publish-pypi` and `publish-success-gate`
+- Main CodeQL run `25469910279`: passed
+- Release-commit CodeQL run `25470327515`: passed
+- PyPI latest and pinned install: `tensor-grep==1.8.22` resolves from PyPI
+- Public installer dogfood: `tg update` upgraded the managed install from `1.8.21` to `1.8.22`; profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, and WSL resolved `tensor-grep 1.8.22`, with normal regex alternation still working.
+- Repo dev dogfood: `uv run tg doctor --json --no-lsp` reported `version = 1.8.22`, skipped stale in-tree standalone binaries as `stale-skipped`, left `native_tg_binary` unset, and kept `search_acceleration_backend = rust-core-extension`.
+- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.8.22>
 - Session handoff: `docs/SESSION_HANDOFF.md`
 
-The latest accepted release line fixed the Windows `--files-with-matches` rg-backed argument-vector failure, raw rg-style no-path `--files-with-matches` output, malformed pinned Windows installer extras, root-based path-list output, `-0/--null` path-list/count parsing, `tg ast-info --json`, argv-safe PowerShell shims, UTF-8 path-list output, inaccessible PATH-entry handling, managed shim installation, stale Python package cleanup when an old `Python*\Scripts\tg.exe` shadows managed shims, argv-safe `.cmd` bridging, Git Bash / WSL no-extension shims, WSL-aware `/mnt/c/...` paths, LF-only generated bash shims, one-line default version output with verbose details behind `--verbose`, public `Usage: tg` help text, explicit `doctor` diagnostics for stale in-tree native binaries, implicit stale-native skipping for dev searches, and public `--format rg` help text for exact ripgrep-style output.
+The latest accepted release line fixed the Windows `--files-with-matches` rg-backed argument-vector failure, raw rg-style no-path `--files-with-matches` output, malformed pinned Windows installer extras, root-based path-list output, `-0/--null` path-list/count parsing, `tg ast-info --json`, argv-safe PowerShell shims, UTF-8 path-list output, inaccessible PATH-entry handling, managed shim installation, stale Python package cleanup when an old `Python*\Scripts\tg.exe` shadows managed shims, argv-safe `.cmd` bridging, Git Bash / WSL no-extension shims, WSL-aware `/mnt/c/...` paths, LF-only generated bash shims, one-line default version output with verbose details behind `--verbose`, public `Usage: tg` help text, explicit `doctor` diagnostics for stale in-tree native binaries, implicit stale-native skipping for dev searches, public `--format rg` help text for exact ripgrep-style output, context-render/MCP trust invariants, validation command provenance, and sorted rg parity edges for files-with-matches, files-without-match, and replacement output.
 
 Known current weak spots:
 
 - `rg` remains the raw cold exact-text benchmark; `tg` should be treated as the agent-native code intelligence layer.
+- `ast-grep` remains the structural-search feature/performance baseline; `tg run` is a useful validated AST slice, not a blanket ast-grep replacement.
 - `context-render` and MCP context output are agent trust surfaces. `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, selected files/sources, follow-up reads, and `rendered_context` must agree or `context_consistency` must report the omission and confidence downgrade.
 - Default JSON/LLM context rendering must include executable behavior for selected functions. Compact rendering can strip low-value text, but it must not reduce selected code to signatures unless a future summary-only profile explicitly asks for that.
 - Validation commands are hints with provenance. Require `validation_plan[].detection`, do not suggest npm/package-manager commands without `package.json` evidence, do not suggest Python test commands without Python/test/project evidence, and omit commands entirely when no runner evidence exists.
@@ -86,6 +88,14 @@ uv run pytest tests/unit/test_cpu_backend.py -q
 uv run pytest tests/unit/test_cli_bootstrap.py -q
 uv run pytest tests/unit/test_release_assets_validation.py -q
 ```
+
+For fast pre-push dogfood on agent-critical surfaces, run the agent-readiness dogfood gate:
+
+```powershell
+python scripts/agent_readiness.py --output artifacts/agent_readiness.json
+```
+
+This 3-5 minute gate checks public shell version resolution, repo doctor sanity, `context_consistency`, deterministic rg edge parity, AST smoke, MCP context-render smoke, and docs claim hygiene. It complements, not replaces, the full local validation gate.
 
 ## Benchmark Rules
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Current accepted full-suite artifact:
 
 - [`artifacts/pytest_full_report.json`](artifacts/pytest_full_report.json)
 
+## Fast Agent Readiness Gate
+
+Before pushing agent-facing changes, run the fast dogfood gate:
+
+```powershell
+python scripts/agent_readiness.py --output artifacts/agent_readiness.json
+```
+
+This checks the current `v1.8.22` shell/version resolution, repo doctor sanity, `context_consistency`, deterministic rg parity edges, AST smoke, MCP context-render smoke, docs claim hygiene, and the current positioning: `rg` remains the cold exact-text baseline, `ast-grep` remains the structural-search feature/performance baseline, and `tg` is the agent-native orchestration layer.
+
 ## Bounded Heavy-Root AI Handoff
 
 For large internal-library roots, `tensor-grep` supports a bounded context-render path that keeps the AI handoff compact and actionable without letting symbol navigation escape the capped repo-map universe.
@@ -74,7 +84,7 @@ tg blast-radius . --symbol prepareCursorWorkerInvocation --max-repo-files 512 --
 Current accepted production proof:
 
 - [`artifacts/external_validation/agent_studio_patch_driver_validation_summary_capped.json`](artifacts/external_validation/agent_studio_patch_driver_validation_summary_capped.json)
-- `v1.8.21` release closeout: main CI run `25414052583`, main CodeQL run `25414051923`, and release-commit CodeQL run `25414407901` passed; semantic-release published GitHub release `v1.8.21`; the PyPI publish/parity gate passed; the public installer dogfood resolved profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, and WSL probes to `tensor-grep 1.8.21` while preserving regex alternation in normal shell entrypoints; and repo-dev doctor/search dogfood confirmed stale in-tree standalone binaries are skipped unless explicitly pinned
+- `v1.8.22` release closeout: main CI run `25469910767`, main CodeQL run `25469910279`, and release-commit CodeQL run `25470327515` passed; semantic-release published GitHub release `v1.8.22`; the PyPI publish/parity gate passed; the public installer/update dogfood resolved profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, and WSL probes to `tensor-grep 1.8.22` while preserving regex alternation in normal shell entrypoints; and repo-dev doctor/search dogfood confirmed stale in-tree standalone binaries are skipped unless explicitly pinned
 - blast-radius boundedness artifact: `artifacts/bench_blast_radius_benchmarks_v188_prefilter.json`
 
 What the bounded path preserves:

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,21 +7,22 @@ description: Use when searching code, logs, or repositories with tensor-grep; va
 
 ## Current State
 
-As of 2026-05-06, the current released version is `v1.8.21`.
+As of 2026-05-07, the current released version is `v1.8.22`.
 
 Current release facts:
 
-- Release commit: `4e83e6d chore(release): v1.8.21 [skip ci]`
-- Latest fix commit: `1bf2c76 fix: ignore stale native binaries in dev resolution`
-- PR #44 `fix: ignore stale native binaries in dev resolution` merged, released, and publicly dogfooded
-- Main CI run `25414052583` passed through `publish-success-gate`; CodeQL runs `25414051923` and `25414407901` passed
-- PyPI latest and pinned public installer dogfood both resolve `tensor-grep==1.8.21`
+- Release commit: `5a0d6d9 chore(release): v1.8.22 [skip ci]`
+- Latest fix commit: `8a061ee fix: improve agent context trust and rg parity`
+- PR #46 `fix: improve agent context trust and rg parity` merged, released, and publicly dogfooded
+- Main CI run `25469910767` passed through `publish-success-gate`; CodeQL runs `25469910279` and `25470327515` passed
+- PyPI latest and pinned public installer dogfood both resolve `tensor-grep==1.8.22`
 - Repo-dev doctor/search dogfood confirms stale in-tree standalone binaries are skipped unless `TG_NATIVE_TG_BINARY` or `TG_MCP_TG_BINARY` explicitly pins one
 - Latest handoff: `docs/SESSION_HANDOFF.md`
 
 Current product read:
 
 - `rg` remains the benchmark for raw cold exact-text search.
+- `ast-grep` remains the structural-search feature/performance baseline; `tg run` is a validated useful slice, not full ast-grep equivalence.
 - `tg` is strongest as agent-native code intelligence: scoped search, JSON/NDJSON, repo maps, defs, source, refs, callers, context bundles, blast-radius, AST search, rewrite planning, GPU inventory, and MCP.
 - `context-render` / MCP context output must keep `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, selected files/sources, and follow-up reads consistent. Check `context_consistency` when debugging agent handoff quality.
 - Default JSON/LLM context rendering must include executable body lines for selected functions. Compactness may strip comments, docstrings when optimized, blank lines, type-only imports, and boilerplate, but it is not a summary-only profile.
@@ -136,6 +137,14 @@ uv run ruff format --check --preview .
 uv run mypy src/tensor_grep
 uv run pytest -q
 ```
+
+For fast agent-readiness dogfood before push, run:
+
+```powershell
+python scripts/agent_readiness.py --output artifacts/agent_readiness.json
+```
+
+This gate checks public shell version resolution, repo doctor sanity, `context_consistency`, deterministic rg edge parity, AST smoke, MCP context-render smoke, docs claim hygiene, and the current `v1.8.22` positioning. It does not replace the full validation gate.
 
 For hot-path or benchmark-relevant changes, run the matching benchmark before updating claims:
 

--- a/docs/CONTINUATION_PLAN.md
+++ b/docs/CONTINUATION_PLAN.md
@@ -2,24 +2,25 @@
 
 ## For: Next agent picking up after the native CPU/GPU/index/rewrite milestones
 
-## 2026-05-06 Current Handoff
+## 2026-05-07 Current Handoff
 
-The current released state is `v1.8.21`. Use [docs/SESSION_HANDOFF.md](SESSION_HANDOFF.md) as the live handoff for release status, current weak spots, release completion contract, and next-session commands. This continuation plan remains useful as the historical workstream map, but it is no longer the freshest operational state.
+The current released state is `v1.8.22`. Use [docs/SESSION_HANDOFF.md](SESSION_HANDOFF.md) as the live handoff for release status, current weak spots, release completion contract, and next-session commands. This continuation plan remains useful as the historical workstream map, but it is no longer the freshest operational state.
 
 Current release facts:
 
-- Release commit: `4e83e6d chore(release): v1.8.21 [skip ci]`
-- Latest fix commit: `1bf2c76 fix: ignore stale native binaries in dev resolution`
-- Main CI run `25414052583`: passed through `publish-success-gate`
-- Main CodeQL run `25414051923`: passed
-- Release-commit CodeQL run `25414407901`: passed
-- Local managed `tg --version`: `tensor-grep 1.8.21`
-- PyPI pinned public installer dogfood: `1.8.21` installed and verified across profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, WSL, normal regex alternation, one-line version output, public help, doctor PATH-version parity, and repo-dev stale-native skipping.
+- Release commit: `5a0d6d9 chore(release): v1.8.22 [skip ci]`
+- Latest fix commit: `8a061ee fix: improve agent context trust and rg parity`
+- Main CI run `25469910767`: passed through `publish-success-gate`
+- Main CodeQL run `25469910279`: passed
+- Release-commit CodeQL run `25470327515`: passed
+- Local managed `tg --version`: `tensor-grep 1.8.22`
+- PyPI pinned public installer dogfood: `1.8.22` installed and verified across profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, WSL, normal regex alternation, one-line version output, public help, doctor PATH-version parity, and repo-dev stale-native skipping.
 
 Current product read:
 
 - `tg` is production-usable for scoped agent search, source lookup, refs, context bundles, and bounded blast-radius.
 - `rg` remains the benchmark for raw cold exact-text search.
+- `ast-grep` remains the structural-search feature/performance baseline; `tg run` is a useful validated slice, not full ast-grep equivalence.
 - GPU exists and devices are detected locally, but GPU routing remains benchmark-governed.
 - Active follow-up work is improving agent context trust and deterministic rg parity, not changing the speed story: context rendering should keep edit seed, navigation target, selected sources, and MCP output consistent; default LLM rendering should preserve executable body lines; validation plans should only emit commands with runner evidence; and the rg claim should stay a validated compatibility set.
 - Broad generated roots still need guardrails before unattended agent use.
@@ -29,7 +30,7 @@ Current product read:
 
 Current next work:
 
-1. Add a 3-5 minute agent-readiness gate covering context-render trust, sorted rg edge parity, AST smoke, MCP smoke, and docs claim checks.
+1. Keep the fast agent-readiness gate (`python scripts/agent_readiness.py --output artifacts/agent_readiness.json`) covering context-render trust, `context_consistency`, sorted rg edge parity, AST smoke, MCP smoke, shell version probes, and docs claim checks.
 2. Add progress, partial output, or stronger guardrails for broad generated-root scans.
 3. Calibrate or de-emphasize `impact --symbol` so agents prefer `blast-radius` for direct symbol impact.
 4. Track public shim performance, AST parity roadmap, GPU readiness, and classify provider/cache UX as blockers for a future "100% ready" claim.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -51,6 +51,7 @@ Agent automation contracts:
 - `tg search --type-list` prints a built-in fallback list when no ripgrep or standalone native binary is available. `--pcre2-version` follows ripgrep semantics and exits with an error when no PCRE2-capable backend is available.
 - `tg ast-info --json` exposes AST language identifiers via `{"languages": [...]}` for agent discovery without help-text scraping.
 - On Windows, PowerShell automation should invoke `tg` or `tg.ps1` for regex metacharacters. Direct `.cmd` invocation from PowerShell is not a safe argv-preserving contract for unescaped metacharacters such as `|` because `cmd.exe` parses the line before the batch wrapper receives arguments; `tg.cmd` is for `cmd.exe`.
+- The fast agent-readiness dogfood gate is `python scripts/agent_readiness.py --output artifacts/agent_readiness.json`. For the current `v1.8.22` line it checks public shell version probes, repo doctor sanity, `context_consistency`, deterministic rg parity edges, AST smoke, MCP context-render smoke, docs claim hygiene, and the public positioning that `rg` remains the cold exact-text baseline while `ast-grep` remains the structural-search feature/performance baseline.
 
 Context and edit-planning contracts:
 - `context-render` and MCP context output must not let `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, rendered source sections, and follow-up reads contradict each other.

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,22 +1,22 @@
 # tensor-grep Session Handoff
 
-Last updated: 2026-05-06
+Last updated: 2026-05-07
 
 ## Current Release State
 
-- Latest released version: `v1.8.21`
-- Latest release commit: `4e83e6d chore(release): v1.8.21 [skip ci]`
-- Latest fix commit: `1bf2c76 fix: ignore stale native binaries in dev resolution`
-- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.8.21>
-- Main CI run `25414052583`: passed through `publish-success-gate`
-- Main CodeQL run `25414051923`: passed
-- Release-commit CodeQL run `25414407901`: passed
-- Local managed `tg --version`: `tensor-grep 1.8.21`
-- PyPI latest and pinned install: `tensor-grep==1.8.21` resolves from PyPI
-- Public Windows installer `TENSOR_GREP_VERSION=1.8.21`: installed `tensor-grep==1.8.21`, refreshed managed shims, and left profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, and WSL resolving `1.8.21`.
+- Latest released version: `v1.8.22`
+- Latest release commit: `5a0d6d9 chore(release): v1.8.22 [skip ci]`
+- Latest fix commit: `8a061ee fix: improve agent context trust and rg parity`
+- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.8.22>
+- Main CI run `25469910767`: passed through `publish-pypi`, artifact validation, and `publish-success-gate`
+- Main CodeQL run `25469910279`: passed
+- Release-commit CodeQL run `25470327515`: passed
+- Local managed `tg --version`: `tensor-grep 1.8.22`
+- PyPI latest and pinned install: `tensor-grep==1.8.22` resolves from PyPI
+- Public update dogfood: `tg update` upgraded the managed install from `1.8.21` to `1.8.22`; profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, and WSL resolved `tensor-grep 1.8.22`.
 - Public shell dogfood: normal PowerShell, `cmd.exe`, Git Bash, and WSL regex alternation worked; `tg --version` prints one line by default, `tg --version --verbose` prints feature details, and help starts with `Usage: tg`.
-- Public doctor dogfood: from outside the repo, `tg doctor --json` reported `version = 1.8.21`, `search_acceleration_backend = rust-core-extension`, and `path_tg_first_version_matches = true`.
-- Repo-dev dogfood: `uv run tg doctor --json --no-lsp` reported `version = 1.8.21`, `native_tg_binary = null`, `rust_binary_version_status = stale-skipped`, `skipped_native_tg_binaries = 2`, and `search_acceleration_backend = rust-core-extension`; `uv run tg search --json 'class|def' src/tensor_grep/core/result.py` routed through `RipgrepBackend`.
+- Public doctor dogfood: from outside the repo, `tg doctor --json` reported `version = 1.8.22`, `search_acceleration_backend = rust-core-extension`, and `path_tg_first_version_matches = true`.
+- Repo-dev dogfood: `uv run tg doctor --json --no-lsp` reported `version = 1.8.22`, `native_tg_binary = null`, `rust_binary_version_status = stale-skipped`, `skipped_native_tg_binaries = 2`, and `search_acceleration_backend = rust-core-extension`.
 
 ## Release Completion Contract
 
@@ -30,7 +30,7 @@ Do not report final version state before the GitHub release, PyPI/package publis
 
 For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and merge only when requested or clearly required. After merge, main CI should pass, but semantic-release should skip release publishing.
 
-## What v1.8.12-v1.8.21 Fixed
+## What v1.8.12-v1.8.22 Fixed
 
 - Windows `--files-with-matches` no longer expands huge candidate file lists into the ripgrep subprocess argv, avoiding `WinError 206`.
 - No-path `--files-with-matches` now preserves raw rg-style paths such as `AGENTS.md` instead of emitting `.\AGENTS.md`.
@@ -46,6 +46,10 @@ For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and m
 - Installed CLI help now uses the public program name (`Usage: tg ...`) instead of the Python module path.
 - `tg doctor --json` labels stale in-tree native binaries and includes remediation instead of leaving contributors to infer stale native state from a raw mismatch; current dev-path safety should skip stale implicit binaries unless `TG_NATIVE_TG_BINARY` pins one explicitly.
 - Implicit native resolution now refuses stale in-tree standalone binaries for dev searches unless `TG_NATIVE_TG_BINARY` or `TG_MCP_TG_BINARY` explicitly pins one; `--format rg` is documented as the public exact ripgrep-style text-output mode.
+- `context-render` and MCP context output now enforce agent trust invariants: `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, selected files/sources, follow-up reads, and `rendered_context` must agree or report the issue through `context_consistency`.
+- Default JSON/LLM context rendering preserves executable function body lines instead of reducing selected functions to signature-only output.
+- Validation plans report `validation_plan[].detection`, avoid npm/package-manager commands without `package.json` evidence, avoid Python test commands without Python/test/project evidence, and omit commands entirely when no runner evidence exists.
+- The validated compatibility set now covers deterministic `--files-with-matches --sort path`, `--files-without-match --sort path`, `--replace --sort path`, path separators on Windows, git ignored directories, binary exclusion by default, and match/no-match/parse-error/binary-skip exit-code behavior.
 - Windows installers now uninstall the tensor-grep Python package that owns a stale `Python*\Scripts\tg.exe` when direct stale-launcher removal cannot clear a PATH shadow.
 - Python path-list output uses the UTF-8-safe stdout path and preserves discovery order for `--files-with-matches` fallback output.
 - PATH-entry scans skip inaccessible machine PATH directories instead of aborting installation after package install.
@@ -61,6 +65,7 @@ For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and m
 - PR #40 `fix: write WSL bash shims with LF newlines`: merged and released as `v1.8.19`
 - PR #42 `fix: polish CLI version help and doctor diagnostics`: merged and released as `v1.8.20`
 - PR #44 `fix: ignore stale native binaries in dev resolution`: merged and released as `v1.8.21`
+- PR #46 `fix: improve agent context trust and rg parity`: merged and released as `v1.8.22`
 - `uv run pytest tests/unit/test_install_scripts.py -q`: `18 passed` on the LF-shim fix branch
 - `uv run pytest tests/unit/test_cli_bootstrap.py tests/unit/test_cli_modes.py tests/unit/test_public_docs_governance.py -q`: `287 passed` on the CLI polish branch
 - PowerShell parser checks for `scripts/install.ps1` under both `pwsh` and Windows PowerShell: passed
@@ -69,29 +74,32 @@ For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and m
 - `uv run ruff format --check --preview .`: passed
 - `uv run mypy src/tensor_grep`: passed
 - `uv run pytest -q`: `1845 passed, 16 skipped`
-- `uv run pytest -q`: `1815 passed, 50 skipped` on the `v1.8.21` fix branch
-- Main CI run `25414052583`: passed through `publish-pypi`, `validate-pypi-artifacts`, and `publish-success-gate`
-- Main CodeQL run `25414051923`: passed
-- Release-commit CodeQL run `25414407901`: passed
-- PyPI reports `tensor-grep 1.8.21` as latest and pinned `tensor-grep==1.8.21` resolves from PyPI.
-- Public `v1.8.21` installer dogfood passed profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, WSL version resolution, PowerShell alternation through the normal `tg` shim, `cmd.exe` double-quoted alternation, Git Bash alternation, WSL alternation search, script-friendly one-line version output, verbose version details, public `Usage: tg` help, and public doctor PATH-version parity.
+- `uv run pytest -q`: `1867 passed, 16 skipped` on the `v1.8.22` fix branch
+- `python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.json`: parity passed on all 10 rows; `check_regression.py --allow-env-mismatch` reported no tg benchmark regressions on the Python-version-mismatched host.
+- Main CI run `25469910767`: passed through `publish-pypi`, `validate-pypi-artifacts`, and `publish-success-gate`
+- Main CodeQL run `25469910279`: passed
+- Release-commit CodeQL run `25470327515`: passed
+- PyPI reports `tensor-grep 1.8.22` as latest and pinned `tensor-grep==1.8.22` resolves from PyPI.
+- Public `v1.8.22` update dogfood passed profiled PowerShell, `cmd`, `pwsh -NoProfile`, Git Bash, WSL version resolution, PowerShell alternation through the normal `tg` shim, `cmd.exe` double-quoted alternation, Git Bash alternation, WSL alternation search, script-friendly one-line version output, public `Usage: tg` help, and public doctor PATH-version parity.
 
 ## What Works Well Now
 
 - Scoped text search, JSON, NDJSON, multi-root search, globs, `--column`, `--vimgrep`, `--path-separator`, `--type-list`, and invalid-regex diagnostics are stable enough for agent workflows.
-- Normal PowerShell `tg`, `cmd /c tg`, `pwsh -NoProfile -Command "tg ..."`, Git Bash `tg`, and WSL `tg` resolve the public `1.8.21` install on this host.
+- Normal PowerShell `tg`, `cmd /c tg`, `pwsh -NoProfile -Command "tg ..."`, Git Bash `tg`, and WSL `tg` resolve the public `1.8.22` install on this host.
 - `tg --version` is script-friendly by default; use `tg --version --verbose` for feature/SIMD/Arrow diagnostics.
 - Public help starts with `Usage: tg`, including `python -m tensor_grep --help` and installed command help paths.
 - `defs`, `source`, `refs`, `callers`, `context-render`, and `blast-radius` are useful for scoped repo navigation and planning.
-- Current unreleased context work tightens `context-render` / MCP trust: source-body evidence ranks natural queries, default LLM rendering preserves executable body lines, `context_consistency` reports seed/render/navigation agreement, and validation commands carry detection provenance.
+- Released context work tightens `context-render` / MCP trust: source-body evidence ranks natural queries, default LLM rendering preserves executable body lines, `context_consistency` reports seed/render/navigation agreement, and validation commands carry detection provenance.
 - Symbol outputs are compact on hits and no-matches; CommonJS symbol extraction and reference dedupe are materially improved.
 - Bounded blast-radius defaults and output-limit metadata make scoped impact checks safer for agent loops.
 - MCP entrypoint is present via `tg mcp --help`; MCP tool behavior is covered by the repo tests.
 - GPU devices are detected locally; GPU routing remains benchmark-governed and should not be marketed as automatic crossover.
+- `ast-grep` remains the structural-search feature/performance baseline; `tg run` is a useful validated slice, not full ast-grep equivalence.
 
 ## Known Weak Spots
 
 - `rg` remains the raw cold exact-text benchmark. `tg` should win on agent-native code intelligence, not by pretending every grep workload is faster.
+- `ast-grep` remains the structural-search feature/performance baseline until the AST compatibility roadmap is closed with tests and benchmark evidence.
 - Broad generated roots can still be agent-hostile. Use scoped paths, globs, file types, and `--max-depth` for `tg search`; `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
 - `impact --symbol` is still less trustworthy than `blast-radius` for direct symbol impact.
 - `validation_commands` can still be heuristic when stack evidence is partial. Treat targeted commands as hints, not proof of full coverage; require `validation_plan[].detection`, do not trust npm/package-manager hints without `package.json` evidence, and omit commands entirely when no runner evidence exists.
@@ -103,7 +111,7 @@ For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and m
 
 ## Next Highest-Value Work
 
-1. Add a 3-5 minute agent-readiness dogfood gate that covers context trust, rg sorted edges, AST smoke, MCP smoke, and docs claim checks.
+1. Keep the agent-readiness dogfood gate (`python scripts/agent_readiness.py --output artifacts/agent_readiness.json`) fast and representative; it should cover context trust, rg sorted edges, AST smoke, MCP smoke, shell version probes, and docs claim checks.
 2. Add progress, partial output, or stronger guardrails for broad generated-root scans.
 3. Calibrate or de-emphasize `impact --symbol` so agents prefer `blast-radius` for direct impact.
 4. Track public shim performance, AST parity roadmap gaps, GPU benchmark/no-match cleanup, and `classify` provider/cache UX as blockers for a future "world-class" claim, not as blockers for this correctness PR.
@@ -117,7 +125,8 @@ git log -3 --oneline
 uv run tg --version
 uv run tg doctor --json
 python -m pip index versions tensor-grep --index-url https://pypi.org/simple --no-cache-dir
-gh release view v1.8.21 --json tagName,publishedAt,url
+gh release view v1.8.22 --json tagName,publishedAt,url
+python scripts/agent_readiness.py --output artifacts/agent_readiness.json
 tg --version
 cmd /c tg --version
 pwsh -NoProfile -Command "tg --version"

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import tomllib
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, NamedTuple
+
+ROOT = Path(__file__).resolve().parents[1]
+IS_WINDOWS = os.name == "nt"
+
+
+class ReadinessError(RuntimeError):
+    """Raised when an agent-readiness check returns invalid output."""
+
+
+Validator = Callable[[str, Path, str], None]
+
+
+class Check(NamedTuple):
+    name: str
+    command: list[str]
+    description: str
+    timeout_s: int = 60
+    validator: Validator | None = None
+    required: bool = True
+
+
+def read_project_version(repo_root: Path) -> str:
+    data = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    return str(data["project"]["version"])
+
+
+def _json_from_stdout(stdout: str) -> Any:
+    stripped = stdout.strip()
+    if not stripped:
+        raise ReadinessError("expected JSON output, got empty stdout")
+    starts = [idx for idx in (stripped.find("{"), stripped.find("[")) if idx >= 0]
+    if not starts:
+        raise ReadinessError("expected JSON output, found no JSON object or array")
+    decoder = json.JSONDecoder()
+    payload, _offset = decoder.raw_decode(stripped[min(starts) :])
+    return payload
+
+
+def _norm_path(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).replace("\\", "/").rstrip("/").lower()
+
+
+def validate_version_output(stdout: str, _repo_root: Path, expected_version: str) -> None:
+    expected_line = f"tensor-grep {expected_version}"
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if expected_line not in lines:
+        raise ReadinessError(
+            f"expected `{expected_line}` in version output, got {lines or ['<empty>']}"
+        )
+
+
+def validate_doctor_payload(stdout: str, _repo_root: Path, expected_version: str) -> None:
+    payload = _json_from_stdout(stdout)
+    if not isinstance(payload, dict):
+        raise ReadinessError("doctor JSON must be an object")
+    if payload.get("version") != expected_version:
+        raise ReadinessError(
+            f"doctor version mismatch: expected {expected_version}, got {payload.get('version')}"
+        )
+    first_matches = payload.get("path_tg_first_version_matches")
+    if first_matches is False:
+        raise ReadinessError("doctor reports PATH first tg version does not match")
+    backend = payload.get("search_acceleration_backend")
+    if backend not in {
+        "rust-core-extension",
+        "native-standalone",
+        "standalone-native-tg",
+        "python",
+    }:
+        raise ReadinessError(f"unexpected search acceleration backend: {backend!r}")
+
+
+def validate_context_render_payload(
+    stdout: str, _repo_root: Path | None = None, *, expected_fragment: str
+) -> None:
+    payload = _json_from_stdout(stdout)
+    if not isinstance(payload, dict):
+        raise ReadinessError("context-render JSON must be an object")
+
+    primary_file = _norm_path((payload.get("edit_plan_seed") or {}).get("primary_file"))
+    if not primary_file:
+        raise ReadinessError("context-render missing edit_plan_seed.primary_file")
+
+    consistency = payload.get("context_consistency")
+    if not isinstance(consistency, dict):
+        raise ReadinessError("context-render missing context_consistency object")
+
+    selected_files = {
+        _norm_path(item.get("path")) for item in payload.get("files", []) if isinstance(item, dict)
+    }
+    selected_sources = {
+        _norm_path(item.get("file") or item.get("path"))
+        for item in payload.get("sources", [])
+        if isinstance(item, dict)
+    }
+    follow_ups = {
+        _norm_path(item.get("path") or item.get("file"))
+        for item in (payload.get("navigation_pack") or {}).get("follow_up_reads", [])
+        if isinstance(item, dict)
+    }
+    represented_paths = selected_files | selected_sources | follow_ups
+    is_represented = any(
+        path and (path == primary_file or path.endswith(primary_file)) for path in represented_paths
+    )
+    omitted_primary = consistency.get("omitted_primary_file")
+    if not is_represented and not omitted_primary:
+        raise ReadinessError(
+            "edit_plan_seed.primary_file is not represented and no omission reason was emitted"
+        )
+
+    nav_file = _norm_path(
+        ((payload.get("navigation_pack") or {}).get("primary_target") or {}).get("file")
+    )
+    if (
+        nav_file
+        and primary_file
+        and nav_file != primary_file
+        and not nav_file.endswith(primary_file)
+    ):
+        raise ReadinessError(
+            "navigation_pack.primary_target contradicts edit_plan_seed.primary_file"
+        )
+
+    rendered_context = str(payload.get("rendered_context") or "")
+    rendered_sources = "\n".join(
+        str(item.get("rendered_source") or "")
+        for item in payload.get("sources", [])
+        if isinstance(item, dict)
+    )
+    if expected_fragment not in rendered_context and expected_fragment not in rendered_sources:
+        raise ReadinessError(f"missing expected context fragment: {expected_fragment}")
+
+
+def _validate_invoice_context(stdout: str, repo_root: Path, _expected_version: str) -> None:
+    validate_context_render_payload(
+        stdout, repo_root, expected_fragment="tax = subtotal * TAX_RATE"
+    )
+
+
+def validate_ast_info(stdout: str, _repo_root: Path, _expected_version: str) -> None:
+    payload = _json_from_stdout(stdout)
+    languages: object
+    if isinstance(payload, dict):
+        languages = payload.get("languages")
+    else:
+        languages = payload
+    if not isinstance(languages, list) or "python" not in {str(item) for item in languages}:
+        raise ReadinessError("ast-info JSON must expose the python language identifier")
+
+
+def validate_ast_run(stdout: str, _repo_root: Path, _expected_version: str) -> None:
+    payload = _json_from_stdout(stdout)
+    text = json.dumps(payload, sort_keys=True)
+    if "class" not in text and "name" not in text:
+        raise ReadinessError("AST run smoke did not emit a class match payload")
+
+
+def validate_docs_claims(_stdout: str, repo_root: Path, expected_version: str) -> None:
+    required_docs = [
+        repo_root / "AGENTS.md",
+        repo_root / "README.md",
+        repo_root / "SKILL.md",
+        repo_root / "docs" / "SESSION_HANDOFF.md",
+        repo_root / "docs" / "CONTINUATION_PLAN.md",
+        repo_root / "docs" / "CONTRACTS.md",
+    ]
+    required_fragments = [
+        f"v{expected_version}",
+        "python scripts/agent_readiness.py",
+        "context_consistency",
+        "validated compatibility set",
+        "rg` remains",
+        "ast-grep",
+    ]
+    missing: list[str] = []
+    for path in required_docs:
+        content = path.read_text(encoding="utf-8")
+        for fragment in required_fragments:
+            if fragment not in content:
+                missing.append(f"{path.relative_to(repo_root)} missing `{fragment}`")
+    if missing:
+        raise ReadinessError("; ".join(missing))
+
+
+def build_check_plan(
+    *,
+    repo_root: Path,
+    expected_version: str,
+    include_shell_probes: bool,
+    include_wsl_probe: bool,
+) -> list[Check]:
+    checks: list[Check] = []
+    if include_shell_probes:
+        powershell_probe = (
+            ["powershell", "-NoProfile", "-Command", "tg --version"]
+            if IS_WINDOWS
+            else ["tg", "--version"]
+        )
+        checks.extend([
+            Check(
+                name="public-version-powershell",
+                command=powershell_probe,
+                description="Verify profiled shell public tg version.",
+                timeout_s=30,
+                validator=validate_version_output,
+            ),
+            Check(
+                name="public-version-cmd",
+                command=["cmd", "/c", "tg --version"],
+                description="Verify cmd.exe public tg version.",
+                timeout_s=30,
+                validator=validate_version_output,
+                required=False,
+            ),
+            Check(
+                name="public-version-pwsh-noprofile",
+                command=["pwsh", "-NoProfile", "-Command", "tg --version"],
+                description="Verify unprofiled PowerShell public tg version.",
+                timeout_s=30,
+                validator=validate_version_output,
+                required=False,
+            ),
+            Check(
+                name="public-version-git-bash",
+                command=["bash", "-lc", "command -v tg && tg --version"],
+                description="Verify Git Bash/no-extension shim public tg version.",
+                timeout_s=30,
+                validator=validate_version_output,
+                required=False,
+            ),
+        ])
+        if include_wsl_probe:
+            checks.append(
+                Check(
+                    name="public-version-wsl",
+                    command=["wsl", "bash", "-lc", "command -v tg && tg --version"],
+                    description="Verify WSL public tg shim version.",
+                    timeout_s=30,
+                    validator=validate_version_output,
+                    required=False,
+                )
+            )
+
+    checks.extend([
+        Check(
+            name="repo-doctor",
+            command=["uv", "run", "tg", "doctor", "--json", "--no-lsp"],
+            description="Verify repo tg doctor reports version and PATH parity.",
+            timeout_s=90,
+            validator=validate_doctor_payload,
+        ),
+        Check(
+            name="context-render-trust",
+            command=[
+                "uv",
+                "run",
+                "tg",
+                "context-render",
+                "tests/unit/test_trust_planning.py",
+                "--query",
+                "invoice tax calculation",
+                "--json",
+            ],
+            description="Verify context-render keeps primary target and body context useful.",
+            timeout_s=90,
+            validator=_validate_invoice_context,
+        ),
+        Check(
+            name="rg-parity-edges",
+            command=["uv", "run", "pytest", "tests/e2e/test_rg_parity_edges.py", "-q"],
+            description="Verify deterministic rg parity edge cases.",
+            timeout_s=180,
+        ),
+        Check(
+            name="ast-info-json",
+            command=["uv", "run", "tg", "ast-info", "--json"],
+            description="Verify AST language inventory JSON is parseable.",
+            timeout_s=60,
+            validator=validate_ast_info,
+        ),
+        Check(
+            name="ast-run-smoke",
+            command=[
+                "uv",
+                "run",
+                "tg",
+                "run",
+                "class $NAME: $$$BODY",
+                "tests/unit/test_trust_planning.py",
+                "--lang",
+                "python",
+                "--json",
+            ],
+            description="Verify AST run smoke through the repo CLI.",
+            timeout_s=90,
+            validator=validate_ast_run,
+        ),
+        Check(
+            name="mcp-context-render-smoke",
+            command=[
+                "uv",
+                "run",
+                "pytest",
+                "tests/unit/test_mcp_server.py",
+                "-q",
+                "-k",
+                "test_tg_context_render_mcp_preserves_invoice_tax_body_and_primary_target",
+            ],
+            description="Verify MCP context-render preserves invoice tax body and target.",
+            timeout_s=120,
+        ),
+        Check(
+            name="docs-claim-check",
+            command=[],
+            description="Verify public docs keep the current positioning and gate command.",
+            timeout_s=5,
+            validator=validate_docs_claims,
+        ),
+    ])
+    return checks
+
+
+def _command_available(command: list[str]) -> bool:
+    if not command:
+        return True
+    return shutil.which(command[0]) is not None
+
+
+def run_check(check: Check, *, repo_root: Path, expected_version: str) -> dict[str, Any]:
+    started = time.monotonic()
+    if not _command_available(check.command):
+        if check.required:
+            status = "failed"
+            message = f"required command not found: {check.command[0]}"
+        else:
+            status = "skipped"
+            message = f"optional command not found: {check.command[0]}"
+        return {
+            "name": check.name,
+            "status": status,
+            "duration_s": round(time.monotonic() - started, 3),
+            "command": check.command,
+            "message": message,
+        }
+
+    stdout = ""
+    stderr = ""
+    returncode = 0
+    try:
+        if check.command:
+            env = dict(os.environ)
+            env.setdefault("PYTHONUTF8", "1")
+            completed = subprocess.run(
+                check.command,
+                cwd=repo_root,
+                env=env,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                timeout=check.timeout_s,
+                check=False,
+            )
+            stdout = completed.stdout
+            stderr = completed.stderr
+            returncode = completed.returncode
+            if completed.returncode != 0:
+                raise ReadinessError(
+                    f"exit {completed.returncode}; stderr={stderr.strip() or '<empty>'}"
+                )
+        if check.validator is not None:
+            check.validator(stdout, repo_root, expected_version)
+    except subprocess.TimeoutExpired as exc:
+        status = "failed"
+        message = f"timed out after {check.timeout_s}s"
+        stdout = str(exc.stdout or "")
+        stderr = str(exc.stderr or "")
+    except ReadinessError as exc:
+        status = "failed"
+        message = str(exc)
+    else:
+        status = "passed"
+        message = "ok"
+
+    return {
+        "name": check.name,
+        "status": status,
+        "duration_s": round(time.monotonic() - started, 3),
+        "command": check.command,
+        "returncode": returncode,
+        "message": message,
+        "stdout_tail": stdout.splitlines()[-20:],
+        "stderr_tail": stderr.splitlines()[-20:],
+    }
+
+
+def build_report(
+    *,
+    results: list[dict[str, Any]],
+    expected_version: str,
+    repo_root: Path,
+) -> dict[str, Any]:
+    return {
+        "artifact": "agent_readiness_report",
+        "expected_version": expected_version,
+        "root": str(repo_root.resolve()),
+        "summary": {
+            "passed": sum(1 for result in results if result["status"] == "passed"),
+            "failed": sum(1 for result in results if result["status"] == "failed"),
+            "skipped": sum(1 for result in results if result["status"] == "skipped"),
+        },
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the fast tensor-grep agent-readiness dogfood gate."
+    )
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to validate.")
+    parser.add_argument(
+        "--expected-version", help="Expected tensor-grep version. Defaults to pyproject."
+    )
+    parser.add_argument("--output", type=Path, help="Optional JSON report path.")
+    parser.add_argument("--json", action="store_true", help="Print JSON report to stdout.")
+    parser.add_argument(
+        "--no-shell-probes", action="store_true", help="Skip public shell version probes."
+    )
+    parser.add_argument("--no-wsl-probe", action="store_true", help="Skip the optional WSL probe.")
+    args = parser.parse_args(argv)
+
+    repo_root = args.root.resolve()
+    expected_version = args.expected_version or read_project_version(repo_root)
+    checks = build_check_plan(
+        repo_root=repo_root,
+        expected_version=expected_version,
+        include_shell_probes=not args.no_shell_probes,
+        include_wsl_probe=not args.no_wsl_probe,
+    )
+
+    results: list[dict[str, Any]] = []
+    for check in checks:
+        result = run_check(check, repo_root=repo_root, expected_version=expected_version)
+        results.append(result)
+        if not args.json:
+            print(
+                f"[{result['status'].upper()}] {check.name} "
+                f"({result['duration_s']}s): {result['message']}"
+            )
+
+    report = build_report(results=results, expected_version=expected_version, repo_root=repo_root)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if report["summary"]["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/test_agent_readiness_script.py
+++ b/tests/unit/test_agent_readiness_script.py
@@ -1,0 +1,152 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_script_module():
+    root = Path(__file__).resolve().parents[2]
+    module_path = root / "scripts" / "agent_readiness.py"
+    spec = importlib.util.spec_from_file_location("agent_readiness_script", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_agent_readiness_plan_should_cover_agent_critical_surfaces() -> None:
+    module = _load_script_module()
+
+    checks = module.build_check_plan(
+        repo_root=Path("C:/repo"),
+        expected_version="1.8.22",
+        include_shell_probes=True,
+        include_wsl_probe=True,
+    )
+
+    names = {check.name for check in checks}
+    assert "public-version-powershell" in names
+    assert "public-version-cmd" in names
+    assert "public-version-pwsh-noprofile" in names
+    assert "public-version-git-bash" in names
+    assert "public-version-wsl" in names
+    assert "repo-doctor" in names
+    assert "context-render-trust" in names
+    assert "rg-parity-edges" in names
+    assert "ast-info-json" in names
+    assert "ast-run-smoke" in names
+    assert "mcp-context-render-smoke" in names
+    assert "docs-claim-check" in names
+
+    rg_check = next(check for check in checks if check.name == "rg-parity-edges")
+    assert rg_check.timeout_s <= 180
+    assert rg_check.command[:4] == ["uv", "run", "pytest", "tests/e2e/test_rg_parity_edges.py"]
+
+    mcp_check = next(check for check in checks if check.name == "mcp-context-render-smoke")
+    assert "test_tg_context_render_mcp_preserves_invoice_tax_body_and_primary_target" in (
+        mcp_check.command
+    )
+
+
+def test_agent_readiness_should_avoid_bare_tg_createprocess_on_windows(monkeypatch) -> None:
+    module = _load_script_module()
+    monkeypatch.setattr(module, "IS_WINDOWS", True)
+
+    checks = module.build_check_plan(
+        repo_root=Path("C:/repo"),
+        expected_version="1.8.22",
+        include_shell_probes=True,
+        include_wsl_probe=False,
+    )
+
+    powershell_probe = next(check for check in checks if check.name == "public-version-powershell")
+    assert powershell_probe.command[0].lower() == "powershell"
+    assert "tg --version" in powershell_probe.command
+
+
+def test_agent_readiness_should_validate_context_render_trust_payload() -> None:
+    module = _load_script_module()
+    payload = {
+        "edit_plan_seed": {"primary_file": "src/payments.py"},
+        "navigation_pack": {"primary_target": {"file": "src/payments.py"}},
+        "files": [{"path": "src/payments.py"}],
+        "sources": [
+            {
+                "file": "src/payments.py",
+                "name": "create_invoice",
+                "rendered_source": (
+                    "def create_invoice(subtotal):\n"
+                    "    tax = subtotal * TAX_RATE\n"
+                    "    return {'tax': tax}\n"
+                ),
+            }
+        ],
+        "rendered_context": "def create_invoice(subtotal):\n    tax = subtotal * TAX_RATE\n",
+        "context_consistency": {"primary_file_represented": True},
+    }
+
+    module.validate_context_render_payload(json.dumps(payload), expected_fragment="TAX_RATE")
+
+
+def test_agent_readiness_should_accept_current_doctor_backend_name() -> None:
+    module = _load_script_module()
+    payload = {
+        "version": "1.8.22",
+        "path_tg_first_version_matches": True,
+        "search_acceleration_backend": "standalone-native-tg",
+    }
+
+    module.validate_doctor_payload(json.dumps(payload), Path("C:/repo"), "1.8.22")
+
+
+def test_agent_readiness_should_reject_signature_only_context_payload() -> None:
+    module = _load_script_module()
+    payload = {
+        "edit_plan_seed": {"primary_file": "src/payments.py"},
+        "navigation_pack": {"primary_target": {"file": "src/payments.py"}},
+        "files": [{"path": "src/payments.py"}],
+        "sources": [
+            {
+                "file": "src/payments.py",
+                "name": "create_invoice",
+                "rendered_source": "def create_invoice(subtotal):\n",
+            }
+        ],
+        "rendered_context": "def create_invoice(subtotal):\n",
+        "context_consistency": {"primary_file_represented": True},
+    }
+
+    try:
+        module.validate_context_render_payload(json.dumps(payload), expected_fragment="TAX_RATE")
+    except module.ReadinessError as exc:
+        assert "missing expected context fragment" in str(exc)
+    else:
+        raise AssertionError("expected context payload validation to fail")
+
+
+def test_agent_readiness_main_should_write_json_summary(monkeypatch, tmp_path) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(module, "read_project_version", lambda _root: "1.8.22")
+    monkeypatch.setattr(
+        module,
+        "build_check_plan",
+        lambda **_kwargs: [
+            module.Check(
+                name="docs-claim-check",
+                command=[],
+                description="Validate docs claims.",
+                validator=lambda _stdout, _root, _expected: None,
+            )
+        ],
+    )
+    output_path = tmp_path / "agent-readiness.json"
+
+    exit_code = module.main(["--output", str(output_path), "--no-shell-probes"])
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert payload["artifact"] == "agent_readiness_report"
+    assert payload["expected_version"] == "1.8.22"
+    assert payload["summary"]["passed"] == 1
+    assert payload["summary"]["failed"] == 0

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -51,7 +51,7 @@ def test_contracts_should_record_windows_shell_and_ordering_limits() -> None:
     assert "stale-skipped" in contracts
 
 
-def test_handoff_docs_should_record_current_v1821_release_state() -> None:
+def test_handoff_docs_should_record_current_v1822_release_state_and_fast_gate() -> None:
     docs = {
         "AGENTS.md": AGENTS_DOC_PATH.read_text(encoding="utf-8"),
         "README.md": README_PATH.read_text(encoding="utf-8"),
@@ -61,7 +61,8 @@ def test_handoff_docs_should_record_current_v1821_release_state() -> None:
     }
 
     for content in docs.values():
-        assert "v1.8.21" in content
+        assert "v1.8.22" in content
+        assert "python scripts/agent_readiness.py" in content
 
     for content in (
         docs["AGENTS.md"],
@@ -69,14 +70,14 @@ def test_handoff_docs_should_record_current_v1821_release_state() -> None:
         docs["docs/SESSION_HANDOFF.md"],
         docs["docs/CONTINUATION_PLAN.md"],
     ):
-        assert "4e83e6d chore(release): v1.8.21 [skip ci]" in content
-        assert "1bf2c76 fix: ignore stale native binaries in dev resolution" in content
+        assert "5a0d6d9 chore(release): v1.8.22 [skip ci]" in content
+        assert "8a061ee fix: improve agent context trust and rg parity" in content
 
     handoff = docs["docs/SESSION_HANDOFF.md"]
-    assert "25414052583" in handoff
-    assert "25414051923" in handoff
-    assert "25414407901" in handoff
-    assert "tensor-grep==1.8.21" in handoff
+    assert "25469910767" in handoff
+    assert "25469910279" in handoff
+    assert "25470327515" in handoff
+    assert "tensor-grep==1.8.22" in handoff
     assert "tg --version --verbose" in handoff
     assert "Usage: tg" in handoff
     assert "rust_binary_version_status = stale-skipped" in handoff
@@ -84,7 +85,7 @@ def test_handoff_docs_should_record_current_v1821_release_state() -> None:
     assert "--format rg" in handoff
     assert "context_consistency" in handoff
     assert "no runner evidence exists" in handoff
-    assert "RipgrepBackend" in handoff
+    assert "agent-readiness dogfood gate" in handoff
 
 
 def test_routing_policy_should_describe_current_native_and_fallback_routes() -> None:


### PR DESCRIPTION
## Summary
- add scripts/agent_readiness.py as a fast dogfood gate for agent-critical surfaces
- cover shell version probes, repo doctor, context-render trust, rg parity edges, AST smoke, MCP smoke, and docs claim checks
- refresh v1.8.22 handoff docs and repo/global tensor-grep skill guidance

## Local validation
- python scripts/agent_readiness.py --output artifacts/agent_readiness.json
- uv run pytest tests/unit/test_agent_readiness_script.py tests/unit/test_public_docs_governance.py -q
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q
- git diff --check