### PR TITLE
fix: discover checkpoints for rollback UX

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -69,6 +69,13 @@ class CheckpointUndoResult:
     removed_paths: int
 
 
+@dataclass
+class CheckpointLatestResult:
+    checkpoint_id: str
+    root: str
+    mode: str
+
+
 @dataclass(frozen=True)
 class _CheckpointScope:
     root: Path
@@ -351,6 +358,40 @@ def discover_checkpoint_scopes(path: str = ".") -> list[CheckpointScopeResult]:
             )
         )
     return scopes
+
+
+def resolve_latest_checkpoint(path: str = ".") -> CheckpointLatestResult:
+    scope = describe_checkpoint_scope(path)
+    if scope.checkpoints:
+        record = scope.checkpoints[0]
+        return CheckpointLatestResult(
+            checkpoint_id=record.checkpoint_id,
+            root=scope.root,
+            mode=scope.mode,
+        )
+
+    discovered = [
+        child_scope for child_scope in discover_checkpoint_scopes(path) if child_scope.checkpoints
+    ]
+    if not discovered:
+        resolved = Path(path).expanduser().resolve()
+        raise FileNotFoundError(f"No checkpoints found under {resolved}.")
+    if len(discovered) > 1:
+        roots = ", ".join(scope.root for scope in discovered[:5])
+        suffix = "" if len(discovered) <= 5 else f", ... ({len(discovered)} total)"
+        raise ValueError(
+            "Multiple checkpoint scopes found under "
+            f"{Path(path).expanduser().resolve()}; pass a narrower PATH or explicit checkpoint id. "
+            f"Scopes: {roots}{suffix}"
+        )
+
+    child_scope = discovered[0]
+    record = child_scope.checkpoints[0]
+    return CheckpointLatestResult(
+        checkpoint_id=record.checkpoint_id,
+        root=child_scope.root,
+        mode=child_scope.mode,
+    )
 
 
 def load_checkpoint_metadata(checkpoint_id: str, path: str = ".") -> dict[str, Any]:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7186,57 +7186,69 @@ def checkpoint_list(
         discover_checkpoint_scopes,
     )
 
+    def _discovered_payloads() -> tuple[list[dict[str, Any]], int]:
+        scope_payloads = [
+            {
+                "root": scope.root,
+                "mode": scope.mode,
+                "checkpoint_count": scope.checkpoint_count,
+                "checkpoints": [record.__dict__ for record in scope.checkpoints],
+            }
+            for scope in discover_checkpoint_scopes(path)
+        ]
+        checkpoint_count = sum(
+            int(cast(int, scope_payload["checkpoint_count"])) for scope_payload in scope_payloads
+        )
+        return scope_payloads, checkpoint_count
+
+    def _emit_discovered(
+        scope_payloads: list[dict[str, Any]], checkpoint_count: int, *, auto_discovered: bool
+    ) -> None:
+        if json_output:
+            payload = {
+                "version": 1,
+                "path": str(Path(path).expanduser().resolve()),
+                "checkpoint_count": checkpoint_count,
+                "discovered_scopes": scope_payloads,
+            }
+            if auto_discovered:
+                payload["auto_discovered"] = True
+            typer.echo(json.dumps(payload, indent=2))
+            return
+
+        if not scope_payloads:
+            typer.echo(f"No checkpoint scopes found under {Path(path).expanduser().resolve()}.")
+            return
+
+        prefix = "Auto-discovered" if auto_discovered else "Discovered"
+        typer.echo(
+            f"{prefix} {checkpoint_count} checkpoint(s) across {len(scope_payloads)} scope(s)."
+        )
+        for scope_payload in scope_payloads:
+            typer.echo(
+                f"Checkpoint root: {scope_payload['root']} "
+                f"({scope_payload['mode']}, count={scope_payload['checkpoint_count']})"
+            )
+            checkpoint_records = cast(list[dict[str, object]], scope_payload["checkpoints"])
+            for record in checkpoint_records:
+                typer.echo(
+                    f"  {record['checkpoint_id']}  {record['mode']}  "
+                    f"{record['created_at']}  files={record['file_count']}"
+                )
+
     try:
         if discover:
