### PR TITLE
fix: harden release docs stamp governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,16 +18,17 @@ The repo should be treated as a benchmark-governed, contract-heavy codebase. Do 
 
 release_docs_current_tag: v1.11.3
 
-As of 2026-05-14, the current tagged release state is `v1.11.3`, and the latest complete public PyPI/release-asset distribution is also `v1.11.2`. The stable installer, release-native asset publication, managed-native `tg upgrade` refresh path, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity fixes, Windows `.cmd` quoted-pattern launcher fix, native-first Windows PATH ordering, top-level validation-command contract, local default `classify`, classify provider provenance, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, explicit language/file-name agent ranking, Windows validation-command quoting, docs/version governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternative-target surfacing, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing are released through `v1.11.2` GitHub assets and PyPI. Follow-up work should focus on context/session latency, GPU production viability, token economy, call-site evidence, AST parity roadmap, classify provider/cache UX, and keeping docs synchronized with release proof.
+As of 2026-05-14, the current tagged release state is `v1.11.3`, and the latest complete public PyPI/release-asset distribution is also `v1.11.3`. The stable installer, release-native asset publication, managed-native `tg upgrade` refresh path, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity fixes, Windows `.cmd` quoted-pattern launcher fix, native-first Windows PATH ordering, top-level validation-command contract, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, explicit language/file-name agent ranking, Windows validation-command quoting, docs/version governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternative-target surfacing, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing are released through `v1.11.3` GitHub assets and PyPI. Follow-up work should focus on context/session latency, GPU production viability, token economy, call-site evidence, AST parity roadmap, classify provider/cache UX, and keeping docs synchronized with release proof.
 
-- Latest tagged release PR: #110 `fix: expose classify provider provenance`
-- Latest tagged merge commit: `ada6a47 fix: expose classify provider provenance (#110)`
-- Latest tagged release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest complete public release PR: #110 `fix: expose classify provider provenance`
-- Latest complete public release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest merged fix commit: `ada6a47 fix: expose classify provider provenance (#110)`
+- Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
+- Latest tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest complete public release PR: #113 `fix: accelerate fixed multi-pattern native search`
+- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest merged fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
 - Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
 - Recent fix commits:
+  - `87d4ca4 fix: accelerate fixed multi-pattern native search`
   - `ada6a47 fix: expose classify provider provenance (#110)`
   - `6ad69b5 fix: harden agent capsule hardcases (#109)`
   - `9ddd20b fix: expose GPU promotion blockers`
@@ -70,11 +71,12 @@ As of 2026-05-14, the current tagged release state is `v1.11.3`, and the latest 
   - `1a06cba fix: remove stale Windows tg launchers`
   - `379b22f fix: harden tg resolution and rg path parity`
 - `v1.11.0` GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.0> exists, but main CI run `25834508800` was cancelled during release-native asset publication; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25839425530`: passed the pre-release matrix, semantic-release, PyPI wheel/sdist validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- Main CodeQL run `25839425282`: passed on the `v1.11.2` release line
-- PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version` reports `tensor-grep 1.11.2`
-- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.2>
-- GitHub release assets: `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, winget manifest, Homebrew formula, and publish instructions are uploaded and verified on `v1.11.2`
+- Main CI run `25860914920`: passed the pre-release matrix, semantic-release, PyPI wheel/sdist validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
+- Main CodeQL run `25860914488`: passed on the `v1.11.3` release line
+- PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` reports `tensor-grep 1.11.3`
+- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.3>
+- GitHub release assets: `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, winget manifest, Homebrew formula, and publish instructions are uploaded and verified on `v1.11.3`
+- Public `v1.11.3` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` verified `tensor-grep 1.11.3`; the release adds a fixed multi-pattern native CPU fast path using one Aho-Corasick pass for safe fixed-string searches while keeping GPU promotion experimental.
 - Public `v1.11.2` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version` verified `tensor-grep 1.11.2`; the release also exposes classify provider provenance so JSON harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
 - Public `v1.10.10` GPU evidence remains experimental: explicit managed GPU requests still report `GpuSidecar` / unsupported rather than a qualifying `NativeGpuBackend` row, so no GPU speed promotion is made.
 - Public `v1.10.8` dogfood: release CI, assets, PyPI, `uvx --refresh-package tensor-grep --from tensor-grep==1.10.8 tg --version`, managed `tg upgrade`, fresh `cmd /c tg --version`, fresh `pwsh -NoProfile -Command "tg --version"`, and direct managed native `tg.exe` all verified `1.10.8`. Python `subprocess.run(["tg", "--version"])` still resolved the foreign Together CLI `tg.exe` from Machine PATH on this host; `tg doctor --json` reported the route as `foreign` with Machine PATH remediation and did not delete or overwrite unrelated launchers.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These documents define the operating and governance surface for teams running `t
 
 release_docs_current_tag: v1.11.3
 
