### PR TITLE
fix: bound checkpoint scope discovery

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -17,6 +17,7 @@ _CHECKPOINTS_SUBDIR = "checkpoints"
 _INDEX_FILE = "index.json"
 _SNAPSHOT_SUBDIR = "snapshot"
 _METADATA_FILE = "metadata.json"
+_DISCOVERY_MAX_DEPTH = 4
 _NON_GIT_IGNORED_DIRS = {
     ".git",
     ".hg",
@@ -29,6 +30,10 @@ _NON_GIT_IGNORED_DIRS = {
     ".ruff_cache",
     ".tensor-grep",
 }
+
+
+def _is_generated_discovery_dir(path: Path) -> bool:
+    return path.name in _NON_GIT_IGNORED_DIRS
 
 
 @dataclass
@@ -323,9 +328,43 @@ def describe_checkpoint_scope(path: str = ".") -> CheckpointScopeResult:
     )
 
 
-def discover_checkpoint_scopes(path: str = ".") -> list[CheckpointScopeResult]:
-    resolved = Path(path).expanduser().resolve()
-    search_root = resolved if resolved.is_dir() else resolved.parent
+def _bounded_checkpoint_index_paths(
+    search_root: Path,
+    *,
+    include_generated: bool,
+    max_depth: int = _DISCOVERY_MAX_DEPTH,
+) -> set[Path]:
+    index_paths: set[Path] = set()
+    stack: list[tuple[Path, int]] = [(search_root, 0)]
+    while stack:
+        current, depth = stack.pop()
+        index_path = _index_path(current)
+        if index_path.exists():
+            index_paths.add(index_path)
+
+        if depth >= max_depth:
+            continue
+
+        try:
+            children = sorted(current.iterdir(), key=lambda child: child.name)
+        except OSError:
+            continue
+        for child in reversed(children):
+            try:
+                is_dir = child.is_dir()
+            except OSError:
+                continue
+            if not is_dir:
+                continue
+            if child.name == _CHECKPOINT_DIRNAME:
+                continue
+            if not include_generated and _is_generated_discovery_dir(child):
+                continue
+            stack.append((child, depth + 1))
+    return index_paths
+
+
+def _full_checkpoint_index_paths(search_root: Path) -> set[Path]:
     index_paths: set[Path] = set()
     own_index = _index_path(search_root)
     if own_index.exists():
@@ -339,6 +378,21 @@ def discover_checkpoint_scopes(path: str = ".") -> list[CheckpointScopeResult]:
         )
     except OSError:
         pass
+    return index_paths
+
+
+def discover_checkpoint_scopes(
+    path: str = ".",
+    *,
+    full: bool = False,
+) -> list[CheckpointScopeResult]:
+    resolved = Path(path).expanduser().resolve()
+    search_root = resolved if resolved.is_dir() else resolved.parent
+    index_paths = (
+        _full_checkpoint_index_paths(search_root)
+        if full
+        else _bounded_checkpoint_index_paths(search_root, include_generated=False)
+    )
 
     scopes: list[CheckpointScopeResult] = []
     seen_roots: set[Path] = set()

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7271,7 +7271,18 @@ def checkpoint_list(
     discover: bool = typer.Option(
         False,
         "--discover",
-        help="Recursively discover checkpoint scopes under PATH instead of listing one detected scope.",
+        help=(
+            "Discover bounded child checkpoint scopes under PATH instead of listing one detected "
+            "scope. Generated/cache roots are skipped."
+        ),
+    ),
+    discover_full: bool = typer.Option(
+        False,
+        "--discover-full",
+        help=(
+            "Exhaustively discover checkpoint scopes under PATH, including generated/cache roots. "
+            "May be slow on broad workspaces."
+        ),
     ),
 ) -> None:
     """List available checkpoints."""
@@ -7280,7 +7291,7 @@ def checkpoint_list(
         discover_checkpoint_scopes,
     )
 
