### PR TITLE
fix: add dogfood progress heartbeats

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -27,6 +27,11 @@ from native_cpu_benchmark_utils import (  # noqa: E402
     resolve_native_cpu_bench_data_dir,
 )
 from tensor_grep.cli.runtime_paths import inspect_native_tg_binary  # noqa: E402
+from tensor_grep.cli.progress import (  # noqa: E402
+    PROGRESS_MODES,
+    ProgressReporter,
+    positive_progress_interval_s,
+)
 from tensor_grep.perf_guard import benchmark_host_key  # noqa: E402
 
 # Scenarios to test
@@ -653,7 +658,14 @@ def compare_results(rg_out, tg_out, scenario_name):
     return True
 
 
-def main() -> int:
+def _argparse_progress_interval_s(value: str) -> float:
+    try:
+        return positive_progress_interval_s(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def main(argv: list[str] | None = None) -> int:
     from tensor_grep.perf_guard import ensure_artifacts_dir, write_json
 
     parser = argparse.ArgumentParser(description="Run text-search benchmarks for tensor-grep.")
@@ -702,7 +714,24 @@ def main() -> int:
             "for claims, such as a stale in-tree native tg binary."
         ),
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--progress",
+        choices=PROGRESS_MODES,
+        default="auto",
+        help="Progress reporting mode: auto, always, or never. Emits to stderr only.",
+    )
+    parser.add_argument(
+        "--progress-interval-s",
+        type=_argparse_progress_interval_s,
+        default=30.0,
+        help="Seconds between progress heartbeats for the active phase.",
+    )
+    args = parser.parse_args(argv)
+    progress = ProgressReporter(
+        mode=args.progress,
+        interval_s=args.progress_interval_s,
+        json_output=False,
+    )
     if args.launcher_mode == "explicit_fast_binary":
         if args.binary:
             tg_binary, tg_binary_source = resolve_tg_binary_with_source(args.binary)
@@ -734,18 +763,20 @@ def main() -> int:
         emit_benchmark_claim_blockers(blockers)
         return 2
 
-    generate_test_data(
-        str(bench_dir), num_files=2, lines_per_file=2_000_000
-    )  # ~240MB total, triggers 50MB GPU chunking bypass
+    with progress.phase("generate-data"):
+        generate_test_data(
+            str(bench_dir), num_files=2, lines_per_file=2_000_000
+        )  # ~240MB total, triggers 50MB GPU chunking bypass
 
     rg_bin = resolve_rg_binary()
     native_fixture_payload: dict[str, object] | None = None
     large_file_path: Path | None = None
     many_file_dir: Path | None = None
     if args.native:
