### PR TITLE
fix: restore doctor lsp provider json alias

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -2488,12 +2488,15 @@ def _build_doctor_payload(
         "session_daemon": _doctor_session_daemon_status(str(root)),
     }
     if with_lsp:
+        lsp_providers = _doctor_lsp_provider_statuses(str(root))
         payload["lsp"] = {
             "enabled": True,
-            "providers": _doctor_lsp_provider_statuses(str(root)),
+            "providers": lsp_providers,
         }
     else:
-        payload["lsp"] = {"enabled": False, "providers": []}
+        lsp_providers = []
+        payload["lsp"] = {"enabled": False, "providers": lsp_providers}
+    payload["lsp_providers"] = lsp_providers
     return payload
 
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1061,6 +1061,7 @@ def test_doctor_json_includes_runtime_session_and_lsp(monkeypatch, tmp_path: Pat
     assert payload["lsp"]["providers"][0]["health_status"] == "ready"
     assert payload["lsp"]["providers"][0]["health_check"] == "probe"
     assert payload["lsp"]["providers"][0]["lsp_proof"] is True
+    assert payload["lsp_providers"] == payload["lsp"]["providers"]
     guidance = payload["shell_escaping_guidance"]
     assert guidance["platform"] == "windows"
     assert "PowerShell double quotes expand $NAME" in guidance["powershell"]["summary"]


### PR DESCRIPTION
## Summary
- restore top-level doctor JSON lsp_providers as an alias of lsp.providers
- add a contract assertion so text and JSON LSP observability do not drift again

## Validation
- uv run --no-sync pytest tests/unit/test_cli_modes.py::test_doctor_json_includes_runtime_session_and_lsp -q
- uv run --no-sync ruff check src/tensor_grep/cli/main.py tests/unit/test_cli_modes.py

Note: local ruff format --check on these two files wants broad pre-existing formatting churn, so this slice keeps the diff minimal.