### PR TITLE
fix: preserve rg files path formatting

### DIFF
--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -402,6 +402,13 @@ class RipgrepBackend(ComputeBackend):
                 cmd.extend(["--max-filesize", config.max_filesize])
             if config.threads > 0:
                 cmd.extend(["-j", str(config.threads)])
+            if config.list_files:
+                cmd.append("--files")
+                if isinstance(file_path, list):
+                    cmd.extend(file_path)
+                else:
+                    cmd.append(file_path)
+                return cmd
 
         patterns = list(config.regexp or []) if config and config.regexp else [pattern]
         for current_pattern in patterns:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -2583,7 +2583,7 @@ def _can_passthrough_rg(
         and format_type == "rg"
         and (not json_mode or rg_json_passthrough)
         and not ndjson_mode
-        and not files_mode
+        and not (files_mode and json_mode)
         and not only_matching
         and not (rg_json_passthrough and stats_mode)
         and not (rg_json_passthrough and (config.count or config.count_matches))

--- a/tests/e2e/test_rg_parity_edges.py
+++ b/tests/e2e/test_rg_parity_edges.py
@@ -32,6 +32,9 @@ def _write_edge_corpus(root: Path) -> None:
         "    return subtotal + tax\n",
         encoding="utf-8",
     )
+    nested_dir = root / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "d.txt").write_text("needle nested\n", encoding="utf-8")
     ignored_dir = root / "ignored"
     ignored_dir.mkdir()
     (ignored_dir / "z.txt").write_text("needle ignored\n", encoding="utf-8")
@@ -99,6 +102,28 @@ def _assert_same_rg_behavior(
     )
     if compare_stdout:
         assert _normalize(tg.stdout, root) == _normalize(rg.stdout, root)
+
+
+def _assert_same_rg_stdout_bytes(
+    *,
+    rg_args: list[str],
+    tg_args: list[str],
+    root: Path,
+    env: dict[str, str],
+    rg_binary: Path,
+) -> None:
+    rg = _run([str(rg_binary), *rg_args], cwd=root, env=env)
+    tg = _run(
+        [sys.executable, "-m", "tensor_grep", "search", *tg_args],
+        cwd=root,
+        env=env,
+    )
+
+    assert tg.returncode == rg.returncode, (
+        f"rg exit={rg.returncode} tg exit={tg.returncode}\n"
+        f"rg stderr={rg.stderr}\ntg stderr={tg.stderr}"
+    )
+    assert tg.stdout.replace("\r\n", "\n") == rg.stdout.replace("\r\n", "\n")
 
 
 @pytest.fixture()
@@ -169,6 +194,27 @@ def test_rg_sorted_output_edges_match(
     _assert_same_rg_behavior(
         rg_args=rg_args,
         tg_args=tg_args,
+        root=root,
+        env=env,
+        rg_binary=rg_binary,
+    )
+
+
+@pytest.mark.characterization
+@pytest.mark.parametrize(
+    "path_arg",
+    [".", "./nested"],
+    ids=["dot-root", "dot-slash-subdir"],
+)
+def test_rg_files_mode_preserves_rg_path_prefixes(
+    edge_corpus: tuple[Path, Path, dict[str, str]],
+    path_arg: str,
+) -> None:
+    root, rg_binary, env = edge_corpus
+
+    _assert_same_rg_stdout_bytes(
+        rg_args=["--files", "--sort", "path", path_arg],
+        tg_args=["--files", "--sort", "path", path_arg],
         root=root,
         env=env,
         rg_binary=rg_binary,

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -227,6 +227,10 @@ def test_main_entry_preserves_files_mode_without_pattern(
     monkeypatch.setattr(sys, "argv", ["tg", "--files", str(project)])
     monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: None)
     monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: None)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.is_available",
+        lambda self: False,
+    )
 
     with pytest.raises(SystemExit) as excinfo:
         bootstrap.main_entry()

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -443,6 +443,49 @@ def test_files_mode_refuses_unbounded_broad_generated_root_scan(tmp_path: Path):
     assert "--allow-broad-generated-scan" in result.output
 
 
