### PR TITLE
fix: emit structured search json errors

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -2629,6 +2629,12 @@ fn run_positional_cli(cli: PositionalCli) -> anyhow::Result<()> {
 
     let pattern = cli.pattern.clone().unwrap();
     let paths = implicit_search_paths(&cli.path, stdin_should_search_implicit_path());
+    exit_json_search_input_error_if_needed(
+        cli.json,
+        cli.ndjson,
+        std::slice::from_ref(&pattern),
+        &paths,
+    );
     let primary_path = paths.first().map(String::as_str).unwrap_or(".");
 
     let rg_available = ripgrep_is_available();
@@ -2836,6 +2842,85 @@ fn implicit_search_paths(
         Vec::new()
     } else {
         vec![".".to_string()]
+    }
+}
+
+fn emit_search_error_json(error: &str, detail: &str) {
+    println!(
+        "{}",
+        serde_json::json!({
+            "version": JSON_OUTPUT_VERSION,
+            "ok": false,
+            "error": error,
+            "detail": detail,
+        })
+    );
+}
+
+fn exit_search_error_json(error: &str, detail: impl Into<String>) -> ! {
+    emit_search_error_json(error, &detail.into());
+    std::process::exit(2);
+}
+
+fn first_missing_search_path(paths: &[String]) -> Option<String> {
+    paths
+        .iter()
+        .find(|path| path.as_str() != "-" && !Path::new(path).exists())
+        .cloned()
+}
+
+fn exit_json_search_input_error_if_needed(
+    json: bool,
+    ndjson: bool,
+    patterns: &[String],
+    paths: &[String],
+) {
+    if !json || ndjson {
+        return;
+    }
+    if patterns.iter().any(|pattern| pattern.is_empty()) {
+        exit_search_error_json("empty_pattern", "PATTERN must not be empty.");
+    }
+    if let Some(missing_path) = first_missing_search_path(paths) {
+        exit_search_error_json(
+            "path_not_found",
+            format!("search path does not exist: {missing_path}"),
+        );
+    }
+}
+
+fn search_error_code_for_message(message: &str) -> Option<&'static str> {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("non-empty pattern") || lower.contains("pattern must not be empty") {
+        Some("empty_pattern")
+    } else if lower.contains("path does not exist") {
+        Some("path_not_found")
+    } else if lower.contains("failed to compile native search pattern")
+        || lower.contains("regex parse error")
+        || lower.contains("error parsing regex")
+        || lower.contains("invalid regex")
+    {
+        Some("invalid_regex")
+    } else {
+        None
+    }
+}
+
+fn normalize_search_error_detail(error: &str, detail: &str) -> String {
+    if error == "invalid_regex" && !detail.to_ascii_lowercase().contains("invalid regex") {
+        format!("invalid regex pattern: {detail}")
+    } else {
+        detail.to_string()
+    }
+}
+
+fn exit_json_search_runtime_error_if_needed(json: bool, ndjson: bool, err: &anyhow::Error) {
+    if !json || ndjson {
+        return;
+    }
+    let detail = err.to_string();
+    if let Some(code) = search_error_code_for_message(&detail) {
+        exit_search_error_json(code, normalize_search_error_detail(code, &detail));
     }
 }
 
