### PR TITLE
fix: harden ast run semantic flag routing

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -737,17 +737,21 @@ pub struct RunArgs {
     #[arg(long = "files-with-matches")]
     pub files_with_matches: bool,
 
-    /// Unsupported ast-grep selector option; accepted only for explicit diagnostics
+    /// ast-grep matcher selector for read-only structural search
     #[arg(long)]
     pub selector: Option<String>,
 
-    /// Unsupported ast-grep strictness option; accepted only for explicit diagnostics
+    /// ast-grep strictness control for read-only structural search
     #[arg(long)]
     pub strictness: Option<String>,
 
-    /// Unsupported ast-grep stdin mode; accepted only for explicit diagnostics
+    /// Read source code from stdin for read-only structural search
     #[arg(long = "stdin")]
     pub stdin_flag: bool,
+
+    /// ast-grep include/exclude glob. Repeat for multiple globs; prefix with ! to exclude.
+    #[arg(long = "globs")]
+    pub globs: Vec<String>,
 
     /// Positional PATTERN and optional PATH, or just PATH when --pattern is used
     #[arg(value_name = "PATTERN_OR_PATH")]
@@ -2481,6 +2485,61 @@ mod tests {
 
         let error = validate_run_args(&rewrite).unwrap_err().to_string();
         assert!(error.contains("read-only search output mode"));
+    }
+
+    #[test]
+    fn run_ast_grep_semantic_options_are_read_only_python_passthrough() {
+        let args = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "print($A)",
+            "--selector",
+            "call",
+            "--strictness",
+            "relaxed",
+            "--globs",
+            "*.py",
+            "fixture.py",
+        ]);
+
+        assert!(validate_run_args(&args).is_ok());
+        assert!(ast_run_requires_python_passthrough(&args));
+
+        let rewrite = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "print($A)",
+            "--selector",
+            "call",
+            "--rewrite",
+            "logger.info($A)",
+            "fixture.py",
+        ]);
+        let error = validate_run_args(&rewrite).unwrap_err().to_string();
+        assert!(error.contains("ast-grep semantic run options are read-only"));
+    }
+
+    #[test]
+    fn run_stdin_rejects_files_with_matches() {
+        let args = parse_run_args(&[
+            "tg",
+            "run",
+            "--lang",
+            "python",
+            "--pattern",
+            "print($A)",
+            "--stdin",
+            "--files-with-matches",
+        ]);
+
+        let error = validate_run_args(&args).unwrap_err().to_string();
+        assert!(error.contains("--stdin cannot be combined with --files-with-matches"));
     }
 
     #[test]
