### PR TITLE
fix: preserve rg regexp stdin parity

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -370,7 +370,7 @@ pub struct SearchArgs {
     pub verbose: bool,
 
     /// A pattern to search for. Can be provided multiple times.
-    #[arg(short = 'e', long = "regexp")]
+    #[arg(short = 'e', long = "regexp", allow_hyphen_values = true)]
     pub regexp: Vec<String>,
 
     /// The search pattern (regex or string)
@@ -1352,6 +1352,14 @@ fn parse_early_ripgrep_args(raw_args: &[OsString]) -> Option<RipgrepSearchArgs> 
             }
             "--sort-files" => args.sort_files = true,
             "--no-sort-files" => args.sort_files = false,
+            "-e" | "--regexp" => {
+                index += 1;
+                args.patterns.push(tokens.get(index)?.clone());
+            }
+            _ if token.starts_with("--regexp=") => {
+                args.patterns
+                    .push(token.split_once('=').map(|(_, value)| value.to_string())?);
+            }
             "-g" | "--glob" => {
                 index += 1;
                 args.globs.push(tokens.get(index)?.clone());
@@ -1366,11 +1374,18 @@ fn parse_early_ripgrep_args(raw_args: &[OsString]) -> Option<RipgrepSearchArgs> 
         index += 1;
     }
 
-    if positionals.len() < 2 {
-        return None;
+    if args.patterns.is_empty() {
+        if positionals.len() < 2 {
+            return None;
+        }
+        args.patterns.push(positionals[0].clone());
+        args.paths = positionals[1..].to_vec();
+    } else {
+        args.paths = positionals;
+        if args.paths.is_empty() && !stdin_should_search_implicit_path() {
+            args.paths.push(".".to_string());
+        }
     }
-    args.patterns.push(positionals[0].clone());
-    args.paths = positionals[1..].to_vec();
     Some(args)
 }
 
