### PR TITLE
fix: warn on PowerShell shim MCP stdio

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -1999,6 +1999,33 @@ def _doctor_path_tg_launcher_warning(
     return None
 
 
+def _doctor_mcp_stdio_launcher_warning(
+    *,
+    native_tg_binary: Path | None,
+    launchers: list[tuple[str, str | None, str | None]],
+) -> str | None:
+    if native_tg_binary is None or native_tg_binary.suffix.lower() != ".exe":
+        return None
+
+    powershell_launchers = [
+        (label, path)
+        for label, kind, path in launchers
+        if path and (kind == "powershell-shim" or Path(path).suffix.lower() == ".ps1")
+    ]
+    if not powershell_launchers:
+        return None
+
+    observed = "; ".join(f"{label} resolves {path}" for label, path in powershell_launchers)
+    script_path = powershell_launchers[0][1]
+    return (
+        "MCP stdio launcher warning: "
+        f"{observed}. Configure MCP clients for `tg mcp` to call the managed native "
+        f"tg.exe directly: {native_tg_binary}. If you intentionally use the PowerShell "
+        "script shim, configure the client to launch it explicitly as "
+        f"`pwsh -NoProfile -File {script_path} mcp`."
+    )
+
+
 def _doctor_tg_foreign_warning(
     *,
     label: str,
@@ -2437,6 +2464,22 @@ def _build_doctor_payload(
             fresh_kind=fresh_shell_path_tg_first_launcher_kind,
             fresh_path=fresh_shell_path_tg_first_path,
         ),
+        "mcp_stdio_launcher_warning": _doctor_mcp_stdio_launcher_warning(
+            native_tg_binary=native_tg_binary,
+            launchers=[
+                ("PATH", path_tg_first_launcher_kind, path_tg_first_path),
+                (
+                    "fresh-shell PATH",
+                    fresh_shell_path_tg_first_launcher_kind,
+                    fresh_shell_path_tg_first_path,
+                ),
+                (
+                    "Python subprocess PATH",
+                    python_subprocess_path_tg_first_launcher_kind,
+                    python_subprocess_path_tg_first_path,
+                ),
+            ],
+        ),
         "shell_escaping_guidance": _doctor_shell_escaping_guidance(),
         "gpu": gpu_status,
         "ast_cache": _doctor_ast_cache_status(str(root), str(resolved_config)),
@@ -2530,6 +2573,8 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
         )
     if launcher_warning := payload.get("path_tg_launcher_warning"):
         lines.append(f"path_tg_launcher_warning: {launcher_warning}")
+    if mcp_stdio_launcher_warning := payload.get("mcp_stdio_launcher_warning"):
+        lines.append(f"mcp_stdio_launcher_warning: {mcp_stdio_launcher_warning}")
     if python_subprocess_warning := payload.get("python_subprocess_path_tg_foreign_warning"):
         lines.append(f"python_subprocess_path_tg_foreign_warning: {python_subprocess_warning}")
     if python_subprocess_remediation := payload.get(

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1540,6 +1540,111 @@ def test_doctor_json_warns_when_current_path_hits_compat_shim_before_fresh_nativ
     assert "restart the shell" in payload["path_tg_launcher_warning"]
 
 
+def test_doctor_json_reports_mcp_stdio_launcher_warning_for_powershell_shim(
+    monkeypatch, tmp_path: Path
+) -> None:
+    shim_tg = tmp_path / "bin" / "tg.ps1"
+    native_tg = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    shim_tg.parent.mkdir(parents=True)
+    native_tg.parent.mkdir(parents=True)
+    shim_tg.write_text("& $PSScriptRoot/tg.exe @args\n", encoding="utf-8")
+    native_tg.write_text("native\n", encoding="utf-8")
+
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.12.52")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_binary_version",
+        lambda _binary: "tg 1.12.52",
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_core_extension_available",
+        lambda: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_lsp_provider_statuses", lambda path: [])
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_path_tg_candidates",
+        lambda: [
+            {"path": str(shim_tg), "version": "tensor-grep 1.12.52"},
+            {"path": str(native_tg), "version": "tg 1.12.52"},
+        ],
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_fresh_shell_path_tg_candidates",
+        lambda: [{"path": str(native_tg), "version": "tg 1.12.52"}],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_python_subprocess_path_tg_candidate",
+        lambda path_value=None: {"path": str(shim_tg), "version": "tensor-grep 1.12.52"},
+        raising=False,
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["path_tg_first_launcher_kind"] == "powershell-shim"
+    assert payload["python_subprocess_path_tg_first_launcher_kind"] == "powershell-shim"
+    warning = payload["mcp_stdio_launcher_warning"]
+    assert "MCP stdio" in warning
+    assert "managed native tg.exe directly" in warning
+    assert str(native_tg) in warning
+    assert "pwsh -NoProfile -File" in warning
+    assert str(shim_tg) in warning
+
+
+def test_doctor_text_reports_mcp_stdio_launcher_warning(monkeypatch, tmp_path: Path) -> None:
+    shim_tg = tmp_path / "bin" / "tg.ps1"
+    native_tg = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    shim_tg.parent.mkdir(parents=True)
+    native_tg.parent.mkdir(parents=True)
+    shim_tg.write_text("& $PSScriptRoot/tg.exe @args\n", encoding="utf-8")
+    native_tg.write_text("native\n", encoding="utf-8")
+
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.12.52")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_binary_version",
+        lambda _binary: "tg 1.12.52",
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_core_extension_available",
+        lambda: True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_lsp_provider_statuses", lambda path: [])
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_path_tg_candidates",
+        lambda: [{"path": str(shim_tg), "version": "tensor-grep 1.12.52"}],
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_fresh_shell_path_tg_candidates",
+        lambda: [{"path": str(native_tg), "version": "tg 1.12.52"}],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_python_subprocess_path_tg_candidate",
+        lambda path_value=None: None,
+        raising=False,
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--no-lsp"])
+
+    assert result.exit_code == 0
+    assert "mcp_stdio_launcher_warning:" in result.stdout
+    assert "managed native tg.exe directly" in result.stdout
+    assert "pwsh -NoProfile -File" in result.stdout
+
+
 def test_doctor_json_reports_python_subprocess_foreign_tg_exe(monkeypatch, tmp_path: Path) -> None:
     foreign_tg = tmp_path / "Python314" / "Scripts" / "tg.exe"
     managed_tg = tmp_path / ".tensor-grep" / "bin" / "tg.exe"


### PR DESCRIPTION
## Summary
- add doctor JSON/text mcp_stdio_launcher_warning when PATH/Python subprocess resolves a PowerShell .ps1 tg shim while managed native 	g.exe is available
- tell MCP stdio clients to call the managed native executable directly, or explicitly launch the script via pwsh -NoProfile -File
- diagnostic only; does not fail launcher readiness

## Research / planning
- Exa research checked Windows Start-Process/stdin behavior and MCP stdio process-launch expectations.
- Thinktank prioritized this as a cheap Windows integration warning after session/list/checkpoint ergonomics.

## Tests
- uv run --no-sync pytest tests/unit/test_cli_modes.py -q -k mcp_stdio_launcher_warning
- uv run --no-sync ruff check src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py
- uv run --no-sync ruff format --check --preview src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py
- git diff --check