### PR TITLE
fix: harden post-release docs governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,15 @@ release_docs_current_tag: v1.11.4
 As of 2026-05-14, the current tagged release state is `v1.11.4`, and the latest complete public PyPI/release-asset distribution is also `v1.11.4`. The stable installer, release-native asset publication, managed-native `tg upgrade` refresh path, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity fixes, Windows `.cmd` quoted-pattern launcher fix, native-first Windows PATH ordering, top-level validation-command contract, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, explicit language/file-name agent ranking, Windows validation-command quoting, docs/version governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternative-target surfacing, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing are released through `v1.11.4` GitHub assets and PyPI. Follow-up work should focus on context/session latency, GPU production viability, token economy, call-site evidence, AST parity roadmap, classify provider/cache UX, and keeping docs synchronized with release proof.
 
 - Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
-- Latest tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest complete public release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest merged fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest tagged merge commit: `2100122 fix: harden release docs stamp governance`
+- Latest tagged release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest complete public release PRs: #114 `fix: harden public GPU unavailable routing`, #115 `fix: harden release docs stamp governance`
+- Latest complete public release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest merged fix commit: `2100122 fix: harden release docs stamp governance`
 - Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
 - Recent fix commits:
+  - `2100122 fix: harden release docs stamp governance`
+  - `361e0db fix: harden public GPU unavailable routing`
   - `87d4ca4 fix: accelerate fixed multi-pattern native search`
   - `ada6a47 fix: expose classify provider provenance (#110)`
   - `6ad69b5 fix: harden agent capsule hardcases (#109)`
@@ -72,11 +74,12 @@ As of 2026-05-14, the current tagged release state is `v1.11.4`, and the latest 
   - `379b22f fix: harden tg resolution and rg path parity`
 - `v1.11.0` GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.0> exists, but main CI run `25834508800` was cancelled during release-native asset publication; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
 - Main CI run `25860914920`: passed the pre-release matrix, semantic-release, PyPI wheel/sdist validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- Main CodeQL run `25860914488`: passed on the `v1.11.3` release line
