### PR TITLE
fix: harden lsp proof semantics

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -128,6 +128,123 @@ def _configuration_settings(language: str) -> dict[str, Any]:
     }
 
 
+def _health_probe_document(language: str, workspace_root: Path) -> dict[str, str]:
+    normalized = canonical_language(language)
+    probes = {
+        "python": (
+            "__tg_lsp_health_probe.py",
+            "python",
+            "def tg_lsp_health_probe():\n    return 1\n",
+            "tg_lsp_health_probe",
+        ),
+        "javascript": (
+            "__tg_lsp_health_probe.js",
+            "javascript",
+            "function tgLspHealthProbe() { return 1; }\n",
+            "tgLspHealthProbe",
+        ),
+        "typescript": (
+            "__tg_lsp_health_probe.ts",
+            "typescript",
+            "function tgLspHealthProbe(): number { return 1; }\n",
+            "tgLspHealthProbe",
+        ),
+        "go": (
+            "__tg_lsp_health_probe.go",
+            "go",
+            "package main\n\nfunc tgLspHealthProbe() int { return 1 }\n",
+            "tgLspHealthProbe",
+        ),
+        "rust": (
+            "__tg_lsp_health_probe.rs",
+            "rust",
+            "fn tg_lsp_health_probe() -> i32 { 1 }\n",
+            "tg_lsp_health_probe",
+        ),
+        "java": (
+            "__TgLspHealthProbe.java",
+            "java",
+            "class TgLspHealthProbe { int tgLspHealthProbe() { return 1; } }\n",
+            "TgLspHealthProbe",
+        ),
+        "c": (
+            "__tg_lsp_health_probe.c",
+            "c",
+            "int tg_lsp_health_probe(void) { return 1; }\n",
+            "tg_lsp_health_probe",
+        ),
+        "cpp": (
+            "__tg_lsp_health_probe.cpp",
+            "cpp",
+            "int tg_lsp_health_probe() { return 1; }\n",
+            "tg_lsp_health_probe",
+        ),
+        "csharp": (
+            "__TgLspHealthProbe.cs",
+            "csharp",
+            "class TgLspHealthProbe { int Probe() { return 1; } }\n",
+            "TgLspHealthProbe",
+        ),
+        "php": (
+            "__tg_lsp_health_probe.php",
+            "php",
+            "<?php function tg_lsp_health_probe() { return 1; }\n",
+            "tg_lsp_health_probe",
+        ),
+        "kotlin": (
+            "__TgLspHealthProbe.kt",
+            "kotlin",
+            "fun tgLspHealthProbe(): Int = 1\n",
+            "tgLspHealthProbe",
+        ),
+        "swift": (
+            "__TgLspHealthProbe.swift",
+            "swift",
+            "func tgLspHealthProbe() -> Int { return 1 }\n",
+            "tgLspHealthProbe",
+        ),
+        "lua": (
+            "__tg_lsp_health_probe.lua",
+            "lua",
+            "function tg_lsp_health_probe()\n  return 1\nend\n",
+            "tg_lsp_health_probe",
+        ),
+    }
+    filename, language_id, text, symbol = probes.get(
+        normalized,
+        (
+            "__tg_lsp_health_probe.txt",
+            normalized,
+            "tg_lsp_health_probe\n",
+            "tg_lsp_health_probe",
+        ),
+    )
+    return {
+        "uri": (workspace_root.resolve() / filename).as_uri(),
+        "language_id": language_id,
+        "text": text,
+        "symbol": symbol,
+    }
+
+
+def _document_symbol_names(result: object) -> list[str]:
+    names: list[str] = []
+    if not isinstance(result, list):
+        return names
+    for item in result:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if isinstance(name, str):
+            names.append(name)
+        names.extend(_document_symbol_names(item.get("children")))
+    return names
+
+
+def _document_symbol_result_contains(result: object, expected_symbol: str) -> bool:
+    return expected_symbol in _document_symbol_names(result)
+
+
 def _lookup_configuration_section(settings: dict[str, Any], section: object) -> Any:
     if not isinstance(section, str) or not section:
         return settings
