### PR TITLE
fix: harden v1.12.7 release positioning governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,14 +20,21 @@ release_docs_current_tag: v1.12.7
 
 As of 2026-05-14, the current tagged release state is `v1.12.7`, and the latest complete public PyPI/release-asset distribution is also `v1.12.7`. The stable installer, release-native asset publication, managed-native `tg upgrade` refresh path, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity fixes, Windows `.cmd` quoted-pattern launcher fix, native-first Windows PATH ordering, top-level validation-command contract, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, explicit language/file-name agent ranking, Windows validation-command quoting, docs/version governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternative-target surfacing, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, and agent capsule hardcase routing are released through `v1.12.7` GitHub assets and PyPI. Follow-up work should focus on context/session latency, GPU production viability, token economy, call-site evidence, AST parity roadmap, classify provider/cache UX, and keeping docs synchronized with release proof.
 
-- Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest tagged merge commit: `a78e33c fix: harden post-release docs governance`
-- Latest tagged release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest complete public release PR: #116 `fix: harden post-release docs governance`
-- Latest complete public release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest merged fix commit: `a78e33c fix: harden post-release docs governance`
-- Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
+- Latest tagged release PR: #128 `fix: harden v1.12.6 dogfood cli contracts`
+- Latest tagged merge commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest tagged release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest complete public release PR: #128 `fix: harden v1.12.6 dogfood cli contracts`
+- Latest complete public release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest merged fix commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest merged feature commit: `a518cc6 feat: add agent success harness`
 - Recent fix commits:
+  - `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+  - `1783e92 fix: harden Windows subprocess exe bridge`
+  - `f75e24a fix: harden gpu proof benchmark hygiene`
+  - `affe7a7 fix: keep rust validation for agent cli intents`
+  - `6b2016c fix: clarify ast subset positioning`
+  - `b038ed5 fix: restore compat schema governance`
+  - `aeead68 fix: align public search flag routing`
   - `a78e33c fix: harden post-release docs governance`
   - `2100122 fix: harden release docs stamp governance`
   - `361e0db fix: harden public GPU unavailable routing`
@@ -74,13 +81,14 @@ As of 2026-05-14, the current tagged release state is `v1.12.7`, and the latest 
   - `1a06cba fix: remove stale Windows tg launchers`
   - `379b22f fix: harden tg resolution and rg path parity`
 - `v1.11.0` GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.11.0> exists, but main CI run `25834508800` was cancelled during release-native asset publication; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25860914920`: passed the pre-release matrix, semantic-release, PyPI wheel/sdist validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- Main CodeQL run `25866868462`: passed on the `v1.11.5` release line
+- Main CI run `25917666403`: passed the pre-release matrix, semantic-release, PyPI wheel/sdist validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
+- Main CodeQL run `25917665808`: passed on the `v1.12.7` release line
 - PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.12.7 tg --version` reports `tensor-grep 1.12.7`
 - GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.12.7>
 - Main CI run `25866871838`: passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- GitHub release assets: `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, winget manifest, Homebrew formula, and publish instructions are uploaded and verified on `v1.11.5`