-Latest tagged GitHub release: [`v1.11.3`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.3). GitHub assets and PyPI publication completed in main CI run `25839425530`; CodeQL run `25839425282` passed.
+Latest tagged GitHub release: [`v1.11.3`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.3). GitHub assets and PyPI publication completed in main CI run `25860914920`; CodeQL run `25860914488` passed.
 Latest complete PyPI release: [`v1.11.3`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.3). This is also the latest complete release-asset distribution.
 
 Current positioning:
@@ -52,11 +52,20 @@ Current positioning:
 - `rg` remains the cold exact-text baseline. Use `--sort path --format rg` when automation needs deterministic ripgrep-shaped stdout.
 - `ast-grep` remains the structural-search feature/performance baseline. `tg run` is a validated useful slice, not a full ast-grep replacement.
 - GPU remains opt-in/experimental until local benchmarks prove a real end-to-end crossover. Default `classify` is now deterministic and local unless `TENSOR_GREP_CLASSIFY_PROVIDER=cybert` opts into the CyBERT/Triton path.
-- Public GPU note: in `v1.11.2`, the public managed binary still reports explicit GPU requests through `GpuSidecar`; only a CUDA-feature native build can produce `NativeGpuBackend` / `sidecar_used = false` evidence. GPU benchmark artifacts now expose `promotion_evidence_contract` and `promotion_blockers` so sidecar rows cannot look like promotion proof. The latest public managed many-pattern dogfood is not promotion-ready: 100 fixed no-match patterns over 1GB ran far slower than fair `rg -F -e ... -e ...` multi-pattern search, and earlier local CUDA-native wins against sequential `rg` are not public GPU readiness. Native CUDA correctness rows are not public GPU readiness, and GPU remains experimental until public managed binaries produce 1GB and 5GB correctness and speed wins for the declared workload on RTX 4070 / RTX 5070 class devices.
+- Public GPU note: in `v1.11.3`, the public managed binary still reports explicit GPU requests through `GpuSidecar`; only a CUDA-feature native build can produce `NativeGpuBackend` / `sidecar_used = false` evidence. GPU benchmark artifacts now expose `promotion_evidence_contract` and `promotion_blockers` so sidecar rows cannot look like promotion proof. The latest public managed many-pattern dogfood is not promotion-ready for GPU: the accepted improvement is a native CPU fixed multi-pattern fast path, not public GPU readiness. Native CUDA correctness rows are not public GPU readiness, and GPU remains experimental until public managed binaries produce 1GB and 5GB correctness and speed wins for the declared workload on RTX 4070 / RTX 5070 class devices.
 - The public native front door is now the performance-critical shell entrypoint. Advertised CLI flags must either execute there or route to the Python sidecar intentionally; help text that advertises flags the native parser rejects is a release blocker.
 - `tg agent --query ... --json` is the first Actionable Context Capsule surface: a bounded, deterministic work packet with primary files/functions, alternative targets, route rationale, snippets with line maps, validation evidence, rollback/checkpoint metadata, omissions, confidence, optional native GPU route evidence, unresolved equal-confidence tie metadata, and an ask-before-editing recommendation. It is an opt-in agent command, not a mutation of raw `--format rg`, `--json`, or `--ndjson`.
 - `tg agent --gpu-device-ids 0,1 --query ... --json` runs an opt-in batched GPU evidence scan for the selected devices and records `gpu_acceleration`; sidecar-routed results are reported as unsupported instead of being counted as GPU acceleration.
 - Capsule confidence must be honest when query language hints, primary target language, selected snippets, and validation commands disagree. Mixed-language agent workflows use `validation_alignment` and ask-before-editing metadata instead of silently pairing a TypeScript target with pytest-only validation.