@@ -177,6 +294,7 @@ class ExternalLSPClient:
         self.last_error: str | None = None
         self.disabled_until_monotonic = 0.0
         self.initialized = False
+        self.lsp_provider_response = False
 
     def start(self) -> None:
         if self.process is not None and self.process.poll() is None:
@@ -286,6 +404,7 @@ class ExternalLSPClient:
             self._opened_documents.clear()
             self.capabilities = {}
             self.initialized = False
+            self.lsp_provider_response = False
             if self._reader_thread is reader_thread:
                 self._reader_thread = None
             self._message_queue = queue.Queue()
@@ -411,6 +530,7 @@ class ExternalLSPClient:
             "running": self.process is not None and self.process.poll() is None,
             "initialized": self.initialized,
             "capabilities": dict(self.capabilities),
+            "lsp_provider_response": self.lsp_provider_response,
             "last_error": self.last_error,
             "opened_documents": len(self._opened_documents),
             "request_timeout_seconds": self.request_timeout_seconds,
@@ -545,6 +665,13 @@ class ExternalLSPProviderManager:
         key = (language.lower(), str(workspace_root.resolve()))
         current = self._clients.get(key)
         if current is not None:
+            if verify_health:
+                return self._verified_provider_status(
+                    client=current,
+                    language=language,
+                    workspace_root=workspace_root,
+                    probe_timeout_seconds=probe_timeout_seconds,
+                )
             status = current.status()
             status["available"] = True
             status["health_status"] = _provider_health_status(status)
@@ -597,25 +724,13 @@ class ExternalLSPProviderManager:
                 request_timeout_seconds=timeout,
                 initialize_timeout_seconds=timeout,
             )
-            try:
-                client.start()
-                status = client.status()
-                status["available"] = True
-                status["initialized"] = True
-                status["health_status"] = "ready"
-                status["health_check"] = "probe"
-                status["probe_timeout_seconds"] = timeout
-                return _attach_lsp_proof_fields(status)
-            except (FileNotFoundError, LSPTransportError, OSError, ValueError) as exc:
-                status = client.status()
-                status["available"] = True
-                status["health_status"] = "unhealthy"
-                status["health_check"] = "probe"
-                status["last_error"] = status.get("last_error") or str(exc)
-                status["probe_timeout_seconds"] = timeout
-                return _attach_lsp_proof_fields(status)
-            finally:
-                client.stop()
+            return self._verified_provider_status(
+                client=client,
+                language=language,
+                workspace_root=workspace_root,
+                probe_timeout_seconds=timeout,
+                stop_after_probe=True,
+            )
         return _attach_lsp_proof_fields({
             "language": language.lower(),
             "workspace_root": str(workspace_root.resolve()),
@@ -634,6 +749,71 @@ class ExternalLSPProviderManager:
             "initialize_timeout_seconds": initialize_timeout_seconds,
             "cooldown_remaining_s": 0.0,
         })
