### PR TITLE
test: lock bare search flag forwarding

### DIFF
--- a/rust_core/tests/test_public_native_cli_parity.rs
+++ b/rust_core/tests/test_public_native_cli_parity.rs
@@ -909,6 +909,67 @@ fn test_option_first_root_search_flags_forward_to_search_frontdoor() {
 }
 
 #[test]
+fn test_option_first_root_type_flag_forwards_to_search_frontdoor() {
+    let dir = tempdir().unwrap();
+    let fake_rg =
+        fake_rg_asserting_args_script(dir.path(), &["-t", "js", "-e", "ERROR", "."], "accepted\n");
+    fs::write(dir.path().join("app.js"), "console.error('ERROR');\n").unwrap();
+
+    let output = tg()
+        .current_dir(dir.path())
+        .args(["-t", "js", "ERROR", "."])
+        .env("TG_RG_PATH", &fake_rg)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "accepted\n"
+    );
+}
+
+#[test]
+fn test_option_first_root_count_matches_forwards_to_search_frontdoor() {
+    let dir = tempdir().unwrap();
+    let fake_rg = fake_rg_asserting_args_script(
+        dir.path(),
+        &["--count-matches", "-e", "ERROR", "."],
+        "app.js:2\n",
+    );
+    fs::write(
+        dir.path().join("app.js"),
+        "console.error('ERROR');\nconsole.error('ERROR');\n",
+    )
+    .unwrap();
+
+    let output = tg()
+        .current_dir(dir.path())
+        .args(["--count-matches", "ERROR", "."])
+        .env("TG_RG_PATH", &fake_rg)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "app.js:2\n"
+    );
+}
+
+#[test]
 fn test_option_first_root_search_forwards_no_line_number_to_rg() {
     let dir = tempdir().unwrap();
     let fake_rg =

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -87,6 +87,40 @@ def test_main_entry_should_passthrough_raw_rg_style_invocation(monkeypatch):
     assert seen == {"binary_name": "rg", "search_args": ["-i", "ERROR", "."]}
 
 
+@pytest.mark.parametrize(
+    ("argv", "expected_search_args"),
+    [
+        (["tg", "-t", "js", "ERROR", "."], ["-t", "js", "ERROR", "."]),
+        (
+            ["tg", "--count-matches", "ERROR", "."],
+            ["--count-matches", "ERROR", "."],
+        ),
+    ],
+)
+def test_main_entry_should_passthrough_option_first_root_search_flags(
+    monkeypatch, argv: list[str], expected_search_args: list[str]
+):
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda binary_name, search_args: (
+            seen.update({"binary_name": binary_name, "search_args": list(search_args)}) or 0
+        ),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    assert excinfo.value.code == 0
+    assert seen == {"binary_name": "rg", "search_args": expected_search_args}
+
+
 def test_main_entry_should_strip_noop_rg_format_for_rg_passthrough(monkeypatch):
     seen: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- add Python bootstrap regression coverage for option-first bare search flags
- add native front-door coverage for bare -t js and --count-matches forwarding
- no production-code change because current forwarding behavior already satisfies the contract

## Validation
- uv run --no-sync pytest tests/unit/test_cli_bootstrap.py -q -k option_first_root_search_flags
- C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml option_first_root
- uv run --no-sync ruff check tests/unit/test_cli_bootstrap.py
- uv run --no-sync ruff format --check --preview tests/unit/test_cli_bootstrap.py
- C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check
- git diff --check

Note: uv run pytest without --no-sync hit the known local rustup cache lock in this worktree.