+- Main CodeQL run `25863751937`: passed on the `v1.11.4` release line
 - PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.4 tg --version` reports `tensor-grep 1.11.4`
 - GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.4>
-- GitHub release assets: `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, winget manifest, Homebrew formula, and publish instructions are uploaded and verified on `v1.11.3`
-- Public `v1.11.3` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` verified `tensor-grep 1.11.3`; the release adds a fixed multi-pattern native CPU fast path using one Aho-Corasick pass for safe fixed-string searches while keeping GPU promotion experimental.
+- Main CI run `25863754902`: passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
+- GitHub release assets: `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, winget manifest, Homebrew formula, and publish instructions are uploaded and verified on `v1.11.4`
+- Public `v1.11.4` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.4 tg --version` verified `tensor-grep 1.11.4`; the release includes `361e0db fix: harden public GPU unavailable routing` and `2100122 fix: harden release docs stamp governance`, while preserving the `87d4ca4 fix: accelerate fixed multi-pattern native search` CPU lane from `v1.11.3`. Explicit public GPU requests without sidecar configuration now report native GPU unavailable and fall back to `NativeCpuBackend`.
 - Public `v1.11.2` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version` verified `tensor-grep 1.11.2`; the release also exposes classify provider provenance so JSON harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
 - Public `v1.10.10` GPU evidence remains experimental: explicit managed GPU requests still report `GpuSidecar` / unsupported rather than a qualifying `NativeGpuBackend` row, so no GPU speed promotion is made.
 - Public `v1.10.8` dogfood: release CI, assets, PyPI, `uvx --refresh-package tensor-grep --from tensor-grep==1.10.8 tg --version`, managed `tg upgrade`, fresh `cmd /c tg --version`, fresh `pwsh -NoProfile -Command "tg --version"`, and direct managed native `tg.exe` all verified `1.10.8`. Python `subprocess.run(["tg", "--version"])` still resolved the foreign Together CLI `tg.exe` from Machine PATH on this host; `tg doctor --json` reported the route as `foreign` with Machine PATH remediation and did not delete or overwrite unrelated launchers.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ These documents define the operating and governance surface for teams running `t
 
 release_docs_current_tag: v1.11.4
 
-Latest tagged GitHub release: [`v1.11.4`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.4). GitHub assets and PyPI publication completed in main CI run `25860914920`; CodeQL run `25860914488` passed.
+Latest tagged GitHub release: [`v1.11.4`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.4). GitHub assets and PyPI publication are verified by main CI before `publish-success-gate` passes.
 Latest complete PyPI release: [`v1.11.4`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.4). This is also the latest complete release-asset distribution.
+Latest verified release proof: `v1.11.4` completed in main CI run `25863754902`; CodeQL run `25863751937` passed.
 
 Current positioning:
 
@@ -57,6 +58,15 @@ Current positioning:
 - `tg agent --query ... --json` is the first Actionable Context Capsule surface: a bounded, deterministic work packet with primary files/functions, alternative targets, route rationale, snippets with line maps, validation evidence, rollback/checkpoint metadata, omissions, confidence, optional native GPU route evidence, unresolved equal-confidence tie metadata, and an ask-before-editing recommendation. It is an opt-in agent command, not a mutation of raw `--format rg`, `--json`, or `--ndjson`.
 - `tg agent --gpu-device-ids 0,1 --query ... --json` runs an opt-in batched GPU evidence scan for the selected devices and records `gpu_acceleration`; sidecar-routed results are reported as unsupported instead of being counted as GPU acceleration.
 - Capsule confidence must be honest when query language hints, primary target language, selected snippets, and validation commands disagree. Mixed-language agent workflows use `validation_alignment` and ask-before-editing metadata instead of silently pairing a TypeScript target with pytest-only validation.
+
+What `v1.11.4` closed:
+
+- PR #114 `fix: harden public GPU unavailable routing` merged as `361e0db fix: harden public GPU unavailable routing`
+- PR #115 `fix: harden release docs stamp governance` shipped the release as merge commit `2100122 fix: harden release docs stamp governance` and release commit `49a7c9a chore(release): v1.11.4 [skip ci]`
+- main CI run `25863754902` passed semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`; CodeQL run `25863751937` passed
+- GitHub release assets for `v1.11.4` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions; `uvx --refresh-package tensor-grep --from tensor-grep==1.11.4 tg --version` reports `tensor-grep 1.11.4`
+- explicit public GPU requests without an explicit sidecar now report native GPU unavailable and fall back to `NativeCpuBackend` instead of making sidecar routing look like promotion evidence
+- post-release-safe docs governance: current tag labels can move with semantic-release while detailed proof blocks keep the last verified CI/CodeQL/release evidence accurate
 
 What `v1.11.3` closed:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,11 +13,12 @@ As of 2026-05-14, the current tagged version is `v1.11.4`, and the latest comple
 
 Current release facts:
 
-- PR #113 `fix: accelerate fixed multi-pattern native search` merged and released as `v1.11.3`
-- Tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
-- Tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest merged fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- PR #114 `361e0db fix: harden public GPU unavailable routing` and PR #115 `2100122 fix: harden release docs stamp governance` merged and released as `v1.11.4`
+- PR #113 `87d4ca4 fix: accelerate fixed multi-pattern native search` merged and released as `v1.11.3`
+- Tagged merge commit: `2100122 fix: harden release docs stamp governance`
+- Tagged release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest complete public release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest merged fix commit: `2100122 fix: harden release docs stamp governance`
 - Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
 - PR #110 `fix: expose classify provider provenance` merged and released as `v1.11.2`
 - PR #105 `fix: add explicit Windows subprocess launcher repair` merged and released as `v1.10.10`
@@ -44,10 +45,10 @@ Current release facts:
 - Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`
 - PR #66 `docs: define agent context capsule roadmap` merged; Main CI run `25561521904` passed, CodeQL/dynamic main run `25561520180` passed, and semantic-release correctly skipped publishing.
 - `v1.11.0` main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25860914920` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. CodeQL run `25860914488` passed on the `v1.11.3` release line.
