### PR TITLE
fix: list symbol locations in text output

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6014,6 +6014,49 @@ def edit_plan(
     )
 
 
+def _positive_int(value: Any) -> int | None:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def _format_symbol_location_row(row: dict[str, Any]) -> str:
+    file_name = str(row.get("file", "")).strip()
+    if not file_name:
+        return ""
+
+    line = _positive_int(row.get("line", row.get("start_line")))
+    location = file_name if line is None else f"{file_name}:{line}"
+    column = _positive_int(row.get("column", row.get("col", row.get("start_column"))))
+    if line is not None and column is not None:
+        location = f"{location}:{column}"
+
+    details: list[str] = []
+    kind = str(row.get("kind", "")).strip()
+    name = str(row.get("name", "")).strip()
+    text = " ".join(str(row.get("text", "")).strip().split())
+    if kind:
+        details.append(kind)
+    if name:
+        details.append(name)
+    if text:
+        details.append(f"| {text}")
+    if not details:
+        return location
+    return f"{location} {' '.join(details)}"
+
+
+def _echo_symbol_location_rows(rows: list[dict[str, Any]]) -> None:
+    for row in rows:
+        rendered = _format_symbol_location_row(row)
+        if rendered:
+            typer.echo(rendered)
+
+
 @app.command()
 def defs(
     path: str = typer.Argument(".", help="File or directory to inventory"),
@@ -6056,6 +6099,7 @@ def defs(
 
     typer.echo(f"Definitions for {payload['symbol']} in {payload['path']}")
     typer.echo(f"definitions={len(payload['definitions'])}")
+    _echo_symbol_location_rows(payload["definitions"])
 
 
 @app.command()
@@ -6189,6 +6233,7 @@ def refs(
 
     typer.echo(f"References for {payload['symbol']} in {payload['path']}")
     typer.echo(f"references={len(payload['references'])} files={len(payload['files'])}")
+    _echo_symbol_location_rows(payload["references"])
 
 
 @app.command()
@@ -6233,6 +6278,7 @@ def callers(
 
     typer.echo(f"Callers for {payload['symbol']} in {payload['path']}")
     typer.echo(f"callers={len(payload['callers'])} files={len(payload['files'])}")
+    _echo_symbol_location_rows(payload["callers"])
 
 
 @app.command(name="blast-radius")

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2872,6 +2872,28 @@ def test_defs_json_returns_exact_symbol_definitions(tmp_path):
     assert [symbol["name"] for symbol in payload["symbols"]] == ["create_invoice"]
 
 
+def test_defs_text_lists_definition_locations(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+
+    module_path = src_dir / "payments.py"
+    module_path.write_text(
+        "class PaymentService:\n"
+        "    pass\n\n"
+        "def create_invoice(total, tax):\n"
+        "    return total + tax\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["defs", "--symbol", "create_invoice", str(project)])
+
+    assert result.exit_code == 0
+    assert "definitions=1" in result.stdout
+    assert f"{module_path.resolve()}:4" in result.stdout
+    assert "create_invoice" in result.stdout
+
+
 def test_impact_json_returns_ranked_files_and_tests_for_symbol(tmp_path):
     project = tmp_path / "project"
     src_dir = project / "src"
@@ -3068,6 +3090,30 @@ def test_refs_json_returns_python_references_for_symbol(tmp_path):
     assert str(other_path.resolve()) in payload["files"]
 
 
+def test_refs_text_lists_reference_locations(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+
+    module_path = src_dir / "payments.py"
+    module_path.write_text(
+        "def create_invoice(total, tax):\n    return total + tax\n",
+        encoding="utf-8",
+    )
+    other_path = src_dir / "billing.py"
+    other_path.write_text(
+        "from src.payments import create_invoice\n\nresult = create_invoice(10, 2)\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["refs", "--symbol", "create_invoice", str(project)])
+
+    assert result.exit_code == 0
+    assert "references=" in result.stdout
+    assert f"{other_path.resolve()}:3" in result.stdout
+    assert "result = create_invoice(10, 2)" in result.stdout
+
+
 def test_refs_json_deduplicates_parser_call_references(tmp_path):
     project = tmp_path / "project"
     src_dir = project / "src"
@@ -3136,6 +3182,32 @@ def test_callers_json_returns_python_call_sites_for_symbol(tmp_path):
     assert any(caller["file"] == str(other_path.resolve()) for caller in payload["callers"])
     assert str(other_path.resolve()) in payload["files"]
     assert payload["tests"][0] == str(test_path.resolve())
+
+
+def test_callers_text_lists_caller_locations(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+
+    module_path = src_dir / "payments.py"
+    module_path.write_text(
+        "def create_invoice(total, tax):\n    return total + tax\n",
+        encoding="utf-8",
+    )
+    other_path = src_dir / "billing.py"
+    other_path.write_text(
+        "from src.payments import create_invoice\n\n"
+        "def invoice_total():\n"
+        "    return create_invoice(10, 2)\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["callers", "--symbol", "create_invoice", str(project)])
+
+    assert result.exit_code == 0
+    assert "callers=1" in result.stdout
+    assert f"{other_path.resolve()}:4" in result.stdout
+    assert "return create_invoice(10, 2)" in result.stdout
 
 
 def test_blast_radius_json_returns_transitive_symbol_radius(tmp_path):


### PR DESCRIPTION
## Summary
- add non-JSON location rows for tg defs, refs, and callers
- keep JSON payloads unchanged
- cover defs/refs/callers text output with CLI tests

## Validation
- uv run pytest tests/unit/test_cli_modes.py -q
- uv run ruff check src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py
- uv run ruff format --check --preview src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py
- git diff --check