### PR TITLE
fix: add generated-root scan guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Known current weak spots:
 - `context-render` and MCP context output are agent trust surfaces. `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, selected files/sources, follow-up reads, and `rendered_context` must agree or `context_consistency` must report the omission and confidence downgrade.
 - Default JSON/LLM context rendering must include executable behavior for selected functions. Compact rendering can strip low-value text, but it must not reduce selected code to signatures unless a future summary-only profile explicitly asks for that.
 - Validation commands are hints with provenance. Require `validation_plan[].detection`, do not suggest npm/package-manager commands without `package.json` evidence, do not suggest Python test commands without Python/test/project evidence, and omit commands entirely when no runner evidence exists.
-- Broad generated roots can still be hostile to unattended agents. Use scoped paths, globs, file types, and `--max-depth` for `tg search`; `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
+- Unbounded broad generated-root scans are hostile to unattended agents. `tg search --files --hidden` and no-ignore/unrestricted fallback scans now refuse roots that contain generated/cache/dependency directories unless the request is bounded by `--glob`, `--type`, or `--max-depth`, or explicitly opts in with `--allow-broad-generated-scan`. Use scoped paths, globs, file types, and `--max-depth` for `tg search` before reaching for opt-in. `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
 - Prefer `blast-radius` over `impact --symbol` when direct symbol impact matters.
 - Windows launcher/path-list hardening should force UTF-8 for managed shims and Python path-list output; still scope broad file-list commands to avoid generated-tree volume.
 - If `cmd /c tg --version` or `pwsh -NoProfile -Command "tg --version"` resolves an old `Python*\Scripts\tg.exe`, treat it as installer regression evidence. The Windows installer should remove or uninstall tensor-grep-owned stale Python launchers instead of only warning about them.
@@ -95,7 +95,7 @@ For fast pre-push dogfood on agent-critical surfaces, run the agent-readiness do
 python scripts/agent_readiness.py --output artifacts/agent_readiness.json
 ```
 
-This 3-5 minute gate checks public shell version resolution, repo doctor sanity, `context_consistency`, deterministic rg edge parity, AST smoke, MCP context-render smoke, and docs claim hygiene. It complements, not replaces, the full local validation gate.
+This 3-5 minute gate checks public shell version resolution, repo doctor sanity, `context_consistency`, deterministic rg edge parity, broad generated-root scan guardrails, AST smoke, MCP context-render smoke, and docs claim hygiene. It complements, not replaces, the full local validation gate.
 
 ## Benchmark Rules
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ python scripts/agent_readiness.py --output artifacts/agent_readiness.json
 ```
 
 This checks the current `v1.8.22` shell/version resolution, repo doctor sanity, `context_consistency`, deterministic rg parity edges, AST smoke, MCP context-render smoke, docs claim hygiene, and the current positioning: `rg` remains the cold exact-text baseline, `ast-grep` remains the structural-search feature/performance baseline, and `tg` is the agent-native orchestration layer.
+It also covers the broad generated-root scan guard: unbounded `tg search --files` roots that combine hidden/no-ignore-style scanning with generated, cache, or dependency directories must be scoped, bounded, or explicitly opted in with `--allow-broad-generated-scan`.
 
 ## Bounded Heavy-Root AI Handoff
 
@@ -365,6 +366,16 @@ $ tg search foobar . --files-without-match
 ```
 
 Add `--no-ignore` when you want ignored files and directories included in the candidate set for this mode.