+- Main CI run `25863754902` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. CodeQL run `25863751937` passed on the `v1.11.4` release line.
 - PyPI pinned public install resolves with `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version`
-- GitHub release assets for `v1.11.3` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
-- Public `v1.11.3` dogfood verified PyPI, `uvx`, GitHub assets, and fixed multi-pattern native CPU search; `v1.10.10` remains the historical Windows subprocess launcher repair release.
+- GitHub release assets for `v1.11.4` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
+- Public `v1.11.4` dogfood verified PyPI, `uvx`, GitHub assets, native GPU unavailable fallback to `NativeCpuBackend`, and post-release-safe docs governance; `v1.11.3` remains the fixed multi-pattern native CPU release and `v1.10.10` remains the historical Windows subprocess launcher repair release.
 - Public `v1.11.2` dogfood verified PyPI, `uvx`, GitHub assets, and classify provider provenance in JSON output.
 - PR #102 `fix: harden v1.10.7 dogfood followups` merged and released as `v1.10.8`
 - Public `v1.9.9` dogfood: direct managed native `~/.tensor-grep/bin/tg.exe` reports `tg 1.9.9`; `uvx --from tensor-grep==1.9.9 tg --version` reports `tensor-grep 1.9.9`; `tg update` advanced `1.9.8` to `1.9.9`, refreshed the managed native front door, and fresh `cmd` plus unprofiled `pwsh` report `tg 1.9.9`.

--- a/docs/CONTINUATION_PLAN.md
+++ b/docs/CONTINUATION_PLAN.md
@@ -11,18 +11,20 @@ The current tagged state is `v1.11.4`, and the latest complete public PyPI/relea
 Current release facts:
 
 - Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
-- Latest tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest merged fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest tagged merge commit: `2100122 fix: harden release docs stamp governance`
+- Latest tagged release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest complete public release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest merged fix commit: `2100122 fix: harden release docs stamp governance`
 - Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
-- Latest complete public release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest complete public merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest complete public release PRs: #114 `fix: harden public GPU unavailable routing`, #115 `fix: harden release docs stamp governance`
+- Latest complete public merge commits: `361e0db fix: harden public GPU unavailable routing`, `2100122 fix: harden release docs stamp governance`
 - `v1.11.0` main CI run `25834508800` passed pre-release checks and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
 - Main CI run `25860914920`: passed pre-release checks, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
-- CodeQL run `25860914488`: passed on the v1.11.3 release line.
+- Main CI run `25863754902`: passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
+- CodeQL run `25863751937`: passed on the v1.11.4 release line.
 - PyPI pinned public install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` reports `tensor-grep 1.11.3`.
-- GitHub release assets for `v1.11.3` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions.
+- GitHub release assets for `v1.11.4` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions.
+- Public `v1.11.4` dogfood verified native GPU unavailable fallback to `NativeCpuBackend` and post-release-safe docs governance; `87d4ca4 fix: accelerate fixed multi-pattern native search` remains the `v1.11.3` CPU many-pattern lane.
 - Historical `v1.10.10` launcher dogfood: direct `C:\Users\oimir\.tensor-grep\bin\tg.exe --version`, fresh `cmd`, unprofiled `pwsh`, and Python `subprocess.run(["tg", "--version"])` all reported `tg 1.10.10` after the explicit repair command.
 - Prior managed native-upgrade dogfood: `tg update` from `v1.9.3` installed sidecar `tensor-grep==1.9.4` and refreshed the native front door to `tg 1.9.4` after transient PyPI propagation lag.
 - Public capsule dogfood: `tg agent src/tensor_grep/cli --query "agent context capsule" --json` returns the Actionable Context Capsule contract.

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -9,19 +9,21 @@ release_docs_current_tag: v1.11.4
 - Latest tagged version: `v1.11.4`
 - Latest complete PyPI version: `v1.11.4`
 - Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest tagged merge commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
-- Latest tagged release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest complete public release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest complete public release commit: `2731659 chore(release): v1.11.3 [skip ci]`
-- Latest fix commit: `87d4ca4 fix: accelerate fixed multi-pattern native search`
+- Latest tagged merge commit: `2100122 fix: harden release docs stamp governance`
+- Latest tagged release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest complete public release PRs: #114 `fix: harden public GPU unavailable routing`, #115 `fix: harden release docs stamp governance`
+- Latest complete public release commit: `49a7c9a chore(release): v1.11.4 [skip ci]`
+- Latest fix commit: `2100122 fix: harden release docs stamp governance`
 - Latest feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
 - GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.4>
 - `v1.11.0` publication caveat: main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed, `publish-github-release-assets` / `publish-pypi` did not complete, and PyPI latest remains `1.10.10`.
 - Main CI run `25860914920`: passed the pre-release matrix, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- Main CodeQL run `25860914488`: passed on the `v1.11.3` release line
+- Main CodeQL run `25863751937`: passed on the `v1.11.4` release line
+- Main CI run `25863754902`: passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
 - PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.4 tg --version` reports `tensor-grep 1.11.4`
 - GitHub release assets: `v1.11.4` has uploaded native CPU front doors for Windows/Linux/macOS, checksums, winget manifest, Homebrew formula, and publish instructions
