### PR TITLE
fix: harden edit JSON and capsule validation trust

### DIFF
--- a/docs/examples/rewrite_apply_verify_validation_failed.json
+++ b/docs/examples/rewrite_apply_verify_validation_failed.json
@@ -74,5 +74,13 @@
     "total_edits": 1,
     "verified": 1,
     "mismatches": []
+  },
+  "rollback": {
+    "triggered_by": "validation",
+    "success": true,
+    "files_restored": [
+      "C:\\dev\\projects\\tensor-grep\\bench_data\\harness_api_doc_inputs\\rewrite\\rewrite_fixture.py"
+    ],
+    "errors": []
   }
 }

--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -1309,7 +1309,7 @@ Failure-mode companion examples:
 - [`examples/defs_provider_disagreement.json`](examples/defs_provider_disagreement.json): symbol-navigation payload showing provider disagreement metadata
 - [`examples/provider_status_unavailable.json`](examples/provider_status_unavailable.json): provider unavailable snapshot; treat provider disagreement or provider unavailable state as diagnostic context rather than a separate schema
 - [`examples/provider_status_unavailable.json`](examples/provider_status_unavailable.json): standalone provider health snapshot showing `provider_status.last_error`; keep routing native until provider transport health is restored
-- [`examples/rewrite_apply_verify_validation_failed.json`](examples/rewrite_apply_verify_validation_failed.json): apply/verify payload where edits verified byte-for-byte but post-apply validation failed
+- [`examples/rewrite_apply_verify_validation_failed.json`](examples/rewrite_apply_verify_validation_failed.json): apply/verify payload where edits verified byte-for-byte but post-apply validation failed and rollback metadata records restored files
 
 These examples reuse the existing public contracts above; they are not separate schema families.
 

--- a/docs/harness_cookbook.md
+++ b/docs/harness_cookbook.md
@@ -479,7 +479,7 @@ Use these public examples when wiring retries or stop conditions into an externa
 - [`examples/defs_provider_disagreement.json`](examples/defs_provider_disagreement.json): provider disagreement metadata; treat provider state as diagnostic context, not proof that the native answer is wrong
 - [`examples/provider_status_unavailable.json`](examples/provider_status_unavailable.json): provider unavailable snapshot; fall back to native behavior or surface the limitation to the caller
 - [`examples/provider_status_unavailable.json`](examples/provider_status_unavailable.json): provider unavailable; read `provider_status.last_error`, stay on native routing, and avoid blind provider retries
-- [`examples/rewrite_apply_verify_validation_failed.json`](examples/rewrite_apply_verify_validation_failed.json): patch applied and verified, but repo validation failed; rollback or repair before continuing
+- [`examples/rewrite_apply_verify_validation_failed.json`](examples/rewrite_apply_verify_validation_failed.json): patch applied and verified, but repo validation failed; rollback metadata records the restored files before retry or repair
 
 Recommended control-flow policy:
 

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -3071,6 +3071,18 @@ struct ApplyVerifyJson<'a> {
     plan: &'a tensor_grep_rs::backend_ast::RewritePlan,
     verification: Option<&'a tensor_grep_rs::backend_ast::VerifyResult>,
     validation: Option<&'a ValidationSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rollback: Option<&'a ValidationRollbackSummary>,
+}
+
+#[derive(Serialize)]
+struct RewriteDiffJson<'a> {
+    version: u32,
+    routing_backend: &'static str,
+    routing_reason: &'static str,
+    sidecar_used: bool,
+    plan: &'a tensor_grep_rs::backend_ast::RewritePlan,
+    diff: String,
 }
 
 #[derive(Serialize)]
@@ -3084,6 +3096,18 @@ struct BatchApplyVerifyJson<'a> {
     plan: &'a BatchRewritePlan,
     verification: Option<&'a tensor_grep_rs::backend_ast::VerifyResult>,
     validation: Option<&'a ValidationSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rollback: Option<&'a ValidationRollbackSummary>,