-            scope_payloads: list[dict[str, Any]] = [
-                {
-                    "root": scope.root,
-                    "mode": scope.mode,
-                    "checkpoint_count": scope.checkpoint_count,
-                    "checkpoints": [record.__dict__ for record in scope.checkpoints],
-                }
-                for scope in discover_checkpoint_scopes(path)
-            ]
-            checkpoint_count = sum(
-                int(cast(int, scope_payload["checkpoint_count"]))
-                for scope_payload in scope_payloads
-            )
-            if json_output:
-                typer.echo(
-                    json.dumps(
-                        {
-                            "version": 1,
-                            "path": str(Path(path).expanduser().resolve()),
-                            "checkpoint_count": checkpoint_count,
-                            "discovered_scopes": scope_payloads,
-                        },
-                        indent=2,
-                    )
-                )
-                return
-
-            if not scope_payloads:
-                typer.echo(f"No checkpoint scopes found under {Path(path).expanduser().resolve()}.")
-                return
-
-            typer.echo(
-                f"Discovered {checkpoint_count} checkpoint(s) across {len(scope_payloads)} scope(s)."
-            )
-            for scope_payload in scope_payloads:
-                typer.echo(
-                    f"Checkpoint root: {scope_payload['root']} "
-                    f"({scope_payload['mode']}, count={scope_payload['checkpoint_count']})"
-                )
-                checkpoint_records = cast(list[dict[str, object]], scope_payload["checkpoints"])
-                for record in checkpoint_records:
-                    typer.echo(
-                        f"  {record['checkpoint_id']}  {record['mode']}  "
-                        f"{record['created_at']}  files={record['file_count']}"
-                    )
+            scope_payloads, checkpoint_count = _discovered_payloads()
+            _emit_discovered(scope_payloads, checkpoint_count, auto_discovered=False)
             return
 
         scope_result = describe_checkpoint_scope(path)
         records = [record.__dict__ for record in scope_result.checkpoints]
