### PR TITLE
test: expose session edit-plan timing

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -357,22 +357,27 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                     "root_count": server.payload_cache.root_count,
                 }
             else:
+                overall_started_at = monotonic()
                 try:
+                    load_started_at = monotonic()
                     payload, cache_status = _load_payload_with_status_retry(
                         server.payload_cache,
                         request_session_id,
                         request_path,
                     )
+                    loaded_at = monotonic()
                     response = serve_session_request(
                         request_session_id,
                         request,
                         request_path,
                         payload=payload,
                     )
+                    served_at = monotonic()
                 except Exception:
                     refresh_on_stale = bool(request.get("refresh_on_stale", False))
                     if not refresh_on_stale:
                         raise
+                    load_started_at = monotonic()
                     refresh_session(
                         request_session_id,
                         request_path,
@@ -384,17 +389,26 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                         request_session_id,
                         request_path,
                     )
+                    loaded_at = monotonic()
                     response = serve_session_request(
                         request_session_id,
                         request,
                         request_path,
                         payload=payload,
                     )
+                    served_at = monotonic()
                 response["serve_cache"] = {
                     "status": cache_status,
                     "session_count": server.payload_cache.session_count,
                     "root_count": server.payload_cache.root_count,
                 }
+                if command == "context_edit_plan":
+                    response["session_timing"] = {
+                        "cache_status": cache_status,
+                        "load_session_seconds": max(0.0, loaded_at - load_started_at),
+                        "build_edit_plan_seconds": max(0.0, served_at - loaded_at),
+                        "total_seconds": max(0.0, served_at - overall_started_at),
+                    }
         except Exception as exc:
             response = {
                 "version": _SESSION_VERSION,

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -539,7 +539,9 @@ def session_context_edit_plan(
     max_symbols: int = 5,
     refresh_on_stale: bool = False,
 ) -> dict[str, Any]:
+    started_at = monotonic()
     payload = _load_session_payload(session_id, path, refresh_on_stale=refresh_on_stale)
+    loaded_at = monotonic()
     context = build_context_edit_plan_from_map(
         payload["repo_map"],
         query,
@@ -548,8 +550,15 @@ def session_context_edit_plan(
         max_tokens=max_tokens,
         max_symbols=max_symbols,
     )
+    built_at = monotonic()
     context["session_id"] = session_id
     context["routing_reason"] = "session-context-edit-plan"
+    context["session_timing"] = {
+        "cache_status": "disk-load",
+        "load_session_seconds": max(0.0, loaded_at - started_at),
+        "build_edit_plan_seconds": max(0.0, built_at - loaded_at),
+        "total_seconds": max(0.0, built_at - started_at),
+    }
     return context
 
 

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -203,6 +203,11 @@ def test_session_edit_plan_does_not_walk_repo_for_validation_discovery(
     assert payload["routing_reason"] == "session-context-edit-plan"
     assert payload["files"] == [str(module_path.resolve())]
     assert payload["validation_commands"] == []
+    timing = payload["session_timing"]
+    assert timing["cache_status"] == "disk-load"
+    assert timing["load_session_seconds"] >= 0
+    assert timing["build_edit_plan_seconds"] >= 0
+    assert timing["total_seconds"] >= 0
 
 
 def test_session_edit_plan_uses_cached_validation_evidence_after_open(
@@ -861,6 +866,7 @@ def test_session_context_can_use_daemon(tmp_path: Path) -> None:
     assert payload["session_id"] == opened["session_id"]
     assert payload["routing_reason"] == "session-context"
     assert payload["files"] == [str(module_path.resolve())]
+    assert "session_timing" not in payload
     session_daemon.stop_session_daemon(str(project))
 
 
@@ -897,6 +903,10 @@ def test_session_edit_plan_can_use_daemon(tmp_path: Path) -> None:
         assert payload["routing_reason"] == "session-context-edit-plan"
         assert payload["files"] == [str(module_path.resolve())]
         assert payload["serve_cache"]["status"] in {"hit", "miss"}
+        assert payload["session_timing"]["cache_status"] == payload["serve_cache"]["status"]
+        assert payload["session_timing"]["load_session_seconds"] >= 0
+        assert payload["session_timing"]["build_edit_plan_seconds"] >= 0
+        assert payload["session_timing"]["total_seconds"] >= 0
     finally:
         session_daemon.stop_session_daemon(str(project))
 


### PR DESCRIPTION
## Summary
- add phase timing metadata to direct session edit-plan responses
- add daemon session edit-plan load/serve/total timings tied to serve_cache status
- keep this as instrumentation only before optimizing the warm path

## Validation
- uv run --no-sync pytest tests/unit/test_session_cli.py -q
- uv run --no-sync ruff check src/tensor_grep/cli/session_store.py src/tensor_grep/cli/session_daemon.py tests/unit/test_session_cli.py
- git diff --check

This does not claim a warm-path speedup; it gives dogfood artifacts the timing/cache fields needed to locate the remaining slowdown.