+
+For broad file-list discovery, prefer a scoped path or a bound:
+
+```bash
+$ tg search --files src --hidden
+$ tg search --files . --hidden --glob "*.py"
+$ tg search --files . --hidden --max-depth 3
+```
+
+Unbounded generated/cache/dependency roots combined with hidden, no-ignore, or unrestricted scanning are refused by default. Pass `--allow-broad-generated-scan` only when the large generated-tree walk is intentional.
 
 Search only Python and Javascript files:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,7 +28,7 @@ Current product read:
 - Default JSON/LLM context rendering must include executable body lines for selected functions. Compactness may strip comments, docstrings when optimized, blank lines, type-only imports, and boilerplate, but it is not a summary-only profile.
 - `tg ast-info --json` exposes AST language identifiers for agents without help-text scraping.
 - GPU support exists and local devices can be detected, but GPU routing is benchmark-governed. Do not claim GPU speedups without the matching benchmark artifact.
-- Broad generated roots need bounds. Use scoped paths, globs, file types, and `--max-depth` for `tg search`; `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
+- Broad generated roots need bounds. Unbounded `tg search --files --hidden` scans and no-ignore/unrestricted fallback scans through generated/cache/dependency directories are refused unless bounded with `--glob`, `--type`, or `--max-depth`, or explicitly opted in with `--allow-broad-generated-scan`. Use scoped paths, globs, file types, and `--max-depth` for `tg search` before reaching for opt-in. `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
 
 Known current weak spots:
 
@@ -82,6 +82,16 @@ Avoid broad generated-root file lists unless the task needs them:
 ```powershell
 tg search --files "AGENTS.md" . --hidden
 ```
+
+Use one of these instead for agent-safe file discovery:
+
+```powershell
+tg search --files src --hidden
+tg search --files . --hidden --glob "*.py"
+tg search --files . --hidden --max-depth 3
+```
+
+Only pass `--allow-broad-generated-scan` when the generated/cache/dependency tree walk is intentional.
 
 ## Core CLI Workflows
 
