### PR TITLE
fix: harden v1.12.24 dogfood proof hygiene

### DIFF
--- a/benchmarks/run_compat_checks.py
+++ b/benchmarks/run_compat_checks.py
@@ -471,7 +471,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--progress",
         choices=PROGRESS_MODES,
-        default="auto",
+        default="always",
         help="Progress reporting mode: auto, always, or never. Emits to stderr only.",
     )
     parser.add_argument(

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -44,8 +44,8 @@ use tensor_grep_rs::rg_passthrough::{
     ripgrep_is_available, RipgrepSearchArgs,
 };
 use tensor_grep_rs::routing::{
-    route_search, BackendSelection, IndexRoutingState, RoutingDecision, SearchRoutingCalibration,
-    SearchRoutingConfig,
+    gpu_proof_fields, route_search, BackendSelection, IndexRoutingState, RoutingDecision,
+    SearchRoutingCalibration, SearchRoutingConfig,
 };
 
 const ENVIRONMENT_OVERRIDES_HELP: &str = "Agent and GPU contracts:\n  tg agent --query TEXT --json        Emit an Actionable Context Capsule with validation, rollback, confidence, and optional gpu_acceleration evidence.\n  tg agent --gpu-device-ids 0,1       Run opt-in native GPU evidence probes; sidecar-routed GPU results are reported as unsupported.\n  --gpu-device-ids                    Pin selected GPUs for explicit search, benchmark, and agent evidence probes. GPU remains experimental until it beats rg and tg_cpu.\n\nSearch routing switches:\n  tg search                           Validated common rg-compatible subset, not a full ripgrep replacement.\n  --format rg --json                  Emit ripgrep JSON Lines events; plain --json is tensor-grep aggregate JSON.\n  --smart-case                        CPU/sidecar honor lowercase-insensitive smart case; native GPU falls back when case-insensitive semantics are required.\n  --hidden, --max-depth N, --text      Structured CPU/sidecar search honors these switches; native GPU falls back when a requested switch changes unsupported semantics.\n\nLSP provider status:\n  tg lsp --provider hybrid            Optional experimental semantic provider mode; provider availability is not LSP proof.\n  tg doctor --with-lsp                Report provider availability plus health_status/health_check diagnostics.\n\nLauncher repair:\n  tg repair-launcher --allow-foreign-rename\n                                      Explicitly back up a foreign Windows tg.exe that blocks Python subprocess resolution and replace it with the verified tensor-grep front door.\n\nEnvironment overrides:\n  TG_SIDECAR_PYTHON                  Path to the Python executable used for sidecar-backed commands.\n  TG_NATIVE_TG_BINARY                Path to the native front door used by Python-backed commands.\n  TG_RG_PATH                         Path to the ripgrep executable used for text-search passthrough.\n  TG_FORCE_CPU                       Force CPU routing for search commands.\n  TG_SIDECAR_TIMEOUT_MS              Timeout for sidecar-backed commands.\n  TENSOR_GREP_DEVICE_IDS             Comma-separated GPU IDs available to tensor-grep.\n  TENSOR_GREP_CLASSIFY_PROVIDER      Set to cybert to opt into CyBERT/Triton classification.\n  TENSOR_GREP_TRITON_TIMEOUT_SECONDS Timeout for Triton-backed NLP probes.\n  TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS Total per-command budget for optional external LSP provider requests.";
@@ -3846,6 +3846,14 @@ struct SearchResultJson<'a> {
     sidecar_used: bool,
     requested_gpu_device_ids: Vec<i32>,
     routing_gpu_device_ids: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_evidence_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_proof: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_gpu_unavailable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_gpu_proof_reason: Option<String>,
     query: &'a str,
     path: &'a str,
     total_matches: usize,
@@ -3865,6 +3873,14 @@ struct GpuNativeSearchResultJson<'a> {
     total_files: usize,
     requested_gpu_device_ids: Vec<i32>,
     routing_gpu_device_ids: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_evidence_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_proof: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_gpu_unavailable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_gpu_proof_reason: Option<String>,
     pipeline: &'a GpuPipelineStats,
     matches: Vec<SearchMatchJson>,
 }
@@ -4123,6 +4139,14 @@ struct SearchMatchNdjson<'a> {
     sidecar_used: bool,
     requested_gpu_device_ids: Vec<i32>,
     routing_gpu_device_ids: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_evidence_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_proof: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_gpu_unavailable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_gpu_proof_reason: Option<String>,
     query: &'a str,
     path: &'a str,
     file: &'a str,