+}
+
+#[derive(Serialize)]
+struct BatchRewriteDiffJson<'a> {
+    version: u32,
+    routing_backend: &'static str,
+    routing_reason: &'static str,
+    sidecar_used: bool,
+    plan: &'a BatchRewritePlan,
+    diff: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -3120,6 +3144,14 @@ struct CheckpointMetadata {
 struct ValidationSummary {
     success: bool,
     commands: Vec<ValidationCommandResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ValidationRollbackSummary {
+    triggered_by: &'static str,
+    success: bool,
+    files_restored: Vec<String>,
+    errors: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -4030,6 +4062,58 @@ fn collect_pre_apply_hashes(
     Ok(hashes)
 }
 
+fn collect_validation_rollback_snapshots(
+    edits: &[tensor_grep_rs::backend_ast::RewriteEdit],
+) -> anyhow::Result<BTreeMap<String, Vec<u8>>> {
+    let mut snapshots = BTreeMap::new();
+    for file in edits
+        .iter()
+        .map(|edit| edit.file.clone())
+        .collect::<std::collections::BTreeSet<_>>()
+    {
+        let bytes = std::fs::read(&file).with_context(|| {
+            format!("failed to read {} for validation rollback", file.display())
+        })?;
+        snapshots.insert(file.to_string_lossy().to_string(), bytes);
+    }
+    Ok(snapshots)
+}
+
+fn restore_validation_rollback_snapshots(
+    snapshots: &BTreeMap<String, Vec<u8>>,
+) -> ValidationRollbackSummary {
+    let mut files_restored = Vec::new();
+    let mut errors = Vec::new();
+
+    for (file, bytes) in snapshots {
+        match std::fs::write(file, bytes) {
+            Ok(()) => files_restored.push(file.clone()),
+            Err(error) => errors.push(format!("failed to restore {file}: {error}")),
+        }
+    }
+
+    ValidationRollbackSummary {
+        triggered_by: "validation",
+        success: errors.is_empty(),
+        files_restored,
+        errors,
+    }
+}
+
+fn emit_rollback_status(summary: &ValidationRollbackSummary) {
+    if summary.success {
+        eprintln!(
+            "[rollback] restored {} file(s) after failed validation",
+            summary.files_restored.len()
+        );
+    } else {
+        eprintln!(
+            "[rollback] failed to restore {} file(s) after failed validation",
+            summary.errors.len()
+        );
+    }
+}
+
 struct AuditManifestWriteInput<'a> {
     path: &'a Path,
     lang: &'a str,
@@ -4388,12 +4472,41 @@ fn handle_ast_rewrite(
     }
 
     if plan.edits.is_empty() {
+        if args.diff && args.json {
+            let payload = RewriteDiffJson {
+                version: plan.version,
+                routing_backend: plan.routing_backend,
+                routing_reason: plan.routing_reason,
+                sidecar_used: plan.sidecar_used,
+                plan: &plan,
+                diff: String::new(),
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+            return Ok(());
+        }
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&plan)?);
+            return Ok(());
+        }
         eprintln!("[rewrite] no matches found, nothing to rewrite");
         return Ok(());
     }
 
     if args.diff {
-        print!("{}", plan.generate_diff()?);
+        let diff = plan.generate_diff()?;
+        if args.json {
+            let payload = RewriteDiffJson {
+                version: plan.version,
+                routing_backend: plan.routing_backend,
+                routing_reason: plan.routing_reason,
+                sidecar_used: plan.sidecar_used,
+                plan: &plan,
+                diff,
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            print!("{diff}");
+        }
         return Ok(());
     }
 
@@ -4435,17 +4548,41 @@ fn handle_ast_rewrite_apply(
     };
 
     if plan.edits.is_empty() && plan.rejected_overlaps.is_empty() {
-        eprintln!("[rewrite] no matches found, nothing to rewrite");
+        if args.json {
+            let payload = ApplyVerifyJson {
+                version: plan.version,
+                routing_backend: plan.routing_backend,
+                routing_reason: plan.routing_reason,
+                sidecar_used: plan.sidecar_used,
+                checkpoint: None,
+                audit_manifest: None,
+                plan: &plan,
+                verification: None,
+                validation: None,
+                rollback: None,
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            eprintln!("[rewrite] no matches found, nothing to rewrite");
+        }
         return Ok(());
     }
 
     let checkpoint = if args.checkpoint {
         let checkpoint = create_checkpoint(path)?;
-        eprintln!(
-            "[checkpoint] created {} ({}, files={})",
-            checkpoint.checkpoint_id, checkpoint.mode, checkpoint.file_count
-        );
+        if !args.json {
+            eprintln!(
+                "[checkpoint] created {} ({}, files={})",
+                checkpoint.checkpoint_id, checkpoint.mode, checkpoint.file_count
+            );
+        }
         Some(checkpoint)
+    } else {
+        None
+    };
+
+    let rollback_snapshots = if args.lint_cmd.is_some() || args.test_cmd.is_some() {
+        Some(collect_validation_rollback_snapshots(&plan.edits)?)
     } else {
         None
     };
@@ -4460,26 +4597,30 @@ fn handle_ast_rewrite_apply(
         AstBackend::apply_rewrites(&plan)?;
     }
 
-    if !plan.rejected_overlaps.is_empty() {
+    if !plan.rejected_overlaps.is_empty() && !args.json {
         eprintln!(
             "[rewrite] {} overlapping edit(s) rejected",
             plan.rejected_overlaps.len()
         );
     }
 
-    eprintln!("[rewrite] applied {} edit(s)", plan.edits.len(),);
+    if !args.json {
+        eprintln!("[rewrite] applied {} edit(s)", plan.edits.len(),);
+    }
 
     let verification = if args.verify {
         let v = plan.verify(backend)?;
-        if v.mismatches.is_empty() {
-            eprintln!("[verify] {}/{} edits verified", v.verified, v.total_edits);
-        } else {
-            eprintln!(
-                "[verify] {}/{} edits verified, {} mismatches",
-                v.verified,
-                v.total_edits,
-                v.mismatches.len()
-            );
+        if !args.json {
+            if v.mismatches.is_empty() {
+                eprintln!("[verify] {}/{} edits verified", v.verified, v.total_edits);
+            } else {
+                eprintln!(
+                    "[verify] {}/{} edits verified, {} mismatches",
+                    v.verified,
+                    v.total_edits,
+                    v.mismatches.len()
+                );
+            }
         }
         Some(v)
     } else {
@@ -4487,9 +4628,29 @@ fn handle_ast_rewrite_apply(
     };
 
     let validation = run_post_apply_validation(args, path);
-    if let Some(summary) = &validation {
-        emit_validation_status(summary);
+    if !args.json {
+        if let Some(summary) = &validation {
+            emit_validation_status(summary);
+        }
     }
+
+    let rollback = if let Some(summary) = &validation {
+        if !summary.success {
+            let rollback = rollback_snapshots
+                .as_ref()
+                .map(restore_validation_rollback_snapshots);
+            if !args.json {
+                if let Some(rollback_summary) = &rollback {
+                    emit_rollback_status(rollback_summary);
+                }
+            }
+            rollback
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     let audit_manifest = if let Some(audit_manifest_path) = &args.audit_manifest {
         Some(write_audit_manifest_for_plan(AuditManifestWriteInput {
@@ -4520,6 +4681,7 @@ fn handle_ast_rewrite_apply(
             plan: &plan,
             verification: verification.as_ref(),
             validation: validation.as_ref(),
+            rollback: rollback.as_ref(),
         };
         println!("{}", serde_json::to_string_pretty(&payload)?);
     }
@@ -4554,6 +4716,22 @@ fn handle_ast_batch_rewrite(
     }
 
     if plan.edits.is_empty() && plan.rejected_overlaps.is_empty() {
+        if args.diff && args.json {
+            let payload = BatchRewriteDiffJson {
+                version: plan.version,
+                routing_backend: plan.routing_backend,
+                routing_reason: plan.routing_reason,
+                sidecar_used: plan.sidecar_used,
+                plan: &plan,
+                diff: String::new(),
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+            return Ok(());
+        }
+        if args.json {
+            println!("{}", serde_json::to_string_pretty(&plan)?);
+            return Ok(());
+        }
         eprintln!("[rewrite] no matches found, nothing to rewrite");
         return Ok(());
     }
@@ -4563,7 +4741,20 @@ fn handle_ast_batch_rewrite(
             eprintln!("[rewrite] no non-overlapping matches found, nothing to diff");
             return Ok(());
         }
-        print!("{}", plan.generate_diff()?);
+        let diff = plan.generate_diff()?;
+        if args.json {
+            let payload = BatchRewriteDiffJson {
+                version: plan.version,
+                routing_backend: plan.routing_backend,
+                routing_reason: plan.routing_reason,
+                sidecar_used: plan.sidecar_used,
+                plan: &plan,
+                diff,
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            print!("{diff}");
+        }
         return Ok(());
     }
 
@@ -4600,17 +4791,41 @@ fn handle_ast_batch_rewrite_apply(
     let plan = filter_batch_rewrite_plan(&plan, args)?;
 
     if plan.edits.is_empty() && plan.rejected_overlaps.is_empty() {
-        eprintln!("[rewrite] no matches found, nothing to rewrite");
+        if args.json {
+            let payload = BatchApplyVerifyJson {
+                version: plan.version,
+                routing_backend: plan.routing_backend,
+                routing_reason: plan.routing_reason,
+                sidecar_used: plan.sidecar_used,
+                checkpoint: None,
+                audit_manifest: None,
+                plan: &plan,
+                verification: None,
+                validation: None,
+                rollback: None,
+            };
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            eprintln!("[rewrite] no matches found, nothing to rewrite");
+        }
         return Ok(());
     }
 
     let checkpoint = if args.checkpoint {
         let checkpoint = create_checkpoint(path)?;
-        eprintln!(
-            "[checkpoint] created {} ({}, files={})",
-            checkpoint.checkpoint_id, checkpoint.mode, checkpoint.file_count
-        );
+        if !args.json {
+            eprintln!(
+                "[checkpoint] created {} ({}, files={})",
+                checkpoint.checkpoint_id, checkpoint.mode, checkpoint.file_count
+            );
+        }
         Some(checkpoint)
+    } else {
+        None
+    };
+
+    let rollback_snapshots = if args.lint_cmd.is_some() || args.test_cmd.is_some() {
+        Some(collect_validation_rollback_snapshots(&plan.edits)?)
     } else {
         None
     };
@@ -4623,33 +4838,37 @@ fn handle_ast_batch_rewrite_apply(
 
     AstBackend::apply_batch_rewrites(&plan)?;
 
-    if !plan.rejected_overlaps.is_empty() {
+    if !plan.rejected_overlaps.is_empty() && !args.json {
         eprintln!(
             "[rewrite] {} overlapping edit(s) rejected",
             plan.rejected_overlaps.len()
         );
     }
 
-    if plan.edits.is_empty() {
-        eprintln!("[rewrite] no non-overlapping edits applied");
-    } else {
-        eprintln!("[rewrite] applied {} edit(s)", plan.edits.len());
+    if !args.json {
+        if plan.edits.is_empty() {
+            eprintln!("[rewrite] no non-overlapping edits applied");
+        } else {
+            eprintln!("[rewrite] applied {} edit(s)", plan.edits.len());
+        }
     }
 
     let verification = if config.verify || args.verify {
         let result = plan.verify(backend)?;
-        if result.mismatches.is_empty() {
-            eprintln!(
-                "[verify] {}/{} edits verified",
-                result.verified, result.total_edits
-            );
-        } else {
-            eprintln!(
-                "[verify] {}/{} edits verified, {} mismatches",
-                result.verified,
-                result.total_edits,
-                result.mismatches.len()
-            );
+        if !args.json {
+            if result.mismatches.is_empty() {
+                eprintln!(
+                    "[verify] {}/{} edits verified",
+                    result.verified, result.total_edits
+                );
+            } else {
+                eprintln!(
+                    "[verify] {}/{} edits verified, {} mismatches",
+                    result.verified,
+                    result.total_edits,
+                    result.mismatches.len()
+                );
+            }
         }
         Some(result)
     } else {
@@ -4657,9 +4876,29 @@ fn handle_ast_batch_rewrite_apply(
     };
 
     let validation = run_post_apply_validation(args, path);
-    if let Some(summary) = &validation {
-        emit_validation_status(summary);
+    if !args.json {
+        if let Some(summary) = &validation {
+            emit_validation_status(summary);
+        }
     }
+
+    let rollback = if let Some(summary) = &validation {
+        if !summary.success {
+            let rollback = rollback_snapshots
+                .as_ref()
+                .map(restore_validation_rollback_snapshots);
+            if !args.json {
+                if let Some(rollback_summary) = &rollback {
+                    emit_rollback_status(rollback_summary);
+                }
+            }
+            rollback
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     let audit_manifest = if let Some(audit_manifest_path) = &args.audit_manifest {
         Some(write_audit_manifest_for_plan(AuditManifestWriteInput {
@@ -4690,6 +4929,7 @@ fn handle_ast_batch_rewrite_apply(
             plan: &plan,
             verification: verification.as_ref(),
             validation: validation.as_ref(),
+            rollback: rollback.as_ref(),
         };
         println!("{}", serde_json::to_string_pretty(&payload)?);
     }

--- a/rust_core/tests/test_ast_rewrite.rs
+++ b/rust_core/tests/test_ast_rewrite.rs
@@ -398,6 +398,43 @@ fn test_tg_run_rewrite_apply_no_matches_reports_nothing() {
 }
 
 #[test]
+fn test_tg_run_rewrite_apply_json_no_matches_emits_empty_payload() {
+    let (_dir, file_path) = write_source_file("py", "x = 1\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--apply")
+        .arg("--json")
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value =
+        serde_json::from_slice(&output.stdout).expect("no-match apply stdout must still be JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["plan"]["total_edits"], 0);
+    assert_eq!(parsed["validation"], Value::Null);
+    assert_eq!(parsed["verification"], Value::Null);
+    assert_eq!(parsed["rollback"], Value::Null);
+    assert_eq!(fs::read_to_string(&file_path).unwrap(), "x = 1\n");
+    assert!(
+        output.stderr.is_empty(),
+        "json no-match apply should not emit human stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_rewrite_plan_json_contract_fields() {
     let source = "def add(x, y): return x + y\ndef mul(a, b): return a * b\n";
     let (_dir, file_path) = write_source_file("py", source);
@@ -529,6 +566,87 @@ fn test_tg_run_rewrite_diff_shows_unified_diff() {
 
     let content = fs::read_to_string(&file_path).unwrap();
     assert_eq!(content, source, "diff should not modify file");
+}
+
+#[test]
+fn test_tg_run_rewrite_diff_json_wraps_unified_diff() {
+    let source = "x = 1\ndef add(x, y): return x + y\nz = 3\n";
+    let (_dir, file_path) = write_source_file("py", source);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--diff")
+        .arg("--json")
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value = serde_json::from_slice(&output.stdout).expect("diff stdout must be JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["routing_backend"], "AstBackend");
+    assert_eq!(parsed["routing_reason"], "ast-native");
+    assert_eq!(parsed["sidecar_used"], false);
+    assert_eq!(parsed["plan"]["total_edits"], 1);
+    let diff = parsed["diff"].as_str().expect("diff must be a string");
+    assert!(diff.contains("--- a/"), "should contain --- header: {diff}");
+    assert!(diff.contains("+++ b/"), "should contain +++ header: {diff}");
+    assert!(diff.contains("@@"), "should contain hunk header: {diff}");
+    assert!(
+        diff.contains("-def add(x, y): return x + y"),
+        "should show removed line: {diff}"
+    );
+    assert!(
+        diff.contains("+lambda x, y: x + y"),
+        "should show added line: {diff}"
+    );
+
+    let content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(content, source, "diff should not modify file");
+}
+
+#[test]
+fn test_tg_run_rewrite_diff_json_no_matches_emits_empty_payload() {
+    let source = "x = 1\n";
+    let (_dir, file_path) = write_source_file("py", source);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--diff")
+        .arg("--json")
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value =
+        serde_json::from_slice(&output.stdout).expect("no-match diff stdout must still be JSON");
+    assert_eq!(parsed["version"], 1);
+    assert_eq!(parsed["plan"]["total_edits"], 0);
+    assert_eq!(parsed["diff"], "");
+    assert!(
+        output.stderr.is_empty(),
+        "json no-match diff should not emit human stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -1587,9 +1705,18 @@ fn test_tg_run_apply_verify_json_reports_failed_validation_and_exits_non_zero() 
         .as_str()
         .unwrap()
         .contains("lint-fail"));
+    assert_eq!(parsed["rollback"]["success"], true);
+    assert_eq!(parsed["rollback"]["triggered_by"], "validation");
+    assert_eq!(
+        parsed["rollback"]["files_restored"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
     assert_eq!(
         fs::read_to_string(&file_path).unwrap(),
-        "lambda x, y: x + y\n"
+        "def add(x, y): return x + y\n"
     );
 }
 

--- a/rust_core/tests/test_schema_compat.rs
+++ b/rust_core/tests/test_schema_compat.rs
@@ -555,6 +555,7 @@ struct ApplyVerifyExample {
     audit_manifest: Option<AuditManifestExample>,
     plan: RewritePlanExample,
     validation: Option<ValidationSummaryExample>,
+    rollback: Option<ValidationRollbackSummaryExample>,
     verification: Option<VerifyResultExample>,
 }
 
@@ -578,6 +579,16 @@ struct AuditManifestExample {
     applied_edit_count: usize,
     signed: bool,
     signature_kind: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ValidationRollbackSummaryExample {
+    triggered_by: String,
+    success: bool,
+    files_restored: Vec<PathBuf>,
+    errors: Vec<String>,
 }
 
 #[allow(dead_code)]
@@ -1758,6 +1769,38 @@ fn assert_apply_verify_validation_failed_example(path: &Path) {
     assert!(
         !validation.commands.is_empty(),
         "{} validation commands must not be empty",
+        path.display()
+    );
+    let rollback = example
+        .rollback
+        .as_ref()
+        .unwrap_or_else(|| panic!("{} rollback payload missing", path.display()));
+    assert_eq!(
+        rollback.triggered_by,
+        "validation",
+        "{} rollback should be triggered by validation failure",
+        path.display()
+    );
+    assert!(
+        rollback.success,
+        "{} validation failure should record successful rollback",
+        path.display()
+    );
+    assert!(
+        !rollback.files_restored.is_empty(),
+        "{} rollback files_restored must not be empty",
+        path.display()
+    );
+    for restored_file in &rollback.files_restored {
+        assert!(
+            is_portable_absolute_path(restored_file),
+            "{} rollback restored file should be absolute or an absolute Windows path literal",
+            path.display()
+        );
+    }
+    assert!(
+        rollback.errors.is_empty(),
+        "{} successful rollback must not include errors",
         path.display()
     );
     let verification = example

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -97,6 +97,7 @@ def _capsule_trust_checks(
     downgrade_reasons: list[str] = []
     ask_reasons: list[str] = []
     validation_filtered_count = int(validation_alignment.get("filtered_count", 0) or 0)
+    validation_kept_count = int(validation_alignment.get("kept_count", 0) or 0)
 
     if (
         query_language_hints
@@ -111,7 +112,7 @@ def _capsule_trust_checks(
         downgrade_reasons.append(reason)
         ask_reasons.append(reason)
 
-    if validation_filtered_count > 0:
+    if validation_filtered_count > 0 and validation_kept_count == 0:
         confidence_cap = min(confidence_cap, 0.65)
         reason = "validation commands did not align with primary target language"
         downgrade_reasons.append(reason)

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -8186,7 +8186,8 @@ def _apply_context_consistency_invariants(payload: dict[str, Any]) -> dict[str, 
         else {}
     )
     validation_filtered_count = int(validation_alignment.get("filtered_count", 0) or 0)
-    if validation_filtered_count > 0:
+    validation_kept_count = int(validation_alignment.get("kept_count", 0) or 0)
+    if validation_filtered_count > 0 and validation_kept_count == 0:
         confidence_downgraded = True
     primary_target_language = _target_language_for_path(primary_file)
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2614,6 +2614,22 @@ def test_agent_capsule_python_invoice_tax_query_selects_python_evidence(tmp_path
     assert payload["context_consistency"]["primary_target_language"] == "python"
 
 
+def test_agent_capsule_python_invoice_tax_query_keeps_python_target_with_js_manifest(tmp_path):
+    paths = _write_mixed_invoice_fixture(tmp_path, package_json=True)
+
+    payload = _agent_capsule_payload_for_query(
+        paths["project"],
+        "python invoice tax calculation",
+    )
+
+    assert payload["primary_target"]["file"] == str(paths["python"].resolve())
+    assert payload["primary_target"]["symbol"] == "create_invoice"
+    assert payload["context_consistency"]["query_language_hints"] == ["python"]
+    assert payload["context_consistency"]["primary_target_language"] == "python"
+    assert any("pytest" in command for command in payload["validation_commands"])
+    assert payload["ask_user_before_editing"]["required"] is False
+
+
 def test_agent_capsule_change_invoice_tax_query_prefers_python_body_and_tests(tmp_path):
     paths = _write_mixed_invoice_fixture(tmp_path)
 

--- a/tests/unit/test_harness_api_docs.py
+++ b/tests/unit/test_harness_api_docs.py
@@ -449,6 +449,9 @@ def test_failure_mode_examples_exist_and_have_actionable_shapes() -> None:
             assert payload["verification"]["mismatches"] == []
             assert payload["validation"]["success"] is False
             assert payload["validation"]["commands"]
+            assert payload["rollback"]["triggered_by"] == "validation"
+            assert payload["rollback"]["success"] is True
+            assert payload["rollback"]["files_restored"]
         elif file_name == "session_invalid_request_stale.json":
             assert payload["error"]["code"] == "invalid_request"
             assert "stale" in payload["error"]["message"].lower()
@@ -508,3 +511,4 @@ def test_harness_api_failure_mode_examples_exist_and_match_documented_shapes() -
     assert validation_failed["validation"] is not None
     assert validation_failed["validation"]["success"] is False
     assert validation_failed["verification"]["mismatches"] == []
+    assert validation_failed["rollback"]["success"] is True


### PR DESCRIPTION
## Summary

- make native rewrite `--diff --json` emit a structured JSON envelope instead of plain unified diff, including no-match cases
- make native rewrite `--apply --json` keep stdout parseable, suppress human progress logs, and report validation rollback metadata
- restore edited files automatically when post-apply validation fails
- avoid downgrading capsule trust when mismatched validation commands were filtered but aligned validation commands remain
- update harness examples/schema docs for validation rollback metadata

## Validation

- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `C:\Users\oimir\.cargo\bin\cargo.exe fmt --manifest-path rust_core\Cargo.toml -- --check`
- `C:\Users\oimir\.cargo\bin\cargo.exe test --manifest-path rust_core\Cargo.toml`
- `uv run pytest -q` -> `1969 passed, 16 skipped`
- `python scripts\agent_readiness.py --output artifacts\agent_readiness_edit_json_ranking.json` -> 16/16 passed
- direct native dogfood for parseable diff JSON, failed-validation rollback, restored file content, and no-match JSON diff/apply

## Release intent

Patch release. This is a correctness and machine-contract fix for agent-facing edit automation and capsule trust behavior.