### PR TITLE
fix: accept ast run pattern aliases

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -404,6 +404,10 @@ pub struct RunArgs {
     #[arg(long, default_value = "python")]
     pub lang: String,
 
+    /// The structural pattern to match
+    #[arg(short = 'p', long = "pattern")]
+    pub pattern_option: Option<String>,
+
     /// Rewrite matched nodes with this replacement pattern (metavar substitution supported)
     #[arg(short = 'r', long, conflicts_with = "batch_rewrite")]
     pub rewrite: Option<String>,
@@ -468,11 +472,13 @@ pub struct RunArgs {
     #[arg(long)]
     pub verbose: bool,
 
-    /// The structural pattern to match
-    pub pattern: Option<String>,
+    /// Print only paths with at least one AST match
+    #[arg(long = "files-with-matches")]
+    pub files_with_matches: bool,
 
-    /// File or directory to search
-    pub path: Option<String>,
+    /// Positional PATTERN and optional PATH, or just PATH when --pattern is used
+    #[arg(value_name = "PATTERN_OR_PATH")]
+    pub positional: Vec<String>,
 }
 
 #[derive(Args, Debug, Clone, Default)]
@@ -1797,6 +1803,72 @@ mod tests {
             select_rewrite_apply_mode(&json),
             RewriteApplyMode::PlanThenApply
         );
+    }
+
+    #[test]
+    fn run_accepts_ast_grep_pattern_option() {
+        let args = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "class $NAME: $$$BODY",
+            "fixture.py",
+        ]);
+
+        assert_eq!(run_pattern(&args).unwrap(), "class $NAME: $$$BODY");
+        assert_eq!(run_search_path(&args), "fixture.py");
+    }
+
+    #[test]
+    fn run_rejects_duplicate_pattern_forms() {
+        let args = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "class $NAME: $$$BODY",
+            "def $F(): $$$BODY",
+            "fixture.py",
+        ]);
+
+        let error = run_pattern(&args).unwrap_err().to_string();
+        assert!(error.contains("--pattern accepts at most one positional PATH"));
+    }
+
+    #[test]
+    fn run_files_with_matches_is_read_only() {
+        let args = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "class $NAME: $$$BODY",
+            "--files-with-matches",
+            "fixture.py",
+        ]);
+
+        assert!(args.files_with_matches);
+        assert!(validate_run_args(&args).is_ok());
+
+        let rewrite = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "class $NAME: $$$BODY",
+            "--files-with-matches",
+            "--rewrite",
+            "class $NAME: pass",
+            "fixture.py",
+        ]);
+
+        let error = validate_run_args(&rewrite).unwrap_err().to_string();
+        assert!(error.contains("read-only search output mode"));
     }
 
     #[test]