-- Public `v1.11.3` dogfood verified PyPI, `uvx`, release assets, and the fixed multi-pattern native CPU lane. `v1.11.3` uses a single Aho-Corasick pass for safe fixed-string multi-pattern searches and keeps GPU promotion separate from this CPU workload-class win.
+- Public `v1.11.4` dogfood verified PyPI, `uvx`, release assets, the native GPU unavailable fallback to `NativeCpuBackend`, and post-release-safe docs governance. `v1.11.3` uses `87d4ca4 fix: accelerate fixed multi-pattern native search` to run a single Aho-Corasick pass for safe fixed-string multi-pattern searches and keeps GPU promotion separate from this CPU workload-class win.
+- Closed v1.11.4 native GPU unavailable and docs-governance gap: `361e0db fix: harden public GPU unavailable routing` prevents sidecar routing from looking like native GPU proof when no explicit sidecar is configured, and `2100122 fix: harden release docs stamp governance` keeps post-release-safe docs governance aligned with semantic-release tag stamping.
 - Public `v1.11.2` dogfood verified PyPI, `uvx`, release assets, and classify provider provenance in JSON output. `v1.11.2` exposes `classification_backend` so harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
 - Closed v1.11.3 fixed multi-pattern lane gap: `v1.11.3` routes safe fixed-string multi-pattern native searches through one Aho-Corasick pass, preserves fallback for unsupported semantics, and records the local 100 fixed no-match patterns over 1GB CPU win separately from GPU promotion evidence.
 - Closed v1.11.2 classify provenance gap: `v1.11.2` exposes `classification_backend` in JSON output so harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
@@ -66,7 +68,7 @@ release_docs_current_tag: v1.11.4
 
 ## Current Post-v1.11.3 Scope
 
