### PR TITLE
fix: restore dogfood docs claim wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## Unreleased
+
+### Bug Fixes
+
+- Restore the README `broad generated-root scan` wording required by dogfood docs-claim checks.
+
+
 ## v1.12.46 (2026-05-21)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ tg dogfood --output artifacts/dogfood_readiness.json
 
 This checks the current `v1.12.46` shell/version resolution, `public-windows-launcher-quoted-patterns`, installed-public advertised search flag acceptance via `public-search-advertised-flag-sweep`, repo doctor sanity, foreign launcher diagnostics, `context_consistency`, `agent-capsule`, `agent-capsule-mixed-language`, `agent-capsule-hardcases`, deterministic rg edge parity, AST smoke, MCP context-render smoke, docs claim hygiene, and the current positioning: `rg` remains the cold exact-text baseline, `ast-grep` remains the structural-search feature/performance baseline, and `tg` is the agent-native orchestration layer. `tg dogfood` wraps the same gate with a release-readiness verdict for agent and CI logs.
 It also tracks the managed native-upgrade contract so sidecar and release-native front-door versions stay aligned after `tg upgrade`.
-It also covers the broad generated/workspace-root scan guard: unbounded `tg search --files` roots that combine hidden/no-ignore-style scanning with generated, cache, or dependency directories, and unbounded searches against a parent containing multiple child project roots, must be scoped, bounded, or explicitly opted in with `--allow-broad-generated-scan`.
+It also covers the broad generated-root scan and workspace-root scan guard: unbounded `tg search --files` roots that combine hidden/no-ignore-style scanning with generated, cache, or dependency directories, and unbounded searches against a parent containing multiple child project roots, must be scoped, bounded, or explicitly opted in with `--allow-broad-generated-scan`.
 
 ## Bounded Heavy-Root AI Handoff
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,67 +9,54 @@ description: Use when searching code, logs, or repositories with tensor-grep; va
 
 release_docs_current_tag: v1.12.46
 
-As of 2026-05-14, the current tagged version is `v1.12.46`, and the latest complete public PyPI/release-asset distribution is also `v1.12.46`. Stable installer, PyPI metadata refresh, release-native asset publication, managed-native front-door refresh after `tg upgrade`, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity for advertised public flags, Windows `.cmd` quoted-pattern launcher handling, native-first Windows PATH ordering, top-level validation-command JSON, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, the opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, capsule validation-trust fixes, explicit language/file-name ranking, quoted Windows validation commands, docs governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternatives, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, agent capsule hardcase routing, and Windows subprocess bridge ranking hardening are in the public `v1.12.46` GitHub asset and PyPI release line.
+As of 2026-05-21, the current tagged version is `v1.12.46`, and the latest complete public PyPI/release-asset distribution is also `v1.12.46`. Stable installer, PyPI metadata refresh, release-native asset publication, managed-native front-door refresh after `tg upgrade`, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity for advertised public flags, Windows `.cmd` quoted-pattern launcher handling, native-first Windows PATH ordering, top-level validation-command JSON, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, the opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, capsule validation-trust fixes, explicit language/file-name ranking, quoted Windows validation commands, docs governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternatives, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, agent capsule hardcase routing, Windows subprocess bridge ranking hardening, broad multi-project workspace-root scan guardrails, and `tg doctor` Windows shell escaping diagnostics are in the public `v1.12.46` GitHub asset and PyPI release line.
 
 Current release facts:
 
