### PR TITLE
fix: harden lsp provider health proof

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -25,8 +25,25 @@ class LSPTransportError(RuntimeError):
 
 _DEFAULT_LSP_REQUEST_TIMEOUT_SECONDS = 3.0
 _DEFAULT_LSP_INITIALIZE_TIMEOUT_SECONDS = 15.0
+_DEFAULT_LSP_STOP_TIMEOUT_SECONDS = 1.0
 _LSP_REQUEST_TIMEOUT_ENV_VAR = "TENSOR_GREP_LSP_REQUEST_TIMEOUT_SECONDS"
 _LSP_INITIALIZE_TIMEOUT_ENV_VAR = "TENSOR_GREP_LSP_INITIALIZE_TIMEOUT_SECONDS"
+_GENERATED_CACHE_EXCLUDES = [
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "artifacts",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+    "venv",
+]
 
 
 def _configured_timeout_seconds(env_var: str, default: float) -> float:
@@ -96,6 +113,21 @@ def _provider_command(language: str) -> list[str]:
     raise ValueError(f"Unsupported LSP language: {language}")
 
 
+def _configuration_settings(language: str) -> dict[str, Any]:
+    if canonical_language(language) != "python":
+        return {"settings": {}}
+    return {
+        "settings": {
+            "python": {
+                "analysis": {
+                    "diagnosticMode": "openFilesOnly",
+                    "exclude": list(_GENERATED_CACHE_EXCLUDES),
+                }
+            }
+        }
+    }
+
+
 class ExternalLSPClient:
     def __init__(
         self,
@@ -133,6 +165,7 @@ class ExternalLSPClient:
         self.capabilities: dict[str, Any] = {}
         self.last_error: str | None = None
         self.disabled_until_monotonic = 0.0
+        self.initialized = False
 
     def start(self) -> None:
         if self.process is not None and self.process.poll() is None:
@@ -178,15 +211,21 @@ class ExternalLSPClient:
         if isinstance(result, dict):
             self.capabilities = dict(result.get("capabilities", {}))
         self.notify("initialized", {})
+        self.initialized = True
+        try:
+            self.notify("workspace/didChangeConfiguration", _configuration_settings(self.language))
+        except Exception:
+            pass
 
     def stop(self) -> None:
         process = self.process
         if process is None:
             return
         reader_thread = self._reader_thread
+        self._request_shutdown_for_stop()
         with self._lock:
             try:
-                self._write_notification("shutdown", {})
+                self._write_notification("exit", None)
             except Exception:
                 pass
             try:
@@ -223,9 +262,48 @@ class ExternalLSPClient:
                 self.process = None
             self._opened_documents.clear()
             self.capabilities = {}
+            self.initialized = False
             if self._reader_thread is reader_thread:
                 self._reader_thread = None
             self._message_queue = queue.Queue()
+
+    def _request_shutdown_for_stop(self) -> None:
+        process = self.process
+        if process is None or process.stdin is None:
+            return
+        try:
+            with self._lock:
+                self._request_id += 1
+                request_id = self._request_id
+                self._write_request(request_id, "shutdown", None)
+        except Exception:
+            return
+
+        timeout_seconds = min(
+            max(float(self.request_timeout_seconds), 0.0),
+            _DEFAULT_LSP_STOP_TIMEOUT_SECONDS,
+        )
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            remaining = max(0.0, deadline - time.monotonic())
+            try:
+                message = self._message_queue.get(timeout=remaining)
+            except queue.Empty:
+                return
+            if message is None:
+                return
+            if "id" not in message:
+                if remaining <= 0:
+                    return
+                continue
+            try:
+                message_id = int(message["id"])
+            except (TypeError, ValueError):
+                continue
+            if message_id == request_id:
+                return
+            if remaining <= 0:
+                return
 
     def request(self, method: str, params: dict[str, Any]) -> Any:
         self.start()
@@ -306,6 +384,7 @@ class ExternalLSPClient:
             "command_source": _command_source(self.command),
             "managed_provider_root": str(_managed_provider_root()),
             "running": self.process is not None and self.process.poll() is None,
+            "initialized": self.initialized,
             "capabilities": dict(self.capabilities),
             "last_error": self.last_error,
             "opened_documents": len(self._opened_documents),
@@ -314,20 +393,23 @@ class ExternalLSPClient:
             "cooldown_remaining_s": max(0.0, self.disabled_until_monotonic - time.monotonic()),
         }
 