-Current release branch is publication-complete for `v1.11.3`: PR #113 `fix: accelerate fixed multi-pattern native search` was squash-merged as `87d4ca4`, release commit `2731659 chore(release): v1.11.3 [skip ci]` exists, main CI run `25860914920` passed tests/assets, GitHub asset upload, PyPI publish, and `publish-success-gate`, and CodeQL run `25860914488` passed. Public dogfood verified PyPI, release assets, `uvx`, and the fixed multi-pattern native CPU lane. The `v1.10.10` Windows subprocess launcher repair remains the public launcher repair baseline; keep foreign launcher handling opt-in and auditable rather than deleting unrelated tools.
+Current release branch is publication-complete for `v1.11.4`: PR #114 `fix: harden public GPU unavailable routing` was squash-merged as `361e0db`, PR #115 `fix: harden release docs stamp governance` was squash-merged as `2100122`, release commit `49a7c9a chore(release): v1.11.4 [skip ci]` exists, main CI run `25863754902` passed tests/assets, GitHub asset upload, PyPI publish, and `publish-success-gate`, and CodeQL run `25863751937` passed. Public dogfood verified PyPI, release assets, `uvx`, native GPU unavailable fallback, and post-release-safe docs governance. The `v1.10.10` Windows subprocess launcher repair remains the public launcher repair baseline; keep foreign launcher handling opt-in and auditable rather than deleting unrelated tools.
 
 The public Windows `.cmd` bridge quoted multi-word no-match follow-up shipped in `v1.8.30`. The Windows native-first PATH, agent JSON validation-command, local default classify, and GPU scale benchmark follow-ups shipped in `v1.8.31`. The launcher-route observability and benchmark launcher-attribution follow-up shipped in `v1.8.32`. The explicit GPU probe scoping and benchmark launcher warning follow-up shipped in `v1.8.33`. The Actionable Context Capsule v1 shipped in `v1.9.0`; mixed-language capsule trust alignment and GPU recommendation hygiene shipped in `v1.9.1`; edit JSON/rollback safety shipped in `v1.9.2`; explicit Python ranking and quoted validation commands shipped in `v1.9.3`; docs-governance and validation placeholders shipped in `v1.9.4`; native CUDA gate hardening, capsule alternatives, help diagnostics, and foreign launcher diagnostics shipped in `v1.9.5`; directory validation, CUDA 12.8 install paths, help coverage, and release-proof governance shipped in `v1.9.6`; GPU benchmark promotion-gate taxonomy and cold-search positioning shipped in `v1.9.7`; stale tensor-grep-owned `tg.com` bridge refresh after upgrade shipped in `v1.9.8`; agent workflow benchmark governance shipped in `v1.9.9`; capsule confidence/secrets/docs dogfood follow-ups shipped in source/GitHub assets in `v1.9.10`; and release wheel Cargo prefetch retries shipped in `v1.9.11`.
 

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -21,14 +21,16 @@ def _project_release_tag() -> str:
 
 
 CURRENT_RELEASE_TAG = _project_release_tag()
-CURRENT_RELEASE_COMMIT = "2731659 chore(release): v1.11.3 [skip ci]"
-CURRENT_FIX_COMMIT = "87d4ca4 fix: accelerate fixed multi-pattern native search"
+CURRENT_RELEASE_COMMIT = "49a7c9a chore(release): v1.11.4 [skip ci]"
+CURRENT_FIX_COMMIT = "2100122 fix: harden release docs stamp governance"
+CURRENT_GPU_FIX_COMMIT = "361e0db fix: harden public GPU unavailable routing"
+CURRENT_MULTIPATTERN_FIX_COMMIT = "87d4ca4 fix: accelerate fixed multi-pattern native search"
 CURRENT_FEATURE_COMMIT = "213d383 feat: add dogfood readiness verdict and checkpoint UX"
 LATEST_COMPLETE_RELEASE_TAG = CURRENT_RELEASE_TAG
 LATEST_COMPLETE_RELEASE_COMMIT = CURRENT_RELEASE_COMMIT
 LATEST_COMPLETE_FIX_COMMIT = CURRENT_FIX_COMMIT
-LATEST_COMPLETE_MAIN_CI = "25860914920"
-LATEST_COMPLETE_CODEQL = "25860914488"
+LATEST_COMPLETE_MAIN_CI = "25863754902"
+LATEST_COMPLETE_CODEQL = "25863751937"
 
 
 def test_readme_should_point_to_canonical_public_docs() -> None:
@@ -132,6 +134,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     ):
         assert CURRENT_RELEASE_COMMIT in content
         assert CURRENT_FIX_COMMIT in content
+        assert CURRENT_GPU_FIX_COMMIT in content
+        assert CURRENT_MULTIPATTERN_FIX_COMMIT in content
         assert CURRENT_FEATURE_COMMIT in content
 
     handoff = docs["docs/SESSION_HANDOFF.md"]
@@ -146,6 +150,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert LATEST_COMPLETE_MAIN_CI in handoff
     assert LATEST_COMPLETE_CODEQL in handoff
     assert f"tensor-grep=={LATEST_COMPLETE_RELEASE_TAG.removeprefix('v')}" in handoff
