### PR TITLE
fix: harden ast scan input errors

### DIFF
--- a/src/tensor_grep/backends/ast_backend.py
+++ b/src/tensor_grep/backends/ast_backend.py
@@ -25,25 +25,109 @@ ParsedSourceCacheEntry = tuple[FileSignature, bytes, list[str], Any, int]
 NodeTypeIndexCacheEntry = tuple[FileSignature, dict[str, list[int]]]
 
 
+_AST_LANGUAGE_ALIASES = {
+    "bash": "bash",
+    "sh": "bash",
+    "c": "c",
+    "cc": "cpp",
+    "c++": "cpp",
+    "cpp": "cpp",
+    "cxx": "cpp",
+    "c-sharp": "csharp",
+    "c#": "csharp",
+    "c_sharp": "csharp",
+    "cs": "csharp",
+    "csharp": "csharp",
+    "css": "css",
+    "elixir": "elixir",
+    "ex": "elixir",
+    "go": "go",
+    "golang": "go",
+    "haskell": "haskell",
+    "hs": "haskell",
+    "hcl": "hcl",
+    "html": "html",
+    "java": "java",
+    "python": "python",
+    "py": "python",
+    "javascript": "javascript",
+    "jsx": "javascript",
+    "js": "javascript",
+    "json": "json",
+    "kotlin": "kotlin",
+    "kt": "kotlin",
+    "lua": "lua",
+    "nix": "nix",
+    "php": "php",
+    "ruby": "ruby",
+    "rb": "ruby",
+    "scala": "scala",
+    "sol": "solidity",
+    "solidity": "solidity",
+    "swift": "swift",
+    "typescript": "typescript",
+    "ts": "typescript",
+    "tsx": "tsx",
+    "rust": "rust",
+    "rs": "rust",
+    "yaml": "yaml",
+    "yml": "yaml",
+}
+_SUPPORTED_AST_LANGUAGES = (
+    "bash",
+    "c",
+    "cpp",
+    "csharp",
+    "css",
+    "elixir",
+    "go",
+    "haskell",
+    "hcl",
+    "html",
+    "java",
+    "javascript",
+    "json",
+    "kotlin",
+    "lua",
+    "nix",
+    "php",
+    "python",
+    "ruby",
+    "rust",
+    "scala",
+    "solidity",
+    "swift",
+    "typescript",
+    "tsx",
+    "yaml",
+)
+_NATIVE_AST_LANGUAGES = ("python", "javascript", "typescript", "tsx", "rust")
+
+
+def normalize_ast_language(language: object | None, *, default: str = "python") -> str:
+    """Normalize supported ast-grep language names to tg internal identifiers."""
+    raw_language = default if language is None or not str(language).strip() else str(language)
+    normalized = _AST_LANGUAGE_ALIASES.get(raw_language.strip().lower())
+    if normalized is None:
+        supported = ", ".join(_SUPPORTED_AST_LANGUAGES)
+        raise ValueError(
+            f"Unsupported AST language {raw_language}. Supported languages: {supported}."
+        )
+    return normalized
+
+
+def is_native_ast_language(language: object | None) -> bool:
+    """Return whether tg's in-process tree-sitter backend can parse the language."""
+    try:
+        normalized = normalize_ast_language(language)
+    except ValueError:
+        return False
+    return normalized in _NATIVE_AST_LANGUAGES
+
+
 def get_supported_languages() -> list[str]:
-    """Return a list of languages with supported tree-sitter grammars."""
-    # This matches the logic in _get_parser
-    return [
-        "python",
-        "javascript",
-        "typescript",
-        "tsx",
-        "rust",
-        "go",
-        "java",
-        "c",
-        "cpp",
-        "c_sharp",
-        "ruby",
-        "php",
-        "html",
-        "css",
-    ]
+    """Return language identifiers supported by tg AST surfaces."""
+    return list(_SUPPORTED_AST_LANGUAGES)
 
 
 class AstBackend(ComputeBackend):
@@ -375,6 +459,7 @@ class AstBackend(ComputeBackend):
     def _get_parser(self, lang: str) -> Any:
         import tree_sitter
 
+        lang = normalize_ast_language(lang)
         if lang in self._parsers:
             return self._parsers[lang]
 
@@ -384,22 +469,31 @@ class AstBackend(ComputeBackend):
                 import tree_sitter_python
 
                 parser = tree_sitter.Parser(tree_sitter.Language(tree_sitter_python.language()))
