### PR TITLE
fix: harden docs governance and validation placeholders

### DIFF
--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -609,6 +609,7 @@ Optional edit selection flags:
 
 When edit selection flags are present, the emitted `plan` object reflects the filtered subset that was actually applied and verified.
 When validation flags are present, the emitted payload also includes a structured `validation` object describing each post-apply command.
+Validation command templates may use `$file` or `{file}` for the target path passed to `tg run`; quote the placeholder in the command template when paths may contain spaces, for example `--lint-cmd 'python -m py_compile "$file"'` in PowerShell.
 
 Example: [`examples/rewrite_apply_verify.json`](examples/rewrite_apply_verify.json)
 

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -4111,15 +4111,39 @@ fn run_validation_command(
     }
 }
 
+fn validation_template_file_path(path: &str) -> String {
+    let candidate = Path::new(path);
+    let absolute = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(candidate)
+    };
+    absolute.to_string_lossy().to_string()
+}
+
+fn expand_validation_command_template(command: &str, path: &str) -> String {
+    if !command.contains("$file") && !command.contains("{file}") {
+        return command.to_string();
+    }
+    let file_path = validation_template_file_path(path);
+    command
+        .replace("$file", &file_path)
+        .replace("{file}", &file_path)
+}
+
 fn run_post_apply_validation(args: &RunArgs, path: &str) -> Option<ValidationSummary> {
     let mut commands = Vec::new();
     let working_dir = validation_working_dir(path);
 
     if let Some(command) = &args.lint_cmd {
-        commands.push(run_validation_command("lint", command, &working_dir));
+        let expanded = expand_validation_command_template(command, path);
+        commands.push(run_validation_command("lint", &expanded, &working_dir));
     }
     if let Some(command) = &args.test_cmd {
-        commands.push(run_validation_command("test", command, &working_dir));
+        let expanded = expand_validation_command_template(command, path);
+        commands.push(run_validation_command("test", &expanded, &working_dir));
     }
 
     if commands.is_empty() {

--- a/rust_core/tests/test_ast_rewrite.rs
+++ b/rust_core/tests/test_ast_rewrite.rs
@@ -1401,6 +1401,47 @@ fn test_tg_run_apply_validation_accepts_quoted_windows_path_with_spaces() {
 }
 
 #[test]
+fn test_tg_run_apply_validation_substitutes_file_placeholder() {
+    let dir = tempdir().unwrap();
+    let spaced_dir = dir.path().join("path with spaces");
+    fs::create_dir(&spaced_dir).unwrap();
+    let file_path = spaced_dir.join("app.py");
+    fs::write(&file_path, "def add(x, y): return x + y\n").unwrap();
+    let expected_cmd = format!("python -m py_compile \"{}\"", file_path.display());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--apply")
+        .arg("--verify")
+        .arg("--json")
+        .arg("--lint-cmd")
+        .arg(r#"python -m py_compile "$file""#)
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["validation"]["success"], true);
+    assert_eq!(
+        parsed["validation"]["commands"][0]["command"]
+            .as_str()
+            .unwrap(),
+        expected_cmd
+    );
+}
+
+#[test]
 fn test_tg_run_apply_verify_json_can_emit_audit_manifest() {
     let (_dir, file_path) = write_source_file("py", "def add(x, y): return x + y\n");
     let audit_manifest_path = file_path.parent().unwrap().join("rewrite-audit.json");

--- a/tests/unit/test_harness_api_docs.py
+++ b/tests/unit/test_harness_api_docs.py
@@ -183,6 +183,8 @@ def test_harness_api_doc_covers_all_required_json_shapes() -> None:
     assert "--checkpoint" in doc
     assert "--lint-cmd" in doc
     assert "--test-cmd" in doc
+    assert "$file" in doc
+    assert "{file}" in doc
     assert "--batch-rewrite" in doc
     assert "rewrites" in doc
     assert "verify" in doc

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -1,3 +1,4 @@
+import tomllib
 from pathlib import Path
 
 README_PATH = Path("README.md")
@@ -17,6 +18,11 @@ CURRENT_RELEASE_COMMIT = "8143ccb chore(release): v1.9.2 [skip ci]"
 CURRENT_FIX_COMMIT = "faf67ed fix: harden edit JSON and capsule validation trust"
 CURRENT_MAIN_CI = "25609611007"
 CURRENT_CODEQL = "25609610737"
+
+
+def _project_release_tag() -> str:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    return f"v{pyproject['project']['version']}"
 
 
 def test_readme_should_point_to_canonical_public_docs() -> None:
@@ -93,7 +99,7 @@ def test_handoff_docs_should_record_current_v192_release_state_and_fast_gate() -
 
     for content in docs.values():
         assert CURRENT_RELEASE_TAG in content
-        assert "release_docs_current_tag: v1.9.2" in content
+        assert f"release_docs_current_tag: {_project_release_tag()}" in content
         assert "python scripts/agent_readiness.py" in content
 
     for content in (


### PR DESCRIPTION
## Summary
- parameterize docs governance around the semantic-release-managed `release_docs_current_tag`
- expand `$file` and `{file}` in post-apply validation command templates before running lint/test commands
- document the validation placeholder contract and cover quoted paths with spaces

## Root cause
- `test_public_docs_governance.py` hard-coded `release_docs_current_tag: v1.9.2`, so the full suite failed after semantic-release correctly updated docs to `v1.9.3`.
- edit validation commands were passed through literally, so `--lint-cmd 'python -m py_compile "$file"'` tried to compile a file named `$file` and rolled back.

## Validation
- `uv run pytest tests/unit/test_public_docs_governance.py::test_handoff_docs_should_record_current_v192_release_state_and_fast_gate -q`
- `cargo test --manifest-path rust_core/Cargo.toml --test test_ast_rewrite test_tg_run_apply_validation_substitutes_file_placeholder -- --nocapture`
- `uv run pytest tests/unit/test_public_docs_governance.py tests/unit/test_harness_api_docs.py -q`
- `cargo test --manifest-path rust_core/Cargo.toml --test test_ast_rewrite`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `cargo fmt --manifest-path rust_core/Cargo.toml -- --check`
- `cargo clippy --manifest-path rust_core/Cargo.toml -- -D warnings`
- `uv run pytest -q`
- `cargo test --manifest-path rust_core/Cargo.toml`
- `python scripts/agent_readiness.py --output artifacts/agent_readiness_194_fix.json`
