### PR TITLE
fix: bound map and context agent outputs

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -399,12 +399,24 @@ def _summarize_agent_gpu_json_result(
     result: dict[str, Any],
     *,
     match_preview_limit: int = 3,
+    redact_probe_paths: bool = False,
 ) -> dict[str, Any]:
+    summary = {key: value for key, value in result.items() if key != "payload"}
+    if redact_probe_paths:
+        if "argv" in summary:
+            summary["argv"] = [
+                "<agent-gpu-probe-root>" if "tg-agent-gpu-probe-" in str(arg) else str(arg)
+                for arg in _as_list_of_strings(summary.get("argv"))
+            ]
+        if "command" in summary:
+            summary["command"] = subprocess.list2cmdline([
+                str(arg) for arg in summary.get("argv", [])
+            ])
+
     payload = _as_dict(result.get("payload"))
     if not payload:
-        return result
+        return summary
 
-    summary = {key: value for key, value in result.items() if key != "payload"}
     payload_summary: dict[str, Any] = {}
     for key in (
         "version",
@@ -419,7 +431,10 @@ def _summarize_agent_gpu_json_result(
         "routing_gpu_device_ids",
     ):
         if key in payload:
-            payload_summary[key] = payload[key]
+            if redact_probe_paths and key == "path":
+                payload_summary[key] = "<agent-gpu-probe-root>"
+            else:
+                payload_summary[key] = payload[key]
 
     pipeline = _as_dict(payload.get("pipeline"))
     if pipeline:
@@ -443,7 +458,11 @@ def _summarize_agent_gpu_json_result(
     for match in matches[:match_preview_limit]:
         text = str(match.get("text") or "")
         preview.append({
-            "file": match.get("file") or match.get("path"),
+            "file": (
+                "<agent-gpu-probe-file>"
+                if redact_probe_paths
+                else match.get("file") or match.get("path")
+            ),
             "line": match.get("line") or match.get("line_number"),
             "pattern_id": match.get("pattern_id"),
             "pattern_text": match.get("pattern_text") or match.get("pattern"),
@@ -552,7 +571,7 @@ def _agent_gpu_evidence(
             "used_for_evidence": False,
             "promotion_claim": False,
             "reason": str(probe.get("reason") or "GPU route probe failed."),
-            "probe": _summarize_agent_gpu_json_result(probe),
+            "probe": _summarize_agent_gpu_json_result(probe, redact_probe_paths=True),
         }
 
     probe_payload = _as_dict(probe.get("payload"))
@@ -565,7 +584,7 @@ def _agent_gpu_evidence(
             "used_for_evidence": False,
             "promotion_claim": False,
             "reason": route_rejection,
-            "probe": _summarize_agent_gpu_json_result(probe),
+            "probe": _summarize_agent_gpu_json_result(probe, redact_probe_paths=True),
             **route_fields,
         }
 
@@ -577,7 +596,7 @@ def _agent_gpu_evidence(
             "used_for_evidence": False,
             "promotion_claim": False,
             "reason": "Native GPU route passed, but the query produced no evidence terms.",
-            "probe": _summarize_agent_gpu_json_result(probe),
+            "probe": _summarize_agent_gpu_json_result(probe, redact_probe_paths=True),
             **route_fields,
         }
 
@@ -604,7 +623,7 @@ def _agent_gpu_evidence(
             "used_for_evidence": False,
             "promotion_claim": False,
             "reason": str(evidence.get("reason") or "GPU evidence scan failed."),
-            "probe": _summarize_agent_gpu_json_result(probe),
+            "probe": _summarize_agent_gpu_json_result(probe, redact_probe_paths=True),
             "evidence": _summarize_agent_gpu_json_result(evidence),
             **route_fields,
         }
@@ -619,7 +638,7 @@ def _agent_gpu_evidence(
             "used_for_evidence": False,
             "promotion_claim": False,
             "reason": evidence_route_rejection,
-            "probe": _summarize_agent_gpu_json_result(probe),
+            "probe": _summarize_agent_gpu_json_result(probe, redact_probe_paths=True),
             "evidence": _summarize_agent_gpu_json_result(evidence),
             **evidence_route_fields,
         }
@@ -657,7 +676,7 @@ def _agent_gpu_evidence(
         "matched_files": matched_files[:max_files],
         "total_matches": total_matches,
         "matches": evidence_matches,
-        "probe": _summarize_agent_gpu_json_result(probe),
+        "probe": _summarize_agent_gpu_json_result(probe, redact_probe_paths=True),
         "evidence": _summarize_agent_gpu_json_result(evidence),
         **evidence_route_fields,
     }

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -1767,7 +1767,7 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
             sentinel,
             str(probe_file),
         ]
-        base["command"] = " ".join(command)
+        base["command"] = " ".join([*command[:-1], "<doctor-gpu-probe-file>"])
         try:
             result = subprocess.run(
                 command,
@@ -4926,17 +4926,34 @@ def devices(
 @app.command()
 def map(
     path: str = typer.Argument(".", help="File or directory to inventory"),
+    max_files: int | None = typer.Option(
+        None, "--max-files", min=1, help="Maximum source files to include in output."
+    ),
+    max_repo_files: int | None = typer.Option(
+        None, "--max-repo-files", min=1, help="Maximum repo files to scan before returning."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return a deterministic repository map for AI editing workflows."""
-    from tensor_grep.cli.repo_map import build_repo_map, build_repo_map_json
+    from tensor_grep.cli.repo_map import (
+        apply_repo_map_output_limits,
+        build_repo_map,
+        build_repo_map_json,
+    )
 
     try:
         if json_output:
-            typer.echo(build_repo_map_json(path))
+            typer.echo(
+                build_repo_map_json(
+                    path,
+                    max_files=max_files,
+                    max_repo_files=max_repo_files,
+                )
+            )
             return
 
-        payload = build_repo_map(path)
+        payload = build_repo_map(path, max_repo_files=max_repo_files)
+        payload = apply_repo_map_output_limits(payload, max_files=max_files)
     except FileNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -4952,6 +4969,12 @@ def context(
     query: str = typer.Option(
         ..., "--query", help="Query text used to rank relevant repo context."
     ),
+    max_files: int | None = typer.Option(
+        None, "--max-files", min=1, help="Maximum ranked source files to include."
+    ),
+    max_repo_files: int | None = typer.Option(
+        None, "--max-repo-files", min=1, help="Maximum repo files to scan before ranking."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return a ranked repository context pack for edit planning."""
@@ -4959,10 +4982,22 @@ def context(
 
     try:
         if json_output:
-            typer.echo(build_context_pack_json(query, path))
+            typer.echo(
+                build_context_pack_json(
+                    query,
+                    path,
+                    max_files=max_files,
+                    max_repo_files=max_repo_files,
+                )
+            )
             return
 
-        payload = build_context_pack(query, path)
+        payload = build_context_pack(
+            query,
+            path,
+            max_files=max_files,
+            max_repo_files=max_repo_files,
+        )
     except FileNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4062,8 +4062,72 @@ def build_repo_map_incremental(
     return payload
 
 
-def build_repo_map_json(path: str | Path = ".") -> str:
-    return json.dumps(build_repo_map(path), indent=2)
+def apply_repo_map_output_limits(
+    payload: dict[str, Any],
+    *,
+    max_files: int | None = None,
+) -> dict[str, Any]:
+    if max_files is None:
+        return payload
+
+    normalized_max_files = max(1, int(max_files))
+    limited = dict(payload)
+    original_files = [str(current) for current in payload.get("files", [])]
+    selected_files = original_files[:normalized_max_files]
+    selected_file_set = set(selected_files)
+    original_tests = [str(current) for current in payload.get("tests", [])]
+    selected_tests = original_tests[:normalized_max_files]
+    selected_test_set = set(selected_tests)
+
+    limited["files"] = selected_files
+    limited["tests"] = selected_tests
+    limited["symbols"] = [
+        dict(symbol)
+        for symbol in payload.get("symbols", [])
+        if str(symbol.get("file", "")) in selected_file_set
+    ]
+    limited["imports"] = [
+        dict(entry)
+        for entry in payload.get("imports", [])
+        if str(entry.get("file", "")) in selected_file_set
+    ]
+    for key in ("file_matches", "file_summaries", "sources"):
+        if key in payload:
+            limited[key] = [
+                dict(entry)
+                for entry in payload.get(key, [])
+                if str(entry.get("path", entry.get("file", ""))) in selected_file_set
+            ]
+    if "test_matches" in payload:
+        limited["test_matches"] = [
+            dict(entry)
+            for entry in payload.get("test_matches", [])
+            if str(entry.get("path", entry.get("file", ""))) in selected_test_set
+        ]
+    if "related_paths" in payload:
+        allowed_related_paths = selected_file_set | selected_test_set
+        limited["related_paths"] = [
+            str(path)
+            for path in payload.get("related_paths", [])
+            if str(path) in allowed_related_paths
+        ]
+    limited["output_limit"] = {
+        "max_files": normalized_max_files,
+        "emitted_files": len(selected_files),
+        "original_files": len(original_files),
+        "possibly_truncated": len(original_files) > normalized_max_files,
+    }
+    return limited
+
+
+def build_repo_map_json(
+    path: str | Path = ".",
+    *,
+    max_files: int | None = None,
+    max_repo_files: int | None = None,
+) -> str:
+    payload = build_repo_map(path, max_repo_files=max_repo_files)
+    return json.dumps(apply_repo_map_output_limits(payload, max_files=max_files), indent=2)
 
 
 def _query_terms(query: str) -> list[str]:
@@ -4989,18 +5053,34 @@ def build_context_pack(
     query: str,
     path: str | Path = ".",
     *,
+    max_files: int | None = None,
+    max_repo_files: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
-    payload = build_repo_map(path, _profiling_collector=_profiling_collector)
-    return build_context_pack_from_map(
+    payload = build_repo_map(
+        path,
+        max_repo_files=max_repo_files,
+        _profiling_collector=_profiling_collector,
+    )
+    context_payload = build_context_pack_from_map(
         payload,
         query,
         _profiling_collector=_profiling_collector,
     )
+    return apply_repo_map_output_limits(context_payload, max_files=max_files)
 
 
-def build_context_pack_json(query: str, path: str | Path = ".") -> str:
-    return json.dumps(build_context_pack(query, path), indent=2)
+def build_context_pack_json(
+    query: str,
+    path: str | Path = ".",
+    *,
+    max_files: int | None = None,
+    max_repo_files: int | None = None,
+) -> str:
+    return json.dumps(
+        build_context_pack(query, path, max_files=max_files, max_repo_files=max_repo_files),
+        indent=2,
+    )
 
 
 def _render_context_parts(payload: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -915,6 +915,32 @@ def test_doctor_json_includes_gpu_search_runtime_probe(monkeypatch, tmp_path: Pa
     assert "NativeGpuBackend" in probe["error"]
 
 
+def test_doctor_gpu_runtime_probe_redacts_temp_probe_path(monkeypatch, tmp_path: Path) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        payload = {
+            "routing_backend": "GpuSidecar",
+            "routing_reason": "gpu-device-ids-explicit",
+            "sidecar_used": True,
+            "routing_gpu_device_ids": [],
+            "path": str(command[-1]),
+            "matches": [{"file": str(command[-1]), "line": 1, "text": "probe"}],
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+    serialized = json.dumps(probe)
+
+    assert probe["status"] == "unsupported"
+    assert "tg-doctor-gpu-probe" not in serialized
+    assert "probe.log" not in serialized
+    assert "<doctor-gpu-probe-file>" in probe["command"]
+
+
 def test_doctor_json_reports_native_version_mismatch(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.8.1")
     monkeypatch.setattr(
@@ -2306,6 +2332,28 @@ def test_map_json_emits_repo_inventory_envelope(tmp_path):
     assert str(module_path.resolve()) in payload["related_paths"]
 
 
+def test_map_json_accepts_agent_output_bounds(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    first_path = src_dir / "alpha.py"
+    first_path.write_text("def alpha():\n    return 1\n", encoding="utf-8")
+    (src_dir / "beta.py").write_text("def beta():\n    return 2\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["map", "--json", "--max-files", "1", str(project)])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["files"] == [str(first_path.resolve())]
+    assert payload["output_limit"] == {
+        "max_files": 1,
+        "emitted_files": 1,
+        "original_files": 2,
+        "possibly_truncated": True,
+    }
+
+
 def test_context_json_ranks_related_files_symbols_and_tests(tmp_path):
     project = tmp_path / "project"
     src_dir = project / "src"
@@ -2352,6 +2400,42 @@ def test_context_json_ranks_related_files_symbols_and_tests(tmp_path):
     )
     assert payload["related_paths"][0] == str(module_path.resolve())
     assert str(test_path.resolve()) in payload["related_paths"]
+
+
+def test_context_json_accepts_agent_output_bounds(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    tests_dir = project / "tests"
+    src_dir.mkdir(parents=True)
+    tests_dir.mkdir()
+
+    module_path = src_dir / "payments.py"
+    module_path.write_text(
+        "def create_invoice(total, tax):\n    return total + tax\n",
+        encoding="utf-8",
+    )
+    other_path = src_dir / "users.py"
+    other_path.write_text("def invoice_user(user_id):\n    return user_id\n", encoding="utf-8")
+    test_path = tests_dir / "test_payments.py"
+    test_path.write_text("from src.payments import create_invoice\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["context", "--query", "invoice payment", "--json", "--max-files", "1", str(project)],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["files"] == [str(module_path.resolve())]
+    assert str(other_path.resolve()) not in payload["files"]
+    assert payload["tests"] == [str(test_path.resolve())]
+    assert payload["output_limit"] == {
+        "max_files": 1,
+        "emitted_files": 1,
+        "original_files": 2,
+        "possibly_truncated": True,
+    }
 
 
 def test_defs_json_returns_exact_symbol_definitions(tmp_path):
@@ -3227,6 +3311,59 @@ def test_agent_capsule_gpu_evidence_rejects_sidecar_route(monkeypatch, tmp_path)
     assert acceleration["sidecar_used"] is True
     assert "sidecar-routed" in acceleration["reason"]
     assert len(calls) == 1
+
+
+def test_agent_capsule_gpu_probe_summary_redacts_probe_paths(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "app.py").write_text(
+        "def create_invoice(total):\n    return total\n",
+        encoding="utf-8",
+    )
+
+    def _fake_gpu_run(command, **_kwargs):
+        payload = {
+            "routing_backend": "GpuSidecar",
+            "routing_reason": "gpu-device-ids-explicit",
+            "sidecar_used": True,
+            "path": str(command[-1]),
+            "total_matches": 1,
+            "matches": [{"file": str(command[-1]) + "/probe.log", "line": 1, "text": "probe"}],
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr(agent_capsule, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_gpu_run)
+
+    payload = agent_capsule.build_agent_capsule(
+        "change invoice tax calculation",
+        project,
+        gpu_device_ids=[0],
+        gpu_timeout_s=1,
+    )
+
+    probe = payload["gpu_acceleration"]["probe"]
+    serialized = json.dumps(probe)
+    assert "tg-agent-gpu-probe" not in serialized
+    assert "probe.log" not in serialized
+    assert probe["payload"]["path"] == "<agent-gpu-probe-root>"
+    assert probe["payload"]["matches_preview"][0]["file"] == "<agent-gpu-probe-file>"
+
+
+def test_agent_capsule_gpu_probe_failure_redacts_probe_command_path(tmp_path):
+    probe_root = tmp_path / "tg-agent-gpu-probe-secret"
+    probe = agent_capsule._summarize_agent_gpu_json_result(
+        {
+            "status": "timeout",
+            "command": f"tg search --json {probe_root}",
+            "argv": ["tg", "search", "--json", str(probe_root)],
+        },
+        redact_probe_paths=True,
+    )
+    serialized = json.dumps(probe)
+
+    assert "tg-agent-gpu-probe" not in serialized
+    assert probe["argv"][-1] == "<agent-gpu-probe-root>"
 
 
 def test_agent_capsule_cli_accepts_gpu_device_ids(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- adds `--max-files` and `--max-repo-files` to `tg map` and `tg context`
- emits `output_limit` metadata when source-file output is truncated
- redacts doctor and agent GPU route-probe temp paths from JSON probe summaries

## Validation
- `uv run pytest tests/unit/test_cli_modes.py::test_doctor_gpu_runtime_probe_redacts_temp_probe_path tests/unit/test_cli_modes.py::test_agent_capsule_gpu_probe_summary_redacts_probe_paths tests/unit/test_cli_modes.py::test_agent_capsule_gpu_probe_failure_redacts_probe_command_path tests/unit/test_cli_modes.py::test_agent_capsule_gpu_evidence_payload_is_bounded tests/unit/test_cli_modes.py::test_map_json_accepts_agent_output_bounds tests/unit/test_cli_modes.py::test_context_json_accepts_agent_output_bounds tests/unit/test_cli_modes.py::test_map_json_emits_repo_inventory_envelope tests/unit/test_cli_modes.py::test_context_json_ranks_related_files_symbols_and_tests -q` -> 8 passed
- `uv run tg map --help` -> shows `--max-files` / `--max-repo-files`
- `uv run tg context --help` -> shows `--max-files` / `--max-repo-files`
- `uv run tg map --json --max-files 1 src/tensor_grep/cli` -> exit 0
- `uv run tg context --query "Windows subprocess bridge" --json --max-files 1 src/tensor_grep/cli` -> exit 0
- `uv run ruff check .` -> passed
- `uv run ruff format --check --preview .` -> 419 files already formatted
- `uv run mypy src/tensor_grep` -> success
- `git diff --check` -> no whitespace errors

## External review
- Subagent read-only review confirmed the same map/context root cause and identified doctor/agent GPU probe temp-path leakage.
- Gemini review attempted, but Gemini CLI returned repeated 429 `MODEL_CAPACITY_EXHAUSTED` for `gemini-2.5-flash`.