@@ -4983,24 +5042,19 @@ fn ast_match_to_search_json(
 }
 
 fn validate_run_args(args: &RunArgs) -> anyhow::Result<()> {
-    let mut unsupported_flags = Vec::new();
-    if args.selector.is_some() {
-        unsupported_flags.push("--selector");
-    }
-    if args.strictness.is_some() {
-        unsupported_flags.push("--strictness");
-    }
-    if args.stdin_flag {
-        unsupported_flags.push("--stdin");
-    }
-    if !unsupported_flags.is_empty() {
-        anyhow::bail!(
-            "{} is not supported by tg run yet. Use ast-grep directly for this semantic matcher.",
-            unsupported_flags.join(", ")
-        );
-    }
     if args.batch_rewrite.is_some() && args.pattern_option.is_some() {
         anyhow::bail!("tg run --batch-rewrite uses the positional argument as PATH and does not accept --pattern");
+    }
+    if args.stdin_flag && run_has_path_arg(args) {
+        anyhow::bail!("tg run --stdin cannot be combined with a PATH argument");
+    }
+    if args.stdin_flag && args.files_with_matches {
+        anyhow::bail!("tg run --stdin cannot be combined with --files-with-matches");
+    }
+    if ast_run_requires_python_passthrough(args) && run_has_mutating_options(args) {
+        anyhow::bail!(
+            "ast-grep semantic run options are read-only in tg run; use ast-grep directly for semantic rewrites"
+        );
     }
     if args.files_with_matches
         && (args.rewrite.is_some()
@@ -5025,6 +5079,36 @@ fn validate_run_args(args: &RunArgs) -> anyhow::Result<()> {
         anyhow::bail!("--checkpoint requires --apply");
     }
     Ok(())
+}
+
+fn ast_run_requires_python_passthrough(args: &RunArgs) -> bool {
+    args.selector.is_some()
+        || args.strictness.is_some()
+        || args.stdin_flag
+        || !args.globs.is_empty()
+}
+
+fn run_has_path_arg(args: &RunArgs) -> bool {
+    if args.pattern_option.is_some() {
+        return !args.positional.is_empty();
+    }
+    args.positional.len() > 1
+}
+
+fn run_has_mutating_options(args: &RunArgs) -> bool {
+    args.rewrite.is_some()
+        || args.batch_rewrite.is_some()
+        || args.apply
+        || args.update_all
+        || args.diff
+        || args.verify
+        || args.checkpoint
+        || args.audit_manifest.is_some()
+        || args.audit_signing_key.is_some()
+        || !args.apply_edit_ids.is_empty()
+        || !args.reject_edit_ids.is_empty()
+        || args.lint_cmd.is_some()
+        || args.test_cmd.is_some()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6197,6 +6281,9 @@ fn handle_ast_run(mut args: RunArgs) -> anyhow::Result<()> {
         args.apply = true;
     }
     validate_run_args(&args)?;
+    if ast_run_requires_python_passthrough(&args) {
+        return handle_python_passthrough("run", ast_run_python_passthrough_args(&args)?);
+    }
     let backend = AstBackend::new();
 
     if let Some(config_path) = &args.batch_rewrite {
@@ -6264,6 +6351,46 @@ fn handle_ast_run(mut args: RunArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn ast_run_python_passthrough_args(args: &RunArgs) -> anyhow::Result<Vec<String>> {
+    let mut passthrough_args = vec!["--lang".to_string(), args.lang.clone()];
+    let pattern = run_pattern(args)?.to_string();
+    passthrough_args.push("--pattern".to_string());
+    passthrough_args.push(pattern);
+
+    if let Some(path) = run_optional_path(args) {
+        passthrough_args.push(path.to_string());
+    }
+    if args.json {
+        passthrough_args.push("--json".to_string());
+    }
+    if args.files_with_matches {
+        passthrough_args.push("--files-with-matches".to_string());
+    }
+    if let Some(selector) = &args.selector {
+        passthrough_args.push("--selector".to_string());
+        passthrough_args.push(selector.clone());
+    }
+    if let Some(strictness) = &args.strictness {
+        passthrough_args.push("--strictness".to_string());
+        passthrough_args.push(strictness.clone());
+    }
+    if args.stdin_flag {
+        passthrough_args.push("--stdin".to_string());
+    }
+    for glob in &args.globs {
+        passthrough_args.push("--globs".to_string());
+        passthrough_args.push(glob.clone());
+    }
+    Ok(passthrough_args)
+}
+
+fn run_optional_path(args: &RunArgs) -> Option<&str> {
+    if args.pattern_option.is_some() {
+        return args.positional.first().map(String::as_str);
+    }
+    args.positional.get(1).map(String::as_str)
 }
 
 fn handle_ast_rewrite(

--- a/rust_core/tests/test_public_native_cli_parity.rs
+++ b/rust_core/tests/test_public_native_cli_parity.rs
@@ -1190,22 +1190,46 @@ fn test_ast_compatibility_flags_route_or_fail_explicitly_on_public_native_frontd
         String::from_utf8_lossy(&new_output.stdout)
     );
 
-    let selector_output = run_tg(
+    let run_python = fake_python_passthrough_asserting_args_script(
+        dir.path(),
         &[
+            "-m",
+            "tensor_grep",
             "run",
             "--pattern",
             "print($A)",
             "--selector",
             "call_expression",
+            "--strictness",
+            "relaxed",
+            "--globs",
+            "*.py",
             ".",
         ],
-        dir.path(),
+        "python-route-ok",
     );
-    assert!(!selector_output.status.success());
+    let selector_output = tg()
+        .current_dir(dir.path())
+        .args([
+            "run",
+            "--pattern",
+            "print($A)",
+            "--selector",
+            "call_expression",
+            "--strictness",
+            "relaxed",
+            "--globs",
+            "*.py",
+            ".",
+        ])
+        .env("TG_SIDECAR_PYTHON", &run_python)
+        .output()
+        .unwrap();
+    assert!(selector_output.status.success());
     assert!(
-        String::from_utf8_lossy(&selector_output.stderr).contains("not supported by tg run yet"),
-        "stderr={}",
-        String::from_utf8_lossy(&selector_output.stderr)
+        String::from_utf8_lossy(&selector_output.stdout).contains("python-route-ok"),
+        "stdout={}",
+        String::from_utf8_lossy(&selector_output.stdout)
     );
 }
 

--- a/rust_core/tests/test_runtime_path_resolution.rs
+++ b/rust_core/tests/test_runtime_path_resolution.rs
@@ -245,6 +245,10 @@ fn test_run_help_positions_ast_as_validated_slice_not_ast_grep_parity() {
     );
     assert!(stdout.contains("--pattern"), "stdout={stdout}");
     assert!(stdout.contains("--files-with-matches"), "stdout={stdout}");
+    assert!(stdout.contains("--selector"), "stdout={stdout}");
+    assert!(stdout.contains("--strictness"), "stdout={stdout}");
+    assert!(stdout.contains("--stdin"), "stdout={stdout}");
+    assert!(stdout.contains("--globs"), "stdout={stdout}");
     assert!(!stdout.contains("ast-grep parity"), "stdout={stdout}");
     assert!(!stdout.contains("ast-grep replacement"), "stdout={stdout}");
 }

--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -42,11 +42,30 @@ class AstGrepWrapperBackend(ComputeBackend):
         self, pattern: str, paths: list[str], config: SearchConfig | None = None
     ) -> tuple[list[str], AbstractContextManager[object]]:
         lang = normalize_ast_language(config.lang) if config and config.lang else None
+        selector = config.ast_selector if config else None
+        strictness = config.ast_strictness if config else None
+        globs = list(config.glob or []) if config else []
+        stdin_enabled = bool(config.ast_stdin) if config else False
+        if ("\n" in pattern or "\r" in pattern) and (
+            selector or strictness or globs or stdin_enabled
+        ):
+            raise RuntimeError(
+                "ast-grep semantic run options are not supported for multiline patterns yet"
+            )
         if "\n" not in pattern and "\r" not in pattern:
             cmd = [self._get_binary_name(), "run", "--json", "-p", pattern]
             if lang:
                 cmd.extend(["--lang", lang])
-            cmd.extend(paths)
+            if selector:
+                cmd.extend(["--selector", selector])
+            if strictness:
+                cmd.extend(["--strictness", strictness])
+            for glob in globs:
+                cmd.extend(["--globs", glob])
+            if stdin_enabled:
+                cmd.append("--stdin")
+            else:
+                cmd.extend(paths)
             return cmd, nullcontext()
 
         context = TemporaryDirectory(prefix="tg_ast_wrapper_rule_")
@@ -192,6 +211,7 @@ class AstGrepWrapperBackend(ComputeBackend):
                     text=True,
                     check=False,
                     encoding="utf-8",
+                    input=config.ast_stdin_input if config and config.ast_stdin else None,
                 )
                 self._raise_for_nonzero(result)
                 return self._parse_result(result.stdout)
@@ -215,6 +235,7 @@ class AstGrepWrapperBackend(ComputeBackend):
                     text=True,
                     check=False,
                     encoding="utf-8",
+                    input=config.ast_stdin_input if config and config.ast_stdin else None,
                 )
                 self._raise_for_nonzero(result)
                 return self._parse_result(result.stdout, fallback_file=file_path)