@@ -144,7 +154,7 @@ For fast agent-readiness dogfood before push, run:
 python scripts/agent_readiness.py --output artifacts/agent_readiness.json
 ```
 
-This gate checks public shell version resolution, repo doctor sanity, `context_consistency`, deterministic rg edge parity, AST smoke, MCP context-render smoke, docs claim hygiene, and the current `v1.8.22` positioning. It does not replace the full validation gate.
+This gate checks public shell version resolution, repo doctor sanity, `context_consistency`, deterministic rg edge parity, broad generated-root scan guardrails, AST smoke, MCP context-render smoke, docs claim hygiene, and the current `v1.8.22` positioning. It does not replace the full validation gate.
 
 For hot-path or benchmark-relevant changes, run the matching benchmark before updating claims:
 
@@ -165,7 +175,7 @@ GPU benchmark `SKIP` is valid infrastructure state when dependencies such as Tor
 | --- | --- |
 | Claiming `tg` is always faster than `rg` | Keep `rg` as the cold exact-text benchmark; position `tg` as agent-native code intelligence with a validated compatibility set. |
 | Searching with `rg` by habit inside this repo | Use `tg search` first, then `rg` for parity or fallback. |
-| Running broad generated-root scans | Scope the path and use output/scan limits. |
+| Running broad generated-root scans | Scope the path, use `--glob` / `--type` / `--max-depth`, or opt in with `--allow-broad-generated-scan` only when the generated-tree walk is intentional. |
 | Trusting stale native diagnostics | Check `uv run tg doctor --json`; stale in-tree binaries should be `stale-skipped`, not selected implicitly. Rebuild or pin `TG_NATIVE_TG_BINARY` to opt in. |
 | Trusting invented validation commands | Check `validation_plan[].detection`; package-manager commands require `package.json`, Python commands require Python/test/project evidence, and absent evidence should mean no command. |
 | Claiming GPU wins from device detection | Run the GPU benchmark and record the accepted artifact. |

--- a/docs/CONTINUATION_PLAN.md
+++ b/docs/CONTINUATION_PLAN.md
@@ -23,15 +23,15 @@ Current product read:
 - `ast-grep` remains the structural-search feature/performance baseline; `tg run` is a useful validated slice, not full ast-grep equivalence.
 - GPU exists and devices are detected locally, but GPU routing remains benchmark-governed.
 - Active follow-up work is improving agent context trust and deterministic rg parity, not changing the speed story: context rendering should keep edit seed, navigation target, selected sources, and MCP output consistent; default LLM rendering should preserve executable body lines; validation plans should only emit commands with runner evidence; and the rg claim should stay a validated compatibility set.
-- Broad generated roots still need guardrails before unattended agent use.
+- Broad generated roots have an explicit guardrail path: unbounded `tg search --files --hidden` scans and no-ignore/unrestricted fallback scans through generated/cache/dependency directories should be refused unless bounded with `--glob`, `--type`, or `--max-depth`, or explicitly opted in with `--allow-broad-generated-scan`.
 - Windows/WSL installer shims are materially cleaner. Direct `.cmd` invocation from PowerShell still cannot receive an unescaped `|` because `cmd.exe` parses it before the batch file receives argv; use normal PowerShell `tg` / `tg.ps1` for regex metacharacters.
 - Dev-path native safety should ignore stale in-tree standalone binaries unless `TG_NATIVE_TG_BINARY` pins one explicitly; `uv run tg doctor --json` should report skipped stale candidates instead of letting searches validate through old native code.
 - Raw unsorted root output is semantic parity. Use `--sort path --format rg` for automation that needs deterministic ripgrep-style stdout.
 
 Current next work:
 
-1. Keep the fast agent-readiness gate (`python scripts/agent_readiness.py --output artifacts/agent_readiness.json`) covering context-render trust, `context_consistency`, sorted rg edge parity, AST smoke, MCP smoke, shell version probes, and docs claim checks.
-2. Add progress, partial output, or stronger guardrails for broad generated-root scans.
+1. Keep the fast agent-readiness gate (`python scripts/agent_readiness.py --output artifacts/agent_readiness.json`) covering context-render trust, `context_consistency`, sorted rg edge parity, broad generated-root scan guardrails, AST smoke, MCP smoke, shell version probes, and docs claim checks.
+2. Add progress or partial output for explicitly opted-in broad generated-root scans.
 3. Calibrate or de-emphasize `impact --symbol` so agents prefer `blast-radius` for direct symbol impact.
 4. Track public shim performance, AST parity roadmap, GPU readiness, and classify provider/cache UX as blockers for a future "100% ready" claim.
 5. Continue dogfooding and preserve exact failing commands as product evidence.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -48,10 +48,11 @@ Agent automation contracts:
 - `--sort path` is the deterministic contract for `--files-with-matches`, `--files-without-match`, `--replace`, and path-list automation. The parity suite also checks match, no-match, parse-error, and binary-skip exit-code behavior.
 - Default output ordering for root-scale `--files-with-matches`, `--count`, and `--force-cpu` is a semantic result parity contract, not a golden stdout ordering contract. Use `--sort path` when automation needs deterministic path ordering across backends.
 - Broad generated roots such as `.claude` are routed through Python guardrails instead of rust-first/native passthrough so generated `.claude/context` snapshots can be pruned by default.
+- Unbounded broad generated-root scan requests are refused with exit code `2` when hidden file-list scans or no-ignore/unrestricted fallback search paths contain generated, cache, or dependency directories. Scope the path, add `--glob`, `--type`, or `--max-depth`, or pass `--allow-broad-generated-scan` to make the large generated-tree walk explicit.
 - `tg search --type-list` prints a built-in fallback list when no ripgrep or standalone native binary is available. `--pcre2-version` follows ripgrep semantics and exits with an error when no PCRE2-capable backend is available.
 - `tg ast-info --json` exposes AST language identifiers via `{"languages": [...]}` for agent discovery without help-text scraping.
 - On Windows, PowerShell automation should invoke `tg` or `tg.ps1` for regex metacharacters. Direct `.cmd` invocation from PowerShell is not a safe argv-preserving contract for unescaped metacharacters such as `|` because `cmd.exe` parses the line before the batch wrapper receives arguments; `tg.cmd` is for `cmd.exe`.
-- The fast agent-readiness dogfood gate is `python scripts/agent_readiness.py --output artifacts/agent_readiness.json`. For the current `v1.8.22` line it checks public shell version probes, repo doctor sanity, `context_consistency`, deterministic rg parity edges, AST smoke, MCP context-render smoke, docs claim hygiene, and the public positioning that `rg` remains the cold exact-text baseline while `ast-grep` remains the structural-search feature/performance baseline.
+- The fast agent-readiness dogfood gate is `python scripts/agent_readiness.py --output artifacts/agent_readiness.json`. For the current `v1.8.22` line it checks public shell version probes, repo doctor sanity, `context_consistency`, deterministic rg parity edges, broad generated-root scan guardrails, AST smoke, MCP context-render smoke, docs claim hygiene, and the public positioning that `rg` remains the cold exact-text baseline while `ast-grep` remains the structural-search feature/performance baseline.
 
 Context and edit-planning contracts:
 - `context-render` and MCP context output must not let `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, rendered source sections, and follow-up reads contradict each other.