-    def _discovered_payloads() -> tuple[list[dict[str, Any]], int]:
+    def _discovered_payloads(*, full: bool = False) -> tuple[list[dict[str, Any]], int]:
         scope_payloads = [
             {
                 "root": scope.root,
@@ -7288,7 +7299,7 @@ def checkpoint_list(
                 "checkpoint_count": scope.checkpoint_count,
                 "checkpoints": [record.__dict__ for record in scope.checkpoints],
             }
-            for scope in discover_checkpoint_scopes(path)
+            for scope in discover_checkpoint_scopes(path, full=full)
         ]
         checkpoint_count = sum(
             int(cast(int, scope_payload["checkpoint_count"])) for scope_payload in scope_payloads
@@ -7331,8 +7342,11 @@ def checkpoint_list(
                 )
 
     try:
-        if discover:
-            scope_payloads, checkpoint_count = _discovered_payloads()
+        if discover and discover_full:
+            typer.echo("Use either --discover or --discover-full, not both.", err=True)
+            raise typer.Exit(1)
+        if discover or discover_full:
+            scope_payloads, checkpoint_count = _discovered_payloads(full=discover_full)
             _emit_discovered(scope_payloads, checkpoint_count, auto_discovered=False)
             return
 

--- a/tests/unit/test_checkpoint_cli.py
+++ b/tests/unit/test_checkpoint_cli.py
@@ -263,6 +263,76 @@ def test_checkpoint_list_auto_discovers_child_scope_when_direct_scope_is_empty(
     assert payload["discovered_scopes"][0]["checkpoints"][0]["checkpoint_id"] == checkpoint_id
 
 
+def test_checkpoint_list_auto_discovery_does_not_use_unbounded_rglob(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    project = workspace / "project"
+    project.mkdir(parents=True)
+    (project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    create_result = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert create_result.exit_code == 0
+    checkpoint_id = json.loads(create_result.stdout)["checkpoint_id"]
+
+    def fail_rglob(self: Path, pattern: str):
+        raise AssertionError(f"unbounded rglob should not run for {self} pattern={pattern}")
+
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    list_result = runner.invoke(app, ["checkpoint", "list", str(workspace), "--json"])
+
+    assert list_result.exit_code == 0
+    payload = json.loads(list_result.stdout)
+    assert payload["auto_discovered"] is True
+    assert payload["discovered_scopes"][0]["root"] == str(project.resolve())
+    assert payload["discovered_scopes"][0]["checkpoints"][0]["checkpoint_id"] == checkpoint_id
+
+
+def test_checkpoint_list_default_discovery_skips_generated_roots(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    generated_project = workspace / "node_modules" / "dep"
+    generated_project.mkdir(parents=True)
+    (generated_project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    create_result = runner.invoke(app, ["checkpoint", "create", str(generated_project), "--json"])
+    assert create_result.exit_code == 0
+
+    list_result = runner.invoke(app, ["checkpoint", "list", str(workspace), "--json"])
+
+    assert list_result.exit_code == 0
+    payload = json.loads(list_result.stdout)
+    assert payload["checkpoint_count"] == 0
+    assert "auto_discovered" not in payload
+    assert "discovered_scopes" not in payload
+
+
+def test_checkpoint_list_discover_full_can_include_generated_roots(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    generated_project = workspace / "node_modules" / "dep"
+    generated_project.mkdir(parents=True)
+    (generated_project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    create_result = runner.invoke(app, ["checkpoint", "create", str(generated_project), "--json"])
+    assert create_result.exit_code == 0
+    checkpoint_id = json.loads(create_result.stdout)["checkpoint_id"]
+
+    list_result = runner.invoke(
+        app,
+        ["checkpoint", "list", str(workspace), "--discover-full", "--json"],
+    )
+
+    assert list_result.exit_code == 0
+    payload = json.loads(list_result.stdout)
+    assert payload["checkpoint_count"] == 1
+    assert payload["discovered_scopes"][0]["root"] == str(generated_project.resolve())
+    assert payload["discovered_scopes"][0]["checkpoints"][0]["checkpoint_id"] == checkpoint_id
+
+
 def test_checkpoint_list_keeps_direct_scope_when_records_exist(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     project = workspace / "project"


### PR DESCRIPTION
## Summary
- replace default checkpoint auto-discovery rglob with a bounded, generated-root-pruned walk
- keep shallow child-scope auto-discovery working for normal projects
- add explicit --discover-full for exhaustive checkpoint discovery, including generated/cache roots

## Validation
- uv run --no-sync pytest tests/unit/test_checkpoint_cli.py -q
- uv run --no-sync ruff check src/tensor_grep/cli/checkpoint_store.py src/tensor_grep/cli/main.py tests/unit/test_checkpoint_cli.py
- git diff --check

Note: local ruff format --check on the touched large CLI files still wants broad pre-existing formatting churn, so this PR keeps the diff scoped.