### PR TITLE
fix: harden stale python launcher cleanup

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -480,6 +480,24 @@ def _managed_native_frontdoor_path_from_env() -> Path | None:
     return native_path
 
 
+def _managed_native_frontdoor_path() -> Path | None:
+    native_path = _managed_native_frontdoor_path_from_env()
+    if native_path is not None:
+        return native_path
+    if not sys.platform.startswith("win"):
+        return None
+    try:
+        if not Path(sys.executable).expanduser().is_absolute():
+            return None
+    except RuntimeError:
+        return None
+    managed_bin_dir = _windows_managed_native_bin_dir()
+    if managed_bin_dir is None:
+        return None
+    native_path = managed_bin_dir / "tg.exe"
+    return native_path if native_path.is_file() else None
+
+
 def _download_native_frontdoor_asset(url: str, destination: Path) -> None:
     import urllib.request
 
@@ -773,7 +791,8 @@ def _windows_tensor_grep_python_launcher_scan(
                 continue
 
             version = candidate.get("version")
-            if _native_tg_version_matches(expected_version, version):
+            shadows_managed_native = not native_seen
+            if _native_tg_version_matches(expected_version, version) and not shadows_managed_native:
                 continue
 
             if not _doctor_tg_version_looks_like_tensor_grep(version):
@@ -1385,7 +1404,7 @@ def _schedule_windows_native_frontdoor_refresh(
 
 
 def _refresh_managed_native_frontdoor(expected_version: str) -> str | None:
-    native_path = _managed_native_frontdoor_path_from_env()
+    native_path = _managed_native_frontdoor_path()
     if native_path is None:
         return None
 
@@ -8065,8 +8084,155 @@ def upgrade() -> None:
             def _version_matches(version_text: str) -> bool:
                 return bool(expected_version and expected_version in version_text)
 
+            def _same_path(left: Path, right: Path) -> bool:
+                try:
+                    return left.resolve() == right.resolve()
+                except OSError:
+                    return left == right
+
+            def _python_scripts_launcher_python(candidate: Path) -> Path | None:
+                if candidate.name.lower() != "tg.exe":
+                    return None
+                if candidate.parent.name.lower() != "scripts":
+                    return None
+                parts = tuple(part.lower() for part in candidate.parts)
+                if ".tensor-grep" in parts or ".venv" in parts or "venv" in parts:
+                    return None
+                python_executable = candidate.parent.parent / "python.exe"
+                if not python_executable.is_file():
+                    return None
+                return python_executable
+
+            def _package_owns_launcher(
+                python_executable: Path,
+                launcher_path: Path,
+            ) -> str:
+                try:
+                    result = subprocess.run(
+                        [
+                            str(python_executable),
+                            "-m",
+                            "pip",
+                            "show",
+                            "-f",
+                            "tensor-grep",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                except Exception:
+                    return ""
+                if result.returncode != 0:
+                    return ""
+                location: Path | None = None
+                version = ""
+                files_started = False
+                files: list[str] = []
+                for raw_line in result.stdout.splitlines():
+                    line = raw_line.rstrip()
+                    if line.startswith("Location:"):
+                        value = line.split(":", 1)[1].strip()
+                        if value:
+                            location = Path(value)
+                    elif line.startswith("Version:"):
+                        version = line.split(":", 1)[1].strip()
+                    elif line.strip() == "Files:":
+                        files_started = True
+                    elif files_started:
+                        value = line.strip()
+                        if value:
+                            files.append(value)
+                if location is None:
+                    return ""
+                try:
+                    resolved_launcher = launcher_path.resolve()
+                except OSError:
+                    resolved_launcher = launcher_path
+                for relative_file in files:
+                    try:
+                        resolved_file = (location / relative_file).resolve()
+                    except OSError:
+                        resolved_file = location / relative_file
+                    if _same_path(resolved_file, resolved_launcher):
+                        return version or "installed"
+                return ""
+
+            def _cleanup_stale_python_launchers() -> str:
+                if not expected_version or native_path is None:
+                    return ""
+                removed: list[str] = []
+                failed: list[str] = []
+                seen: set[str] = set()
+                native_seen = False
+                for entry in os.environ.get("PATH", "").split(os.pathsep):
+                    if not entry:
+                        continue
+                    candidate = Path(entry.strip('"')) / "tg.exe"
+                    if _same_path(candidate, native_path):
+                        native_seen = True
+                        continue
+                    python_executable = _python_scripts_launcher_python(candidate)
+                    if python_executable is None:
+                        continue
+                    try:
+                        key = str(candidate.resolve()).lower()
+                    except OSError:
+                        key = str(candidate).lower()
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    version = _version(candidate)
+                    if _version_matches(version) and native_seen:
+                        continue
+                    if version and not version.strip().lower().startswith("tensor-grep "):
+                        continue
+                    package_version = _package_owns_launcher(python_executable, candidate)
+                    if not package_version:
+                        continue
+                    reason = version or "tensor-grep package " + package_version
+                    try:
+                        result = subprocess.run(
+                            [
+                                str(python_executable),
+                                "-m",
+                                "pip",
+                                "uninstall",
+                                "-y",
+                                "tensor-grep",
+                            ],
+                            capture_output=True,
+                            text=True,
+                            timeout=120,
+                        )
+                        if result.returncode != 0:
+                            error = (result.stderr or result.stdout or "").strip()
+                            raise RuntimeError(
+                                "pip uninstall tensor-grep failed"
+                                + (": " + error if error else "")
+                            )
+                        candidate.unlink(missing_ok=True)
+                        if candidate.exists():
+                            raise OSError("launcher still exists after cleanup")
+                        removed.append("- " + str(candidate) + " (" + reason + ")")
+                    except Exception as exc:
+                        failed.append("- " + str(candidate) + " (" + reason + "): " + str(exc))
+                sections: list[str] = []
+                if removed:
+                    sections.append(
+                        "Removed stale tensor-grep Python package launchers from PATH:\\n"
+                        + "\\n".join(removed)
+                    )
+                if failed:
+                    sections.append(
+                        "WARNING: stale tensor-grep Python package launchers remain "
+                        "ahead of managed native tg.exe:\\n"
+                        + "\\n".join(failed)
+                    )
+                return "\\n".join(sections)
+
             def _refresh_native_frontdoor_and_bridges() -> str:
-                # refresh native front door and stale PATH tensor-grep front-door copies after locked self-upgrade
+                # refresh native front door, stale PATH copies, and stale Python launchers after locked self-upgrade
                 if not expected_version or native_path is None:
                     return ""
 
@@ -8148,6 +8314,9 @@ def upgrade() -> None:
                         "Refreshed PATH tensor-grep front-door copies:\\n"
                         + "\\n".join(refreshed_bridges)
                     )
+                cleanup_payload = _cleanup_stale_python_launchers()
+                if cleanup_payload:
+                    messages.append(cleanup_payload)
                 return "\\n".join(messages)
 
             ok, method, payload = _run_attempts()
@@ -8290,7 +8459,7 @@ def upgrade() -> None:
                 expected_version = latest_version
             else:
                 package_spec = "tensor-grep"
-            native_path = _managed_native_frontdoor_path_from_env()
+            native_path = _managed_native_frontdoor_path()
             path_order_message = (
                 _ensure_windows_managed_native_first_on_path(native_path)
                 if native_path is not None

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -7521,6 +7521,74 @@ def test_upgrade_removes_stale_tensor_grep_python_scripts_launcher(
     assert [str(stale_python), "-m", "pip", "uninstall", "-y", "tensor-grep"] in calls
 
 
+def test_upgrade_removes_shadowing_tensor_grep_python_scripts_launcher_even_when_current(
+    monkeypatch,
+    tmp_path,
+):
+    native_binary = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    stale_dir = tmp_path / "Python314" / "Scripts"
+    native_binary.parent.mkdir(parents=True)
+    stale_dir.mkdir(parents=True)
+    native_binary.write_text("managed native", encoding="utf-8")
+    stale_tg = stale_dir / "tg.exe"
+    stale_tg.write_text("shadowing tensor-grep launcher", encoding="utf-8")
+    stale_python = stale_dir.parent / "python.exe"
+    stale_python.write_text("", encoding="utf-8")
+    package_location = stale_dir.parent / "Lib" / "site-packages"
+    package_launcher = os.path.relpath(stale_tg, package_location)
+    calls: list[list[str]] = []
+
+    def _fake_candidate_version(path):
+        candidate = Path(path)
+        if candidate == native_binary:
+            return "tg 0.33.0"
+        if candidate == stale_tg:
+            return "tensor-grep 0.33.0"
+        return None
+
+    def _fake_run(cmd, capture_output=True, text=True, timeout=None, **_kwargs):
+        command = [str(part) for part in cmd]
+        calls.append(command)
+        if command[:5] == [str(stale_python), "-m", "pip", "show", "-f"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "Name: tensor-grep\n"
+                    "Version: 0.33.0\n"
+                    f"Location: {package_location}\n"
+                    "Files:\n"
+                    f"{package_launcher}\n"
+                ),
+                stderr="",
+            )
+        if command[:4] == [str(stale_python), "-m", "pip", "uninstall"]:
+            stale_tg.unlink(missing_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, stdout="uninstalled\n", stderr="")
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("PATH", f"{native_binary.parent};{stale_dir}")
+    monkeypatch.setattr(
+        cli_main,
+        "_doctor_fresh_shell_path_value",
+        lambda: f"{stale_dir};{native_binary.parent}",
+    )
+    monkeypatch.setattr(cli_main, "_doctor_tg_candidate_version", _fake_candidate_version)
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    message = cli_main._remove_windows_stale_tensor_grep_python_launchers(
+        "0.33.0",
+        native_binary,
+    )
+
+    assert message is not None
+    assert "Removed stale tensor-grep Python package launchers" in message
+    assert not stale_tg.exists()
+    assert [str(stale_python), "-m", "pip", "show", "-f", "tensor-grep"] in calls
+    assert [str(stale_python), "-m", "pip", "uninstall", "-y", "tensor-grep"] in calls
+
+
 def test_upgrade_removes_broken_tensor_grep_python_scripts_launcher_by_package_owner(
     monkeypatch,
     tmp_path,
@@ -7835,6 +7903,46 @@ def test_managed_frontdoor_refresh_runs_stale_python_launcher_cleanup(
 
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(sys, "executable", str(python_executable))
+    monkeypatch.setattr(cli_main, "_native_tg_version", lambda path: "tg 0.33.0")
+    monkeypatch.setattr(cli_main, "_ensure_windows_managed_native_first_on_path", lambda path: None)
+    monkeypatch.setattr(cli_main, "_windows_stale_tensor_grep_com_bridges", lambda *_args: [])
+    monkeypatch.setattr(cli_main, "_refresh_windows_tensor_grep_com_bridges", lambda *_args: [])
+
+    def _fake_cleanup(expected_version, native_path):
+        cleanup_calls.append((expected_version, native_path))
+        return "Removed stale tensor-grep Python package launchers from PATH:\n- stale"
+
+    monkeypatch.setattr(
+        cli_main,
+        "_remove_windows_stale_tensor_grep_python_launchers",
+        _fake_cleanup,
+    )
+
+    message = cli_main._refresh_managed_native_frontdoor("0.33.0")
+
+    assert cleanup_calls == [("0.33.0", native_binary)]
+    assert message is not None
+    assert "Removed stale tensor-grep Python package launchers" in message
+
+
+def test_managed_frontdoor_refresh_uses_default_install_when_upgrade_runs_from_external_python(
+    monkeypatch,
+    tmp_path,
+):
+    install_dir = tmp_path / ".tensor-grep"
+    external_python = tmp_path / "Python314" / "python.exe"
+    native_binary = install_dir / "bin" / "tg.exe"
+    external_python.parent.mkdir(parents=True)
+    native_binary.parent.mkdir(parents=True)
+    external_python.write_text("", encoding="utf-8")
+    native_binary.write_text("managed native", encoding="utf-8")
+    cleanup_calls: list[tuple[str, Path]] = []
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(sys, "executable", str(external_python))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
+    monkeypatch.delenv("TG_SIDECAR_PYTHON", raising=False)
     monkeypatch.setattr(cli_main, "_native_tg_version", lambda path: "tg 0.33.0")
     monkeypatch.setattr(cli_main, "_ensure_windows_managed_native_first_on_path", lambda path: None)
     monkeypatch.setattr(cli_main, "_windows_stale_tensor_grep_com_bridges", lambda *_args: [])
@@ -8619,7 +8727,10 @@ def test_upgrade_scheduled_windows_helper_refreshes_stale_com_bridge(monkeypatch
     assert result.exit_code == 0
     assert popen_calls
     helper_code = popen_calls[0][2]
-    assert "refresh native front door and stale PATH tensor-grep front-door copies" in helper_code
+    compile(helper_code, "<scheduled-upgrade-helper>", "exec")
+    assert "refresh native front door, stale PATH copies, and stale Python launchers" in helper_code
+    assert '"show",' in helper_code
+    assert "Removed stale tensor-grep Python package launchers from PATH" in helper_code
     assert popen_calls[0][7] == str(native_binary)
     helper_assets = json.loads(popen_calls[0][8])
     assert helper_assets == [


### PR DESCRIPTION
## Summary
- discover the existing managed native front door during `tg upgrade` even when upgrade runs from an external absolute Python launcher
- remove tensor-grep-owned Python `Scripts\tg.exe` launchers when they shadow managed native, even when their version string is current
- add the same ownership-based cleanup to the scheduled Windows self-upgrade helper

## Validation
- `uv run --no-sync pytest tests/unit/test_cli_modes.py -q -k "upgrade or doctor or repair_launcher"` -> 55 passed
- `uv run --no-sync pytest -q` -> 2310 passed, 16 skipped
- `uv run --no-sync ruff check .` -> passed
- `uv run --no-sync mypy src` -> passed
- `git diff --check` -> passed
- `C:\Users\oimir\.cargo\bin\cargo.exe fmt --manifest-path rust_core/Cargo.toml --check` -> passed
- `C:\Users\oimir\.cargo\bin\cargo.exe test --manifest-path rust_core/Cargo.toml` -> passed

## Review Notes
- Exa checked current pip `show -f` ownership behavior and Windows process/PATH search documentation.
- Thinktank notes supported this PR-sized launcher cleanup slice.
- Gemini review was attempted twice in read-only mode but did not produce a report because the CLI stalled after MCP/policy noise; no Gemini approval is counted.