### PR TITLE
fix: add evidence-gated python validation fallback

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -6627,7 +6627,50 @@ def _primary_language_fallback_validation_steps(
                 "confidence": 0.5,
                 "detection": "detected",
             })
+    elif primary_language == "python" and _has_python_validation_fallback_evidence(root):
+        detected = _detect_validation_runners_from_root(root)
+        if detected.python_detection == "detected":
+            steps.append({
+                "command": "uv run pytest -q",
+                "scope": "repo",
+                "runner": "pytest",
+                "confidence": 0.55,
+                "detection": "detected",
+            })
     return steps
+
+
+def _has_python_validation_fallback_evidence(root: Path) -> bool:
+    if any(
+        (root / marker).is_file()
+        for marker in (
+            "pyproject.toml",
+            "pytest.ini",
+            "setup.py",
+            "setup.cfg",
+            "tox.ini",
+        )
+    ):
+        return True
+    return any(
+        current.suffix == ".py" and _is_test_file(current)
+        for current in _iter_repo_files(root, max_files=_VALIDATION_RUNNER_SCAN_LIMIT)
+    )
+
+
+def _without_heuristic_repo_cargo_fallback(
+    validation_plan: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        dict(step)
+        for step in validation_plan
+        if not (
+            str(step.get("runner") or "") == "cargo"
+            and str(step.get("command") or "") == "cargo test"
+            and str(step.get("scope") or "") == "repo"
+            and str(step.get("detection") or "") == "heuristic"
+        )
+    ]
 
 
 def _ensure_primary_language_validation_fallback(
@@ -6672,11 +6715,18 @@ def _ensure_primary_language_validation_fallback(
             ]
             augmented.extend(dict(step) for step in fallback_steps)
             return augmented
+        if primary_language == "python" and fallback_commands:
+            return _without_heuristic_repo_cargo_fallback(validation_plan)
         return validation_plan
     if not fallback_steps:
         return validation_plan
-    seen = {str(step.get("command") or "") for step in validation_plan}
-    augmented = [dict(step) for step in validation_plan]
+    base_plan = (
+        _without_heuristic_repo_cargo_fallback(validation_plan)
+        if primary_language == "python"
+        else validation_plan
+    )
+    seen = {str(step.get("command") or "") for step in base_plan}
+    augmented = [dict(step) for step in base_plan]
     for step in fallback_steps:
         command = str(step.get("command") or "")
         if command and command not in seen:

--- a/tests/unit/test_validation_commands.py
+++ b/tests/unit/test_validation_commands.py
@@ -602,6 +602,73 @@ def test_rust_primary_replaces_heuristic_repo_fallback_with_nested_manifest(
     assert alignment["filtered_count"] == 0
 
 
+def test_python_primary_uses_detected_repo_pytest_fallback_with_rust_present(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    python_src = project / "src"
+    rust_src = project / "rust_core" / "src"
+    tests_dir = project / "tests"
+    python_src.mkdir(parents=True)
+    rust_src.mkdir(parents=True)
+    tests_dir.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (project / "rust_core" / "Cargo.toml").write_text(
+        '[package]\nname = "sample-rust-core"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    primary_file = python_src / "payments.py"
+    primary_file.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+    (rust_src / "main.rs").write_text("pub fn native() -> bool { true }\n", encoding="utf-8")
+
+    plan, alignment = repo_map._validation_plan_and_alignment_for_tests(
+        [],
+        repo_root=project,
+        primary_file=str(primary_file.resolve()),
+        query="python cli source target",
+    )
+
+    assert plan == [
+        {
+            "command": "uv run pytest -q",
+            "scope": "repo",
+            "runner": "pytest",
+            "confidence": 0.55,
+            "detection": "detected",
+        }
+    ]
+    assert alignment["status"] == "aligned"
+    assert alignment["primary_target_language"] == "python"
+    assert alignment["kept_count"] == 1
+    assert alignment["filtered_count"] == 0
+
+
+def test_python_primary_without_project_or_test_evidence_has_no_validation(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    primary_file = src_dir / "payments.py"
+    primary_file.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+
+    plan, alignment = repo_map._validation_plan_and_alignment_for_tests(
+        [],
+        repo_root=project,
+        primary_file=str(primary_file.resolve()),
+        query="python source target",
+    )
+
+    assert plan == []
+    assert alignment["status"] == "no-validation"
+    assert alignment["primary_target_language"] == "python"
+    assert alignment["kept_count"] == 0
+    assert alignment["filtered_count"] == 0
+
+
 def test_detect_validation_runners_is_cached_per_repo_root(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()


### PR DESCRIPTION
## Summary
- Add an evidence-gated Python primary-file validation fallback for agent/context capsules.
- Require explicit Python project/test evidence before suggesting `uv run pytest -q`, so JS/TS-only `tests/` directories do not trigger pytest.
- Strip only the heuristic repo-wide `cargo test` fallback before adding Python validation, preserving stronger detected Rust validation where appropriate.

## Research / Review
- Exa anchors checked current pytest, Cargo, Ruff, and mypy CLI contracts; this slice deliberately limits fallback to pytest and avoids broad lint/type/package-manager guesses.
- Thinktank consensus was to add a narrow Python fallback only when local runner evidence exists, and to preserve language-alignment filtering.
- Gemini read-only diff review returned APPROVE after the final regression fix; its transient model-capacity stack did not affect the final audit result.

## Validation
- `uv run pytest tests/unit/test_cli_modes.py::test_validation_alignment_filters_javascript_commands_for_python_primary_file tests/unit/test_validation_commands.py::test_python_primary_uses_detected_repo_pytest_fallback_with_rust_present tests/unit/test_validation_commands.py::test_python_primary_without_project_or_test_evidence_has_no_validation -q` -> 3 passed
- `uv run pytest tests/unit/test_validation_commands.py tests/unit/test_agent_capsule_hardcases.py -q` -> 44 passed
- `uv run ruff check .` -> passed
- `uv run ruff format --check --preview .` -> passed
- `uv run mypy src/tensor_grep` -> passed
- `uv run pytest -q` -> 2190 passed, 16 skipped
- `git diff --check` -> passed