### PR TITLE
fix: keep rust validation for agent cli intents

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -6185,6 +6185,123 @@ def _rust_uses_nested_test_target(test_path: Path, repo_root: Path) -> bool:
     return len(parts[tests_index + 1 :]) > 1
 
 
+def _nearest_cargo_manifest_for_path(path: str | Path, repo_root: Path) -> Path | None:
+    try:
+        current = Path(path).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
+    if current.is_file() or current.suffix:
+        current = current.parent
+    try:
+        boundary = repo_root.expanduser().resolve()
+    except (OSError, RuntimeError):
+        boundary = repo_root
+    while True:
+        manifest = current / "Cargo.toml"
+        if manifest.is_file():
+            return manifest
+        if current == boundary or current.parent == current:
+            break
+        current = current.parent
+    return None
+
+
+def _cargo_test_command_for_primary_file(
+    primary_file: str | Path | None,
+    repo_root: Path,
+) -> str | None:
+    if primary_file is None or _target_language_for_path(primary_file) != "rust":
+        return None
+    manifest = _nearest_cargo_manifest_for_path(primary_file, repo_root)
+    if manifest is None:
+        return None
+    try:
+        if manifest.parent.resolve() == repo_root.resolve():
+            return "cargo test"
+    except (OSError, RuntimeError):
+        pass
+    relative_manifest = _relative_validation_path(manifest, repo_root)
+    return f"cargo test --manifest-path {relative_manifest}"
+
+
+def _primary_language_fallback_validation_steps(
+    *,
+    repo_root: str | Path,
+    primary_file: str | Path | None,
+) -> list[dict[str, Any]]:
+    if primary_file is None:
+        return []
+    root = _validation_repo_root(repo_root)
+    primary_language = _target_language_for_path(primary_file)
+    steps: list[dict[str, Any]] = []
+    if primary_language == "rust":
+        command = _cargo_test_command_for_primary_file(primary_file, root)
+        if command is not None:
+            steps.append({
+                "command": command,
+                "scope": "repo",
+                "runner": "cargo",
+                "confidence": 0.5,
+                "detection": "detected",
+            })
+    return steps
+
+
+def _ensure_primary_language_validation_fallback(
+    validation_plan: list[dict[str, Any]],
+    *,
+    repo_root: str | Path,
+    primary_file: str | Path | None,
+) -> list[dict[str, Any]]:
+    primary_language = _target_language_for_path(primary_file)
+    if primary_language is None:
+        return validation_plan
+    fallback_steps = _primary_language_fallback_validation_steps(
+        repo_root=repo_root,
+        primary_file=primary_file,
+    )
+    if any(
+        _validation_step_matches_primary_language(step, primary_language)
+        for step in validation_plan
+    ):
+        fallback_commands = {str(step.get("command") or "") for step in fallback_steps}
+        if (
+            primary_language == "rust"
+            and fallback_commands
+            and not any(
+                str(step.get("command") or "") in fallback_commands for step in validation_plan
+            )
+            and any(
+                str(step.get("runner") or "") == "cargo"
+                and str(step.get("command") or "") == "cargo test"
+                and str(step.get("detection") or "") == "heuristic"
+                for step in validation_plan
+            )
+        ):
+            augmented = [
+                dict(step)
+                for step in validation_plan
+                if not (
+                    str(step.get("runner") or "") == "cargo"
+                    and str(step.get("command") or "") == "cargo test"
+                    and str(step.get("detection") or "") == "heuristic"
+                )
+            ]
+            augmented.extend(dict(step) for step in fallback_steps)
+            return augmented
+        return validation_plan
+    if not fallback_steps:
+        return validation_plan
+    seen = {str(step.get("command") or "") for step in validation_plan}
+    augmented = [dict(step) for step in validation_plan]
+    for step in fallback_steps:
+        command = str(step.get("command") or "")
+        if command and command not in seen:
+            seen.add(command)
+            augmented.append(dict(step))
+    return augmented
+
+
 def _validation_commands_for_tests(
     tests: list[str],
     *,
@@ -6579,6 +6696,11 @@ def _validation_plan_and_alignment_for_tests(
         str(primary_symbol.get("file"))
         if isinstance(primary_symbol, dict) and primary_symbol.get("file")
         else (str(primary_file) if primary_file is not None and str(primary_file) else None)
+    )
+    raw_plan = _ensure_primary_language_validation_fallback(
+        raw_plan,
+        repo_root=repo_root,
+        primary_file=resolved_primary_file,
     )
     return _align_validation_plan_for_primary_language(raw_plan, resolved_primary_file)
 

--- a/tests/unit/test_agent_capsule_hardcases.py
+++ b/tests/unit/test_agent_capsule_hardcases.py
@@ -178,3 +178,40 @@ def test_agent_capsule_hardcase_rust_language_hint_selects_rust_target(tmp_path)
     assert payload["primary_target"]["symbol"] == "create_invoice"
     assert payload["context_consistency"]["query_language_hints"] == ["rust"]
     assert payload["context_consistency"]["primary_target_language"] == "rust"
+
+
+def test_agent_capsule_keeps_rust_validation_for_cli_parser_intent_with_python_tests(
+    tmp_path,
+):
+    project = tmp_path / "workspace"
+    rust_src = project / "rust_core" / "src"
+    rust_src.mkdir(parents=True)
+    tests_dir = project / "tests" / "unit"
+    tests_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (project / "rust_core" / "Cargo.toml").write_text(
+        '[package]\nname = "sample-rust-core"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    rust_file = rust_src / "main.rs"
+    rust_file.write_text(
+        "pub fn parse_native_cli_flags_passthru() -> bool {\n    true\n}\n",
+        encoding="utf-8",
+    )
+    (tests_dir / "test_cli_modes.py").write_text(
+        "def test_cli_flags_passthru_parser_error():\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    payload = _agent_payload(
+        project,
+        "rust parse_native_cli_flags_passthru CLI parser passthru failure",
+    )
+
+    assert payload["primary_target"]["file"] == str(rust_file.resolve())
+    assert payload["context_consistency"]["primary_target_language"] == "rust"
+    assert payload["validation_commands"] == ["cargo test --manifest-path rust_core/Cargo.toml"]
+    assert payload["context_consistency"]["validation_alignment"]["kept_count"] == 1

--- a/tests/unit/test_validation_commands.py
+++ b/tests/unit/test_validation_commands.py
@@ -532,6 +532,76 @@ def test_multi_language_repo_includes_commands_for_all_detected_languages(tmp_pa
     ]
 
 
+def test_rust_primary_keeps_manifest_validation_when_python_cli_tests_match(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    rust_src = project / "rust_core" / "src"
+    rust_src.mkdir(parents=True)
+    tests_dir = project / "tests" / "unit"
+    tests_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (project / "rust_core" / "Cargo.toml").write_text(
+        '[package]\nname = "sample-rust-core"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    primary_file = rust_src / "main.rs"
+    primary_file.write_text(
+        "pub fn parse_native_search_flags_passthru() -> bool {\n    true\n}\n",
+        encoding="utf-8",
+    )
+    python_test = tests_dir / "test_cli_modes.py"
+    python_test.write_text(
+        "def test_cli_parser_rejects_passthru_flag():\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    plan, alignment = repo_map._validation_plan_and_alignment_for_tests(
+        [str(python_test.resolve())],
+        repo_root=project,
+        primary_file=str(primary_file.resolve()),
+        query="rust native CLI parser passthru flag failure",
+    )
+
+    assert [step["command"] for step in plan] == ["cargo test --manifest-path rust_core/Cargo.toml"]
+    assert alignment["primary_target_language"] == "rust"
+    assert alignment["kept_count"] == 1
+    assert alignment["filtered_count"] >= 1
+    assert any("filtered pytest validation for rust" in issue for issue in alignment["issues"])
+
+
+def test_rust_primary_replaces_heuristic_repo_fallback_with_nested_manifest(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    rust_src = project / "rust_core" / "src"
+    rust_src.mkdir(parents=True)
+    (project / "rust_core" / "Cargo.toml").write_text(
+        '[package]\nname = "sample-rust-core"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    primary_file = rust_src / "main.rs"
+    primary_file.write_text(
+        "pub fn parse_native_search_flags_passthru() -> bool {\n    true\n}\n",
+        encoding="utf-8",
+    )
+
+    plan, alignment = repo_map._validation_plan_and_alignment_for_tests(
+        [],
+        repo_root=project,
+        primary_file=str(primary_file.resolve()),
+        query="rust native CLI parser passthru flag failure",
+    )
+
+    assert [step["command"] for step in plan] == ["cargo test --manifest-path rust_core/Cargo.toml"]
+    assert alignment["status"] == "aligned"
+    assert alignment["kept_count"] == 1
+    assert alignment["filtered_count"] == 0
+
+
 def test_detect_validation_runners_is_cached_per_repo_root(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()


### PR DESCRIPTION
## Summary

- keep agent validation evidence aligned when a Rust primary target is selected for CLI/tooling intents
- add a nearest-`Cargo.toml` fallback that emits repo-relative `cargo test --manifest-path ...`
- replace the old heuristic root `cargo test` suggestion for nested Rust crates when a manifest-specific command is available

## Why

Dogfood found that `tg agent` could identify plausible CLI/parser targets but return no validation commands after Python-only suggestions were filtered for a Rust primary target. That left agents with context but no executable validation hint.

## Validation

- `uv run pytest tests/unit/test_validation_commands.py::test_rust_primary_keeps_manifest_validation_when_python_cli_tests_match -q` -> failed before implementation, passed after
- `uv run pytest tests/unit/test_validation_commands.py::test_rust_primary_replaces_heuristic_repo_fallback_with_nested_manifest -q` -> failed before implementation, passed after
- `uv run pytest tests/unit/test_agent_capsule_hardcases.py::test_agent_capsule_keeps_rust_validation_for_cli_parser_intent_with_python_tests tests/unit/test_validation_commands.py::test_rust_primary_keeps_manifest_validation_when_python_cli_tests_match -q`
- `uv run pytest tests/unit/test_validation_commands.py tests/unit/test_agent_capsule_hardcases.py -q`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `uv run pytest -q` -> 2057 passed, 50 skipped
- `C:\Users\oimir\.cargo\bin\cargo.exe fmt --manifest-path rust_core/Cargo.toml --check`
- `git diff --check`
- `python scripts/agent_readiness.py --no-wsl-probe --output artifacts/agent_readiness_pr125.json`

## Review

- Gemini read-only review: `FINAL: PASS`; no blockers.