+
+    def _verified_provider_status(
+        self,
+        *,
+        client: ExternalLSPClient,
+        language: str,
+        workspace_root: Path,
+        probe_timeout_seconds: float | None,
+        stop_after_probe: bool = False,
+    ) -> dict[str, Any]:
+        timeout = (
+            max(float(probe_timeout_seconds), 0.0)
+            if probe_timeout_seconds is not None
+            else min(client.request_timeout_seconds, client.initialize_timeout_seconds)
+        )
+        probe = _health_probe_document(language, workspace_root)
+        phase = "initialize"
+        original_request_timeout = client.request_timeout_seconds
+        original_initialize_timeout = client.initialize_timeout_seconds
+        probe_succeeded = False
+        probe_error: Exception | None = None
+        client.request_timeout_seconds = timeout
+        client.initialize_timeout_seconds = timeout
+        try:
+            client.start()
+            phase = "did_open"
+            client.ensure_document(
+                uri=probe["uri"],
+                text=probe["text"],
+                language_id=probe["language_id"],
+            )
+            phase = "document_symbol"
+            result = client.request(
+                "textDocument/documentSymbol",
+                {"textDocument": {"uri": probe["uri"]}},
+            )
+            if not _document_symbol_result_contains(result, probe["symbol"]):
+                raise LSPTransportError("semantic documentSymbol probe returned no matching symbol")
+            probe_succeeded = True
+            client.lsp_provider_response = True
+        except (FileNotFoundError, LSPTransportError, OSError, ValueError) as exc:
+            probe_error = exc
+            client.lsp_provider_response = False
+        finally:
+            client.request_timeout_seconds = original_request_timeout
+            client.initialize_timeout_seconds = original_initialize_timeout
+        status = client.status()
+        status["available"] = True
+        status["health_check"] = "semantic-document-symbol"
+        status["health_phase"] = phase
+        status["probe_timeout_seconds"] = timeout
+        status["probe_document_uri"] = probe["uri"]
+        status["probe_symbol"] = probe["symbol"]
+        if probe_succeeded:
+            status["health_status"] = "ready"
+        else:
+            status["health_status"] = "unhealthy"
+            status["lsp_provider_response"] = False
+            if probe_error is not None:
+                status["last_error"] = status.get("last_error") or str(probe_error)
+        try:
+            return _attach_lsp_proof_fields(status)
+        finally:
+            if stop_after_probe:
+                client.stop()
 
     def stop_all(self) -> None:
         clients = list(self._clients.values())
@@ -675,7 +855,12 @@ def _provider_health_status(status: dict[str, Any]) -> str:
 def _attach_lsp_proof_fields(status: dict[str, Any]) -> dict[str, Any]:
     health_status = str(status.get("health_status", _provider_health_status(status)))
     health_check = str(status.get("health_check", "not_run"))
-    lsp_proof = bool(status.get("available")) and health_status == "ready"
+    status.setdefault("lsp_provider_response", False)
+    lsp_proof = (
+        bool(status.get("available"))
+        and health_status == "ready"
+        and status.get("lsp_provider_response") is True
+    )
     status["health_status"] = health_status
     status["health_check"] = health_check
     status["lsp_proof"] = lsp_proof
@@ -687,7 +872,9 @@ def _attach_lsp_proof_fields(status: dict[str, Any]) -> dict[str, Any]:
     elif health_status == "available_unverified" and health_check == "not_run":
         reason = "Provider binary is available but health was not verified."
     elif health_status == "unhealthy":
-        reason = "Provider health probe failed or timed out."
+        reason = "Provider semantic health probe failed or timed out."
+    elif health_status == "ready" and status.get("lsp_provider_response") is not True:
+        reason = "Provider initialized, but semantic health has not been verified in this session."
     else:
         reason = "Provider has not completed a successful initialization probe."
     status["not_lsp_proof_reason"] = reason

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -25,6 +25,7 @@ def test_provider_status_reports_missing_binary(tmp_path: Path) -> None:
     assert status["health_status"] == "missing"
     assert status["running"] is False
     assert status["capabilities"] == {}
+    assert status["lsp_provider_response"] is False
     assert status["last_error"]
 
 
@@ -54,6 +55,35 @@ def test_provider_status_reports_cached_client_state(
         status["initialize_timeout_seconds"]
         == provider_module._DEFAULT_LSP_INITIALIZE_TIMEOUT_SECONDS
     )