-    def _write_request(self, request_id: int, method: str, params: dict[str, Any]) -> None:
+    def _write_request(self, request_id: int, method: str, params: dict[str, Any] | None) -> None:
         if self.process is None or self.process.stdin is None:
             raise LSPTransportError("LSP process is not available")
-        _write_message(
-            self.process.stdin,
-            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
-        )
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            payload["params"] = params
+        _write_message(self.process.stdin, payload)
 
-    def _write_notification(self, method: str, params: dict[str, Any]) -> None:
+    def _write_notification(self, method: str, params: dict[str, Any] | None) -> None:
         if self.process is None or self.process.stdin is None:
             raise LSPTransportError("LSP process is not available")
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
         _write_message(
             self.process.stdin,
-            {"jsonrpc": "2.0", "method": method, "params": params},
+            payload,
         )
 
     def _reader_loop(self) -> None:
@@ -359,7 +441,14 @@ class ExternalLSPProviderManager:
             self._clients[key] = current
         return current
 
-    def provider_status(self, *, language: str, workspace_root: Path) -> dict[str, Any]:
+    def provider_status(
+        self,
+        *,
+        language: str,
+        workspace_root: Path,
+        verify_health: bool = False,
+        probe_timeout_seconds: float | None = None,
+    ) -> dict[str, Any]:
         key = (language.lower(), str(workspace_root.resolve()))
         current = self._clients.get(key)
         if current is not None:
@@ -367,11 +456,11 @@ class ExternalLSPProviderManager:
             status["available"] = True
             status["health_status"] = _provider_health_status(status)
             status["health_check"] = "cached-client"
-            return status
+            return _attach_lsp_proof_fields(status)
         try:
             command = _provider_command(language)
         except (FileNotFoundError, ValueError) as exc:
-            return {
+            return _attach_lsp_proof_fields({
                 "language": language.lower(),
                 "workspace_root": str(workspace_root.resolve()),
                 "available": False,
@@ -381,6 +470,7 @@ class ExternalLSPProviderManager:
                 "command": [],
                 "command_source": "missing",
                 "managed_provider_root": str(_managed_provider_root()),
+                "initialized": False,
                 "capabilities": {},
                 "last_error": str(exc),
                 "opened_documents": 0,
@@ -392,8 +482,48 @@ class ExternalLSPProviderManager:
                     _LSP_INITIALIZE_TIMEOUT_ENV_VAR,
                     _DEFAULT_LSP_INITIALIZE_TIMEOUT_SECONDS,
                 ),
-            }
-        return {
+                "cooldown_remaining_s": 0.0,
+            })
+        request_timeout_seconds = _configured_timeout_seconds(
+            _LSP_REQUEST_TIMEOUT_ENV_VAR,
+            _DEFAULT_LSP_REQUEST_TIMEOUT_SECONDS,
+        )
+        initialize_timeout_seconds = _configured_timeout_seconds(
+            _LSP_INITIALIZE_TIMEOUT_ENV_VAR,
+            _DEFAULT_LSP_INITIALIZE_TIMEOUT_SECONDS,
+        )
+        if verify_health:
+            timeout = (
+                max(float(probe_timeout_seconds), 0.0)
+                if probe_timeout_seconds is not None
+                else min(request_timeout_seconds, initialize_timeout_seconds)
+            )
+            client = ExternalLSPClient(
+                language=language,
+                workspace_root=workspace_root,
+                request_timeout_seconds=timeout,
+                initialize_timeout_seconds=timeout,
+            )
+            try:
+                client.start()
+                status = client.status()
+                status["available"] = True
+                status["initialized"] = True
+                status["health_status"] = "ready"
+                status["health_check"] = "probe"
+                status["probe_timeout_seconds"] = timeout
+                return _attach_lsp_proof_fields(status)
+            except (FileNotFoundError, LSPTransportError, OSError, ValueError) as exc:
+                status = client.status()
+                status["available"] = True
+                status["health_status"] = "unhealthy"
+                status["health_check"] = "probe"
+                status["last_error"] = status.get("last_error") or str(exc)
+                status["probe_timeout_seconds"] = timeout
+                return _attach_lsp_proof_fields(status)
+            finally:
+                client.stop()
+        return _attach_lsp_proof_fields({
             "language": language.lower(),
             "workspace_root": str(workspace_root.resolve()),
             "available": True,
@@ -403,19 +533,14 @@ class ExternalLSPProviderManager:
             "command": command,
             "command_source": _command_source(command),
             "managed_provider_root": str(_managed_provider_root()),
+            "initialized": False,
             "capabilities": {},
             "last_error": None,
             "opened_documents": 0,
-            "request_timeout_seconds": _configured_timeout_seconds(
-                _LSP_REQUEST_TIMEOUT_ENV_VAR,
-                _DEFAULT_LSP_REQUEST_TIMEOUT_SECONDS,
-            ),
-            "initialize_timeout_seconds": _configured_timeout_seconds(
-                _LSP_INITIALIZE_TIMEOUT_ENV_VAR,
-                _DEFAULT_LSP_INITIALIZE_TIMEOUT_SECONDS,
-            ),
+            "request_timeout_seconds": request_timeout_seconds,
+            "initialize_timeout_seconds": initialize_timeout_seconds,
             "cooldown_remaining_s": 0.0,
-        }
+        })
 
     def stop_all(self) -> None:
         clients = list(self._clients.values())