-        native_data_dir = resolve_native_cpu_bench_data_dir()
-        large_fixture = ensure_large_file_fixture(native_data_dir)
-        many_fixture = ensure_many_file_fixture(native_data_dir)
+        with progress.phase("native-fixtures"):
+            native_data_dir = resolve_native_cpu_bench_data_dir()
+            large_fixture = ensure_large_file_fixture(native_data_dir)
+            many_fixture = ensure_many_file_fixture(native_data_dir)
         large_file_path = Path(large_fixture["path"])
         many_file_dir = Path(many_fixture["path"])
         native_fixture_payload = {
@@ -780,71 +811,73 @@ def main() -> int:
     parity_failures = 0
     parity_jobs: list[tuple[str, list[str], list[str], dict[str, object]]] = []
 
-    for scenario in benchmark_scenarios:
-        rg_cmd = scenario["rg_cmd"]
-        actual_tg_cmd = scenario["tg_cmd"]
-        capture_stdout_for_timing = scenario_timing_should_capture_stdout(str(scenario["name"]))
+    with progress.phase("timing"):
+        for scenario in benchmark_scenarios:
+            rg_cmd = scenario["rg_cmd"]
+            actual_tg_cmd = scenario["tg_cmd"]
+            capture_stdout_for_timing = scenario_timing_should_capture_stdout(str(scenario["name"]))
 
-        # Warmup to reduce first-run jitter (regex compilation/import effects).
-        for _ in range(scenario_timing_warmup_runs(str(scenario["name"]))):
-            run_cmd_timing(rg_cmd, capture_stdout=capture_stdout_for_timing)
+            # Warmup to reduce first-run jitter (regex compilation/import effects).
+            for _ in range(scenario_timing_warmup_runs(str(scenario["name"]))):
+                run_cmd_timing(rg_cmd, capture_stdout=capture_stdout_for_timing)
+                if tg_env_overrides:
+                    run_cmd_timing(
+                        actual_tg_cmd,
+                        capture_stdout=capture_stdout_for_timing,
+                        env_overrides=tg_env_overrides,
+                    )
+                else:
+                    run_cmd_timing(actual_tg_cmd, capture_stdout=capture_stdout_for_timing)
+
+            # Actual benchmark
+            rg_time, rg_samples = collect_timing_samples(
+                rg_cmd,
+                capture_stdout=capture_stdout_for_timing,
+            )
+
             if tg_env_overrides:
-                run_cmd_timing(
+                tg_time, tg_samples = collect_timing_samples(
                     actual_tg_cmd,
                     capture_stdout=capture_stdout_for_timing,
                     env_overrides=tg_env_overrides,
                 )
             else:
-                run_cmd_timing(actual_tg_cmd, capture_stdout=capture_stdout_for_timing)
+                tg_time, tg_samples = collect_timing_samples(
+                    actual_tg_cmd,
+                    capture_stdout=capture_stdout_for_timing,
+                )
 
-        # Actual benchmark
-        rg_time, rg_samples = collect_timing_samples(
-            rg_cmd,
-            capture_stdout=capture_stdout_for_timing,
-        )
+            row = {
+                "name": scenario["name"],
+                "rg_samples_s": rg_samples,
+                "rg_time_s": rg_time,
+                "tg_samples_s": tg_samples,
+                "tg_time_s": tg_time,
+                "parity": "PENDING",
+            }
+            rows.append(row)
+            parity_jobs.append((str(scenario["name"]), rg_cmd, actual_tg_cmd, row))
 
-        if tg_env_overrides:
-            tg_time, tg_samples = collect_timing_samples(
-                actual_tg_cmd,
-                capture_stdout=capture_stdout_for_timing,
-                env_overrides=tg_env_overrides,
+    with progress.phase("parity"):
+        for scenario_name, rg_cmd, actual_tg_cmd, row in parity_jobs:
+            _, rg_out = run_cmd_capture(rg_cmd)
+            if tg_env_overrides:
+                _, tg_out = run_cmd_capture(actual_tg_cmd, env_overrides=tg_env_overrides)
+            else:
+                _, tg_out = run_cmd_capture(actual_tg_cmd)
+
+            parity_ok = compare_results(rg_out, tg_out, scenario_name)
+            parity_str = "PASS" if parity_ok else "FAIL"
+            row["parity"] = parity_str
+            if not parity_ok:
+                parity_failures += 1
+
+            print(
+                f"{scenario_name:<35} | {row['rg_time_s']:>8.3f}s | {row['tg_time_s']:>8.3f}s | {parity_str}"
             )
-        else:
-            tg_time, tg_samples = collect_timing_samples(
-                actual_tg_cmd,
-                capture_stdout=capture_stdout_for_timing,
-            )
-
-        row = {
-            "name": scenario["name"],
-            "rg_samples_s": rg_samples,
-            "rg_time_s": rg_time,
-            "tg_samples_s": tg_samples,
-            "tg_time_s": tg_time,
-            "parity": "PENDING",
-        }
-        rows.append(row)
-        parity_jobs.append((str(scenario["name"]), rg_cmd, actual_tg_cmd, row))
-
-    for scenario_name, rg_cmd, actual_tg_cmd, row in parity_jobs:
-        _, rg_out = run_cmd_capture(rg_cmd)
-        if tg_env_overrides:
-            _, tg_out = run_cmd_capture(actual_tg_cmd, env_overrides=tg_env_overrides)
-        else:
-            _, tg_out = run_cmd_capture(actual_tg_cmd)
-
-        parity_ok = compare_results(rg_out, tg_out, scenario_name)
-        parity_str = "PASS" if parity_ok else "FAIL"
-        row["parity"] = parity_str
-        if not parity_ok:
-            parity_failures += 1
-
-        print(
-            f"{scenario_name:<35} | {row['rg_time_s']:>8.3f}s | {row['tg_time_s']:>8.3f}s | {parity_str}"
-        )
-        del rg_out
-        del tg_out
-        gc.collect()
+            del rg_out
+            del tg_out
+            gc.collect()
 
     artifacts_dir = ensure_artifacts_dir(ROOT_DIR)
     payload = {

--- a/benchmarks/run_compat_checks.py
+++ b/benchmarks/run_compat_checks.py
@@ -26,6 +26,12 @@ SRC_DIR = ROOT_DIR / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
+from tensor_grep.cli.progress import (  # noqa: E402
+    PROGRESS_MODES,
+    ProgressReporter,
+    positive_progress_interval_s,
+)
+
 WINDOWS_RG_DIRNAME = "ripgrep-14.1.0-x86_64-pc-windows-msvc"
 ROUTING_MATCH_PREVIEW_LIMIT = 20
 ROUTING_PATH_PREVIEW_LIMIT = 50
@@ -428,7 +434,14 @@ def run_compat_suite(
     }
 
 
-def parse_args() -> argparse.Namespace:
+def _argparse_progress_interval_s(value: str) -> float:
+    try:
+        return positive_progress_interval_s(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Run the CLI parity and compatibility gate. Both tools are forced to use "
@@ -455,13 +468,25 @@ def parse_args() -> argparse.Namespace:
         "--output",
         help="Optional path for the compat JSON report. Defaults to artifacts/compat_report.json.",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--progress",
+        choices=PROGRESS_MODES,
+        default="auto",
+        help="Progress reporting mode: auto, always, or never. Emits to stderr only.",
+    )
+    parser.add_argument(
+        "--progress-interval-s",
+        type=_argparse_progress_interval_s,
+        default=30.0,
+        help="Seconds between progress heartbeats for the active phase.",
+    )
+    return parser.parse_args(argv)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     from tensor_grep.perf_guard import ensure_artifacts_dir, write_json
 
-    args = parse_args()
+    args = parse_args(argv)
     tg_binary = Path(args.binary)
     bench_data_dir = Path(args.bench_data_dir)
     schema_path = Path(args.schema)
@@ -482,12 +507,18 @@ def main() -> int:
         print(str(exc), file=sys.stderr)
         return 2
 
-    report = run_compat_suite(
-        tg_binary=tg_binary,
-        rg_binary=rg_binary,
-        bench_data_dir=bench_data_dir,
-        schema_path=schema_path,
+    progress = ProgressReporter(
+        mode=args.progress,
+        interval_s=args.progress_interval_s,
+        json_output=False,
     )
+    with progress.phase("compat-suite"):
+        report = run_compat_suite(
+            tg_binary=tg_binary,
+            rg_binary=rg_binary,
+            bench_data_dir=bench_data_dir,
+            schema_path=schema_path,
+        )
 
     output_path = (
         Path(args.output) if args.output else ensure_artifacts_dir(ROOT_DIR) / "compat_report.json"

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -14,7 +14,16 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
 IS_WINDOWS = os.name == "nt"
+
+from tensor_grep.cli.progress import (  # noqa: E402
+    PROGRESS_MODES,
+    ProgressReporter,
+    positive_progress_interval_s,
+)
 
 
 class ReadinessError(RuntimeError):
@@ -680,6 +689,13 @@ def _command_available(command: list[str]) -> bool:
     return shutil.which(command[0]) is not None
 
 
+def _argparse_progress_interval_s(value: str) -> float:
+    try:
+        return positive_progress_interval_s(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def run_check(check: Check, *, repo_root: Path, expected_version: str) -> dict[str, Any]:
     started = time.monotonic()
     if not _command_available(check.command):
@@ -778,6 +794,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", type=Path, help="Optional JSON report path.")
     parser.add_argument("--json", action="store_true", help="Print JSON report to stdout.")
     parser.add_argument(
+        "--progress",
+        choices=PROGRESS_MODES,
+        default="auto",
+        help="Progress reporting mode: auto, always, or never. Emits to stderr only.",
+    )
+    parser.add_argument(
+        "--progress-interval-s",
+        type=_argparse_progress_interval_s,
+        default=30.0,
+        help="Seconds between progress heartbeats for the active phase.",
+    )
+    parser.add_argument(
         "--no-shell-probes", action="store_true", help="Skip public shell version probes."
     )
     parser.add_argument("--no-wsl-probe", action="store_true", help="Skip the optional WSL probe.")
@@ -792,9 +820,15 @@ def main(argv: list[str] | None = None) -> int:
         include_wsl_probe=not args.no_wsl_probe,
     )
 
+    progress = ProgressReporter(
+        mode=args.progress,
+        interval_s=args.progress_interval_s,
+        json_output=args.json,
+    )
     results: list[dict[str, Any]] = []
     for check in checks:
-        result = run_check(check, repo_root=repo_root, expected_version=expected_version)
+        with progress.phase(check.name):
+            result = run_check(check, repo_root=repo_root, expected_version=expected_version)
         results.append(result)
         if not args.json:
             print(

--- a/src/tensor_grep/cli/dogfood.py
+++ b/src/tensor_grep/cli/dogfood.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from tensor_grep.cli.progress import ProgressReporter
+
 
 def _json_from_stdout(stdout: str) -> dict[str, Any]:
     stripped = stdout.strip()
@@ -47,6 +49,9 @@ def run_dogfood_readiness(
     expected_version: str | None = None,
     include_shell_probes: bool = True,
     include_wsl_probe: bool = True,
+    progress_mode: str = "auto",
+    progress_interval_s: float = 30.0,
+    json_output: bool = False,
 ) -> tuple[int, dict[str, Any]]:
     repo_root = root.expanduser().resolve()
     readiness_script = repo_root / "scripts" / "agent_readiness.py"
@@ -64,56 +69,62 @@ def run_dogfood_readiness(
     if not include_wsl_probe:
         command.append("--no-wsl-probe")
 
-    if not readiness_script.exists():
-        agent_readiness: dict[str, Any] = {
-            "artifact": "agent_readiness_report",
-            "root": str(repo_root),
-            "summary": {"passed": 0, "failed": 1, "skipped": 0},
-            "results": [
-                {
-                    "name": "agent-readiness-script",
-                    "status": "failed",
-                    "message": f"missing readiness script: {readiness_script}",
-                }
-            ],
-        }
-        returncode = 1
-        stdout = ""
-        stderr = f"missing readiness script: {readiness_script}"
-    else:
-        env = dict(os.environ)
-        env.setdefault("PYTHONUTF8", "1")
-        completed = subprocess.run(
-            command,
-            cwd=repo_root,
-            env=env,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            capture_output=True,
-            check=False,
-        )
-        returncode = completed.returncode
-        stdout = completed.stdout
-        stderr = completed.stderr
-        try:
-            agent_readiness = _json_from_stdout(stdout)
-        except ValueError as exc:
+    progress = ProgressReporter(
+        mode=progress_mode,
+        interval_s=progress_interval_s,
+        json_output=json_output,
+    )
+    with progress.phase("agent-readiness"):
+        if not readiness_script.exists():
             agent_readiness = {
                 "artifact": "agent_readiness_report",
                 "root": str(repo_root),
                 "summary": {"passed": 0, "failed": 1, "skipped": 0},
                 "results": [
                     {
-                        "name": "agent-readiness-json",
+                        "name": "agent-readiness-script",
                         "status": "failed",
-                        "message": str(exc),
-                        "stdout_tail": stdout.splitlines()[-20:],
-                        "stderr_tail": stderr.splitlines()[-20:],
+                        "message": f"missing readiness script: {readiness_script}",
                     }
                 ],
             }
             returncode = 1
+            stdout = ""
+            stderr = f"missing readiness script: {readiness_script}"
+        else:
+            env = dict(os.environ)
+            env.setdefault("PYTHONUTF8", "1")
+            completed = subprocess.run(
+                command,
+                cwd=repo_root,
+                env=env,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                check=False,
+            )
+            returncode = completed.returncode
+            stdout = completed.stdout
+            stderr = completed.stderr
+            try:
+                agent_readiness = _json_from_stdout(stdout)
+            except ValueError as exc:
+                agent_readiness = {
+                    "artifact": "agent_readiness_report",
+                    "root": str(repo_root),
+                    "summary": {"passed": 0, "failed": 1, "skipped": 0},
+                    "results": [
+                        {
+                            "name": "agent-readiness-json",
+                            "status": "failed",
+                            "message": str(exc),
+                            "stdout_tail": stdout.splitlines()[-20:],
+                            "stderr_tail": stderr.splitlines()[-20:],
+                        }
+                    ],
+                }
+                returncode = 1
 
     report = {
         "artifact": "dogfood_readiness_report",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7107,6 +7107,16 @@ def dogfood(
         None, "--expected-version", help="Expected tensor-grep version. Defaults to pyproject."
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+    progress: str = typer.Option(
+        "auto",
+        "--progress",
+        help="Progress reporting mode: auto, always, or never. Emits to stderr only.",
+    ),
+    progress_interval_s: float = typer.Option(
+        30.0,
+        "--progress-interval-s",
+        help="Seconds between progress heartbeats for the active phase.",
+    ),
     no_shell_probes: bool = typer.Option(
         False, "--no-shell-probes", help="Skip public shell version probes."
     ),
@@ -7114,13 +7124,24 @@ def dogfood(
 ) -> None:
     """Run the agent-readiness dogfood gate and emit a release-readiness verdict."""
     from tensor_grep.cli.dogfood import run_dogfood_readiness
+    from tensor_grep.cli.progress import normalize_progress_mode
 
+    try:
+        progress_mode = normalize_progress_mode(progress)
+        if progress_interval_s <= 0:
+            raise ValueError("progress interval must be greater than 0")
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
     exit_code, report = run_dogfood_readiness(
         root=root,
         output=output,
         expected_version=expected_version,
         include_shell_probes=not no_shell_probes,
         include_wsl_probe=not no_wsl_probe,
+        progress_mode=progress_mode,
+        progress_interval_s=progress_interval_s,
+        json_output=json_output,
     )
     if json_output:
         typer.echo(json.dumps(report, indent=2, sort_keys=True))

--- a/src/tensor_grep/cli/progress.py
+++ b/src/tensor_grep/cli/progress.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Literal, TextIO, cast
+
+ProgressMode = Literal["auto", "always", "never"]
+PROGRESS_MODES: tuple[ProgressMode, ...] = ("auto", "always", "never")
+
+
+def normalize_progress_mode(value: str) -> ProgressMode:
+    mode = value.strip().lower()
+    if mode not in PROGRESS_MODES:
+        choices = ", ".join(PROGRESS_MODES)
+        raise ValueError(f"invalid progress mode {value!r}; expected one of: {choices}")
+    return cast(ProgressMode, mode)
+
+
+def positive_progress_interval_s(value: str) -> float:
+    try:
+        interval = float(value)
+    except ValueError as exc:
+        raise ValueError("progress interval must be a number") from exc
+    if interval <= 0:
+        raise ValueError("progress interval must be greater than 0")
+    return interval
+
+
+class ProgressReporter:
+    def __init__(
+        self,
+        *,
+        mode: str = "auto",
+        interval_s: float = 30.0,
+        json_output: bool = False,
+        stream: TextIO | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.mode = normalize_progress_mode(mode)
+        if interval_s <= 0:
+            raise ValueError("progress interval must be greater than 0")
+        self.interval_s = interval_s
+        self.stream = stream if stream is not None else sys.stderr
+        self.clock = clock
+        self.enabled = self._should_emit(json_output=json_output)
+
+    def _should_emit(self, *, json_output: bool) -> bool:
+        if self.mode == "always":
+            return True
+        if self.mode == "never" or json_output:
+            return False
+        return bool(os.environ.get("CI")) or self.stream.isatty()
+
+    def _emit(self, message: str) -> None:
+        if not self.enabled:
+            return
+        print(f"[progress] {message}", file=self.stream, flush=True)
+
+    def _elapsed_s(self, started_at: float) -> int:
+        return max(0, int(self.clock() - started_at))
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        started_at = self.clock()
+        stop_event = threading.Event()
+        heartbeat_thread: threading.Thread | None = None
+        self._emit(f"{name} start")
+
+        if self.enabled:
+
+            def _heartbeat() -> None:
+                while not stop_event.wait(self.interval_s):
+                    self._emit(f"{name} running {self._elapsed_s(started_at)}s")
+
+            heartbeat_thread = threading.Thread(target=_heartbeat, daemon=True)
+            heartbeat_thread.start()
+
+        try:
+            yield
+        except BaseException:
+            stop_event.set()
+            if heartbeat_thread is not None:
+                heartbeat_thread.join(timeout=0.2)
+            self._emit(f"{name} failed {self._elapsed_s(started_at)}s")
+            raise
+        else:
+            stop_event.set()
+            if heartbeat_thread is not None:
+                heartbeat_thread.join(timeout=0.2)
+            self._emit(f"{name} done {self._elapsed_s(started_at)}s")

--- a/src/tensor_grep/cli/progress.py
+++ b/src/tensor_grep/cli/progress.py
@@ -6,7 +6,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from typing import Literal, TextIO, cast
+from typing import Literal, TextIO
 
 ProgressMode = Literal["auto", "always", "never"]
 PROGRESS_MODES: tuple[ProgressMode, ...] = ("auto", "always", "never")
@@ -14,10 +14,14 @@ PROGRESS_MODES: tuple[ProgressMode, ...] = ("auto", "always", "never")
 
 def normalize_progress_mode(value: str) -> ProgressMode:
     mode = value.strip().lower()
-    if mode not in PROGRESS_MODES:
-        choices = ", ".join(PROGRESS_MODES)
-        raise ValueError(f"invalid progress mode {value!r}; expected one of: {choices}")
-    return cast(ProgressMode, mode)
+    if mode == "auto":
+        return "auto"
+    if mode == "always":
+        return "always"
+    if mode == "never":
+        return "never"
+    choices = ", ".join(PROGRESS_MODES)
+    raise ValueError(f"invalid progress mode {value!r}; expected one of: {choices}")
 
 
 def positive_progress_interval_s(value: str) -> float:

--- a/tests/unit/test_agent_readiness_script.py
+++ b/tests/unit/test_agent_readiness_script.py
@@ -1,7 +1,9 @@
 import importlib.util
+import io
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -562,3 +564,136 @@ def test_agent_readiness_main_should_write_json_summary(monkeypatch, tmp_path) -
     assert payload["expected_version"] == "1.8.22"
     assert payload["summary"]["passed"] == 1
     assert payload["summary"]["failed"] == 0
+
+
+def test_agent_readiness_json_auto_progress_keeps_stdout_json_and_captured_stderr_quiet(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(module, "read_project_version", lambda _root: "1.8.22")
+    monkeypatch.setattr(
+        module,
+        "build_check_plan",
+        lambda **_kwargs: [
+            module.Check(
+                name="docs-claim-check",
+                command=[],
+                description="Validate docs claims.",
+                validator=lambda _stdout, _root, _expected: None,
+            )
+        ],
+    )
+
+    exit_code = module.main(["--root", str(tmp_path), "--json", "--no-shell-probes"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["summary"]["passed"] == 1
+    assert captured.err == ""
+
+    exit_code = module.main([
+        "--root",
+        str(tmp_path),
+        "--json",
+        "--progress",
+        "never",
+        "--no-shell-probes",
+    ])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["summary"]["passed"] == 1
+    assert captured.err == ""
+
+    exit_code = module.main([
+        "--root",
+        str(tmp_path),
+        "--json",
+        "--progress",
+        "auto",
+        "--no-shell-probes",
+    ])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["summary"]["passed"] == 1
+    assert captured.err == ""
+
+
+def test_agent_readiness_json_progress_always_uses_stderr_only(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(module, "read_project_version", lambda _root: "1.8.22")
+    monkeypatch.setattr(
+        module,
+        "build_check_plan",
+        lambda **_kwargs: [
+            module.Check(
+                name="docs-claim-check",
+                command=[],
+                description="Validate docs claims.",
+                validator=lambda _stdout, _root, _expected: None,
+            )
+        ],
+    )
+
+    exit_code = module.main([
+        "--root",
+        str(tmp_path),
+        "--json",
+        "--progress",
+        "always",
+        "--no-shell-probes",
+    ])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out)["summary"]["passed"] == 1
+    assert "[progress]" in captured.err
+    assert "[progress]" not in captured.out
+
+
+def test_progress_reporter_emits_phase_heartbeat_to_configured_stream() -> None:
+    from tensor_grep.cli.progress import ProgressReporter
+
+    stream = io.StringIO()
+    reporter = ProgressReporter(
+        mode="always",
+        interval_s=0.001,
+        json_output=True,
+        stream=stream,
+    )
+
+    with reporter.phase("readiness"):
+        deadline = time.monotonic() + 1.0
+        while "readiness running" not in stream.getvalue() and time.monotonic() < deadline:
+            time.sleep(0.005)
+
+    lines = stream.getvalue().splitlines()
+    assert lines[0] == "[progress] readiness start"
+    assert any(line.startswith("[progress] readiness running ") for line in lines)
+    assert lines[-1].startswith("[progress] readiness done ")
+
+
+def test_progress_reporter_auto_emits_in_ci_without_json(monkeypatch) -> None:
+    from tensor_grep.cli.progress import ProgressReporter
+
+    stream = io.StringIO()
+    monkeypatch.setenv("CI", "true")
+    reporter = ProgressReporter(
+        mode="auto",
+        interval_s=30.0,
+        json_output=False,
+        stream=stream,
+    )
+
+    with reporter.phase("readiness"):
+        pass
+
+    assert stream.getvalue().splitlines() == [
+        "[progress] readiness start",
+        "[progress] readiness done 0s",
+    ]

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -411,6 +411,55 @@ def test_run_compat_checks_routing_metadata_report_caps_payload_previews():
     assert summary["match_counts_by_file_count"] == 3
 
 
+def test_run_compat_checks_progress_always_uses_stderr_without_changing_report(
+    monkeypatch, tmp_path, capsys
+):
+    module = _load_script_module(
+        "run_compat_checks_progress_script", "benchmarks/run_compat_checks.py"
+    )
+    tg_binary = tmp_path / "tg"
+    tg_binary.write_text("fake tg", encoding="utf-8")
+    bench_data_dir = tmp_path / "bench_data"
+    bench_data_dir.mkdir()
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{}", encoding="utf-8")
+    output_path = tmp_path / "compat_report.json"
+    expected_report = {
+        "suite": "run_compat_checks",
+        "scenarios": [],
+        "routing_metadata": {"valid": True},
+        "pytest": {"passed": True},
+        "all_passed": True,
+    }
+    monkeypatch.setattr(module, "resolve_rg_binary", lambda: Path("rg"))
+    monkeypatch.setattr(module, "run_compat_suite", lambda **_kwargs: dict(expected_report))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_compat_checks.py",
+            "--binary",
+            str(tg_binary),
+            "--bench-data-dir",
+            str(bench_data_dir),
+            "--schema",
+            str(schema_path),
+            "--output",
+            str(output_path),
+            "--progress",
+            "always",
+        ],
+    )
+
+    exit_code = module.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(output_path.read_text(encoding="utf-8")) == expected_report
+    assert "[progress]" in captured.err
+    assert "[progress]" not in captured.out
+
+
 def test_build_attempt_ledger_cli_should_write_output_file(tmp_path):
     module = _load_script_module(
         "build_attempt_ledger_cli_script", "benchmarks/build_attempt_ledger.py"
@@ -1443,6 +1492,84 @@ def test_run_benchmarks_should_honor_output_and_milestone_args(monkeypatch, tmp_
     assert exit_code == 0
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["milestone"] == "m2"
+
+
+def test_run_benchmarks_progress_always_uses_stderr_without_changing_report(
+    monkeypatch, tmp_path, capsys
+):
+    module = _load_script_module("run_benchmarks_progress_script", "benchmarks/run_benchmarks.py")
+    tg_binary = tmp_path / "tg"
+    tg_binary.write_text("fake tg", encoding="utf-8")
+    monkeypatch.setattr(
+        module,
+        "SCENARIOS",
+        [
+            {
+                "name": "1. Simple String Match",
+                "rg_args": ["rg", "ERROR", "bench_data"],
+                "tg_args": ["tg", "search", "ERROR", "bench_data"],
+            }
+        ],
+    )
+    monkeypatch.setattr(module, "generate_test_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(module, "resolve_bench_data_dir", lambda: tmp_path / "bench_data")
+    monkeypatch.setattr(module, "resolve_rg_binary", lambda: "rg")
+    monkeypatch.setattr(
+        module,
+        "resolve_tg_binary_with_source",
+        lambda *_args, **_kwargs: (tg_binary, "explicit_arg"),
+    )
+    monkeypatch.setattr(
+        module,
+        "inspect_native_tg_binary",
+        lambda *_args, **_kwargs: {
+            "kind": "release-native",
+            "version": "9.9.9",
+            "expected_version": "9.9.9",
+            "version_status": "matches",
+        },
+    )
+    monkeypatch.setattr(module, "benchmark_binary_warnings", lambda _binary: [])
+    monkeypatch.setattr(module, "run_cmd_timing", lambda *_args, **_kwargs: 0.1)
+    monkeypatch.setattr(
+        module,
+        "collect_timing_samples",
+        lambda *_args, **_kwargs: (0.1, [0.1, 0.1, 0.1]),
+    )
+    monkeypatch.setattr(module, "run_cmd_capture", lambda *_args, **_kwargs: (0.0, "ok"))
+    monkeypatch.setattr(module, "compare_results", lambda *_args, **_kwargs: True)
+    output_path = tmp_path / "bench_run.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_benchmarks.py",
+            "--output",
+            str(output_path),
+            "--progress",
+            "always",
+        ],
+    )
+
+    exit_code = module.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["artifact"] == "bench_run_benchmarks"
+    assert payload["rows"] == [
+        {
+            "name": "1. Simple String Match",
+            "rg_samples_s": [0.1, 0.1, 0.1],
+            "rg_time_s": 0.1,
+            "tg_samples_s": [0.1, 0.1, 0.1],
+            "tg_time_s": 0.1,
+            "parity": "PASS",
+        }
+    ]
+    assert "progress" not in json.dumps(payload).lower()
+    assert "[progress]" in captured.err
+    assert "[progress]" not in captured.out
 
 
 def test_run_hot_query_benchmarks_should_report_regression_status(monkeypatch, tmp_path):

--- a/tests/unit/test_dogfood_cli.py
+++ b/tests/unit/test_dogfood_cli.py
@@ -78,3 +78,62 @@ def test_dogfood_command_returns_failure_when_readiness_fails(tmp_path: Path) ->
     payload = json.loads(result.stdout)
     assert payload["verdict"]["status"] == "FAIL"
     assert payload["verdict"]["failed_checks"] == ["docs-claim-check"]
+
+
+def test_dogfood_json_progress_always_uses_stderr_only(tmp_path: Path) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    script = scripts_dir / "agent_readiness.py"
+    script.write_text(
+        "\n".join([
+            "import json",
+            "payload = {",
+            "  'artifact': 'agent_readiness_report',",
+            "  'expected_version': '9.9.9',",
+            "  'root': '.',",
+            "  'summary': {'passed': 1, 'failed': 0, 'skipped': 0},",
+            "  'results': [],",
+            "}",
+            "print(json.dumps(payload))",
+        ]),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "dogfood",
+            "--root",
+            str(tmp_path),
+            "--json",
+            "--progress",
+            "always",
+            "--no-shell-probes",
+            "--no-wsl-probe",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["verdict"]["status"] == "PASS"
+    assert payload["stderr_tail"] == []
+    assert "[progress]" in result.stderr
+    assert "[progress]" not in result.stdout
+
+
+def test_dogfood_rejects_non_positive_progress_interval(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "dogfood",
+            "--root",
+            str(tmp_path),
+            "--progress-interval-s",
+            "0",
+            "--no-shell-probes",
+            "--no-wsl-probe",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "progress interval must be greater than 0" in result.stderr


### PR DESCRIPTION
## Summary
- add stderr-only progress reporter with auto/always/never modes and heartbeat interval validation
- wire progress controls into agent_readiness, tg dogfood, run_compat_checks, and run_benchmarks
- preserve JSON stdout/artifact contracts with regression tests for captured output and CI auto behavior

## Research / Review
- Exa anchor: gh-aw progress output patterns favor short stderr-only timer updates and stdout preservation
- Thinktank consensus: explicit auto/always/never, stderr-only, suppress auto for JSON stdout, no schema changes
- Gemini review: APPROVE; added follow-up coverage for progress=never, CI auto, and invalid interval handling

## Validation
- uv run pytest tests/unit/test_agent_readiness_script.py tests/unit/test_dogfood_cli.py tests/unit/test_benchmark_scripts.py -q -> 283 passed
- uv run ruff check . -> passed
- uv run ruff format --check --preview . -> passed
- uv run mypy src/tensor_grep -> passed
- uv run pytest -q -> 2198 passed, 16 skipped
- git diff --check -> passed with CRLF working-copy warnings only