-- PR #143 `21e5437 fix: collect capsule call-site evidence` merged and released as `v1.12.14`
-- PR #142 `8a73f8d fix: harden agent bridge ranking` merged and released as `v1.12.13`
-- PR #141 `b601366 fix: harden agent output budget hygiene` merged and released as `v1.12.12`
-- PR #140 `2aebac6 fix: harden ast cli contract hygiene (#140)` merged and released as `v1.12.11`
-- PR #139 `bbc08e4 fix: harden rg flag contract aliases (#139)` merged and released as `v1.12.10`
-- PR #138 `21627d2 fix: harden v1.12.8 dogfood contracts` merged and released as `v1.12.9`
-- PR #137 `f848748 fix: route cold rg-shaped searches to rg (#137)` merged and released as `v1.12.8`
-- PR #128 `da44a2f fix: harden v1.12.6 dogfood cli contracts` merged and released as `v1.12.7`
-- PR #116 `a78e33c fix: harden post-release docs governance` merged and released as `v1.11.5`
-- PR #114 `361e0db fix: harden public GPU unavailable routing` and PR #115 `2100122 fix: harden release docs stamp governance` merged and released as `v1.11.4`
-- PR #113 `87d4ca4 fix: accelerate fixed multi-pattern native search` merged and released as `v1.11.3`
-- Latest verified release proof merge commit: `c0cb613 fix: harden v1.12.33 dogfood contracts`
-- Latest verified release proof commit: `e069f67 chore(release): v1.12.34 [skip ci]`
-- Latest verified proof public release commit: `e069f67 chore(release): v1.12.34 [skip ci]`
-- Latest merged fix commit: `c0cb613 fix: harden v1.12.33 dogfood contracts`
-- Latest merged feature commit: `a518cc6 feat: add agent success harness`
-- PR #110 `fix: expose classify provider provenance` merged and released as `v1.11.2`
-- PR #105 `fix: add explicit Windows subprocess launcher repair` merged and released as `v1.10.10`
-- Merge commit: `dd995fc fix: add explicit Windows subprocess launcher repair`
-- PR #101 `fix: harden gpu search accuracy contracts` merged and released as `v1.10.7`
-- PR #100 `fix: harden v1.10.5 dogfood blockers` merged and released as `v1.10.6`
-- PR #91 `fix: harden release wheel retries` merged and released as `v1.9.11`
-- PR #90 `fix: harden v1.9.9 dogfood followups` merged and released as `v1.9.10` on GitHub assets; PyPI publication was completed by the v1.9.11 release-wheel retry follow-up
-- PR #89 `fix: add agent workflow benchmark governance` merged and released as `v1.9.9`
-- PR #87 `fix: refresh stale tg.com bridge after upgrade` merged and released as `v1.9.8`
-- PR #86 `fix: clarify GPU benchmark promotion gates` merged and released as `v1.9.7`
-- PR #84 `fix: harden v1.9.5 dogfood blockers` merged and released as `v1.9.6`
-- PR #83 `fix: harden GPU gates and launcher diagnostics` merged and released
-- PR #82 `fix: harden docs governance and validation placeholders` merged and released
-- PR #81 `fix: harden agent ranking docs and validation quoting` merged and released
-- PR #80 `fix: harden edit JSON and capsule validation trust` merged and released
-- PR #78 `fix: harden agent capsule trust alignment` merged and released
-- PR #76 `feat: add actionable agent context capsule` merged and released
-- Previous GPU/benchmark warning fix commit: `e2bd7c2 fix: scope GPU probing and benchmark launcher warnings`
-- PR #74 `fix: scope GPU probing and benchmark launcher warnings` merged and released as `v1.8.33`
-- Previous launcher observability fix commit: `ab2635a fix: expose launcher route observability`
-- Previous agent-contract fix commit: `015fad9 fix: harden public launcher and agent contracts`
-- Previous launcher fix commit: `e6d09a5 fix: preserve quoted patterns in Windows cmd shim`
-- Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`
+- PR #181 `524f6d4 fix: expose windows shell escaping diagnostics` merged and released as `v1.12.46`.
+- Release commit: `6fb1c0d chore(release): v1.12.46 [skip ci]`.
+- Main CI run `26213038896` passed; CodeQL run `26213037961` passed.
+- GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.12.46>.
+- PyPI/public install proof: `uvx --refresh-package tensor-grep --from tensor-grep==1.12.46 tg --version` reports `tensor-grep 1.12.46`.
+- PR #180 `e15e99d fix: guard broad workspace root searches` merged and released as `v1.12.45`; release commit `a2312c7 chore(release): v1.12.45 [skip ci]`.
+- Latest merged feature commit: `a518cc6 feat: add agent success harness`.
+- Historical v1.12.34 proof retained for docs-governance context: `c0cb613 fix: harden v1.12.33 dogfood contracts`; `e069f67 chore(release): v1.12.34 [skip ci]`; Main CI run `26094452260`; CodeQL proof run `26064676072`; prior CodeQL run `25951813292`.
+- PR #143 `21e5437 fix: collect capsule call-site evidence` merged and released as `v1.12.14`.
+- PR #142 `8a73f8d fix: harden agent bridge ranking` merged and released as `v1.12.13`.
+- PR #141 `b601366 fix: harden agent output budget hygiene` merged and released as `v1.12.12`.
+- PR #140 `2aebac6 fix: harden ast cli contract hygiene (#140)` merged and released as `v1.12.11`.
+- PR #139 `bbc08e4 fix: harden rg flag contract aliases (#139)` merged and released as `v1.12.10`.
+- PR #138 `21627d2 fix: harden v1.12.8 dogfood contracts` merged and released as `v1.12.9`.
+- PR #137 `f848748 fix: route cold rg-shaped searches to rg (#137)` merged and released as `v1.12.8`.
+- PR #128 `da44a2f fix: harden v1.12.6 dogfood cli contracts` merged and released as `v1.12.7`.
+- PR #116 `a78e33c fix: harden post-release docs governance` merged and released as `v1.11.5`.
+- PR #114 `361e0db fix: harden public GPU unavailable routing` and PR #115 `2100122 fix: harden release docs stamp governance` merged and released as `v1.11.4`.
+- PR #113 `87d4ca4 fix: accelerate fixed multi-pattern native search` merged and released as `v1.11.3`.
+- PR #110 `fix: expose classify provider provenance` merged and released as `v1.11.2`.
+- PR #105 `fix: add explicit Windows subprocess launcher repair` merged and released as `v1.10.10`; merge commit `dd995fc fix: add explicit Windows subprocess launcher repair`.
+- PR #101 `fix: harden gpu search accuracy contracts` merged and released as `v1.10.7`.
+- PR #100 `fix: harden v1.10.5 dogfood blockers` merged and released as `v1.10.6`.
+- PR #91 `fix: harden release wheel retries` merged and released as `v1.9.11`.
+- PR #90 `fix: harden v1.9.9 dogfood followups` merged and released as `v1.9.10` on GitHub assets; PyPI publication was completed by the v1.9.11 release-wheel retry follow-up.
+- PR #89 `fix: add agent workflow benchmark governance` merged and released as `v1.9.9`.
+- PR #87 `fix: refresh stale tg.com bridge after upgrade` merged and released as `v1.9.8`.
+- PR #86 `fix: clarify GPU benchmark promotion gates` merged and released as `v1.9.7`.
+- PR #84 `fix: harden v1.9.5 dogfood blockers` merged and released as `v1.9.6`.
+- PR #83 `fix: harden GPU gates and launcher diagnostics` merged and released.
+- PR #82 `fix: harden docs governance and validation placeholders` merged and released.
+- PR #81 `fix: harden agent ranking docs and validation quoting` merged and released.
+- PR #80 `fix: harden edit JSON and capsule validation trust` merged and released.
+- PR #78 `fix: harden agent capsule trust alignment` merged and released.
+- PR #76 `feat: add actionable agent context capsule` merged and released.
+- Previous GPU/benchmark warning fix commit: `e2bd7c2 fix: scope GPU probing and benchmark launcher warnings`.
+- PR #74 `fix: scope GPU probing and benchmark launcher warnings` merged and released as `v1.8.33`.
+- Previous launcher observability fix commit: `ab2635a fix: expose launcher route observability`.
+- Previous agent-contract fix commit: `015fad9 fix: harden public launcher and agent contracts`.
+- Previous launcher fix commit: `e6d09a5 fix: preserve quoted patterns in Windows cmd shim`.
+- Latest merged docs/product commit: `f311469 docs: define agent context capsule roadmap`.
 - PR #66 `docs: define agent context capsule roadmap` merged; Main CI run `25561521904` passed, CodeQL/dynamic main run `25561520180` passed, and semantic-release correctly skipped publishing.
-- `v1.11.0` main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remains `1.10.10`.
-- Main CI run `26094452260` passed the pre-release matrix, semantic-release, PyPI artifact validation, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`. Latest CodeQL proof run `26064676072` passed on the `v1.12.32` release line; prior CodeQL run `25951813292` passed on the `v1.12.14` release line.
-- PyPI pinned public install resolves with `uvx --refresh-package tensor-grep --from tensor-grep==1.12.14 tg --version`
-- GitHub release assets for `v1.12.14` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
-- Public `v1.12.14` dogfood verified PyPI, `uvx`, GitHub assets, public launcher resolution, bounded capsule call-site evidence, agent bridge ranking hardening, agent output-budget hygiene, AST CLI contract hygiene, bounded map/context output, `tg run --pattern`, root cold rg-shaped routing, accepted search/native-front-door CLI drift fixes, `tg new --base-dir`, edit-plan budget flags, explicit rg JSON Lines routing via `--format rg --json`, explicit JSON/NDJSON schema positioning, and rg flag-contract aliases; public managed GPU remains not promotion-ready and falls back to CPU or unsupported rows unless a CUDA-feature native build proves `NativeGpuBackend` with `sidecar_used = false`.
-- Public `v1.11.5` dogfood verified PyPI, `uvx`, GitHub assets, and post-release-safe docs governance; `v1.11.4` remains the native GPU unavailable fallback to `NativeCpuBackend` release, `v1.11.3` remains the fixed multi-pattern native CPU release, and `v1.10.10` remains the historical Windows subprocess launcher repair release.
-- Public `v1.11.2` dogfood verified PyPI, `uvx`, GitHub assets, and classify provider provenance in JSON output.
-- PR #102 `fix: harden v1.10.7 dogfood followups` merged and released as `v1.10.8`
-- Public `v1.9.9` dogfood: direct managed native `~/.tensor-grep/bin/tg.exe` reports `tg 1.9.9`; `uvx --from tensor-grep==1.9.9 tg --version` reports `tensor-grep 1.9.9`; `tg update` advanced `1.9.8` to `1.9.9`, refreshed the managed native front door, and fresh `cmd` plus unprofiled `pwsh` report `tg 1.9.9`.
-- Prior public update dogfood: `tg update` from `v1.9.3` initially saw PyPI propagation lag, then installed sidecar `tensor-grep==1.9.4`, refreshed `~/.tensor-grep/bin/tg.exe`, and verified `tg 1.9.4`. Profiled PowerShell, `cmd`, `pwsh -NoProfile`, WSL, Git Bash, and direct managed native `tg.exe` resolved `tg 1.9.4`; `tg doctor --json` reported `version = 1.9.4`, `rust_binary_version_status = matches`, `search_acceleration_backend = standalone-native-tg`, `path_tg_first_launcher_kind = cmd-shim`, `fresh_shell_path_tg_first_launcher_kind = managed-native`, and a `path_tg_launcher_warning` for current shells that still route through the compatibility shim before fresh-shell PATH.
-- Prior public installer dogfood: rerunning `scripts/install.ps1` for `v1.8.31` put `C:\Users\oimir\.tensor-grep\bin` ahead of compatibility shim directories on User PATH. A simulated fresh shell resolves `C:\Users\oimir\.tensor-grep\bin\tg.exe` before `C:\Users\oimir\bin\tg.cmd`.
-- Public native CLI dogfood: `tg search --multiline`, `tg search -U`, `tg search --files`, `tg search --null`, `tg run -r`, and `tg classify --format json` all accept the advertised public shape on the installed front door.
-- Public Windows launcher dogfood: `cmd /c tg`, direct managed `tg.cmd`, native `tg.exe`, and Python `subprocess.run([...])` all return exit `1` with empty stdout for fresh quoted no-match phrases.
-- Fast gate before PR #76: `python scripts/agent_readiness.py --output artifacts/agent_readiness_agent_capsule.json` passed all checks.
-- Repo-dev doctor/search dogfood confirms stale in-tree standalone binaries are skipped unless `TG_NATIVE_TG_BINARY` or `TG_MCP_TG_BINARY` explicitly pins one
-- Post-`v1.9.6` local dogfood: native CUDA release search passes exact correctness on both RTX 4070 (`sm_89`) and RTX 5070 (`sm_120`) smoke corpora plus 1GB/5GB scale gates but remains slower than both `rg` and `tg_cpu`; GPU benchmark sidecar rows are marked unsupported for native CUDA scale gates unless the benchmark uses a CUDA-enabled native binary; root `tg --help` advertises current agent/GPU/launcher/validation contracts; and `tg doctor --json` classifies unrelated first-PATH `tg` commands such as Together CLI as `foreign` with explicit remediation. Local fresh-shell dogfood now passes after `tg update` moved from `1.9.5` to `1.9.6`, and a non-destructive `tg.com` bridge was placed ahead of the foreign `tg.exe` where Machine PATH ordering could not be changed.
-- Latest handoff: `docs/SESSION_HANDOFF.md`
+- `v1.11.0` main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed and PyPI latest remained `1.10.10` until later releases.
+- Latest handoff: `docs/SESSION_HANDOFF.md`.
 
 Current product read:
 
@@ -77,17 +64,17 @@ Current product read:
 - `ast-grep` remains the structural-search feature/performance baseline; `tg run` is a validated useful slice, not full ast-grep equivalence.
 - `tg` is strongest as agent-native code intelligence: scoped search, JSON/NDJSON, repo maps, defs, source, refs, callers, context bundles, blast-radius, AST search, rewrite planning, GPU inventory, and MCP.
 - The native front door must accept advertised public flags or intentionally route them to the sidecar. The current release line covers `tg search --files`, `tg search --multiline` / `-U`, `tg search --null`, `tg run -r`, `tg classify --format json`, advertised rg-style search flags, option-first root `tg ...` forwarding, Windows `.cmd` quoted multi-word no-match patterns, native-first Windows PATH ordering for fresh managed shells, and launcher-route observability for current-process versus fresh-shell PATH drift.
-- Post-`v1.12.6` dogfood hardening in progress: keep Python/dev and native/public search flag surfaces aligned for accepted rg-compatibility aliases such as `--passthrough`, `--unicode`, `--auto-hybrid-regex`, and `tg search --version`; top-level structured search flags such as `tg --json --no-ignore PATTERN PATH` must parse through the native front door; `tg new` must either create the requested scaffold under the requested base directory or fail before writing files; `edit-plan`, MCP `tg_edit_plan`, and session edit-plan should accept `max_sources` / `max_tokens` for agent command-surface parity while still emitting no rendered source text.
+- The current release line keeps Python/dev and native/public search flag surfaces aligned for accepted rg-compatibility aliases such as `--passthrough`, `--unicode`, `--auto-hybrid-regex`, and `tg search --version`; top-level structured search flags such as `tg --json --no-ignore PATTERN PATH` must parse through the native front door; `tg new` must either create the requested scaffold under the requested base directory or fail before writing files; `edit-plan`, MCP `tg_edit_plan`, and session edit-plan should accept `max_sources` / `max_tokens` for agent command-surface parity while still emitting no rendered source text.
 - The quoted multi-word no-match pattern case from `cmd.exe`, direct `tg.cmd`, and Python `subprocess.run([...])` is a public Windows launcher contract. A split pattern can become a shorter false-positive search plus bogus paths, so keep `public-windows-launcher-quoted-patterns` in the fast agent-readiness gate.
 - Stable managed installs should prefer the matching release-native CPU front door when the GitHub release asset exists, while keeping the isolated Python environment as sidecar/fallback via `TG_SIDECAR_PYTHON` and `TG_NATIVE_TG_BINARY`. Installer changes should preserve the staged replacement contract so a failed install cannot break an existing public shim, including checking native installer command exit codes before the staged swap. On Windows, the managed native front-door directory should be ahead of compatibility `.cmd` shim directories on PATH so `cmd`, unprofiled PowerShell, and Python subprocess calls resolve `~/.tensor-grep/bin/tg.exe` before the slower argv-safe bridge. If a copied tensor-grep `tg.com` bridge is used to outrank a foreign same-directory `tg.exe`, it must still discover `~/.tensor-grep/.venv` for sidecar commands and point `TG_NATIVE_TG_BINARY` back to the managed native front door. Python subprocess resolution must be checked directly because `CreateProcess` can choose a foreign `.exe` route that shell `PATHEXT` hides. `tg upgrade` must verify the sidecar import/version before claiming success, including the scheduled Windows self-upgrade path, and managed native front doors must be refreshed when the verified sidecar version moves ahead of `tg.exe`.
-- `tg doctor --json` is the first check for launcher drift. Inspect `path_tg_first_launcher_kind`, `fresh_shell_path_tg_first_launcher_kind`, `python_subprocess_path_tg_first_launcher_kind`, `path_tg_launcher_warning`, and any `*_is_foreign` / `*_foreign_remediation` fields before trusting Windows benchmark timings; existing shells can retain the slower compatibility shim even after fresh User PATH resolves the native front door, Python subprocesses can resolve differently from shells, and unrelated tools can own a different `tg` command.
+- `tg doctor --json` is the first check for launcher drift and Windows shell pitfalls. Inspect `path_tg_first_launcher_kind`, `fresh_shell_path_tg_first_launcher_kind`, `python_subprocess_path_tg_first_launcher_kind`, `path_tg_launcher_warning`, `shell_escaping_guidance`, and any `*_is_foreign` / `*_foreign_remediation` fields before trusting Windows benchmark timings; existing shells can retain the slower compatibility shim even after fresh User PATH resolves the native front door, Python subprocesses can resolve differently from shells, PowerShell double quotes expand `$NAME`, and unrelated tools can own a different `tg` command.
 - Cold-path benchmark artifacts should separate configured launcher mode from actual timed command kind. Use `environment.tg_launcher_mode` for the experiment and `environment.tg_launcher_command_kind` to distinguish native-exe, `.cmd` shim, `uv`, and Python-module routes. Also preserve `tg_binary_version_status`; stale in-tree native binaries block claim-quality benchmark scripts by default unless `--allow-claim-unsafe-launcher` marks the run as exploratory. Treat benchmark warnings about shim/interpreter overhead as blocking for performance comparisons.
 - Explicit `--gpu-device-ids` routing should only probe selected CUDA ordinals. Selecting GPU 0 must not initialize or warn about unrelated unsupported devices such as GPU 1.
 - GPU benchmark auto-recommendation must stay false unless required 1GB/5GB correctness checks pass and a selected GPU beats both `rg` and `tg_cpu` at required scale. Unsupported-device inventory warnings should stay top-level or on the unsupported device row, not on unrelated selected-GPU timing rows. GPU-requested CPU fallback or sidecar compatibility output must report `gpu_evidence_status = unsupported`, `gpu_proof = false`, `native_gpu_unavailable`, and `not_gpu_proof_reason`; unsupported rows should carry `promotion_evidence = false`.
 - `--format rg --sort path` is the deterministic rg-shaped stdout contract. Token-saving output work should be a separate opt-in agent profile, not a mutation of raw rg/json/ndjson contracts.
 - `tg search --json` is tensor-grep aggregate JSON, not rg JSON Lines. `tg search --format rg --json` is the explicit rg JSON Lines compatibility route and emits raw rg events without the tensor-grep envelope. `tg search --ndjson` is tensor-grep's flattened streaming row schema, not the rg event schema. Use `--format rg` for rg-shaped output and keep schema claims explicit.
 - `tg agent` / Actionable Context Capsule is the product wedge: an opt-in workflow packet with primary file/function, route rationale, bounded snippets with line maps, validation evidence, edit order, checkpoint/rollback metadata, omission counts, confidence, call-site evidence status, and an "ask user before editing" recommendation when evidence is weak. Capsule v1 leaves `related_call_sites` empty unless verified call-site evidence is explicitly collected. Evidence labels should distinguish `parser-backed`, `rg-backed`, `graph-derived`, `heuristic`, `LSP-confirmed`, and `stale/uncertain` conclusions.
-- LSP provider-backed navigation is optional and experimental. `tg lsp-setup` / `tg doctor --with-lsp` provider availability means the binary is installed, not that semantic requests work; inspect `health_status`, `health_check`, `lsp_proof`, `lsp_evidence_status`, and `not_lsp_proof_reason` before treating an `lsp` / `hybrid` result as provider-confirmed. Rows require `lsp_provider_response = true` from a completed provider request before they can contribute to `lsp_proof`.
+- LSP provider-backed navigation is optional and experimental. Provider availability is not navigation proof. `tg lsp-setup` / `tg doctor --with-lsp` provider availability means the binary is installed, not that semantic requests work; inspect `health_status`, `health_check`, `lsp_proof`, `lsp_evidence_status`, and `not_lsp_proof_reason` before treating an `lsp` / `hybrid` result as provider-confirmed. Rows require `lsp_provider_response = true` from a completed provider request before they can contribute to `lsp_proof`.
 - Before editing from an agent capsule, inspect top-level `ambiguity`. `ambiguity.status = "tie_requires_confirmation"` is a hard stop for autonomous edits. `ambiguity.status = "tie_resolved"` is acceptable only when `ambiguity.resolved_by` contains explicit evidence.
 - `tg agent --gpu-device-ids ... --json` and MCP `tg_agent_capsule(..., gpu_device_ids=[...])` are opt-in GPU evidence paths. They should expose `gpu_acceleration`, require `NativeGpuBackend` with `sidecar_used = false` before using the evidence, and report sidecar-routed GPU as unsupported.
 - Feature or tool changes must update the matching implementation, tests, docs/contracts, README, CLI help (`tg --help` and command-specific help), native front-door help when applicable, MCP signatures/docs when agent-facing, and this skill when repo operating practice changes.
@@ -113,18 +100,12 @@ Dogfood follow-up workflow:
 
 Current post-`v1.12.46` dogfood slice ledger:
 
-- PR order: 1; scope: accept and forward remaining rg config-override flags (`--pcre2-unicode`, `--ignore`, `--messages`, `--require-git`, `--no-hidden`) in native/Python search and add them to the installed-public sweep; Exa anchors: ripgrep manpage option inversion/config behavior plus ripgrep guide automatic-filtering defaults; thinktank/planning consensus: local planning review, external council not applicable for this parser/forwarding contract slice; subagent ownership: not applicable; Gemini review: unavailable because Gemini CLI 0.42.0 hung on a one-token read-only model probe and was killed; validation: Rust crate tests, full pytest, lint, format, mypy, and diff whitespace checks pass locally; PR CI/main CI: pending.
-- PR order: 1; scope: make `run_agent_success_harness.py` refuse stale in-tree native `tg` binaries by default and mark `--allow-claim-unsafe-launcher` runs as exploratory; Exa anchors: not applicable beyond existing benchmark-governance policy; thinktank/planning consensus: local planning review aligned with `run_benchmarks.py` stale-binary refusal; subagent ownership: not applicable; Gemini review: unavailable because Gemini CLI 0.42.0 hung on a one-token read-only model probe and was killed; validation: Rust crate tests, full pytest, lint, format, mypy, and diff whitespace checks pass locally; PR CI/main CI: pending.
-- PR order: 1; scope: accept and forward the 25 remaining ripgrep inverse/config-override flags found by `parser_sweep_1_12_31_codex.json`, including `--no-auto-hybrid-regex`, `--no-pcre2-unicode`, `--no-text`, `--no-binary`, `--no-follow`, `--ignore-dot`, `--ignore-vcs`, `--no-json`, and `--no-stats`, and batch those 25 installed-public sweep probes into one command to avoid adding dogfood latency; Exa anchors: current ripgrep guide/manpage behavior for config override flags plus local `rg 15.1.0` acceptance sweep; thinktank/planning consensus: local planning review only, external council not applicable because this is parser/forwarding contract work and does not alter GPU/LSP/product positioning; subagent ownership: not applicable, no subagents requested for this turn; Gemini review: unavailable because `gemini-3.1-pro-preview` returned an invalid empty stream and `gemini-2.5-flash` stalled after startup; validation: targeted parser/backend/readiness tests, full `test_public_native_cli_parity`, direct built-native acceptance of all 25 flags, full Python/Rust suites, lint, format, mypy, diff whitespace, and fast readiness pass locally; PR CI/main CI: pending.
-- PR order: 1; scope: add `world_class_readiness.status = "not_claimed"` plus `agent_target_selection_metrics` to `tg dogfood` reports so a PASS cannot be mistaken for full rg replacement, full ast-grep replacement, public GPU promotion, production LSP proof, or enterprise target-selection accuracy; Exa anchors: ripgrep JSON/config-override docs, ast-grep CLI docs, Cursor/Sourcegraph agentic context docs, and NVIDIA CUDA profiling/transfer guidance; thinktank/planning consensus: Gemini plan-mode read-only review rejected a separate `next_pr_slices` planning array as source-of-truth duplication and recommended adding the missing target-selection surface to the existing limitations contract; subagent ownership: not applicable, no Codex subagents requested for this turn; Gemini review: completed for planning, final diff-review retry unavailable because `gemini-3.1-pro-preview` returned an invalid empty stream and `gemini-2.5-flash` stalled after startup; validation: targeted dogfood/docs tests, full Python/Rust suites, lint, format, mypy, diff whitespace, and fast readiness pass locally; PR CI/main CI: pending.
-- PR order: 2; scope: make GPU promotion workload-scoped in benchmark artifacts and public dogfood/docs, including `promotion_scope = "declared_workload_class_only"`, fair many-pattern baseline `rg -F -e ... -e ...`, and candidate classes for `many_fixed_patterns_single_dispatch` / `resident_repeated_query`; Exa anchors: CUDA-grep final/checkpoint reports on transfer amortization and many-regex workloads, NVIDIA CUDA Graphs and pinned-memory async transfer docs, and ripgrep `-F`/`-e` multiple-pattern docs; thinktank/planning consensus: read-only GPU proof and release-governance seats both recommended an artifact/schema hardening PR rather than CUDA kernel work; subagent ownership: Jason reviewed GPU performance/proof, Lovelace reviewed release/governance; Gemini review: unavailable because `gemini-3.1-pro-preview` returned an invalid empty stream and `gemini-2.5-flash` stalled after startup; validation: targeted GPU benchmark contract, dogfood, public docs, benchmark-script, and readiness tests; `uv run ruff check .`; `uv run ruff format --check --preview .`; `uv run mypy src/tensor_grep`; `cargo fmt --manifest-path rust_core/Cargo.toml --check`; `cargo test --manifest-path rust_core/Cargo.toml`; `uv run pytest -q` (`2248 passed, 16 skipped`); `uv run python scripts/agent_readiness.py --no-shell-probes --no-wsl-probe --json` (`12 passed, 0 failed`); and `git diff --check` pass locally; PR CI/main CI: pending.
-- PR order: 3; scope: add public managed GPU proof plumbing with `tg-native-metadata.json`, Python upgrade/install script metadata writers, `--public-managed-proof`, and artifact fields `public_managed_promotion_ready` / `public_gpu_proof`; Exa anchors: NVIDIA Blackwell compatibility guidance, cudarc 0.19 CUDA 13/dynamic-loading docs, and GitHub Actions GPU runner docs; thinktank/planning consensus: Gemini plan-mode review rejected path-shape-only proof and recommended explicit managed front-door provenance; subagent ownership: attempted read-only Codex explorer, but the agent thread limit was reached, so implementation stayed local; Gemini review: planning review completed with file-read limitation, final diff review not run yet; validation: targeted runtime/installer/GPU benchmark/docs tests (`91 passed`), `uv run pytest -q` (`2261 passed, 16 skipped`), `uv run ruff check .`, `uv run ruff format --check --preview .`, `uv run mypy src/tensor_grep`, and `git diff --check` pass locally; PR CI/main CI: pending.
-- PR order: 4; scope: add a dispatch-only public managed GPU proof workflow and strengthen the native GPU proof gate so public promotion requires fixed GPU runner labels, managed NVIDIA asset verification, direct `rg --json` 1GB/5GB correctness, `NativeGpuBackend`, `sidecar_used = false`, and speed wins over both `rg` and `tg_cpu`; Exa anchors: GitHub Actions self-hosted/GPU runner docs, NVIDIA Blackwell/CUDA compatibility docs, CUDA compute-capability docs, and ripgrep JSON output semantics; thinktank/planning consensus: Mill/Mencius/Descartes agreed to separate public proof workflow/governance from local CUDA implementation evidence and to reject weak `promotion_ready` summaries; subagent ownership: Mill reviewed workflow scope, Mencius reviewed release/security workflow requirements, Descartes reviewed benchmark proof semantics; Gemini review: unavailable; `gemini-3.1-pro-preview` stalled after startup with no report and was stopped; validation: targeted GPU benchmark contract, benchmark-script, release-workflow validator, and release asset validator tests pass locally; PR CI/main CI: pending.
-- PR order: 1; scope: close the `v1.12.33` rg column-override edge by accepting and forwarding `--column --no-column` through both `tg search --format rg ...` and root-level `tg --format rg ...`, add installed-native sweep coverage, improve stale repo-local `uv run tg` warmup diagnostics, and pin the `ripgrep binary resolution` capsule hardcase; Exa anchors: ripgrep inverse/config-override docs where last flag wins, ripgrep JSON/output docs for preserving rg-vs-tg schema boundaries, Sourcegraph/Cody context docs for agent target-selection evidence, LSP initialize-timeout evidence for keeping LSP experimental, and CUDA-grep transfer-amortization notes for keeping GPU unpromoted; thinktank/planning consensus: two read-only seats recommended this narrow contract/readiness/capsule regression slice and explicitly rejected raw-speed, GPU, LSP, or ast-grep claim changes; subagent ownership: thinktank seats Lagrange and Hegel reviewed the plan, implementation stayed local due tight parser/readiness coupling; Gemini review: attempted with gemini CLI 0.42.0 / gemini-2.5-flash in read-only plan mode; unavailable because the model returned an invalid empty stream / malformed tool call; validation: targeted rg contract/parity tests, readiness stale-entrypoint and flag-sweep tests, agent hardcase test, Rust parser unit test, Rust public-native parity test, full Rust crate tests, full pytest, lint, format, mypy, fast readiness, and diff whitespace passed locally; PR CI/main CI: PR #163 passed, squash merge produced `c0cb613`, main CI run `26094452260` passed semantic-release, GitHub release assets, PyPI publish, and `publish-success-gate`; release/public proof: `v1.12.34` tag/release assets exist and `uvx --refresh-package tensor-grep --from tensor-grep==1.12.34 tg --version` reports `tensor-grep 1.12.34`.
+- PR order: 1; scope: guard broad multi-project workspace-root searches while preserving scoped `tg search --files` workflows; Exa anchors: not applicable beyond existing generated-root guardrail policy; thinktank/planning consensus: local planning review; subagent ownership: not applicable; Gemini review: unavailable; validation: targeted guardrail/docs tests plus local gates; PR CI/main CI: PR #180 passed, squash merge produced `e15e99d`, main CI released `v1.12.45`.
+- PR order: 2; scope: expose Windows shell escaping diagnostics in `tg doctor`, `tg --help`, README, contracts, and this skill so PowerShell `$NAME` expansion and `cmd.exe` metacharacter escaping are visible; Exa anchors: Microsoft PowerShell quoting/parsing docs and Microsoft cmd metacharacter docs; thinktank/planning consensus: not applicable for this narrow UX/docs contract; subagent ownership: not applicable; Gemini review: pass with low-risk notes; validation: targeted CLI/docs tests, ruff, format check, mypy, diff whitespace, PR CI, main CI, CodeQL, GitHub release assets, PyPI, and public `uvx` install proof; PR CI/main CI: PR #181 passed, squash merge produced `524f6d4`, main CI released `v1.12.46`.
 
 Known current weak spots:
 
-- Broad `tg search --files ...` over generated artifact trees can still be expensive; the managed Windows launchers and Python path-list output should force UTF-8, but scope file-list commands to the smallest useful root.
+- Broad `tg search --files ...` over generated artifact trees and multi-project workspace roots is now guarded when unbounded, but still scope file-list commands to the smallest useful root for latency, disk, and token budget.
 - Windows command resolution must be checked across profiled PowerShell, `pwsh -NoProfile`, and `cmd`. Old tensor-grep-owned `Python*\Scripts\tg.exe` launchers should now be removed or uninstalled by the Windows installer; any recurrence is release-regression evidence. A `Python*\Scripts\tg.exe` that reports another product's version is a foreign PATH-shadow blocker instead: report/remediate it, but do not delete it automatically.
 - WSL and Git Bash no-extension shims are part of the Windows installer contract. Verify WSL with `wsl bash -lc 'tg --version'` after shim changes.
 - In PowerShell, invoke `tg` or `tg.ps1` for regex metacharacters. Direct `tg.cmd` invocation with unescaped `|` is parsed by `cmd.exe` before the batch file receives argv.
@@ -168,6 +149,8 @@ where.exe tg
 uv run tg doctor --json
 ```
 
+On Windows, `tg doctor --json` includes `shell_escaping_guidance`. Use it to catch PowerShell `$NAME` expansion and `cmd.exe` metacharacter escaping issues before blaming `tg` parsing.
+
 Release dogfood checklist:
 
 ```powershell
@@ -188,15 +171,17 @@ tg search --json "<query>" src tests docs
 tg search --ndjson "<query>" src tests docs
 ```
 
-Avoid broad generated-root file lists unless the task needs them:
+Avoid broad generated-root or whole-workspace file lists unless the task needs them:
 
 ```powershell
-tg search --files "AGENTS.md" . --hidden
+# Avoid this unless the whole workspace scan is intentional:
+tg search --files C:\dev\projects --hidden --no-ignore
 ```
 
 Use one of these instead for agent-safe file discovery:
 
 ```powershell
+tg search --files . --hidden --glob "AGENTS.md"
 tg search --files src --hidden
 tg search --files . --hidden --glob "*.py"
 tg search --files . --hidden --max-depth 3
@@ -223,8 +208,37 @@ Only pass `--allow-broad-generated-scan` when the generated/cache/dependency tre
 | Context bundle | `tg context-render src --query "how routing works" --render-profile llm --json` |
 | Device inventory | `tg devices --json` |
 | MCP server | `tg mcp` |
+| **LSP setup** | `tg lsp-setup [--json]` |
+| **LSP server** | `tg lsp --provider native` or `tg lsp --provider hybrid` |
+| **Edit Planning** | `tg edit-plan src --query "change invoice tax"` |
+| **Interactive Session** | `tg session open [PATH] --json` |
+| **Session Daemon** | `tg session daemon start [PATH] --json` |
+| **Create Checkpoint (Rewind)** | `tg checkpoint create [PATH] --json` |
+| **List Checkpoints** | `tg checkpoint list [PATH] --json` |
+| **Rollback / Rewind to checkpoint** | `tg checkpoint undo <checkpoint_id> [PATH] --json` |
 
-PowerShell expands `$NAME` and `$$$ARGS` inside double quotes. Use single quotes for AST metavariable patterns.
+## Advanced Features: LSP, Editing, and Checkpoints (Rewind)
+
+### 1. LSP (Language Server Protocol) Integration
+`tensor-grep` contains an optional LSP coordinator for semantic navigation experiments (`defs`, `source`, `refs`, `callers`, `blast-radius`).
+- **Setup**: Run `tg lsp-setup [--json]` to install managed LSP providers into `~/.tensor-grep/providers`.
+- **Diagnostics**: Run `tg doctor --with-lsp --json` and inspect `health_status`, `health_check`, `lsp_proof`, `lsp_evidence_status`, and `not_lsp_proof_reason`.
+- **Server**: Run `tg lsp --provider native`, `tg lsp --provider lsp`, or `tg lsp --provider hybrid`. Provider availability is not navigation proof.
+
+### 2. Machine-Readable Edit-Planning and Sessions
+For agentic editing loops, `tg` supports structured edit tracking and map caches.
+- **Edit Plan**: `tg edit-plan` constructs a plan of edits across files matching a natural language query, specifying targets and files to touch.
+- **Session Open**: `tg session open [PATH] --json` creates a cached repo-map session for repeated edit loops.
+- **Session Daemon**: `tg session daemon start [PATH] --json` starts or reuses the warm localhost daemon for repeated repo-map and symbol requests.
+
+### 3. Checkpoints & Rollbacks (Rewind)
+Before initiating a complex code rewrite, agents should create a checkpoint when rollback evidence matters.
+- **Checkpoint Creation**: `tg checkpoint create [PATH] --json` creates a checkpoint scoped to the current editable tree or supplied path.
+- **Listing Checkpoints**: `tg checkpoint list [PATH] --json` lists available checkpoints; add `--discover` to recursively discover checkpoint scopes.
+- **Undo / Rollback (Rewind)**: `tg checkpoint undo <checkpoint_id> [PATH] --json` restores the selected checkpoint for that scope.
+
+
+PowerShell expands `$NAME` and `$$$ARGS` inside double quotes. For literal patterns, use single quotes or escape `$`. In `cmd.exe`, quote or caret-escape metacharacters such as `|`, `&`, `<`, `>`, `^`, `(`, and `)`.
 
 ## MCP Surface
 

--- a/tests/e2e/test_cli_search.py
+++ b/tests/e2e/test_cli_search.py
@@ -7,6 +7,8 @@ import pytest
 
 pytestmark = pytest.mark.acceptance
 
+CLI_SUBPROCESS_TIMEOUT_SECONDS = 20 if os.name == "nt" else 5
+
 
 class TestCLISearch:
     def _write_fake_rg_json_binary(self, tmp_path):
@@ -76,7 +78,7 @@ class TestCLISearch:
             ],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=CLI_SUBPROCESS_TIMEOUT_SECONDS,
         )
 
         assert result.returncode == 0
@@ -104,7 +106,7 @@ class TestCLISearch:
             capture_output=True,
             text=True,
             env=env,
-            timeout=5,
+            timeout=CLI_SUBPROCESS_TIMEOUT_SECONDS,
         )
 
         assert result.returncode == 0

--- a/tests/unit/test_public_docs_governance.py
+++ b/tests/unit/test_public_docs_governance.py
@@ -59,6 +59,7 @@ def test_readme_should_point_to_canonical_public_docs() -> None:
     assert "--apply" in readme
     assert "atomic temp-file rename contract" in readme
     assert "multi-project workspace roots" in readme
+    assert "broad generated-root scan" in readme
     assert "PowerShell double quotes expand `$NAME`" in readme
     assert "cmd.exe metacharacters" in readme
 
@@ -596,6 +597,23 @@ def test_tensor_grep_skill_should_record_latest_docs_merge_state() -> None:
     assert "agent-capsule-hardcases" in skill
     assert "validation_alignment" in skill
     assert "$file" in skill
+
+
+def test_tensor_grep_skill_should_match_current_public_cli_syntax() -> None:
+    skill = SKILL_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "PR #181 `524f6d4 fix: expose windows shell escaping diagnostics`" in skill
+    assert "Release commit: `6fb1c0d chore(release): v1.12.46 [skip ci]`" in skill
+    assert "Main CI run `26213038896` passed" in skill
+    assert "CodeQL run `26213037961` passed" in skill
+    assert "shell_escaping_guidance" in skill
+    assert "use single quotes or escape `$`" in skill
+    assert "tg checkpoint create [PATH]" in skill
+    assert "tg checkpoint undo <checkpoint_id> [PATH]" in skill
+    assert "tg checkpoint create [checkpoint_name]" not in skill
+    assert "dramatically speed" not in skill
+    assert "ensure zero data loss" not in skill
+    assert "Provider availability is not navigation proof" in skill
 
 
 def test_routing_policy_should_describe_current_native_and_fallback_routes() -> None:


### PR DESCRIPTION
## Summary
- restored README `broad generated-root scan` wording required by dogfood docs-claim checks
- refreshed repo and installed tensor-grep `SKILL.md` with current v1.12.46 syntax/proof and added docs-governance coverage
- hardened Windows E2E CLI subprocess timeout after the py3.12 CI lane exceeded the old 5s budget on the `--format rg --json` fake-rg route

## Validation
- `uv run --no-sync pytest -q tests/unit/test_public_docs_governance.py`
- `uv run --no-sync pytest -q tests/e2e/test_cli_search.py::TestCLISearch::test_should_emit_json_without_hanging tests/e2e/test_cli_search.py::TestCLISearch::test_should_emit_ripgrep_json_lines_when_format_rg_is_explicit -vv`
- `uv run --no-sync pytest -q tests/e2e/test_cli_search.py tests/unit/test_public_docs_governance.py`
- `uv run --no-sync ruff check tests/e2e/test_cli_search.py tests/unit/test_public_docs_governance.py`
- `uv run --no-sync ruff format --check --preview tests/e2e/test_cli_search.py tests/unit/test_public_docs_governance.py`
- `git diff --check -- CHANGELOG.md README.md SKILL.md tests/unit/test_public_docs_governance.py tests/e2e/test_cli_search.py`
- `uv run --no-sync python scripts/agent_readiness.py --root . --json --no-shell-probes --no-wsl-probe` -> 12 passed / 0 failed / 0 skipped
- `uv run --no-sync tg dogfood --no-shell-probes --no-wsl-probe --output artifacts/dogfood_1_12_46_readme_docs_fix.json --json` -> 12 passed / 0 failed / 0 skipped
- Gemini read-only diff review: `PASS`