### PR TITLE
fix: harden rg json-lines parity contract

### DIFF
--- a/src/tensor_grep/cli/rg_contract.py
+++ b/src/tensor_grep/cli/rg_contract.py
@@ -113,6 +113,15 @@ RG_CONTRACT_ROWS: tuple[RGContractRow, ...] = (
         "benchmarkable": False,
     },
     {
+        "id": "rg-json-lines",
+        "public_flags": ("--format", "--json"),
+        "rg_args": ("--json",),
+        "tg_args": ("--format", "rg", "--json"),
+        "output_mode": "json",
+        "parity_expectation": "normalized",
+        "benchmarkable": False,
+    },
+    {
         "id": "ndjson",
         "public_flags": ("--ndjson",),
         "rg_args": ("--ndjson",),

--- a/tests/helpers/rg_parity.py
+++ b/tests/helpers/rg_parity.py
@@ -80,6 +80,7 @@ ROW_SCENARIOS: dict[str, _ScenarioSpec] = {
         ("files-match.txt", "files-nested-miss.txt"),
     ),
     "json": _ScenarioSpec("json sentinel", ("root",)),
+    "rg-json-lines": _ScenarioSpec("json sentinel", ("root",)),
     # ripgrep exposes only --json, so the parity comparator normalizes tg --ndjson
     # against rg --json match events.
     "ndjson": _ScenarioSpec("ndjson sentinel", ("root",), rg_args=("--json",)),
@@ -497,6 +498,9 @@ def _normalize_machine_output(
     matches: list[tuple[str, int, str]] = []
 
     if tool == "tg":
+        if rows and all(isinstance(row, dict) and "type" in row for row in rows):
+            return _normalize_rg_json_events(rows, corpus=corpus)
+
         if len(rows) == 1 and isinstance(rows[0], dict) and "matches" in rows[0]:
             for match in rows[0]["matches"]:
                 matches.append((
@@ -514,7 +518,18 @@ def _normalize_machine_output(
             ))
         return {"matches": sorted(matches)}
 
+    return _normalize_rg_json_events(rows, corpus=corpus)
+
+
+def _normalize_rg_json_events(
+    rows: list[object],
+    *,
+    corpus: RGParityCorpus,
+) -> dict[str, list[tuple[str, int, str]]]:
+    matches: list[tuple[str, int, str]] = []
     for row in rows:
+        if not isinstance(row, dict):
+            continue
         if row.get("type") != "match":
             continue
         data = row["data"]

--- a/tests/unit/test_rg_contract.py
+++ b/tests/unit/test_rg_contract.py
@@ -16,6 +16,7 @@ EXPECTED_ROWS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "files-with-matches": (("-l", "--files-with-matches"), ("--files-with-matches",)),
     "files-without-match": (("--files-without-match",), ("--files-without-match",)),
     "json": (("--json",), ("--json",)),
+    "rg-json-lines": (("--format", "--json"), ("--json",)),
     "ndjson": (("--ndjson",), ("--ndjson",)),
     "fixed-strings": (("-F", "--fixed-strings"), ("--fixed-strings",)),
     "word-regexp": (("-w", "--word-regexp"), ("--word-regexp",)),
@@ -46,6 +47,9 @@ EXPECTED_ROWS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "type-list": (("--type-list",), ("--type-list",)),
     "pcre2-version": (("--pcre2-version",), ("--pcre2-version",)),
 }
+EXPECTED_TG_ARGS_OVERRIDES: dict[str, tuple[str, ...]] = {
+    "rg-json-lines": ("--format", "rg", "--json"),
+}
 
 
 def _load_rows() -> tuple[RGContractRow, ...]:
@@ -62,7 +66,6 @@ def _assert_row_contract(row: RGContractRow) -> None:
     )
     assert len(set(row["rg_args"])) == len(row["rg_args"]), f"Row {row['id']} has duplicate rg args"
     assert len(set(row["tg_args"])) == len(row["tg_args"]), f"Row {row['id']} has duplicate tg args"
-    assert row["rg_args"] == row["tg_args"], f"Row {row['id']} must use one canonical scenario"
     assert row["output_mode"] in {
         "text",
         "count",
@@ -79,9 +82,10 @@ def _assert_row_contract(row: RGContractRow) -> None:
     )
 
     expected_public_flags, expected_args = EXPECTED_ROWS[row["id"]]
+    expected_tg_args = EXPECTED_TG_ARGS_OVERRIDES.get(row["id"], expected_args)
     assert row["public_flags"] == expected_public_flags
     assert row["rg_args"] == expected_args
-    assert row["tg_args"] == expected_args
+    assert row["tg_args"] == expected_tg_args
 
 
 def test_rg_contract_rows_have_unique_ids_and_expected_shapes() -> None:


### PR DESCRIPTION
## Summary

Harden the rg JSON Lines parity contract for the dogfood order-only failure.

- add an explicit `rg-json-lines` parity row for `tg search --format rg --json`
- compare that row against `rg --json` by normalized match set, not raw event order
- teach the parity helper to recognize rg event objects emitted by tg's explicit rg JSON Lines route

## Why

The v1.12.43 dogfood parity artifact showed `format-rg-json` had the same matches but a different unsorted event order. Upstream ripgrep documents that unsorted output can be nondeterministic because of parallel search, and `--sort path` is the deterministic route.

Exa source checked: BurntSushi/ripgrep FAQ `How can I get results in a consistent order?` and GUIDE `--sort path` note.

## Validation

- `uv run --no-sync pytest tests/unit/test_rg_contract.py -q`
- `uv run --no-sync pytest tests/e2e/test_rg_parity_matrix.py -q -k "rg_json_lines or json"`
- `uv run --no-sync pytest tests/e2e/test_rg_parity_matrix.py tests/e2e/test_rg_parity_edges.py tests/unit/test_rg_contract.py tests/e2e/test_routing_parity.py::test_search_help_exposes_required_public_flags -q`
- `uv run --no-sync ruff check src/tensor_grep/cli/rg_contract.py tests/helpers/rg_parity.py tests/unit/test_rg_contract.py`
- `uv run --no-sync mypy src/tensor_grep/cli/rg_contract.py`
- `git diff --check -- src/tensor_grep/cli/rg_contract.py tests/helpers/rg_parity.py tests/unit/test_rg_contract.py`

## Notes

- No product-speed, GPU, LSP, or raw grep replacement claim changes.
- Existing local `SKILL.md` edit was not included.
