### PR TITLE
fix: expose dogfood promotion guardrails

### DIFF
--- a/src/tensor_grep/cli/dogfood.py
+++ b/src/tensor_grep/cli/dogfood.py
@@ -74,6 +74,18 @@ def _build_world_class_readiness() -> dict[str, Any]:
     """Describe proof-gated surfaces that a passing dogfood gate does not promote."""
     return {
         "status": "not_claimed",
+        "raw_cold_search_baseline": "rg",
+        "raw_cold_search_claim_status": "not_claimed",
+        "launcher_startup_tax_status": "measured_separately",
+        "launcher_startup_tax_note": (
+            "Cold search benchmark artifacts must separate native-exe timings "
+            "from shim, uv, and Python-module launcher overhead before speed claims."
+        ),
+        "gpu_promotion_ready": False,
+        "gpu_promotion_blockers": (
+            "NativeGpuBackend; sidecar_used=false; 1GB/5GB correctness; "
+            "speed wins over rg and tg_cpu; public managed NVIDIA release metadata"
+        ),
         "summary": (
             "PASS means the fast release-readiness gate passed; it is not proof "
             "that tensor-grep replaces rg, ast-grep, public GPU search, or "

--- a/tests/unit/test_dogfood_cli.py
+++ b/tests/unit/test_dogfood_cli.py
@@ -49,6 +49,13 @@ def test_dogfood_command_wraps_agent_readiness_report(tmp_path: Path) -> None:
     assert payload["artifact"] == "dogfood_readiness_report"
     assert payload["verdict"]["status"] == "PASS"
     assert payload["world_class_readiness"]["status"] == "not_claimed"
+    assert payload["world_class_readiness"]["raw_cold_search_baseline"] == "rg"
+    assert payload["world_class_readiness"]["raw_cold_search_claim_status"] == "not_claimed"
+    assert payload["world_class_readiness"]["launcher_startup_tax_status"] == "measured_separately"
+    assert payload["world_class_readiness"]["gpu_promotion_ready"] is False
+    assert "NativeGpuBackend" in payload["world_class_readiness"]["gpu_promotion_blockers"]
+    assert "sidecar_used=false" in payload["world_class_readiness"]["gpu_promotion_blockers"]
+    assert "public managed NVIDIA" in payload["world_class_readiness"]["gpu_promotion_blockers"]
     assert "fast release-readiness gate" in payload["world_class_readiness"]["summary"]
     limitation_surfaces = {
         item["surface"] for item in payload["world_class_readiness"]["limitations"]


### PR DESCRIPTION
## Summary
- add machine-readable dogfood fields for raw cold-search baseline, launcher startup-tax attribution, and GPU promotion readiness
- keep cold rg and GPU surfaces explicitly not claimed even when fast dogfood passes
- preserve existing world-class limitations list and runtime behavior

## Research / planning
- Exa research checked benchmark metadata practices and current GPU proof guardrail patterns.
- Thinktank recommended guardrail-only GPU/startup work, not premature acceleration claims.

## Tests
- uv run --no-sync pytest tests/unit/test_dogfood_cli.py -q
- uv run --no-sync ruff check src/tensor_grep/cli/dogfood.py tests/unit/test_dogfood_cli.py
- uv run --no-sync ruff format --check --preview src/tensor_grep/cli/dogfood.py tests/unit/test_dogfood_cli.py
- git diff --check