### PR TITLE
fix: harden tight-budget agent resolver ranking

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4303,6 +4303,12 @@ def _symbol_name_matches_query_bridge(symbol_name: str, query: str) -> bool:
     )
 
 
+def _symbol_name_terms_cover_query(symbol_name: str, terms: list[str]) -> bool:
+    symbol_terms = set(split_terms(symbol_name))
+    meaningful_query_terms = {term for term in terms if len(term) > 2}
+    return bool(len(symbol_terms) >= 2 and symbol_terms <= meaningful_query_terms)
+
+
 def _score_file_path(path: str, terms: list[str]) -> int:
     return _score_text_terms(Path(path).name, terms) + _score_text_terms(path, terms)
 
@@ -4313,9 +4319,7 @@ def _score_symbol(symbol: dict[str, Any], terms: list[str]) -> int:
         + _score_text_terms(str(symbol["kind"]), terms)
         + _score_file_path(str(symbol["file"]), terms)
     )
-    symbol_terms = set(split_terms(str(symbol["name"])))
-    meaningful_query_terms = {term for term in terms if len(term) > 2}
-    if symbol_terms and symbol_terms <= meaningful_query_terms:
+    if _symbol_name_terms_cover_query(str(symbol["name"]), terms):
         score += 2
     return score
 
@@ -4902,11 +4906,16 @@ def _build_context_pack_from_map(
             symbol_name = str(scored_symbol["name"])
             exact_query_match = _symbol_name_matches_query_exactly(symbol_name, query)
             bridge_query_match = _symbol_name_matches_query_bridge(symbol_name, query)
-            if symbol_name_score > 0 and (exact_query_match or bridge_query_match):
+            covered_query_match = _symbol_name_terms_cover_query(symbol_name, symbol_terms)
+            if symbol_name_score > 0 and (
+                exact_query_match or bridge_query_match or covered_query_match
+            ):
                 if exact_query_match:
                     scored_symbol["exact_query_match"] = True
                 elif bridge_query_match:
                     scored_symbol["bridge_query_match"] = True
+                elif covered_query_match:
+                    scored_symbol["covered_query_match"] = True
                 _append_reason(file_reasons, current_path, "definition")
                 _append_reason(file_reasons, current_path, "symbol")
             scored_symbols.append(scored_symbol)
@@ -4915,11 +4924,13 @@ def _build_context_pack_from_map(
             current = str(symbol["file"])
             exact_symbol_bonus = 36 if bool(symbol.get("exact_query_match")) else 0
             bridge_symbol_bonus = 8 if bool(symbol.get("bridge_query_match")) else 0
+            covered_symbol_bonus = 24 if bool(symbol.get("covered_query_match")) else 0
             file_scores[current] = (
                 file_scores.get(current, 0)
                 + int(symbol["score"]) * 3
                 + exact_symbol_bonus
                 + bridge_symbol_bonus
+                + covered_symbol_bonus
             )
 
         scored_imports: list[dict[str, Any]] = []

--- a/tests/unit/test_agent_capsule_hardcases.py
+++ b/tests/unit/test_agent_capsule_hardcases.py
@@ -353,6 +353,21 @@ def test_agent_capsule_tight_budget_prefers_exact_resolver_over_binary_notice(tm
     assert payload["primary_target"]["symbol"] == "resolve_ripgrep_binary"
 
 
+def test_agent_capsule_live_repo_tight_budget_prefers_ripgrep_resolver():
+    repo_root = Path(__file__).resolve().parents[2]
+
+    payload = _agent_payload(
+        repo_root / "src" / "tensor_grep",
+        "ripgrep binary resolution",
+        max_files=3,
+    )
+
+    assert payload["primary_target"]["file"] == str(
+        (repo_root / "src" / "tensor_grep" / "cli" / "runtime_paths.py").resolve()
+    )
+    assert payload["primary_target"]["symbol"] == "resolve_ripgrep_binary"
+
+
 def test_agent_capsule_marker_query_keeps_exe_bridge_marker_primary():
     repo_root = Path(__file__).resolve().parents[2]
 


### PR DESCRIPTION
## Summary
- Treat multi-term symbol names fully covered by a natural-language query as definition-level evidence.
- Keep the `ripgrep binary resolution --max-files 3` capsule hardcase on the real repo pointed at `runtime_paths.py::resolve_ripgrep_binary`.

## Validation
- `uv run --no-sync pytest -q tests/unit/test_agent_capsule_hardcases.py::test_agent_capsule_live_repo_tight_budget_prefers_ripgrep_resolver` failed before the fix and passed after it.
- `uv run --no-sync pytest -q tests/unit/test_agent_capsule_hardcases.py tests/unit/test_trust_planning.py tests/unit/test_repo_map_lexical_ranking.py tests/unit/test_token_budget.py` -> 63 passed.
- `uv run --no-sync pytest -q` -> 2289 passed, 16 skipped.
- `uv run --no-sync ruff check .` -> passed.
- `uv run --no-sync ruff format --check --preview .` -> passed.
- `uv run --no-sync mypy src/tensor_grep` -> passed.
- `uv run --no-sync python scripts/agent_readiness.py --output artifacts/agent_readiness_ripgrep_resolution_fix.json` -> passed.
- `uv run --no-sync python benchmarks/run_agent_workflow_benchmarks.py --output artifacts/bench_agent_workflow_ripgrep_resolution_fix.json` -> all passed.
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml` -> passed.
- `C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml -- --check` -> passed.
- `git diff --check` -> passed.