+    assert "post-release-safe docs governance" in handoff
+    assert "native GPU unavailable" in handoff
     assert 'subprocess.run(["tg", ...])' in handoff
     assert "Closed GPU gates and launcher diagnostics gap" in handoff
     assert "Closed docs/version governance and validation placeholder gap" in handoff
@@ -209,6 +215,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert LATEST_COMPLETE_CODEQL in readme
     assert LATEST_COMPLETE_RELEASE_COMMIT in readme
     assert LATEST_COMPLETE_FIX_COMMIT in readme
+    assert CURRENT_GPU_FIX_COMMIT in readme
+    assert CURRENT_MULTIPATTERN_FIX_COMMIT in readme
     assert f"GitHub release assets for `{LATEST_COMPLETE_RELEASE_TAG}`" in readme
     assert f"tensor-grep=={LATEST_COMPLETE_RELEASE_TAG.removeprefix('v')}" in readme
     assert "PyPI latest remains `1.10.10`" in readme
@@ -227,7 +235,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert "only initialize selected devices" in readme
     assert "Actionable Context Capsule" in readme
     assert "validation_alignment" in readme
-    current_closed_heading = "What `v1.11.3` closed:"
+    current_closed_heading = "What `v1.11.4` closed:"
+    v1113_heading = "What `v1.11.3` closed:"
     v1112_heading = "What `v1.11.2` closed:"
     v1111_heading = "What `v1.11.1` closed:"
     v1110_failed_heading = "What `v1.11.0` tagged but did not complete:"
@@ -249,7 +258,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     v193_heading = "What `v1.9.3` closed:"
     v192_heading = "What `v1.9.2` closed:"
     follow_up_heading = f"Active post-`{CURRENT_RELEASE_TAG}` follow-up:"
-    current_closed_block = readme.split(current_closed_heading, 1)[1].split(v1112_heading, 1)[0]
+    current_closed_block = readme.split(current_closed_heading, 1)[1].split(v1113_heading, 1)[0]
+    v1113_closed_block = readme.split(v1113_heading, 1)[1].split(v1112_heading, 1)[0]
     v1112_closed_block = readme.split(v1112_heading, 1)[1].split(v1111_heading, 1)[0]
     v1111_closed_block = readme.split(v1111_heading, 1)[1].split(v1110_failed_heading, 1)[0]
     v1110_failed_block = readme.split(v1110_failed_heading, 1)[1].split(v11010_heading, 1)[0]
@@ -270,9 +280,12 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     v194_closed_block = readme.split(v194_heading, 1)[1].split(v193_heading, 1)[0]
     v192_closed_block = readme.split(v192_heading, 1)[1].split("What `v1.9.1` closed:", 1)[0]
     follow_up_block = readme.split(follow_up_heading, 1)[1]
-    assert "fixed multi-pattern" in current_closed_block
-    assert "Aho-Corasick" in current_closed_block
-    assert "100 fixed no-match patterns over 1GB" in current_closed_block
+    assert "post-release-safe docs governance" in current_closed_block
+    assert "native GPU unavailable" in current_closed_block
+    assert "NativeCpuBackend" in current_closed_block
+    assert "fixed multi-pattern" in v1113_closed_block
+    assert "Aho-Corasick" in v1113_closed_block
+    assert "100 fixed no-match patterns over 1GB" in v1113_closed_block
     assert "classify provider provenance" in v1112_closed_block
     assert "classification_backend" in v1112_closed_block
     assert "tg classify --format json" in v1112_closed_block


### PR DESCRIPTION
## Summary
- record v1.11.4 release proof after the successful publish run
- make docs-governance tests distinguish auto-stamped current release labels from verified proof blocks
- keep native GPU unavailable and v1.11.3 multi-pattern evidence explicit

## Validation
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest tests/unit/test_public_docs_governance.py -q
- uv run pytest -q
- python scripts/stamp_release_assets.py --check
- python scripts/agent_readiness.py --no-wsl-probe --output artifacts/agent_readiness_1.11.4_post_release_governance.json
- git diff --check