### PR TITLE
fix: clean stale python launchers after upgrade

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -158,11 +158,43 @@ function Remove-StalePythonPackageLauncher {
         if (!(Test-Path -LiteralPath $pythonExe -ErrorAction Stop)) {
             return $false
         }
-        $packageInfo = & $pythonExe -m pip show tensor-grep 2>$null
+        $packageInfo = & $pythonExe -m pip show -f tensor-grep 2>$null
     } catch {
         return $false
     }
     if (!$packageInfo) {
+        return $false
+    }
+    $packageLocation = $null
+    $candidateOwnedByPackage = $false
+    try {
+        $resolvedCandidate = (Resolve-Path -LiteralPath $candidatePath -ErrorAction Stop).Path
+    } catch {
+        return $false
+    }
+    foreach ($packageLine in $packageInfo) {
+        if ($packageLine -match '^Location:\s*(.+)$') {
+            $packageLocation = $Matches[1].Trim()
+            continue
+        }
+        if (!$packageLocation) {
+            continue
+        }
+        $packageFile = $packageLine.Trim()
+        if (!$packageFile -or $packageFile -eq "Files:") {
+            continue
+        }
+        try {
+            $resolvedPackageFile = (Resolve-Path -LiteralPath (Join-Path $packageLocation $packageFile) -ErrorAction Stop).Path
+        } catch {
+            continue
+        }
+        if ($resolvedPackageFile.ToLowerInvariant() -eq $resolvedCandidate.ToLowerInvariant()) {
+            $candidateOwnedByPackage = $true
+            break
+        }
+    }
+    if (!$candidateOwnedByPackage) {
         return $false
     }
 
@@ -245,12 +277,36 @@ function Remove-StalePathLauncher {
                 continue
             }
             $candidateVersion = ""