+        if not records:
+            scope_payloads, checkpoint_count = _discovered_payloads()
+            if scope_payloads:
+                _emit_discovered(scope_payloads, checkpoint_count, auto_discovered=True)
+                return
     except Exception as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -7275,15 +7287,36 @@ def checkpoint_list(
 
 @checkpoint_app.command("undo")
 def checkpoint_undo(
-    checkpoint_id: str = typer.Argument(..., help="Checkpoint ID to restore."),
+    checkpoint_id: str | None = typer.Argument(
+        None,
+        help="Checkpoint ID to restore, or omit when using --last.",
+    ),
     path: str = typer.Argument(".", help="File or directory rooted at the checkpoint scope."),
+    last: bool = typer.Option(False, "--last", help="Restore the newest checkpoint in scope."),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Restore a checkpoint."""
-    from tensor_grep.cli.checkpoint_store import undo_checkpoint
+    from tensor_grep.cli.checkpoint_store import resolve_latest_checkpoint, undo_checkpoint
 
     try:
-        payload = undo_checkpoint(checkpoint_id, path)
+        if last:
+            if checkpoint_id is not None and path != ".":
+                typer.echo("Use either a checkpoint id or --last, not both.", err=True)
+                raise typer.Exit(1)
+            latest_path = path
+            if checkpoint_id is not None:
+                candidate = Path(checkpoint_id).expanduser()
+                if not candidate.exists() and checkpoint_id.startswith("ckpt-"):
+                    typer.echo("Use either a checkpoint id or --last, not both.", err=True)
+                    raise typer.Exit(1)
+                latest_path = checkpoint_id
+            latest = resolve_latest_checkpoint(latest_path)
+            payload = undo_checkpoint(latest.checkpoint_id, latest.root)
+        else:
+            if checkpoint_id is None:
+                typer.echo("Checkpoint id is required unless --last is provided.", err=True)
+                raise typer.Exit(1)
+            payload = undo_checkpoint(checkpoint_id, path)
     except Exception as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc

--- a/tests/unit/test_checkpoint_cli.py
+++ b/tests/unit/test_checkpoint_cli.py
@@ -240,6 +240,125 @@ def test_checkpoint_list_discover_finds_child_checkpoint_scope(tmp_path: Path) -
     assert payload["discovered_scopes"][0]["checkpoints"][0]["checkpoint_id"] == checkpoint_id
 
 
+def test_checkpoint_list_auto_discovers_child_scope_when_direct_scope_is_empty(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    project = workspace / "project"
+    project.mkdir(parents=True)
+    (project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    create_result = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert create_result.exit_code == 0
+    checkpoint_id = json.loads(create_result.stdout)["checkpoint_id"]
+
+    list_result = runner.invoke(app, ["checkpoint", "list", str(workspace), "--json"])
+
+    assert list_result.exit_code == 0
+    payload = json.loads(list_result.stdout)
+    assert payload["checkpoint_count"] == 1
+    assert payload["auto_discovered"] is True
+    assert payload["discovered_scopes"][0]["root"] == str(project.resolve())
+    assert payload["discovered_scopes"][0]["checkpoints"][0]["checkpoint_id"] == checkpoint_id
+
+
+def test_checkpoint_list_keeps_direct_scope_when_records_exist(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    project = workspace / "project"
+    project.mkdir(parents=True)
+    (workspace / "workspace.py").write_text("print('workspace')\n", encoding="utf-8")
+    (project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    workspace_create = runner.invoke(app, ["checkpoint", "create", str(workspace), "--json"])
+    assert workspace_create.exit_code == 0
+    workspace_checkpoint_id = json.loads(workspace_create.stdout)["checkpoint_id"]
+    child_create = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert child_create.exit_code == 0
+
+    list_result = runner.invoke(app, ["checkpoint", "list", str(workspace), "--json"])
+
+    assert list_result.exit_code == 0
+    payload = json.loads(list_result.stdout)
+    assert payload["root"] == str(workspace.resolve())
+    assert payload["checkpoint_count"] == 1
+    assert payload["checkpoints"][0]["checkpoint_id"] == workspace_checkpoint_id
+    assert "discovered_scopes" not in payload
+
+
+def test_checkpoint_undo_last_restores_latest_child_scope_checkpoint(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    project = workspace / "project"
+    project.mkdir(parents=True)
+    source_file = project / "sample.py"
+    source_file.write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    first_create = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert first_create.exit_code == 0
+    source_file.write_text("print('middle')\n", encoding="utf-8")
+    second_create = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert second_create.exit_code == 0
+    latest_checkpoint_id = json.loads(second_create.stdout)["checkpoint_id"]
+    source_file.write_text("print('after')\n", encoding="utf-8")
+
+    undo_result = runner.invoke(app, ["checkpoint", "undo", "--last", str(workspace), "--json"])
+
+    assert undo_result.exit_code == 0
+    restored = json.loads(undo_result.stdout)
+    assert restored["checkpoint_id"] == latest_checkpoint_id
+    assert restored["root"] == str(project.resolve())
+    assert source_file.read_text(encoding="utf-8") == "print('middle')\n"
+
+
+def test_checkpoint_undo_last_rejects_broad_path_with_multiple_child_scopes(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    project_a = workspace / "project-a"
+    project_b = workspace / "project-b"
+    project_a.mkdir(parents=True)
+    project_b.mkdir()
+    (project_a / "sample.py").write_text("print('a')\n", encoding="utf-8")
+    (project_b / "sample.py").write_text("print('b')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    assert runner.invoke(app, ["checkpoint", "create", str(project_a), "--json"]).exit_code == 0
+    assert runner.invoke(app, ["checkpoint", "create", str(project_b), "--json"]).exit_code == 0
+
+    undo_result = runner.invoke(app, ["checkpoint", "undo", "--last", str(workspace)])
+
+    assert undo_result.exit_code == 1
+    assert "Multiple checkpoint scopes found" in undo_result.stderr
+    assert "pass a narrower PATH or explicit checkpoint id" in undo_result.stderr
+
+
+def test_checkpoint_undo_last_rejects_explicit_checkpoint_id(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    create_result = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert create_result.exit_code == 0
+    checkpoint_id = json.loads(create_result.stdout)["checkpoint_id"]
+
+    undo_result = runner.invoke(app, ["checkpoint", "undo", checkpoint_id, str(project), "--last"])
+
+    assert undo_result.exit_code == 1
+    assert "Use either a checkpoint id or --last, not both." in undo_result.stderr
+
+
+def test_checkpoint_undo_last_fails_clearly_when_no_checkpoints(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    undo_result = runner.invoke(app, ["checkpoint", "undo", "--last", str(tmp_path)])
+
+    assert undo_result.exit_code == 1
+    assert "No checkpoints found" in undo_result.stderr
+
+
 @pytest.mark.skipif(shutil.which("git") is None, reason="git is required for git checkpoint tests")
 def test_checkpoint_create_and_undo_reports_git_mode(tmp_path: Path) -> None:
     project = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- auto-discover child checkpoint scopes when direct checkpoint list scope is empty
- add safe tg checkpoint undo --last support for latest direct or unambiguous discovered scope
- reject ambiguous broad rollback paths and checkpoint-id/--last combinations

## Validation
- uv run pytest tests/unit/test_checkpoint_cli.py -q
- uv run ruff check src/tensor_grep/cli/checkpoint_store.py src/tensor_grep/cli/main.py tests/unit/test_checkpoint_cli.py
- uv run ruff format --check --preview src/tensor_grep/cli/checkpoint_store.py src/tensor_grep/cli/main.py tests/unit/test_checkpoint_cli.py
- git diff --check