### PR TITLE
fix: harden exe bridge agent ranking

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4209,7 +4209,34 @@ def _query_file_name_hint_score(path: str | Path, query: str) -> int:
 
 def _score_text_terms(text: str, terms: list[str]) -> int:
     haystack = text.lower()
-    return sum(1 for term in terms if term in haystack)
+    haystack_terms = set(split_terms(text))
+    score = 0
+    for term in terms:
+        normalized = term.lower()
+        if len(normalized) <= 3:
+            if normalized in haystack_terms:
+                score += 1
+        elif normalized in haystack or normalized in haystack_terms:
+            score += 1
+    return score
+
+
+def _symbol_span_length(symbol: dict[str, Any]) -> int:
+    line = int(symbol.get("line", symbol.get("start_line", 0)) or 0)
+    start_line = int(symbol.get("start_line", line) or line)
+    end_line = int(symbol.get("end_line", start_line) or start_line)
+    return max(1, end_line - start_line + 1)
+
+
+def _symbol_rank_key(symbol: dict[str, Any]) -> tuple[int, int, int, str, int, str]:
+    return (
+        -int(symbol.get("score", 0)),
+        0 if str(symbol.get("kind")) == "function" else 1,
+        -_symbol_span_length(symbol),
+        str(symbol.get("file")),
+        int(symbol.get("line", 0)),
+        str(symbol.get("name")),
+    )
 
 
 def _symbol_lookup_key(text: str) -> str:
