### PR TITLE
fix: harden gpu promotion workload gates

### DIFF
--- a/benchmarks/run_gpu_benchmarks.py
+++ b/benchmarks/run_gpu_benchmarks.py
@@ -34,6 +34,7 @@ DEFAULT_CORRECTNESS_PATTERNS = (
     "WARN retry budget exhausted",
     "Database connection timeout",
 )
+GPU_SCALE_WORKLOAD_CLASS = "single_pattern_cold_grep"
 RECOMMENDATION_REQUIRED_CORPUS_SIZES = (1 * GB, 5 * GB)
 GPU_RECOMMENDATION_MIN_SPEEDUP_PCT = 20.0
 PAYLOAD_FILLER = "payload=" + ("0123456789abcdef" * 224)
@@ -1014,6 +1015,7 @@ def analyze_gpu_auto_recommendation(
         }
 
     winners: list[dict[str, object]] = []
+    winning_sizes_by_device: dict[str, set[int]] = {}
     skipped_non_native_route = False
     for row in rows:
         if row.get("size_bytes") not in required_size_bytes:
@@ -1050,6 +1052,9 @@ def analyze_gpu_auto_recommendation(
             gpu_result["speedup_vs_rg_pct"] = speedup_vs_rg_pct
             gpu_result["speedup_vs_tg_cpu_pct"] = speedup_vs_tg_cpu_pct
             if speedup_vs_rg_pct >= min_speedup_pct and speedup_vs_tg_cpu_pct >= min_speedup_pct:
+                winning_sizes_by_device.setdefault(str(device_id), set()).add(
+                    int(row.get("size_bytes", 0))
+                )
                 winners.append({
                     "device_id": device_id,
                     "size_label": row.get("size_label"),
@@ -1058,17 +1063,23 @@ def analyze_gpu_auto_recommendation(
                     "speedup_vs_tg_cpu_pct": speedup_vs_tg_cpu_pct,
                 })
 
-    if not winners:
+    qualifying_devices = {
+        device_id
+        for device_id, winning_sizes in winning_sizes_by_device.items()
+        if required_size_bytes.issubset(winning_sizes)
+    }
+
+    if not winners or not qualifying_devices:
         if skipped_non_native_route:
             reason = (
                 "No correctness-passing GPU row used NativeGpuBackend with sidecar_used=false "
-                f"and beat both rg and tg_cpu by at least {min_speedup_pct:.0f}% at the "
+                f"and beat both rg and tg_cpu by at least {min_speedup_pct:.0f}% at every "
                 f"required {required_size_labels} scale."
             )
         else:
             reason = (
-                "No correctness-passing GPU row beat both rg and tg_cpu by at least "
-                f"{min_speedup_pct:.0f}% at the required {required_size_labels} scale."
+                "No correctness-passing GPU device beat both rg and tg_cpu by at least "
+                f"{min_speedup_pct:.0f}% at every required {required_size_labels} scale."
             )
         return {
             "should_add_flag": False,
@@ -1079,10 +1090,12 @@ def analyze_gpu_auto_recommendation(
     return {
         "should_add_flag": True,
         "reason": (
-            "At least one GPU row passed required correctness and beat both rg and "
-            f"tg_cpu by {min_speedup_pct:.0f}% or more at required scale."
+            "At least one GPU device passed required correctness and beat both rg and "
+            f"tg_cpu by {min_speedup_pct:.0f}% or more at every required scale."
         ),
-        "winning_rows": winners,
+        "winning_rows": [
+            winner for winner in winners if str(winner.get("device_id")) in qualifying_devices
+        ],
     }
 
 
@@ -1094,11 +1107,13 @@ def _promotion_evidence_contract(required_labels: list[str]) -> dict[str, object
     return {
         "required_runtime_backend": "NativeGpuBackend",
         "required_sidecar_used": False,
+        "required_workload_class": GPU_SCALE_WORKLOAD_CLASS,
         "required_correctness_sizes": required_labels,
         "required_speed_baselines": ["rg", "tg_cpu"],
         "sidecar_routing_counts_as_promotion": False,
         "fallback_or_sidecar_counts_as_gpu_proof": False,
         "public_managed_rows_must_not_be_sidecar": True,
+        "many_pattern_claim_requires_fair_rg_multi_pattern_baseline": True,
     }
 
 
@@ -1281,6 +1296,7 @@ def build_scale_gate_summary(
 
     return {
         "benchmark_surface": "python-gpu-scale",
+        "workload_class": GPU_SCALE_WORKLOAD_CLASS,
         "promotion_evidence_contract": _promotion_evidence_contract(required_labels),
         "native_cuda_scale_gate": native_gate,
         "correctness_gate": correctness_gate,

--- a/benchmarks/run_gpu_native_benchmarks.py
+++ b/benchmarks/run_gpu_native_benchmarks.py
@@ -36,6 +36,8 @@ DEFAULT_RUNS = 3
 DEFAULT_WARMUP = 0
 DEFAULT_COMMAND_TIMEOUT_S = 180
 DEFAULT_GPU_DEVICE_ID = 0
+NATIVE_SCALE_WORKLOAD_CLASS = "single_pattern_cold_grep"
+NATIVE_MANY_PATTERN_WORKLOAD_CLASS = "many_fixed_patterns_single_dispatch"
 DEFAULT_TIMEOUT_SIMULATION_MS = 300
 DEFAULT_TIMEOUT_DESCRIPTION = "simulation-backed via TG_TEST_CUDA_BEHAVIOR"
 DEFAULT_ADVANCED_TRANSFER_TOTAL_BYTES = 1 * GB
@@ -97,6 +99,18 @@ def _build_command_env(extra: dict[str, str] | None = None) -> dict[str, str]:
 
 def build_rg_search_command(rg_binary: str, pattern: str, corpus_dir: Path) -> list[str]:
     return [rg_binary, "--no-ignore", "-F", pattern, str(corpus_dir)]
+
+
+def build_rg_multi_pattern_search_command(
+    rg_binary: str,
+    patterns: list[str] | tuple[str, ...],
+    corpus_dir: Path,
+) -> list[str]:
+    command = [rg_binary, "--no-ignore", "-F"]
+    for pattern in patterns:
+        command.extend(["-e", pattern])
+    command.append(str(corpus_dir))
+    return command
 
 
 def build_tg_cpu_search_command(tg_binary: Path, pattern: str, corpus_dir: Path) -> list[str]:
@@ -960,11 +974,13 @@ def _promotion_evidence_contract(required_labels: list[str]) -> dict[str, object
     return {
         "required_runtime_backend": "NativeGpuBackend",
         "required_sidecar_used": False,
+        "required_workload_class": NATIVE_SCALE_WORKLOAD_CLASS,
         "required_correctness_sizes": required_labels,
         "required_speed_baselines": ["rg", "tg_cpu"],
         "sidecar_routing_counts_as_promotion": False,
         "fallback_or_sidecar_counts_as_gpu_proof": False,
         "public_managed_rows_must_not_be_sidecar": True,
+        "many_pattern_claim_requires_fair_rg_multi_pattern_baseline": True,
     }
 
 
@@ -1031,16 +1047,16 @@ def _native_speed_gate(
         ):
             best_attempt = attempt
 
-    status = "PASS" if winning_sizes else "FAIL"
+    status = "PASS" if required_labels.issubset(set(winning_sizes)) else "FAIL"
     return {
         "status": status,
         "required_baselines": ["rg", "tg_cpu"],
         "winning_sizes": winning_sizes,
         "best_attempt": best_attempt,
         "reason": (
-            "Native CUDA beat both rg and tg_cpu at the required scale."
-            if winning_sizes
-            else "Native CUDA did not beat both rg and tg_cpu at the required scale."
+            "Native CUDA beat both rg and tg_cpu at every required scale."
+            if status == "PASS"
+            else "Native CUDA did not beat both rg and tg_cpu at every required scale."
         ),
     }
 
@@ -1281,6 +1297,7 @@ def build_native_scale_gate_summary(
 
     return {
         "benchmark_surface": "native-cuda-scale",
+        "workload_class": NATIVE_SCALE_WORKLOAD_CLASS,
         "promotion_evidence_contract": _promotion_evidence_contract(required_labels),
         "native_cuda_runtime_gate": runtime_gate,
         "correctness_gate": correctness_gate,
@@ -2023,6 +2040,14 @@ def run_advanced_gpu_native_benchmarks(
         timeout_s=command_timeout_s,
         workload_bytes=one_gib_actual_bytes * len(multi_patterns),
     )
+    multi_pattern_rg_benchmark = benchmark_search_command(
+        build_rg_multi_pattern_search_command(rg_binary, multi_patterns, one_gib_corpus),
+        env=env,
+        runs=runs,
+        warmup=warmup,
+        timeout_s=command_timeout_s,
+        corpus_bytes=one_gib_actual_bytes,
+    )
     multi_pattern_gpu_stats = (
         multi_pattern_gpu_benchmark.pop("payload", {})
         if isinstance(multi_pattern_gpu_benchmark.get("payload"), dict)
@@ -2030,10 +2055,18 @@ def run_advanced_gpu_native_benchmarks(
     )
     multi_pattern_gpu_median = multi_pattern_gpu_benchmark.get("median_s")
     multi_pattern_cpu_median = multi_pattern_cpu_benchmark.get("median_s")
+    multi_pattern_rg_median = multi_pattern_rg_benchmark.get("median_s")
     multi_pattern_speedup = (
         round(float(multi_pattern_cpu_median) / float(multi_pattern_gpu_median), 4)
         if isinstance(multi_pattern_gpu_median, (float, int))
         and isinstance(multi_pattern_cpu_median, (float, int))
+        and float(multi_pattern_gpu_median) > 0
+        else None
+    )
+    multi_pattern_rg_speedup = (
+        round(float(multi_pattern_rg_median) / float(multi_pattern_gpu_median), 4)
+        if isinstance(multi_pattern_gpu_median, (float, int))
+        and isinstance(multi_pattern_rg_median, (float, int))
         and float(multi_pattern_gpu_median) > 0
         else None
     )
@@ -2042,22 +2075,32 @@ def run_advanced_gpu_native_benchmarks(
         "PASS"
         if multi_pattern_gpu_benchmark.get("status") == "PASS"
         and multi_pattern_cpu_benchmark.get("status") == "PASS"
+        and multi_pattern_rg_benchmark.get("status") == "PASS"
         and int(multi_pattern_pipeline.get("pattern_count", 0)) == len(multi_patterns)
         and bool(multi_pattern_pipeline.get("single_dispatch"))
         and multi_pattern_speedup is not None
         and multi_pattern_speedup > 1.0
+        and multi_pattern_rg_speedup is not None
+        and multi_pattern_rg_speedup > 1.0
         else "FAIL"
     )
     advanced["multi_pattern"] = {
         "status": multi_pattern_status,
+        "workload_class": NATIVE_MANY_PATTERN_WORKLOAD_CLASS,
+        "fair_rg_baseline": "single_invocation_rg_fixed_multi_pattern",
         "patterns": multi_patterns,
         "gpu": multi_pattern_gpu_benchmark,
         "cpu_sequential": multi_pattern_cpu_benchmark,
+        "rg_multi_pattern": multi_pattern_rg_benchmark,
         "speedup_vs_cpu": multi_pattern_speedup,
+        "speedup_vs_rg_multi_pattern": multi_pattern_rg_speedup,
         "gpu_stats": multi_pattern_gpu_stats,
     }
     if multi_pattern_status != "PASS":
-        errors.append("Multi-pattern GPU benchmark did not beat sequential CPU execution.")
+        errors.append(
+            "Multi-pattern GPU benchmark did not beat both sequential CPU and fair rg "
+            "multi-pattern execution."
+        )
 
     single_gpu_benchmark = benchmark_json_metric_command(
         build_tg_gpu_native_stats_command(

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -3532,6 +3532,30 @@ def test_run_gpu_native_benchmarks_should_emit_advanced_sections_when_enabled(
     assert payload["advanced"]["oom_validation"]["status"] == "PASS"
 
 
+def test_run_gpu_native_benchmarks_should_build_fair_rg_multi_pattern_command(tmp_path):
+    module = _load_script_module(
+        "run_gpu_native_benchmarks_fair_rg_multi_pattern",
+        "benchmarks/run_gpu_native_benchmarks.py",
+    )
+    corpus_dir = tmp_path / "corpus"
+    patterns = ["ERROR timeout", "WARN retry", "Database connection timeout"]
+
+    command = module.build_rg_multi_pattern_search_command("rg", patterns, corpus_dir)
+
+    assert command == [
+        "rg",
+        "--no-ignore",
+        "-F",
+        "-e",
+        "ERROR timeout",
+        "-e",
+        "WARN retry",
+        "-e",
+        "Database connection timeout",
+        str(corpus_dir),
+    ]
+
+
 def test_run_hot_query_benchmarks_should_default_data_dir_to_artifacts(monkeypatch):
     module = _load_script_module(
         "run_hot_query_benchmarks_script", "benchmarks/run_hot_query_benchmarks.py"

--- a/tests/unit/test_gpu_benchmark_scale_contracts.py
+++ b/tests/unit/test_gpu_benchmark_scale_contracts.py
@@ -29,6 +29,29 @@ def test_run_gpu_benchmarks_should_parse_5gb_corpus_size():
     )
 
 
+def test_gpu_promotion_contract_should_name_single_pattern_workload_class():
+    module = _load_script_module(
+        "run_gpu_benchmarks_workload_contract", "benchmarks/run_gpu_benchmarks.py"
+    )
+
+    contract = module._promotion_evidence_contract(["1GB", "5GB"])
+
+    assert contract["required_workload_class"] == "single_pattern_cold_grep"
+    assert contract["many_pattern_claim_requires_fair_rg_multi_pattern_baseline"] is True
+
+
+def test_gpu_native_promotion_contract_should_name_single_pattern_workload_class():
+    module = _load_script_module(
+        "run_gpu_native_benchmarks_workload_contract",
+        "benchmarks/run_gpu_native_benchmarks.py",
+    )
+
+    contract = module._promotion_evidence_contract(["1GB", "5GB"])
+
+    assert contract["required_workload_class"] == "single_pattern_cold_grep"
+    assert contract["many_pattern_claim_requires_fair_rg_multi_pattern_baseline"] is True
+
+
 def test_gpu_pipeline_helpers_should_summarize_bottleneck_stage():
     module = _load_script_module(
         "run_gpu_benchmarks_pipeline_summary", "benchmarks/run_gpu_benchmarks.py"
@@ -515,14 +538,17 @@ def test_run_gpu_benchmarks_should_skip_sidecar_contaminated_native_runtime_for_
     assert "sidecar" in payload["not_gpu_proof_reason"]
     assert payload["scale_gate_summary"] == {
         "benchmark_surface": "python-gpu-scale",
+        "workload_class": "single_pattern_cold_grep",
         "promotion_evidence_contract": {
             "required_runtime_backend": "NativeGpuBackend",
             "required_sidecar_used": False,
+            "required_workload_class": "single_pattern_cold_grep",
             "required_correctness_sizes": ["1GB", "5GB"],
             "required_speed_baselines": ["rg", "tg_cpu"],
             "sidecar_routing_counts_as_promotion": False,
             "fallback_or_sidecar_counts_as_gpu_proof": False,
             "public_managed_rows_must_not_be_sidecar": True,
+            "many_pattern_claim_requires_fair_rg_multi_pattern_baseline": True,
         },
         "native_cuda_scale_gate": {
             "status": "UNSUPPORTED",
@@ -764,7 +790,7 @@ def test_gpu_auto_recommendation_should_reject_sidecar_contaminated_native_rows(
     assert "NativeGpuBackend with sidecar_used=false" in recommendation["reason"]
 
 
-def test_gpu_auto_recommendation_should_recommend_required_scale_win_with_correctness():
+def test_gpu_auto_recommendation_should_require_every_required_scale_to_win():
     module = _load_script_module(
         "run_gpu_benchmarks_required_recommendation",
         "benchmarks/run_gpu_benchmarks.py",
@@ -820,6 +846,67 @@ def test_gpu_auto_recommendation_should_recommend_required_scale_win_with_correc
         correctness_patterns=("gpu benchmark sentinel", "WARN retry budget exhausted"),
     )
 
+    assert recommendation["should_add_flag"] is False
+    assert recommendation["winning_rows"] == []
+    assert "every required 1GB/5GB scale" in recommendation["reason"]
+
+
+def test_gpu_auto_recommendation_should_recommend_when_all_required_scales_win():
+    module = _load_script_module(
+        "run_gpu_benchmarks_all_required_recommendation",
+        "benchmarks/run_gpu_benchmarks.py",
+    )
+    rows = [
+        {
+            "size_label": "1GB",
+            "size_bytes": module.GB,
+            "rg": {"status": "PASS", "median_s": 10.0},
+            "tg_cpu": {"status": "PASS", "median_s": 12.0},
+            "gpu": [
+                {
+                    "device_id": 0,
+                    "status": "PASS",
+                    "median_s": 5.0,
+                    "tg_runtime_backend": "NativeGpuBackend",
+                    "tg_runtime_sidecar_used": False,
+                }
+            ],
+        },
+        {
+            "size_label": "5GB",
+            "size_bytes": 5 * module.GB,
+            "rg": {"status": "PASS", "median_s": 60.0},
+            "tg_cpu": {"status": "PASS", "median_s": 70.0},
+            "gpu": [
+                {
+                    "device_id": 0,
+                    "status": "PASS",
+                    "median_s": 40.0,
+                    "tg_runtime_backend": "NativeGpuBackend",
+                    "tg_runtime_sidecar_used": False,
+                }
+            ],
+        },
+    ]
+    correctness_checks = [
+        {
+            "device_id": 0,
+            "corpus_size_label": size_label,
+            "pattern": pattern,
+            "status": "PASS",
+            "matches_equal": True,
+            "files_equal": True,
+        }
+        for size_label in ("1GB", "5GB")
+        for pattern in ("gpu benchmark sentinel", "WARN retry budget exhausted")
+    ]
+
+    recommendation = module.analyze_gpu_auto_recommendation(
+        rows,
+        correctness_checks=correctness_checks,
+        correctness_patterns=("gpu benchmark sentinel", "WARN retry budget exhausted"),
+    )
+
     assert recommendation["should_add_flag"] is True
     assert recommendation["winning_rows"] == [
         {
@@ -828,7 +915,14 @@ def test_gpu_auto_recommendation_should_recommend_required_scale_win_with_correc
             "size_bytes": module.GB,
             "speedup_vs_rg_pct": 50.0,
             "speedup_vs_tg_cpu_pct": 58.33,
-        }
+        },
+        {
+            "device_id": 0,
+            "size_label": "5GB",
+            "size_bytes": 5 * module.GB,
+            "speedup_vs_rg_pct": 33.33,
+            "speedup_vs_tg_cpu_pct": 42.86,
+        },
     ]
 
 
@@ -1334,14 +1428,17 @@ def test_run_gpu_native_benchmarks_should_separate_correctness_pass_from_speed_f
     )
 
     assert summary["benchmark_surface"] == "native-cuda-scale"
+    assert summary["workload_class"] == "single_pattern_cold_grep"
     assert summary["promotion_evidence_contract"] == {
         "required_runtime_backend": "NativeGpuBackend",
         "required_sidecar_used": False,
+        "required_workload_class": "single_pattern_cold_grep",
         "required_correctness_sizes": ["1GB", "5GB"],
         "required_speed_baselines": ["rg", "tg_cpu"],
         "sidecar_routing_counts_as_promotion": False,
         "fallback_or_sidecar_counts_as_gpu_proof": False,
         "public_managed_rows_must_not_be_sidecar": True,
+        "many_pattern_claim_requires_fair_rg_multi_pattern_baseline": True,
     }
     assert summary["native_cuda_runtime_gate"] == {
         "status": "PASS",
@@ -1365,7 +1462,7 @@ def test_run_gpu_native_benchmarks_should_separate_correctness_pass_from_speed_f
             "gpu_rg_ratio": 36.8,
             "gpu_tg_cpu_ratio": 38.3333,
         },
-        "reason": "Native CUDA did not beat both rg and tg_cpu at the required scale.",
+        "reason": "Native CUDA did not beat both rg and tg_cpu at every required scale.",
     }
     assert summary["promotion_blockers"] == ["speed_gate_failed"]
     assert summary["promotion_ready"] is False


### PR DESCRIPTION
## Summary
- add explicit GPU promotion workload class metadata to public and native scale summaries
- require a correctness-passing GPU device to beat both rg and tg_cpu at every required 1GB/5GB scale before recommendation/promotion
- add a fair single-invocation rg fixed multi-pattern baseline to native advanced many-pattern diagnostics

## Research / planning anchors
- Exa: CUDA grep only amortizes GPU transfer/startup on many-pattern workloads; ripgrep remains the cold raw grep baseline
- Thinktank: separate route proof from promotion proof, require workload_class, and avoid many-pattern claims without fair rg multi-pattern baseline

## Validation
- uv run pytest tests/unit/test_gpu_benchmark_scale_contracts.py tests/unit/test_benchmark_scripts.py -q
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest -q