### PR TITLE
fix: prefer source version for dev diagnostics

### DIFF
--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -65,12 +65,16 @@ def _read_project_version_fallback() -> str:
 
 
 def _expected_tg_version() -> str:
+    source_version = _read_project_version_fallback()
     try:
         from importlib.metadata import version
 
-        return version("tensor-grep")
+        installed_version = version("tensor-grep")
     except Exception:
-        return _read_project_version_fallback()
+        return source_version
+    if source_version != "0.0.0" and source_version != installed_version:
+        return source_version
+    return installed_version
 
 
 def _native_tg_version(candidate: Path) -> str | None:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import json
 import os
 import sys
@@ -168,6 +169,17 @@ def test_inspect_native_tg_binary_reports_matching_in_tree_binary(monkeypatch, t
     assert inspected["kind"] == "in-tree-debug"
     assert inspected["version_status"] == "matches"
     assert inspected["version"] == "tensor-grep 1.12.4"
+
+
+def test_expected_tg_version_prefers_repo_source_when_editable_metadata_is_stale(monkeypatch):
+    monkeypatch.setattr(
+        importlib.metadata,
+        "version",
+        lambda package_name: "1.12.39" if package_name == "tensor-grep" else "0.0.0",
+    )
+    monkeypatch.setattr(runtime_paths, "_read_project_version_fallback", lambda: "1.12.40")
+
+    assert runtime_paths._expected_tg_version() == "1.12.40"
 
 
 def test_inspect_native_tg_binary_reads_managed_frontdoor_metadata(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- prefer the repo source version from pyproject.toml when editable/install metadata is stale under repo-local uv run --no-sync
- keeps rebuilt in-tree native binaries from being falsely reported stale after release metadata advances in the source tree

## Validation
- red test first: uv run --no-sync pytest -q tests/unit/test_runtime_paths.py -k expected_tg_version failed before implementation
- uv run --no-sync pytest -q tests/unit/test_runtime_paths.py tests/unit/test_run_benchmarks_launcher_modes.py
- uv run --no-sync python -c "from pathlib import Path; from tensor_grep.cli.runtime_paths import inspect_native_tg_binary, _expected_tg_version; print(_expected_tg_version()); print(inspect_native_tg_binary(Path(''rust_core/target/release/tg.exe''))[''version_status''])" -> 1.12.40 / matches
- uv run --no-sync ruff check src/tensor_grep/cli/runtime_paths.py tests/unit/test_runtime_paths.py
- uv run --no-sync ruff format --check --preview src/tensor_grep/cli/runtime_paths.py tests/unit/test_runtime_paths.py
- uv run --no-sync mypy src/tensor_grep
- git diff --check

## Review note
Gemini CLI was already observed stalling on the previous small diff in this session after MCP/tool-loading noise, so I did not block this operational diagnostics slice on another Gemini run.