-            elif lang == "javascript" or lang == "js":
+            elif lang == "javascript":
                 import tree_sitter_javascript
 
                 parser = tree_sitter.Parser(tree_sitter.Language(tree_sitter_javascript.language()))
-            elif lang == "typescript" or lang == "ts":
+            elif lang == "typescript":
                 import tree_sitter_typescript
 
                 parser = tree_sitter.Parser(
                     tree_sitter.Language(tree_sitter_typescript.language_typescript())
                 )
-            elif lang == "rust" or lang == "rs":
+            elif lang == "tsx":
+                import tree_sitter_typescript
+
+                parser = tree_sitter.Parser(
+                    tree_sitter.Language(tree_sitter_typescript.language_tsx())
+                )
+            elif lang == "rust":
                 import tree_sitter_rust
 
                 parser = tree_sitter.Parser(tree_sitter.Language(tree_sitter_rust.language()))
             else:
-                raise ValueError(f"Language '{lang}' is not yet supported by the AstBackend.")
+                raise ValueError(
+                    f"Language '{lang}' is supported by the ast-grep wrapper but not by "
+                    "the native AstBackend."
+                )
         except Exception as e:
             raise RuntimeError(f"Failed to load tree-sitter grammar for {lang}: {e}") from e
 

--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+from tensor_grep.backends.ast_backend import normalize_ast_language
 from tensor_grep.backends.base import ComputeBackend
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
@@ -40,7 +41,7 @@ class AstGrepWrapperBackend(ComputeBackend):
     def _build_command(
         self, pattern: str, paths: list[str], config: SearchConfig | None = None
     ) -> tuple[list[str], AbstractContextManager[object]]:
-        lang = config.lang if config and config.lang else None
+        lang = normalize_ast_language(config.lang) if config and config.lang else None
         if "\n" not in pattern and "\r" not in pattern:
             cmd = [self._get_binary_name(), "run", "--json", "-p", pattern]
             if lang:
@@ -65,6 +66,21 @@ class AstGrepWrapperBackend(ComputeBackend):
         )
         cmd = [self._get_binary_name(), "scan", "--json", "--rule", str(rule_file), *paths]
         return cmd, context
+
+    def _raise_for_nonzero(self, result: subprocess.CompletedProcess[str]) -> None:
+        raw_returncode = getattr(result, "returncode", 0)
+        returncode = raw_returncode if isinstance(raw_returncode, int) else 0
+        if returncode == 0:
+            return
+
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        if not stderr and stdout.startswith("["):
+            return
+
+        detail = stderr or stdout or "no error output"
+        detail = detail.splitlines()[0]
+        raise RuntimeError(f"ast-grep failed with exit code {returncode}: {detail}")
 
     def _parse_result(self, stdout: str, fallback_file: str | None = None) -> SearchResult:
         matches: list[MatchLine] = []
@@ -146,6 +162,7 @@ class AstGrepWrapperBackend(ComputeBackend):
         except Exception as e:
             raise RuntimeError(f"AstGrepWrapperBackend failed: {e}") from e
 
+        self._raise_for_nonzero(result)
         grouped_matches: dict[str, list[dict[str, Any]]] = {}
         for item in self._parse_json_items(result.stdout):
             rule_id = item.get("ruleId") or item.get("rule_id")
@@ -176,6 +193,7 @@ class AstGrepWrapperBackend(ComputeBackend):
                     check=False,
                     encoding="utf-8",
                 )
+                self._raise_for_nonzero(result)
                 return self._parse_result(result.stdout)
         except Exception as e:
             raise RuntimeError(f"AstGrepWrapperBackend failed: {e}") from e
@@ -198,6 +216,7 @@ class AstGrepWrapperBackend(ComputeBackend):
                     check=False,
                     encoding="utf-8",
                 )
+                self._raise_for_nonzero(result)
                 return self._parse_result(result.stdout, fallback_file=file_path)
 
         except Exception as e:

--- a/src/tensor_grep/cli/ast_workflows.py
+++ b/src/tensor_grep/cli/ast_workflows.py
@@ -9,6 +9,8 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
+from tensor_grep.backends.ast_backend import is_native_ast_language, normalize_ast_language
+
 if TYPE_CHECKING:
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.result import MatchLine, SearchResult
@@ -87,7 +89,11 @@ def _load_yaml_dict(path: Path) -> dict[str, object]:
             _reset_yaml_cache()
             yaml_mod, _loader = _get_yaml()
             handle.seek(0)
