### PR TITLE
fix: accelerate fixed multi-pattern native search

### DIFF
--- a/rust_core/Cargo.toml
+++ b/rust_core/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 cuda = ["dep:cudarc"]
 
 [dependencies]
+aho-corasick = "1.1.4"
 anyhow = "1.0.102"
 clap = { version = "4.5.60", features = ["derive"] }
 hmac = "0.12.1"

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -32,7 +32,8 @@ use tensor_grep_rs::index::TrigramIndex;
 #[cfg(feature = "cuda")]
 use tensor_grep_rs::native_search::smart_case_pattern_is_case_insensitive;
 use tensor_grep_rs::native_search::{
-    run_native_search, NativeOutputTarget, NativeSearchConfig, SearchStats,
+    run_native_fixed_multi_pattern_search, run_native_search, NativeOutputTarget,
+    NativeSearchConfig, SearchStats,
 };
 use tensor_grep_rs::python_sidecar::{
     execute_python_passthrough_command, execute_python_passthrough_command_captured,
@@ -2711,6 +2712,21 @@ fn collect_native_multi_pattern_matches(
     mut base_config: NativeSearchConfig,
 ) -> anyhow::Result<Vec<SearchMatchJson>> {
     let include_pattern_metadata = patterns.len() > 1;
+    if let Some(matches) = run_native_fixed_multi_pattern_search(base_config.clone(), patterns)? {
+        return Ok(matches
+            .into_iter()
+            .map(|matched| SearchMatchJson {
+                file: matched.path.to_string_lossy().into_owned(),
+                line: matched.line_number as usize,
+                text: matched.text,
+                range: None,
+                meta_variables: None,
+                pattern_id: include_pattern_metadata.then_some(matched.pattern_id),
+                pattern_text: include_pattern_metadata.then_some(matched.pattern_text),
+            })
+            .collect());
+    }
+
     base_config.json = false;
     base_config.ndjson = false;
     base_config.count = false;

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -1,3 +1,4 @@
+use aho_corasick::{AhoCorasick, MatchKind};
 use anyhow::{anyhow, Context, Result};
 use grep_matcher::{LineTerminator, Matcher};
 use grep_printer::StandardBuilder;
@@ -30,6 +31,15 @@ pub struct NativeSearchMatch {
     pub path: PathBuf,
     pub line_number: Option<u64>,
     pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NativeMultiPatternMatch {
+    pub path: PathBuf,
+    pub line_number: u64,
+    pub text: String,
+    pub pattern_id: usize,
+    pub pattern_text: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -679,6 +689,137 @@ pub fn run_native_search(config: NativeSearchConfig) -> Result<SearchStats> {
     }
 
     Ok(stats)
+}
+
+pub fn run_native_fixed_multi_pattern_search(
+    config: NativeSearchConfig,
+    patterns: &[String],
+) -> Result<Option<Vec<NativeMultiPatternMatch>>> {
+    if !supports_native_fixed_multi_pattern_search(&config, patterns) {
+        return Ok(None);
+    }
+
+    let inputs = split_search_inputs(&config)?;
+    let mut files = inputs.files;
+    if !inputs.roots.is_empty() {
+        files.extend(collect_walked_files(&config, &inputs.roots)?);
+    }
+    files.sort_unstable();
+    files.dedup();
+
+    let matcher = AhoCorasick::builder()
+        .match_kind(MatchKind::Standard)
+        .build(patterns)
+        .context("failed to build native fixed multi-pattern matcher")?;
+    let mut matches = Vec::new();
+    for file_path in files {
+        let contents = fs::read(&file_path).with_context(|| {
+            format!("failed to read native search path {}", file_path.display())
+        })?;
+        if !config.text && memchr(0, &contents).is_some() {
+            return Ok(None);
+        }
+        collect_fixed_multi_pattern_file_matches(
+            &matcher,
+            patterns,
+            &file_path,
+            &contents,
+            &mut matches,
+        );
+    }
+
+    matches.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then(left.line_number.cmp(&right.line_number))
+            .then(left.pattern_id.cmp(&right.pattern_id))
+            .then(left.text.cmp(&right.text))
+    });
+    Ok(Some(matches))
+}
+
+fn supports_native_fixed_multi_pattern_search(
+    config: &NativeSearchConfig,
+    patterns: &[String],
+) -> bool {
+    patterns.len() > 1
+        && config.fixed_strings
+        && !patterns.iter().any(|pattern| pattern.is_empty())
+        && !config.ignore_case
+        && !config.smart_case
+        && !config.word_boundary
+        && !config.invert_match
+        && config.before_context == 0
+        && config.after_context == 0
+        && config.max_count.is_none()
+        && !config.quiet
+        && !config.only_matching
+        && !config.null_data
+        && !config.crlf
+        && config.replace.is_none()
+}
+
+fn collect_fixed_multi_pattern_file_matches(
+    matcher: &AhoCorasick,
+    patterns: &[String],
+    path: &Path,
+    contents: &[u8],
+    matches: &mut Vec<NativeMultiPatternMatch>,
+) {
+    let mut line_start = 0usize;
+    let mut line_number = 1u64;
+    for newline_index in memchr_iter(b'\n', contents) {
+        collect_fixed_multi_pattern_line_matches(
+            matcher,
+            patterns,
+            path,
+            line_number,
+            &contents[line_start..newline_index],
+            matches,
+        );
+        line_start = newline_index + 1;
+        line_number += 1;
+    }
+
+    if line_start < contents.len() {
+        collect_fixed_multi_pattern_line_matches(
+            matcher,
+            patterns,
+            path,
+            line_number,
+            &contents[line_start..],
+            matches,
+        );
+    }
+}
+
+fn collect_fixed_multi_pattern_line_matches(
+    matcher: &AhoCorasick,
+    patterns: &[String],
+    path: &Path,
+    line_number: u64,
+    raw_line: &[u8],
+    matches: &mut Vec<NativeMultiPatternMatch>,
+) {
+    let line = raw_line.strip_suffix(b"\r").unwrap_or(raw_line);
+    let mut pattern_ids = std::collections::BTreeSet::new();
+    for matched in matcher.find_overlapping_iter(line) {
+        pattern_ids.insert(matched.pattern().as_usize());
+    }
+    if pattern_ids.is_empty() {
+        return;
+    }
+
+    let text = String::from_utf8_lossy(line).into_owned();
+    for pattern_id in pattern_ids {
+        matches.push(NativeMultiPatternMatch {
+            path: path.to_path_buf(),
+            line_number,
+            text: text.clone(),
+            pattern_id,
+            pattern_text: patterns[pattern_id].clone(),
+        });
+    }
 }
 
 fn run_native_search_files(

--- a/rust_core/tests/test_routing.rs
+++ b/rust_core/tests/test_routing.rs
@@ -1822,6 +1822,66 @@ fn test_rust_control_plane_positional_word_regexp_uses_word_boundaries() {
 }
 
 #[test]
+fn test_native_cpu_fixed_multi_pattern_uses_single_pass_fast_path() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("multi.txt");
+    fs::write(
+        &file,
+        "alpha and beta\n\nbeta after blank\nalpha after beta\n",
+    )
+    .unwrap();
+
+    let output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--json")
+        .arg("-e")
+        .arg("alpha")
+        .arg("-e")
+        .arg("beta")
+        .arg(&file)
+        .env("TG_DISABLE_RG", "1")
+        .env("PATH", "")
+        .env(
+            "TG_TEST_NATIVE_SEARCH_FORCE_ERROR",
+            "sequential native search path used",
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let matches = payload["matches"].as_array().unwrap();
+    let tuples = matches
+        .iter()
+        .map(|entry| {
+            (
+                entry["line"].as_u64().unwrap(),
+                entry["text"].as_str().unwrap().to_string(),
+                entry["pattern_id"].as_u64().unwrap(),
+                entry["pattern_text"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        tuples,
+        vec![
+            (1, "alpha and beta".to_string(), 0, "alpha".to_string()),
+            (1, "alpha and beta".to_string(), 1, "beta".to_string()),
+            (3, "beta after blank".to_string(), 1, "beta".to_string()),
+            (4, "alpha after beta".to_string(), 0, "alpha".to_string()),
+            (4, "alpha after beta".to_string(), 1, "beta".to_string()),
+        ]
+    );
+}
+
+#[test]
 fn test_rust_control_plane_rejection() {
     let dir = tempdir().unwrap();
     write_text_corpus(dir.path());


### PR DESCRIPTION
## Summary
- add an Aho-Corasick single-pass native CPU path for safe fixed multi-pattern searches
- preserve unsupported semantic shapes by falling back to the existing per-pattern path
- add a routing regression that fails if the sequential native path is used for the safe multi-pattern case

## Validation
- RED: test_native_cpu_fixed_multi_pattern_uses_single_pass_fast_path failed before implementation with the forced sequential-path error
- C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml --test test_routing test_native_cpu_fixed_multi_pattern_uses_single_pass_fast_path -- --exact --nocapture
- C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check
- git diff --check origin/main...HEAD
- Superset stack validation also passed: uv run ruff check ., uv run ruff format --check --preview ., uv run mypy src/tensor_grep, uv run pytest -q, and C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml

## Benchmark evidence
- 100 fixed no-match patterns over the existing 1GB dogfood corpus, 5 repeats: rg multi-pattern median ~0.0347s; native tg fixed multi-pattern median ~0.0239s.