### PR TITLE
ci: move release upload action to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,7 +908,7 @@ jobs:
             --expected-version "${{ needs.release.outputs.release_version }}"
 
       - name: Upload GitHub release native assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.release.outputs.release_version }}
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           subject-path: artifacts/**
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             artifacts/**/tg-*

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -931,10 +931,10 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                         "CI workflow publish-github-release-assets job must include "
                         "step `Upload GitHub release native assets`"
                     )
-                elif upload_step.get("uses") != "softprops/action-gh-release@v2":
+                elif upload_step.get("uses") != "softprops/action-gh-release@v3":
                     errors.append(
                         "CI workflow publish-github-release-assets "
-                        "`Upload GitHub release native assets` step must use `softprops/action-gh-release@v2`"
+                        "`Upload GitHub release native assets` step must use `softprops/action-gh-release@v3`"
                     )
                 else:
                     with_block = upload_step.get("with", {})
@@ -2545,9 +2545,9 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
             )
         else:
             uses_value = github_release_step.get("uses")
-            if uses_value != "softprops/action-gh-release@v2":
+            if uses_value != "softprops/action-gh-release@v3":
                 errors.append(
-                    "Release workflow create-release `Create GitHub Release` step must use `softprops/action-gh-release@v2`"
+                    "Release workflow create-release `Create GitHub Release` step must use `softprops/action-gh-release@v3`"
                 )
             with_block = github_release_step.get("with")
             if not isinstance(with_block, dict):

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -1721,7 +1721,7 @@ def test_should_require_ci_release_native_assets_to_use_rust_frontdoor_not_nuitk
           - name: Validate native release asset matrix and generate checksums
             run: uv run python scripts/validate_release_binary_artifacts.py --expected-profile native-frontdoor --checksums-out artifacts/CHECKSUMS.txt
           - name: Upload GitHub release native assets
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@v3
             with:
               tag_name: v${{ needs.release.outputs.release_version }}
               files: |
@@ -2469,7 +2469,7 @@ def test_should_require_release_to_publish_package_manager_bundle_assets():
       create-release:
         steps:
           - name: Create GitHub Release
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@v3
             with:
               files: |
                 artifacts/**/tg-*
@@ -3462,7 +3462,7 @@ def test_should_require_release_create_github_release_step_contract():
     """
     errors = module.validate_release_workflow_content(release_workflow=release_workflow)
     assert any(
-        "create-release `Create GitHub Release` step must use `softprops/action-gh-release@v2`"
+        "create-release `Create GitHub Release` step must use `softprops/action-gh-release@v3`"
         in err
         for err in errors
     )
@@ -3513,7 +3513,7 @@ def test_should_require_release_validate_tag_version_parity_setup_and_command():
           - name: Smoke-test package-manager bundle contracts
             run: uv run python scripts/smoke_test_package_manager_bundle.py --bundle-dir artifacts/package-manager-bundle
           - name: Create GitHub Release
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@v3
             with:
               files: |
                 artifacts/**/tg-*
@@ -3602,7 +3602,7 @@ def test_should_require_release_publish_npm_setup_node_contract():
           - name: Smoke-test package-manager bundle contracts
             run: uv run python scripts/smoke_test_package_manager_bundle.py --bundle-dir artifacts/package-manager-bundle
           - name: Create GitHub Release
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@v3
             with:
               files: |
                 artifacts/**/tg-*


### PR DESCRIPTION
## Summary
- update GitHub release upload steps from softprops/action-gh-release@v2 to @v3
- update release asset workflow validators to require the Node 24-compatible action
- update focused validator tests and fixtures

## Validation
- tg search --fixed-strings "softprops/action-gh-release@v2" .github scripts tests -g "*.yml" -g "*.yaml" -g "*.py" -> no matches
- uv run python scripts/validate_release_assets.py -> passed
- uv run pytest tests/unit/test_release_assets_validation.py -q -> 124 passed
- uv run ruff check . -> passed
- uv run ruff format --check --preview . -> passed
- uv run mypy src/tensor_grep -> passed
- uv run pytest -q -> 2073 passed, 50 skipped
- git diff --check -> no whitespace errors; CRLF warnings only for workflow files