-            loaded = yaml_mod.safe_load(handle) or {}
+            try:
+                loaded = yaml_mod.safe_load(handle) or {}
+            except yaml_mod.YAMLError as exc:
+                detail = str(exc).splitlines()[0] if str(exc).strip() else "parse error"
+                raise ValueError(f"Invalid YAML in {path}: {detail}") from exc
     if not isinstance(loaded, dict):
         raise ValueError(f"YAML in {path} must be a mapping.")
     return loaded
@@ -215,7 +221,7 @@ def _load_ast_project_data(
         "root_dir": str(root_dir),
         "rule_dirs": _normalize_string_list(raw_cfg.get("ruleDirs"), ["rules"]),
         "test_dirs": _normalize_string_list(raw_cfg.get("testDirs"), ["tests"]),
-        "language": str(raw_cfg.get("language") or "python"),
+        "language": normalize_ast_language(raw_cfg.get("language") or "python"),
     }
 
     # Load rule specs and track files
@@ -280,7 +286,11 @@ def _select_ast_backend_name_for_pattern(pattern: str, language: str) -> str:
             or _SUPPORTED_NATIVE_PATTERN_RE.fullmatch(stripped_pattern)
         )
     )
-    return "AstBackend" if supports_native_pattern else "AstGrepWrapperBackend"
+    return (
+        "AstBackend"
+        if supports_native_pattern and is_native_ast_language(language)
+        else "AstGrepWrapperBackend"
+    )
 
 
 def _load_rule_specs_and_meta(
@@ -309,7 +319,7 @@ def _load_rule_specs_and_meta(
                 specs.append({
                     "id": str(item.get("id") or f"{rule_file.stem}-{idx + 1}"),
                     "pattern": pattern,
-                    "language": str(
+                    "language": normalize_ast_language(
                         item.get("language") or payload.get("language") or default_language
                     ),
                     "severity": str(item.get("severity") or payload.get("severity") or "warning"),
@@ -323,7 +333,7 @@ def _load_rule_specs_and_meta(
         specs.append({
             "id": str(payload.get("id") or rule_file.stem),
             "pattern": pattern,
-            "language": str(payload.get("language") or default_language),
+            "language": normalize_ast_language(payload.get("language") or default_language),
             "severity": str(payload.get("severity") or "warning"),
             "message": str(payload.get("message") or ""),
         })
@@ -787,7 +797,13 @@ def _select_ast_backend_for_pattern(
         )
     )
     pattern_kind = (
-        "native" if base_config.ast_prefer_native and supports_native_pattern else "wrapper"
+        "native"
+        if (
+            base_config.ast_prefer_native
+            and supports_native_pattern
+            and is_native_ast_language(base_config.lang)
+        )
+        else "wrapper"
     )
     cache_key = (base_config.lang, pattern_kind, base_config.ast_prefer_native)
     if backend_cache is not None and cache_key in backend_cache:
@@ -850,8 +866,11 @@ def scan_command(
             rules = yaml_mod.load(inline_rules, Loader=loader)
             if not isinstance(rules, list):
                 rules = [rules]
+            for rule in rules:
+                if isinstance(rule, dict):
+                    rule["language"] = normalize_ast_language(rule.get("language") or "python")
             project_cfg = {
-                "language": rules[0].get("language", "python"),
+                "language": normalize_ast_language(rules[0].get("language", "python")),
                 "root_dir": Path(path or ".").resolve(),
             }
             hints: dict[str, Any] = {}
@@ -866,8 +885,12 @@ def scan_command(
             )
             if not json_mode:
                 print("Scanning project using inline rules...")
-        except Exception as exc:
-            print(f"Error parsing inline rules: {exc}", file=sys.stderr)
+        except yaml_mod.YAMLError as exc:
+            detail = str(exc).splitlines()[0] if str(exc).strip() else "parse error"
+            print(f"Error: Invalid inline rules YAML: {detail}", file=sys.stderr)
+            return 1
+        except (AttributeError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
             return 1
     elif ruleset:
         from tensor_grep.cli.rule_packs import resolve_rule_pack
@@ -1037,9 +1060,13 @@ def scan_command(
         matched_files: set[str] = set()
 
         if type(backend).__name__ == "AstGrepWrapperBackend" and hasattr(backend, "search_many"):
-            result = cast(Any, backend).search_many(
-                [str(root_dir)], rule["pattern"], config=rule_cfg
-            )
+            try:
+                result = cast(Any, backend).search_many(
+                    [str(root_dir)], rule["pattern"], config=rule_cfg
+                )
+            except RuntimeError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 1
             rule_matches = result.total_matches
             matched_files.update(result.matched_file_paths)
             if not matched_files and result.total_files > 0:
@@ -1047,7 +1074,11 @@ def scan_command(
         else:
             rule_matches = 0
             for current_file in candidate_files:
-                result = backend.search(current_file, rule["pattern"], config=rule_cfg)
+                try:
+                    result = backend.search(current_file, rule["pattern"], config=rule_cfg)
+                except RuntimeError as exc:
+                    print(f"Error: {exc}", file=sys.stderr)
+                    return 1
                 rule_matches += result.total_matches
                 if result.total_files > 0 or result.total_matches > 0:
                     matched_files.add(current_file)
@@ -1183,10 +1214,16 @@ def test_command(config: str | None = "sgconfig.yml") -> int:
                 case_id = str(case.get("id") or test_file_entry["stem"])
                 linked_rule = case.get("ruleId")
                 pattern = _extract_rule_pattern(case)
-                language = str(case.get("language") or cfg.lang or "python")
-                if not pattern and isinstance(linked_rule, str) and linked_rule in rules_by_id:
-                    pattern = rules_by_id[linked_rule]["pattern"]
-                    language = str(case.get("language") or rules_by_id[linked_rule]["language"])
+                try:
+                    language = normalize_ast_language(case.get("language") or cfg.lang or "python")
+                    if not pattern and isinstance(linked_rule, str) and linked_rule in rules_by_id:
+                        pattern = rules_by_id[linked_rule]["pattern"]
+                        language = normalize_ast_language(
+                            case.get("language") or rules_by_id[linked_rule]["language"]
+                        )
+                except ValueError as exc:
+                    failures.append(f"{test_file}:{case_id}: {exc}")
+                    continue
                 if not pattern:
                     failures.append(f"{test_file}:{case_id}: missing pattern or ruleId")
                     continue

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -59,10 +59,12 @@ _SCAN_FULL_CLI_FLAGS = {
     "--max-evidence-snippet-chars",
     "--max-evidence-snippets-per-file",
     "--path",
+    "--rule",
     "--ruleset",
     "--suppressions",
     "--write-baseline",
     "--write-suppressions",
+    "-r",
 }
 
 _SCAN_FULL_CLI_FLAG_PREFIXES = (
@@ -72,6 +74,7 @@ _SCAN_FULL_CLI_FLAG_PREFIXES = (
     "--max-evidence-snippet-chars=",
     "--max-evidence-snippets-per-file=",
     "--path=",
+    "--rule=",
     "--ruleset=",
     "--suppressions=",
     "--write-baseline=",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -23,6 +23,7 @@ if sys.platform.startswith("win") and not sys.stdout.isatty():
 
 import typer
 
+from tensor_grep.backends.ast_backend import is_native_ast_language, normalize_ast_language
 from tensor_grep.cli import ast_workflows
 from tensor_grep.cli.formatters.base import OutputFormatter
 from tensor_grep.cli.lsp_provider_setup import (
@@ -2867,7 +2868,11 @@ def _load_yaml_dict(path: Path) -> dict[str, object]:
     import yaml
 
     with path.open(encoding="utf-8") as handle:
-        loaded = yaml.safe_load(handle) or {}
+        try:
+            loaded = yaml.safe_load(handle) or {}
+        except yaml.YAMLError as exc:
+            detail = str(exc).splitlines()[0] if str(exc).strip() else "parse error"
+            raise ValueError(f"Invalid YAML in {path}: {detail}") from exc
     if not isinstance(loaded, dict):
         raise ValueError(f"YAML in {path} must be a mapping.")
     return loaded
@@ -2885,7 +2890,7 @@ def _load_sg_project_config(config_path: str | None) -> dict[str, object]:
         "rule_dirs": _normalize_string_list(raw.get("ruleDirs"), ["rules"]),
         "test_dirs": _normalize_string_list(raw.get("testDirs"), ["tests"]),
         "utils_dir": str(raw.get("utilsDir") or "utils"),
-        "language": str(raw.get("language") or "python"),
+        "language": normalize_ast_language(str(raw.get("language") or "python")),
     }
 
 
@@ -2937,7 +2942,7 @@ def _load_rule_specs(project_cfg: dict[str, object]) -> list[dict[str, str]]:
                 specs.append({
                     "id": str(item.get("id") or f"{rule_file.stem}-{idx + 1}"),
                     "pattern": pattern,
-                    "language": str(
+                    "language": normalize_ast_language(
                         item.get("language") or payload.get("language") or default_language
                     ),
                 })
@@ -2949,7 +2954,7 @@ def _load_rule_specs(project_cfg: dict[str, object]) -> list[dict[str, str]]:
         specs.append({
             "id": str(payload.get("id") or rule_file.stem),
             "pattern": pattern,
-            "language": str(payload.get("language") or default_language),
+            "language": normalize_ast_language(str(payload.get("language") or default_language)),
         })
 
     return specs
@@ -2963,10 +2968,13 @@ def _load_inline_rule_specs(
     loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
     specs: list[dict[str, str]] = []
 
-    for document_index, payload in enumerate(
-        yaml.load_all(inline_rules_text, Loader=loader),
-        start=1,
-    ):
+    try:
+        documents = list(yaml.load_all(inline_rules_text, Loader=loader))
+    except yaml.YAMLError as exc:
+        detail = str(exc).splitlines()[0] if str(exc).strip() else "parse error"
+        raise ValueError(f"Invalid inline rules YAML: {detail}") from exc
+
+    for document_index, payload in enumerate(documents, start=1):
         if payload is None:
             continue
         if not isinstance(payload, dict):
@@ -2983,7 +2991,7 @@ def _load_inline_rule_specs(
                 spec = {
                     "id": str(item.get("id") or f"inline-rule-{document_index}-{rule_index}"),
                     "pattern": pattern,
-                    "language": str(
+                    "language": normalize_ast_language(
                         item.get("language")
                         or payload.get("language")
                         or default_language
@@ -3004,7 +3012,9 @@ def _load_inline_rule_specs(
         spec = {
             "id": str(payload.get("id") or f"inline-rule-{document_index}"),
             "pattern": pattern,
-            "language": str(payload.get("language") or default_language or "python"),
+            "language": normalize_ast_language(
+                str(payload.get("language") or default_language or "python")
+            ),
         }
         for metadata_key in ("severity", "message"):
             if payload.get(metadata_key) is not None:
@@ -3479,10 +3489,18 @@ def _run_ast_scan_payload(
     from tensor_grep.core.result import SearchResult
     from tensor_grep.io.directory_scanner import DirectoryScanner
 
+    project_language = normalize_ast_language(project_cfg.get("language"))
+    normalized_rules: list[dict[str, str]] = []
+    for rule in rules:
+        normalized_rule = dict(rule)
+        normalized_rule["language"] = normalize_ast_language(rule.get("language"))
+        normalized_rules.append(normalized_rule)
+    rules = normalized_rules
+
     cfg = SearchConfig(
         ast=True,
         ast_prefer_native=True,
-        lang=cast(str, project_cfg["language"]),
+        lang=project_language,
     )
     root_dir = cast(Path, project_cfg["root_dir"])
     include_scan_paths_in_payload = bool(scan_paths)
@@ -3910,7 +3928,13 @@ def _select_ast_backend_for_pattern(
         )
     )
     pattern_kind = (
-        "native" if base_config.ast_prefer_native and supports_native_pattern else "wrapper"
+        "native"
+        if (
+            base_config.ast_prefer_native
+            and supports_native_pattern
+            and is_native_ast_language(base_config.lang)
+        )
+        else "wrapper"
     )
     cache_key = (base_config.lang, pattern_kind, base_config.ast_prefer_native)
     if backend_cache is not None and cache_key in backend_cache:
@@ -6763,8 +6787,9 @@ def scan(
     candidate_files: list[str] | None = None
     project_scan_fast_path = False
     if ruleset:
+        ruleset_language = normalize_ast_language(language) if language is not None else None
         try:
-            ruleset_meta, rules = resolve_rule_pack(ruleset, language)
+            ruleset_meta, rules = resolve_rule_pack(ruleset, ruleset_language)
         except ValueError as exc:
             typer.echo(f"Error: {exc}", err=True)
             sys.exit(1)
@@ -6796,7 +6821,9 @@ def scan(
         if not rules:
             typer.echo(f"Error: No valid rule was found in {rule_path}.", err=True)
             sys.exit(1)
-        inferred_language = language or str(rules[0]["language"])
+        inferred_language = (
+            normalize_ast_language(language) if language else str(rules[0]["language"])
+        )
         project_cfg = {
             "config_path": rule_path,
             "root_dir": Path(effective_scan_paths[0]).resolve(),
@@ -6815,7 +6842,9 @@ def scan(
         if not rules:
             typer.echo("Error: No valid inline rules were found.", err=True)
             sys.exit(1)
-        inferred_language = language or str(rules[0]["language"])
+        inferred_language = (
+            normalize_ast_language(language) if language else str(rules[0]["language"])
+        )
         project_cfg = {
             "config_path": "inline-rules",
             "root_dir": Path(effective_scan_paths[0]).resolve(),
@@ -6871,7 +6900,7 @@ def scan(
             max_evidence_snippets_per_file=max_evidence_snippets_per_file,
             max_evidence_snippet_chars=max_evidence_snippet_chars,
         )
-    except ValueError as exc:
+    except (ValueError, RuntimeError) as exc:
         typer.echo(f"Error: {exc}", err=True)
         sys.exit(1)
     if json_output:

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -72,7 +72,10 @@ def _has_ast_grep_binary() -> bool:
 
 
 def _skip_if_real_ruleset_scan_fixture_is_unsupported(source_file: Path) -> None:
-    payload = _scan_baseline_payload(source_file)
+    try:
+        payload = _scan_baseline_payload(source_file)
+    except RuntimeError as exc:
+        pytest.skip(f"real ruleset scan fixture unsupported on this backend: {exc}")
     findings = payload.get("findings")
     if not isinstance(findings, list):
         pytest.skip("real ruleset scan fixture unsupported on this backend")

--- a/tests/unit/test_ast_backend.py
+++ b/tests/unit/test_ast_backend.py
@@ -52,6 +52,35 @@ class TestAstBackend:
 
         AstBackend._clear_shared_caches()
 
+    def test_supported_languages_should_preserve_ast_grep_wrapper_surface(self):
+        from tensor_grep.backends.ast_backend import get_supported_languages
+
+        languages = set(get_supported_languages())
+
+        assert {"python", "javascript", "typescript", "tsx", "rust", "go", "java"}.issubset(
+            languages
+        )
+
+    @pytest.mark.parametrize(
+        ("raw_language", "normalized_language"),
+        [
+            ("Python", "python"),
+            ("JavaScript", "javascript"),
+            ("TypeScript", "typescript"),
+            ("Tsx", "tsx"),
+            ("Go", "go"),
+            ("CSharp", "csharp"),
+            ("C-sharp", "csharp"),
+            ("Yaml", "yaml"),
+        ],
+    )
+    def test_normalize_ast_language_should_accept_ast_grep_aliases(
+        self, raw_language, normalized_language
+    ):
+        from tensor_grep.backends.ast_backend import normalize_ast_language
+
+        assert normalize_ast_language(raw_language) == normalized_language
+
     def test_should_report_unavailable_when_tree_sitter_missing(self, mocker):
         # Arrange
         mocker.patch.dict("sys.modules", {"tree_sitter": None})

--- a/tests/unit/test_ast_workflows.py
+++ b/tests/unit/test_ast_workflows.py
@@ -161,6 +161,89 @@ def test_scan_command_should_use_wrapper_project_fast_path(monkeypatch, tmp_path
     assert AstGrepWrapperBackend.search_many_calls == 0
 
 
+def test_scan_command_reports_wrapper_runtime_errors_without_traceback(
+    monkeypatch, tmp_path, capsys
+):
+    from tensor_grep.cli.ast_workflows import scan_command
+
+    class ErroringAstGrepWrapperBackend:
+        def is_available(self):
+            return True
+
+        def search_project(self, root_path: str, config_path: str):
+            _ = root_path
+            _ = config_path
+            raise RuntimeError("ast-grep failed with exit code 8: invalid language")
+
+        def search_many(self, file_paths, pattern, config=None):
+            _ = file_paths
+            _ = pattern
+            _ = config
+            raise RuntimeError("ast-grep failed with exit code 8: invalid language")
+
+    ErroringAstGrepWrapperBackend.__name__ = "AstGrepWrapperBackend"
+
+    monkeypatch.setattr(
+        "tensor_grep.backends.ast_backend.AstBackend",
+        AstBackend,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend",
+        ErroringAstGrepWrapperBackend,
+    )
+
+    (tmp_path / "sgconfig.yml").write_text(
+        "ruleDirs:\n  - rules\nlanguage: python\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "rules").mkdir()
+    (tmp_path / "rules" / "error.yml").write_text(
+        "id: error-rule\nlanguage: python\nrule:\n  pattern: ERROR\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "a.py").write_text("ERROR in file\n", encoding="utf-8")
+
+    exit_code = scan_command(str(tmp_path / "sgconfig.yml"))
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Error: ast-grep failed with exit code 8: invalid language" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_test_command_reports_unsupported_case_language_without_traceback(tmp_path, capsys):
+    from tensor_grep.cli.ast_workflows import test_command
+
+    (tmp_path / "sgconfig.yml").write_text(
+        "ruleDirs:\n  - rules\ntestDirs:\n  - tests\nlanguage: python\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "rules").mkdir()
+    (tmp_path / "rules" / "error.yml").write_text(
+        "id: error-rule\nlanguage: python\nrule:\n  pattern: ERROR\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "error-test.yml").write_text(
+        "\n".join([
+            "tests:",
+            "  - id: unsupported-language",
+            "    ruleId: error-rule",
+            "    language: Dart",
+            "    valid:",
+            "      - OK",
+        ]),
+        encoding="utf-8",
+    )
+
+    exit_code = test_command(str(tmp_path / "sgconfig.yml"))
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Unsupported AST language Dart" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_ast_project_data_cache_invalidation(tmp_path, monkeypatch):
     import time
 

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tensor_grep.backends.ast_wrapper_backend import AstGrepWrapperBackend
 from tensor_grep.core.config import SearchConfig
 
@@ -185,3 +187,41 @@ def test_ast_wrapper_backend_should_group_project_scan_results_by_rule_id():
     assert results["rule-a"].matched_file_paths == ["a.py"]
     assert results["rule-b"].total_matches == 1
     assert results["rule-b"].matched_file_paths == ["b.py"]
+
+
+def test_ast_wrapper_backend_should_surface_nonzero_search_many_errors():
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 2
+    mock_result.stdout = ""
+    mock_result.stderr = "invalid rule config"
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+        pytest.raises(RuntimeError, match="invalid rule config"),
+    ):
+        backend.search_many(
+            ["example.py"],
+            "def $FUNC($$$ARGS):",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+
+def test_ast_wrapper_backend_should_surface_nonzero_project_scan_errors():
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 2
+    mock_result.stdout = "[]"
+    mock_result.stderr = "failed to parse config"
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+        pytest.raises(RuntimeError, match="failed to parse config"),
+    ):
+        backend.search_project("project", "sgconfig.yml")

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -216,6 +216,32 @@ def test_main_entry_should_fallback_to_full_cli_for_scan_inline_rules(monkeypatc
     assert called["full_cli"] is True
 
 
+@pytest.mark.parametrize(
+    "rule_args",
+    [
+        ["--rule", "rules/no-print.yml"],
+        ["--rule=rules/no-print.yml"],
+        ["-r", "rules/no-print.yml"],
+    ],
+)
+def test_main_entry_should_fallback_to_full_cli_for_scan_rule_file(
+    monkeypatch, rule_args: list[str]
+) -> None:
+    called = {"full_cli": False}
+
+    monkeypatch.setattr(sys, "argv", ["tg", "scan", *rule_args, "src"])
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_ast_workflow_cli",
+        lambda _argv: pytest.fail("ast workflow fast path should not run"),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
+
+    bootstrap.main_entry()
+
+    assert called["full_cli"] is True
+
+
 def test_main_entry_preserves_files_mode_without_pattern(
     monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -9140,6 +9140,135 @@ def test_scan_inline_rules_json_preserves_rule_metadata(monkeypatch, tmp_path: P
     assert finding["message"] == "Avoid print in library code."
 
 
+@pytest.mark.parametrize(
+    ("ast_grep_language", "normalized_language"),
+    [
+        ("Python", "python"),
+        ("JavaScript", "javascript"),
+        ("TypeScript", "typescript"),
+        ("Tsx", "tsx"),
+        ("Go", "go"),
+        ("Rust", "rust"),
+    ],
+)
+def test_scan_inline_rules_normalizes_ast_grep_language_names(
+    monkeypatch,
+    tmp_path: Path,
+    ast_grep_language: str,
+    normalized_language: str,
+) -> None:
+    seen_config_languages: list[str | None] = []
+
+    class AstGrepWrapperBackend:
+        def search_many(self, file_paths: list[str], pattern: str, config=None) -> SearchResult:
+            _ = file_paths
+            _ = pattern
+            seen_config_languages.append(config.lang if config is not None else None)
+            return SearchResult(
+                matches=[],
+                matched_file_paths=[],
+                total_files=0,
+                total_matches=0,
+                routing_backend="AstGrepWrapperBackend",
+                routing_reason="ast_grep_json",
+                routing_distributed=False,
+                routing_worker_count=1,
+            )
+
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._select_ast_backend_for_pattern",
+        lambda *_args, **_kwargs: AstGrepWrapperBackend(),
+    )
+
+    inline_rules = "\n".join([
+        "id: normalized-language",
+        f"language: {ast_grep_language}",
+        "rule:",
+        "  pattern: ERROR",
+    ])
+
+    result = CliRunner().invoke(
+        app,
+        ["scan", "--inline-rules", inline_rules, "--path", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["findings"][0]["language"] == normalized_language
+    assert seen_config_languages == [normalized_language]
+
+
+def test_scan_inline_rules_rejects_unsupported_language(tmp_path: Path) -> None:
+    inline_rules = "\n".join([
+        "id: unsupported-language",
+        "language: Dart",
+        "rule:",
+        "  pattern: print($A)",
+    ])
+
+    result = CliRunner().invoke(
+        app,
+        ["scan", "--inline-rules", inline_rules, "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: Unsupported AST language Dart" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_scan_inline_rules_reports_invalid_yaml_without_traceback(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        ["scan", "--inline-rules", "id: broken\nrule: [", "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "YAML" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_scan_rule_file_reports_invalid_yaml_without_traceback(tmp_path: Path) -> None:
+    rule_file = tmp_path / "broken.yml"
+    rule_file.write_text("id: broken\nrule: [", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["scan", "--rule", str(rule_file), str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "YAML" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_scan_wrapper_runtime_errors_do_not_show_traceback(monkeypatch, tmp_path: Path) -> None:
+    class AstGrepWrapperBackend:
+        def search_many(self, file_paths: list[str], pattern: str, config=None) -> SearchResult:
+            _ = file_paths
+            _ = pattern
+            _ = config
+            raise RuntimeError("ast-grep failed with exit code 8: invalid language")
+
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._select_ast_backend_for_pattern",
+        lambda *_args, **_kwargs: AstGrepWrapperBackend(),
+    )
+    inline_rules = "\n".join([
+        "id: wrapper-error",
+        "language: Python",
+        "rule:",
+        "  pattern: print($A)",
+    ])
+
+    result = CliRunner().invoke(
+        app,
+        ["scan", "--inline-rules", inline_rules, "--path", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: ast-grep failed with exit code 8: invalid language" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_scan_builtin_ruleset_can_compare_and_write_baseline(monkeypatch):
     monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
     monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)


### PR DESCRIPTION
## Summary
- normalize ast-grep language names without shrinking the wrapper language surface
- route wrapper-supported/non-native languages to ast-grep instead of native AST
- convert invalid YAML, unsupported language, and wrapper runtime failures into concise scan/test errors without tracebacks
- route scan --rule/-r through the full CLI contract path

## Research / review
- Exa/docs anchor: ast-grep language docs list canonical language names including Python, JavaScript, TypeScript, Rust, and the broader wrapper surface such as TSX, Go, Java, C/C++, CSharp, YAML
- Thinktank consensus: preserve the ast-grep wrapper surface while hardening tg's native subset and user-input errors
- Gemini read-only review: initial review found the language-surface regression and tg test traceback gap; follow-up review reported no blocking findings

## Validation
- uv run pytest -q tests/unit/test_cli_bootstrap.py::test_main_entry_should_fallback_to_full_cli_for_scan_rule_file tests/unit/test_cli_modes.py::test_scan_inline_rules_normalizes_ast_grep_language_names tests/unit/test_cli_modes.py::test_scan_inline_rules_rejects_unsupported_language tests/unit/test_cli_modes.py::test_scan_inline_rules_reports_invalid_yaml_without_traceback tests/unit/test_cli_modes.py::test_scan_rule_file_reports_invalid_yaml_without_traceback tests/unit/test_cli_modes.py::test_scan_wrapper_runtime_errors_do_not_show_traceback tests/unit/test_ast_workflows.py::test_scan_command_reports_wrapper_runtime_errors_without_traceback tests/unit/test_ast_wrapper_backend.py::test_ast_wrapper_backend_should_surface_nonzero_search_many_errors tests/unit/test_ast_wrapper_backend.py::test_ast_wrapper_backend_should_surface_nonzero_project_scan_errors
- uv run pytest tests/unit/test_ast_backend.py tests/unit/test_cli_bootstrap.py tests/unit/test_cli_modes.py tests/unit/test_ast_wrapper_backend.py tests/unit/test_ast_workflows.py -q
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q -> 2181 passed, 16 skipped
- git diff --check