### PR TITLE
fix: harden v1.8.23 dogfood regressions

### DIFF
--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -1341,7 +1341,7 @@ Capability modes:
 | `tools[].mode` | `string` | One of `python-local`, `embedded-safe`, or `native-required`. |
 | `tools[].native_required` | `boolean` | True for tools that cannot run without standalone native `tg`. |
 | `tools[].embedded_fallback` | `boolean` | True for tools with simple embedded rewrite fallback. |
-| `tools[].native_required_options` | `array<string>` | Options that make an otherwise embedded-safe tool require standalone native `tg`; for `tg_rewrite_apply`, this includes `verify`, `checkpoint`, `audit_manifest`, `audit_signing_key`, `lint_cmd`, and `test_cmd`. |
+| `tools[].native_required_options` | `array<string>` | Options that make an otherwise embedded-safe tool require standalone native `tg`; for `tg_rewrite_apply`, this includes `verify`, `audit_manifest`, `audit_signing_key`, `lint_cmd`, and `test_cmd`. Checkpointed apply can use the embedded fallback. |
 | `tools[].notes` | `string` | Human-readable routing note. |
 
 Native-unavailable error responses use `error.code = "unavailable"`, `routing_reason = "native-tg-unavailable"`, include the `tool` name, and include `error.remediation` with `TG_NATIVE_TG_BINARY` guidance.

--- a/docs/harness_cookbook.md
+++ b/docs/harness_cookbook.md
@@ -255,8 +255,8 @@ Recommended consumer behavior:
 1. call `tg_mcp_capabilities` before picking rewrite/index tools in PyPI or sandboxed installs
 2. preserve machine-readable envelopes from each tool instead of scraping prose
 3. treat `native-required` tools as unavailable unless `native_tg.available = true`
-4. inspect `native_required_options` before calling `tg_rewrite_apply`; `verify`, `checkpoint`, `audit_manifest`, `audit_signing_key`, `lint_cmd`, and `test_cmd` require standalone native `tg`
-5. use simple `tg_rewrite_plan` / `tg_rewrite_apply` as the embedded-safe fallback when native `tg` is unavailable
+4. inspect `native_required_options` before calling `tg_rewrite_apply`; `verify`, `audit_manifest`, `audit_signing_key`, `lint_cmd`, and `test_cmd` require standalone native `tg`
+5. use simple `tg_rewrite_plan` / `tg_rewrite_apply`, including checkpointed apply, as the embedded-safe fallback when native `tg` is unavailable
 6. treat `tg_edit_plan` as the plan contract and `tg_rewrite_apply` as the patch-attempt plus validation contract
 7. use `tg_audit_manifest_verify` when the workflow needs trust or replay validation
 8. if final outcome needs benchmark-style scoring, hand the produced patch artifact to `run_patch_bakeoff.py`

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -246,6 +246,10 @@ class RipgrepBackend(ComputeBackend):
                 cmd.append("-x")
             if config.fixed_strings:
                 cmd.append("-F")