-- Public `v1.11.5` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.5 tg --version` verified `tensor-grep 1.11.5`; the release includes `a78e33c fix: harden post-release docs governance` while preserving `361e0db fix: harden public GPU unavailable routing`, `2100122 fix: harden release docs stamp governance`, and the `87d4ca4 fix: accelerate fixed multi-pattern native search` CPU lane from `v1.11.3`. Explicit public GPU requests without sidecar configuration report native GPU unavailable and fall back to `NativeCpuBackend`.
+- GitHub release assets: `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, winget manifest, Homebrew formula, and publish instructions are uploaded and verified on `v1.12.7`
+- Public `v1.12.7` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.12.7 tg --version` verified `tensor-grep 1.12.7`; the release includes `da44a2f fix: harden v1.12.6 dogfood cli contracts` while preserving `a78e33c fix: harden post-release docs governance`, `361e0db fix: harden public GPU unavailable routing`, `2100122 fix: harden release docs stamp governance`, and the `87d4ca4 fix: accelerate fixed multi-pattern native search` CPU lane from `v1.11.3`. Explicit public GPU requests without sidecar configuration report native GPU unavailable and fall back to `NativeCpuBackend`; public managed GPU is not promotion-ready.
+- Public `v1.11.5` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.5 tg --version` verified `tensor-grep 1.11.5`; the release includes `a78e33c fix: harden post-release docs governance` while preserving `361e0db fix: harden public GPU unavailable routing`, `2100122 fix: harden release docs stamp governance`, and the `87d4ca4 fix: accelerate fixed multi-pattern native search` CPU lane from `v1.11.3`.
 - Public `v1.11.2` dogfood: release CI, assets, PyPI, and `uvx --refresh-package tensor-grep --from tensor-grep==1.11.2 tg --version` verified `tensor-grep 1.11.2`; the release also exposes classify provider provenance so JSON harnesses can distinguish local deterministic classification from opt-in provider-backed classification.
 - Public `v1.10.10` GPU evidence remains experimental: explicit managed GPU requests still report `GpuSidecar` / unsupported rather than a qualifying `NativeGpuBackend` row, so no GPU speed promotion is made.
 - Public `v1.10.8` dogfood: release CI, assets, PyPI, `uvx --refresh-package tensor-grep --from tensor-grep==1.10.8 tg --version`, managed `tg upgrade`, fresh `cmd /c tg --version`, fresh `pwsh -NoProfile -Command "tg --version"`, and direct managed native `tg.exe` all verified `1.10.8`. Python `subprocess.run(["tg", "--version"])` still resolved the foreign Together CLI `tg.exe` from Machine PATH on this host; `tg doctor --json` reported the route as `foreign` with Machine PATH remediation and did not delete or overwrite unrelated launchers.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ release_docs_current_tag: v1.12.7
 
 Latest tagged GitHub release: [`v1.12.7`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.12.7). GitHub assets and PyPI publication are verified by main CI before `publish-success-gate` passes.
 Latest complete PyPI release: [`v1.12.7`](https://github.com/oimiragieo/tensor-grep/releases/tag/v1.12.7). This is also the latest complete release-asset distribution.
-Latest verified release proof: `v1.11.5` completed in main CI run `25866871838`; CodeQL run `25866868462` passed.
+Latest verified release proof: `v1.12.7` completed in main CI run `25917666403`; CodeQL run `25917665808` passed.
 
 Current positioning:
 
@@ -53,11 +53,21 @@ Current positioning:
 - `rg` remains the cold exact-text baseline. Use `--sort path --format rg` when automation needs deterministic ripgrep-shaped stdout.
 - `ast-grep` remains the structural-search feature/performance baseline. `tg run` is a validated useful slice, not a full ast-grep replacement.
 - GPU remains opt-in/experimental until local benchmarks prove a real end-to-end crossover. Default `classify` is now deterministic and local unless `TENSOR_GREP_CLASSIFY_PROVIDER=cybert` opts into the CyBERT/Triton path.
-- Public GPU note: in `v1.11.3`, the public managed binary still reports explicit GPU requests through `GpuSidecar`; only a CUDA-feature native build can produce `NativeGpuBackend` / `sidecar_used = false` evidence. GPU benchmark artifacts now expose `promotion_evidence_contract` and `promotion_blockers` so sidecar rows cannot look like promotion proof. The latest public managed many-pattern dogfood is not promotion-ready for GPU: the accepted improvement is a native CPU fixed multi-pattern fast path, not public GPU readiness. Native CUDA correctness rows are not public GPU readiness, and GPU remains experimental until public managed binaries produce 1GB and 5GB correctness and speed wins for the declared workload on RTX 4070 / RTX 5070 class devices.
+- Public GPU note: in `v1.12.7`, public managed GPU is not promotion-ready. The public managed binary falls back to `NativeCpuBackend` or reports unsupported for explicit GPU requests unless a CUDA-feature native build can produce `NativeGpuBackend` / `sidecar_used = false` evidence. GPU benchmark artifacts expose `promotion_evidence_contract` and `promotion_blockers` so fallback or sidecar rows cannot look like promotion proof. The latest public managed many-pattern dogfood is not promotion-ready for GPU: the accepted improvement is a native CPU fixed multi-pattern fast path, not public GPU readiness. Native CUDA correctness rows are not public GPU readiness, and GPU remains experimental until public managed binaries produce 1GB and 5GB correctness and speed wins for the declared workload on RTX 4070 / RTX 5070 class devices.
 - The public native front door is now the performance-critical shell entrypoint. Advertised CLI flags must either execute there or route to the Python sidecar intentionally; help text that advertises flags the native parser rejects is a release blocker.
 - `tg agent --query ... --json` is the first Actionable Context Capsule surface: a bounded, deterministic work packet with primary files/functions, alternative targets, route rationale, snippets with line maps, validation evidence, rollback/checkpoint metadata, omissions, confidence, optional native GPU route evidence, unresolved equal-confidence tie metadata, and an ask-before-editing recommendation. It is an opt-in agent command, not a mutation of raw `--format rg`, `--json`, or `--ndjson`.
-- `tg agent --gpu-device-ids 0,1 --query ... --json` runs an opt-in batched GPU evidence scan for the selected devices and records `gpu_acceleration`; sidecar-routed results are reported as unsupported instead of being counted as GPU acceleration.
+- `tg agent --gpu-device-ids 0,1 --query ... --json` runs an opt-in batched GPU evidence scan for the selected devices and records `gpu_acceleration`; sidecar-routed or CPU-fallback results are reported as unsupported instead of being counted as GPU proof.
 - Capsule confidence must be honest when query language hints, primary target language, selected snippets, and validation commands disagree. Mixed-language agent workflows use `validation_alignment` and ask-before-editing metadata instead of silently pairing a TypeScript target with pytest-only validation.
+
+What `v1.12.7` closed:
+
+- PR #128 `fix: harden v1.12.6 dogfood cli contracts` shipped the release as merge commit `da44a2f fix: harden v1.12.6 dogfood cli contracts` and release commit `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest merged feature commit before this release line: `a518cc6 feat: add agent success harness`
+- main CI run `25917666403` passed semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`; CodeQL run `25917665808` passed
+- GitHub release assets for `v1.12.7` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions; `uvx --refresh-package tensor-grep --from tensor-grep==1.12.7 tg --version` reports `tensor-grep 1.12.7`
+- public native/dev CLI drift is closed for accepted search flags and option-first structured search: `tg --json --no-ignore ...`, `tg search --passthrough`, `--unicode`, `--auto-hybrid-regex`, `--type-list`, `--pcre2-version`, and `tg search --version` execute or route intentionally
+- `tg new` fails before writing files for unsupported scaffold shapes and respects `--base-dir` for supported scaffolds; `edit-plan` and MCP/session edit-plan accept agent budget flags while keeping output source-bounded
+- `tg search --json` is tensor-grep aggregate JSON, not ripgrep JSON Lines; `tg search --ndjson` is tensor-grep flattened streaming rows, not the rg event schema
 
 What `v1.11.5` closed:
 
@@ -715,7 +725,7 @@ $ tg --gpu-device-ids 0 foobar
 $ tg --gpu-device-ids 0,1 foobar
 ```
 
-Search for multiple patterns in a single pass (GPU-accelerated):
+Search for multiple fixed patterns in one native CPU pass:
 
 ```bash
 $ tg -e "ERROR" -e "FATAL" -e "PANIC" ./logs
@@ -871,9 +881,9 @@ The `cuda` feature links against `cudarc` (Rust-native CUDA bindings), compiles 
 
 The native CPU engine requires only a Rust toolchain. No GPU, CUDA, or Python runtime is needed for the native binary. Current performance claims should be taken from [docs/benchmarks.md](docs/benchmarks.md), not this README.
 
-### GPU-accelerated (native CUDA)
+### Experimental Native CUDA
 
-To unlock GPU acceleration, your system must meet these requirements. End-to-end GPU routing is still benchmark-governed and host-specific; see [docs/gpu_crossover.md](docs/gpu_crossover.md) for the current measured line.
+To evaluate native CUDA search, your system must meet these requirements. End-to-end GPU routing is still benchmark-governed and host-specific; see [docs/gpu_crossover.md](docs/gpu_crossover.md) for the current measured line. Public managed GPU remains experimental until public binaries produce `NativeGpuBackend`, `sidecar_used = false`, 1GB/5GB correctness, and speed wins over both `rg` and `tg_cpu`.
 
 * **Hardware:**
   * NVIDIA GPU (RTX 30/40 series recommended; RTX 50-series / sm_120 support depends on the CUDA/PyTorch stack described in [docs/runbooks/gpu-troubleshooting.md](docs/runbooks/gpu-troubleshooting.md))

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,14 +13,15 @@ As of 2026-05-14, the current tagged version is `v1.12.7`, and the latest comple
 
 Current release facts:
 
+- PR #128 `da44a2f fix: harden v1.12.6 dogfood cli contracts` merged and released as `v1.12.7`
 - PR #116 `a78e33c fix: harden post-release docs governance` merged and released as `v1.11.5`
 - PR #114 `361e0db fix: harden public GPU unavailable routing` and PR #115 `2100122 fix: harden release docs stamp governance` merged and released as `v1.11.4`
 - PR #113 `87d4ca4 fix: accelerate fixed multi-pattern native search` merged and released as `v1.11.3`
-- Tagged merge commit: `a78e33c fix: harden post-release docs governance`
-- Tagged release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest complete public release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest merged fix commit: `a78e33c fix: harden post-release docs governance`
-- Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
+- Tagged merge commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Tagged release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest complete public release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest merged fix commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest merged feature commit: `a518cc6 feat: add agent success harness`
 - PR #110 `fix: expose classify provider provenance` merged and released as `v1.11.2`
 - PR #105 `fix: add explicit Windows subprocess launcher repair` merged and released as `v1.10.10`
 - Merge commit: `dd995fc fix: add explicit Windows subprocess launcher repair`
@@ -46,9 +47,10 @@ Current release facts:
 - Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`
 - PR #66 `docs: define agent context capsule roadmap` merged; Main CI run `25561521904` passed, CodeQL/dynamic main run `25561520180` passed, and semantic-release correctly skipped publishing.
 - `v1.11.0` main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25866871838` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. CodeQL run `25866868462` passed on the `v1.11.5` release line.
-- PyPI pinned public install resolves with `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version`
-- GitHub release assets for `v1.11.5` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
+- Main CI run `25917666403` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. CodeQL run `25917665808` passed on the `v1.12.7` release line.
+- PyPI pinned public install resolves with `uvx --refresh-package tensor-grep --from tensor-grep==1.12.7 tg --version`
+- GitHub release assets for `v1.12.7` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
+- Public `v1.12.7` dogfood verified PyPI, `uvx`, GitHub assets, public launcher resolution, accepted search/native-front-door CLI drift fixes, `tg new --base-dir`, edit-plan budget flags, and explicit JSON/NDJSON schema positioning; public managed GPU remains not promotion-ready and falls back to CPU or unsupported rows unless a CUDA-feature native build proves `NativeGpuBackend` with `sidecar_used = false`.
 - Public `v1.11.5` dogfood verified PyPI, `uvx`, GitHub assets, and post-release-safe docs governance; `v1.11.4` remains the native GPU unavailable fallback to `NativeCpuBackend` release, `v1.11.3` remains the fixed multi-pattern native CPU release, and `v1.10.10` remains the historical Windows subprocess launcher repair release.
 - Public `v1.11.2` dogfood verified PyPI, `uvx`, GitHub assets, and classify provider provenance in JSON output.
 - PR #102 `fix: harden v1.10.7 dogfood followups` merged and released as `v1.10.8`

--- a/docs/CONTINUATION_PLAN.md
+++ b/docs/CONTINUATION_PLAN.md
@@ -10,21 +10,22 @@ The current tagged state is `v1.12.7`, and the latest complete public PyPI/relea
 
 Current release facts:
 
-- Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest tagged merge commit: `a78e33c fix: harden post-release docs governance`
-- Latest tagged release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest complete public release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest merged fix commit: `a78e33c fix: harden post-release docs governance`
-- Latest merged feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
-- Latest complete public release PR: #116 `fix: harden post-release docs governance`
-- Latest complete public merge commit: `a78e33c fix: harden post-release docs governance`
+- Latest tagged release PR: #128 `fix: harden v1.12.6 dogfood cli contracts`
+- Latest tagged merge commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest tagged release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest complete public release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest merged fix commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest merged feature commit: `a518cc6 feat: add agent success harness`
+- Latest complete public release PR: #128 `fix: harden v1.12.6 dogfood cli contracts`
+- Latest complete public merge commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
 - `v1.11.0` main CI run `25834508800` passed pre-release checks and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `25860914920`: passed pre-release checks, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
+- Main CI run `25917666403`: passed pre-release checks, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
 - Main CI run `25866871838`: passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`.
-- CodeQL run `25866868462`: passed on the v1.11.5 release line.
-- PyPI pinned public install: `uvx --refresh-package tensor-grep --from tensor-grep==1.11.3 tg --version` reports `tensor-grep 1.11.3`.
-- GitHub release assets for `v1.11.5` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions.
-- Public `v1.11.5` dogfood verified post-release-safe docs governance; `2100122 fix: harden release docs stamp governance` remains the release-stamper alignment fix, `361e0db fix: harden public GPU unavailable routing` remains the native GPU unavailable fallback, and `87d4ca4 fix: accelerate fixed multi-pattern native search` remains the `v1.11.3` CPU many-pattern lane.
+- CodeQL run `25917665808`: passed on the v1.12.7 release line.
+- PyPI pinned public install: `uvx --refresh-package tensor-grep --from tensor-grep==1.12.7 tg --version` reports `tensor-grep 1.12.7`.
+- GitHub release assets for `v1.12.7` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions.
+- Public `v1.12.7` dogfood verified post-release-safe docs governance, public launcher resolution, accepted native/dev CLI flag alignment, `tg new --base-dir`, edit-plan budget flags, and explicit JSON/NDJSON schema positioning; public managed GPU remains not promotion-ready and falls back to CPU or unsupported rows unless a CUDA-feature native build proves `NativeGpuBackend` with `sidecar_used = false`.
+- Current retained release-baseline commits: `361e0db fix: harden public GPU unavailable routing`, `2100122 fix: harden release docs stamp governance`, and `87d4ca4 fix: accelerate fixed multi-pattern native search`.
 - Historical `v1.10.10` launcher dogfood: direct `C:\Users\oimir\.tensor-grep\bin\tg.exe --version`, fresh `cmd`, unprofiled `pwsh`, and Python `subprocess.run(["tg", "--version"])` all reported `tg 1.10.10` after the explicit repair command.
 - Prior managed native-upgrade dogfood: `tg update` from `v1.9.3` installed sidecar `tensor-grep==1.9.4` and refreshed the native front door to `tg 1.9.4` after transient PyPI propagation lag.
 - Public capsule dogfood: `tg agent src/tensor_grep/cli --query "agent context capsule" --json` returns the Actionable Context Capsule contract.

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -8,20 +8,21 @@ release_docs_current_tag: v1.12.7
 
 - Latest tagged version: `v1.12.7`
 - Latest complete PyPI version: `v1.12.7`
-- Latest tagged release PR: #113 `fix: accelerate fixed multi-pattern native search`
-- Latest tagged merge commit: `a78e33c fix: harden post-release docs governance`
-- Latest tagged release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest complete public release PR: #116 `fix: harden post-release docs governance`
-- Latest complete public release commit: `e33c2ba chore(release): v1.11.5 [skip ci]`
-- Latest fix commit: `a78e33c fix: harden post-release docs governance`
-- Latest feature commit: `213d383 feat: add dogfood readiness verdict and checkpoint UX`
+- Latest tagged release PR: #128 `fix: harden v1.12.6 dogfood cli contracts`
+- Latest tagged merge commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest tagged release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest complete public release PR: #128 `fix: harden v1.12.6 dogfood cli contracts`
+- Latest complete public release commit: `5d9a775 chore(release): v1.12.7 [skip ci]`
+- Latest fix commit: `da44a2f fix: harden v1.12.6 dogfood cli contracts`
+- Latest feature commit: `a518cc6 feat: add agent success harness`
 - GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.12.7>
 - `v1.11.0` publication caveat: main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed, `publish-github-release-assets` / `publish-pypi` did not complete, and PyPI latest remains `1.10.10`.
-- Main CI run `25860914920`: passed the pre-release matrix, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
-- Main CodeQL run `25866868462`: passed on the `v1.11.5` release line
+- Main CI run `25917666403`: passed the pre-release matrix, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
+- Main CodeQL run `25917665808`: passed on the `v1.12.7` release line
 - Main CI run `25866871838`: passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`
 - PyPI pinned install: `uvx --refresh-package tensor-grep --from tensor-grep==1.12.7 tg --version` reports `tensor-grep 1.12.7`
 - GitHub release assets: `v1.12.7` has uploaded native CPU front doors for Windows/Linux/macOS, checksums, winget manifest, Homebrew formula, and publish instructions
+- Public `v1.12.7` dogfood verified PyPI, `uvx`, release assets, public launcher resolution, accepted search/native-front-door CLI drift fixes, `tg new --base-dir`, edit-plan budget flags, and explicit JSON/NDJSON schema positioning. Public managed GPU is not promotion-ready: explicit GPU requests fall back to `NativeCpuBackend` or unsupported rows unless a CUDA-feature native build proves `NativeGpuBackend` with `sidecar_used = false`.
 - Public `v1.11.5` dogfood verified PyPI, `uvx`, release assets, and post-release-safe docs governance. `v1.11.4` verifies the native GPU unavailable fallback to `NativeCpuBackend`, and `v1.11.3` uses `87d4ca4 fix: accelerate fixed multi-pattern native search` to run a single Aho-Corasick pass for safe fixed-string multi-pattern searches while keeping GPU promotion separate from this CPU workload-class win.
 - Closed v1.11.5 post-release-safe docs governance gap: `a78e33c fix: harden post-release docs governance` separates auto-stamped current tag labels from latest verified release proof blocks so release commits remain locally testable after semantic-release bumps the version.
 - Closed v1.11.4 native GPU unavailable and docs-governance gap: `361e0db fix: harden public GPU unavailable routing` prevents sidecar routing from looking like native GPU proof when no explicit sidecar is configured, and `2100122 fix: harden release docs stamp governance` keeps post-release-safe docs governance aligned with semantic-release tag stamping.
@@ -69,7 +70,7 @@ release_docs_current_tag: v1.12.7
 
 ## Current Post-v1.11.3 Scope
 
-Current release branch is publication-complete for `v1.11.5`: PR #116 `fix: harden post-release docs governance` was squash-merged as `a78e33c`, release commit `e33c2ba chore(release): v1.11.5 [skip ci]` exists, main CI run `25866871838` passed tests/assets, GitHub asset upload, PyPI publish, and `publish-success-gate`, and CodeQL run `25866868462` passed. Public dogfood verified PyPI, release assets, `uvx`, and post-release-safe docs governance. The `v1.10.10` Windows subprocess launcher repair remains the public launcher repair baseline; keep foreign launcher handling opt-in and auditable rather than deleting unrelated tools.
+Current release branch is publication-complete for `v1.12.7`: PR #128 `fix: harden v1.12.6 dogfood cli contracts` was squash-merged as `da44a2f`, release commit `5d9a775 chore(release): v1.12.7 [skip ci]` exists, main CI run `25917666403` passed tests/assets, GitHub asset upload, PyPI publish, and `publish-success-gate`, and CodeQL run `25917665808` passed. Public dogfood verified PyPI, release assets, `uvx`, launcher resolution, accepted native/dev CLI flag alignment, `tg new --base-dir`, edit-plan budget flags, and explicit JSON/NDJSON schema positioning. The `v1.10.10` Windows subprocess launcher repair remains the historical public launcher repair baseline; keep foreign launcher handling opt-in and auditable rather than deleting unrelated tools.
 
 The public Windows `.cmd` bridge quoted multi-word no-match follow-up shipped in `v1.8.30`. The Windows native-first PATH, agent JSON validation-command, local default classify, and GPU scale benchmark follow-ups shipped in `v1.8.31`. The launcher-route observability and benchmark launcher-attribution follow-up shipped in `v1.8.32`. The explicit GPU probe scoping and benchmark launcher warning follow-up shipped in `v1.8.33`. The Actionable Context Capsule v1 shipped in `v1.9.0`; mixed-language capsule trust alignment and GPU recommendation hygiene shipped in `v1.9.1`; edit JSON/rollback safety shipped in `v1.9.2`; explicit Python ranking and quoted validation commands shipped in `v1.9.3`; docs-governance and validation placeholders shipped in `v1.9.4`; native CUDA gate hardening, capsule alternatives, help diagnostics, and foreign launcher diagnostics shipped in `v1.9.5`; directory validation, CUDA 12.8 install paths, help coverage, and release-proof governance shipped in `v1.9.6`; GPU benchmark promotion-gate taxonomy and cold-search positioning shipped in `v1.9.7`; stale tensor-grep-owned `tg.com` bridge refresh after upgrade shipped in `v1.9.8`; agent workflow benchmark governance shipped in `v1.9.9`; capsule confidence/secrets/docs dogfood follow-ups shipped in source/GitHub assets in `v1.9.10`; and release wheel Cargo prefetch retries shipped in `v1.9.11`.
 

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -1890,6 +1890,7 @@ def validate_readme_contract(*, readme_content: str) -> list[str]:
         "faster than rg",
         "faster than `rg`",
         "GPU-ready",
+        "GPU-accelerated",
     ]
     for fragment in banned_positioning:
         if fragment in readme_content:

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -21,21 +21,21 @@ def _project_release_tag() -> str:
 
 
 CURRENT_RELEASE_TAG = _project_release_tag()
-VERIFIED_RELEASE_TAG = "v1.11.5"
-VERIFIED_RELEASE_COMMIT = "e33c2ba chore(release): v1.11.5 [skip ci]"
-VERIFIED_FIX_COMMIT = "a78e33c fix: harden post-release docs governance"
+VERIFIED_RELEASE_TAG = CURRENT_RELEASE_TAG
+VERIFIED_RELEASE_COMMIT = "5d9a775 chore(release): v1.12.7 [skip ci]"
+VERIFIED_FIX_COMMIT = "da44a2f fix: harden v1.12.6 dogfood cli contracts"
 CURRENT_RELEASE_COMMIT = VERIFIED_RELEASE_COMMIT
 CURRENT_FIX_COMMIT = VERIFIED_FIX_COMMIT
 CURRENT_GPU_FIX_COMMIT = "361e0db fix: harden public GPU unavailable routing"
 CURRENT_DOCS_STAMP_FIX_COMMIT = "2100122 fix: harden release docs stamp governance"
 CURRENT_MULTIPATTERN_FIX_COMMIT = "87d4ca4 fix: accelerate fixed multi-pattern native search"
-CURRENT_FEATURE_COMMIT = "213d383 feat: add dogfood readiness verdict and checkpoint UX"
+CURRENT_FEATURE_COMMIT = "a518cc6 feat: add agent success harness"
 LATEST_COMPLETE_RELEASE_TAG = CURRENT_RELEASE_TAG
 LATEST_COMPLETE_RELEASE_COMMIT = VERIFIED_RELEASE_COMMIT
 LATEST_COMPLETE_FIX_COMMIT = VERIFIED_FIX_COMMIT
 LATEST_VERIFIED_RELEASE_TAG = VERIFIED_RELEASE_TAG
-LATEST_VERIFIED_MAIN_CI = "25866871838"
-LATEST_VERIFIED_CODEQL = "25866868462"
+LATEST_VERIFIED_MAIN_CI = "25917666403"
+LATEST_VERIFIED_CODEQL = "25917665808"
 
 
 def test_readme_should_point_to_canonical_public_docs() -> None:
@@ -251,6 +251,8 @@ def test_handoff_docs_should_record_current_release_state_and_fast_gate() -> Non
     assert "only initialize selected devices" in readme
     assert "Actionable Context Capsule" in readme
     assert "validation_alignment" in readme
+    assert "public managed GPU is not promotion-ready" in readme
+    assert "tg search --json` is tensor-grep aggregate JSON" in readme
 
     current_closed_heading = f"What `{LATEST_VERIFIED_RELEASE_TAG}` closed:"
     v1114_heading = "What `v1.11.4` closed:"
@@ -490,6 +492,7 @@ def test_public_docs_should_not_contain_unaccepted_gpu_or_cold_rg_marketing() ->
         "further buries",
         "designed to win on larger files",
         "GPU-ready",
+        "GPU-accelerated",
     ]
 
     for path, doc in docs.items():


### PR DESCRIPTION
## Summary
- updates release-governance docs and tests to the verified v1.12.7 release proof
- removes public `GPU-accelerated` README wording and bans it from README release validation
- records that search JSON/NDJSON are tensor-grep schemas, not rg JSON Lines compatibility

## Validation
- `uv run pytest tests/unit/test_public_docs_governance.py tests/unit/test_release_assets_validation.py -q` -> 163 passed
- `uv run ruff check .` -> passed
- `uv run ruff format --check --preview .` -> 419 files already formatted
- `uv run mypy src/tensor_grep` -> success
- `git diff --check` -> no whitespace errors

## External review
- Gemini read-only diff review: no blocking findings; confirmed the prior GPU wording issue is fixed and the new governance tests enforce it.