@@ -1387,11 +1402,7 @@ fn parse_default_search_frontdoor_args(raw_args: &[OsString]) -> Option<RipgrepS
 fn parse_early_positional_ripgrep_args(raw_args: &[OsString]) -> Option<RipgrepSearchArgs> {
     let cli = PositionalCli::try_parse_from(raw_args).ok()?;
     let pattern = cli.pattern.clone()?;
-    let paths = if cli.path.is_empty() {
-        vec![".".to_string()]
-    } else {
-        cli.path.clone()
-    };
+    let paths = implicit_search_paths(&cli.path, stdin_should_search_implicit_path());
 
     if cli.replace.is_some() || cli.force_cpu || !cli.gpu_device_ids.is_empty() {
         return None;
@@ -1576,6 +1587,19 @@ mod tests {
         assert_eq!(
             command_ripgrep_args(&args, &request).patterns,
             vec!["TODO".to_string(), "FIXME".to_string()]
+        );
+    }
+
+    #[test]
+    fn search_request_accepts_dash_leading_regexp_pattern() {
+        let args = parse_search_args(&["tg", "search", "-e", "-needle", "--sort", "path", "."]);
+        let request = resolve_search_request(&args).expect("expected search request");
+
+        assert_eq!(request.patterns, vec!["-needle".to_string()]);
+        assert_eq!(request.paths, vec![".".to_string()]);
+        assert_eq!(
+            command_ripgrep_args(&args, &request).patterns,
+            vec!["-needle".to_string()]
         );
     }
 
@@ -2141,6 +2165,24 @@ mod tests {
     }
 
     #[test]
+    fn implicit_search_paths_follow_rg_stdin_semantics() {
+        assert_eq!(
+            implicit_search_paths(&[], false),
+            vec![".".to_string()],
+            "without readable stdin, no-path searches should default to cwd"
+        );
+        assert!(
+            implicit_search_paths(&[], true).is_empty(),
+            "with readable stdin, no-path searches should let rg read stdin"
+        );
+        assert_eq!(
+            implicit_search_paths(&["fixture.txt".to_string()], true),
+            vec!["fixture.txt".to_string()],
+            "explicit paths must beat piped stdin"
+        );
+    }
+
+    #[test]
     fn early_positional_ripgrep_args_parse_max_count_shape() {
         let raw_args = ["tg", "-m", "1", "warning", "bench_data"]
             .into_iter()
@@ -2586,11 +2628,7 @@ fn run_positional_cli(cli: PositionalCli) -> anyhow::Result<()> {
     }
 
     let pattern = cli.pattern.clone().unwrap();
-    let paths = if cli.path.is_empty() {
-        vec![".".to_string()]
-    } else {
-        cli.path.clone()
-    };
+    let paths = implicit_search_paths(&cli.path, stdin_should_search_implicit_path());
     let primary_path = paths.first().map(String::as_str).unwrap_or(".");
 
     let rg_available = ripgrep_is_available();
@@ -2783,14 +2821,43 @@ fn is_known_python_command(token: &str) -> bool {
     })
 }
 
+fn stdin_should_search_implicit_path() -> bool {
+    grep_cli::is_readable_stdin()
+}
+
+fn implicit_search_paths(
+    explicit_paths: &[String],
+    stdin_searches_implicit_path: bool,
+) -> Vec<String> {
+    if !explicit_paths.is_empty() {
+        return explicit_paths.to_vec();
+    }
+    if stdin_searches_implicit_path {
+        Vec::new()
+    } else {
+        vec![".".to_string()]
+    }
+}
+
 fn resolve_search_request(args: &SearchArgs) -> anyhow::Result<ResolvedSearchRequest> {
+    resolve_search_request_with_stdin(args, stdin_should_search_implicit_path())
+}
+
+fn resolve_search_request_with_stdin(
+    args: &SearchArgs,
+    stdin_searches_implicit_path: bool,
+) -> anyhow::Result<ResolvedSearchRequest> {
     let mut patterns = args.regexp.clone();
     let paths = if args.regexp.is_empty() {
         if let Some(pattern) = args.pattern.as_ref() {
             patterns.push(pattern.clone());
         }
         if args.path.is_empty() {
-            vec![".".to_string()]
+            if stdin_searches_implicit_path {
+                Vec::new()
+            } else {
+                vec![".".to_string()]
+            }
         } else {
             args.path.clone()
         }
@@ -2801,7 +2868,11 @@ fn resolve_search_request(args: &SearchArgs) -> anyhow::Result<ResolvedSearchReq
         }
         paths.extend(args.path.clone());
         if paths.is_empty() {
-            vec![".".to_string()]
+            if stdin_searches_implicit_path {
+                Vec::new()
+            } else {
+                vec![".".to_string()]
+            }
         } else {
             paths
         }

--- a/rust_core/tests/test_public_native_cli_parity.rs
+++ b/rust_core/tests/test_public_native_cli_parity.rs
@@ -1,6 +1,7 @@
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 
 use serde_json::Value;
 use tempfile::tempdir;
@@ -153,6 +154,120 @@ sys.stdout.write(json.loads({stdout_text_json:?}))
 }
 
 #[test]
+fn test_search_no_path_piped_stdin_forwards_no_default_path_to_rg() {
+    let dir = tempdir().unwrap();
+    let fake_rg = fake_rg_exact_args_script(dir.path(), &["-e", "needle"], "stdin needle\n");
+
+    let mut child = tg()
+        .current_dir(dir.path())
+        .args(["search", "needle"])
+        .env("TG_RG_PATH", &fake_rg)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"stdin needle\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "stdin needle\n"
+    );
+}
+
+#[test]
+fn test_search_explicit_path_keeps_path_when_stdin_is_piped() {
+    let dir = tempdir().unwrap();
+    let fake_rg = fake_rg_exact_args_script(
+        dir.path(),
+        &["-e", "needle", "fixture.txt"],
+        "fixture.txt:needle file\n",
+    );
+    fs::write(dir.path().join("fixture.txt"), "needle file\n").unwrap();
+
+    let mut child = tg()
+        .current_dir(dir.path())
+        .args(["search", "needle", "fixture.txt"])
+        .env("TG_RG_PATH", &fake_rg)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"stdin needle\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "fixture.txt:needle file\n"
+    );
+}
+
+#[test]
+fn test_root_no_path_piped_stdin_forwards_no_default_path_to_rg() {
+    let dir = tempdir().unwrap();
+    let fake_rg = fake_rg_exact_args_script(
+        dir.path(),
+        &["--no-ignore", "-e", "needle"],
+        "stdin needle\n",
+    );
+
+    let mut child = tg()
+        .current_dir(dir.path())
+        .arg("needle")
+        .env("TG_RG_PATH", &fake_rg)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"stdin needle\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "stdin needle\n"
+    );
+}
+
+#[test]
 fn test_search_accepts_multiline_flags_on_public_native_frontdoor() {
     let dir = tempdir().unwrap();
     let fake_rg = fake_rg_script(dir.path(), "invoice.py:def create_invoice\n");
@@ -268,6 +383,41 @@ fn test_lsp_provider_args_are_forwarded_on_public_native_frontdoor() {
         "stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn fake_rg_exact_args_script(dir: &Path, expected_args: &[&str], stdout_text: &str) -> PathBuf {
+    let script = dir.join("fake-rg-exact.py");
+    let expected_args_json = serde_json::to_string(expected_args).unwrap();
+    let stdout_text_json = serde_json::to_string(stdout_text).unwrap();
+    fs::write(
+        &script,
+        format!(
+            r#"import json, sys
+expected = json.loads({expected_args_json:?})
+actual = sys.argv[1:]
+if actual != expected:
+    sys.stderr.write("expected rg args " + repr(expected) + " but saw " + repr(actual) + "\n")
+    raise SystemExit(2)
+sys.stdin.buffer.read()
+sys.stdout.write(json.loads({stdout_text_json:?}))
+"#,
+        ),
+    )
+    .unwrap();
+
+    if cfg!(windows) {
+        write_executable_script(
+            dir,
+            "fake-rg-exact.cmd",
+            &format!("@echo off\r\npython \"{}\" %*\r\n", script.display()),
+        )
+    } else {
+        write_executable_script(
+            dir,
+            "fake-rg-exact",
+            &format!("#!/bin/sh\npython \"{}\" \"$@\"\n", script.display()),
+        )
+    }
 }
 
 #[test]

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -403,8 +403,12 @@ class RipgrepBackend(ComputeBackend):
             if config.threads > 0:
                 cmd.extend(["-j", str(config.threads)])
 
-        # The pattern
-        cmd.append(pattern)
+        patterns = list(config.regexp or []) if config and config.regexp else [pattern]
+        for current_pattern in patterns:
+            if len(patterns) > 1 or current_pattern.startswith("-"):
+                cmd.extend(["-e", current_pattern])
+            else:
+                cmd.append(current_pattern)
         if isinstance(file_path, list):
             cmd.extend(file_path)
         else:

--- a/tests/e2e/test_rg_parity_edges.py
+++ b/tests/e2e/test_rg_parity_edges.py
@@ -23,6 +23,7 @@ def _write_edge_corpus(root: Path) -> None:
     (root / "b.txt").write_text("needle beta\n", encoding="utf-8")
     (root / "a.txt").write_text("needle alpha\n", encoding="utf-8")
     (root / "c.txt").write_text("plain text\n", encoding="utf-8")
+    (root / "dash.txt").write_text("-needle dash\nplain text\n", encoding="utf-8")
     (root / "pcre-z.txt").write_text("needle pcre\n", encoding="utf-8")
     (root / "multi.py").write_text(
         "# needle multiline fixture\n"
@@ -40,12 +41,20 @@ def _write_edge_corpus(root: Path) -> None:
     subprocess.run(["git", "init"], cwd=root, check=False, capture_output=True, text=True)
 
 
-def _run(argv: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    stdin = subprocess.DEVNULL if input_text is None else None
     return subprocess.run(
         argv,
         cwd=cwd,
         env=env,
-        stdin=subprocess.DEVNULL,
+        input=input_text,
+        stdin=stdin,
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -74,9 +83,15 @@ def _assert_same_rg_behavior(
     env: dict[str, str],
     rg_binary: Path,
     compare_stdout: bool = True,
+    input_text: str | None = None,
 ) -> None:
-    rg = _run([str(rg_binary), *rg_args], cwd=root, env=env)
-    tg = _run([sys.executable, "-m", "tensor_grep", "search", *tg_args], cwd=root, env=env)
+    rg = _run([str(rg_binary), *rg_args], cwd=root, env=env, input_text=input_text)
+    tg = _run(
+        [sys.executable, "-m", "tensor_grep", "search", *tg_args],
+        cwd=root,
+        env=env,
+        input_text=input_text,
+    )
 
     assert tg.returncode == rg.returncode, (
         f"rg exit={rg.returncode} tg exit={tg.returncode}\n"
@@ -172,6 +187,83 @@ def test_rg_pcre2_sorted_output_matches(
         root=root,
         env=env,
         rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+def test_rg_dash_leading_regexp_pattern_matches(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["-e", "-needle", "--sort", "path", "."],
+        tg_args=["-e", "-needle", "--sort", "path", "."],
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+def test_rg_multiple_regexp_patterns_match(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["-e", "-needle", "-e", "plain", "--sort", "path", "."],
+        tg_args=["-e", "-needle", "-e", "plain", "--sort", "path", "."],
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+def test_rg_no_path_searches_piped_stdin(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["needle"],
+        tg_args=["needle"],
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+        input_text="stdin needle\nstdin other\n",
+    )
+
+
+@pytest.mark.characterization
+def test_rg_no_stdin_default_path_still_searches_cwd(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["--sort", "path", "needle", "."],
+        tg_args=["--sort", "path", "needle"],
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+def test_rg_explicit_path_ignores_piped_stdin(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_behavior(
+        rg_args=["needle", "a.txt"],
+        tg_args=["needle", "a.txt"],
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+        input_text="stdin needle\n",
     )
 
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -406,6 +406,23 @@ def test_files_mode_lists_candidates_without_pattern(monkeypatch):
     assert result.stdout.strip().splitlines() == ["a.py", "b.py"]
 
 
+def test_ripgrep_backend_builds_regexp_patterns_as_e_options(monkeypatch):
+    from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+
+    monkeypatch.setattr(RipgrepBackend, "_get_binary_name", lambda self: "rg")
+
+    cmd = RipgrepBackend()._build_cmd(
+        file_path=["."],
+        pattern="-needle",
+        config=SearchConfig(regexp=["-needle", "plain"], sort_by="path", line_number=None),
+        json_mode=False,
+    )
+
+    pattern_index = cmd.index("-needle")
+    assert cmd[pattern_index - 1 : pattern_index + 3] == ["-e", "-needle", "-e", "plain"]
+    assert cmd[-1] == "."
+
+
 def test_files_mode_refuses_unbounded_broad_generated_root_scan(tmp_path: Path):
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Accept dash-leading `-e/--regexp` patterns in native and Python rg-backed search paths.
- Preserve repeated `-e PATTERN` argv construction for multi-pattern ripgrep passthrough.
- Align no-path readable-stdin behavior with ripgrep for `tg search PATTERN` and root-position `tg PATTERN`, while keeping explicit paths authoritative.

## Dogfood issue
v1.12.16 rg CLI parity matrix had three remaining search-shape gaps:
- `tg search -e -needle` rejected dash-leading patterns that rg accepts.
- No-path piped stdin searched cwd instead of stdin.
- Explicit paths needed regression coverage to stay file-bound when stdin is piped.

## Research / planning
- Exa/ripgrep anchor: ripgrep documents `rg [OPTIONS] -e PATTERN ... [PATH ...]`; `-e/--regexp` is the compatible route for patterns beginning with `-`.
- Exa/ripgrep anchor: ripgrep reads stdin when stdin is readable and no path is supplied; explicit paths search files.
- Thinktank consensus: fix rg dash-leading and stdin/no-path semantics before later path-format/help-surface slices; keep JSON schemas unchanged and use contract tests.
- Subagent implementation: Raman prepared the initial rg/stdin patch; I reviewed it, added root-position stdin coverage, and validated locally.
- Gemini review: attempted read-only plan-mode review twice, including a static-diff prompt outside the repo; Gemini CLI stalled before producing an audit, so there were no findings to accept or reject.

## Validation
- `uv run pytest -q tests/unit/test_cli_modes.py -k "ripgrep_backend_builds_regexp"`
- `uv run pytest -q tests/e2e/test_rg_parity_edges.py -k "dash_leading or multiple_regexp or no_path_searches_piped_stdin or no_stdin_default_path or explicit_path_ignores"`
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml search_request_accepts_dash_leading_regexp_pattern -- --nocapture`
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml implicit_search_paths -- --nocapture`
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml --test test_public_native_cli_parity stdin -- --nocapture`
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml --test test_public_native_cli_parity -- --nocapture`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check`
- `git diff --check` (CRLF warnings only)