@@ -6736,6 +6760,11 @@ fn emit_json_search_results(
     requested_gpu_device_ids: &[i32],
     matches: Vec<SearchMatchJson>,
 ) -> anyhow::Result<()> {
+    let proof_fields = gpu_proof_fields(
+        requested_gpu_device_ids,
+        decision.routing_backend(),
+        decision.sidecar_used(),
+    );
     let payload = SearchResultJson {
         version: JSON_OUTPUT_VERSION,
         routing_backend: decision.routing_backend(),
@@ -6743,6 +6772,10 @@ fn emit_json_search_results(
         sidecar_used: decision.sidecar_used(),
         requested_gpu_device_ids: requested_gpu_device_ids.to_vec(),
         routing_gpu_device_ids: Vec::new(),
+        gpu_evidence_status: proof_fields.gpu_evidence_status,
+        gpu_proof: proof_fields.gpu_proof,
+        native_gpu_unavailable: proof_fields.native_gpu_unavailable,
+        not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
         query: pattern,
         path,
         total_matches: matches.len(),
@@ -6841,6 +6874,11 @@ fn emit_gpu_native_json_results(
     params: &GpuSearchParams<'_>,
     stats: &GpuNativeSearchStats,
 ) -> anyhow::Result<()> {
+    let proof_fields = gpu_proof_fields(
+        params.gpu_device_ids,
+        decision.routing_backend(),
+        decision.sidecar_used(),
+    );
     let payload = GpuNativeSearchResultJson {
         version: JSON_OUTPUT_VERSION,
         routing_backend: decision.routing_backend(),
@@ -6856,6 +6894,10 @@ fn emit_gpu_native_json_results(
             .iter()
             .map(|device| device.device_id)
             .collect(),
+        gpu_evidence_status: proof_fields.gpu_evidence_status,
+        gpu_proof: proof_fields.gpu_proof,
+        native_gpu_unavailable: proof_fields.native_gpu_unavailable,
+        not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
         pipeline: &stats.pipeline,
         matches: gpu_native_match_json_entries(stats),
     };
@@ -6972,6 +7014,11 @@ fn emit_ndjson_search_results(
     matches: Vec<SearchMatchJson>,
 ) -> anyhow::Result<()> {
     for matched in matches {
+        let proof_fields = gpu_proof_fields(
+            requested_gpu_device_ids,
+            decision.routing_backend(),
+            decision.sidecar_used(),
+        );
         let payload = SearchMatchNdjson {
             version: JSON_OUTPUT_VERSION,
             routing_backend: decision.routing_backend(),
@@ -6979,6 +7026,10 @@ fn emit_ndjson_search_results(
             sidecar_used: decision.sidecar_used(),
             requested_gpu_device_ids: requested_gpu_device_ids.to_vec(),
             routing_gpu_device_ids: Vec::new(),
+            gpu_evidence_status: proof_fields.gpu_evidence_status,
+            gpu_proof: proof_fields.gpu_proof,
+            native_gpu_unavailable: proof_fields.native_gpu_unavailable,
+            not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
             query: pattern,
             path,
             file: &matched.file,
@@ -7006,6 +7057,11 @@ fn normalize_gpu_sidecar_json(
     requested_gpu_device_ids: &[i32],
 ) -> anyhow::Result<serde_json::Value> {
     let payload = parse_gpu_sidecar_search_payload(stdout)?;
+    let proof_fields = gpu_proof_fields(
+        requested_gpu_device_ids,
+        RoutingDecision::gpu_sidecar().routing_backend(),
+        RoutingDecision::gpu_sidecar().sidecar_used(),
+    );
     let requested_gpu_device_ids = requested_gpu_device_ids
         .iter()
         .copied()
@@ -7032,7 +7088,7 @@ fn normalize_gpu_sidecar_json(
         })
         .collect::<Vec<_>>();
 
-    Ok(serde_json::json!({
+    let mut value = serde_json::json!({
         "version": JSON_OUTPUT_VERSION,
         "routing_backend": RoutingDecision::gpu_sidecar().routing_backend(),
         "routing_reason": RoutingDecision::gpu_sidecar().reason,
@@ -7042,7 +7098,20 @@ fn normalize_gpu_sidecar_json(
         "requested_gpu_device_ids": requested_gpu_device_ids,
         "routing_gpu_device_ids": payload.routing_gpu_device_ids,
         "matches": normalized_matches,
-    }))
+    });
+    if let Some(gpu_evidence_status) = proof_fields.gpu_evidence_status {
+        value["gpu_evidence_status"] = serde_json::json!(gpu_evidence_status);
+    }
+    if let Some(gpu_proof) = proof_fields.gpu_proof {
+        value["gpu_proof"] = serde_json::json!(gpu_proof);
+    }
+    if let Some(native_gpu_unavailable) = proof_fields.native_gpu_unavailable {
+        value["native_gpu_unavailable"] = serde_json::json!(native_gpu_unavailable);
+    }
+    if let Some(not_gpu_proof_reason) = proof_fields.not_gpu_proof_reason {
+        value["not_gpu_proof_reason"] = serde_json::json!(not_gpu_proof_reason);
+    }
+    Ok(value)
 }
 
 fn emit_verbose_metadata(decision: RoutingDecision) {

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -21,6 +21,8 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+use crate::routing::gpu_proof_fields;
+
 const JSON_OUTPUT_VERSION: u32 = 1;
 const LARGE_FILE_CHUNK_THRESHOLD_BYTES: usize = 50 * 1024 * 1024;
 const STREAMING_OUTPUT_FLUSH_BYTES: usize = 64 * 1024;
@@ -625,6 +627,14 @@ struct NativeJsonOutput<'a> {
     sidecar_used: bool,
     requested_gpu_device_ids: Vec<i32>,
     routing_gpu_device_ids: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_evidence_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_proof: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_gpu_unavailable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_gpu_proof_reason: Option<String>,
     query: &'a str,
     path: String,
     total_matches: usize,
@@ -646,6 +656,14 @@ struct NativeNdjsonMatch<'a> {
     sidecar_used: bool,
     requested_gpu_device_ids: Vec<i32>,
     routing_gpu_device_ids: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_evidence_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gpu_proof: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_gpu_unavailable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_gpu_proof_reason: Option<String>,
     query: &'a str,
     path: &'a str,
     file: &'a str,
@@ -1870,6 +1888,11 @@ fn native_match_from_sink(path: &Path, mat: &SinkMatch<'_>) -> NativeSearchMatch
 }
 
 fn emit_json_matches(config: &NativeSearchConfig, stats: &SearchStats) -> Result<()> {
+    let proof_fields = gpu_proof_fields(
+        &config.requested_gpu_device_ids,
+        config.routing_backend,
+        config.sidecar_used,
+    );
     let payload = NativeJsonOutput {
         version: JSON_OUTPUT_VERSION,
         routing_backend: config.routing_backend,
@@ -1877,6 +1900,10 @@ fn emit_json_matches(config: &NativeSearchConfig, stats: &SearchStats) -> Result
         sidecar_used: config.sidecar_used,
         requested_gpu_device_ids: config.requested_gpu_device_ids.clone(),
         routing_gpu_device_ids: Vec::new(),
+        gpu_evidence_status: proof_fields.gpu_evidence_status,
+        gpu_proof: proof_fields.gpu_proof,
+        native_gpu_unavailable: proof_fields.native_gpu_unavailable,
+        not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
         query: &config.pattern,
         path: display_search_path(&config.paths),
         total_matches: stats.total_matches,
@@ -1910,6 +1937,11 @@ fn append_ndjson_match_bytes(
 ) -> Result<()> {
     let line = native_match_line_number(matched)?;
     let file = matched.path.to_string_lossy().into_owned();
+    let proof_fields = gpu_proof_fields(
+        &config.requested_gpu_device_ids,
+        config.routing_backend,
+        config.sidecar_used,
+    );
     let payload = NativeNdjsonMatch {
         version: JSON_OUTPUT_VERSION,
         routing_backend: config.routing_backend,
@@ -1917,6 +1949,10 @@ fn append_ndjson_match_bytes(
         sidecar_used: config.sidecar_used,
         requested_gpu_device_ids: config.requested_gpu_device_ids.clone(),
         routing_gpu_device_ids: Vec::new(),
+        gpu_evidence_status: proof_fields.gpu_evidence_status,
+        gpu_proof: proof_fields.gpu_proof,
+        native_gpu_unavailable: proof_fields.native_gpu_unavailable,
+        not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
         query: &config.pattern,
         path: search_path,
         file: &file,

--- a/rust_core/src/routing.rs
+++ b/rust_core/src/routing.rs
@@ -72,6 +72,50 @@ pub struct RoutingDecision {
     pub allow_rg_fallback: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuProofFields {
+    pub gpu_evidence_status: Option<&'static str>,
+    pub gpu_proof: Option<bool>,
+    pub native_gpu_unavailable: Option<bool>,
+    pub not_gpu_proof_reason: Option<String>,
+}
+
+pub fn gpu_proof_fields(
+    requested_gpu_device_ids: &[i32],
+    routing_backend: &str,
+    sidecar_used: bool,
+) -> GpuProofFields {
+    if requested_gpu_device_ids.is_empty() {
+        return GpuProofFields {
+            gpu_evidence_status: None,
+            gpu_proof: None,
+            native_gpu_unavailable: None,
+            not_gpu_proof_reason: None,
+        };
+    }
+
+    let native_gpu_proof = routing_backend == "NativeGpuBackend" && !sidecar_used;
+    if native_gpu_proof {
+        return GpuProofFields {
+            gpu_evidence_status: Some("native"),
+            gpu_proof: Some(true),
+            native_gpu_unavailable: Some(false),
+            not_gpu_proof_reason: None,
+        };
+    }
+
+    GpuProofFields {
+        gpu_evidence_status: Some("unsupported"),
+        gpu_proof: Some(false),
+        native_gpu_unavailable: Some(true),
+        not_gpu_proof_reason: Some(format!(
+            "Requested GPU execution did not produce NativeGpuBackend with sidecar_used=false \
+             (routing_backend={routing_backend}, sidecar_used={sidecar_used}); this is \
+             CPU/sidecar compatibility output, not GPU acceleration proof."
+        )),
+    }
+}
+
 impl RoutingDecision {
     pub const fn routing_backend(self) -> &'static str {
         self.selection.routing_backend()

--- a/rust_core/tests/test_routing.rs
+++ b/rust_core/tests/test_routing.rs
@@ -1883,6 +1883,16 @@ fn test_public_gpu_request_without_explicit_sidecar_falls_back_to_native_cpu() {
     assert_eq!(payload["total_matches"], 3);
     assert_eq!(payload["requested_gpu_device_ids"], serde_json::json!([0]));
     assert_eq!(payload["routing_gpu_device_ids"], serde_json::json!([]));
+    assert_eq!(payload["gpu_evidence_status"], "unsupported");
+    assert_eq!(payload["gpu_proof"], false);
+    assert_eq!(payload["native_gpu_unavailable"], true);
+    assert!(
+        payload["not_gpu_proof_reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not GPU acceleration proof"),
+        "payload={payload}"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("native GPU unavailable"), "stderr={stderr}");
@@ -1930,6 +1940,16 @@ fn test_public_gpu_ndjson_fallback_reports_no_routed_gpu_devices() {
         assert_eq!(payload["sidecar_used"], false);
         assert_eq!(payload["requested_gpu_device_ids"], serde_json::json!([0]));
         assert_eq!(payload["routing_gpu_device_ids"], serde_json::json!([]));
+        assert_eq!(payload["gpu_evidence_status"], "unsupported");
+        assert_eq!(payload["gpu_proof"], false);
+        assert_eq!(payload["native_gpu_unavailable"], true);
+        assert!(
+            payload["not_gpu_proof_reason"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("not GPU acceleration proof"),
+            "payload={payload}"
+        );
         rows += 1;
     }
     assert_eq!(rows, 3);

--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -222,6 +222,10 @@ class ExternalLSPClient:
         if process is None:
             return
         reader_thread = self._reader_thread
+        stop_timeout_seconds = min(
+            max(float(self.request_timeout_seconds), 0.0),
+            _DEFAULT_LSP_STOP_TIMEOUT_SECONDS,
+        )
         self._request_shutdown_for_stop()
         with self._lock:
             try:
@@ -238,14 +242,14 @@ class ExternalLSPClient:
             except Exception:
                 pass
         try:
-            process.wait(timeout=2.0)
+            process.wait(timeout=stop_timeout_seconds)
         except subprocess.TimeoutExpired:
             try:
                 process.kill()
             except Exception:
                 pass
             try:
-                process.wait(timeout=2.0)
+                process.wait(timeout=stop_timeout_seconds)
             except Exception:
                 pass
         finally:
@@ -256,7 +260,7 @@ class ExternalLSPClient:
                 except Exception:
                     pass
         if reader_thread is not None and reader_thread.is_alive():
-            reader_thread.join(timeout=2.0)
+            reader_thread.join(timeout=stop_timeout_seconds)
         with self._lock:
             if self.process is process:
                 self.process = None

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -451,16 +451,15 @@ def _managed_native_frontdoor_path_from_env() -> Path | None:
     if install_root.name != ".tensor-grep":
         return None
     binary_name = "tg.exe" if sys.platform.startswith("win") else "tg-native"
-    native_path = (
-        Path(native_env).expanduser() if native_env else install_root / "bin" / binary_name
-    )
+    expected_native_path = install_root / "bin" / binary_name
+    native_path = Path(native_env).expanduser() if native_env else expected_native_path
     try:
         native_parent = native_path.parent.resolve()
-        expected_parent = (install_root / "bin").resolve()
+        expected_parent = expected_native_path.parent.resolve()
     except OSError:
-        return None
+        return expected_native_path
     if native_parent != expected_parent:
-        return None
+        return expected_native_path
     return native_path
 
 
@@ -3527,7 +3526,9 @@ def _run_ast_scan_payload(
         else [str(root_dir)]
     )
     scanner: DirectoryScanner | None = None
-    resolved_candidate_files = list(candidate_files) if candidate_files is not None else None
+    resolved_candidate_files = (
+        None if scan_paths else list(candidate_files) if candidate_files is not None else None
+    )
     backend_cache: dict[tuple[str | None, str, bool], ComputeBackend] = {}
     backend_names_used: set[str] = set()
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -22,7 +22,7 @@ from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 JSON_OUTPUT_VERSION = 1
 ROUTING_BACKEND = "RepoMap"
 ROUTING_REASON = "repo-map"
-_DEFAULT_LSP_OPERATION_BUDGET_SECONDS = 8.0
+_DEFAULT_LSP_OPERATION_BUDGET_SECONDS = 2.0
 _LSP_OPERATION_BUDGET_ENV_VAR = "TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS"
 _SKIP_DIR_NAMES = {
     ".tensor-grep",

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -113,6 +113,26 @@ def _native_candidate_matches_current_package(candidate: Path, *, expected_versi
     return _native_tg_version_matches(expected_version, _native_tg_version(candidate))
 
 
+def _path_binary_candidates(binary_name: str) -> list[Path]:
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for raw_entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not raw_entry:
+            continue
+        candidate = Path(raw_entry).expanduser() / binary_name
+        if not candidate.is_file():
+            continue
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate.absolute()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        candidates.append(resolved)
+    return candidates
+
+
 def inspect_native_tg_binary(
     candidate: Path,
     *,
@@ -180,19 +200,19 @@ def resolve_native_tg_binary() -> Path | None:
         if _native_candidate_matches_current_package(candidate, expected_version=expected_version):
             return candidate
 
-    # Priority 3: PATH installations
-    if which_tg := shutil.which(binary_name):
-        resolved = Path(which_tg).resolve()
+    # Priority 3: PATH installations. Scan every candidate so a Python
+    # console-entrypoint shim in an active repo venv cannot hide a later
+    # managed native front door.
+    for resolved in _path_binary_candidates(binary_name):
         if not _looks_like_python_scripts_launcher(
             resolved
         ) and _native_candidate_matches_current_package(
             resolved, expected_version=expected_version
         ):
             return resolved
-    if which_tensor_grep := shutil.which(
-        "tensor-grep" + (".exe" if sys.platform.startswith("win") else "")
-    ):
-        resolved = Path(which_tensor_grep).resolve()
+
+    tensor_grep_binary_name = "tensor-grep" + (".exe" if sys.platform.startswith("win") else "")
+    for resolved in _path_binary_candidates(tensor_grep_binary_name):
         if not _looks_like_python_scripts_launcher(
             resolved
         ) and _native_candidate_matches_current_package(

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -460,6 +460,51 @@ def test_run_compat_checks_progress_always_uses_stderr_without_changing_report(
     assert "[progress]" not in captured.out
 
 
+def test_run_compat_checks_progress_is_on_by_default(monkeypatch, tmp_path, capsys):
+    module = _load_script_module(
+        "run_compat_checks_default_progress_script", "benchmarks/run_compat_checks.py"
+    )
+    tg_binary = tmp_path / "tg"
+    tg_binary.write_text("fake tg", encoding="utf-8")
+    bench_data_dir = tmp_path / "bench_data"
+    bench_data_dir.mkdir()
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{}", encoding="utf-8")
+    output_path = tmp_path / "compat_report.json"
+    expected_report = {
+        "suite": "run_compat_checks",
+        "scenarios": [],
+        "routing_metadata": {"valid": True},
+        "pytest": {"passed": True},
+        "all_passed": True,
+    }
+    monkeypatch.setattr(module, "resolve_rg_binary", lambda: Path("rg"))
+    monkeypatch.setattr(module, "run_compat_suite", lambda **_kwargs: dict(expected_report))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_compat_checks.py",
+            "--binary",
+            str(tg_binary),
+            "--bench-data-dir",
+            str(bench_data_dir),
+            "--schema",
+            str(schema_path),
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    exit_code = module.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "[progress] compat-suite start" in captured.err
+    assert "[progress] compat-suite done" in captured.err
+    assert "[progress]" not in captured.out
+
+
 def test_build_attempt_ledger_cli_should_write_output_file(tmp_path):
     module = _load_script_module(
         "build_attempt_ledger_cli_script", "benchmarks/build_attempt_ledger.py"

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -6976,6 +6976,9 @@ def test_upgrade_refreshes_managed_native_frontdoor_after_package_upgrade(monkey
     native_binary.parent.mkdir(parents=True)
     python_executable.write_text("", encoding="utf-8")
     native_binary.write_text("old native", encoding="utf-8")
+    unrelated_native_env = tmp_path / "other" / "bin" / "tg.exe"
+    unrelated_native_env.parent.mkdir(parents=True)
+    unrelated_native_env.write_text("other native", encoding="utf-8")
     downloads: list[str] = []
 
     def _fake_run(cmd, capture_output=True, text=True, check=True, timeout=None):
@@ -7002,6 +7005,7 @@ def test_upgrade_refreshes_managed_native_frontdoor_after_package_upgrade(monkey
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr("platform.machine", lambda: "AMD64")
     monkeypatch.setenv("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR", "cpu")
+    monkeypatch.setenv("TG_NATIVE_TG_BINARY", str(unrelated_native_env))
     monkeypatch.setattr("importlib.metadata.version", lambda _name: "0.32.0")
     monkeypatch.setattr("subprocess.run", _fake_run)
     monkeypatch.setattr("urllib.request.urlretrieve", _fake_urlretrieve)
@@ -9117,6 +9121,78 @@ def test_scan_filter_limits_project_rules(monkeypatch, tmp_path: Path) -> None:
     payload = json.loads(result.output)
     assert payload["rule_count"] == 1
     assert [finding["rule_id"] for finding in payload["findings"]] == ["no-print"]
+
+
+def test_scan_project_filter_respects_positional_scan_paths(monkeypatch, tmp_path: Path) -> None:
+    class CountingAstBackend:
+        def search(self, file_path: str, pattern: str, config=None) -> SearchResult:
+            _ = config
+            try:
+                lines = Path(file_path).read_text(encoding="utf-8").splitlines()
+            except OSError:
+                lines = []
+            matches = [
+                MatchLine(line_number=line_number, text=line, file=file_path)
+                for line_number, line in enumerate(lines, start=1)
+                if pattern in line
+            ]
+            total_matches = sum(line.count(pattern) for line in lines)
+            return SearchResult(
+                matches=matches,
+                matched_file_paths=[file_path] if total_matches else [],
+                total_files=1 if total_matches else 0,
+                total_matches=total_matches,
+                routing_backend="AstBackend",
+                routing_reason="ast_native",
+                routing_distributed=False,
+                routing_worker_count=1,
+            )
+
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._select_ast_backend_for_pattern",
+        lambda *_args, **_kwargs: CountingAstBackend(),
+    )
+
+    src_dir = tmp_path / "src"
+    rules_dir = tmp_path / "rules"
+    src_dir.mkdir()
+    rules_dir.mkdir()
+    (tmp_path / "sgconfig.yml").write_text(
+        "ruleDirs:\n  - rules\nlanguage: python\n", encoding="utf-8"
+    )
+    (rules_dir / "no-pass.yml").write_text(
+        "\n".join([
+            "id: no-pass",
+            "language: python",
+            "message: avoid pass",
+            "rule:",
+            "  pattern: pass",
+        ]),
+        encoding="utf-8",
+    )
+    (src_dir / "sample.py").write_text("def f():\n    pass\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "scan",
+            "--config",
+            str(tmp_path / "sgconfig.yml"),
+            "--filter",
+            "no-pass",
+            str(src_dir),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["scan_paths"] == [str(src_dir.resolve())]
+    assert payload["total_matches"] == 1
+    assert payload["findings"][0]["files"] == [str((src_dir / "sample.py").resolve())]
+    assert all(
+        "rules" not in Path(file_path).parts for file_path in payload["findings"][0]["files"]
+    )
 
 
 def test_scan_inline_rules_json_preserves_rule_metadata(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -70,6 +70,7 @@ def test_resolve_native_tg_binary_ignores_legacy_benchmark_binary(monkeypatch, t
     monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", "")
     monkeypatch.setattr(runtime_paths.shutil, "which", lambda _: None)
     resolve_native_tg_binary.cache_clear()
 
@@ -92,6 +93,7 @@ def test_resolve_native_tg_binary_ignores_stale_in_tree_binary_without_explicit_
     monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", "")
     monkeypatch.setattr(runtime_paths.shutil, "which", lambda _: None)
     monkeypatch.setattr(runtime_paths, "_expected_tg_version", lambda: "1.8.21", raising=False)
     monkeypatch.setattr(runtime_paths, "_native_tg_version", lambda _: "tg 1.8.14", raising=False)
@@ -114,6 +116,7 @@ def test_resolve_native_tg_binary_uses_matching_in_tree_binary(monkeypatch, tmp_
     monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", "")
     monkeypatch.setattr(runtime_paths.shutil, "which", lambda _: None)
     monkeypatch.setattr(runtime_paths, "_expected_tg_version", lambda: "1.8.21", raising=False)
     monkeypatch.setattr(runtime_paths, "_native_tg_version", lambda _: "tg 1.8.21", raising=False)
@@ -183,6 +186,7 @@ def test_resolve_native_tg_binary_ignores_current_python_launcher(monkeypatch, t
     monkeypatch.setattr(runtime_paths.sys, "executable", str(python_path))
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", str(venv_dir))
     monkeypatch.setattr(
         runtime_paths.shutil,
         "which",
@@ -224,6 +228,7 @@ def test_resolve_native_tg_binary_ignores_current_python_launcher_when_python_re
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
     monkeypatch.setattr(runtime_paths.Path, "resolve", fake_resolve)
+    monkeypatch.setenv("PATH", str(venv_dir))
     monkeypatch.setattr(
         runtime_paths.shutil,
         "which",
@@ -232,6 +237,49 @@ def test_resolve_native_tg_binary_ignores_current_python_launcher_when_python_re
     resolve_native_tg_binary.cache_clear()
 
     assert resolve_native_tg_binary() is None
+
+
+def test_resolve_native_tg_binary_skips_python_launcher_and_uses_later_matching_path_candidate(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "repo"
+    runtime_file = repo_root / "src" / "tensor_grep" / "cli" / "runtime_paths.py"
+    runtime_file.parent.mkdir(parents=True, exist_ok=True)
+    runtime_file.write_text("# stub\n", encoding="utf-8")
+
+    binary_name = "tg.exe" if sys.platform.startswith("win") else "tg"
+    python_name = "python.exe" if sys.platform.startswith("win") else "python"
+    current_venv_dir = (
+        tmp_path / "repo" / ".venv" / ("Scripts" if sys.platform.startswith("win") else "bin")
+    )
+    current_venv_dir.mkdir(parents=True, exist_ok=True)
+    current_python = current_venv_dir / python_name
+    current_python.write_text("python\n", encoding="utf-8")
+    python_launcher = current_venv_dir / binary_name
+    python_launcher.write_text("python console entrypoint\n", encoding="utf-8")
+
+    managed_dir = tmp_path / ".tensor-grep" / "bin"
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    managed_native = managed_dir / binary_name
+    managed_native.write_text("native tg\n", encoding="utf-8")
+
+    monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
+    monkeypatch.setattr(runtime_paths.sys, "executable", str(current_python))
+    monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
+    monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", os.pathsep.join([str(current_venv_dir), str(managed_dir)]))
+    monkeypatch.setattr(runtime_paths, "_in_tree_native_tg_candidates", lambda **_kwargs: [])
+    monkeypatch.setattr(runtime_paths, "_expected_tg_version", lambda: "1.12.24")
+    monkeypatch.setattr(
+        runtime_paths,
+        "_native_candidate_matches_current_package",
+        lambda candidate, *, expected_version: (
+            Path(candidate).resolve() == managed_native.resolve()
+        ),
+    )
+    resolve_native_tg_binary.cache_clear()
+
+    assert resolve_native_tg_binary() == managed_native.resolve()
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows launcher layout")
@@ -259,6 +307,7 @@ def test_resolve_native_tg_binary_ignores_foreign_python_install_scripts_launche
     monkeypatch.setattr(runtime_paths.sys, "executable", str(current_python))
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", str(foreign_scripts_dir))
     monkeypatch.setattr(
         runtime_paths.shutil,
         "which",

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -172,6 +172,59 @@ def test_external_lsp_workspace_symbol_queries_are_operation_budgeted(
     assert initialize_timeout <= 0.25
 
 
+def test_external_lsp_workspace_symbol_default_budget_is_agent_loop_sized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service_path = tmp_path / "service.py"
+    service_path.write_text(
+        "def create_invoice(total: int) -> int:\n    return total + 1\n", encoding="utf-8"
+    )
+    query_timeouts: list[tuple[float, float]] = []
+
+    class _SlowClient:
+        request_timeout_seconds = 30.0
+        initialize_timeout_seconds = 30.0
+
+        def request(self, method: str, params: dict[str, object]) -> list[dict[str, object]]:
+            _ = method
+            _ = params
+            query_timeouts.append((
+                self.request_timeout_seconds,
+                self.initialize_timeout_seconds,
+            ))
+            return []
+
+    class _FakeManager:
+        def get_client(self, *, language: str, workspace_root: Path) -> _SlowClient:
+            _ = language
+            _ = workspace_root
+            return _SlowClient()
+
+    monkeypatch.delenv("TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS", raising=False)
+    monkeypatch.setattr(repo_map, "_EXTERNAL_LSP_PROVIDER_MANAGER", _FakeManager())
+
+    repo_map._external_workspace_symbols(
+        tmp_path,
+        "create_invoice",
+        repo_map={
+            "path": str(tmp_path),
+            "symbols": [
+                {
+                    "name": "create_invoice",
+                    "file": str(service_path),
+                    "line": 1,
+                    "kind": "function",
+                }
+            ],
+        },
+    )
+
+    assert query_timeouts
+    request_timeout, initialize_timeout = query_timeouts[0]
+    assert request_timeout <= 2.0
+    assert initialize_timeout <= 2.0
+
+
 def test_repo_map_callers_can_use_lsp_provider(tmp_path: Path, monkeypatch) -> None:
     service_path = tmp_path / "service.py"
     consumer_path = tmp_path / "consumer.py"


### PR DESCRIPTION
## Summary

Fixes concrete v1.12.24 dogfood follow-ups that were release-readiness blockers or misleading proof gaps:

- prevents `tg scan --config ... --filter ... <scan-path>` from scanning root-wide project candidates outside the positional scan path
- adds native Rust GPU proof fields to explicit GPU fallback JSON/NDJSON and sidecar-normalized JSON
- makes optional LSP provider requests fail fast by default for agent loops and bounds stop cleanup waits
- makes native `tg` runtime resolution skip Python console-entrypoint shims and continue to later matching native PATH candidates
- keeps managed `tg upgrade` native-front-door refresh deterministic when ambient `TG_NATIVE_TG_BINARY` points elsewhere
- turns compat progress heartbeats on by default, stderr-only

## Validation

- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `C:\Users\oimir\.cargo\bin\cargo.exe fmt --manifest-path rust_core/Cargo.toml --check`
- `C:\Users\oimir\.cargo\bin\cargo.exe test --manifest-path rust_core/Cargo.toml --test test_routing -- --nocapture` -> 68 passed
- `uv run pytest -q` -> 2202 passed, 16 skipped
- `git diff --check`

## Review notes

- Exa anchors checked for the dogfood baseline: ripgrep getting started/options, ast-grep CLI/JSON docs, Cursor codebase indexing, and Sourcegraph agentic context.
- Read-only subagents independently reviewed AST scan leakage and launcher/env determinism; their findings drove the regression tests.
- Gemini review was attempted twice in read-only plan mode, but Gemini CLI returned `Invalid stream: The model returned an empty response or malformed tool call` both times before producing findings.