@@ -447,8 +572,30 @@ def _provider_health_status(status: dict[str, Any]) -> str:
         return "missing"
     if status.get("last_error"):
         return "unhealthy"
-    if status.get("running") and status.get("capabilities"):
+    if status.get("running") and (status.get("initialized") or status.get("capabilities")):
         return "ready"
     if status.get("running"):
         return "running_unverified"
     return "available_unverified"
+
+
+def _attach_lsp_proof_fields(status: dict[str, Any]) -> dict[str, Any]:
+    health_status = str(status.get("health_status", _provider_health_status(status)))
+    health_check = str(status.get("health_check", "not_run"))
+    lsp_proof = bool(status.get("available")) and health_status == "ready"
+    status["health_status"] = health_status
+    status["health_check"] = health_check
+    status["lsp_proof"] = lsp_proof
+    if lsp_proof:
+        status.pop("not_lsp_proof_reason", None)
+        return status
+    if not status.get("available"):
+        reason = "Provider binary is unavailable."
+    elif health_status == "available_unverified" and health_check == "not_run":
+        reason = "Provider binary is available but health was not verified."
+    elif health_status == "unhealthy":
+        reason = "Provider health probe failed or timed out."
+    else:
+        reason = "Provider has not completed a successful initialization probe."
+    status["not_lsp_proof_reason"] = reason
+    return status

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 _DEFAULT_AGENT_REPO_SCAN_LIMIT = 512
 _DEFAULT_BLAST_RADIUS_JSON_MAX_CALLERS = 25
 _DEFAULT_BLAST_RADIUS_JSON_MAX_FILES = 25
+_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS = 1.0
 _GUARDED_BROAD_SEARCH_ROOTS = {".claude", ".claude/context"}
 _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "__pycache__",
@@ -1298,10 +1299,18 @@ def _doctor_lsp_provider_statuses(path: str) -> list[dict[str, Any]]:
 
     manager = ExternalLSPProviderManager()
     workspace_root = Path(path).resolve()
-    return [
-        manager.provider_status(language=language, workspace_root=workspace_root)
-        for language in _doctor_lsp_languages()
-    ]
+    try:
+        return [
+            manager.provider_status(
+                language=language,
+                workspace_root=workspace_root,
+                verify_health=True,
+                probe_timeout_seconds=_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS,
+            )
+            for language in _doctor_lsp_languages()
+        ]
+    finally:
+        manager.stop_all()
 
 
 def _doctor_rust_core_extension_available() -> bool:
