### PR TITLE
chore: add uv rust cache keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ module-name = "tensor_grep.rust_core"
 manifest-path = "rust_core/Cargo.toml"
 
 [tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "rust_core/Cargo.toml" },
+    { file = "rust_core/Cargo.lock" },
+    { file = "rust_core/src/**/*.rs" },
+]
 constraint-dependencies = [
     "aiohttp>=3.13.4",
     "cryptography>=46.0.7",

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -40,3 +40,19 @@ def test_ruff_should_extend_default_excludes_for_repo_specific_bench_dirs() -> N
         "benchmarks/gpu_bench_data",
         "benchmarks/external_repos",
     ]
+
+
+def test_uv_cache_keys_should_include_rust_native_inputs_without_forced_reinstall() -> None:
+    uv_config = _pyproject_payload()["tool"]["uv"]
+    cache_keys = uv_config["cache-keys"]
+    file_entries = {
+        str(entry["file"])
+        for entry in cache_keys
+        if isinstance(entry, dict) and isinstance(entry.get("file"), str)
+    }
+
+    assert "pyproject.toml" in file_entries
+    assert "rust_core/Cargo.toml" in file_entries
+    assert "rust_core/Cargo.lock" in file_entries
+    assert "rust_core/src/**/*.rs" in file_entries
+    assert "tensor-grep" not in uv_config.get("reinstall-package", [])


### PR DESCRIPTION
## Summary
- add narrow `[tool.uv].cache-keys` for pyproject and Rust native inputs so repo-local `uv run tg` rebuilds when Rust sources or Cargo metadata change
- include `pyproject.toml` because uv replaces default cache keys when custom keys are set
- add a static config contract preventing `reinstall-package = ["tensor-grep"]` as a daily-loop heavy hammer

## External contract checked
- Official uv cache docs: custom `tool.uv.cache-keys` replace defaults, so required defaults like `pyproject.toml` must be included explicitly

## Validation
- uv run --no-sync pytest -q tests/unit/test_pyproject_dependencies.py tests/unit/test_release_assets_validation.py::test_should_accept_uv_security_floor_constraints_when_all_required_entries_present tests/unit/test_release_assets_validation.py::test_should_require_uv_security_floor_constraints_for_audited_transitive_dependencies
- uv run --no-sync ruff check .
- uv run --no-sync ruff format --check --preview .
- uv run --no-sync mypy src/tensor_grep
- git diff --check / git diff --check origin/main...HEAD

## Review
- Gemini 3 Flash read-only review: APPROVED, no blocking/high findings