### PR TITLE
fix: harden Windows subprocess exe bridge

### DIFF
--- a/rust_core/src/python_sidecar.rs
+++ b/rust_core/src/python_sidecar.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::io::{self, Read, Write};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
@@ -19,6 +20,8 @@ const TG_NATIVE_TG_BINARY_ENV: &str = "TG_NATIVE_TG_BINARY";
 const DEFAULT_SIDECAR_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_HELP_PROBE_TIMEOUT_MS: u64 = 750;
 const MAX_SOURCE_ROOT_ANCESTOR_DEPTH: usize = 4;
+const WINDOWS_EXE_BRIDGE_MARKER: &str = "tg.exe.tensor-grep-bridge";
+const WINDOWS_EXE_BRIDGE_MARKER_CONTENT: &str = "tensor-grep managed tg.exe bridge";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SidecarRequest {
@@ -536,6 +539,14 @@ fn resolve_python_command_for_context(
         }
     }
 
+    if current_exe.is_some_and(|path| is_managed_windows_exe_bridge(path, home_dirs)) {
+        for home_dir in home_dirs {
+            if let Some(managed_python) = managed_install_python_from_home(home_dir) {
+                return managed_python.into_os_string();
+            }
+        }
+    }
+
     OsString::from("python")
 }
 
@@ -543,6 +554,32 @@ fn is_windows_com_bridge(path: &Path) -> bool {
     path.file_name()
         .and_then(OsStr::to_str)
         .is_some_and(|name| name.eq_ignore_ascii_case("tg.com"))
+}
+
+fn is_external_windows_exe_bridge(path: &Path) -> bool {
+    if !cfg!(windows) {
+        return false;
+    }
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name.eq_ignore_ascii_case("tg.exe"))
+}
+
+fn is_managed_windows_exe_bridge(path: &Path, home_dirs: &[PathBuf]) -> bool {
+    if !is_external_windows_exe_bridge(path) {
+        return false;
+    }
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    if !home_dirs.iter().any(|home_dir| {
+        paths_equivalent(parent, &home_dir.join("bin"))
+            || paths_equivalent(parent, &home_dir.join(".local").join("bin"))
+    }) {
+        return false;
+    }
+    fs::read_to_string(path.with_file_name(WINDOWS_EXE_BRIDGE_MARKER))
+        .is_ok_and(|content| content.trim() == WINDOWS_EXE_BRIDGE_MARKER_CONTENT)
 }
 
 fn managed_home_dirs_from_env() -> Vec<PathBuf> {
@@ -634,7 +671,31 @@ fn native_tg_binary_env_override_for_context(
             }
         }
     }
+    if current_exe
+        .as_ref()
+        .is_some_and(|path| is_managed_windows_exe_bridge(path, home_dirs))
+    {
+        for home_dir in home_dirs {
+            if let Some(managed_native) = managed_install_native_binary_from_home(home_dir) {
+                if !paths_equivalent(
+                    current_exe.as_ref().expect("checked current_exe"),
+                    &managed_native,
+                ) {
+                    return Some(managed_native.into_os_string());
+                }
+            }
+        }
+    }
     current_exe.map(Into::into)
