### PR TITLE
fix: harden fair fixed multi-pattern search

### DIFF
--- a/benchmarks/run_native_cpu_benchmarks.py
+++ b/benchmarks/run_native_cpu_benchmarks.py
@@ -6,6 +6,7 @@ import platform
 import subprocess
 import sys
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -18,6 +19,7 @@ for candidate in (SRC_DIR, BENCHMARKS_DIR):
 from native_cpu_benchmark_utils import (  # noqa: E402
     DEFAULT_LARGE_FILE_BYTES,
     DEFAULT_MANY_FILE_COUNT,
+    NATIVE_CPU_BENCHMARK_PATTERN,
     ensure_large_file_fixture,
     ensure_many_file_fixture,
     resolve_native_cpu_bench_data_dir,
@@ -36,11 +38,46 @@ from run_benchmarks import (  # noqa: E402
 DEFAULT_TIMING_SAMPLES = 5
 DEFAULT_WARMUP_RUNS = 1
 NATIVE_TG_ENV = {"TG_DISABLE_RG": "1"}
+PatternArg = str | Sequence[str]
+
+
+def append_patterns(cmd: list[str], pattern: PatternArg) -> None:
+    if isinstance(pattern, str):
+        cmd.append(pattern)
+        return
+
+    patterns = list(pattern)
+    if not patterns:
+        raise ValueError("at least one search pattern is required")
+    if len(patterns) == 1:
+        cmd.append(patterns[0])
+        return
+    for item in patterns:
+        cmd.extend(["-e", item])
+
+
+def pattern_display(pattern: PatternArg) -> str:
+    if isinstance(pattern, str):
+        return pattern
+    return " | ".join(pattern)
+
+
+def build_fixed_multi_pattern_terms(
+    *,
+    include_matching_pattern: bool,
+    count: int = 100,
+) -> list[str]:
+    patterns = [
+        f"native cpu absent fixed pattern {index:03d} :: 6e87d59b" for index in range(count)
+    ]
+    if include_matching_pattern:
+        patterns[0] = NATIVE_CPU_BENCHMARK_PATTERN
+    return patterns
 
 
 def build_rg_search_command(
     rg_binary: str,
-    pattern: str,
+    pattern: PatternArg,
     target: Path,
     *,
     fixed_strings: bool = False,
@@ -48,13 +85,14 @@ def build_rg_search_command(
     cmd = [rg_binary, "--no-ignore"]
     if fixed_strings:
         cmd.append("-F")
-    cmd.extend([pattern, str(target)])
+    append_patterns(cmd, pattern)
+    cmd.append(str(target))
     return cmd
 
 
 def build_tg_cpu_search_command(
     tg_binary: Path,
-    pattern: str,
+    pattern: PatternArg,
     target: Path,
     *,
     fixed_strings: bool = False,
@@ -62,13 +100,14 @@ def build_tg_cpu_search_command(
     cmd = [str(tg_binary), "search", "--cpu", "--no-ignore"]
     if fixed_strings:
         cmd.append("-F")
-    cmd.extend([pattern, str(target)])
+    append_patterns(cmd, pattern)
+    cmd.append(str(target))
     return cmd
 
 
 def build_rg_count_command(
     rg_binary: str,
-    pattern: str,
+    pattern: PatternArg,
     target: Path,
     *,
     fixed_strings: bool = False,
@@ -76,13 +115,14 @@ def build_rg_count_command(
     cmd = [rg_binary, "--no-ignore", "-c"]
     if fixed_strings:
         cmd.append("-F")
-    cmd.extend([pattern, str(target)])
+    append_patterns(cmd, pattern)
+    cmd.append(str(target))
     return cmd
 
 
 def build_tg_cpu_count_command(
     tg_binary: Path,
-    pattern: str,
+    pattern: PatternArg,
     target: Path,
     *,
     fixed_strings: bool = False,
@@ -90,7 +130,8 @@ def build_tg_cpu_count_command(
     cmd = [str(tg_binary), "search", "--cpu", "--no-ignore", "-c"]
     if fixed_strings:
         cmd.append("-F")
-    cmd.extend([pattern, str(target)])
+    append_patterns(cmd, pattern)
+    cmd.append(str(target))
     return cmd
 
 
@@ -121,16 +162,17 @@ def run_match_count(
 def run_native_cpu_benchmark_case(
     *,
     name: str,
-    pattern: str,
+    pattern: PatternArg,
     target: Path,
     rg_binary: str,
     tg_binary: Path,
     sample_count: int,
     warmup_runs: int,
-    max_ratio_vs_rg: float,
+    max_ratio_vs_rg: float | None,
     require_tg_faster: bool = False,
     fixed_strings: bool = False,
     benchmark_count_mode: bool = False,
+    gated: bool = True,
 ) -> dict[str, object]:
     if benchmark_count_mode:
         rg_cmd = build_rg_count_command(rg_binary, pattern, target, fixed_strings=fixed_strings)
@@ -162,14 +204,19 @@ def run_native_cpu_benchmark_case(
     counts_match = rg_counts["total_matches"] == tg_counts["total_matches"]
 
     ratio_vs_rg = round(tg_time / rg_time, 4) if rg_time > 0 else None
-    threshold_pass = ratio_vs_rg is not None and ratio_vs_rg <= max_ratio_vs_rg
+    threshold_pass = None
+    if max_ratio_vs_rg is not None:
+        threshold_pass = ratio_vs_rg is not None and ratio_vs_rg <= max_ratio_vs_rg
     if require_tg_faster:
         threshold_pass = bool(rg_time > tg_time)
-    status = "PASS" if counts_match and threshold_pass else "FAIL"
+    if gated:
+        status = "PASS" if counts_match and threshold_pass else "FAIL"
+    else:
+        status = "DIAGNOSTIC" if counts_match else "FAIL"
 
     return {
         "name": name,
-        "pattern": pattern,
+        "pattern": pattern_display(pattern),
         "target": str(target),
         "rg_cmd": subprocess.list2cmdline(rg_cmd) if os.name == "nt" else " ".join(rg_cmd),
         "tg_cmd": subprocess.list2cmdline(tg_cmd) if os.name == "nt" else " ".join(tg_cmd),
@@ -180,6 +227,8 @@ def run_native_cpu_benchmark_case(
         "tg_time_s": tg_time,
         "ratio_vs_rg": ratio_vs_rg,
         "threshold_ratio": max_ratio_vs_rg,
+        "threshold_pass": threshold_pass,
+        "gated": gated,
         "require_tg_faster": require_tg_faster,
         "fixed_strings": fixed_strings,
         "benchmark_count_mode": benchmark_count_mode,
@@ -260,6 +309,26 @@ def main() -> int:
             "benchmark_count_mode": True,
         },
         {
+            "name": "large_file_200mb_fixed_multi_pattern_no_match",
+            "pattern": build_fixed_multi_pattern_terms(include_matching_pattern=False),
+            "target": Path(large_fixture["path"]),
+            "max_ratio_vs_rg": None,
+            "require_tg_faster": False,
+            "fixed_strings": True,
+            "benchmark_count_mode": False,
+            "gated": False,
+        },
+        {
+            "name": "large_file_200mb_fixed_multi_pattern_count",
+            "pattern": build_fixed_multi_pattern_terms(include_matching_pattern=True),
+            "target": Path(large_fixture["path"]),
+            "max_ratio_vs_rg": None,
+            "require_tg_faster": False,
+            "fixed_strings": True,
+            "benchmark_count_mode": True,
+            "gated": False,
+        },
+        {
             "name": "many_file_directory",
             "pattern": "ERROR",
             "target": Path(many_fixture["path"]),
@@ -283,10 +352,11 @@ def main() -> int:
             require_tg_faster=case["require_tg_faster"],
             fixed_strings=case["fixed_strings"],
             benchmark_count_mode=case.get("benchmark_count_mode", False),
+            gated=case.get("gated", True),
         )
         for case in cases
     ]
-    passed = all(row["status"] == "PASS" for row in rows)
+    passed = all(row["status"] != "FAIL" for row in rows)
 
     payload = {
         "artifact": "bench_run_native_cpu_benchmarks",
@@ -304,6 +374,7 @@ def main() -> int:
             "cold_standard_corpus_max_ratio_vs_rg": 1.05,
             "large_file_200mb_max_ratio_vs_rg": 1.15,
             "large_file_200mb_count_requires_tg_faster": True,
+            "large_file_200mb_fixed_multi_pattern_rows_are_diagnostic": True,
             "many_file_directory_max_ratio_vs_rg": 1.05,
         },
         "fixtures": {

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1332,6 +1332,34 @@ mod tests {
     }
 
     #[test]
+    fn search_request_resolves_multiple_regexp_patterns_and_paths() {
+        let args = parse_search_args(&[
+            "tg",
+            "search",
+            "--fixed-strings",
+            "-e",
+            "TODO",
+            "-e",
+            "FIXME",
+            "src",
+            "tests",
+        ]);
+        let request = resolve_search_request(&args).expect("expected search request");
+
+        assert_eq!(
+            request.patterns,
+            vec!["TODO".to_string(), "FIXME".to_string()]
+        );
+        assert_eq!(request.paths, vec!["src".to_string(), "tests".to_string()]);
+        assert_eq!(request.query_display(), "TODO | FIXME");
+        assert_eq!(request.path_display(), "src tests");
+        assert_eq!(
+            command_ripgrep_args(&args, &request).patterns,
+            vec!["TODO".to_string(), "FIXME".to_string()]
+        );
+    }
+
+    #[test]
     fn default_search_frontdoor_treats_format_rg_as_noop() {
         let args = parse_default_frontdoor_args(&[
             "tg",
@@ -2758,6 +2786,7 @@ struct NativeSearchOutputOptions<'a> {
     json: bool,
     ndjson: bool,
     count: bool,
+    line_number: bool,
 }
 
 fn emit_multi_pattern_native_results(
@@ -2784,7 +2813,7 @@ fn emit_multi_pattern_native_results(
     } else if options.count {
         emit_count_search_matches(options.path, &matches);
     } else {
-        emit_plain_search_matches(options.path, &matches);
+        emit_plain_search_matches_with_line_number(options.path, &matches, options.line_number);
     }
 
     if !has_matches {
@@ -3006,6 +3035,7 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
                         json: args.json,
                         ndjson: args.ndjson,
                         count: args.count,
+                        line_number: args.line_number,
                     },
                     matches,
                 );
@@ -5354,6 +5384,7 @@ fn handle_native_gpu_unavailable_cpu_fallback(
                 json: params.json,
                 ndjson: params.ndjson,
                 count: params.count,
+                line_number: params.line_number,
             },
             matches,
         );
@@ -5783,6 +5814,7 @@ fn handle_auto_gpu_search(
                                 json: params.json,
                                 ndjson: params.ndjson,
                                 count: params.count,
+                                line_number: params.line_number,
                             },
                             matches,
                         );
@@ -5885,6 +5917,7 @@ fn handle_gpu_native_search(params: GpuSearchParams<'_>) -> anyhow::Result<()> {
                                 json: params.json,
                                 ndjson: params.ndjson,
                                 count: params.count,
+                                line_number: params.line_number,
                             },
                             matches,
                         );
@@ -6048,6 +6081,14 @@ fn unique_line_matches(matches: &[SearchMatchJson]) -> Vec<SearchMatchJson> {
 }
 
 fn emit_plain_search_matches(path: &str, matches: &[SearchMatchJson]) {
+    emit_plain_search_matches_with_line_number(path, matches, true);
+}
+
+fn emit_plain_search_matches_with_line_number(
+    path: &str,
+    matches: &[SearchMatchJson],
+    line_number: bool,
+) {
     let unique = unique_line_matches(matches);
     let with_filename = unique
         .iter()
@@ -6057,10 +6098,11 @@ fn emit_plain_search_matches(path: &str, matches: &[SearchMatchJson]) {
         > 1
         || Path::new(path).is_dir();
     for matched in unique {
-        if with_filename {
-            println!("{}:{}:{}", matched.file, matched.line, matched.text);
-        } else {
-            println!("{}:{}", matched.line, matched.text);
+        match (with_filename, line_number) {
+            (true, true) => println!("{}:{}:{}", matched.file, matched.line, matched.text),
+            (true, false) => println!("{}:{}", matched.file, matched.text),
+            (false, true) => println!("{}:{}", matched.line, matched.text),
+            (false, false) => println!("{}", matched.text),
         }
     }
 }

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -719,6 +719,9 @@ pub fn run_native_fixed_multi_pattern_search(
         if !config.text && memchr(0, &contents).is_some() {
             return Ok(None);
         }
+        if !matcher.is_match(&contents) {
+            continue;
+        }
         collect_fixed_multi_pattern_file_matches(
             &matcher,
             patterns,

--- a/rust_core/tests/test_routing.rs
+++ b/rust_core/tests/test_routing.rs
@@ -1910,6 +1910,125 @@ fn test_native_cpu_fixed_multi_pattern_uses_single_pass_fast_path() {
 }
 
 #[test]
+fn test_native_cpu_fixed_multi_pattern_plain_output_omits_line_numbers_by_default() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("multi.txt");
+    fs::write(
+        &file,
+        "alpha and beta\n\nbeta after blank\nalpha after beta\n",
+    )
+    .unwrap();
+
+    let output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("-e")
+        .arg("alpha")
+        .arg("-e")
+        .arg("beta")
+        .arg(&file)
+        .env("TG_DISABLE_RG", "1")
+        .env("PATH", "")
+        .env(
+            "TG_TEST_NATIVE_SEARCH_FORCE_ERROR",
+            "sequential native search path used",
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        normalize_newlines(&String::from_utf8_lossy(&output.stdout)),
+        "alpha and beta\nbeta after blank\nalpha after beta\n"
+    );
+}
+
+#[test]
+fn test_native_cpu_fixed_multi_pattern_plain_output_honors_line_number_flag() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("multi.txt");
+    fs::write(
+        &file,
+        "alpha and beta\n\nbeta after blank\nalpha after beta\n",
+    )
+    .unwrap();
+
+    let output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--line-number")
+        .arg("-e")
+        .arg("alpha")
+        .arg("-e")
+        .arg("beta")
+        .arg(&file)
+        .env("TG_DISABLE_RG", "1")
+        .env("PATH", "")
+        .env(
+            "TG_TEST_NATIVE_SEARCH_FORCE_ERROR",
+            "sequential native search path used",
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        normalize_newlines(&String::from_utf8_lossy(&output.stdout)),
+        "1:alpha and beta\n3:beta after blank\n4:alpha after beta\n"
+    );
+}
+
+#[test]
+fn test_native_cpu_fixed_multi_pattern_count_counts_matching_lines_once() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("multi.txt");
+    fs::write(
+        &file,
+        "alpha and beta\n\nbeta after blank\nalpha after beta\n",
+    )
+    .unwrap();
+
+    let output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("-e")
+        .arg("alpha")
+        .arg("-e")
+        .arg("beta")
+        .arg(&file)
+        .env("TG_DISABLE_RG", "1")
+        .env("PATH", "")
+        .env(
+            "TG_TEST_NATIVE_SEARCH_FORCE_ERROR",
+            "sequential native search path used",
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        normalize_newlines(&String::from_utf8_lossy(&output.stdout)),
+        "3\n"
+    );
+}
+
+#[test]
 fn test_rust_control_plane_rejection() {
     let dir = tempdir().unwrap();
     write_text_corpus(dir.path());

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -735,6 +735,54 @@ def test_run_native_cpu_benchmarks_should_disable_rg_for_tg_cpu_measurements(mon
     assert row["tg_env"] == module.NATIVE_TG_ENV
 
 
+def test_run_native_cpu_benchmarks_should_build_fair_fixed_multi_pattern_commands(tmp_path):
+    module = _load_script_module(
+        "run_native_cpu_benchmarks_multi_pattern_script",
+        "benchmarks/run_native_cpu_benchmarks.py",
+    )
+    tg_binary = tmp_path / "tg.exe"
+    target = tmp_path / "fixture.log"
+    patterns = ["TODO", "FIXME", "BUG"]
+
+    rg_cmd = module.build_rg_search_command("rg", patterns, target, fixed_strings=True)
+    tg_cmd = module.build_tg_cpu_search_command(tg_binary, patterns, target, fixed_strings=True)
+    rg_count_cmd = module.build_rg_count_command("rg", patterns, target, fixed_strings=True)
+    tg_count_cmd = module.build_tg_cpu_count_command(
+        tg_binary, patterns, target, fixed_strings=True
+    )
+
+    assert rg_cmd == [
+        "rg",
+        "--no-ignore",
+        "-F",
+        "-e",
+        "TODO",
+        "-e",
+        "FIXME",
+        "-e",
+        "BUG",
+        str(target),
+    ]
+    assert tg_cmd == [
+        str(tg_binary),
+        "search",
+        "--cpu",
+        "--no-ignore",
+        "-F",
+        "-e",
+        "TODO",
+        "-e",
+        "FIXME",
+        "-e",
+        "BUG",
+        str(target),
+    ]
+    assert rg_count_cmd[:3] == ["rg", "--no-ignore", "-c"]
+    assert rg_count_cmd[3:] == rg_cmd[2:]
+    assert tg_count_cmd[:5] == [str(tg_binary), "search", "--cpu", "--no-ignore", "-c"]
+    assert tg_count_cmd[5:] == tg_cmd[4:]
+
+
 def test_run_benchmarks_should_extract_windows_rg_zip_when_rg_missing(monkeypatch, tmp_path):
     module = _load_script_module("run_benchmarks_script_rg_zip", "benchmarks/run_benchmarks.py")
     bench_dir = tmp_path / "benchmarks"
@@ -1287,6 +1335,38 @@ def test_run_native_cpu_benchmarks_should_report_threshold_statuses(monkeypatch,
             "counts_match": True,
         },
         {
+            "name": "large_file_200mb_fixed_multi_pattern_no_match",
+            "target": str(tmp_path / "large_fixture.log"),
+            "pattern": "absent 001 | absent 002",
+            "rg_time_s": 1.0,
+            "tg_time_s": 1.9,
+            "rg_samples_s": [1.0, 1.01, 0.99],
+            "tg_samples_s": [1.9, 1.92, 1.88],
+            "ratio_vs_rg": 1.9,
+            "threshold_ratio": None,
+            "threshold_pass": None,
+            "gated": False,
+            "require_tg_faster": False,
+            "status": "DIAGNOSTIC",
+            "counts_match": True,
+        },
+        {
+            "name": "large_file_200mb_fixed_multi_pattern_count",
+            "target": str(tmp_path / "large_fixture.log"),
+            "pattern": "ERROR native cpu benchmark sentinel | absent 001",
+            "rg_time_s": 1.0,
+            "tg_time_s": 2.1,
+            "rg_samples_s": [1.0, 1.01, 0.99],
+            "tg_samples_s": [2.1, 2.12, 2.08],
+            "ratio_vs_rg": 2.1,
+            "threshold_ratio": None,
+            "threshold_pass": None,
+            "gated": False,
+            "require_tg_faster": False,
+            "status": "DIAGNOSTIC",
+            "counts_match": True,
+        },
+        {
             "name": "many_file_directory",
             "target": str(tmp_path / "many_files"),
             "pattern": "ERROR native cpu benchmark sentinel",
@@ -1319,16 +1399,28 @@ def test_run_native_cpu_benchmarks_should_report_threshold_statuses(monkeypatch,
         "cold_standard_corpus",
         "large_file_200mb",
         "large_file_200mb_count",
+        "large_file_200mb_fixed_multi_pattern_no_match",
+        "large_file_200mb_fixed_multi_pattern_count",
         "many_file_directory",
     ]
-    assert [row["status"] for row in payload["rows"]] == ["PASS", "PASS", "PASS", "PASS"]
+    assert [row["status"] for row in payload["rows"]] == [
+        "PASS",
+        "PASS",
+        "PASS",
+        "DIAGNOSTIC",
+        "DIAGNOSTIC",
+        "PASS",
+    ]
     assert payload["rows"][0]["ratio_vs_rg"] == 1.04
     assert payload["rows"][1]["ratio_vs_rg"] == 1.12
     assert payload["rows"][2]["ratio_vs_rg"] == 0.92
+    assert payload["rows"][3]["ratio_vs_rg"] == 1.9
+    assert payload["rows"][4]["ratio_vs_rg"] == 2.1
     assert payload["thresholds"] == {
         "cold_standard_corpus_max_ratio_vs_rg": 1.05,
         "large_file_200mb_max_ratio_vs_rg": 1.15,
         "large_file_200mb_count_requires_tg_faster": True,
+        "large_file_200mb_fixed_multi_pattern_rows_are_diagnostic": True,
         "many_file_directory_max_ratio_vs_rg": 1.05,
     }
 


### PR DESCRIPTION
## Summary
- make native fixed multi-pattern plain output match rg line-number behavior, including de-duplicating lines that match multiple patterns
- preserve matching-line count semantics for fixed multi-pattern native CPU search
- add fair `rg -F -e ... -e ...` native CPU benchmark command builders and diagnostic many-pattern rows instead of promotion gates
- add a small no-match precheck before per-line Aho-Corasick collection

## Validation
- cargo test --manifest-path rust_core/Cargo.toml --test test_routing fixed_multi_pattern -- --nocapture
- cargo test --manifest-path rust_core/Cargo.toml --bin tg search_request_resolves_multiple_regexp_patterns_and_paths -- --nocapture
- uv run pytest tests/unit/test_benchmark_scripts.py::test_run_native_cpu_benchmarks_should_build_fair_fixed_multi_pattern_commands tests/unit/test_benchmark_scripts.py::test_run_native_cpu_benchmarks_should_report_threshold_statuses -q
- uv run ruff check .
- uv run ruff format --check --preview .
- cargo fmt --manifest-path rust_core/Cargo.toml --check
- uv run mypy src/tensor_grep
- uv run pytest -q
- git diff --check origin/main...HEAD

## Benchmark evidence
- cargo build --manifest-path rust_core/Cargo.toml --release
- python benchmarks/run_native_cpu_benchmarks.py --binary rust_core\target\release\tg.exe --output artifacts\bench_run_native_cpu_benchmarks_pr2_full.json

The benchmark command wrote the fair many-pattern diagnostic rows, but exited 1 because existing gated cold-standard and many-file rows failed on this host. The new fixed multi-pattern rows are diagnostic by design and should not be read as a raw-search promotion claim.

## Gemini review
Gemini 2.5 Flash reviewed the benchmark command-shape and diagnostic-row parts and reported no issue there, then hit model-capacity 429s before completing the Rust review. Rust behavior is covered by the new cargo regression tests listed above.