@@ -61,8 +62,8 @@ Context and edit-planning contracts:
 - Repo-map and context-ranking defaults exclude generated/cache/dependency directories, binary files, logs, and hidden non-code files from normal code context.
 
 Known current limitations:
-- Broad plain path-list output from `tg search --files ...` over generated artifact trees can still be expensive. The Python path-list output path and managed Windows launchers force UTF-8, but scope file-list commands to the smallest useful root.
-- Broad generated roots can still be expensive for unattended agents. Use scoped paths, globs, file types, and `--max-depth` for `tg search`; `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
+- Explicitly opted-in broad generated-root walks can still be expensive. The Python path-list output path and managed Windows launchers force UTF-8, but scope file-list commands to the smallest useful root whenever possible.
+- Broad generated roots remain agent-hostile when callers opt in to them. Use scoped paths, globs, file types, and `--max-depth` for `tg search` before reaching for opt-in; `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
 - `impact --symbol` is a broader planning signal and can be noisier than `blast-radius`; use `blast-radius` for direct symbol impact checks.
 
 ## 4. Machine-readable CLI output (`--json` and `--ndjson`)

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -100,19 +100,19 @@ For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and m
 
 - `rg` remains the raw cold exact-text benchmark. `tg` should win on agent-native code intelligence, not by pretending every grep workload is faster.
 - `ast-grep` remains the structural-search feature/performance baseline until the AST compatibility roadmap is closed with tests and benchmark evidence.
