### PR TITLE
fix: restore compat schema governance

### DIFF
--- a/benchmarks/run_compat_checks.py
+++ b/benchmarks/run_compat_checks.py
@@ -313,7 +313,7 @@ def validate_routing_metadata(
 ) -> dict[str, Any]:
     env = os.environ.copy()
     env["TG_RG_PATH"] = str(rg_binary)
-    command = [str(tg_binary), "--json", "ERROR", str(bench_data_dir)]
+    command = [str(tg_binary), "--json", "--no-ignore", "ERROR", str(bench_data_dir)]
     result = run_command(command, env=env, cwd=ROOT_DIR)
 
     report: dict[str, Any] = {

--- a/tests/schemas/tg_output.schema.json
+++ b/tests/schemas/tg_output.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tensor-grep.dev/schemas/tg_output.schema.json",
+  "title": "tensor-grep search JSON output",
+  "type": "object",
+  "required": [
+    "version",
+    "routing_backend",
+    "routing_reason",
+    "sidecar_used",
+    "requested_gpu_device_ids",
+    "routing_gpu_device_ids",
+    "total_matches",
+    "matches"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "routing_backend": {
+      "type": "string",
+      "minLength": 1
+    },
+    "routing_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sidecar_used": {
+      "type": "boolean"
+    },
+    "requested_gpu_device_ids": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "routing_gpu_device_ids": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "routing_gpu_chunk_plan_mb": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["device_id", "chunk_mb"],
+        "properties": {
+          "device_id": {
+            "type": "integer"
+          },
+          "chunk_mb": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "routing_distributed": {
+      "type": "boolean"
+    },
+    "routing_worker_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "query": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "total_matches": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "total_files": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "matched_file_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "match_counts_by_file": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "matches": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/match"
+      }
+    }
+  },
+  "$defs": {
+    "match": {
+      "type": "object",
+      "required": ["file", "text"],
+      "anyOf": [
+        {
+          "required": ["line"]
+        },
+        {
+          "required": ["line_number"]
+        }
+      ],
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "line_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "text": {
+          "type": "string"
+        },
+        "pattern_id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pattern_text": {
+          "type": "string"
+        },
+        "range": {
+          "$ref": "#/$defs/range"
+        },
+        "metaVariables": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": true
+    },
+    "range": {
+      "type": "object",
+      "properties": {
+        "byteOffset": {
+          "$ref": "#/$defs/span"
+        },
+        "start": {
+          "$ref": "#/$defs/position"
+        },
+        "end": {
+          "$ref": "#/$defs/position"
+        }
+      },
+      "additionalProperties": true
+    },
+    "span": {
+      "type": "object",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "position": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -258,6 +258,112 @@ def test_build_attempt_ledger_should_normalize_payload_shape(tmp_path):
     assert payload["generated_at_epoch_s"] > 0
 
 
+def test_run_compat_checks_should_ship_default_tg_output_schema():
+    module = _load_script_module(
+        "run_compat_checks_schema_script", "benchmarks/run_compat_checks.py"
+    )
+    schema_path = module.default_schema_path()
+
+    assert schema_path.exists()
+
+    module.validate_json_instance(
+        {
+            "version": 1,
+            "routing_backend": "NativeCpuBackend",
+            "routing_reason": "json_output",
+            "sidecar_used": False,
+            "requested_gpu_device_ids": [],
+            "routing_gpu_device_ids": [],
+            "query": "ERROR",
+            "path": "bench_data",
+            "total_matches": 1,
+            "matches": [
+                {
+                    "file": "bench_data/app.log",
+                    "line": 1,
+                    "text": "ERROR timeout",
+                }
+            ],
+        },
+        schema_path,
+    )
+    module.validate_json_instance(
+        {
+            "version": 1,
+            "routing_backend": "NativeCpuBackend",
+            "routing_reason": "python-cli",
+            "sidecar_used": False,
+            "requested_gpu_device_ids": [],
+            "routing_gpu_device_ids": [],
+            "routing_gpu_chunk_plan_mb": [],
+            "routing_distributed": False,
+            "routing_worker_count": 1,
+            "total_matches": 1,
+            "total_files": 1,
+            "matched_file_paths": ["bench_data/app.log"],
+            "match_counts_by_file": {"bench_data/app.log": 1},
+            "matches": [
+                {
+                    "file": "bench_data/app.log",
+                    "line_number": 1,
+                    "text": "ERROR timeout",
+                }
+            ],
+        },
+        schema_path,
+    )
+
+
+def test_run_compat_checks_routing_metadata_probe_should_disable_ignores(monkeypatch, tmp_path):
+    module = _load_script_module(
+        "run_compat_checks_routing_script", "benchmarks/run_compat_checks.py"
+    )
+    bench_data_dir = tmp_path / "bench_data"
+    bench_data_dir.mkdir()
+    captured: dict[str, object] = {}
+
+    def _fake_run_command(cmd, *, env=None, cwd=None):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["cwd"] = cwd
+        return module.CommandResult(
+            0,
+            json.dumps({
+                "version": 1,
+                "routing_backend": "NativeCpuBackend",
+                "routing_reason": "json_output",
+                "sidecar_used": False,
+                "requested_gpu_device_ids": [],
+                "routing_gpu_device_ids": [],
+                "query": "ERROR",
+                "path": str(bench_data_dir),
+                "total_matches": 1,
+                "matches": [
+                    {
+                        "file": str(bench_data_dir / "app.log"),
+                        "line": 1,
+                        "text": "ERROR timeout",
+                    }
+                ],
+            }),
+            "",
+        )
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+
+    report = module.validate_routing_metadata(
+        Path("tg"),
+        bench_data_dir,
+        module.default_schema_path(),
+        Path("rg"),
+    )
+
+    assert report["valid"] is True
+    assert captured["cmd"] == ["tg", "--json", "--no-ignore", "ERROR", str(bench_data_dir)]
+    assert captured["env"]["TG_RG_PATH"] == "rg"
+    assert captured["cwd"] == module.ROOT_DIR
+
+
 def test_build_attempt_ledger_cli_should_write_output_file(tmp_path):
     module = _load_script_module(
         "build_attempt_ledger_cli_script", "benchmarks/build_attempt_ledger.py"


### PR DESCRIPTION
## Summary
- ship the tg search JSON schema referenced by run_compat_checks.py
- validate both native and Python JSON envelope shapes against the schema
- make the routing metadata probe use --no-ignore so ignored bench_data logs are searched consistently

## Research / planning anchors
- Exa: ripgrep guide confirmed ignore handling is part of rg-compatible search semantics
- Thinktank-equivalent review: Claude and Gemini both ranked compat schema governance as a high-priority release-contract slice
- Gemini PR review: no blockers in .tmp/gemini_pr2_compat_schema_review.log

## Validation
- uv run pytest tests/unit/test_benchmark_scripts.py::test_run_compat_checks_should_ship_default_tg_output_schema tests/unit/test_benchmark_scripts.py::test_run_compat_checks_routing_metadata_probe_should_disable_ignores -q
- uv run pytest tests/unit/test_benchmark_scripts.py -q
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q