@@ -3767,21 +3839,34 @@ struct GpuSidecarSearchMatch {
 }
 
 fn run_search_path(args: &RunArgs) -> &str {
-    args.path.as_deref().unwrap_or(".")
+    if args.pattern_option.is_some() {
+        args.positional.first().map(String::as_str).unwrap_or(".")
+    } else {
+        args.positional.get(1).map(String::as_str).unwrap_or(".")
+    }
 }
 
 fn run_batch_path(args: &RunArgs) -> anyhow::Result<&str> {
-    if args.path.is_some() {
+    if args.positional.len() > 1 {
         anyhow::bail!("tg run --batch-rewrite accepts exactly one PATH argument")
     }
 
-    Ok(args.pattern.as_deref().unwrap_or("."))
+    Ok(args.positional.first().map(String::as_str).unwrap_or("."))
 }
 
 fn run_pattern(args: &RunArgs) -> anyhow::Result<&str> {
-    args.pattern.as_deref().ok_or_else(|| {
-        anyhow::anyhow!("tg run requires PATTERN unless --batch-rewrite <config.json> is provided")
-    })
+    if let Some(pattern) = args.pattern_option.as_deref() {
+        if args.positional.len() > 1 {
+            anyhow::bail!("tg run --pattern accepts at most one positional PATH argument");
+        }
+        return Ok(pattern);
+    }
+    match args.positional.first().map(String::as_str) {
+        Some(pattern) => Ok(pattern),
+        None => anyhow::bail!(
+            "tg run requires --pattern <PATTERN> or positional PATTERN unless --batch-rewrite <config.json> is provided"
+        ),
+    }
 }
 
 fn build_search_line_starts(source: &str) -> Vec<usize> {
@@ -3893,6 +3978,25 @@ fn ast_match_to_search_json(
 }
 
 fn validate_run_args(args: &RunArgs) -> anyhow::Result<()> {
+    if args.batch_rewrite.is_some() && args.pattern_option.is_some() {
+        anyhow::bail!("tg run --batch-rewrite uses the positional argument as PATH and does not accept --pattern");
+    }
+    if args.files_with_matches
+        && (args.rewrite.is_some()
+            || args.batch_rewrite.is_some()
+            || args.apply
+            || args.diff
+            || args.verify
+            || args.checkpoint
+            || args.audit_manifest.is_some()
+            || args.audit_signing_key.is_some()
+            || !args.apply_edit_ids.is_empty()
+            || !args.reject_edit_ids.is_empty()
+            || args.lint_cmd.is_some()
+            || args.test_cmd.is_some())
+    {
+        anyhow::bail!("tg run --files-with-matches is a read-only search output mode");
+    }
     if (args.lint_cmd.is_some() || args.test_cmd.is_some()) && !args.apply {
         anyhow::bail!("--lint-cmd and --test-cmd require --apply");
     }
@@ -5022,6 +5126,15 @@ fn handle_ast_run(args: RunArgs) -> anyhow::Result<()> {
 
     let stdout = io::stdout();
     let mut stdout = io::BufWriter::new(stdout.lock());
+    if args.files_with_matches {
+        for file_matches in matches {
+            if !file_matches.matches.is_empty() {
+                writeln!(stdout, "{}", file_matches.file.display())?;
+            }
+        }
+        return Ok(());
+    }
+
     for file_matches in matches {
         for matched in file_matches.matches {
             writeln!(

--- a/rust_core/tests/test_ast_backend.rs
+++ b/rust_core/tests/test_ast_backend.rs
@@ -147,6 +147,35 @@ fn test_tg_run_json_metadata_uses_ast_backend_routing() {
 }
 
 #[test]
+fn test_tg_run_accepts_ast_grep_pattern_option_and_files_with_matches() {
+    let (_dir, file_path) = write_source_file("py", "def add(a, b):\n    return a + b\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--pattern")
+        .arg("def $F($$$ARGS): $$$BODY")
+        .arg("--files-with-matches")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        file_path.to_string_lossy()
+    );
+}
+
+#[test]
 fn test_tg_run_json_metadata_preserves_ast_match_details() {
     let (_dir, file_path) = write_source_file("py", "def add(a, b):\n    return a + b\n");
 

--- a/rust_core/tests/test_runtime_path_resolution.rs
+++ b/rust_core/tests/test_runtime_path_resolution.rs
@@ -233,6 +233,8 @@ fn test_run_help_positions_ast_as_validated_slice_not_ast_grep_parity() {
         normalized_stdout.contains("validated AST slice"),
         "stdout={stdout}"
     );
+    assert!(stdout.contains("--pattern"), "stdout={stdout}");
+    assert!(stdout.contains("--files-with-matches"), "stdout={stdout}");
     assert!(!stdout.contains("ast-grep parity"), "stdout={stdout}");
     assert!(!stdout.contains("ast-grep replacement"), "stdout={stdout}");
 }

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -590,6 +590,7 @@ def build_check_plan(
                 "run",
                 "tg",
                 "run",
+                "--pattern",
                 "class $NAME: $$$BODY",
                 "tests/unit/test_trust_planning.py",
                 "--lang",

--- a/src/tensor_grep/cli/ast_workflows.py
+++ b/src/tensor_grep/cli/ast_workflows.py
@@ -511,6 +511,7 @@ def run_command(
     policy: str | None = None,
     interactive: bool = False,
     filter_regex: str | None = None,
+    files_with_matches: bool = False,
 ) -> int:
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.result import SearchResult
@@ -531,6 +532,22 @@ def run_command(
         return 1
     if interactive and not rewrite:
         print("--interactive requires --rewrite.", file=sys.stderr)
+        return 1
+
+    if files_with_matches and (
+        rewrite is not None
+        or apply
+        or verify
+        or checkpoint
+        or audit_manifest is not None
+        or audit_signing_key is not None
+        or lint_cmd is not None
+        or test_cmd is not None
+        or policy is not None
+        or interactive
+        or json_mode
+    ):
+        print("--files-with-matches is a read-only text output mode.", file=sys.stderr)
         return 1
 
     if rewrite is not None and not apply and not interactive:
@@ -569,7 +586,7 @@ def run_command(
     backend = _select_ast_backend_for_pattern(cfg, pattern)
     backend_name = type(backend).__name__
 
-    if not json_mode:
+    if not json_mode and not files_with_matches:
         _safe_stdout_line(f"Executing {_describe_ast_backend_mode(backend_name)} run...")
 
         if backend_name not in {"AstBackend", "AstGrepWrapperBackend"}:
@@ -696,6 +713,22 @@ def run_command(
             ],
         }
         _safe_stdout_line(json.dumps(payload))
+        return 0
+
+    if files_with_matches:
+        seen_paths: set[str] = set()
+        ordered_paths: list[str] = []
+        for match in all_results.matches:
+            if match.file and match.file not in seen_paths:
+                seen_paths.add(match.file)
+                ordered_paths.append(match.file)
+        if not ordered_paths:
+            for matched_path in all_results.matched_file_paths:
+                if matched_path not in seen_paths:
+                    seen_paths.add(matched_path)
+                    ordered_paths.append(matched_path)
+        for matched_path in ordered_paths:
+            _safe_stdout_line(matched_path)
         return 0
 
     from tensor_grep.cli.formatters.ripgrep_fmt import RipgrepFormatter
@@ -1291,8 +1324,8 @@ def main_entry(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     run_parser = subparsers.add_parser("run")
-    run_parser.add_argument("pattern")
-    run_parser.add_argument("path", nargs="?")
+    run_parser.add_argument("positionals", nargs="*")
+    run_parser.add_argument("--pattern", "-p", dest="pattern_option", default=None)
     run_parser.add_argument("--rewrite", "-r", default=None)
     run_parser.add_argument("--lang", "-l", default=None)
     run_parser.add_argument("--apply", action="store_true")
@@ -1304,6 +1337,7 @@ def main_entry(argv: list[str] | None = None) -> None:
     run_parser.add_argument("--lint-cmd", default=None)
     run_parser.add_argument("--test-cmd", default=None)
     run_parser.add_argument("--policy", default=None)
+    run_parser.add_argument("--files-with-matches", action="store_true")
 
     scan_parser = subparsers.add_parser("scan")
     scan_parser.add_argument("path", nargs="?", default=".")
@@ -1323,10 +1357,23 @@ def main_entry(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
     if args.command == "run":
+        positionals = list(args.positionals or [])
+        if args.pattern_option:
+            if len(positionals) > 1:
+                parser.error("run --pattern accepts at most one positional PATH argument")
+            pattern = args.pattern_option
+            path = positionals[0] if positionals else None
+        else:
+            if len(positionals) > 2:
+                parser.error("run accepts at most PATTERN and PATH positionals")
+            pattern = positionals[0] if positionals else None
+            path = positionals[1] if len(positionals) > 1 else None
+        if not pattern:
+            parser.error("run requires --pattern <PATTERN> or positional PATTERN")
         raise SystemExit(
             run_command(
-                args.pattern,
-                args.path,
+                pattern,
+                path,
                 rewrite=args.rewrite,
                 lang=args.lang,
                 apply=args.apply,
@@ -1338,6 +1385,7 @@ def main_entry(argv: list[str] | None = None) -> None:
                 lint_cmd=args.lint_cmd,
                 test_cmd=args.test_cmd,
                 policy=args.policy,
+                files_with_matches=args.files_with_matches,
             )
         )
     if args.command == "scan":

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8018,8 +8018,16 @@ def ast_info(
     help="Run a validated AST slice for structural search and guarded rewrites.",
 )
 def run(
-    pattern: str = typer.Argument(..., help="The AST pattern to search for."),
-    path: str | None = typer.Argument(None, help="The path to search in."),
+    arguments: list[str] | None = typer.Argument(
+        None,
+        help="The positional AST pattern and optional path, or just path when --pattern is used.",
+    ),
+    pattern_option: str | None = typer.Option(
+        None,
+        "--pattern",
+        "-p",
+        help="The AST pattern to search for, matching ast-grep's option form.",
+    ),
     rewrite: str | None = typer.Option(None, "--rewrite", "-r", help="Replacement pattern."),
     lang: str | None = typer.Option(None, "--lang", "-l", help="Language for AST parsing."),
     apply: bool = typer.Option(False, "--apply", help="Apply the rewrite to files."),
@@ -8032,12 +8040,40 @@ def run(
     filter_regex: str | None = typer.Option(
         None, "--filter", help="Filter matched AST nodes by text regex"
     ),
+    files_with_matches: bool = typer.Option(
+        False,
+        "--files-with-matches",
+        help="Print only paths with at least one AST match.",
+    ),
 ) -> None:
     from tensor_grep.cli.ast_workflows import run_command as execute_run
 
+    positional_args = list(arguments or [])
+    if pattern_option:
+        if len(positional_args) > 1:
+            typer.echo(
+                "Error: tg run --pattern accepts at most one positional PATH argument.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        resolved_pattern = pattern_option
+        resolved_path = positional_args[0] if positional_args else None
+    else:
+        if not positional_args:
+            typer.echo(
+                "Error: tg run requires --pattern <PATTERN> or positional PATTERN.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if len(positional_args) > 2:
+            typer.echo("Error: tg run accepts at most PATTERN and PATH positionals.", err=True)
+            raise typer.Exit(code=2)
+        resolved_pattern = positional_args[0]
+        resolved_path = positional_args[1] if len(positional_args) > 1 else None
+
     exit_code = execute_run(
-        pattern=pattern,
-        path=path,
+        pattern=resolved_pattern,
+        path=resolved_path,
         rewrite=rewrite,
         lang=lang,
         apply=apply,
@@ -8046,6 +8082,7 @@ def run(
         checkpoint=checkpoint,
         interactive=interactive,
         filter_regex=filter_regex,
+        files_with_matches=files_with_matches,
     )
     if exit_code != 0:
         raise typer.Exit(code=exit_code)

--- a/tests/unit/test_ast_workflows.py
+++ b/tests/unit/test_ast_workflows.py
@@ -567,3 +567,73 @@ def test_run_command_should_escape_unencodable_ast_output_without_binary_buffer(
         "Executing ast-grep structural matching run..." in chunk for chunk in stdout.text_writes
     )
     assert "1:def \\u6f22():\n" in stdout.text_writes
+
+
+def test_run_command_files_with_matches_outputs_only_paths(tmp_path, monkeypatch, capsys):
+    """Verify AST file-list mode stays quiet and deduplicates matched files."""
+    from tensor_grep.cli.ast_workflows import run_command
+
+    first = tmp_path / "first.py"
+    second = tmp_path / "second.py"
+
+    class AstGrepWrapperBackend:
+        def search_many(self, file_paths, pattern, config=None) -> SearchResult:
+            _ = file_paths
+            _ = pattern
+            _ = config
+            return SearchResult(
+                matches=[
+                    MatchLine(line_number=1, text="class First: pass", file=str(first)),
+                    MatchLine(line_number=2, text="class FirstAgain: pass", file=str(first)),
+                    MatchLine(line_number=1, text="class Second: pass", file=str(second)),
+                ],
+                matched_file_paths=[str(first), str(second)],
+                total_files=2,
+                total_matches=3,
+            )
+
+    monkeypatch.setattr(
+        "tensor_grep.cli.ast_workflows._select_ast_backend_for_pattern",
+        lambda config, pattern: AstGrepWrapperBackend(),
+    )
+
+    exit_code = run_command(
+        pattern="class $NAME: $$$BODY",
+        path=str(tmp_path),
+        lang="python",
+        files_with_matches=True,
+    )
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.splitlines() == [str(first), str(second)]
+
+
+def test_ast_workflow_entry_accepts_ast_grep_pattern_option(monkeypatch):
+    """Verify the lightweight workflow parser accepts `run --pattern`, like ast-grep."""
+    from tensor_grep.cli import ast_workflows
+
+    seen: dict[str, object] = {}
+
+    def fake_run_command(pattern: str, path: str | None = None, **kwargs: object) -> int:
+        seen["pattern"] = pattern
+        seen["path"] = path
+        seen["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(ast_workflows, "run_command", fake_run_command)
+
+    with pytest.raises(SystemExit) as raised:
+        ast_workflows.main_entry([
+            "run",
+            "--pattern",
+            "class $NAME: $$$BODY",
+            "--files-with-matches",
+            "src",
+            "--lang",
+            "python",
+        ])
+
+    assert raised.value.code == 0
+    assert seen["pattern"] == "class $NAME: $$$BODY"
+    assert seen["path"] == "src"
+    assert seen["kwargs"]["files_with_matches"] is True

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -9895,7 +9895,40 @@ def test_full_cli_run_help_should_not_expose_config_option() -> None:
     result = runner.invoke(app, ["run", "--help"])
 
     assert result.exit_code == 0
-    assert "--config" not in _strip_ansi(result.stdout)
+    help_text = _strip_ansi(result.stdout)
+    assert "--config" not in help_text
+    assert "--pattern" in help_text
+    assert "--files-with-matches" in help_text
+
+
+def test_full_cli_run_accepts_ast_grep_pattern_option(monkeypatch, tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run_command(pattern: str, path: str | None = None, **kwargs: object) -> int:
+        seen["pattern"] = pattern
+        seen["path"] = path
+        seen["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr("tensor_grep.cli.ast_workflows.run_command", fake_run_command)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--pattern",
+            "class $NAME: $$$BODY",
+            "--files-with-matches",
+            str(tmp_path),
+            "--lang",
+            "python",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert seen["pattern"] == "class $NAME: $$$BODY"
+    assert seen["path"] == str(tmp_path)
+    assert seen["kwargs"]["files_with_matches"] is True
 
 
 def test_app_help_should_expose_the_python_public_top_level_surface():


### PR DESCRIPTION
## Summary
- add `tg run -p/--pattern <PATTERN> [PATH]` as the ast-grep-compatible pattern carrier
- add read-only `tg run --files-with-matches` output to native Rust and Python workflow paths
- update readiness smoke to exercise the option-pattern form and pin help/contract tests

## Validation
- `cargo test --manifest-path rust_core/Cargo.toml run_ -- --nocapture`
- `cargo test --manifest-path rust_core/Cargo.toml --test test_ast_backend test_tg_run_accepts_ast_grep_pattern_option_and_files_with_matches -- --exact --nocapture`
- `cargo test --manifest-path rust_core/Cargo.toml --test test_runtime_path_resolution test_run_help_positions_ast_as_validated_slice_not_ast_grep_parity -- --exact --nocapture`
- `uv run pytest tests/unit/test_ast_workflows.py tests/unit/test_ast_parity.py tests/unit/test_cli_modes.py::test_full_cli_run_accepts_ast_grep_pattern_option tests/unit/test_cli_modes.py::test_full_cli_run_help_should_not_expose_config_option -q`
- `uv run tg run --pattern 'class $NAME: $$$BODY' tests/unit/test_ast_workflows.py --lang python --files-with-matches`
- `cargo fmt --manifest-path rust_core/Cargo.toml --check`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `git diff --check`

## Review notes
- Exa/web anchor: ast-grep current `run` reference documents `-p, --pattern <PATTERN>` as the structural pattern option.
- Gemini read-only review was attempted with `gemini-2.5-pro --approval-mode plan`, but the CLI returned `MODEL_CAPACITY_EXHAUSTED` repeatedly and was stopped.