+
+What `v1.11.3` closed:
+
+- PR #113 `fix: accelerate fixed multi-pattern native search` shipped the release as merge commit `87d4ca4 fix: accelerate fixed multi-pattern native search` and release commit `2731659 chore(release): v1.11.3 [skip ci]`
+- main CI run `25860914920` passed semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`; CodeQL run `25860914488` passed
+- GitHub release assets for `v1.11.3` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions; `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` reports `tensor-grep 1.11.3`
+- fixed multi-pattern fixed-string native CPU search now uses a single Aho-Corasick pass instead of sequentially scanning once per pattern when requested semantics are safe for that route
+- local release evidence for 100 fixed no-match patterns over 1GB measured the native `tg` fixed multi-pattern path at about `0.0239s` median versus fair `rg -F -e ... -e ...` multi-pattern at about `0.0347s`; this is a CPU workload-class win, not a GPU promotion claim
+- public GPU remains experimental: managed GPU requests still route through `GpuSidecar` / unsupported rather than public `NativeGpuBackend` evidence
 
 What `v1.11.2` closed:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,16 +9,17 @@ description: Use when searching code, logs, or repositories with tensor-grep; va
 
 release_docs_current_tag: v1.11.3
 
-As of 2026-05-14, the current tagged version is `v1.11.3`, and the latest complete public PyPI/release-asset distribution is also `v1.11.2`. Stable installer, PyPI metadata refresh, release-native asset publication, managed-native front-door refresh after `tg upgrade`, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity for advertised public flags, Windows `.cmd` quoted-pattern launcher handling, native-first Windows PATH ordering, top-level validation-command JSON, local default `classify`, classify provider provenance, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, the opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, capsule validation-trust fixes, explicit language/file-name ranking, quoted Windows validation commands, docs governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternatives, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing are in the public `v1.11.2` GitHub asset and PyPI release line.
+As of 2026-05-14, the current tagged version is `v1.11.3`, and the latest complete public PyPI/release-asset distribution is also `v1.11.3`. Stable installer, PyPI metadata refresh, release-native asset publication, managed-native front-door refresh after `tg upgrade`, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity for advertised public flags, Windows `.cmd` quoted-pattern launcher handling, native-first Windows PATH ordering, top-level validation-command JSON, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, the opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, capsule validation-trust fixes, explicit language/file-name ranking, quoted Windows validation commands, docs governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternatives, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing are in the public `v1.11.3` GitHub asset and PyPI release line.
 
 Current release facts:
 
-- PR #110 `fix: expose classify provider provenance` merged and released as `v1.11.2`
-- Tagged merge commit: `ada6a47 fix: expose classify provider provenance (#110)`
-- Tagged release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest complete public release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest merged fix commit: `ada6a47 fix: expose classify provider provenance (#110)`
+- PR #113 `fix: accelerate fixed multi-pattern native search` merged and released as `v1.11.3`
+- Tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest merged fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
 - Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
+- PR #110 `fix: expose classify provider provenance` merged and released as `v1.11.2`
 - PR #105 `fix: add explicit Windows subprocess launcher repair` merged and released as `v1.10.10`
 - Merge commit: `dd995fc fix: add explicit Windows subprocess launcher repair`
 - PR #101 `fix: harden gpu search accuracy contracts` merged and released as `v1.10.7`
@@ -43,10 +44,11 @@ Current release facts:
 - Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`
 - PR #66 `docs: define agent context capsule roadmap` merged; Main CI run `25561521904` passed, CodeQL/dynamic main run `25561520180` passed, and semantic-release correctly skipped publishing.
 - `v1.11.0` main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25839425530` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. CodeQL run `25839425282` passed on the `v1.11.2` release line.
-- PyPI pinned public install resolves with `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version`
-- GitHub release assets for `v1.11.2` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
-- Public `v1.11.2` dogfood verified PyPI, `uvx`, GitHub assets, and classify provider provenance in JSON output; `v1.10.10` remains the historical Windows subprocess launcher repair release.
+- Main CI run `25860914920` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. CodeQL run `25860914488` passed on the `v1.11.3` release line.
+- PyPI pinned public install resolves with `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version`
+- GitHub release assets for `v1.11.3` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
+- Public `v1.11.3` dogfood verified PyPI, `uvx`, GitHub assets, and fixed multi-pattern native CPU search; `v1.10.10` remains the historical Windows subprocess launcher repair release.
+- Public `v1.11.2` dogfood verified PyPI, `uvx`, GitHub assets, and classify provider provenance in JSON output.
 - PR #102 `fix: harden v1.10.7 dogfood followups` merged and released as `v1.10.8`
 - Public `v1.9.9` dogfood: direct managed native `~/.tensor-grep/bin/tg.exe` reports `tg 1.9.9`; `uvx --from tensor-grep==1.9.9 tg --version` reports `tensor-grep 1.9.9`; `tg update` advanced `1.9.8` to `1.9.9`, refreshed the managed native front door, and fresh `cmd` plus unprofiled `pwsh` report `tg 1.9.9`.
 - Prior public update dogfood: `tg update` from `v1.9.3` initially saw PyPI propagation lag, then installed sidecar `tensor-grep==1.9.4`, refreshed `~/.tensor-grep/bin/tg.exe`, and verified `tg 1.9.4`. Profiled PowerShell, `cmd`, `pwsh -NoProfile`, WSL, Git Bash, and direct managed native `tg.exe` resolved `tg 1.9.4`; `tg doctor --json` reported `version = 1.9.4`, `rust_binary_version_status = matches`, `search_acceleration_backend = standalone-native-tg`, `path_tg_first_launcher_kind = cmd-shim`, `fresh_shell_path_tg_first_launcher_kind = managed-native`, and a `path_tg_launcher_warning` for current shells that still route through the compatibility shim before fresh-shell PATH.

--- a/docs/CONTINUATION_PLAN.md
+++ b/docs/CONTINUATION_PLAN.md
@@ -6,23 +6,23 @@
 
 release_docs_current_tag: v1.11.3
 
-The current tagged state is `v1.11.2`, and the latest complete public PyPI/release-asset distribution is also `v1.11.2`. Stable installer and sidecar upgrade hardening shipped through `v1.11.2`, including managed-native front-door refresh after `tg upgrade`, refresh of stale tensor-grep-owned `tg.com` PATH bridges after upgrade, public native-front-door parity for advertised Python-backed shapes, Windows `.cmd` quoted-pattern handling, fresh-shell launcher diagnostics, Python-subprocess launcher diagnostics, top-level `validation_commands`, deterministic local `classify`, classify provider provenance, GPU scale correctness gates, benchmark launcher attribution, scoped GPU device probing, `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, edit JSON/rollback safety, ambiguous capsule tie metadata, workflow benchmark governance, release-doc synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing. Public v1.11.2 dogfood verified PyPI, GitHub assets, `uvx`, and classify provider provenance; the `v1.10.10` repair release remains the Windows subprocess launcher repair baseline. Public GPU remains experimental because managed GPU requests still route through `GpuSidecar` / unsupported instead of qualifying `NativeGpuBackend`, while large-file CPU behavior is the near-term performance story. Use [docs/SESSION_HANDOFF.md](SESSION_HANDOFF.md) as the live handoff for release status, current weak spots, release completion contract, and next-session commands. This continuation plan remains useful as the historical workstream map, but it is no longer the freshest operational state.
+The current tagged state is `v1.11.3`, and the latest complete public PyPI/release-asset distribution is also `v1.11.3`. Stable installer and sidecar upgrade hardening shipped through `v1.11.3`, including managed-native front-door refresh after `tg upgrade`, refresh of stale tensor-grep-owned `tg.com` PATH bridges after upgrade, public native-front-door parity for advertised Python-backed shapes, Windows `.cmd` quoted-pattern handling, fresh-shell launcher diagnostics, Python-subprocess launcher diagnostics, top-level `validation_commands`, deterministic local `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale correctness gates, benchmark launcher attribution, scoped GPU device probing, `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, edit JSON/rollback safety, ambiguous capsule tie metadata, workflow benchmark governance, release-doc synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing. Public v1.11.3 dogfood verified PyPI, GitHub assets, `uvx`, and the fixed multi-pattern native CPU lane; the `v1.10.10` repair release remains the Windows subprocess launcher repair baseline. Public GPU remains experimental because managed GPU requests still route through `GpuSidecar` / unsupported instead of qualifying `NativeGpuBackend`, while native CPU fixed multi-pattern search is the accepted many-pattern improvement. Use [docs/SESSION_HANDOFF.md](SESSION_HANDOFF.md) as the live handoff for release status, current weak spots, release completion contract, and next-session commands. This continuation plan remains useful as the historical workstream map, but it is no longer the freshest operational state.
 
 Current release facts:
 
-- Latest tagged release PR: #110 `fix: expose classify provider provenance`
-- Latest tagged merge commit: `ada6a47 fix: expose classify provider provenance (#110)`
-- Latest tagged release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest complete public release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest merged fix commit: `ada6a47 fix: expose classify provider provenance (#110)`
+- Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
+- Latest tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest merged fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
 - Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
-- Latest complete public release PR: #110 `fix: expose classify provider provenance`
-- Latest complete public merge commit: `ada6a47 fix: expose classify provider provenance (#110)`
+- Latest complete public release PR: #113 `fix: accelerate fixed multi-pattern native search`
+- Latest complete public merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
 - `v1.11.0` main CI run `25834508800` passed pre-release checks and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25839425530`: passed pre-release checks, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
-- CodeQL run `25839425282`: passed on the v1.11.2 release line.
-- PyPI pinned public install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version` reports `tensor-grep 1.11.2`.
-- GitHub release assets for `v1.11.2` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions.
+- Main CI run `25860914920`: passed pre-release checks, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
+- CodeQL run `25860914488`: passed on the v1.11.3 release line.
+- PyPI pinned public install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` reports `tensor-grep 1.11.3`.
+- GitHub release assets for `v1.11.3` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions.
 - Historical `v1.10.10` launcher dogfood: direct `C:\Users\oimir\.tensor-grep\bin\tg.exe --version`, fresh `cmd`, unprofiled `pwsh`, and Python `subprocess.run(["tg", "--version"])` all reported `tg 1.10.10` after the explicit repair command.
 - Prior managed native-upgrade dogfood: `tg update` from `v1.9.3` installed sidecar `tensor-grep==1.9.4` and refreshed the native front door to `tg 1.9.4` after transient PyPI propagation lag.
 - Public capsule dogfood: `tg agent src/tensor_grep/cli --query "agent context capsule" --json` returns the Actionable Context Capsule contract.

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -8,20 +8,23 @@ release_docs_current_tag: v1.11.3
 
 - Latest tagged version: `v1.11.3`
 - Latest complete PyPI version: `v1.11.3`
-- Latest tagged release PR: #110 `fix: expose classify provider provenance`
-- Latest tagged merge commit: `ada6a47 fix: expose classify provider provenance (#110)`
-- Latest tagged release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest complete public release PR: #110 `fix: expose classify provider provenance`
-- Latest complete public release commit: `5679b22 chore(release): v1.11.2 [skip ci]`
-- Latest fix commit: `ada6a47 fix: expose classify provider provenance (#110)`
+- Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
+- Latest tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest complete public release PR: #113 `fix: accelerate fixed multi-pattern native search`
+- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
+- Latest fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
 - Latest feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
-- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.2>
+- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.3>
 - `v1.11.0` publication caveat: main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed, `publish-github-release-assets` / `publish-pypi` did not complete, and PyPI latest remains `1.10.10`.
-- Main CI run `25839425530`: passed the pre-release matrix, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- Main CodeQL run `25839425282`: passed on the `v1.11.2` release line
-- PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version` reports `tensor-grep 1.11.2`
-- GitHub release assets: `v1.11.2` has uploaded native CPU front doors for Windows/Linux/macOS, checksums, winget manifest, Homebrew formula, and publish instructions
+- Main CI run `25860914920`: passed the pre-release matrix, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
+- Main CodeQL run `25860914488`: passed on the `v1.11.3` release line
+- PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` reports `tensor-grep 1.11.3`
+- GitHub release assets: `v1.11.3` has uploaded native CPU front doors for Windows/Linux/macOS, checksums, winget manifest, Homebrew formula, and publish instructions
+- Public `v1.11.3` dogfood verified PyPI, `uvx`, release assets, and the fixed multi-pattern native CPU lane. `v1.11.3` uses a single Aho-Corasick pass for safe fixed-string multi-pattern searches and keeps GPU promotion separate from this CPU workload-class win.
 - Public `v1.11.2` dogfood verified PyPI, `uvx`, release assets, and classify provider provenance in JSON output. `v1.11.2` exposes `classification_backend` so harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
+- Closed v1.11.3 fixed multi-pattern lane gap: `v1.11.3` routes safe fixed-string multi-pattern native searches through one Aho-Corasick pass, preserves fallback for unsupported semantics, and records the local 100 fixed no-match patterns over 1GB CPU win separately from GPU promotion evidence.
+- Closed v1.11.2 classify provenance gap: `v1.11.2` exposes `classification_backend` in JSON output so harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
 - Public `v1.10.10` managed-upgrade and launcher dogfood verified the pinned managed installer, direct managed native `tg.exe`, fresh `cmd /c tg --version`, fresh `pwsh -NoProfile -Command "tg --version"`, Python `subprocess.run(["tg", "--version"])`, PyPI, `uvx`, and GitHub assets. `tg repair-launcher --allow-foreign-rename` backed up the foreign Together CLI `tg.exe` before installing the verified managed native front door into that PATH slot.
 - Public `v1.10.10` dogfood lesson: Python subprocess resolution is now repairable with explicit operator opt-in, while GPU remains public-experimental because managed GPU requests still report `GpuSidecar` / unsupported instead of qualifying `NativeGpuBackend`.
 - Closed v1.10.10 Python subprocess launcher gap: `v1.10.10` adds `tg repair-launcher --allow-foreign-rename`, documents it in root help, preserves foreign launchers unless explicitly opted in, refreshes stale tensor-grep-owned PATH bridges, and verifies `cmd`, unprofiled `pwsh`, direct managed native, and Python `subprocess.run(["tg", "--version"])` at `tg 1.10.10` after repair.
@@ -61,9 +64,9 @@ release_docs_current_tag: v1.11.3
 - Fast agent-readiness dogfood before PR #72: `python scripts/agent_readiness.py --output artifacts/agent_readiness_launcher_observability.json` passed all checks, including public version probes, `public-windows-launcher-quoted-patterns`, repo doctor, context consistency, deterministic rg parity edges, generated-root guardrails, AST smoke, MCP context-render smoke, and docs claim hygiene.
 - Repo-dev dogfood: stale in-tree standalone binaries remain skipped unless explicitly pinned with `TG_NATIVE_TG_BINARY` or `TG_MCP_TG_BINARY`.
 
-## Current Post-v1.11.2 Scope
+## Current Post-v1.11.3 Scope
 
-Current release branch is publication-complete for `v1.11.2`: PR #110 `fix: expose classify provider provenance` was squash-merged as `ada6a47`, release commit `5679b22 chore(release): v1.11.2 [skip ci]` exists, main CI run `25839425530` passed tests/assets, GitHub asset upload, PyPI publish, and `publish-success-gate`, and CodeQL run `25839425282` passed. Public dogfood verified PyPI, release assets, `uvx`, and classify provider provenance. The `v1.10.10` Windows subprocess launcher repair remains the public launcher repair baseline; keep foreign launcher handling opt-in and auditable rather than deleting unrelated tools.
+Current release branch is publication-complete for `v1.11.3`: PR #113 `fix: accelerate fixed multi-pattern native search` was squash-merged as `87d4ca4`, release commit `2731659 chore(release): v1.11.3 [skip ci]` exists, main CI run `25860914920` passed tests/assets, GitHub asset upload, PyPI publish, and `publish-success-gate`, and CodeQL run `25860914488` passed. Public dogfood verified PyPI, release assets, `uvx`, and the fixed multi-pattern native CPU lane. The `v1.10.10` Windows subprocess launcher repair remains the public launcher repair baseline; keep foreign launcher handling opt-in and auditable rather than deleting unrelated tools.
 
 The public Windows `.cmd` bridge quoted multi-word no-match follow-up shipped in `v1.8.30`. The Windows native-first PATH, agent JSON validation-command, local default classify, and GPU scale benchmark follow-ups shipped in `v1.8.31`. The launcher-route observability and benchmark launcher-attribution follow-up shipped in `v1.8.32`. The explicit GPU probe scoping and benchmark launcher warning follow-up shipped in `v1.8.33`. The Actionable Context Capsule v1 shipped in `v1.9.0`; mixed-language capsule trust alignment and GPU recommendation hygiene shipped in `v1.9.1`; edit JSON/rollback safety shipped in `v1.9.2`; explicit Python ranking and quoted validation commands shipped in `v1.9.3`; docs-governance and validation placeholders shipped in `v1.9.4`; native CUDA gate hardening, capsule alternatives, help diagnostics, and foreign launcher diagnostics shipped in `v1.9.5`; directory validation, CUDA 12.8 install paths, help coverage, and release-proof governance shipped in `v1.9.6`; GPU benchmark promotion-gate taxonomy and cold-search positioning shipped in `v1.9.7`; stale tensor-grep-owned `tg.com` bridge refresh after upgrade shipped in `v1.9.8`; agent workflow benchmark governance shipped in `v1.9.9`; capsule confidence/secrets/docs dogfood follow-ups shipped in source/GitHub assets in `v1.9.10`; and release wheel Cargo prefetch retries shipped in `v1.9.11`.
 

--- a/scripts/stamp_release_assets.py
+++ b/scripts/stamp_release_assets.py
@@ -52,6 +52,22 @@ def _stamp_release_doc(content: str, *, version: str) -> str:
             rf"current tagged \1 is `{tag}`",
         ),
         (
+            r"current tagged state is `v\d+\.\d+\.\d+`",
+            f"current tagged state is `{tag}`",
+        ),
+        (
+            r"latest complete public PyPI/release-asset distribution is also `v\d+\.\d+\.\d+`",
+            f"latest complete public PyPI/release-asset distribution is also `{tag}`",
+        ),
+        (
+            r"released through `v\d+\.\d+\.\d+` GitHub assets and PyPI",
+            f"released through `{tag}` GitHub assets and PyPI",
+        ),
+        (
+            r"in the public `v\d+\.\d+\.\d+` GitHub asset and PyPI release line",
+            f"in the public `{tag}` GitHub asset and PyPI release line",
+        ),
+        (
             r"Latest tagged GitHub release: \[`v\d+\.\d+\.\d+`\]\(https://github\.com/oimiragieo/tensor-grep/releases/tag/v\d+\.\d+\.\d+\)",
             f"Latest tagged GitHub release: [`{tag}`](https://github.com/oimiragieo/tensor-grep/releases/tag/{tag})",
         ),
@@ -66,6 +82,18 @@ def _stamp_release_doc(content: str, *, version: str) -> str:
         (
             r"(?m)^(- Latest complete PyPI version:\s*)`v\d+\.\d+\.\d+`",
             rf"\g<1>`{tag}`",
+        ),
+        (
+            r"(?m)^(- GitHub release: <https://github\.com/oimiragieo/tensor-grep/releases/tag/)v\d+\.\d+\.\d+(>)",
+            rf"\g<1>{tag}\2",
+        ),
+        (
+            r"(?m)^(- PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==)\d+\.\d+\.\d+( tg --version` reports `tensor-grep )\d+\.\d+\.\d+(`)",
+            rf"\g<1>{version}\g<2>{version}\3",
+        ),
+        (
+            r"(?m)^(- GitHub release assets: `)v\d+\.\d+\.\d+(` has uploaded)",
+            rf"\g<1>{tag}\2",
         ),
         (
             r"post-`v\d+\.\d+\.\d+`",

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -21,14 +21,14 @@ def _project_release_tag() -> str:
 
 
 CURRENT_RELEASE_TAG = _project_release_tag()
-CURRENT_RELEASE_COMMIT = "5679b22 chore(release): v1.11.2 [skip ci]"
-CURRENT_FIX_COMMIT = "ada6a47 fix: expose classify provider provenance (#110)"
+CURRENT_RELEASE_COMMIT = "2731659 chore(release): v1.11.3 [skip ci]"
+CURRENT_FIX_COMMIT = "87d4ca4 fix: accelerate fixed multi-pattern native search"
 CURRENT_FEATURE_COMMIT = "213d383 feat: add dogfood readiness verdict and checkpoint UX"
-LATEST_COMPLETE_RELEASE_TAG = "v1.11.2"
-LATEST_COMPLETE_RELEASE_COMMIT = "5679b22 chore(release): v1.11.2 [skip ci]"
-LATEST_COMPLETE_FIX_COMMIT = "ada6a47 fix: expose classify provider provenance (#110)"
-LATEST_COMPLETE_MAIN_CI = "25839425530"
-LATEST_COMPLETE_CODEQL = "25839425282"
+LATEST_COMPLETE_RELEASE_TAG = CURRENT_RELEASE_TAG
+LATEST_COMPLETE_RELEASE_COMMIT = CURRENT_RELEASE_COMMIT
+LATEST_COMPLETE_FIX_COMMIT = CURRENT_FIX_COMMIT
+LATEST_COMPLETE_MAIN_CI = "25860914920"
+LATEST_COMPLETE_CODEQL = "25860914488"
 
 
 def test_readme_should_point_to_canonical_public_docs() -> None:
@@ -112,6 +112,17 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
         assert f"release_docs_current_tag: {_project_release_tag()}" in content
         assert "python scripts/agent_readiness.py" in content
         assert "tg dogfood" in content
+
+    for path in ("AGENTS.md", "SKILL.md"):
+        assert (
+            "latest complete public PyPI/release-asset distribution is also "
+            f"`{CURRENT_RELEASE_TAG}`"
+        ) in docs[path]
+
+    assert f"current tagged state is `{CURRENT_RELEASE_TAG}`" in docs["docs/CONTINUATION_PLAN.md"]
+    assert (
+        f"latest complete public PyPI/release-asset distribution is also `{CURRENT_RELEASE_TAG}`"
+    ) in docs["docs/CONTINUATION_PLAN.md"]
 
     for content in (
         docs["AGENTS.md"],
@@ -216,7 +227,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert "only initialize selected devices" in readme
     assert "Actionable Context Capsule" in readme
     assert "validation_alignment" in readme
-    current_closed_heading = "What `v1.11.2` closed:"
+    current_closed_heading = "What `v1.11.3` closed:"
+    v1112_heading = "What `v1.11.2` closed:"
     v1111_heading = "What `v1.11.1` closed:"
     v1110_failed_heading = "What `v1.11.0` tagged but did not complete:"
     v11010_heading = "What `v1.10.10` closed:"
@@ -237,7 +249,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     v193_heading = "What `v1.9.3` closed:"
     v192_heading = "What `v1.9.2` closed:"
     follow_up_heading = f"Active post-`{CURRENT_RELEASE_TAG}` follow-up:"
-    current_closed_block = readme.split(current_closed_heading, 1)[1].split(v1111_heading, 1)[0]
+    current_closed_block = readme.split(current_closed_heading, 1)[1].split(v1112_heading, 1)[0]
+    v1112_closed_block = readme.split(v1112_heading, 1)[1].split(v1111_heading, 1)[0]
     v1111_closed_block = readme.split(v1111_heading, 1)[1].split(v1110_failed_heading, 1)[0]
     v1110_failed_block = readme.split(v1110_failed_heading, 1)[1].split(v11010_heading, 1)[0]
     v11010_closed_block = readme.split(v11010_heading, 1)[1].split(v1109_heading, 1)[0]
@@ -257,9 +270,12 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     v194_closed_block = readme.split(v194_heading, 1)[1].split(v193_heading, 1)[0]
     v192_closed_block = readme.split(v192_heading, 1)[1].split("What `v1.9.1` closed:", 1)[0]
     follow_up_block = readme.split(follow_up_heading, 1)[1]
-    assert "classify provider provenance" in current_closed_block
-    assert "classification_backend" in current_closed_block
-    assert "tg classify --format json" in current_closed_block
+    assert "fixed multi-pattern" in current_closed_block
+    assert "Aho-Corasick" in current_closed_block
+    assert "100 fixed no-match patterns over 1GB" in current_closed_block
+    assert "classify provider provenance" in v1112_closed_block
+    assert "classification_backend" in v1112_closed_block
+    assert "tg classify --format json" in v1112_closed_block
     assert "agent capsule hardcases" in v1111_closed_block
     assert "implementation files outrank preview/mention files" in v1111_closed_block
     assert "release docs governance" in v1111_closed_block


### PR DESCRIPTION
## Summary
- update release governance docs to the completed v1.11.3 release proof
- make release docs governance derive the latest complete tag from the current project version
- teach the release stamper to update complete-public-distribution prose and pinned release lines

## Validation
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest tests/unit/test_public_docs_governance.py -q
- uv run pytest -q
- python scripts/stamp_release_assets.py --check
- python scripts/agent_readiness.py --no-wsl-probe --output artifacts/agent_readiness_release_docs_stamp_fix.json