### PR TITLE
fix: harden lsp server request handshake

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -128,6 +128,17 @@ def _configuration_settings(language: str) -> dict[str, Any]:
     }
 
 
+def _lookup_configuration_section(settings: dict[str, Any], section: object) -> Any:
+    if not isinstance(section, str) or not section:
+        return settings
+    current: Any = settings
+    for part in section.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
 class ExternalLSPClient:
     def __init__(
         self,
@@ -194,7 +205,15 @@ class ExternalLSPClient:
                 {
                     "processId": None,
                     "rootUri": self.workspace_root.as_uri(),
-                    "capabilities": {},
+                    "capabilities": {
+                        "workspace": {
+                            "configuration": True,
+                            "workspaceFolders": True,
+                        }
+                    },
+                    "initializationOptions": _configuration_settings(self.language).get(
+                        "settings", {}
+                    ),
                     "workspaceFolders": [
                         {
                             "uri": self.workspace_root.as_uri(),
@@ -322,24 +341,26 @@ class ExternalLSPClient:
             self._request_id += 1
             request_id = self._request_id
             self._write_request(request_id, method, params)
-            while True:
-                try:
-                    message = self._message_queue.get(timeout=timeout_seconds)
-                except queue.Empty as exc:
-                    self.last_error = f"timeout waiting for LSP response: {method}"
-                    raise LSPTransportError(self.last_error) from exc
-                if message is None:
-                    self.last_error = f"LSP process closed during request: {method}"
-                    raise LSPTransportError(f"LSP process closed during request: {method}")
-                if "id" not in message:
-                    continue
-                if int(message["id"]) != request_id:
-                    continue
-                if "error" in message:
-                    self.last_error = str(message["error"])
-                    raise LSPTransportError(self.last_error)
-                self.last_error = None
-                return message.get("result")
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            remaining = max(0.0, deadline - time.monotonic())
+            try:
+                message = self._message_queue.get(timeout=remaining)
+            except queue.Empty as exc:
+                self.last_error = f"timeout waiting for LSP response: {method}"
+                raise LSPTransportError(self.last_error) from exc
+            if message is None:
+                self.last_error = f"LSP process closed during request: {method}"
+                raise LSPTransportError(f"LSP process closed during request: {method}")
+            if "id" not in message:
+                continue
+            if int(message["id"]) != request_id:
+                continue
+            if "error" in message:
+                self.last_error = str(message["error"])
+                raise LSPTransportError(self.last_error)
+            self.last_error = None
+            return message.get("result")
 
     def notify(self, method: str, params: dict[str, Any]) -> None:
         self.start()
@@ -416,6 +437,72 @@ class ExternalLSPClient:
             payload,
         )
 
+    def _write_response(self, request_id: object, result: Any) -> None:
+        if self.process is None or self.process.stdin is None:
+            raise LSPTransportError("LSP process is not available")
+        payload = {"jsonrpc": "2.0", "id": request_id, "result": result}
+        _write_message(self.process.stdin, payload)
+
+    def _write_error_response(self, request_id: object, *, code: int, message: str) -> None:
+        if self.process is None or self.process.stdin is None:
+            raise LSPTransportError("LSP process is not available")
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+        _write_message(self.process.stdin, payload)
+
+    def _configuration_response(self, params: object) -> list[Any]:
+        settings = _configuration_settings(self.language).get("settings", {})
+        if not isinstance(params, dict):
+            return [settings]
+        items = params.get("items")
+        if not isinstance(items, list):
+            return [settings]
+        return [
+            _lookup_configuration_section(
+                settings,
+                item.get("section") if isinstance(item, dict) else None,
+            )
+            for item in items
+        ]
+
+    def _handle_server_request(self, message: dict[str, Any]) -> bool:
+        if "id" not in message or "method" not in message:
+            return False
+        method = str(message.get("method"))
+        request_id = message.get("id")
+        try:
+            if method == "workspace/configuration":
+                result = self._configuration_response(message.get("params"))
+            elif method == "workspace/workspaceFolders":
+                result = [{"uri": self.workspace_root.as_uri(), "name": self.workspace_root.name}]
+            elif method in {
+                "client/registerCapability",
+                "client/unregisterCapability",
+                "window/workDoneProgress/create",
+            }:
+                result = None
+            else:
+                with self._lock:
+                    self._write_error_response(
+                        request_id,
+                        code=-32601,
+                        message=f"Unsupported LSP server request: {method}",
+                    )
+                return True
+            with self._lock:
+                self._write_response(request_id, result)
+            return True
+        except Exception as exc:
+            try:
+                with self._lock:
+                    self._write_error_response(request_id, code=-32603, message=str(exc))
+            except Exception:
+                pass
+            return True
+
     def _reader_loop(self) -> None:
         process = self.process
         if process is None or process.stdout is None:
@@ -427,6 +514,8 @@ class ExternalLSPClient:
                 if message is None:
                     self._message_queue.put(None)
                     return
+                if self._handle_server_request(message):
+                    continue
                 self._message_queue.put(message)
         except Exception as exc:
             self.last_error = str(exc)

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -304,12 +304,197 @@ def test_external_provider_client_start_orders_initialize_initialized_and_config
     ]
     initialize_message = written_messages[0]
     assert "id" in initialize_message
+    assert initialize_message["params"]["capabilities"]["workspace"] == {
+        "configuration": True,
+        "workspaceFolders": True,
+    }
+    assert (
+        initialize_message["params"]["initializationOptions"]["python"]["analysis"][
+            "diagnosticMode"
+        ]
+        == "openFilesOnly"
+    )
     settings = written_messages[2]["params"]["settings"]
     analysis_settings = settings["python"]["analysis"]
     assert analysis_settings["diagnosticMode"] == "openFilesOnly"
     assert "node_modules" in analysis_settings["exclude"]
     assert "__pycache__" in analysis_settings["exclude"]
     assert ".venv" in analysis_settings["exclude"]
+
+
+def test_external_provider_client_answers_server_configuration_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    written_messages: list[dict[str, Any]] = []
+    responses: queue.Queue[dict[str, Any] | None] = queue.Queue()
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "workspace/configuration",
+        "params": {
+            "items": [
+                {"section": "python.analysis"},
+                {"section": "python"},
+                {},
+            ]
+        },
+    })
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"capabilities": {"definitionProvider": True}},
+    })
+    responses.put(None)
+
+    class _FakeStream:
+        def close(self) -> None:
+            return None
+
+    class _FakeProcess:
+        stdin = _FakeStream()
+        stdout = _FakeStream()
+        stderr = _FakeStream()
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(provider_module.subprocess, "Popen", lambda *args, **kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        provider_module,
+        "_write_message",
+        lambda _stream, payload: written_messages.append(dict(payload)),
+    )
+    monkeypatch.setattr(provider_module, "_read_message", lambda _stream: responses.get())
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.start()
+
+    server_response = next(
+        message for message in written_messages if message.get("id") == 1 and "result" in message
+    )
+    assert "error" not in server_response
+    analysis_settings, python_settings, full_settings = server_response["result"]
+    assert analysis_settings["diagnosticMode"] == "openFilesOnly"
+    assert "artifacts" in analysis_settings["exclude"]
+    assert python_settings["analysis"]["diagnosticMode"] == "openFilesOnly"
+    assert full_settings["python"]["analysis"]["diagnosticMode"] == "openFilesOnly"
+    assert [message["method"] for message in written_messages if "method" in message] == [
+        "initialize",
+        "initialized",
+        "workspace/didChangeConfiguration",
+    ]
+
+
+def test_external_provider_client_answers_workspace_folder_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    written_messages: list[dict[str, Any]] = []
+    responses: queue.Queue[dict[str, Any] | None] = queue.Queue()
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "workspace/workspaceFolders",
+    })
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"capabilities": {"definitionProvider": True}},
+    })
+    responses.put(None)
+
+    class _FakeStream:
+        def close(self) -> None:
+            return None
+
+    class _FakeProcess:
+        stdin = _FakeStream()
+        stdout = _FakeStream()
+        stderr = _FakeStream()
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(provider_module.subprocess, "Popen", lambda *args, **kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        provider_module,
+        "_write_message",
+        lambda _stream, payload: written_messages.append(dict(payload)),
+    )
+    monkeypatch.setattr(provider_module, "_read_message", lambda _stream: responses.get())
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.start()
+
+    server_response = next(message for message in written_messages if message.get("id") == 42)
+    assert server_response["result"] == [
+        {"uri": tmp_path.resolve().as_uri(), "name": tmp_path.name}
+    ]
+
+
+def test_external_provider_client_rejects_unknown_server_requests_without_poisoning_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    written_messages: list[dict[str, Any]] = []
+    responses: queue.Queue[dict[str, Any] | None] = queue.Queue()
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": "server-unknown",
+        "method": "experimental/unknown",
+    })
+    responses.put({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"capabilities": {"definitionProvider": True}},
+    })
+    responses.put(None)
+
+    class _FakeStream:
+        def close(self) -> None:
+            return None
+
+    class _FakeProcess:
+        stdin = _FakeStream()
+        stdout = _FakeStream()
+        stderr = _FakeStream()
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(provider_module.subprocess, "Popen", lambda *args, **kwargs: _FakeProcess())
+    monkeypatch.setattr(
+        provider_module,
+        "_write_message",
+        lambda _stream, payload: written_messages.append(dict(payload)),
+    )
+    monkeypatch.setattr(provider_module, "_read_message", lambda _stream: responses.get())
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.start()
+
+    server_response = next(
+        message for message in written_messages if message.get("id") == "server-unknown"
+    )
+    assert server_response["error"]["code"] == -32601
+    assert "Unsupported LSP server request" in server_response["error"]["message"]
+    assert client.capabilities == {"definitionProvider": True}
 
 
 def test_external_provider_client_stop_sends_shutdown_request_then_exit_notification(


### PR DESCRIPTION
## Summary
- answer LSP server-initiated configuration, workspace folder, registration, and progress requests
- stop holding the LSP request lock while waiting for responses, using a monotonic request deadline instead
- send lightweight provider configuration during initialize while preserving the post-initialized configuration notification

## Research / planning anchors
- Exa: Pyright clients can stall without configuration handling; LSP clients must handle server requests instead of treating provider availability as navigation proof
- Thinktank: preserve row-based lsp_proof and test the id-collision/server-request path before implementation

## Validation
- uv run pytest tests/unit/test_lsp_external_provider.py tests/unit/test_semantic_provider_navigation.py -q
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q