-- Broad generated roots can still be agent-hostile. Use scoped paths, globs, file types, and `--max-depth` for `tg search`; `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
+- Broad generated roots remain agent-hostile when callers opt into them. Unbounded `tg search --files --hidden` scans and no-ignore/unrestricted fallback scans through generated/cache/dependency directories are refused unless the request is bounded with `--glob`, `--type`, or `--max-depth`, or explicitly opts in with `--allow-broad-generated-scan`. Use scoped paths, globs, file types, and `--max-depth` for `tg search` before reaching for opt-in. `--max-repo-files`, `--max-callers`, and `--max-files` are code-intelligence command budgets, not `tg search` flags.
 - `impact --symbol` is still less trustworthy than `blast-radius` for direct symbol impact.
 - `validation_commands` can still be heuristic when stack evidence is partial. Treat targeted commands as hints, not proof of full coverage; require `validation_plan[].detection`, do not trust npm/package-manager hints without `package.json` evidence, and omit commands entirely when no runner evidence exists.
 - Local `uv run tg doctor --json` can find stale in-tree standalone binaries at `rust_core/target/debug/tg.exe` or `rust_core/target/release/tg.exe`. Current dev-path safety should ignore them for implicit native delegation, report them under `skipped_native_tg_binaries`, set `rust_binary_version_status = stale-skipped`, and keep `search_acceleration_backend = rust-core-extension` when the embedded extension is available. Rebuild with `C:/Users/oimir/.cargo/bin/cargo.exe build --manifest-path rust_core/Cargo.toml --release` or pin `TG_NATIVE_TG_BINARY` to opt in to a specific standalone binary.
-- Broad `tg search --files ...` over generated artifact trees can still be expensive. The managed Windows launchers and Python path-list output should force UTF-8, but scope file-list commands to the smallest useful root.
+- Explicitly opted-in broad `tg search --files ...` over generated artifact trees can still be expensive. The managed Windows launchers and Python path-list output should force UTF-8, but scope file-list commands to the smallest useful root.
 - Root-scale unsorted `--files-with-matches`, `--count`, and `--force-cpu` can still differ from raw `rg` in output ordering even when the file set and counts match. Use `--sort path` for deterministic path ordering and `--format rg` for exact ripgrep-style text formatting before claiming golden stdout parity; sorted files-with-matches, files-without-match, and replacement output are now regression-covered parity edges on the active branch.
 - Directly invoking `C:\Users\oimir\bin\tg.cmd` from PowerShell with an unescaped metacharacter such as `|` is still a `cmd.exe` parser limitation; use normal PowerShell `tg` / `tg.ps1` or quote the metacharacter argument for `cmd.exe`.
 - Always verify command resolution with `tg --version`, `cmd /c tg --version`, `pwsh -NoProfile -Command "tg --version"`, `where.exe tg`, `Get-Command tg -All`, and WSL `wsl bash -lc 'command -v tg; tg --version'` after installer changes. A stale `Python*\Scripts\tg.exe` returning an older tensor-grep version is a release blocker.
 
 ## Next Highest-Value Work
 
-1. Keep the agent-readiness dogfood gate (`python scripts/agent_readiness.py --output artifacts/agent_readiness.json`) fast and representative; it should cover context trust, rg sorted edges, AST smoke, MCP smoke, shell version probes, and docs claim checks.
-2. Add progress, partial output, or stronger guardrails for broad generated-root scans.
+1. Keep the agent-readiness dogfood gate (`python scripts/agent_readiness.py --output artifacts/agent_readiness.json`) fast and representative; it should cover context trust, rg sorted edges, broad generated-root scan guardrails, AST smoke, MCP smoke, shell version probes, and docs claim checks.
+2. Add progress or partial output for explicitly opted-in broad generated-root scans.
 3. Calibrate or de-emphasize `impact --symbol` so agents prefer `blast-radius` for direct impact.
 4. Track public shim performance, AST parity roadmap gaps, GPU benchmark/no-match cleanup, and `classify` provider/cache UX as blockers for a future "world-class" claim, not as blockers for this correctness PR.
 5. Keep dogfooding `tg` first and record exact failing commands, exit codes, and outputs as product evidence.
@@ -137,8 +137,10 @@ uv run tg search --fixed-strings "safeParseJSON" src tests docs -C 2
 uv run pytest tests/unit/test_ripgrep_backend.py tests/unit/test_cli_modes.py tests/unit/test_ast_parity.py -q
 ```
 
-Avoid broad generated-root file-list probes unless the task needs them:
+Avoid broad generated-root file-list probes unless the task needs them. Bound the request or opt in explicitly:
 
 ```powershell
-tg search --files "AGENTS.md" . --hidden
+tg search --files . --hidden --glob "*.py"
+tg search --files . --hidden --max-depth 3
+tg search --files . --hidden --no-ignore --allow-broad-generated-scan
 ```

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -184,6 +184,7 @@ def validate_docs_claims(_stdout: str, repo_root: Path, expected_version: str) -
         "python scripts/agent_readiness.py",
         "context_consistency",
         "validated compatibility set",
