### PR TITLE
fix: require real LSP proof rows

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -9716,7 +9716,7 @@ def _attach_lsp_evidence_status(
 def _is_lsp_proof_row(row: dict[str, Any]) -> bool:
     provenance = str(row.get("provenance", ""))
     return (
-        bool(row.get("lsp_provider_response"))
+        row.get("lsp_provider_response") is True
         and provenance.startswith("lsp-")
         and "-fallback" not in provenance
     )
@@ -10024,8 +10024,11 @@ def build_symbol_defs_from_map(
             repo_map=repo_map,
         )
         if normalized_provider == "lsp":
-            fallback_used = not bool(_lsp_proof_row_count(external_definitions))
-            definitions = external_definitions or definitions
+            proof_definitions = [
+                dict(current) for current in external_definitions if _is_lsp_proof_row(current)
+            ]
+            fallback_used = not bool(proof_definitions)
+            definitions = proof_definitions or definitions
         else:
             merged: dict[tuple[str, int, int, str], dict[str, Any]] = {}
             for current in [*external_definitions, *definitions]:
@@ -10549,8 +10552,9 @@ def build_symbol_refs_from_map(
             if str(Path(str(current.get("file", ""))).expanduser().resolve()) in bounded_file_set
         ]
         if normalized_provider == "lsp":
-            fallback_used = not bool(_lsp_proof_row_count(external_refs))
-            references = external_refs or references
+            proof_refs = [dict(current) for current in external_refs if _is_lsp_proof_row(current)]
+            fallback_used = not bool(proof_refs)
+            references = proof_refs or references
         else:
             merged_refs: dict[tuple[str, int, int], dict[str, Any]] = {}
             for current_ref in [*external_refs, *references]:

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -408,6 +408,113 @@ def test_lsp_proof_requires_provider_response_marker_not_provenance_only(
     assert "native fallback" in payload["not_lsp_proof_reason"].lower()
 
 
+def test_lsp_proof_requires_boolean_provider_response_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+    monkeypatch.setattr(
+        repo_map,
+        "_external_workspace_symbols",
+        lambda root, symbol, **kwargs: [
+            {
+                "name": symbol,
+                "kind": "function",
+                "file": str(module_path.resolve()),
+                "line": 1,
+                "end_line": 1,
+                "provenance": "lsp-python",
+                "lsp_provider_response": "false",
+            }
+        ],
+    )
+
+    payload = repo_map.build_symbol_defs("create_invoice", tmp_path, semantic_provider="lsp")
+
+    assert payload["lsp_evidence_status"] == "fallback_native"
+    assert payload["lsp_proof"] is False
+    assert payload["definitions"][0]["provenance"] == "python-ast"
+    assert "native fallback" in payload["not_lsp_proof_reason"].lower()
+
+
+@pytest.mark.parametrize(
+    ("command", "collection_key"),
+    [
+        ("defs", "definitions"),
+        ("source", "sources"),
+        ("refs", "references"),
+        ("callers", "callers"),
+        ("blast-radius", "callers"),
+    ],
+)
+def test_cli_lsp_timeout_reports_explicit_native_fallback_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    collection_key: str,
+) -> None:
+    service_path = tmp_path / "service.py"
+    consumer_path = tmp_path / "consumer.py"
+    service_path.write_text(
+        "def create_invoice(total: int) -> int:\n    return total + 1\n", encoding="utf-8"
+    )
+    consumer_path.write_text(
+        "from service import create_invoice\n\nresult = create_invoice(3)\n",
+        encoding="utf-8",
+    )
+
+    class _TimeoutClient:
+        request_timeout_seconds = 3.0
+        initialize_timeout_seconds = 3.0
+
+        def ensure_document(self, **kwargs: object) -> None:
+            _ = kwargs
+            raise repo_map.LSPTransportError("timeout waiting for LSP response: initialize")
+
+        def request(self, method: str, params: dict[str, object]) -> list[dict[str, object]]:
+            _ = method
+            _ = params
+            raise repo_map.LSPTransportError("timeout waiting for LSP response: initialize")
+
+    class _TimeoutManager:
+        def get_client(self, *, language: str, workspace_root: Path) -> _TimeoutClient:
+            _ = language
+            _ = workspace_root
+            return _TimeoutClient()
+
+        def provider_status(self, *, language: str, workspace_root: Path) -> dict[str, object]:
+            return {
+                "language": language,
+                "workspace_root": str(workspace_root),
+                "available": True,
+                "health_status": "unhealthy",
+                "health_check": "semantic-document-symbol",
+                "health_phase": "initialize",
+                "lsp_provider_response": False,
+                "lsp_proof": False,
+                "lsp_evidence_status": "fallback_native",
+                "not_lsp_proof_reason": "Provider semantic health probe failed or timed out.",
+                "last_error": "timeout waiting for LSP response: initialize",
+            }
+
+    monkeypatch.setattr(repo_map, "_EXTERNAL_LSP_PROVIDER_MANAGER", _TimeoutManager())
+
+    result = CliRunner().invoke(
+        app,
+        [command, str(tmp_path), "--symbol", "create_invoice", "--provider", "lsp", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["semantic_provider"] == "lsp"
+    assert payload["lsp_evidence_status"] == "fallback_native"
+    assert payload["lsp_proof"] is False
+    assert "native fallback" in payload["not_lsp_proof_reason"].lower()
+    assert payload["provider_status"]["providers"][0]["lsp_proof"] is False
+    assert "timed out" in payload["provider_status"]["providers"][0]["not_lsp_proof_reason"]
+    assert collection_key in payload
+
+
 def test_repo_map_callers_can_use_lsp_provider(tmp_path: Path, monkeypatch) -> None:
     service_path = tmp_path / "service.py"
     consumer_path = tmp_path / "consumer.py"
@@ -775,6 +882,7 @@ def test_repo_map_blast_radius_propagates_semantic_provider(tmp_path: Path, monk
                 "line": 1,
                 "end_line": 1,
                 "provenance": "lsp-python",
+                "lsp_provider_response": True,
             }
         ],
     )


### PR DESCRIPTION
## Summary
- require lsp_provider_response is True for LSP proof rows instead of accepting truthy strings
- make --provider lsp discard non-proof external rows and fall back to native definitions/refs
- add CLI JSON regressions proving timeout/unhealthy LSP paths report explicit native fallback across defs/source/refs/callers/blast-radius

## Research / planning
- Exa research checked the LSP 3.17 initialize contract and timeout failure patterns in pyright/provider tooling.
- Thinktank recommended proof/downgrade hardening before any production LSP claim.

## Tests
- uv run --no-sync pytest tests/unit/test_semantic_provider_navigation.py -q -k lsp_timeout_reports_explicit_native_fallback_json-or-boolean_provider_response_marker-or-provider_response_marker_not_provenance_only
- uv run --no-sync ruff check src/tensor_grep/cli/repo_map.py tests/unit/test_semantic_provider_navigation.py
- uv run --no-sync ruff format --check --preview src/tensor_grep/cli/repo_map.py tests/unit/test_semantic_provider_navigation.py
- git diff --check