### PR TITLE
docs: update tensor-grep skill handoff state

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -14,6 +14,8 @@ Current release facts:
 - Release commit: `648a740 chore(release): v1.8.29 [skip ci]`
 - Latest merged fix commit: `7742258 fix: harden native front-door CLI parity`
 - PR #64 `fix: harden native front-door CLI parity` merged and released
+- Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`
+- PR #66 `docs: define agent context capsule roadmap` merged; Main CI run `25561521904` passed, CodeQL/dynamic main run `25561520180` passed, and semantic-release correctly skipped publishing. Latest release remains `v1.8.29`.
 - Main CI run `25557263658` passed through semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`; CodeQL run `25557263900` passed
 - PyPI latest and pinned public install both resolve `tensor-grep==1.8.29`
 - GitHub release assets for `v1.8.29` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
@@ -32,6 +34,7 @@ Current product read:
 - Stable managed installs should prefer the matching release-native CPU front door when the GitHub release asset exists, while keeping the isolated Python environment as sidecar/fallback via `TG_SIDECAR_PYTHON` and `TG_NATIVE_TG_BINARY`. Installer changes should preserve the staged replacement contract so a failed install cannot break an existing public shim, including checking native installer command exit codes before the staged swap. `tg upgrade` must verify the sidecar import/version before claiming success, including the scheduled Windows self-upgrade path, and managed native front doors must be refreshed when the verified sidecar version moves ahead of `tg.exe`.
 - `--format rg --sort path` is the deterministic rg-shaped stdout contract. Token-saving output work should be a separate opt-in agent profile, not a mutation of raw rg/json/ndjson contracts.
 - Future `tg agent` / Actionable Context Capsule work should be treated as the product wedge: an opt-in workflow packet with primary file/function, route rationale, bounded snippets with line maps, related call sites, validation evidence, edit order, checkpoint/rollback metadata, omission counts, confidence, and an "ask user before editing" recommendation when evidence is weak. Evidence labels should distinguish `parser-backed`, `rg-backed`, `graph-derived`, `heuristic`, `LSP-confirmed`, and `stale/uncertain` conclusions.
+- Product-roadmap docs are current through PR #66. Future sessions should implement capsule behavior behind explicit contracts and regression tests, not reinterpret the roadmap as permission to alter raw search output.
 - `context-render` / MCP context output must keep `edit_plan_seed.primary_file`, `navigation_pack.primary_target.file`, selected files/sources, and follow-up reads consistent. Check `context_consistency` when debugging agent handoff quality.
 - Default JSON/LLM context rendering must include executable body lines for selected functions. Compactness may strip comments, docstrings when optimized, blank lines, type-only imports, and boilerplate, but it is not a summary-only profile.
 - `tg ast-info --json` exposes AST language identifiers for agents without help-text scraping.

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -21,7 +21,7 @@ Last updated: 2026-05-08
 
 ## Current Post-v1.8.29 Scope
 
-Current release branch is closed. Use a new branch from `origin/main` for follow-up work. The active follow-up branch is docs-only handoff cleanup for `v1.8.29`.
+Current release branch is closed. Use a new branch from `origin/main` for follow-up work. The latest docs/product merge is PR #66 `docs: define agent context capsule roadmap` at `f311469`; main CI run `25561521904` and CodeQL/dynamic main run `25561520180` passed, and semantic-release correctly skipped publishing because the change was docs-only.
 
 The immediate `v1.8.28` native-front-door CLI parity follow-up shipped in `v1.8.29`:
 

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -134,6 +134,20 @@ def test_handoff_docs_should_record_current_v1829_release_state_and_fast_gate() 
     assert "not a default agent primitive" in readme
 
 
+def test_tensor_grep_skill_should_record_latest_docs_merge_state() -> None:
+    skill = SKILL_DOC_PATH.read_text(encoding="utf-8")
+
+    assert (
+        "Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`"
+        in skill
+    )
+    assert "PR #66 `docs: define agent context capsule roadmap` merged" in skill
+    assert "Main CI run `25561521904` passed" in skill
+    assert "CodeQL/dynamic main run `25561520180` passed" in skill
+    assert "semantic-release correctly skipped publishing" in skill
+    assert "Latest release remains `v1.8.29`" in skill
+
+
 def test_routing_policy_should_describe_current_native_and_fallback_routes() -> None:
     doc = ROUTING_DOC_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- update the checked-in tensor-grep skill with the latest PR #66 docs/product merge state while keeping v1.8.29 as the latest release
- correct the session handoff so it no longer describes the completed docs cleanup branch as active
- add a public docs governance regression to keep the skill handoff current
- update the installed global tensor-grep skill at C:/Users/oimir/.agents/skills/tensor-grep/SKILL.md outside git

## Validation
- uv run pytest tests/unit/test_public_docs_governance.py::test_tensor_grep_skill_should_record_latest_docs_merge_state -q
- uv run pytest tests/unit/test_public_docs_governance.py -q
- git diff --check
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- python scripts/agent_readiness.py --output artifacts/agent_readiness_skill_update.json