--- a/src/tensor_grep/cli/ast_workflows.py
+++ b/src/tensor_grep/cli/ast_workflows.py
@@ -522,6 +522,10 @@ def run_command(
     interactive: bool = False,
     filter_regex: str | None = None,
     files_with_matches: bool = False,
+    selector: str | None = None,
+    strictness: str | None = None,
+    stdin: bool = False,
+    globs: list[str] | None = None,
 ) -> int:
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.result import SearchResult
@@ -542,6 +546,31 @@ def run_command(
         return 1
     if interactive and not rewrite:
         print("--interactive requires --rewrite.", file=sys.stderr)
+        return 1
+    semantic_run_options = bool(selector or strictness or stdin or globs)
+    if semantic_run_options and (
+        rewrite is not None
+        or apply
+        or verify
+        or checkpoint
+        or audit_manifest is not None
+        or audit_signing_key is not None
+        or lint_cmd is not None
+        or test_cmd is not None
+        or policy is not None
+        or interactive
+    ):
+        print(
+            "ast-grep semantic run options are read-only in tg run; use ast-grep directly "
+            "for semantic rewrites.",
+            file=sys.stderr,
+        )
+        return 1
+    if stdin and files_with_matches:
+        print("--stdin cannot be combined with --files-with-matches.", file=sys.stderr)
+        return 1
+    if stdin and path:
+        print("--stdin cannot be combined with a PATH argument.", file=sys.stderr)
         return 1
 
     if files_with_matches and (
@@ -592,7 +621,18 @@ def run_command(
         return exit_code
 
     search_path = path or "."
-    cfg = SearchConfig(ast=True, ast_prefer_native=True, lang=lang, query_pattern=pattern)
+    stdin_input = sys.stdin.read() if stdin else None
+    cfg = SearchConfig(
+        ast=True,
+        ast_prefer_native=not semantic_run_options,
+        lang=lang or ("python" if stdin else None),
+        query_pattern=pattern,
+        ast_selector=selector,
+        ast_strictness=strictness,
+        ast_stdin=stdin,
+        ast_stdin_input=stdin_input,
+        glob=list(globs or []),
+    )
     backend = _select_ast_backend_for_pattern(cfg, pattern)
     backend_name = type(backend).__name__
 
@@ -609,7 +649,8 @@ def run_command(
     all_results = SearchResult(matches=[], total_files=0, total_matches=0)
 
     if backend_name == "AstGrepWrapperBackend" and hasattr(backend, "search_many"):
-        result = cast(Any, backend).search_many([search_path], pattern, config=cfg)
+        search_paths = [] if stdin else [search_path]
+        result = cast(Any, backend).search_many(search_paths, pattern, config=cfg)
         all_results.matches.extend(result.matches)
         all_results.matched_file_paths.extend(result.matched_file_paths)
         all_results.total_matches += result.total_matches
@@ -779,7 +820,7 @@ def _check_backend_available(name: str) -> bool:
 def _select_ast_backend_for_pattern(
     base_config: SearchConfig,
     pattern: str,
-    backend_cache: dict[tuple[str | None, str, bool], Any] | None = None,
+    backend_cache: dict[tuple[str | None, str, bool, bool], Any] | None = None,
 ) -> Any:
     global _SUPPORTED_NATIVE_PATTERN_RE, _BACKEND_AVAILABILITY, _CACHED_BACKENDS
 
@@ -796,16 +837,28 @@ def _select_ast_backend_for_pattern(
             or _SUPPORTED_NATIVE_PATTERN_RE.fullmatch(stripped_pattern)
         )
     )
+    requires_ast_grep_wrapper = bool(
+        base_config.ast_selector
+        or base_config.ast_strictness
+        or base_config.ast_stdin
+        or base_config.glob
+    )
     pattern_kind = (
         "native"
         if (
             base_config.ast_prefer_native
+            and not requires_ast_grep_wrapper
             and supports_native_pattern
             and is_native_ast_language(base_config.lang)
         )
         else "wrapper"
     )
-    cache_key = (base_config.lang, pattern_kind, base_config.ast_prefer_native)
+    cache_key = (
+        base_config.lang,
+        pattern_kind,
+        base_config.ast_prefer_native,
+        requires_ast_grep_wrapper,
+    )
     if backend_cache is not None and cache_key in backend_cache:
         return backend_cache[cache_key]
 
@@ -1194,7 +1247,7 @@ def test_command(config: str | None = "sgconfig.yml") -> int:
     cfg = SearchConfig(ast=True, ast_prefer_native=True, lang=cast(str, project_cfg["language"]))
     backend_names_used: set[str] = set()
     rule_case_groups: dict[tuple[int, str, str], dict[str, Any]] = {}
-    backend_cache: dict[tuple[str | None, str, bool], Any] = {}
+    backend_cache: dict[tuple[str | None, str, bool, bool], Any] = {}
 
     total_cases = 0
     failures: list[str] = []
@@ -1375,6 +1428,10 @@ def main_entry(argv: list[str] | None = None) -> None:
     run_parser.add_argument("--test-cmd", default=None)
     run_parser.add_argument("--policy", default=None)
     run_parser.add_argument("--files-with-matches", action="store_true")
+    run_parser.add_argument("--selector", default=None)
+    run_parser.add_argument("--strictness", default=None)
+    run_parser.add_argument("--stdin", action="store_true")
+    run_parser.add_argument("--globs", action="append", default=None)
 
     scan_parser = subparsers.add_parser("scan")
     scan_parser.add_argument("path", nargs="?", default=".")
@@ -1423,6 +1480,10 @@ def main_entry(argv: list[str] | None = None) -> None:
                 test_cmd=args.test_cmd,
                 policy=args.policy,
                 files_with_matches=args.files_with_matches,
+                selector=args.selector,
+                strictness=args.strictness,
+                stdin=args.stdin,
+                globs=args.globs,
             )
         )
     if args.command == "scan":

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8573,17 +8573,22 @@ def run(
     selector: str | None = typer.Option(
         None,
         "--selector",
-        help="Unsupported ast-grep semantic matcher selector; fails explicitly.",
+        help="ast-grep matcher selector for read-only structural search.",
     ),
     strictness: str | None = typer.Option(
         None,
         "--strictness",
-        help="Unsupported ast-grep strictness control; fails explicitly.",
+        help="ast-grep strictness control for read-only structural search.",
     ),
     stdin: bool = typer.Option(
         False,
         "--stdin",
-        help="Unsupported ast-grep stdin mode; fails explicitly.",
+        help="Read source code from stdin for read-only structural search.",
+    ),
+    globs: list[str] | None = typer.Option(
+        None,
+        "--globs",
+        help="ast-grep include/exclude glob. May be repeated; prefix with ! to exclude.",
     ),
     filter_regex: str | None = typer.Option(
         None, "--filter", help="Filter matched AST nodes by text regex"
@@ -8596,23 +8601,6 @@ def run(
 ) -> None:
     from tensor_grep.cli.ast_workflows import run_command as execute_run
 
-    unsupported_semantic_flags = [
-        flag
-        for flag, value in (
-            ("--selector", selector),
-            ("--strictness", strictness),
-            ("--stdin", stdin),
-        )
-        if value
-    ]
-    if unsupported_semantic_flags:
-        typer.echo(
-            "Error: "
-            + ", ".join(unsupported_semantic_flags)
-            + " is not supported by tg run yet. Use ast-grep directly for this semantic matcher.",
-            err=True,
-        )
-        raise typer.Exit(code=2)
     if update_all and rewrite is None:
         typer.echo("Error: tg run --update-all requires --rewrite.", err=True)
         raise typer.Exit(code=2)
@@ -8652,6 +8640,10 @@ def run(
         interactive=interactive,
         filter_regex=filter_regex,
         files_with_matches=files_with_matches,
+        selector=selector,
+        strictness=strictness,
+        stdin=stdin,
+        globs=globs,
     )
     if exit_code != 0:
         raise typer.Exit(code=exit_code)

--- a/src/tensor_grep/core/config.py
+++ b/src/tensor_grep/core/config.py
@@ -165,6 +165,10 @@ class SearchConfig:
     ast: bool = False
     ast_prefer_native: bool = False
     lang: str | None = None
+    ast_selector: str | None = None
+    ast_strictness: str | None = None
+    ast_stdin: bool = False
+    ast_stdin_input: str | None = None
     use_jit: bool = False
     ltl: bool = False
     query_pattern: str | None = None

--- a/tests/unit/test_ast_workflows.py
+++ b/tests/unit/test_ast_workflows.py
@@ -691,6 +691,109 @@ def test_run_command_files_with_matches_outputs_only_paths(tmp_path, monkeypatch
     assert capsys.readouterr().out.splitlines() == [str(first), str(second)]
 
 
+def test_run_command_should_force_wrapper_for_ast_grep_semantic_options(monkeypatch):
+    from tensor_grep.cli import ast_workflows
+    from tensor_grep.cli.ast_workflows import run_command
+
+    seen: dict[str, object] = {}
+
+    class AstGrepWrapperBackend:
+        def search_many(self, file_paths, pattern, config=None) -> SearchResult:
+            seen["file_paths"] = file_paths
+            seen["pattern"] = pattern
+            seen["config"] = config
+            return SearchResult(matches=[], matched_file_paths=[], total_files=0, total_matches=0)
+
+    def fake_select(config, pattern):
+        seen["selected_config"] = config
+        seen["selected_pattern"] = pattern
+        return AstGrepWrapperBackend()
+
+    monkeypatch.setattr(ast_workflows, "_select_ast_backend_for_pattern", fake_select)
+
+    exit_code = run_command(
+        pattern="print($A)",
+        path="src",
+        lang="python",
+        selector="call",
+        strictness="relaxed",
+        globs=["*.py", "!generated/**"],
+        json_mode=True,
+    )
+
+    assert exit_code == 0
+    config = seen["config"]
+    assert config.ast_prefer_native is False
+    assert config.ast_selector == "call"
+    assert config.ast_strictness == "relaxed"
+    assert config.glob == ["*.py", "!generated/**"]
+    assert seen["file_paths"] == ["src"]
+
+
+def test_run_command_should_forward_stdin_without_default_path(monkeypatch):
+    import io
+
+    from tensor_grep.cli import ast_workflows
+    from tensor_grep.cli.ast_workflows import run_command
+
+    seen: dict[str, object] = {}
+
+    class AstGrepWrapperBackend:
+        def search_many(self, file_paths, pattern, config=None) -> SearchResult:
+            seen["file_paths"] = file_paths
+            seen["pattern"] = pattern
+            seen["config"] = config
+            return SearchResult(matches=[], matched_file_paths=[], total_files=0, total_matches=0)
+
+    monkeypatch.setattr(
+        ast_workflows,
+        "_select_ast_backend_for_pattern",
+        lambda config, pattern: AstGrepWrapperBackend(),
+    )
+    monkeypatch.setattr(ast_workflows.sys, "stdin", io.StringIO("print('hello')\n"))
+
+    exit_code = run_command(
+        pattern="print($A)",
+        lang="python",
+        stdin=True,
+        json_mode=True,
+    )
+
+    assert exit_code == 0
+    config = seen["config"]
+    assert seen["file_paths"] == []
+    assert config.ast_stdin is True
+    assert config.ast_stdin_input == "print('hello')\n"
+    assert config.lang == "python"
+
+
+def test_run_command_should_reject_stdin_files_with_matches(capsys):
+    from tensor_grep.cli.ast_workflows import run_command
+
+    exit_code = run_command(
+        pattern="print($A)",
+        lang="python",
+        stdin=True,
+        files_with_matches=True,
+    )
+
+    assert exit_code == 1
+    assert "--stdin cannot be combined with --files-with-matches" in capsys.readouterr().err
+
+
+def test_run_command_should_reject_ast_grep_semantic_options_for_rewrites(capsys):
+    from tensor_grep.cli.ast_workflows import run_command
+
+    exit_code = run_command(
+        pattern="print($A)",
+        rewrite="logger.info($A)",
+        selector="call",
+    )
+
+    assert exit_code == 1
+    assert "ast-grep semantic run options are read-only" in capsys.readouterr().err
+
+
 def test_ast_workflow_entry_accepts_ast_grep_pattern_option(monkeypatch):
     """Verify the lightweight workflow parser accepts `run --pattern`, like ast-grep."""
     from tensor_grep.cli import ast_workflows
@@ -720,3 +823,42 @@ def test_ast_workflow_entry_accepts_ast_grep_pattern_option(monkeypatch):
     assert seen["pattern"] == "class $NAME: $$$BODY"
     assert seen["path"] == "src"
     assert seen["kwargs"]["files_with_matches"] is True
+
+
+def test_ast_workflow_entry_accepts_ast_grep_semantic_run_options(monkeypatch):
+    """Verify the lightweight workflow parser accepts supported ast-grep run options."""
+    from tensor_grep.cli import ast_workflows
+
+    seen: dict[str, object] = {}
+
+    def fake_run_command(pattern: str, path: str | None = None, **kwargs: object) -> int:
+        seen["pattern"] = pattern
+        seen["path"] = path
+        seen["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(ast_workflows, "run_command", fake_run_command)
+
+    with pytest.raises(SystemExit) as raised:
+        ast_workflows.main_entry([
+            "run",
+            "--pattern",
+            "print($A)",
+            "--selector",
+            "call",
+            "--strictness",
+            "relaxed",
+            "--globs",
+            "*.py",
+            "--stdin",
+            "--lang",
+            "python",
+        ])
+
+    assert raised.value.code == 0
+    assert seen["pattern"] == "print($A)"
+    assert seen["path"] is None
+    assert seen["kwargs"]["selector"] == "call"
+    assert seen["kwargs"]["strictness"] == "relaxed"
+    assert seen["kwargs"]["globs"] == ["*.py"]
+    assert seen["kwargs"]["stdin"] is True

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -78,6 +78,133 @@ def test_ast_wrapper_backend_should_batch_many_files():
     assert result.matched_file_paths == ["a.py", "b.py"]
 
 
+def test_ast_wrapper_backend_should_forward_ast_grep_run_semantic_options():
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        backend.search_many(
+            ["src"],
+            "print($A)",
+            config=SearchConfig(
+                ast=True,
+                lang="python",
+                ast_selector="call",
+                ast_strictness="relaxed",
+                glob=["*.py", "!generated/**"],
+            ),
+        )
+
+    assert run.call_args.args[0] == [
+        "sg",
+        "run",
+        "--json",
+        "-p",
+        "print($A)",
+        "--lang",
+        "python",
+        "--selector",
+        "call",
+        "--strictness",
+        "relaxed",
+        "--globs",
+        "*.py",
+        "--globs",
+        "!generated/**",
+        "src",
+    ]
+
+
+def test_ast_wrapper_backend_should_forward_stdin_to_ast_grep_run():
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        backend.search_many(
+            [],
+            "print($A)",
+            config=SearchConfig(
+                ast=True,
+                lang="python",
+                ast_stdin=True,
+                ast_stdin_input="print('hello')\n",
+            ),
+        )
+
+    assert run.call_args.args[0] == [
+        "sg",
+        "run",
+        "--json",
+        "-p",
+        "print($A)",
+        "--lang",
+        "python",
+        "--stdin",
+    ]
+    assert run.call_args.kwargs["input"] == "print('hello')\n"
+
+
+def test_ast_wrapper_backend_should_treat_empty_json_nonzero_as_no_match():
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+    ):
+        result = backend.search_many(
+            ["src"],
+            "print($A)",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+    assert result.total_matches == 0
+
+
+def test_ast_wrapper_backend_should_reject_multiline_semantic_run_options():
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        pytest.raises(RuntimeError, match="multiline"),
+    ):
+        backend.search_many(
+            ["src"],
+            "def $NAME():\n    $$$BODY",
+            config=SearchConfig(
+                ast=True,
+                lang="python",
+                ast_selector="function_definition",
+            ),
+        )
+
+
 def test_ast_wrapper_backend_should_use_rule_file_for_multiline_patterns():
     backend = AstGrepWrapperBackend()
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -6609,6 +6609,10 @@ def test_tg_run_help_should_position_ast_as_validated_slice_not_ast_grep_parity(
     help_text = _strip_ansi(result.stdout)
     normalized_help = re.sub(r"\s+", " ", help_text)
     assert "validated AST slice" in normalized_help
+    assert "--selector" in help_text
+    assert "--strictness" in help_text
+    assert "--stdin" in help_text
+    assert "--globs" in help_text
     assert "ast-grep parity" not in help_text
     assert "ast-grep replacement" not in help_text
 
@@ -10705,15 +10709,49 @@ def test_run_update_all_aliases_apply_for_rewrite(monkeypatch, tmp_path: Path) -
     assert seen["kwargs"]["apply"] is True
 
 
-def test_run_ast_grep_semantic_flags_fail_explicitly() -> None:
+def test_run_ast_grep_semantic_flags_are_forwarded_to_run_workflow(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run_command(pattern: str, path: str | None = None, **kwargs: object) -> int:
+        seen["pattern"] = pattern
+        seen["path"] = path
+        seen["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr("tensor_grep.cli.ast_workflows.run_command", fake_run_command)
+
     result = CliRunner().invoke(
         app,
-        ["run", "--pattern", "print($A)", "--selector", "call", "src"],
+        [
+            "run",
+            "--pattern",
+            "print($A)",
+            "--selector",
+            "call",
+            "--strictness",
+            "relaxed",
+            "--globs",
+            "*.py",
+            "src",
+        ],
     )
 
-    assert result.exit_code == 2
-    assert "not supported by tg run yet" in result.output
-    assert "--selector" in result.output
+    assert result.exit_code == 0, result.output
+    assert seen["pattern"] == "print($A)"
+    assert seen["path"] == "src"
+    assert seen["kwargs"]["selector"] == "call"
+    assert seen["kwargs"]["strictness"] == "relaxed"
+    assert seen["kwargs"]["globs"] == ["*.py"]
+
+
+def test_run_ast_grep_semantic_rewrite_combinations_fail_explicitly() -> None:
+    result = CliRunner().invoke(
+        app,
+        ["run", "--pattern", "print($A)", "--selector", "call", "--rewrite", "logger.info($A)"],
+    )
+
+    assert result.exit_code == 1
+    assert "ast-grep semantic run options are read-only" in result.output
 
 
 def test_main_entry_should_not_rewrite_devices_subcommand(monkeypatch):


### PR DESCRIPTION
## Summary
- route read-only `tg run` semantic ast-grep options (`--selector`, `--strictness`, `--stdin`, `--globs`) through the Python ast-grep wrapper when native cannot faithfully execute them
- preserve native front-door parsing/help and reject mutating semantic combinations explicitly
- add wrapper, CLI, lightweight parser, Rust front-door, and public native regression coverage

## Research / review
- Exa checked current ast-grep CLI contracts for run/scan/test/new surfaces: https://ast-grep.github.io/reference/cli.html and https://ast-grep.github.io/reference/cli/run.html
- Thinktank consensus: keep this PR to a read-only `tg run` compatibility slice; do not claim full ast-grep parity
- Gemini read-only diff review: no blocking findings

## Validation
- `uv run pytest tests/unit/test_ast_wrapper_backend.py tests/unit/test_ast_workflows.py tests/unit/test_cli_modes.py::test_tg_run_help_should_position_ast_as_validated_slice_not_ast_grep_parity tests/unit/test_cli_modes.py::test_run_ast_grep_semantic_flags_are_forwarded_to_run_workflow tests/unit/test_cli_modes.py::test_run_ast_grep_semantic_rewrite_combinations_fail_explicitly -q`
- `cargo test --manifest-path rust_core/Cargo.toml --test test_runtime_path_resolution test_run_help_positions_ast_as_validated_slice_not_ast_grep_parity -- --exact --nocapture`
- `cargo test --manifest-path rust_core/Cargo.toml run_ast_grep_semantic_options_are_read_only_python_passthrough`
- `cargo test --manifest-path rust_core/Cargo.toml run_stdin_rejects_files_with_matches`
- `cargo test --manifest-path rust_core/Cargo.toml --test test_public_native_cli_parity test_ast_compatibility_flags_route_or_fail_explicitly_on_public_native_frontdoor -- --exact --nocapture`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `cargo fmt --manifest-path rust_core/Cargo.toml --check`
- `git diff --check`