+            if config.multiline:
+                cmd.append("--multiline")
+            if config.multiline_dotall:
+                cmd.append("--multiline-dotall")
             if config.no_ignore:
                 cmd.append("--no-ignore")
             if config.only_matching:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -1129,7 +1129,6 @@ def _can_passthrough_rg(
     return bool(
         not config.ast
         and not config.ltl
-        and not config.pcre2
         and not config.force_cpu
         and format_type == "rg"
         and not json_mode
@@ -1500,7 +1499,7 @@ def _load_inline_rule_specs(
                 pattern = _extract_rule_pattern(item)
                 if not pattern:
                     continue
-                specs.append({
+                spec = {
                     "id": str(item.get("id") or f"inline-rule-{document_index}-{rule_index}"),
                     "pattern": pattern,
                     "language": str(
@@ -1509,17 +1508,27 @@ def _load_inline_rule_specs(
                         or default_language
                         or "python"
                     ),
-                })
+                }
+                for metadata_key in ("severity", "message"):
+                    if item.get(metadata_key) is not None:
+                        spec[metadata_key] = str(item[metadata_key])
+                    elif payload.get(metadata_key) is not None:
+                        spec[metadata_key] = str(payload[metadata_key])
+                specs.append(spec)
             continue
 
         pattern = _extract_rule_pattern(payload)
         if not pattern:
             continue
-        specs.append({
+        spec = {
             "id": str(payload.get("id") or f"inline-rule-{document_index}"),
             "pattern": pattern,
             "language": str(payload.get("language") or default_language or "python"),
-        })
+        }
+        for metadata_key in ("severity", "message"):
+            if payload.get(metadata_key) is not None:
+                spec[metadata_key] = str(payload[metadata_key])
+        specs.append(spec)
 
     return specs
 

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -102,7 +102,6 @@ _MCP_TOOL_CAPABILITIES: dict[str, dict[str, object]] = {
             "native_required_options": (
                 [
                     "verify",
-                    "checkpoint",
                     "audit_manifest",
                     "audit_signing_key",
                     "lint_cmd",
@@ -668,15 +667,16 @@ def execute_rewrite_apply_json(
             )
 
     native_tg, _native_error = _resolve_native_tg_binary_for_mcp()
+    checkpoint_payload: dict[str, Any] | None = None
     if native_tg is None:
-        if verify or checkpoint or audit_manifest or audit_signing_key or lint_cmd or test_cmd:
+        if verify or audit_manifest or audit_signing_key or lint_cmd or test_cmd:
             return (
                 _native_unavailable_error(
                     tool="tg_rewrite_apply",
                     payload=_rewrite_envelope(),
                     message=(
                         "tg_rewrite_apply requires a standalone native tg binary for "
-                        "verify, checkpoint, audit, lint, or test rewrite apply options."
+                        "verify, audit, lint, or test rewrite apply options."
                     ),
                 ),
                 1,
@@ -693,6 +693,13 @@ def execute_rewrite_apply_json(
                 ),
                 1,
             )
+        if checkpoint:
+            try:
+                from tensor_grep.cli.checkpoint_store import create_checkpoint
+
+                checkpoint_payload = create_checkpoint(path).__dict__
+            except Exception as exc:
+                return _rewrite_error(f"Failed to create checkpoint: {exc}", code="checkpoint"), 1
         rewrite_json = _execute_embedded_rewrite_json(
             pattern=pattern,
             replacement=replacement,
@@ -716,6 +723,9 @@ def execute_rewrite_apply_json(
         )
         rewrite_json = _execute_rewrite_json_command(command)
     rewrite_payload = json.loads(rewrite_json)
+    if checkpoint_payload is not None:
+        rewrite_payload["checkpoint"] = checkpoint_payload
+        rewrite_json = json.dumps(rewrite_payload, indent=2)
     if rewrite_payload.get("error"):
         return rewrite_json, 1
     if loaded_policy is None:

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4045,12 +4045,20 @@ def _symbol_lookup_key(text: str) -> str:
 
 
 def _symbol_name_matches_query_exactly(symbol_name: str, query: str) -> bool:
+    return any(symbol_name == token for token in re.findall(r"[A-Za-z0-9_]+", query))
+
+
+def _symbol_name_matches_query_bridge(symbol_name: str, query: str) -> bool:
     symbol_key = _symbol_lookup_key(symbol_name)
     if not symbol_key:
         return False
     if symbol_key == _symbol_lookup_key(query):
-        return True
-    return any(symbol_key == _symbol_lookup_key(token) for token in _query_terms(query))
+        return not _symbol_name_matches_query_exactly(symbol_name, query)
+    return any(
+        symbol_key == _symbol_lookup_key(token)
+        for token in _query_terms(query)
+        if symbol_name != token
+    )
 
 
 def _score_file_path(path: str, terms: list[str]) -> int:
@@ -4639,11 +4647,14 @@ def _build_context_pack_from_map(
             if _is_test_file(Path(current_path)):
                 continue
             symbol_name_score = _score_text_terms(str(scored_symbol["name"]), symbol_terms)
-            if symbol_name_score > 0 and _symbol_name_matches_query_exactly(
-                str(scored_symbol["name"]),
-                query,
-            ):
-                scored_symbol["exact_query_match"] = True
+            symbol_name = str(scored_symbol["name"])
+            exact_query_match = _symbol_name_matches_query_exactly(symbol_name, query)
+            bridge_query_match = _symbol_name_matches_query_bridge(symbol_name, query)
+            if symbol_name_score > 0 and (exact_query_match or bridge_query_match):
+                if exact_query_match:
+                    scored_symbol["exact_query_match"] = True
+                elif bridge_query_match:
+                    scored_symbol["bridge_query_match"] = True
                 _append_reason(file_reasons, current_path, "definition")
                 _append_reason(file_reasons, current_path, "symbol")
             scored_symbols.append(scored_symbol)
@@ -4657,9 +4668,13 @@ def _build_context_pack_from_map(
         )
         for symbol in scored_symbols:
             current = str(symbol["file"])
-            exact_symbol_bonus = 12 if bool(symbol.get("exact_query_match")) else 0
+            exact_symbol_bonus = 36 if bool(symbol.get("exact_query_match")) else 0
+            bridge_symbol_bonus = 8 if bool(symbol.get("bridge_query_match")) else 0
             file_scores[current] = (
-                file_scores.get(current, 0) + int(symbol["score"]) * 3 + exact_symbol_bonus
+                file_scores.get(current, 0)
+                + int(symbol["score"]) * 3
+                + exact_symbol_bonus
+                + bridge_symbol_bonus
             )
 
         scored_imports: list[dict[str, Any]] = []
@@ -6081,7 +6096,7 @@ def _validation_plan_for_tests(
         or detected.js_script_command
         or detected.js_fallback_command
     )
-    has_python_validation = detected.python_detection in {"detected", "heuristic"}
+    has_python_validation = detected.python_detection == "detected"
     primary_symbol_name = (
         str(primary_symbol.get("name"))
         if isinstance(primary_symbol, dict) and primary_symbol.get("name")

--- a/src/tensor_grep/cli/rule_packs.py
+++ b/src/tensor_grep/cli/rule_packs.py
@@ -351,6 +351,13 @@ _RULE_PACKS: dict[str, dict[str, Any]] = {
                     "message": "Avoid hardcoding API key literals in source files.",
                 },
                 {
+                    "id": "python-hardcoded-api-key-uppercase",
+                    "pattern": 'API_KEY = "$SECRET"',
+                    "language": "python",
+                    "severity": "medium",
+                    "message": "Avoid hardcoding API key literals in source files.",
+                },
+                {
                     "id": "python-hardcoded-token",
                     "pattern": 'token = "$SECRET"',
                     "language": "python",

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -11,6 +11,7 @@ from typing import Any, TextIO, cast
 from uuid import uuid4
 
 from tensor_grep.cli.repo_map import (
+    _is_repo_context_file,
     _iter_repo_files,
     build_context_edit_plan_from_map,
     build_context_pack_from_map,
@@ -241,7 +242,12 @@ def _stale_changeset(payload: dict[str, Any]) -> dict[str, list[str]] | None:
     snapshot_by_path = {
         str(Path(str(entry["path"])).expanduser().resolve()): entry for entry in snapshot
     }
-    current_files = _iter_repo_files(root)
+    context_root = root if root.is_dir() else root.parent
+    current_files = [
+        current
+        for current in _iter_repo_files(root)
+        if _is_repo_context_file(current, context_root)
+    ]
     current_paths = {str(current): current for current in current_files}
 
     added = sorted(path for path in current_paths if path not in snapshot_by_path)

--- a/tests/e2e/test_rg_parity_edges.py
+++ b/tests/e2e/test_rg_parity_edges.py
@@ -23,6 +23,14 @@ def _write_edge_corpus(root: Path) -> None:
     (root / "b.txt").write_text("needle beta\n", encoding="utf-8")
     (root / "a.txt").write_text("needle alpha\n", encoding="utf-8")
     (root / "c.txt").write_text("plain text\n", encoding="utf-8")
+    (root / "pcre-z.txt").write_text("needle pcre\n", encoding="utf-8")
+    (root / "multi.py").write_text(
+        "# needle multiline fixture\n"
+        "def create_invoice(subtotal):\n"
+        "    tax = subtotal * 0.1\n"
+        "    return subtotal + tax\n",
+        encoding="utf-8",
+    )
     ignored_dir = root / "ignored"
     ignored_dir.mkdir()
     (ignored_dir / "z.txt").write_text("needle ignored\n", encoding="utf-8")
@@ -146,6 +154,36 @@ def test_rg_sorted_output_edges_match(
     _assert_same_rg_behavior(
         rg_args=rg_args,
         tg_args=tg_args,
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+def test_rg_pcre2_sorted_output_matches(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["--pcre2", "--sort", "path", r"need(le|ful)", "."],
+        tg_args=["--pcre2", "--sort", "path", r"need(le|ful)", "."],
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+def test_rg_multiline_output_matches(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["--multiline", r"create_invoice[\s\S]*return", "."],
+        tg_args=["--multiline", r"create_invoice[\s\S]*return", "."],
         root=root,
         env=env,
         rg_binary=rg_binary,

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -3659,6 +3659,24 @@ def test_cli_uses_ripgrep_passthrough_for_files_with_matches(monkeypatch):
     }
 
 
+def test_cli_pcre2_rg_format_is_passthrough_eligible() -> None:
+    from tensor_grep.cli.main import _can_passthrough_rg
+
+    config = SearchConfig(pcre2=True, sort_by="path")
+
+    assert _can_passthrough_rg(
+        config,
+        format_type="rg",
+        json_mode=False,
+        ndjson_mode=False,
+        files_mode=False,
+        files_with_matches=False,
+        files_without_match=False,
+        only_matching=False,
+        stats_mode=False,
+    )
+
+
 def test_cli_uses_implicit_rg_root_for_no_path_files_with_matches(monkeypatch):
     calls: dict[str, object] = {}
 
@@ -5276,6 +5294,68 @@ def test_scan_supports_inline_rules_text(monkeypatch, tmp_path: Path) -> None:
     assert "Scan completed. rules=1 matched_rules=1 total_matches=1" in result.output
 
 
+def test_scan_inline_rules_json_preserves_rule_metadata(monkeypatch, tmp_path: Path) -> None:
+    class AstGrepWrapperBackend:
+        def search_many(self, file_paths: list[str], pattern: str, config=None) -> SearchResult:
+            _ = config
+            matches: list[MatchLine] = []
+            matched_file_paths: list[str] = []
+
+            for file_path in file_paths:
+                candidate = Path(file_path)
+                expanded_paths = (
+                    sorted(str(path) for path in candidate.rglob("*") if path.is_file())
+                    if candidate.is_dir()
+                    else [file_path]
+                )
+                for expanded_path in expanded_paths:
+                    content = Path(expanded_path).read_text(encoding="utf-8")
+                    if pattern == "print($A)" and "print(" in content:
+                        matched_file_paths.append(expanded_path)
+                        matches.append(
+                            MatchLine(line_number=1, text="print('hello')", file=expanded_path)
+                        )
+
+            return SearchResult(
+                matches=matches,
+                matched_file_paths=matched_file_paths,
+                total_files=len(matched_file_paths),
+                total_matches=len(matches),
+                routing_backend="AstGrepWrapperBackend",
+                routing_reason="ast_grep_json",
+                routing_distributed=False,
+                routing_worker_count=1,
+            )
+
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._select_ast_backend_for_pattern",
+        lambda *_args, **_kwargs: AstGrepWrapperBackend(),
+    )
+
+    (tmp_path / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    inline_rules = "\n".join([
+        "id: no-print",
+        "language: python",
+        "severity: warning",
+        "message: Avoid print in library code.",
+        "rule:",
+        "  pattern: print($A)",
+    ])
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["scan", "--inline-rules", inline_rules, "--path", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    finding = payload["findings"][0]
+    assert finding["rule_id"] == "no-print"
+    assert finding["severity"] == "warning"
+    assert finding["message"] == "Avoid print in library code."
+
+
 def test_scan_builtin_ruleset_can_compare_and_write_baseline(monkeypatch):
     monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
     monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
@@ -5483,8 +5563,35 @@ def test_scan_executes_secrets_ruleset(monkeypatch):
     assert "Scanning project using built-in ruleset secrets-basic (python)" in result.output
     assert "[scan] rule=python-hardcoded-password lang=python matches=1 files=1" in result.output
     assert "[scan] rule=python-hardcoded-api-key lang=python matches=0 files=0" in result.output
+    assert (
+        "[scan] rule=python-hardcoded-api-key-uppercase lang=python matches=0 files=0"
+        in result.output
+    )
     assert "[scan] rule=python-hardcoded-token lang=python matches=0 files=0" in result.output
-    assert "Scan completed. rules=3 matched_rules=1 total_matches=1" in result.output
+    assert "Scan completed. rules=4 matched_rules=1 total_matches=1" in result.output
+
+
+def test_scan_executes_secrets_ruleset_uppercase_api_key(monkeypatch):
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
+    monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        from pathlib import Path
+
+        Path("a.py").write_text('API_KEY = "$SECRET"\n', encoding="utf-8")
+        Path("b.py").write_text("ok\n", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["scan", "--ruleset", "secrets-basic", "--language", "python", "--path", "."],
+        )
+
+    assert result.exit_code == 0
+    assert (
+        "[scan] rule=python-hardcoded-api-key-uppercase lang=python matches=1 files=1"
+        in result.output
+    )
 
 
 def test_scan_executes_secrets_ruleset_api_key_pattern(monkeypatch):

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -140,7 +140,6 @@ def _assert_enriched_edit_plan_seed(
     assert isinstance(edit_plan_seed["plan_trust_summary"], str)
     assert edit_plan_seed["plan_trust_summary"]
     assert isinstance(edit_plan_seed["validation_plan"], list)
-    assert edit_plan_seed["validation_plan"]
     for step in edit_plan_seed["validation_plan"]:
         assert {"command", "scope", "runner", "confidence", "detection"} <= set(step)
         assert step["scope"] in {"symbol", "file", "repo"}
@@ -929,7 +928,6 @@ def test_tg_mcp_capabilities_is_registered_and_reports_no_native_runtime(monkeyp
     assert tools["tg_rewrite_apply"]["mode"] == "embedded-safe"
     assert tools["tg_rewrite_apply"]["native_required_options"] == [
         "verify",
-        "checkpoint",
         "audit_manifest",
         "audit_signing_key",
         "lint_cmd",
@@ -1127,6 +1125,32 @@ def test_execute_rewrite_apply_json_should_use_embedded_rust_when_native_binary_
     assert exit_code == 0
     assert payload["plan"]["total_edits"] == 1
     assert payload["plan"]["edits"][0]["replacement_text"] == "lambda x, y: x + y"
+    assert source.read_text(encoding="utf-8") == "lambda x, y: x + y\n"
+
+
+def test_execute_rewrite_apply_json_embedded_checkpoint_when_native_binary_missing(
+    monkeypatch, tmp_path: Path
+):
+    from tensor_grep.cli import mcp_server
+
+    source = tmp_path / "sample.py"
+    source.write_text("def add(x, y): return x + y\n", encoding="utf-8")
+
+    monkeypatch.setattr(mcp_server, "resolve_native_tg_binary", lambda: None)
+
+    payload_json, exit_code = mcp_server.execute_rewrite_apply_json(
+        pattern="def $F($$$ARGS): return $EXPR",
+        replacement="lambda $$$ARGS: $EXPR",
+        lang="python",
+        path=str(source),
+        checkpoint=True,
+    )
+
+    payload = json.loads(payload_json)
+    assert exit_code == 0
+    assert payload["plan"]["total_edits"] == 1
+    assert payload["checkpoint"]["checkpoint_id"].startswith("ckpt-")
+    assert payload["checkpoint"]["file_count"] >= 1
     assert source.read_text(encoding="utf-8") == "lambda x, y: x + y\n"
 
 
@@ -1871,7 +1895,7 @@ def test_tg_session_context_render_uses_cached_repo_map(tmp_path):
     assert rendered["graph_trust_summary"]["edge_kind"] == "reverse-import"
     assert rendered["candidate_edit_targets"]["ranking_quality"] == rendered["ranking_quality"]
     assert rendered["candidate_edit_targets"]["coverage_summary"] == rendered["coverage_summary"]
-    assert rendered["edit_plan_seed"]["validation_commands"] == ["uv run pytest -q"]
+    assert rendered["edit_plan_seed"]["validation_commands"] == []
     _assert_enriched_edit_plan_seed(
         rendered["edit_plan_seed"],
         primary_file=sample_path,

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -131,6 +131,29 @@ def test_passthrough_should_forward_editor_output_flags():
     assert exit_code == 0
 
 
+def test_passthrough_should_forward_multiline_flags():
+    backend = RipgrepBackend()
+    config = SearchConfig(multiline=True, multiline_dotall=True)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch(
+            "tensor_grep.backends.ripgrep_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        exit_code = backend.search_passthrough(
+            ["src"], r"create_invoice[\s\S]*return", config=config
+        )
+
+    cmd = run.call_args[0][0]
+    assert "--multiline" in cmd
+    assert "--multiline-dotall" in cmd
+    assert exit_code == 0
+
+
 def test_search_should_emit_runtime_routing_metadata():
     backend = RipgrepBackend()
 

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -363,6 +363,104 @@ def test_session_context_can_auto_refresh_stale_session(tmp_path: Path) -> None:
     assert any(symbol["name"] == "settle_invoice" for symbol in payload["symbols"])
 
 
+def test_session_context_does_not_go_stale_from_non_context_files(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    module_path = src_dir / "payments.py"
+    module_path.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+    (project / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (project / "debug.log").write_text("create invoice noise\n", encoding="utf-8")
+
+    runner = CliRunner()
+    opened = json.loads(runner.invoke(app, ["session", "open", str(project), "--json"]).stdout)
+
+    result = runner.invoke(
+        app,
+        [
+            "session",
+            "context",
+            opened["session_id"],
+            str(project),
+            "--query",
+            "create invoice",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["files"][0] == str(module_path.resolve())
+
+
+def test_session_refresh_on_stale_recovers_after_context_file_change(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    module_path = src_dir / "payments.py"
+    module_path.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+    (project / ".gitignore").write_text("*.log\n", encoding="utf-8")
+
+    runner = CliRunner()
+    opened = json.loads(runner.invoke(app, ["session", "open", str(project), "--json"]).stdout)
+    module_path.write_text(
+        "def create_invoice():\n    return 1\n\ndef issue_refund():\n    return create_invoice()\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "session",
+            "context",
+            opened["session_id"],
+            str(project),
+            "--query",
+            "issue refund",
+            "--refresh-on-stale",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["session_id"] == opened["session_id"]
+    assert any(symbol["name"] == "issue_refund" for symbol in payload["symbols"])
+
+
+def test_session_context_render_omits_validation_commands_without_runner_evidence(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    module_path = src_dir / "sample.py"
+    module_path.write_text("def add(x):\n    return x + 1\n", encoding="utf-8")
+
+    runner = CliRunner()
+    opened = json.loads(runner.invoke(app, ["session", "open", str(project), "--json"]).stdout)
+
+    result = runner.invoke(
+        app,
+        [
+            "session",
+            "context-render",
+            opened["session_id"],
+            str(project),
+            "--query",
+            "add",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["files"] == [str(module_path.resolve())]
+    assert payload["edit_plan_seed"]["validation_commands"] == []
+    assert payload["edit_plan_seed"]["validation_plan"] == []
+    assert payload["navigation_pack"]["validation_commands"] == []
+
+
 def test_session_serve_reports_cache_stats(tmp_path: Path) -> None:
     from tensor_grep.cli import session_store
 

--- a/tests/unit/test_trust_planning.py
+++ b/tests/unit/test_trust_planning.py
@@ -226,6 +226,51 @@ def test_exact_camel_case_symbol_query_dominates_natural_language_scores(
     assert payload["edit_plan_seed"]["primary_file"] == str(paths["app"].resolve())
 
 
+def test_exact_symbol_query_does_not_mark_snake_case_bridge_as_literal() -> None:
+    assert repo_map._symbol_name_matches_query_exactly("createInvoice", "createInvoice")
+    assert repo_map._symbol_name_matches_query_exactly("create_invoice", "create_invoice")
+    assert not repo_map._symbol_name_matches_query_exactly("create_invoice", "createInvoice")
+
+
+def test_cli_context_render_exact_symbol_query_prefers_literal_symbol(
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+
+    payments_path = src_dir / "aaa_payments.py"
+    payments_path.write_text(
+        "TAX_RATE = 0.0825\n\n"
+        "def create_invoice(subtotal: float) -> dict[str, float]:\n"
+        "    tax = subtotal * TAX_RATE\n"
+        "    total = subtotal + tax\n"
+        "    return {'subtotal': subtotal, 'tax': tax, 'total': total}\n\n"
+        "def create_invoice_receipt(subtotal: float) -> str:\n"
+        "    invoice = create_invoice(subtotal)\n"
+        "    return f\"invoice total {invoice['total']}\"\n",
+        encoding="utf-8",
+    )
+    app_path = src_dir / "zzz_app.ts"
+    app_path.write_text(
+        "export function createInvoice(subtotal: number) {\n  return { subtotal };\n}\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["context-render", "--query", "createInvoice", "--json", str(project)],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["files"][0] == str(app_path.resolve())
+    assert payload["edit_plan_seed"]["primary_symbol"]["name"] == "createInvoice"
+    assert payload["edit_plan_seed"]["primary_file"] == str(app_path.resolve())
+    assert str(payments_path.resolve()) != payload["edit_plan_seed"]["primary_file"]
+
+
 def test_llm_render_keeps_executable_body_lines_for_selected_function(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_validation_commands.py
+++ b/tests/unit/test_validation_commands.py
@@ -424,7 +424,8 @@ def test_rust_target_resolution_patterns(
 @pytest.mark.parametrize(
     ("setup_kind", "tests", "expected"),
     [
-        ("python", [], ["uv run pytest -q"]),
+        ("python-source-only", [], []),
+        ("python-project-marker", [], ["uv run pytest -q"]),
         ("rust", [], ["cargo test"]),
         ("jest-unknown", ["notes/validation.txt"], ["npx jest"]),
         ("default-unknown", ["notes/validation.txt"], []),
@@ -438,12 +439,17 @@ def test_repo_wide_fallback_detection(
 ) -> None:
     project = tmp_path / "project"
     project.mkdir()
-    if setup_kind == "python":
+    if setup_kind in {"python-source-only", "python-project-marker"}:
         src_dir = project / "src"
         src_dir.mkdir()
         (src_dir / "payments.py").write_text(
             "def create_invoice():\n    return 1\n", encoding="utf-8"
         )
+        if setup_kind == "python-project-marker":
+            (project / "pyproject.toml").write_text(
+                '[project]\nname = "sample"\nversion = "0.1.0"\n',
+                encoding="utf-8",
+            )
     elif setup_kind == "rust":
         (project / "Cargo.toml").write_text(
             '[package]\nname = "sample"\nversion = "0.1.0"\n',


### PR DESCRIPTION
## Summary
- Fix rg parity edges for PCRE2 sorted text output and forwarded multiline flags.
- Harden agent context/session trust: literal exact-symbol ranking now beats camel/snake bridge matches, sessions ignore non-context file noise, refresh-on-stale recovers, and source-only no-runner sessions no longer invent pytest commands.
- Make embedded checkpointed AST apply usable without standalone native tg, preserve inline scan metadata, and catch uppercase Python API_KEY secrets.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `python scripts/agent_readiness.py --output artifacts/agent_readiness.json`
- `uv run pytest -q` -> 1891 passed, 16 skipped in 202.89s
- `python benchmarks/run_benchmarks.py --output artifacts/bench_run_benchmarks.json` -> all 10 parity scenarios PASS
- `python benchmarks/check_regression.py --baseline auto --current artifacts/bench_run_benchmarks.json --allow-env-mismatch` -> no benchmark regressions detected; comparator noted Python 3.14.4 vs 3.12.12 baseline environment mismatch