+            $versionProbeFailed = $false
             try {
                 $candidateVersion = (& $candidatePath --version 2>$null | Select-Object -First 1)
             } catch {
+                $versionProbeFailed = $true
+            }
+            if ($versionProbeFailed -or !$candidateVersion) {
+                if (Remove-StalePythonPackageLauncher `
+                        -candidatePath $candidatePath `
+                        -candidateVersion "<unreadable --version>") {
+                    continue
+                }
                 continue
             }
             if (!(Test-TensorGrepLauncher -CandidatePath $candidatePath -VersionLine $candidateVersion)) {
+                continue
+            }
+            if (Remove-StalePythonPackageLauncher `
+                    -candidatePath $candidatePath `
+                    -candidateVersion $candidateVersion) {
+                continue
+            }
+            $candidateDir = Split-Path -Parent $candidatePath
+            if ((Split-Path -Leaf $candidateDir) -eq "Scripts") {
+                Write-Warning (
+                    "WARNING: tensor-grep-looking Python Scripts tg launcher remains ahead of " +
+                    "managed shim because package ownership could not be verified: " +
+                    "$candidatePath ($candidateVersion). Remove it or move the managed shim " +
+                    "directories earlier in Machine PATH."
+                )
                 continue
             }
             try {

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -238,6 +238,20 @@ class _NativeFrontdoorInstallResult:
     asset_name: str
 
 
+@dataclass(frozen=True)
+class _WindowsStalePythonLauncher:
+    path: Path
+    python_executable: Path
+    version: str | None
+    package_version: str | None
+
+
+@dataclass(frozen=True)
+class _WindowsUnownedPythonLauncher:
+    path: Path
+    version: str | None
+
+
 def _version_sort_key(version: str) -> tuple[tuple[int, int | str], ...]:
     parts = re.findall(r"\d+|[A-Za-z]+", version)
     key: list[tuple[int, int | str]] = []
@@ -650,6 +664,213 @@ def _windows_stale_tensor_grep_com_bridges(expected_version: str, native_path: P
             if _directory_has_tensor_grep_shim(directory):
                 _add_path(target)
     return bridges
+
+
+def _windows_python_install_scripts_executable(candidate: Path) -> Path | None:
+    if not sys.platform.startswith("win"):
+        return None
+    if candidate.name.lower() != "tg.exe":
+        return None
+    if candidate.parent.name.lower() != "scripts":
+        return None
+    parts = tuple(part.lower() for part in candidate.parts)
+    if ".tensor-grep" in parts or ".venv" in parts or "venv" in parts:
+        return None
+    python_executable = candidate.parent.parent / "python.exe"
+    if not python_executable.is_file():
+        return None
+    return python_executable
+
+
+def _windows_python_scripts_tensor_grep_package_version(
+    python_executable: Path,
+    launcher_path: Path,
+) -> str | None:
+    try:
+        result = subprocess.run(
+            [str(python_executable), "-m", "pip", "show", "-f", "tensor-grep"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    location: Path | None = None
+    version: str | None = None
+    owns_launcher = False
+    try:
+        resolved_launcher = launcher_path.resolve()
+    except OSError:
+        resolved_launcher = launcher_path
+    for line in result.stdout.splitlines():
+        if line.lower().startswith("location:"):
+            raw_location = line.split(":", 1)[1].strip()
+            if raw_location:
+                location = Path(raw_location)
+            continue
+        if line.lower().startswith("version:"):
+            version = line.split(":", 1)[1].strip() or "installed"
+            continue
+        if location is None:
+            continue
+        relative_file = line.strip()
+        if not relative_file or relative_file.lower() == "files:":
+            continue
+        try:
+            resolved_file = (location / relative_file).resolve()
+        except OSError:
+            resolved_file = location / relative_file
+        if _same_path(resolved_file, resolved_launcher):
+            owns_launcher = True
+    if not owns_launcher:
+        return None
+    return version or "installed"
+
+
+def _windows_stale_tensor_grep_python_launchers(
+    expected_version: str,
+    native_path: Path,
+) -> list[_WindowsStalePythonLauncher]:
+    stale_launchers, _unowned_launchers = _windows_tensor_grep_python_launcher_scan(
+        expected_version,
+        native_path,
+    )
+    return stale_launchers
+
+
+def _windows_tensor_grep_python_launcher_scan(
+    expected_version: str,
+    native_path: Path,
+) -> tuple[list[_WindowsStalePythonLauncher], list[_WindowsUnownedPythonLauncher]]:
+    if not sys.platform.startswith("win"):
+        return [], []
+
+    path_values = [os.environ.get("PATH", "")]
+    fresh_path = _doctor_fresh_shell_path_value()
+    if fresh_path and fresh_path not in path_values:
+        path_values.append(fresh_path)
+
+    stale_launchers: list[_WindowsStalePythonLauncher] = []
+    unowned_launchers: list[_WindowsUnownedPythonLauncher] = []
+    seen: set[str] = set()
+    for path_value in path_values:
+        native_seen = False
+        for candidate in _doctor_path_tg_candidates(path_value):
+            candidate_path = Path(str(candidate.get("path") or ""))
+            if _same_path(candidate_path, native_path):
+                native_seen = True
+                continue
+            python_executable = _windows_python_install_scripts_executable(candidate_path)
+            if python_executable is None:
+                continue
+            try:
+                key = str(candidate_path.resolve()).lower()
+            except OSError:
+                key = str(candidate_path).lower()
+            if key in seen:
+                continue
+
+            version = candidate.get("version")
+            if _native_tg_version_matches(expected_version, version):
+                continue
+
+            if not _doctor_tg_version_looks_like_tensor_grep(version):
+                if version:
+                    continue
+            package_version = _windows_python_scripts_tensor_grep_package_version(
+                python_executable,
+                candidate_path,
+            )
+            if package_version is None:
+                if not native_seen:
+                    seen.add(key)
+                    unowned_launchers.append(
+                        _WindowsUnownedPythonLauncher(
+                            path=candidate_path,
+                            version=version,
+                        )
+                    )
+                continue
+
+            seen.add(key)
+            stale_launchers.append(
+                _WindowsStalePythonLauncher(
+                    path=candidate_path,
+                    python_executable=python_executable,
+                    version=version,
+                    package_version=package_version,
+                )
+            )
+    return stale_launchers, unowned_launchers
+
+
+def _remove_windows_stale_tensor_grep_python_launchers(
+    expected_version: str,
+    native_path: Path,
+) -> str | None:
+    stale_launchers, unowned_launchers = _windows_tensor_grep_python_launcher_scan(
+        expected_version,
+        native_path,
+    )
+    if not stale_launchers and not unowned_launchers:
+        return None
+
+    removed: list[str] = []
+    failed: list[str] = []
+    for launcher in stale_launchers:
+        reason = launcher.version or (
+            f"tensor-grep package {launcher.package_version}"
+            if launcher.package_version
+            else "<unreadable --version>"
+        )
+        try:
+            result = subprocess.run(
+                [
+                    str(launcher.python_executable),
+                    "-m",
+                    "pip",
+                    "uninstall",
+                    "-y",
+                    "tensor-grep",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    "pip uninstall tensor-grep failed"
+                    + (f": {result.stderr.strip()}" if result.stderr else "")
+                )
+            launcher.path.unlink(missing_ok=True)
+            if launcher.path.exists():
+                raise OSError("launcher still exists after cleanup")
+            removed.append(f"- {launcher.path} ({reason})")
+        except Exception as exc:
+            failed.append(f"- {launcher.path} ({reason}): {exc}")
+
+    sections: list[str] = []
+    if removed:
+        sections.append(
+            "Removed stale tensor-grep Python package launchers from PATH:\n" + "\n".join(removed)
+        )
+    if failed:
+        sections.append(
+            "WARNING: stale tensor-grep Python package launchers remain ahead of managed "
+            "native tg.exe:\n" + "\n".join(failed)
+        )
+    if unowned_launchers:
+        sections.append(
+            "WARNING: tensor-grep-looking Python Scripts tg.exe launchers remain ahead of "
+            "managed native tg.exe, but package ownership could not be verified:\n"
+            + "\n".join(
+                f"- {launcher.path} ({launcher.version or '<unreadable --version>'})"
+                for launcher in unowned_launchers
+            )
+        )
+    return "\n".join(sections) if sections else None
 
 
 def _refresh_windows_tensor_grep_com_bridges(
@@ -1172,6 +1393,12 @@ def _refresh_managed_native_frontdoor(expected_version: str) -> str | None:
     path_order_message = _ensure_windows_managed_native_first_on_path(native_path)
     if path_order_message:
         messages.append(path_order_message)
+    stale_python_launcher_message = _remove_windows_stale_tensor_grep_python_launchers(
+        expected_version,
+        native_path,
+    )
+    if stale_python_launcher_message:
+        messages.append(stale_python_launcher_message)
     stale_com_bridges = _windows_stale_tensor_grep_com_bridges(expected_version, native_path)
     current_version = _native_tg_version(native_path) if native_path.is_file() else None
     if not _native_tg_version_matches(expected_version, current_version):

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -7463,6 +7463,8 @@ def test_upgrade_removes_stale_tensor_grep_python_scripts_launcher(
     stale_tg.write_text("stale tensor-grep launcher", encoding="utf-8")
     stale_python = stale_dir.parent / "python.exe"
     stale_python.write_text("", encoding="utf-8")
+    package_location = stale_dir.parent / "Lib" / "site-packages"
+    package_launcher = os.path.relpath(stale_tg, package_location)
     foreign_tg = foreign_dir / "tg.exe"
     foreign_tg.write_text("foreign launcher", encoding="utf-8")
     calls: list[list[str]] = []
@@ -7487,9 +7489,9 @@ def test_upgrade_removes_stale_tensor_grep_python_scripts_launcher(
                 stdout=(
                     "Name: tensor-grep\n"
                     "Version: 0.32.0\n"
-                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    f"Location: {package_location}\n"
                     "Files:\n"
-                    "..\\..\\Scripts\\tg.exe\n"
+                    f"{package_launcher}\n"
                 ),
                 stderr="",
             )
@@ -7532,6 +7534,8 @@ def test_upgrade_removes_broken_tensor_grep_python_scripts_launcher_by_package_o
     stale_tg.write_text("broken tensor-grep launcher", encoding="utf-8")
     stale_python = stale_dir.parent / "python.exe"
     stale_python.write_text("", encoding="utf-8")
+    package_location = stale_dir.parent / "Lib" / "site-packages"
+    package_launcher = os.path.relpath(stale_tg, package_location)
     calls: list[list[str]] = []
 
     def _fake_candidate_version(path):
@@ -7552,9 +7556,9 @@ def test_upgrade_removes_broken_tensor_grep_python_scripts_launcher_by_package_o
                 stdout=(
                     "Name: tensor-grep\n"
                     "Version: 0.32.0\n"
-                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    f"Location: {package_location}\n"
                     "Files:\n"
-                    "..\\..\\Scripts\\tg.exe\n"
+                    f"{package_launcher}\n"
                 ),
                 stderr="",
             )
@@ -7593,6 +7597,8 @@ def test_upgrade_detects_owned_python_scripts_launcher_without_python_named_root
     stale_tg.write_text("stale tensor-grep launcher", encoding="utf-8")
     stale_python = stale_dir.parent / "python.exe"
     stale_python.write_text("", encoding="utf-8")
+    package_location = stale_dir.parent / "Lib" / "site-packages"
+    package_launcher = os.path.relpath(stale_tg, package_location)
 
     def _fake_candidate_version(path):
         candidate = Path(path)
@@ -7611,9 +7617,9 @@ def test_upgrade_detects_owned_python_scripts_launcher_without_python_named_root
                 stdout=(
                     "Name: tensor-grep\n"
                     "Version: 0.32.0\n"
-                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    f"Location: {package_location}\n"
                     "Files:\n"
-                    "..\\..\\Scripts\\tg.exe\n"
+                    f"{package_launcher}\n"
                 ),
                 stderr="",
             )
@@ -7650,6 +7656,8 @@ def test_upgrade_does_not_unlink_owned_python_launcher_when_uninstall_fails(
     stale_tg.write_text("stale tensor-grep launcher", encoding="utf-8")
     stale_python = stale_dir.parent / "python.exe"
     stale_python.write_text("", encoding="utf-8")
+    package_location = stale_dir.parent / "Lib" / "site-packages"
+    package_launcher = os.path.relpath(stale_tg, package_location)
 
     def _fake_candidate_version(path):
         candidate = Path(path)
@@ -7668,9 +7676,9 @@ def test_upgrade_does_not_unlink_owned_python_launcher_when_uninstall_fails(
                 stdout=(
                     "Name: tensor-grep\n"
                     "Version: 0.32.0\n"
-                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    f"Location: {package_location}\n"
                     "Files:\n"
-                    "..\\..\\Scripts\\tg.exe\n"
+                    f"{package_launcher}\n"
                 ),
                 stderr="",
             )

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -7447,6 +7447,408 @@ def test_windows_path_repair_reports_machine_path_python_subprocess_blocker(
     assert "Windows PATH now prefers managed native tg.exe" not in message
 
 
+def test_upgrade_removes_stale_tensor_grep_python_scripts_launcher(
+    monkeypatch,
+    tmp_path,
+):
+    install_dir = tmp_path / ".tensor-grep"
+    native_binary = install_dir / "bin" / "tg.exe"
+    stale_dir = tmp_path / "Python314" / "Scripts"
+    foreign_dir = tmp_path / "ForeignPython" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    stale_dir.mkdir(parents=True)
+    foreign_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    stale_tg = stale_dir / "tg.exe"
+    stale_tg.write_text("stale tensor-grep launcher", encoding="utf-8")
+    stale_python = stale_dir.parent / "python.exe"
+    stale_python.write_text("", encoding="utf-8")
+    foreign_tg = foreign_dir / "tg.exe"
+    foreign_tg.write_text("foreign launcher", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == stale_tg:
+            return "tensor-grep 0.32.0"
+        if candidate == foreign_tg:
+            return "Together CLI (v2.12.0)"
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        calls.append(command)
+        if command[:5] == [str(stale_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.32.0\n"
+                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    "Files:\n"
+                    "..\\..\\Scripts\\tg.exe\n"
+                ),
+                stderr="",
+            )
+        if command[:4] == [str(stale_python), "-m", "pip", "uninstall"]:
+            stale_tg.unlink(missing_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, stdout="uninstalled\n", stderr="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{stale_dir};{native_binary.parent};{foreign_dir}")
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: str(stale_dir))
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert "Removed stale tensor-grep Python package launchers" in message
+    assert str(stale_tg) in message
+    assert not stale_tg.exists()
+    assert foreign_tg.exists()
+    assert native_binary.exists()
+    assert [str(stale_python), "-m", "pip", "show", "-f", "tensor-grep"] in calls
+    assert [str(stale_python), "-m", "pip", "uninstall", "-y", "tensor-grep"] in calls
+
+
+def test_upgrade_removes_broken_tensor_grep_python_scripts_launcher_by_package_owner(
+    monkeypatch,
+    tmp_path,
+):
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    stale_dir = tmp_path / "Python314" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    stale_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    stale_tg = stale_dir / "tg.exe"
+    stale_tg.write_text("broken tensor-grep launcher", encoding="utf-8")
+    stale_python = stale_dir.parent / "python.exe"
+    stale_python.write_text("", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == stale_tg:
+            return None
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        calls.append(command)
+        if command[:5] == [str(stale_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.32.0\n"
+                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    "Files:\n"
+                    "..\\..\\Scripts\\tg.exe\n"
+                ),
+                stderr="",
+            )
+        if command[:4] == [str(stale_python), "-m", "pip", "uninstall"]:
+            stale_tg.unlink(missing_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, stdout="uninstalled\n", stderr="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{stale_dir};{native_binary.parent}")
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: str(stale_dir))
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert not stale_tg.exists()
+    assert [str(stale_python), "-m", "pip", "show", "-f", "tensor-grep"] in calls
+    assert [str(stale_python), "-m", "pip", "uninstall", "-y", "tensor-grep"] in calls
+
+
+def test_upgrade_detects_owned_python_scripts_launcher_without_python_named_root(
+    monkeypatch,
+    tmp_path,
+):
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    stale_dir = tmp_path / "miniconda3" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    stale_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    stale_tg = stale_dir / "tg.exe"
+    stale_tg.write_text("stale tensor-grep launcher", encoding="utf-8")
+    stale_python = stale_dir.parent / "python.exe"
+    stale_python.write_text("", encoding="utf-8")
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == stale_tg:
+            return "tensor-grep 0.32.0"
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        if command[:5] == [str(stale_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.32.0\n"
+                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    "Files:\n"
+                    "..\\..\\Scripts\\tg.exe\n"
+                ),
+                stderr="",
+            )
+        if command[:4] == [str(stale_python), "-m", "pip", "uninstall"]:
+            stale_tg.unlink(missing_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, stdout="uninstalled\n", stderr="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{stale_dir};{native_binary.parent}")
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: "")
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert not stale_tg.exists()
+
+
+def test_upgrade_does_not_unlink_owned_python_launcher_when_uninstall_fails(
+    monkeypatch,
+    tmp_path,
+):
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    stale_dir = tmp_path / "Python314" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    stale_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    stale_tg = stale_dir / "tg.exe"
+    stale_tg.write_text("stale tensor-grep launcher", encoding="utf-8")
+    stale_python = stale_dir.parent / "python.exe"
+    stale_python.write_text("", encoding="utf-8")
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == stale_tg:
+            return "tensor-grep 0.32.0"
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        if command[:5] == [str(stale_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.32.0\n"
+                    f"Location: {stale_dir.parent / 'Lib' / 'site-packages'}\n"
+                    "Files:\n"
+                    "..\\..\\Scripts\\tg.exe\n"
+                ),
+                stderr="",
+            )
+        if command[:4] == [str(stale_python), "-m", "pip", "uninstall"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="permission denied\n")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{stale_dir};{native_binary.parent}")
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: "")
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert "WARNING: stale tensor-grep Python package launchers remain" in message
+    assert "permission denied" in message
+    assert stale_tg.exists()
+
+
+def test_upgrade_does_not_remove_unowned_broken_python_scripts_launcher(
+    monkeypatch,
+    tmp_path,
+):
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    tool_dir = tmp_path / "Python314" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    tool_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    tool_tg = tool_dir / "tg.exe"
+    tool_tg.write_text("foreign broken launcher", encoding="utf-8")
+    tool_python = tool_dir.parent / "python.exe"
+    tool_python.write_text("", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == tool_tg:
+            return None
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        calls.append(command)
+        if command[:5] == [str(tool_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.32.0\n"
+                    f"Location: {tool_dir.parent / 'Lib' / 'site-packages'}\n"
+                    "Files:\n"
+                    "tensor_grep\\__main__.py\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{tool_dir};{native_binary.parent}")
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: str(tool_dir))
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert "package ownership could not be verified" in message
+    assert tool_tg.exists()
+    assert [str(tool_python), "-m", "pip", "uninstall", "-y", "tensor-grep"] not in calls
+
+
+def test_upgrade_does_not_remove_readable_unowned_python_scripts_launcher(
+    monkeypatch,
+    tmp_path,
+):
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    tool_dir = tmp_path / "Python314" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    tool_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    tool_tg = tool_dir / "tg.exe"
+    tool_tg.write_text("manually copied tensor-grep-looking launcher", encoding="utf-8")
+    tool_python = tool_dir.parent / "python.exe"
+    tool_python.write_text("", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == tool_tg:
+            return "tensor-grep 0.32.0"
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        calls.append(command)
+        if command[:5] == [str(tool_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.32.0\n"
+                    f"Location: {tool_dir.parent / 'Lib' / 'site-packages'}\n"
+                    "Files:\n"
+                    "tensor_grep\\__main__.py\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{tool_dir};{native_binary.parent}")
+    monkeypatch.setattr(cli_main, "_doctor_fresh_shell_path_value", lambda: str(tool_dir))
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert "package ownership could not be verified" in message
+    assert tool_tg.exists()
+    assert [str(tool_python), "-m", "pip", "show", "-f", "tensor-grep"] in calls
+    assert [str(tool_python), "-m", "pip", "uninstall", "-y", "tensor-grep"] not in calls
+
+
+def test_managed_frontdoor_refresh_runs_stale_python_launcher_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    install_dir = tmp_path / ".tensor-grep"
+    python_executable = install_dir / ".venv" / "Scripts" / "python.exe"
+    native_binary = install_dir / "bin" / "tg.exe"
+    python_executable.parent.mkdir(parents=True)
+    native_binary.parent.mkdir(parents=True)
+    python_executable.write_text("", encoding="utf-8")
+    native_binary.write_text("managed native", encoding="utf-8")
+    cleanup_calls: list[tuple[str, Path]] = []
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "executable", str(python_executable))
+    monkeypatch.setattr(cli_main, "_native_tg_version", lambda path: "tg 0.33.0")
+    monkeypatch.setattr(cli_main, "_ensure_windows_managed_native_first_on_path", lambda path: None)
+    monkeypatch.setattr(cli_main, "_windows_stale_tensor_grep_com_bridges", lambda *_args: [])
+    monkeypatch.setattr(cli_main, "_refresh_windows_tensor_grep_com_bridges", lambda *_args: [])
+
+    def _fake_cleanup(expected_version, native_path):
+        cleanup_calls.append((expected_version, native_path))
+        return "Removed stale tensor-grep Python package launchers from PATH:\n- stale"
+
+    monkeypatch.setattr(
+        cli_main,
+        "_remove_windows_stale_tensor_grep_python_launchers",
+        _fake_cleanup,
+    )
+
+    message = cli_main._refresh_managed_native_frontdoor("0.33.0")
+
+    assert cleanup_calls == [("0.33.0", native_binary)]
+    assert message is not None
+    assert "Removed stale tensor-grep Python package launchers" in message
+
+
 def test_repair_launcher_requires_explicit_foreign_rename(monkeypatch, tmp_path):
     install_dir = tmp_path / ".tensor-grep"
     native_binary = install_dir / "bin" / "tg.exe"

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -163,6 +163,34 @@ def test_install_ps1_should_uninstall_python_package_that_owns_stale_launcher():
     assert "Attempting to uninstall stale tensor-grep package that owns PATH launcher" in content
     assert "-m pip uninstall -y tensor-grep" in content
     assert "Removed stale tensor-grep Python package from PATH owner" in content
+    assert "$candidateOwnedByPackage" in content
+
+
+def test_install_ps1_should_try_python_package_cleanup_when_version_probe_fails():
+    content = _read_script("scripts/install.ps1")
+
+    assert "$versionProbeFailed = $false" in content
+    assert "$versionProbeFailed = $true" in content
+    assert "if ($versionProbeFailed -or !$candidateVersion)" in content
+    assert "-m pip show -f tensor-grep" in content
+    assert "Remove-StalePythonPackageLauncher `" in content
+    assert "<unreadable --version>" in content
+
+
+def test_install_ps1_should_verify_python_package_ownership_before_removing_readable_launcher():
+    content = _read_script("scripts/install.ps1")
+    stale_path_function = content[content.index("function Remove-StalePathLauncher") :]
+    cleanup_call = (
+        "if (Remove-StalePythonPackageLauncher `\n"
+        "                    -candidatePath $candidatePath `\n"
+        "                    -candidateVersion $candidateVersion)"
+    )
+
+    assert cleanup_call in stale_path_function
+    assert stale_path_function.index(cleanup_call) < stale_path_function.index(
+        "Remove-Item -LiteralPath $candidatePath -Force -ErrorAction Stop"
+    )
+    assert "package ownership could not be verified" in stale_path_function
 
 
 def test_install_ps1_should_skip_inaccessible_path_entries_when_scanning_launchers():


### PR DESCRIPTION
## Summary

- clean stale Windows Python `Scripts\tg.exe` launchers during managed native front-door refresh when `pip show -f tensor-grep` proves package ownership
- preserve foreign and unowned Python `Scripts` launchers, with warnings instead of blind deletion
- align `scripts/install.ps1` with the same ownership proof before removing Python `Scripts` launchers

## Dogfood blocker addressed

Public 1.12.41 dogfood could still resolve stale tensor-grep 1.12.40 from `Python314\Scripts\tg.exe` while the managed native front door was 1.12.41. This slice targets that stale Python entrypoint path without touching unrelated launchers.

## Validation

- `uv run --no-sync pytest -q tests/unit/test_cli_modes.py -k "launcher or frontdoor or bridge or windows_path_repair or doctor_json_reports_python_subprocess or upgrade_refreshes_stale" tests/unit/test_install_scripts.py` -> 48 passed, 349 deselected
- `uv run --no-sync pytest -q` -> 2308 passed, 16 skipped
- `uv run --no-sync ruff check src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py tests/unit/test_install_scripts.py`
- `uv run --no-sync ruff format --check --preview src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py tests/unit/test_install_scripts.py`
- `uv run --no-sync mypy src/tensor_grep`
- `git diff --check`
- non-destructive host detector still identifies `C:\Users\oimir\AppData\Local\Programs\Python\Python314\Scripts\tg.exe` as tensor-grep-owned 1.12.40
- Gemini read-only review: `VERDICT: PASS`, no blocker or major risks