+
+
+def test_provider_status_cached_initialized_client_is_not_lsp_proof_without_provider_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+
+    class _FakeProcess:
+        def poll(self) -> None:
+            return None
+
+    manager = ExternalLSPProviderManager()
+    client = manager.get_client(language="python", workspace_root=tmp_path)
+    client.process = _FakeProcess()  # type: ignore[assignment]
+    client.initialized = True
+    client.capabilities = {"documentSymbolProvider": True}
+
+    status = manager.provider_status(language="python", workspace_root=tmp_path)
+
+    assert status["health_status"] == "ready"
+    assert status["health_check"] == "cached-client"
+    assert status["lsp_provider_response"] is False
+    assert status["lsp_proof"] is False
+    assert "not been verified" in status["not_lsp_proof_reason"]
 
 
 def test_provider_manager_uses_configured_timeouts(
@@ -93,6 +123,7 @@ def test_provider_status_reports_configured_timeouts_without_cached_client(
     assert status["available"] is True
     assert status["health_status"] == "available_unverified"
     assert status["health_check"] == "not_run"
+    assert status["lsp_provider_response"] is False
     assert status["lsp_proof"] is False
     assert "not verified" in status["not_lsp_proof_reason"]
     assert status["request_timeout_seconds"] == 6.0
@@ -117,6 +148,7 @@ def test_provider_status_available_binary_is_unverified_without_probe(
     assert status["available"] is True
     assert status["health_status"] == "available_unverified"
     assert status["health_check"] == "not_run"
+    assert status["lsp_provider_response"] is False
     assert status["lsp_proof"] is False
     assert status["not_lsp_proof_reason"]
 
@@ -131,12 +163,23 @@ def test_provider_status_verify_health_success_reports_lsp_proof(
         lambda _language: ["fake-lsp", "--stdio"],
     )
     seen_timeouts: list[tuple[float, float]] = []
+    opened_documents: list[dict[str, object]] = []
+    requests: list[str] = []
 
     def _fake_start(self: ExternalLSPClient) -> None:
         seen_timeouts.append((self.request_timeout_seconds, self.initialize_timeout_seconds))
-        self.capabilities = {"definitionProvider": True}
+        self.capabilities = {"definitionProvider": True, "documentSymbolProvider": True}
+
+    def _fake_ensure_document(self: ExternalLSPClient, **kwargs: object) -> None:
+        opened_documents.append(dict(kwargs))
+
+    def _fake_request(self: ExternalLSPClient, method: str, params: dict[str, Any]) -> object:
+        requests.append(method)
+        return [{"name": "tg_lsp_health_probe", "kind": 12}]
 
     monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "ensure_document", _fake_ensure_document)
+    monkeypatch.setattr(ExternalLSPClient, "request", _fake_request)
     monkeypatch.setattr(ExternalLSPClient, "stop", lambda self: None)
 
     status = ExternalLSPProviderManager().provider_status(
@@ -147,11 +190,148 @@ def test_provider_status_verify_health_success_reports_lsp_proof(
     )
 
     assert seen_timeouts == [(0.25, 0.25)]
+    assert opened_documents
+    assert requests == ["textDocument/documentSymbol"]
     assert status["available"] is True
     assert status["health_status"] == "ready"
-    assert status["health_check"] == "probe"
+    assert status["health_check"] == "semantic-document-symbol"
+    assert status["health_phase"] == "document_symbol"
+    assert status["lsp_provider_response"] is True
     assert status["lsp_proof"] is True
     assert "not_lsp_proof_reason" not in status
+
+
+def test_provider_status_verify_health_persists_semantic_provider_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+
+    class _FakeProcess:
+        def poll(self) -> None:
+            return None
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        self.process = _FakeProcess()  # type: ignore[assignment]
+        self.initialized = True
+        self.capabilities = {"documentSymbolProvider": True}
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "ensure_document", lambda self, **_kwargs: None)
+    monkeypatch.setattr(
+        ExternalLSPClient,
+        "request",
+        lambda self, method, params: [{"name": "tg_lsp_health_probe", "kind": 12}],
+    )
+
+    manager = ExternalLSPProviderManager()
+    manager.get_client(language="python", workspace_root=tmp_path)
+    probed = manager.provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.25,
+    )
+    cached = manager.provider_status(language="python", workspace_root=tmp_path)
+
+    assert probed["lsp_provider_response"] is True
+    assert probed["lsp_proof"] is True
+    assert cached["health_status"] == "ready"
+    assert cached["health_check"] == "cached-client"
+    assert cached["lsp_provider_response"] is True
+    assert cached["lsp_proof"] is True
+
+
+def test_provider_status_verify_health_bounds_cached_probe_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    seen_timeouts: list[tuple[float, float]] = []
+
+    class _FakeProcess:
+        def poll(self) -> None:
+            return None
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        seen_timeouts.append((self.request_timeout_seconds, self.initialize_timeout_seconds))
+        self.process = _FakeProcess()  # type: ignore[assignment]
+        self.initialized = True
+        self.capabilities = {"documentSymbolProvider": True}
+
+    def _fake_request(self: ExternalLSPClient, method: str, params: dict[str, Any]) -> object:
+        seen_timeouts.append((self.request_timeout_seconds, self.initialize_timeout_seconds))
+        return [{"name": "tg_lsp_health_probe", "kind": 12}]
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "ensure_document", lambda self, **_kwargs: None)
+    monkeypatch.setattr(ExternalLSPClient, "request", _fake_request)
+
+    manager = ExternalLSPProviderManager()
+    client = manager.get_client(language="python", workspace_root=tmp_path)
+    client.request_timeout_seconds = 3.0
+    client.initialize_timeout_seconds = 15.0
+
+    status = manager.provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.2,
+    )
+
+    assert seen_timeouts == [(0.2, 0.2), (0.2, 0.2)]
+    assert status["lsp_proof"] is True
+    assert status["probe_timeout_seconds"] == 0.2
+    assert client.request_timeout_seconds == 3.0
+    assert client.initialize_timeout_seconds == 15.0
+
+
+def test_provider_status_verify_health_requires_semantic_provider_response(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+    requests: list[str] = []
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        self.capabilities = {"documentSymbolProvider": True}
+
+    def _fake_request(self: ExternalLSPClient, method: str, params: dict[str, Any]) -> object:
+        requests.append(method)
+        return []
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "ensure_document", lambda self, **_kwargs: None)
+    monkeypatch.setattr(ExternalLSPClient, "request", _fake_request)
+    monkeypatch.setattr(ExternalLSPClient, "stop", lambda self: None)
+
+    status = ExternalLSPProviderManager().provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.2,
+    )
+
+    assert requests == ["textDocument/documentSymbol"]
+    assert status["available"] is True
+    assert status["health_status"] == "unhealthy"
+    assert status["health_check"] == "semantic-document-symbol"
+    assert status["health_phase"] == "document_symbol"
+    assert status["lsp_provider_response"] is False
+    assert status["lsp_proof"] is False
+    assert "semantic" in status["not_lsp_proof_reason"].lower()
 
 
 def test_provider_status_verify_health_failure_reports_unhealthy(
@@ -180,7 +360,9 @@ def test_provider_status_verify_health_failure_reports_unhealthy(
 
     assert status["available"] is True
     assert status["health_status"] == "unhealthy"
-    assert status["health_check"] == "probe"
+    assert status["health_check"] == "semantic-document-symbol"
+    assert status["health_phase"] == "initialize"
+    assert status["lsp_provider_response"] is False
     assert status["lsp_proof"] is False
     assert status["last_error"] == "timeout waiting for LSP response: initialize"
     assert status["probe_timeout_seconds"] == 0.2


### PR DESCRIPTION
## Summary
- require a semantic textDocument/documentSymbol health probe before reporting lsp_proof=true
- persist lsp_provider_response on cached clients only after a successful provider response
- bound cached-client health probes with the requested probe_timeout_seconds and keep status schema consistent

## Validation
- uv run --no-sync pytest -q tests/unit/test_lsp_external_provider.py tests/unit/test_cli_modes.py::test_doctor_json_includes_runtime_session_and_lsp tests/unit/test_cli_modes.py::test_doctor_text_reports_lsp_health_and_proof_fields tests/unit/test_semantic_provider_navigation.py
- uv run --no-sync ruff check .
- uv run --no-sync ruff format --check --preview .
- uv run --no-sync mypy src/tensor_grep
- uv run --no-sync pytest -q
- C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml
- git diff --check

## Review
- Gemini Flash read-only review: APPROVED