@@ -2234,11 +2243,19 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
             source = current.get("command_source", "path")
             managed_root = current.get("managed_provider_root")
             last_error = current.get("last_error")
+            health_status = current.get("health_status", "unknown")
+            health_check = current.get("health_check", "unknown")
+            lsp_proof = current.get("lsp_proof", False)
+            not_lsp_proof_reason = current.get("not_lsp_proof_reason")
             suffix = f" last_error={last_error}" if last_error else ""
             if managed_root:
                 suffix = f" managed_root={managed_root}{suffix}"
+            if not_lsp_proof_reason:
+                suffix = f"{suffix} not_lsp_proof_reason={not_lsp_proof_reason}"
             lines.append(
-                f"  {current['language']}: {availability}/{status} source={source} command={command_str}{suffix}"
+                f"  {current['language']}: {availability}/{status} "
+                f"health={health_status} health_check={health_check} "
+                f"lsp_proof={lsp_proof} source={source} command={command_str}{suffix}"
             )
     else:
         lines.append("lsp_providers: disabled")

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -9425,6 +9425,15 @@ def _attach_lsp_evidence_status(
     payload["not_lsp_proof_reason"] = "External LSP provider returned no usable evidence."
 
 
+def _is_lsp_proof_row(row: dict[str, Any]) -> bool:
+    provenance = str(row.get("provenance", ""))
+    return provenance.startswith("lsp-") and "-fallback" not in provenance
+
+
+def _lsp_proof_row_count(rows: list[dict[str, Any]]) -> int:
+    return sum(1 for row in rows if _is_lsp_proof_row(row))
+
+
 def _copy_lsp_evidence_status(payload: dict[str, Any], source: dict[str, Any]) -> None:
     for key in ("lsp_evidence_status", "lsp_proof", "not_lsp_proof_reason"):
         if key in source:
@@ -9731,7 +9740,7 @@ def build_symbol_defs_from_map(
             repo_map=repo_map,
         )
         if normalized_provider == "lsp":
-            fallback_used = not bool(external_definitions)
+            fallback_used = not bool(_lsp_proof_row_count(external_definitions))
             definitions = external_definitions or definitions
         else:
             merged: dict[tuple[str, int, int, str], dict[str, Any]] = {}
@@ -9781,10 +9790,11 @@ def build_symbol_defs_from_map(
     payload["related_paths"] = related_paths
     payload["graph_completeness"] = "strong"
     payload["semantic_provider"] = normalized_provider
+    lsp_proof_count = _lsp_proof_row_count(external_definitions)
     payload["provider_agreement"] = _merge_agreement_status(
         semantic_provider=normalized_provider,
         native_count=len(native_definitions),
-        lsp_count=len(external_definitions),
+        lsp_count=lsp_proof_count,
         merged_count=len(definitions),
         fallback_used=fallback_used,
     )
@@ -9797,7 +9807,7 @@ def build_symbol_defs_from_map(
     _attach_lsp_evidence_status(
         payload,
         semantic_provider=normalized_provider,
-        lsp_count=len(external_definitions),
+        lsp_count=lsp_proof_count,
         fallback_used=fallback_used,
     )
     if not definitions:
@@ -10255,7 +10265,7 @@ def build_symbol_refs_from_map(
             if str(Path(str(current.get("file", ""))).expanduser().resolve()) in bounded_file_set
         ]
         if normalized_provider == "lsp":
-            fallback_used = not bool(external_refs)
+            fallback_used = not bool(_lsp_proof_row_count(external_refs))
             references = external_refs or references
         else:
             merged_refs: dict[tuple[str, int, int], dict[str, Any]] = {}
@@ -10289,14 +10299,11 @@ def build_symbol_refs_from_map(
     )
     payload["coverage_summary"] = _coverage_summary(payload)
     payload["semantic_provider"] = normalized_provider
+    lsp_proof_count = _lsp_proof_row_count(external_refs)
     payload["provider_agreement"] = _merge_agreement_status(
         semantic_provider=normalized_provider,
-        native_count=len([
-            current
-            for current in references
-            if not str(current.get("provenance", "")).startswith("lsp-")
-        ]),
-        lsp_count=len(external_refs),
+        native_count=len([current for current in references if not _is_lsp_proof_row(current)]),
+        lsp_count=lsp_proof_count,
         merged_count=len(references),
         fallback_used=fallback_used,
     )
@@ -10309,7 +10316,7 @@ def build_symbol_refs_from_map(
     _attach_lsp_evidence_status(
         payload,
         semantic_provider=normalized_provider,
-        lsp_count=len(external_refs),
+        lsp_count=lsp_proof_count,
         fallback_used=fallback_used,
     )
     return payload
@@ -10630,14 +10637,13 @@ def build_symbol_callers_from_map(
     )
     payload["coverage_summary"] = _coverage_summary(payload)
     payload["semantic_provider"] = normalized_provider
+    lsp_proof_count = _lsp_proof_row_count(external_calls)
+    if normalized_provider != "native" and external_calls and lsp_proof_count == 0:
+        fallback_used = True
     payload["provider_agreement"] = _merge_agreement_status(
         semantic_provider=normalized_provider,
-        native_count=len([
-            current
-            for current in calls
-            if not str(current.get("provenance", "")).startswith("lsp-")
-        ]),
-        lsp_count=len(external_calls),
+        native_count=len([current for current in calls if not _is_lsp_proof_row(current)]),
+        lsp_count=lsp_proof_count,
         merged_count=len(calls),
         fallback_used=fallback_used,
     )
@@ -10650,7 +10656,7 @@ def build_symbol_callers_from_map(
     _attach_lsp_evidence_status(
         payload,
         semantic_provider=normalized_provider,
-        lsp_count=len(external_calls),
+        lsp_count=lsp_proof_count,
         fallback_used=fallback_used,
     )
     _copy_scan_limit(payload, defs_payload)

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -926,6 +926,9 @@ def test_doctor_json_includes_runtime_session_and_lsp(monkeypatch, tmp_path: Pat
                 "command_source": "managed",
                 "managed_provider_root": str(tmp_path / "providers"),
                 "last_error": None,
+                "health_status": "ready",
+                "health_check": "probe",
+                "lsp_proof": True,
             }
         ],
     )
@@ -951,6 +954,9 @@ def test_doctor_json_includes_runtime_session_and_lsp(monkeypatch, tmp_path: Pat
     assert payload["lsp"]["providers"][0]["language"] == "python"
     assert payload["lsp"]["providers"][0]["command_source"] == "managed"
     assert payload["lsp"]["providers"][0]["managed_provider_root"] == str(tmp_path / "providers")
+    assert payload["lsp"]["providers"][0]["health_status"] == "ready"
+    assert payload["lsp"]["providers"][0]["health_check"] == "probe"
+    assert payload["lsp"]["providers"][0]["lsp_proof"] is True
 
 
 def test_doctor_json_includes_gpu_search_runtime_probe(monkeypatch, tmp_path: Path) -> None:
@@ -1647,6 +1653,41 @@ def test_doctor_text_reports_disabled_lsp_and_stopped_daemon(monkeypatch, tmp_pa
     assert "native_tg_binary: missing" in result.stdout
     assert "session_daemon: stopped" in result.stdout
     assert "lsp_providers: disabled" in result.stdout
+
+
+def test_doctor_text_reports_lsp_health_and_proof_fields(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.2.3")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_lsp_provider_statuses",
+        lambda path: [
+            {
+                "language": "python",
+                "available": True,
+                "running": False,
+                "command": ["pyright-langserver", "--stdio"],
+                "command_source": "managed",
+                "managed_provider_root": str(tmp_path / "providers"),
+                "last_error": None,
+                "health_status": "available_unverified",
+                "health_check": "not_run",
+                "lsp_proof": False,
+                "not_lsp_proof_reason": "Provider binary is available but health was not verified.",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "health=available_unverified" in result.stdout
+    assert "health_check=not_run" in result.stdout
+    assert "lsp_proof=False" in result.stdout
+    assert "not_lsp_proof_reason=" in result.stdout
 
 
 def test_doctor_json_explains_rust_core_extension_when_standalone_binary_missing(

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import os
+import queue
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import tensor_grep.cli.lsp_external_provider as provider_module
-from tensor_grep.cli.lsp_external_provider import ExternalLSPClient, ExternalLSPProviderManager
+from tensor_grep.cli.lsp_external_provider import (
+    ExternalLSPClient,
+    ExternalLSPProviderManager,
+    LSPTransportError,
+)
 
 
 def test_provider_status_reports_missing_binary(tmp_path: Path) -> None:
@@ -87,8 +93,98 @@ def test_provider_status_reports_configured_timeouts_without_cached_client(
     assert status["available"] is True
     assert status["health_status"] == "available_unverified"
     assert status["health_check"] == "not_run"
+    assert status["lsp_proof"] is False
+    assert "not verified" in status["not_lsp_proof_reason"]
     assert status["request_timeout_seconds"] == 6.0
     assert status["initialize_timeout_seconds"] == 21.0
+
+
+def test_provider_status_available_binary_is_unverified_without_probe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+
+    status = ExternalLSPProviderManager().provider_status(
+        language="python",
+        workspace_root=tmp_path,
+    )
+
+    assert status["available"] is True
+    assert status["health_status"] == "available_unverified"
+    assert status["health_check"] == "not_run"
+    assert status["lsp_proof"] is False
+    assert status["not_lsp_proof_reason"]
+
+
+def test_provider_status_verify_health_success_reports_lsp_proof(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    seen_timeouts: list[tuple[float, float]] = []
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        seen_timeouts.append((self.request_timeout_seconds, self.initialize_timeout_seconds))
+        self.capabilities = {"definitionProvider": True}
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "stop", lambda self: None)
+
+    status = ExternalLSPProviderManager().provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.25,
+    )
+
+    assert seen_timeouts == [(0.25, 0.25)]
+    assert status["available"] is True
+    assert status["health_status"] == "ready"
+    assert status["health_check"] == "probe"
+    assert status["lsp_proof"] is True
+    assert "not_lsp_proof_reason" not in status
+
+
+def test_provider_status_verify_health_failure_reports_unhealthy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        self.disabled_until_monotonic = time.monotonic() + 30.0
+        raise LSPTransportError("timeout waiting for LSP response: initialize")
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "stop", lambda self: None)
+
+    status = ExternalLSPProviderManager().provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.2,
+    )
+
+    assert status["available"] is True
+    assert status["health_status"] == "unhealthy"
+    assert status["health_check"] == "probe"
+    assert status["lsp_proof"] is False
+    assert status["last_error"] == "timeout waiting for LSP response: initialize"
+    assert status["probe_timeout_seconds"] == 0.2
+    assert status["cooldown_remaining_s"] > 0.0
 
 
 def test_provider_status_prefers_managed_provider_root(
@@ -158,6 +254,111 @@ def test_external_provider_client_starts_managed_provider_with_managed_runtime_e
         else provider_root / "node-runtime" / "bin"
     )
     assert str(expected_node_path) in str(env["PATH"]).split(os.pathsep)
+
+
+def test_external_provider_client_start_orders_initialize_initialized_and_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    written_messages: list[dict[str, Any]] = []
+    responses: queue.Queue[dict[str, Any] | None] = queue.Queue()
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"capabilities": {"definitionProvider": True}},
+    })
+    responses.put(None)
+
+    class _FakeStream:
+        def close(self) -> None:
+            return None
+
+    class _FakeProcess:
+        stdin = _FakeStream()
+        stdout = _FakeStream()
+        stderr = _FakeStream()
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(provider_module.subprocess, "Popen", lambda *args, **kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        provider_module,
+        "_write_message",
+        lambda _stream, payload: written_messages.append(dict(payload)),
+    )
+    monkeypatch.setattr(provider_module, "_read_message", lambda _stream: responses.get())
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.start()
+
+    assert [message["method"] for message in written_messages] == [
+        "initialize",
+        "initialized",
+        "workspace/didChangeConfiguration",
+    ]
+    initialize_message = written_messages[0]
+    assert "id" in initialize_message
+    settings = written_messages[2]["params"]["settings"]
+    analysis_settings = settings["python"]["analysis"]
+    assert analysis_settings["diagnosticMode"] == "openFilesOnly"
+    assert "node_modules" in analysis_settings["exclude"]
+    assert "__pycache__" in analysis_settings["exclude"]
+    assert ".venv" in analysis_settings["exclude"]
+
+
+def test_external_provider_client_stop_sends_shutdown_request_then_exit_notification(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    written_messages: list[dict[str, Any]] = []
+
+    class _FakeStream:
+        def close(self) -> None:
+            return None
+
+    class _FakeProcess:
+        stdin = _FakeStream()
+        stdout = _FakeStream()
+        stderr = _FakeStream()
+
+        def poll(self) -> None:
+            return None
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        provider_module,
+        "_write_message",
+        lambda _stream, payload: written_messages.append(dict(payload)),
+    )
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.process = _FakeProcess()  # type: ignore[assignment]
+    client._message_queue.put({"jsonrpc": "2.0", "id": 1, "result": None})
+
+    client.stop()
+
+    assert [message["method"] for message in written_messages] == ["shutdown", "exit"]
+    assert "id" in written_messages[0]
+    assert "id" not in written_messages[1]
 
 
 def test_external_provider_client_respects_retry_cooldown(

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -338,6 +338,41 @@ def test_repo_map_callers_hybrid_can_expand_js_ts_import_alias_wrappers(
     )
 
 
+def test_repo_map_callers_lsp_fallback_alias_rows_are_not_lsp_proof(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payments_path = tmp_path / "payments.ts"
+    service_path = tmp_path / "service.ts"
+    payments_path.write_text(
+        "export function createInvoiceAliasWrapper(total: number) {\n    return total + 1;\n}\n",
+        encoding="utf-8",
+    )
+    service_path.write_text(
+        'import { createInvoiceAliasWrapper as invoice } from "./payments";\n'
+        "const runInvoice = invoice;\n\n"
+        "export function buildReceipt(total: number) {\n"
+        "  return runInvoice(total);\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", lambda root, symbol, **kwargs: [])
+    monkeypatch.setattr(repo_map, "_external_references", lambda root, symbol, definitions: [])
+
+    payload = repo_map.build_symbol_callers(
+        "createInvoiceAliasWrapper",
+        tmp_path,
+        semantic_provider="lsp",
+    )
+
+    assert payload["semantic_provider"] == "lsp"
+    assert any(current["file"] == str(service_path.resolve()) for current in payload["callers"])
+    assert all("-fallback" in str(current.get("provenance", "")) for current in payload["callers"])
+    assert payload["lsp_evidence_status"] == "fallback_native"
+    assert payload["lsp_proof"] is False
+    assert "native fallback" in payload["not_lsp_proof_reason"].lower()
+
+
 def test_repo_map_blast_radius_hybrid_can_include_js_ts_alias_wrapper_callers(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add bounded LSP health probes that distinguish binary availability from initialized provider proof
- send initialized/configuration in the provider startup path and shutdown/exit in stop
- surface LSP health/proof fields in doctor output
- avoid counting fallback-derived LSP rows as real LSP proof

## Research / review
- Exa: LSP 3.17 lifecycle requires initialize before other messages, initialized after initialize, and shutdown request plus exit notification
- Exa: Pyright settings support `python.analysis.diagnosticMode=openFilesOnly` and generated/cache excludes
- Thinktank: narrowed the slice to bounded, honest evidence instead of broad LSP parity claims
- Gemini: read-only diff review returned APPROVE, no blocking findings

## Validation
- `uv run pytest tests/unit/test_lsp_external_provider.py tests/unit/test_cli_modes.py tests/unit/test_semantic_provider_navigation.py -q` -> 383 passed
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `uv run pytest -q` -> 2154 passed, 50 skipped
- `git diff --check`