@@ -4835,14 +4862,7 @@ def _build_context_pack_from_map(
                 _append_reason(file_reasons, current_path, "definition")
                 _append_reason(file_reasons, current_path, "symbol")
             scored_symbols.append(scored_symbol)
-        scored_symbols.sort(
-            key=lambda item: (
-                -int(item["score"]),
-                str(item["file"]),
-                int(item["line"]),
-                str(item["name"]),
-            )
-        )
+        scored_symbols.sort(key=_symbol_rank_key)
         for symbol in scored_symbols:
             current = str(symbol["file"])
             exact_symbol_bonus = 36 if bool(symbol.get("exact_query_match")) else 0
@@ -7589,6 +7609,49 @@ def _preferred_edit_anchor_symbol(
     return primary_symbol
 
 
+def _promote_substantive_symbol_for_edit_seed(
+    primary_symbol: dict[str, Any] | None,
+    ranked_symbols: list[dict[str, Any]],
+    *,
+    selected_files: set[str],
+    query_language_hints: list[str],
+    primary_file_reasons: set[str],
+) -> dict[str, Any] | None:
+    if primary_symbol is None:
+        return None
+    primary_file = str(primary_symbol.get("file", "") or "")
+    if not primary_file:
+        return primary_symbol
+    if "validation-direct-definition" in primary_file_reasons:
+        return primary_symbol
+    primary_score = int(primary_symbol.get("score", 0) or 0)
+    primary_span = _symbol_span_length(primary_symbol)
+    primary_language_matches_hint = bool(
+        query_language_hints
+        and _path_matches_query_language_hints(primary_file, query_language_hints)
+    )
+    for candidate in ranked_symbols:
+        candidate_file = str(candidate.get("file", "") or "")
+        if not candidate_file or candidate_file not in selected_files:
+            continue
+        if _is_test_file(Path(candidate_file)):
+            continue
+        if primary_language_matches_hint and not _path_matches_query_language_hints(
+            candidate_file, query_language_hints
+        ):
+            continue
+        if candidate_file == primary_file:
+            return primary_symbol
+        candidate_score = int(candidate.get("score", 0) or 0)
+        candidate_span = _symbol_span_length(candidate)
+        if candidate_score > primary_score or (
+            candidate_score == primary_score and candidate_span >= primary_span + 2
+        ):
+            return candidate
+        return primary_symbol
+    return primary_symbol
+
+
 def _should_build_edit_plan_blast_radius(
     symbol: dict[str, Any] | None,
     file_match: dict[str, Any] | None,
@@ -7662,7 +7725,6 @@ def _build_edit_plan_seed(
             current for current in ranked_symbols if str(current.get("file")) == str(primary_file)
         ]
         primary_symbol = next(iter(primary_file_symbols), None)
-
     primary_file_match = next(
         (
             match
@@ -7671,6 +7733,28 @@ def _build_edit_plan_seed(
         ),
         payload.get("file_matches", [{}])[0] if payload.get("file_matches") else {},
     )
+    selected_files = {
+        str(current) for current in list(payload.get("files", []))[: max(1, int(max_files))]
+    }
+    promoted_symbol = _promote_substantive_symbol_for_edit_seed(
+        primary_symbol,
+        ranked_symbols,
+        selected_files=selected_files,
+        query_language_hints=_query_language_hints(query),
+        primary_file_reasons={str(reason) for reason in primary_file_match.get("reasons", [])},
+    )
+    if promoted_symbol is not None and promoted_symbol is not primary_symbol:
+        primary_symbol = promoted_symbol
+        if primary_symbol.get("file"):
+            primary_file = str(primary_symbol["file"])
+            primary_file_match = next(
+                (
+                    match
+                    for match in payload.get("file_matches", [])
+                    if str(match.get("path")) == str(primary_file)
+                ),
+                payload.get("file_matches", [{}])[0] if payload.get("file_matches") else {},
+            )
     validation_tests = list(payload.get("tests", []))[: max(1, min(max_files, 3))]
     primary_symbol_name = (
         str(primary_symbol.get("name"))
@@ -7812,16 +7896,7 @@ def _build_edit_plan_seed(
 
 
 def _sorted_ranked_symbols(symbols: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return sorted(
-        symbols,
-        key=lambda symbol: (
-            -int(symbol.get("score", 0)),
-            0 if str(symbol.get("kind")) == "function" else 1,
-            str(symbol.get("file")),
-            int(symbol.get("line", 0)),
-            str(symbol.get("name")),
-        ),
-    )
+    return sorted(symbols, key=_symbol_rank_key)
 
 
 def _attach_edit_plan_metadata(

--- a/tests/unit/test_agent_capsule_hardcases.py
+++ b/tests/unit/test_agent_capsule_hardcases.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from tensor_grep.cli import repo_map
 from tensor_grep.cli.main import app
 
 
@@ -215,3 +216,60 @@ def test_agent_capsule_keeps_rust_validation_for_cli_parser_intent_with_python_t
     assert payload["context_consistency"]["primary_target_language"] == "rust"
     assert payload["validation_commands"] == ["cargo test --manifest-path rust_core/Cargo.toml"]
     assert payload["context_consistency"]["validation_alignment"]["kept_count"] == 1
+
+
+def test_agent_capsule_prefers_windows_exe_bridge_implementation_over_marker_helpers(
+    tmp_path,
+):
+    project = tmp_path / "workspace"
+    python_src = project / "src" / "tensor_grep" / "cli"
+    rust_src = project / "rust_core" / "src"
+    noise_src = project / "src" / "noise"
+    python_src.mkdir(parents=True)
+    rust_src.mkdir(parents=True)
+    noise_src.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (project / "rust_core" / "Cargo.toml").write_text(
+        '[package]\nname = "sample-rust-core"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    python_file = python_src / "main.py"
+    python_file.write_text(
+        "def _windows_exe_bridge_marker_path(root):\n"
+        "    return root / 'tg.com'\n\n"
+        "def _write_windows_exe_bridge_marker(root):\n"
+        "    return _windows_exe_bridge_marker_path(root)\n\n"
+        "def _windows_python_subprocess_resolution_blocker(path):\n"
+        "    return path.name == 'tg.exe'\n",
+        encoding="utf-8",
+    )
+    rust_file = rust_src / "python_sidecar.rs"
+    rust_file.write_text(
+        "pub fn is_external_windows_exe_bridge(path: &std::path::Path) -> bool {\n"
+        '    let filename = path.file_name().and_then(|value| value.to_str()).unwrap_or("");\n'
+        '    filename.eq_ignore_ascii_case("tg.exe") && !is_managed_windows_exe_bridge(path)\n'
+        "}\n\n"
+        "pub fn is_managed_windows_exe_bridge(path: &std::path::Path) -> bool {\n"
+        '    let parent = path.parent().and_then(|value| value.file_name()).and_then(|value| value.to_str()).unwrap_or("");\n'
+        '    path.file_name().and_then(|value| value.to_str()).unwrap_or("").eq_ignore_ascii_case("tg.exe")\n'
+        '        && parent == "bin"\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    (noise_src / "executor.py").write_text(
+        "def execute_noise_bridge():\n    return 'not a windows exe bridge implementation'\n",
+        encoding="utf-8",
+    )
+
+    payload = _agent_payload(project, "harden Windows subprocess exe bridge")
+
+    assert payload["primary_target"]["file"] == str(rust_file.resolve())
+    assert payload["primary_target"]["symbol"] == "is_managed_windows_exe_bridge"
+
+
+def test_agent_capsule_short_exe_term_does_not_match_execute_noise():
+    assert repo_map._score_text_terms("execute_noise_bridge", ["exe"]) == 0
+    assert repo_map._score_text_terms("tg.exe bridge", ["exe"]) == 1


### PR DESCRIPTION
## Summary
- make short query terms like `exe` token-aware so they do not match `execute` noise
- rank tied symbols with function span as a substance tie-breaker
- allow edit-plan seed selection to promote a higher/substantive symbol only inside the selected file budget, while preserving language-hint and direct-validation anchors
- add a hardcase for `harden Windows subprocess exe bridge`

## Validation
- `uv run pytest tests/unit/test_agent_capsule_hardcases.py::test_agent_capsule_prefers_windows_exe_bridge_implementation_over_marker_helpers -q` (fails before fix)
- `uv run pytest tests/unit/test_agent_capsule_hardcases.py tests/unit/test_trust_planning.py -q`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `git diff --check`

## Review notes
- Independent ranking investigation from subagent Nietzsche identified `_score_text_terms`, symbol tie-breaking, and edit-plan seed selection as the root cause.
- Gemini review was not rerun for this slice because the same session is capacity-blocked with `MODEL_CAPACITY_EXHAUSTED`; the failed Gemini attempt is recorded on #135.