+        "broad generated-root scan",
         "rg` remains",
         "ast-grep",
     ]
@@ -285,6 +286,20 @@ def build_check_plan(
             command=["uv", "run", "pytest", "tests/e2e/test_rg_parity_edges.py", "-q"],
             description="Verify deterministic rg parity edge cases.",
             timeout_s=180,
+        ),
+        Check(
+            name="broad-generated-scan-guard",
+            command=[
+                "uv",
+                "run",
+                "pytest",
+                "tests/unit/test_cli_modes.py",
+                "-q",
+                "-k",
+                "broad_generated_root_scan",
+            ],
+            description="Verify broad generated-root file-list scans require bounds or opt-in.",
+            timeout_s=120,
         ),
         Check(
             name="ast-info-json",

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -26,6 +26,7 @@ _TG_ONLY_SEARCH_FLAGS = {
     "--generate",
     "--glob",
     "--gpu-device-ids",
+    "--allow-broad-generated-scan",
     "--json",
     "--ndjson",
     "--pcre2-version",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -47,6 +47,23 @@ _DEFAULT_AGENT_REPO_SCAN_LIMIT = 512
 _DEFAULT_BLAST_RADIUS_JSON_MAX_CALLERS = 25
 _DEFAULT_BLAST_RADIUS_JSON_MAX_FILES = 25
 _GUARDED_BROAD_SEARCH_ROOTS = {".claude", ".claude/context"}
+_BROAD_GENERATED_SCAN_DIR_NAMES = {
+    "__pycache__",
+    ".claude",
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "artifacts",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+    "venv",
+}
 _GUARDED_BROAD_ROOT_RG_GLOBS = (
     "!context/**",
     "!**/context/**",
@@ -1021,6 +1038,68 @@ def _config_with_guarded_broad_root_globs(config: "SearchConfig") -> "SearchConf
         if glob not in existing_globs:
             existing_globs.append(glob)
     return replace(config, glob=existing_globs)
+
+
+def _generated_scan_dir_names(paths: list[str]) -> list[str]:
+    found: set[str] = set()
+    generated_names = {name.lower() for name in _BROAD_GENERATED_SCAN_DIR_NAMES}
+    for raw_path in paths:
+        if not raw_path or raw_path == "-" or raw_path.startswith("-"):
+            continue
+        path = Path(raw_path)
+        try:
+            if path.is_dir() and path.name.lower() in generated_names:
+                found.add(path.name)
+            if not path.is_dir():
+                continue
+            for child in path.iterdir():
+                if child.is_dir() and child.name.lower() in generated_names:
+                    found.add(child.name)
+        except OSError:
+            continue
+    return sorted(found, key=lambda item: item.lower())
+
+
+def _has_generated_scan_bound(config: "SearchConfig") -> bool:
+    return bool(
+        config.max_depth is not None
+        or config.glob
+        or config.iglob
+        or config.file_type
+        or config.type_not
+    )
+
+
+def _should_refuse_unbounded_generated_scan(
+    paths: list[str],
+    config: "SearchConfig",
+    *,
+    allow_broad_generated_scan: bool,
+    files_mode: bool,
+) -> tuple[bool, list[str]]:
+    if allow_broad_generated_scan or _has_generated_scan_bound(config):
+        return False, []
+    if not (
+        (files_mode and config.hidden)
+        or config.no_ignore
+        or config.no_ignore_files
+        or config.no_ignore_vcs
+        or config.unrestricted > 0
+    ):
+        return False, []
+    generated_dirs = _generated_scan_dir_names(paths)
+    return bool(generated_dirs), generated_dirs
+
+
+def _format_broad_generated_scan_error(generated_dirs: list[str]) -> str:
+    visible_dirs = ", ".join(generated_dirs[:8])
+    if len(generated_dirs) > 8:
+        visible_dirs = f"{visible_dirs}, ..."
+    return (
+        "Error: broad generated-root scan refused: path contains generated, cache, "
+        f"or dependency directories ({visible_dirs}). Scope the path, add --glob, --type, "
+        "or --max-depth, or pass --allow-broad-generated-scan to opt in."
+    )
 
 
 def _sum_total_bytes(paths: list[str]) -> int:
@@ -2645,6 +2724,14 @@ def search_command(
         "--gpu-device-ids",
         help="Comma-separated GPU IDs to pin this search request to (e.g. 0,1).",
     ),
+    allow_broad_generated_scan: bool = typer.Option(
+        False,
+        "--allow-broad-generated-scan",
+        help=(
+            "Permit unbounded file-list/search scans through generated, cache, or dependency "
+            "directories. Prefer scoped paths, --glob, --type, or --max-depth for agent runs."
+        ),
+    ),
 ) -> None:
     """
     Search files for a regex pattern, with GPU acceleration when applicable.
@@ -2840,6 +2927,15 @@ def search_command(
     explicit_hidden_search_root = not config.hidden and any(
         _path_has_hidden_component(path) for path in paths_to_search
     )
+    refuse_generated_scan, generated_scan_dirs = _should_refuse_unbounded_generated_scan(
+        paths_to_search,
+        config,
+        allow_broad_generated_scan=allow_broad_generated_scan,
+        files_mode=files,
+    )
+    if refuse_generated_scan:
+        typer.echo(_format_broad_generated_scan_error(generated_scan_dirs), err=True)
+        raise typer.Exit(2)
 
     native_tg_binary = resolve_native_tg_binary()
     if (

--- a/tests/unit/test_agent_readiness_script.py
+++ b/tests/unit/test_agent_readiness_script.py
@@ -33,6 +33,7 @@ def test_agent_readiness_plan_should_cover_agent_critical_surfaces() -> None:
     assert "repo-doctor" in names
     assert "context-render-trust" in names
     assert "rg-parity-edges" in names
+    assert "broad-generated-scan-guard" in names
     assert "ast-info-json" in names
     assert "ast-run-smoke" in names
     assert "mcp-context-render-smoke" in names
@@ -41,6 +42,11 @@ def test_agent_readiness_plan_should_cover_agent_critical_surfaces() -> None:
     rg_check = next(check for check in checks if check.name == "rg-parity-edges")
     assert rg_check.timeout_s <= 180
     assert rg_check.command[:4] == ["uv", "run", "pytest", "tests/e2e/test_rg_parity_edges.py"]
+
+    broad_scan_check = next(check for check in checks if check.name == "broad-generated-scan-guard")
+    assert broad_scan_check.timeout_s <= 120
+    assert broad_scan_check.command[:4] == ["uv", "run", "pytest", "tests/unit/test_cli_modes.py"]
+    assert "broad_generated_root_scan" in broad_scan_check.command
 
     mcp_check = next(check for check in checks if check.name == "mcp-context-render-smoke")
     assert "test_tg_context_render_mcp_preserves_invoice_tax_body_and_primary_target" in (

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -19,6 +19,7 @@ from tensor_grep.cli import repo_map
 from tensor_grep.cli.main import (
     _safe_stdout_line,
     _select_ast_backend_for_pattern,
+    _should_refuse_unbounded_generated_scan,
     _write_path_list,
     app,
 )
@@ -372,6 +373,102 @@ def test_files_mode_lists_candidates_without_pattern(monkeypatch):
 
     assert result.exit_code == 0
     assert result.stdout.strip().splitlines() == ["a.py", "b.py"]
+
+
+def test_files_mode_refuses_unbounded_broad_generated_root_scan(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--files", str(tmp_path), "--hidden"])
+
+    assert result.exit_code == 2
+    assert "broad generated-root scan refused" in result.output
+    assert "node_modules" in result.output
+    assert "--glob" in result.output
+    assert "--max-depth" in result.output
+    assert "--allow-broad-generated-scan" in result.output
+
+
+def test_files_mode_allows_bounded_broad_generated_root_scan(monkeypatch, tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakePipeline)
+
+    result = CliRunner().invoke(
+        app,
+        ["search", "--files", str(tmp_path), "--hidden", "--glob", "*.py"],
+    )
+
+    assert result.exit_code == 0
+    assert "src" in result.stdout
+    assert "app.py" in result.stdout
+    assert "node_modules" not in result.stdout
+
+
+def test_files_mode_allows_explicit_broad_generated_root_scan(monkeypatch, tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakePipeline)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "search",
+            "--files",
+            str(tmp_path),
+            "--hidden",
+            "--no-ignore",
+            "--allow-broad-generated-scan",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "src" in result.stdout
+    assert "app.py" in result.stdout
+    assert "node_modules" in result.stdout
+    assert "pkg.js" in result.stdout
+
+
+def test_plain_hidden_search_does_not_trigger_broad_generated_root_guard(
+    tmp_path: Path,
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+
+    refused, generated_dirs = _should_refuse_unbounded_generated_scan(
+        [str(tmp_path)],
+        SearchConfig(hidden=True),
+        allow_broad_generated_scan=False,
+        files_mode=False,
+    )
+
+    assert refused is False
+    assert generated_dirs == []
+
+
+def test_no_ignore_search_triggers_broad_generated_root_guard(
+    tmp_path: Path,
+):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+
+    refused, generated_dirs = _should_refuse_unbounded_generated_scan(
+        [str(tmp_path)],
+        SearchConfig(no_ignore=True),
+        allow_broad_generated_scan=False,
+        files_mode=False,
+    )
+
+    assert refused is True
+    assert generated_dirs == ["node_modules"]
 
 
 def test_glob_case_insensitive_matches_case_folded_paths(

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -38,6 +38,8 @@ def test_contracts_should_record_windows_shell_and_ordering_limits() -> None:
     contracts = CONTRACTS_DOC_PATH.read_text(encoding="utf-8")
 
     assert "Direct `.cmd` invocation from PowerShell" in contracts
+    assert "--allow-broad-generated-scan" in contracts
+    assert "broad generated-root scan" in contracts
     assert "semantic result parity" in contracts
     assert "validated compatibility set" in contracts
     assert "`--sort path`" in contracts
@@ -86,6 +88,7 @@ def test_handoff_docs_should_record_current_v1822_release_state_and_fast_gate() 
     assert "context_consistency" in handoff
     assert "no runner evidence exists" in handoff
     assert "agent-readiness dogfood gate" in handoff
+    assert "--allow-broad-generated-scan" in handoff
 
 
 def test_routing_policy_should_describe_current_native_and_fallback_routes() -> None:


### PR DESCRIPTION
## Summary
- refuse unbounded broad generated/cache/dependency root scans unless callers bound the search or explicitly opt in
- add `--allow-broad-generated-scan` as the public opt-in and keep it out of native/rg passthrough
- add the guard to the fast agent-readiness gate and update docs/skills/contracts

## Local Validation
- `git diff --check`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `uv run pytest tests/unit/test_cli_modes.py tests/unit/test_agent_readiness_script.py tests/unit/test_public_docs_governance.py tests/unit/test_cli_bootstrap.py tests/e2e/test_rg_parity_edges.py -q`
- `python scripts/agent_readiness.py --output artifacts/agent_readiness.json`
- `uv run pytest -q`
- `python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.json`
- `python benchmarks/check_regression.py --baseline auto --current artifacts/bench_run_benchmarks.json --allow-env-mismatch`

## Benchmark Note
The regression checker required `--allow-env-mismatch` because the stored auto baseline was Python 3.12.12 and this run used Python 3.14.4. With the override, all benchmark parity rows passed and no tensor-grep regression was detected.