### PR TITLE
fix: codify dogfood workflow ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ When public dogfood identifies multiple independent fixes, preserve the process 
 5. For each slice, write or update the contract test first, implement the smallest fix, run the targeted suite, then run lint and format before moving on.
 6. Push each branch, wait for PR CI, squash-merge intentionally, then watch main CI. Release-bearing work is not complete until semantic-release, assets, PyPI, and public release dogfood pass.
 
-Record the plan, Exa research anchors, thinktank consensus, PR order, Gemini review result, validation commands, PR CI, main CI, and public release dogfood in `docs/SESSION_HANDOFF.md`, `SKILL.md`, and this file when operating practice changes.
+Maintain a per-slice evidence ledger in `docs/SESSION_HANDOFF.md`, `SKILL.md`, and this file when operating practice changes. Each slice entry must record PR order, slice scope, Exa research anchors, thinktank or planning consensus, subagent ownership, Gemini review result, validation commands, PR CI, and main CI. Optional or triggered items may be marked `not applicable` only with a rationale. For release-bearing slices, additionally require semantic-release, release assets, PyPI, and public release dogfood evidence.
 
 ## Required Local Validation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -108,7 +108,8 @@ Dogfood follow-up workflow:
 - Run a thinktank or equivalent independent planning review for benchmark interpretation, GPU promotion policy, product positioning, and release workflow changes.
 - Ask Gemini for a bounded read-only diff review before each PR merge, then verify any finding locally before changing code.
 - For every slice: start with the contract test, implement the smallest fix, run the targeted suite, run lint and format, push the PR, wait for PR CI, squash-merge, then watch main CI.
-- For release-bearing slices, final status also requires semantic-release, GitHub release assets, PyPI/package publication, and public release dogfood evidence.
+- Maintain a per-slice evidence ledger for dogfood follow-up work. Each slice entry must record PR order, slice scope, Exa research anchors, thinktank or planning consensus, subagent ownership, Gemini review result, validation commands, PR CI, and main CI. Optional or triggered items may be marked `not applicable` only with a rationale.
+- For release-bearing slices, final status also requires semantic-release, release assets, PyPI/package publication, and public release dogfood evidence.
 
 Known current weak spots:
 

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -109,7 +109,8 @@ Dogfood follow-up workflow:
 - Run a thinktank or equivalent independent planning review for benchmark interpretation, GPU promotion policy, product positioning, and release workflow changes.
 - Ask Gemini for a bounded read-only diff review before each PR merge, then verify any finding locally before changing code.
 - For each slice: write/update the contract test first, implement the smallest fix, run the targeted suite, run lint and format, push the PR, wait for PR CI, squash-merge, then watch main CI.
-- Release-bearing work is not complete until semantic-release, GitHub release assets, PyPI/package publication, and public release dogfood all pass.
+- Maintain a per-slice evidence ledger for dogfood follow-up work. Each slice entry must record PR order, slice scope, Exa research anchors, thinktank or planning consensus, subagent ownership, Gemini review result, validation commands, PR CI, and main CI. Optional or triggered items may be marked `not applicable` only with a rationale.
+- For release-bearing slices, additionally require semantic-release, release assets, PyPI/package publication, and public release dogfood evidence.
 - Use `benchmarks/run_agent_success_harness.py --output artifacts/bench_agent_success_harness.json` when dogfood asks for an end-to-end agent success proof from query intent through context, edit seed, checkpointed apply, verification, and rollback. Treat the artifact as workflow evidence, not a raw search speed claim.
 
 The immediate `v1.8.28` native-front-door CLI parity follow-up shipped in `v1.8.29`:

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -447,14 +447,27 @@ def test_agent_workflow_docs_should_preserve_dogfood_research_pr_slice_process()
 
     required_fragments = (
         "Dogfood follow-up workflow",
+        "per-slice evidence ledger",
+        "PR order",
+        "slice scope",
         "Exa research",
         "thinktank",
+        "subagent ownership",
         "PR-sized slices",
         "Gemini",
+        "contract test",
+        "targeted suite",
+        "validation commands",
         "lint and format",
         "PR CI",
         "main CI",
+        "release-bearing slices",
+        "semantic-release",
+        "release assets",
+        "PyPI",
         "public release dogfood",
+        "not applicable",
+        "rationale",
         "do not collapse independent fixes into one broad PR",
     )
     for path, content in docs.items():


### PR DESCRIPTION
## Summary
- strengthen the dogfood follow-up governance test to require a per-slice evidence ledger
- document the ledger in AGENTS.md, SKILL.md, and docs/SESSION_HANDOFF.md
- require PR order, scope, Exa anchors, planning consensus, subagent ownership, Gemini review, validation, PR/main CI, and release-bearing evidence when applicable

## Research and review
- Exa anchors: Microsoft Engineering Playbook for short-lived branches, PR CI gates, and documented repeatable releases; Kubernetes PR process for small PRs and local verification; MinimumCD small batches for test-first independent slices
- Thinktank/read-only planning review: approved docs/governance-only slice; recommended semantic phrase tests and not tying to volatile PR/run/tag data
- Gemini read-only diff review: APPROVE, no findings

## Validation
- uv run pytest tests/unit/test_public_docs_governance.py::test_agent_workflow_docs_should_preserve_dogfood_research_pr_slice_process -q
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q -> 2164 passed, 50 skipped
- git diff --check