+}
+
+fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    if cfg!(windows) {
+        left.to_string_lossy()
+            .eq_ignore_ascii_case(&right.to_string_lossy())
+    } else {
+        left == right
+    }
 }
 
 fn resolve_repo_source_root() -> Option<PathBuf> {
@@ -741,11 +802,12 @@ mod tests {
         gpu_device_ids_env_value, managed_install_native_binary_from_home,
         managed_install_python_from_home, merged_pythonpath, native_tg_binary_env_override,
         native_tg_binary_env_override_for_context, resolve_python_command_for_context,
-        resolve_repo_source_root_relative_to_exe, SidecarRequest,
+        resolve_repo_source_root_relative_to_exe, SidecarRequest, WINDOWS_EXE_BRIDGE_MARKER,
+        WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
     };
     use serde_json::json;
     use std::env;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::fs;
     use std::path::Path;
     use tempfile::tempdir;
@@ -851,6 +913,16 @@ mod tests {
         fs::write(&python, b"python").unwrap();
         fs::write(&bridge, b"native").unwrap();
         fs::write(
+            bridge.with_file_name(WINDOWS_EXE_BRIDGE_MARKER),
+            WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
+        )
+        .unwrap();
+        fs::write(
+            bridge.with_file_name(WINDOWS_EXE_BRIDGE_MARKER),
+            WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
+        )
+        .unwrap();
+        fs::write(
             bridge
                 .parent()
                 .unwrap()
@@ -884,6 +956,11 @@ mod tests {
         fs::create_dir_all(bridge.parent().unwrap()).unwrap();
         fs::write(&managed_native, b"native").unwrap();
         fs::write(&bridge, b"bridge").unwrap();
+        fs::write(
+            bridge.with_file_name(WINDOWS_EXE_BRIDGE_MARKER),
+            WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
+        )
+        .unwrap();
 
         assert_eq!(
             managed_install_native_binary_from_home(&home).as_deref(),
@@ -892,6 +969,86 @@ mod tests {
         assert_eq!(
             native_tg_binary_env_override_for_context(None, Some(bridge), &[home]).as_deref(),
             Some(managed_native.as_os_str())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn external_exe_bridge_resolves_managed_home_python() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let python = home
+            .join(".tensor-grep")
+            .join(".venv")
+            .join("Scripts")
+            .join("python.exe");
+        let bridge = home.join("bin").join("tg.exe");
+        fs::create_dir_all(python.parent().unwrap()).unwrap();
+        fs::create_dir_all(bridge.parent().unwrap()).unwrap();
+        fs::write(&python, b"python").unwrap();
+        fs::write(&bridge, b"native").unwrap();
+        fs::write(
+            bridge.with_file_name(WINDOWS_EXE_BRIDGE_MARKER),
+            WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_python_command_for_context(Some(&bridge), &[home]).as_os_str(),
+            python.as_os_str()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn external_exe_bridge_points_sidecar_back_to_managed_native_frontdoor() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let managed_native = home.join(".tensor-grep").join("bin").join("tg.exe");
+        let bridge = home.join("bin").join("tg.exe");
+        fs::create_dir_all(managed_native.parent().unwrap()).unwrap();
+        fs::create_dir_all(bridge.parent().unwrap()).unwrap();
+        fs::write(&managed_native, b"native").unwrap();
+        fs::write(&bridge, b"bridge").unwrap();
+        fs::write(
+            bridge.with_file_name(WINDOWS_EXE_BRIDGE_MARKER),
+            WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
+        )
+        .unwrap();
+
+        assert_eq!(
+            native_tg_binary_env_override_for_context(None, Some(bridge), &[home]).as_deref(),
+            Some(managed_native.as_os_str())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn unmarked_home_bin_exe_does_not_redirect_to_managed_install() {
+        let dir = tempdir().unwrap();
+        let home = dir.path().join("home");
+        let python = home
+            .join(".tensor-grep")
+            .join(".venv")
+            .join("Scripts")
+            .join("python.exe");
+        let managed_native = home.join(".tensor-grep").join("bin").join("tg.exe");
+        let local_exe = home.join("bin").join("tg.exe");
+        fs::create_dir_all(python.parent().unwrap()).unwrap();
+        fs::create_dir_all(managed_native.parent().unwrap()).unwrap();
+        fs::create_dir_all(local_exe.parent().unwrap()).unwrap();
+        fs::write(&python, b"python").unwrap();
+        fs::write(&managed_native, b"managed").unwrap();
+        fs::write(&local_exe, b"local").unwrap();
+
+        assert_eq!(
+            resolve_python_command_for_context(Some(&local_exe), &[home.clone()]).as_os_str(),
+            OsStr::new("python")
+        );
+        assert_eq!(
+            native_tg_binary_env_override_for_context(None, Some(local_exe.clone()), &[home])
+                .as_deref(),
+            Some(local_exe.as_os_str())
         );
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -605,17 +605,41 @@ exec "`$TG_FRONTDOOR" "`$@"
         if (!(Test-Path $shimDir)) {
             New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
         }
+        $foreignExeInShimDir = $false
         foreach ($staleShimName in @("tg.com", "tg.exe", "tg.bat", "tg.ps1", "tg")) {
             $staleShimPath = Join-Path $shimDir $staleShimName
             if (Test-Path -LiteralPath $staleShimPath) {
+                if ($staleShimName -eq "tg.exe") {
+                    $staleVersion = ""
+                    try {
+                        $staleVersion = (& $staleShimPath --version 2>$null | Select-Object -First 1)
+                    } catch {
+                        $staleVersion = ""
+                    }
+                    if (!(Test-TensorGrepLauncher -CandidatePath $staleShimPath -VersionLine $staleVersion)) {
+                        $foreignExeInShimDir = $true
+                        Write-Warning "Skipping foreign tg.exe in tensor-grep shim dir: $staleShimPath"
+                        continue
+                    }
+                }
                 Remove-Item -LiteralPath $staleShimPath -Force
                 Write-Host "Removed stale tg launcher shadowing managed shim: $staleShimPath"
             }
         }
         $cmdShimPath = "$shimDir\tg.cmd"
+        $exeShimPath = "$shimDir\tg.exe"
+        $exeShimMarkerPath = "$shimDir\tg.exe.tensor-grep-bridge"
         $ps1ShimPath = "$shimDir\tg.ps1"
         $bashShimPath = "$shimDir\tg"
         Write-AsciiFile -Path $cmdShimPath -Value $cmdShimContent
+        if ((Test-Path -LiteralPath $nativeFrontdoorPath) -and !$foreignExeInShimDir) {
+            Copy-Item -LiteralPath $nativeFrontdoorPath -Destination $exeShimPath -Force
+            Write-AsciiFile -Path $exeShimMarkerPath -Value "tensor-grep managed tg.exe bridge`r`n"
+            Write-Host "Installed Python subprocess tg.exe bridge: $exeShimPath"
+            $installedShimPaths += $exeShimPath
+        } elseif ($foreignExeInShimDir) {
+            Write-Warning "Python subprocess tg.exe bridge was not installed because a foreign tg.exe already exists: $exeShimPath"
+        }
         Write-AsciiFile -Path $ps1ShimPath -Value $ps1ShimContent
         Write-BashFile -Path $bashShimPath -Value $bashShimContent
         $installedShimPaths += $cmdShimPath

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -520,15 +520,70 @@ def _same_path(left: Path, right: Path) -> bool:
         return left == right
 
 
+_WINDOWS_EXE_BRIDGE_MARKER = "tg.exe.tensor-grep-bridge"
+_WINDOWS_EXE_BRIDGE_MARKER_CONTENT = "tensor-grep managed tg.exe bridge\n"
+
+
+def _windows_exe_bridge_marker_path(path: Path) -> Path:
+    return path.with_name(_WINDOWS_EXE_BRIDGE_MARKER)
+
+
+def _write_windows_exe_bridge_marker(path: Path) -> None:
+    if path.name.lower() == "tg.exe":
+        _windows_exe_bridge_marker_path(path).write_text(
+            _WINDOWS_EXE_BRIDGE_MARKER_CONTENT,
+            encoding="ascii",
+        )
+
+
+def _windows_managed_compat_shim_dirs() -> set[str]:
+    if not sys.platform.startswith("win"):
+        return set()
+    homes: list[Path] = []
+    for env_name in ("USERPROFILE", "HOME"):
+        value = os.environ.get(env_name)
+        if not value:
+            continue
+        home = Path(value)
+        if home not in homes:
+            homes.append(home)
+    dirs: set[str] = set()
+    for home in homes:
+        dirs.add(_windows_path_part_key(str(home / "bin")))
+        dirs.add(_windows_path_part_key(str(home / ".local" / "bin")))
+    return dirs
+
+
 def _windows_stale_tensor_grep_com_bridges(expected_version: str, native_path: Path) -> list[Path]:
     if not sys.platform.startswith("win"):
         return []
+
+    def _add_path(path: Path) -> None:
+        try:
+            key = str(path.resolve()).lower()
+        except OSError:
+            key = str(path).lower()
+        if key in seen:
+            return
+        seen.add(key)
+        bridges.append(path)
+
+    def _directory_has_tensor_grep_shim(directory: Path) -> bool:
+        for shim_name in ("tg.cmd", "tg.ps1", "tg"):
+            shim_path = directory / shim_name
+            if not shim_path.is_file():
+                continue
+            version = _doctor_tg_candidate_version(shim_path)
+            if _doctor_tg_version_looks_like_tensor_grep(version):
+                return True
+        return False
 
     path_values = [os.environ.get("PATH", "")]
     fresh_path = _doctor_fresh_shell_path_value()
     if fresh_path and fresh_path not in path_values:
         path_values.append(fresh_path)
 
+    managed_compat_dirs = _windows_managed_compat_shim_dirs()
     bridges: list[Path] = []
     seen: set[str] = set()
     for path_value in path_values:
@@ -539,12 +594,6 @@ def _windows_stale_tensor_grep_com_bridges(expected_version: str, native_path: P
                 continue
             if _same_path(candidate_path, native_path):
                 continue
-            try:
-                key = str(candidate_path.resolve()).lower()
-            except OSError:
-                key = str(candidate_path).lower()
-            if key in seen:
-                continue
             version = candidate.get("version")
             if not _doctor_tg_version_looks_like_tensor_grep(version):
                 continue
@@ -552,8 +601,19 @@ def _windows_stale_tensor_grep_com_bridges(expected_version: str, native_path: P
                 continue
             if _native_tg_version_matches(expected_version, version):
                 continue
-            seen.add(key)
-            bridges.append(candidate_path)
+            _add_path(candidate_path)
+
+        for entry in path_value.split(_doctor_path_list_separator(path_value)):
+            if not entry:
+                continue
+            directory = Path(entry)
+            if _windows_path_part_key(str(directory)) not in managed_compat_dirs:
+                continue
+            target = directory / "tg.exe"
+            if _same_path(target, native_path) or target.exists():
+                continue
+            if _directory_has_tensor_grep_shim(directory):
+                _add_path(target)
     return bridges
 
 
@@ -571,6 +631,7 @@ def _refresh_windows_tensor_grep_com_bridges(
     refreshed: list[Path] = []
     for bridge_path in paths:
         shutil.copy2(native_path, bridge_path)
+        _write_windows_exe_bridge_marker(bridge_path)
         installed_version = _native_tg_version(bridge_path)
         if not _native_tg_version_matches(expected_version, installed_version):
             raise RuntimeError(

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -6606,6 +6606,118 @@ def test_upgrade_refreshes_stale_tensor_grep_com_bridge_after_native_update(monk
     assert str(repaired_tg) in result.stdout
 
 
+def test_upgrade_targets_current_cmd_shim_dir_for_python_subprocess_bridge(
+    monkeypatch,
+    tmp_path,
+):
+    from tensor_grep.cli import main as cli_main
+
+    install_dir = tmp_path / ".tensor-grep"
+    native_binary = install_dir / "bin" / "tg.exe"
+    shim_dir = tmp_path / "bin"
+    shim_cmd = shim_dir / "tg.cmd"
+    native_binary.parent.mkdir(parents=True)
+    shim_dir.mkdir(parents=True)
+    native_binary.write_text("new native", encoding="utf-8")
+    shim_cmd.write_text("@echo off\n", encoding="utf-8")
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate in {native_binary, shim_cmd, shim_dir / "tg.exe"}:
+            return "tg 0.33.0"
+        return None
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("PATH", str(shim_dir))
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: None)
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr(cli_main, "_native_tg_version", lambda path: _fake_candidate_version(path))
+
+    targets = cli_main._windows_stale_tensor_grep_com_bridges("0.33.0", native_binary)
+
+    assert targets == [shim_dir / "tg.exe"]
+    refreshed = cli_main._refresh_windows_tensor_grep_com_bridges(
+        "0.33.0",
+        native_binary,
+        targets,
+    )
+    assert refreshed == [shim_dir / "tg.exe"]
+    assert (shim_dir / "tg.exe").read_text(encoding="utf-8") == "new native"
+    assert (shim_dir / "tg.exe.tensor-grep-bridge").read_text(encoding="ascii") == (
+        "tensor-grep managed tg.exe bridge\n"
+    )
+
+
+def test_upgrade_does_not_create_python_subprocess_bridge_for_foreign_cmd(
+    monkeypatch,
+    tmp_path,
+):
+    from tensor_grep.cli import main as cli_main
+
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    shim_dir = tmp_path / "bin"
+    foreign_cmd = shim_dir / "tg.cmd"
+    native_binary.parent.mkdir(parents=True)
+    shim_dir.mkdir(parents=True)
+    native_binary.write_text("new native", encoding="utf-8")
+    foreign_cmd.write_text("@echo off\n", encoding="utf-8")
+
+    def _fake_candidate_version(path):
+        if Path(path) == foreign_cmd:
+            return "Together CLI (v2.12.0)"
+        if Path(path) == native_binary:
+            return "tg 0.33.0"
+        return None
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("PATH", str(shim_dir))
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: None)
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+
+    targets = cli_main._windows_stale_tensor_grep_com_bridges("0.33.0", native_binary)
+
+    assert targets == []
+    assert not (shim_dir / "tg.exe").exists()
+
+
+def test_upgrade_does_not_create_python_subprocess_bridge_outside_managed_shim_dirs(
+    monkeypatch,
+    tmp_path,
+):
+    from tensor_grep.cli import main as cli_main
+
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    tool_dir = tmp_path / "tools"
+    wrapper_cmd = tool_dir / "tg.cmd"
+    native_binary.parent.mkdir(parents=True)
+    tool_dir.mkdir(parents=True)
+    native_binary.write_text("new native", encoding="utf-8")
+    wrapper_cmd.write_text("@echo off\n", encoding="utf-8")
+
+    def _fake_candidate_version(path):
+        if Path(path) == wrapper_cmd:
+            return "tg 0.33.0"
+        if Path(path) == native_binary:
+            return "tg 0.33.0"
+        return None
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setenv("PATH", str(tool_dir))
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: None)
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+
+    targets = cli_main._windows_stale_tensor_grep_com_bridges("0.33.0", native_binary)
+
+    assert targets == []
+    assert not (tool_dir / "tg.exe").exists()
+
+
 def test_upgrade_refreshes_stale_com_bridge_when_native_frontdoor_is_current(monkeypatch, tmp_path):
     install_dir = tmp_path / ".tensor-grep"
     python_executable = install_dir / ".venv" / "Scripts" / "python.exe"

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -163,11 +163,32 @@ def test_install_ps1_should_remove_stale_same_dir_tg_launchers_before_cmd_shim()
     content = _read_script("scripts/install.ps1")
 
     assert '"tg.com", "tg.exe", "tg.bat", "tg.ps1"' in content
+    assert 'if ($staleShimName -eq "tg.exe") {' in content
+    assert "Test-TensorGrepLauncher -CandidatePath $staleShimPath" in content
+    assert "Skipping foreign tg.exe in tensor-grep shim dir" in content
+    assert (
+        "Python subprocess tg.exe bridge was not installed because a foreign tg.exe already exists"
+        in content
+    )
     assert "Remove-Item -LiteralPath $staleShimPath -Force" in content
     assert "Removed stale tg launcher shadowing managed shim" in content
     assert content.index("Remove-Item -LiteralPath $staleShimPath -Force") < content.index(
         "Write-AsciiFile -Path $cmdShimPath"
     )
+
+
+def test_install_ps1_should_write_exe_bridge_for_python_subprocess_in_shim_dirs():
+    content = _read_script("scripts/install.ps1")
+
+    assert '$exeShimPath = "$shimDir\\tg.exe"' in content
+    assert '$exeShimMarkerPath = "$shimDir\\tg.exe.tensor-grep-bridge"' in content
+    assert "Copy-Item -LiteralPath $nativeFrontdoorPath -Destination $exeShimPath -Force" in content
+    assert (
+        'Write-AsciiFile -Path $exeShimMarkerPath -Value "tensor-grep managed tg.exe bridge`r`n"'
+        in content
+    )
+    assert "$installedShimPaths += $exeShimPath" in content
+    assert "Python subprocess tg.exe bridge" in content
 
 
 def test_install_ps1_should_create_argv_safe_utf8_powershell_shims():


### PR DESCRIPTION
## Summary
- install a real tensor-grep `tg.exe` bridge into Windows compatibility shim dirs so long-lived agent processes can use `subprocess.run(["tg", ...])` even before their PATH refreshes to `~/.tensor-grep/bin`
- require an adjacent tensor-grep ownership marker before copied `tg.exe` bridges redirect sidecar resolution to the managed install
- restrict upgrade-created missing `tg.exe` bridges to known managed compatibility dirs and avoid foreign launcher overwrite

## Root Cause
Python `subprocess.run(["tg", ...])` on Windows uses `CreateProcess` semantics and needs an executable candidate. The existing shim-only dirs (`~/bin`, `~/.local/bin`) could satisfy shells via `.cmd`/profile shims but not Python subprocess. A raw copied native `tg.exe` fixed `--version` but failed Python-backed commands because the copy resolved its sidecar relative to the shim directory.

Research anchors:
- Python subprocess docs: Windows uses `CreateProcess`; unqualified executable resolution is platform dependent and full paths avoid variation.
- Microsoft CreateProcessW docs: when no extension is present, `.exe` is appended and PATH search is applied.

## Validation
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- cargo fmt --manifest-path rust_core/Cargo.toml --check
- cargo test --manifest-path rust_core/Cargo.toml
- uv run pytest -q
- cargo build --manifest-path rust_core/Cargo.toml --release
- cmd /c tg doctor --json --no-lsp
- python subprocess.run(["tg", "doctor", "--json", "--no-lsp"])
- python scripts/agent_readiness.py --no-wsl-probe --output artifacts/agent_readiness_1.12.5_bridge_marker_fix.json
- git diff --check
- Gemini final diff review: NO_FINDINGS
- two independent agent reviews: initial HIGH findings were addressed with ownership marker + directory restriction + tests