### PR TITLE
fix: harden public GPU unavailable routing

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -2664,7 +2664,6 @@ fn native_search_config_for_command(
     }
 }
 
-#[cfg(feature = "cuda")]
 fn native_search_config_for_gpu_params(
     params: &GpuSearchParams<'_>,
     pattern: &str,
@@ -5319,7 +5318,57 @@ fn handle_gpu_search(params: GpuSearchParams<'_>) -> anyhow::Result<()> {
 
 #[cfg(not(feature = "cuda"))]
 fn handle_gpu_search(params: GpuSearchParams<'_>) -> anyhow::Result<()> {
-    handle_gpu_sidecar_search(params)
+    if explicit_gpu_sidecar_is_available() {
+        return handle_gpu_sidecar_search(params);
+    }
+
+    handle_native_gpu_unavailable_cpu_fallback(
+        params,
+        "native GPU unavailable in this binary; no CUDA-native front door is available",
+    )
+}
+
+#[cfg(not(feature = "cuda"))]
+fn handle_native_gpu_unavailable_cpu_fallback(
+    params: GpuSearchParams<'_>,
+    warning: &str,
+) -> anyhow::Result<()> {
+    eprintln!("warning: {warning}; falling back to native CPU search");
+    let decision = RoutingDecision::native_cpu_gpu_fallback(
+        ripgrep_is_available(),
+        params.json || params.ndjson,
+    );
+    let pattern = params.patterns.first().map_or(params.query, String::as_str);
+    let cpu_config = native_search_config_for_gpu_params(&params, pattern, decision);
+    if cpu_config.verbose {
+        emit_verbose_metadata(decision);
+    }
+    if params.patterns.len() > 1 {
+        let matches = collect_native_multi_pattern_matches(params.patterns, cpu_config)?;
+        return emit_multi_pattern_native_results(
+            NativeSearchOutputOptions {
+                decision,
+                query: params.query,
+                path: params.path,
+                requested_gpu_device_ids: params.gpu_device_ids,
+                json: params.json,
+                ndjson: params.ndjson,
+                count: params.count,
+            },
+            matches,
+        );
+    }
+    run_native_search_with_optional_rg_fallback(cpu_config, None)
+}
+
+#[cfg(not(feature = "cuda"))]
+fn explicit_gpu_sidecar_is_available() -> bool {
+    if env::var_os("TG_SIDECAR_SCRIPT").is_some() {
+        return true;
+    }
+    env::var_os("TG_SIDECAR_PYTHON")
+        .map(PathBuf::from)
+        .is_some_and(|path| path.exists())
 }
 
 #[cfg(feature = "cuda")]

--- a/rust_core/tests/test_routing.rs
+++ b/rust_core/tests/test_routing.rs
@@ -1756,6 +1756,34 @@ fn test_routing_explicit_gpu_device_ids_override_warm_index() {
     }
 }
 
+#[cfg(not(feature = "cuda"))]
+#[test]
+fn test_public_gpu_request_without_explicit_sidecar_falls_back_to_native_cpu() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--gpu-device-ids")
+        .arg("0")
+        .arg("--json")
+        .arg("hello")
+        .arg(dir.path())
+        .env("TG_DISABLE_RG", "1")
+        .env("PATH", "")
+        .env("TG_SIDECAR_PYTHON", "definitely-missing-python")
+        .output()
+        .unwrap();
+
+    let payload = assert_json_routing(&output, "NativeCpuBackend", "gpu-auto-fallback-cpu", false);
+    assert_eq!(payload["total_matches"], 3);
+    assert_eq!(payload["requested_gpu_device_ids"], serde_json::json!([0]));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("native GPU unavailable"), "stderr={stderr}");
+}
+
 #[test]
 fn test_rust_control_plane_plain_explicit() {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- make non-CUDA public native builds explicitly warn that native GPU is unavailable instead of treating ambient sidecar routing as promotion evidence
- fall back to the native CPU route for supported search shapes when no explicit usable GPU sidecar is configured
- preserve explicit sidecar behavior for repo/dev sidecar tests and actionable sidecar diagnostics

## Validation
- RED: test_public_gpu_request_without_explicit_sidecar_falls_back_to_native_cpu failed before implementation by routing to GpuSidecar
- C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml --test test_routing test_public_gpu_request_without_explicit_sidecar_falls_back_to_native_cpu -- --exact --nocapture
- C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml --test test_sidecar_ipc -- --nocapture
- C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml
- C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check
- git diff --check origin/main...HEAD
- Superset stack validation also passed: uv run ruff check ., uv run ruff format --check --preview ., uv run mypy src/tensor_grep, uv run pytest -q