### PR TITLE
fix: forward native lsp help

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -593,6 +593,7 @@ pub enum Commands {
         stop: bool,
     },
     /// Start the Language Server Protocol (LSP) server
+    #[command(disable_help_flag = true)]
     Lsp {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,

--- a/rust_core/tests/test_public_native_cli_parity.rs
+++ b/rust_core/tests/test_public_native_cli_parity.rs
@@ -271,6 +271,39 @@ fn test_lsp_provider_args_are_forwarded_on_public_native_frontdoor() {
 }
 
 #[test]
+fn test_lsp_help_is_forwarded_to_python_help_on_public_native_frontdoor() {
+    let dir = tempdir().unwrap();
+    let fake_python = fake_python_passthrough_asserting_args_script(
+        dir.path(),
+        &["-m", "tensor_grep", "lsp", "--help"],
+        "lsp help with --provider hybrid experimental\n",
+    );
+
+    let output = tg()
+        .current_dir(dir.path())
+        .args(["lsp", "--help"])
+        .env("TG_SIDECAR_PYTHON", &fake_python)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--provider hybrid"), "stdout={stdout}");
+    assert!(stdout.contains("experimental"), "stdout={stdout}");
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("unexpected argument"),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_search_files_and_null_path_output_work_on_public_native_frontdoor() {
     let dir = tempdir().unwrap();
     let fake_python = fake_python_passthrough_script(dir.path(), "visible.rs");


### PR DESCRIPTION
## Summary
- forward public native `tg lsp --help` to the Python LSP help surface
- add a public-native regression so provider/experimental help text cannot drift again

## Research anchors
- Microsoft LSP spec: `initialize` is the first provider request, and request lifecycles must be explicit; help should not imply provider proof just because the wrapper starts.

## Validation
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml --test test_public_native_cli_parity test_lsp_help_is_forwarded_to_python_help_on_public_native_frontdoor -- --exact --nocapture`
- `uv run pytest tests/unit/test_cli_modes.py::test_lsp_help_mentions_provider_modes -q`
- `C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check`