+def test_files_mode_refuses_generated_root_before_rg_passthrough(monkeypatch, tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.is_available",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.search_passthrough",
+        lambda self, paths, pattern, config=None: pytest.fail(
+            "generated-root guard should run before rg passthrough"
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["search", "--files", str(tmp_path), "--hidden"])
+
+    assert result.exit_code == 2
+    assert "broad generated-root scan refused" in result.output
+
+
+def test_files_mode_json_does_not_passthrough_to_rg(monkeypatch, tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakePipeline)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.is_available",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.search_passthrough",
+        lambda self, paths, pattern, config=None: pytest.fail(
+            "--files --json should keep tensor-grep files-mode semantics"
+        ),
+    )
+
+    result = CliRunner().invoke(app, ["search", "--files", "--json", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "app.py" in result.stdout
+
+
 def test_files_mode_refuses_cwd_generated_root_scan(monkeypatch, tmp_path: Path):
     venv_root = tmp_path / ".venv"
     package_dir = venv_root / "Lib" / "site-packages" / "pkg"
@@ -463,6 +506,10 @@ def test_files_mode_allows_bounded_broad_generated_root_scan(monkeypatch, tmp_pa
     (tmp_path / "node_modules").mkdir()
     (tmp_path / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
     monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakePipeline)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.is_available",
+        lambda self: False,
+    )
 
     result = CliRunner().invoke(
         app,
@@ -481,6 +528,10 @@ def test_files_mode_allows_explicit_broad_generated_root_scan(monkeypatch, tmp_p
     (tmp_path / "node_modules").mkdir()
     (tmp_path / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
     monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakePipeline)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ripgrep_backend.RipgrepBackend.is_available",
+        lambda self: False,
+    )
 
     result = CliRunner().invoke(
         app,

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -131,6 +131,33 @@ def test_should_forward_glob_flags():
     assert "!*.tmp" in cmd
 
 
+def test_files_mode_builds_rg_files_command_without_search_pattern():
+    backend = RipgrepBackend()
+    config = SearchConfig(
+        list_files=True,
+        glob=["*.py"],
+        hidden=True,
+        null=True,
+        sort_by="path",
+    )
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[".", "./src"],
+            pattern="SHOULD_NOT_BE_USED",
+            config=config,
+            json_mode=False,
+        )
+
+    assert "--files" in cmd
+    assert "--hidden" in cmd
+    assert "-0" in cmd
+    assert ["-g", "*.py"] == cmd[cmd.index("-g") :][:2]
+    assert ["--sort", "path"] == cmd[cmd.index("--sort") :][:2]
+    assert cmd[cmd.index("--files") + 1 :] == [".", "./src"]
+    assert "SHOULD_NOT_BE_USED" not in cmd
+
+
 def test_should_raise_on_rg_fatal_error():
     backend = RipgrepBackend()
 


### PR DESCRIPTION
## Summary
- route text `tg search --files` through ripgrep when passthrough is safe so `./` / `.\` path prefixes match `rg --files`
- keep `tg search --files --json` on tensor-grep's aggregate schema instead of raw rg passthrough
- preserve generated-root refusal before any rg passthrough attempt

## Research / Planning
- Exa anchors: ripgrep utility mode and manpage semantics for `rg --files [PATH...]`, plus ripgrep guide behavior for path-shaped output.
- Thinktank consensus: use rg passthrough for text `--files` instead of hand-normalizing prefixes; keep JSON/NDJSON as tensor-grep schemas; keep generated-root guard ahead of passthrough.
- Subagent implementation: delegated the initial focused patch and then tightened contract tests locally.
- Gemini read-only review: flagged a possible generated-root bypass and requested explicit JSON coverage. Verified the guard order in code and added tests proving generated-root refusal and JSON non-passthrough.

## Validation
- `uv run pytest -q tests/e2e/test_rg_parity_edges.py::test_rg_files_mode_preserves_rg_path_prefixes tests/unit/test_ripgrep_backend.py::test_files_mode_builds_rg_files_command_without_search_pattern tests/unit/test_cli_modes.py -k files_mode`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check`
- `uv run pytest -q` -> `2121 passed, 50 skipped`