### PR TITLE
fix: clarify AST subset positioning

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -444,7 +444,7 @@ pub struct RunArgs {
     #[arg(long)]
     pub verbose: bool,
 
-    /// The structural ast-grep pattern
+    /// The structural pattern to match
     pub pattern: Option<String>,
 
     /// File or directory to search
@@ -498,7 +498,7 @@ pub enum Commands {
     Mcp,
     /// Run semantic NLP threat classification on logs via cyBERT
     Classify(ClassifyArgs),
-    /// Run AST structural search and optional rewrites (ast-grep parity)
+    /// Run a validated AST slice for structural search and guarded rewrites
     Run(RunArgs),
     /// Scan code by configuration
     Scan {

--- a/rust_core/tests/test_runtime_path_resolution.rs
+++ b/rust_core/tests/test_runtime_path_resolution.rs
@@ -221,6 +221,23 @@ fn test_help_documents_runtime_override_env_vars() {
 }
 
 #[test]
+fn test_run_help_positions_ast_as_validated_slice_not_ast_grep_parity() {
+    let mut tg = Command::new(env!("CARGO_BIN_EXE_tg"));
+    tg.current_dir(repo_root()).arg("run").arg("--help");
+    let output = run_with_timeout(tg, Duration::from_secs(5));
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized_stdout = stdout.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        normalized_stdout.contains("validated AST slice"),
+        "stdout={stdout}"
+    );
+    assert!(!stdout.contains("ast-grep parity"), "stdout={stdout}");
+    assert!(!stdout.contains("ast-grep replacement"), "stdout={stdout}");
+}
+
+#[test]
 fn test_tg_classify_uses_tg_sidecar_python_override() {
     let dir = tempdir().unwrap();
     let file_path = write_sample_log(dir.path());

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3840,7 +3840,7 @@ The stable text-search contract is the validated rg-compatible surface documente
 - `tg devices`: Print routable GPU device IDs and VRAM inventory
 - `tg mcp`: Start the AI-assistant Model Context Protocol (MCP) server
 - `tg classify`: Run log classification with local heuristics by default, or CyBERT when explicitly enabled
-- `tg run`: Run AST structural search and optional rewrites (ast-grep parity)
+- `tg run`: Run a validated AST slice for structural search and guarded rewrites
 - `tg scan` / `tg test` / `tg lsp`: Auxiliary AST workflows
 - `tg upgrade` / `tg update`: Upgrade tensor-grep in place
 """,
@@ -7786,7 +7786,7 @@ def ast_info(
 
 @app.command(
     name="run",
-    help="Run AST structural search and optional rewrites.",
+    help="Run a validated AST slice for structural search and guarded rewrites.",
 )
 def run(
     pattern: str = typer.Argument(..., help="The AST pattern to search for."),

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -5636,6 +5636,31 @@ def test_tg_run_uses_typer_help():
     assert "positional arguments:" not in result.stdout
 
 
+def test_tg_run_help_should_position_ast_as_validated_slice_not_ast_grep_parity():
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["run", "--help"])
+
+    assert result.exit_code == 0
+    help_text = _strip_ansi(result.stdout)
+    normalized_help = re.sub(r"\s+", " ", help_text)
+    assert "validated AST slice" in normalized_help
+    assert "ast-grep parity" not in help_text
+    assert "ast-grep replacement" not in help_text
+
+
+def test_tg_search_help_should_not_claim_tg_run_ast_grep_parity():
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["search", "--help"])
+
+    assert result.exit_code == 0
+    help_text = _strip_ansi(result.stdout)
+    normalized_help = re.sub(r"\s+", " ", help_text)
+    assert "tg run: Run a validated AST slice" in normalized_help
+    assert "ast-grep parity" not in help_text
+
+
 def test_cli_uses_ripgrep_passthrough_fast_path(monkeypatch):
     calls: dict[str, object] = {}
 

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -244,6 +244,7 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert "only initialize selected devices" in readme
     assert "Actionable Context Capsule" in readme
     assert "validation_alignment" in readme
+
     current_closed_heading = f"What `{LATEST_VERIFIED_RELEASE_TAG}` closed:"
     v1114_heading = "What `v1.11.4` closed:"
     v1113_heading = "What `v1.11.3` closed:"
@@ -345,6 +346,25 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert "rolls changed files back" in v192_closed_block
     assert "GPU benchmark auto-recommendation disabled" in follow_up_block
     assert "subprocess.run" in follow_up_block
+
+
+def test_public_ast_positioning_should_not_claim_ast_grep_parity() -> None:
+    public_surfaces = {
+        "README.md": README_PATH.read_text(encoding="utf-8"),
+        "SKILL.md": SKILL_DOC_PATH.read_text(encoding="utf-8"),
+        "AGENTS.md": AGENTS_DOC_PATH.read_text(encoding="utf-8"),
+        "src/tensor_grep/cli/main.py": Path("src/tensor_grep/cli/main.py").read_text(
+            encoding="utf-8"
+        ),
+        "rust_core/src/main.rs": Path("rust_core/src/main.rs").read_text(encoding="utf-8"),
+    }
+
+    for path, text in public_surfaces.items():
+        assert "ast-grep parity" not in text, path
+
+    assert "validated useful slice" in public_surfaces["README.md"]
+    assert "validated useful slice" in public_surfaces["SKILL.md"]
+    assert "useful validated AST slice" in public_surfaces["AGENTS.md"]
 
 
 def test_gpu_docs_should_record_current_gpu_crossover_story() -> None:


### PR DESCRIPTION
## Summary
- replace the public `tg run` ast-grep parity wording with validated AST slice positioning
- add native and Python help contract tests for the AST positioning
- add docs-governance coverage to keep public surfaces from reintroducing ast-grep parity claims

## Research / review
- Exa/web anchor: current ast-grep 0.42 CLI docs list a broader `run` / `scan` / `test` surface (`--pattern`, `--selector`, `--strictness`, stdin, globs, context, interactive/update workflows), so this PR keeps `tg run` honest as a subset rather than implementing a fake parity claim.
- Gemini read-only diff review: `.tmp/gemini_pr3_ast_positioning_review.log` -> `FINAL: PASS`.

## Validation
- `uv run pytest tests/unit/test_cli_modes.py::test_tg_run_uses_typer_help tests/unit/test_cli_modes.py::test_tg_run_help_should_position_ast_as_validated_slice_not_ast_grep_parity tests/unit/test_cli_modes.py::test_tg_search_help_should_not_claim_tg_run_ast_grep_parity tests/unit/test_cli_modes.py::test_bootstrap_run_help_should_not_expose_config_option tests/unit/test_cli_modes.py::test_full_cli_run_help_should_not_expose_config_option tests/unit/test_public_docs_governance.py::test_public_ast_positioning_should_not_claim_ast_grep_parity -q`
- `C:\Users\oimir\.cargo\bin\cargo.exe test --manifest-path rust_core\Cargo.toml --test test_runtime_path_resolution test_run_help_positions_ast_as_validated_slice_not_ast_grep_parity -- --exact --nocapture`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `C:\Users\oimir\.cargo\bin\cargo.exe fmt --manifest-path rust_core\Cargo.toml --check`
- `uv run pytest -q` -> `2088 passed, 16 skipped`
- `git diff --check`