@@ -3426,6 +3511,7 @@ fn run_native_search_with_optional_rg_fallback(
             Ok(())
         }
         Err(err) => {
+            exit_json_search_runtime_error_if_needed(json, ndjson, &err);
             if let Some(rg_args) = rg_fallback {
                 eprintln!("warning: native CPU search failed, falling back to ripgrep: {err}");
                 if !json && !ndjson && verbose {
@@ -3465,6 +3551,12 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
     }
 
     let request = resolve_search_request(&args)?;
+    exit_json_search_input_error_if_needed(
+        args.json,
+        args.ndjson,
+        &request.patterns,
+        &request.paths,
+    );
     let query = request.query_display();
     let path_display = request.path_display();
     let rg_available = ripgrep_is_available();
@@ -3624,7 +3716,7 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
                 .then(|| command_ripgrep_args(&args, &request));
 
             if request.patterns.len() > 1 {
-                let matches = collect_native_multi_pattern_matches(
+                let matches = match collect_native_multi_pattern_matches(
                     &request.patterns,
                     native_search_config_for_command(
                         &args,
@@ -3632,7 +3724,13 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
                         &request.paths,
                         decision,
                     ),
-                )?;
+                ) {
+                    Ok(matches) => matches,
+                    Err(err) => {
+                        exit_json_search_runtime_error_if_needed(args.json, args.ndjson, &err);
+                        return Err(err);
+                    }
+                };
                 return emit_multi_pattern_native_results(
                     NativeSearchOutputOptions {
                         decision,

--- a/rust_core/tests/test_routing.rs
+++ b/rust_core/tests/test_routing.rs
@@ -1343,6 +1343,109 @@ fn test_search_json_and_ndjson_are_mutually_exclusive() {
 }
 
 #[test]
+fn test_search_json_reports_empty_pattern_error() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "output={}",
+        combined_output(&output)
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"], "empty_pattern");
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("PATTERN must not be empty"));
+}
+
+#[test]
+fn test_root_json_reports_empty_pattern_error() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    let output = tg().arg("--json").arg("").arg(dir.path()).output().unwrap();
+
+    assert!(
+        !output.status.success(),
+        "output={}",
+        combined_output(&output)
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"], "empty_pattern");
+}
+
+#[test]
+fn test_search_json_reports_missing_path_error() {
+    let dir = tempdir().unwrap();
+    let missing = dir.path().join("missing.txt");
+
+    let output = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("hello")
+        .arg(&missing)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "output={}",
+        combined_output(&output)
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"], "path_not_found");
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains(&missing.to_string_lossy().to_string()));
+}
+
+#[test]
+fn test_search_json_reports_invalid_regex_error() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("(")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "output={}",
+        combined_output(&output)
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"], "invalid_regex");
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .to_lowercase()
+        .contains("invalid regex"));
+}
+
+#[test]
 fn test_routing_explicit_index_uses_trigram_index_json() {
     let dir = tempdir().unwrap();
     write_text_corpus(dir.path());

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -2443,15 +2443,46 @@ def _is_invalid_regex_error(exc: Exception) -> bool:
     return exc.__class__.__name__ == "InvalidRegexError"
 
 
-def _exit_invalid_regex(exc: Exception) -> None:
+def _search_error_payload(error: str, detail: str) -> dict[str, object]:
+    from tensor_grep.cli.formatters.json_fmt import JSON_OUTPUT_VERSION
+
+    return {
+        "version": JSON_OUTPUT_VERSION,
+        "ok": False,
+        "error": error,
+        "detail": detail,
+    }
+
+
+def _emit_search_error_json(error: str, detail: str) -> None:
+    _safe_stdout_line(json.dumps(_search_error_payload(error, detail)))
+
+
+def _exit_search_error(
+    error: str,
+    detail: str,
+    *,
+    json_mode: bool,
+    stderr_detail: str | None = None,
+    exit_code: int = 2,
+) -> None:
+    if json_mode:
+        _emit_search_error_json(error, detail)
+    else:
+        typer.echo(f"Error: {stderr_detail or detail}", err=True)
+    sys.exit(exit_code)
+
+
+def _exit_invalid_regex(exc: Exception, *, json_mode: bool = False) -> None:
     message = str(exc)
     if "invalid regex" not in message.lower():
         message = f"invalid regex pattern: {message}"
-    typer.echo(
-        f"Error: {message}. Use --fixed-strings (-F) to search this pattern literally.",
-        err=True,
+    _exit_search_error(
+        "invalid_regex",
+        message,
+        json_mode=json_mode,
+        stderr_detail=f"{message}. Use --fixed-strings (-F) to search this pattern literally.",
     )
-    sys.exit(2)
 
 
 def _validate_search_regex(pattern: str, config: "SearchConfig") -> None:
@@ -4400,8 +4431,11 @@ def search_command(
     elif regexp_patterns:
         pattern = regexp_patterns[0]
         if pattern == "":
-            typer.echo("Error: PATTERN must not be empty.", err=True)
-            sys.exit(2)
+            _exit_search_error(
+                "empty_pattern",
+                "PATTERN must not be empty.",
+                json_mode=json,
+            )
         paths_to_search = args or ["."]
         paths_defaulted = not args
     else:
@@ -4410,8 +4444,11 @@ def search_command(
             sys.exit(1)
         pattern = args[0]
         if pattern == "":
-            typer.echo("Error: PATTERN must not be empty.", err=True)
-            sys.exit(2)
+            _exit_search_error(
+                "empty_pattern",
+                "PATTERN must not be empty.",
+                json_mode=json,
+            )
         paths_to_search = args[1:] or ["."]
         paths_defaulted = not args[1:]
 
@@ -4420,9 +4457,16 @@ def search_command(
             path for path in paths_to_search if path != "-" and not Path(path).exists()
         ]
         if missing_paths:
-            for missing_path in missing_paths:
-                typer.echo(f"Error: search path does not exist: {missing_path}", err=True)
-            sys.exit(2)
+            if json:
+                detail = "search path does not exist: " + ", ".join(missing_paths)
+                _exit_search_error("path_not_found", detail, json_mode=True)
+            else:
+                for missing_path in missing_paths:
+                    typer.echo(
+                        f"Error: search path does not exist: {missing_path}",
+                        err=True,
+                    )
+                sys.exit(2)
 
     if line_number is None:
         line_number = sys.stdout.isatty()
@@ -4563,7 +4607,7 @@ def search_command(
                 _validate_search_regex(regex_pattern, config)
         except Exception as exc:
             if _is_invalid_regex_error(exc):
-                _exit_invalid_regex(exc)
+                _exit_invalid_regex(exc, json_mode=json)
             raise
     guarded_broad_root = _search_paths_include_guarded_broad_root(paths_to_search)
     explicit_hidden_search_root = not config.hidden and any(
@@ -4758,7 +4802,7 @@ def search_command(
                 result = rg_backend.search(search_targets, pattern, config=rg_search_config)
             except Exception as exc:
                 if _is_invalid_regex_error(exc):
-                    _exit_invalid_regex(exc)
+                    _exit_invalid_regex(exc, json_mode=json)
                 raise
             if span is not None:
                 span.set_attribute("matches", result.total_matches)
@@ -4784,7 +4828,7 @@ def search_command(
                     result = backend.search(current_file, pattern, config=config)
                 except Exception as exc:
                     if _is_invalid_regex_error(exc):
-                        _exit_invalid_regex(exc)
+                        _exit_invalid_regex(exc, json_mode=json)
                     raise
                 if span is not None:
                     span.set_attribute("matches", result.total_matches)

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1918,11 +1918,36 @@ def test_cli_invalid_regex_is_rejected_before_native_delegation(monkeypatch):
 
     monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
 
-    result = CliRunner().invoke(app, ["search", "(", ".", "--json"])
+    result = CliRunner().invoke(app, ["search", "(", "."])
 
     assert result.exit_code == 2
     assert "invalid regex" in result.stderr.lower()
     assert "Use --fixed-strings" in result.stderr
+    assert "cmd" not in seen
+
+
+def test_cli_invalid_regex_reports_json_error_before_native_delegation(monkeypatch):
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: Path("tg.exe"))
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._can_delegate_to_native_tg_search",
+        lambda *args, **kwargs: True,
+    )
+
+    def _fake_run(cmd, check=False):
+        seen["cmd"] = list(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    result = CliRunner().invoke(app, ["search", "(", ".", "--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "invalid_regex"
+    assert "invalid regex" in payload["detail"].lower()
     assert "cmd" not in seen
 
 
@@ -1960,7 +1985,7 @@ def test_cli_later_invalid_regexp_is_rejected_before_native_delegation(monkeypat
 
     monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
 
-    result = CliRunner().invoke(app, ["search", "-e", "safe", "-e", "(", ".", "--json"])
+    result = CliRunner().invoke(app, ["search", "-e", "safe", "-e", "(", "."])
 
     assert result.exit_code == 2
     assert "invalid regex" in result.stderr.lower()
@@ -6310,6 +6335,20 @@ def test_search_rejects_empty_pattern(tmp_path: Path):
     assert "PATTERN must not be empty" in result.output
 
 
+def test_search_json_reports_empty_pattern_error(tmp_path: Path):
+    target = tmp_path / "sample.py"
+    target.write_text("print('hello')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["search", "--json", "", str(target)])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "empty_pattern"
+    assert "PATTERN must not be empty" in payload["detail"]
+
+
 def test_search_reports_missing_input_paths(tmp_path: Path):
     missing = tmp_path / "missing.py"
 
@@ -6319,6 +6358,20 @@ def test_search_reports_missing_input_paths(tmp_path: Path):
     assert result.exit_code == 2
     assert str(missing) in result.output
     assert "does not exist" in result.output
+
+
+def test_search_json_reports_missing_input_path_error(tmp_path: Path):
+    missing = tmp_path / "missing.py"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["search", "--json", "hello", str(missing)])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "path_not_found"
+    assert str(missing) in payload["detail"]
+    assert "does not exist" in payload["detail"]
 
 
 def test_files_with_matches_null_outputs_nul_separator(tmp_path: Path):


### PR DESCRIPTION
## Summary
- emit stable tensor-grep JSON error envelopes for `tg search --json` invalid input
- cover `empty_pattern`, `path_not_found`, and `invalid_regex` in Python and native Rust front doors
- preserve human stderr for non-JSON errors and rg JSON Lines behavior for `--format rg --json`

## Validation
- `uv run pytest tests/unit/test_cli_modes.py -q` -> 347 passed
- `cargo test --manifest-path rust_core/Cargo.toml --test test_routing -- --nocapture` -> 72 passed
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `cargo fmt --manifest-path rust_core/Cargo.toml --check`
- `uv run mypy src/tensor_grep`
- `uv run pytest -q` -> 2212 passed, 16 skipped
- `git diff --check` -> clean except CRLF normalization warnings on Rust files

## Root Cause
Wrappers had to regex-match human stderr because invalid `--json` search inputs exited nonzero without a machine-readable error payload.