### PR TITLE
fix: make dogfood self-check public roots

### DIFF
--- a/src/tensor_grep/cli/dogfood.py
+++ b/src/tensor_grep/cli/dogfood.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
@@ -200,6 +201,72 @@ def _build_write_policy(repo_root: Path, output: Path | None) -> dict[str, Any]:
     }
 
 
+def _installed_tensor_grep_version() -> str | None:
+    try:
+        return version("tensor-grep")
+    except PackageNotFoundError:
+        return None
+
+
+def _build_public_self_check_readiness(
+    *,
+    repo_root: Path,
+    readiness_script: Path,
+    expected_version: str | None,
+) -> tuple[int, dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    results.append({
+        "name": "public-package-import",
+        "status": "passed",
+        "message": "tensor_grep dogfood module is importable and running from the installed package",
+    })
+    installed_version = _installed_tensor_grep_version()
+    if installed_version is None:
+        results.append({
+            "name": "public-package-metadata",
+            "status": "skipped",
+            "message": "tensor-grep package metadata is unavailable in this environment",
+        })
+    elif expected_version is not None and installed_version != expected_version:
+        results.append({
+            "name": "public-package-metadata",
+            "status": "failed",
+            "message": (
+                f"installed tensor-grep version {installed_version} does not match "
+                f"expected version {expected_version}"
+            ),
+        })
+    else:
+        results.append({
+            "name": "public-package-metadata",
+            "status": "passed",
+            "message": f"installed tensor-grep package version {installed_version}",
+        })
+
+    results.append({
+        "name": "repo-agent-readiness-script",
+        "status": "skipped",
+        "message": (
+            f"repo-only checks are unavailable because {readiness_script} does not exist; "
+            "point --root at a tensor-grep source checkout to run scripts/agent_readiness.py"
+        ),
+    })
+    summary = {
+        "passed": sum(1 for result in results if result["status"] == "passed"),
+        "failed": sum(1 for result in results if result["status"] == "failed"),
+        "skipped": sum(1 for result in results if result["status"] == "skipped"),
+    }
+    returncode = 1 if summary["failed"] else 0
+    return returncode, {
+        "artifact": "agent_readiness_report",
+        "mode": "public-self-check",
+        "root": str(repo_root),
+        "expected_version": expected_version,
+        "summary": summary,
+        "results": results,
+    }
+
+
 def run_dogfood_readiness(
     *,
     root: Path,
@@ -234,21 +301,14 @@ def run_dogfood_readiness(
     )
     with progress.phase("agent-readiness"):
         if not readiness_script.exists():
-            agent_readiness = {
-                "artifact": "agent_readiness_report",
-                "root": str(repo_root),
-                "summary": {"passed": 0, "failed": 1, "skipped": 0},
-                "results": [
-                    {
-                        "name": "agent-readiness-script",
-                        "status": "failed",
-                        "message": f"missing readiness script: {readiness_script}",
-                    }
-                ],
-            }
-            returncode = 1
+            returncode, agent_readiness = _build_public_self_check_readiness(
+                repo_root=repo_root,
+                readiness_script=readiness_script,
+                expected_version=expected_version,
+            )
+            command = []
             stdout = ""
-            stderr = f"missing readiness script: {readiness_script}"
+            stderr = ""
         else:
             env = dict(os.environ)
             env.setdefault("PYTHONUTF8", "1")

--- a/tests/unit/test_dogfood_cli.py
+++ b/tests/unit/test_dogfood_cli.py
@@ -149,6 +149,40 @@ def test_dogfood_command_returns_failure_when_readiness_fails(tmp_path: Path) ->
     assert payload["verdict"]["failed_checks"] == ["docs-claim-check"]
 
 
+def test_dogfood_non_repo_root_uses_public_self_check(tmp_path: Path) -> None:
+    output = tmp_path / "dogfood.json"
+    non_repo_root = tmp_path / "user-project"
+    non_repo_root.mkdir()
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "dogfood",
+            "--root",
+            str(non_repo_root),
+            "--output",
+            str(output),
+            "--no-shell-probes",
+            "--no-wsl-probe",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Dogfood verdict: PASS" in result.stdout
+    assert "failed=0" in result.stdout
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["agent_readiness"]["mode"] == "public-self-check"
+    assert payload["agent_readiness"]["summary"]["failed"] == 0
+    skipped = [
+        result for result in payload["agent_readiness"]["results"] if result["status"] == "skipped"
+    ]
+    assert skipped
+    repo_script_result = next(
+        result for result in skipped if result["name"] == "repo-agent-readiness-script"
+    )
+    assert "scripts/agent_readiness.py" in repo_script_result["message"]
+
+
 def test_dogfood_json_progress_always_uses_stderr_only(tmp_path: Path) -> None:
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()


### PR DESCRIPTION
## Summary
- make tg dogfood outside the tensor-grep repo use a public self-check readiness report instead of failing on missing scripts/agent_readiness.py
- keep repo-only agent-readiness checks as skipped diagnostics when --root points at an end-user project
- preserve version mismatch failure when an explicit expected version is supplied

## Research / planning
- Exa research covered packaged CLI self-check patterns and pytest CLI test practices.
- Thinktank recommended making dogfood self-contained or scope-aware so end users do not see a missing repo script as a tool failure.

## Tests
- uv run --no-sync pytest tests/unit/test_dogfood_cli.py -q
- uv run --no-sync ruff check src/tensor_grep/cli/dogfood.py tests/unit/test_dogfood_cli.py
- uv run --no-sync ruff format --check --preview src/tensor_grep/cli/dogfood.py tests/unit/test_dogfood_cli.py
- git diff --check