### PR TITLE
fix: upgrade starlette audit dependency

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4186,15 +4186,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update the locked Starlette dependency from 0.52.1 to 1.0.1
- fixes the PR-wide pip-audit failure for PYSEC-2026-161
- no product claims changed

## Research
- Starlette release notes list 1.0.1 as the May 21, 2026 fix release: https://www.starlette.io/release-notes/
- PyPI Starlette 1.0.1 still supports Python >=3.10 and the same core anyio dependency family: https://pypi.org/project/starlette/1.0.1/

## Validation
- uv tree --package starlette
- uv run --locked pytest tests/unit/test_runtime_paths.py::test_mcp_sidecar_env_propagation tests/unit/test_trust_parity.py::test_mcp_tool_listing_includes_new_trust_tools -q
- uv run --locked pytest tests/unit/test_mcp_server.py::test_tg_mcp_capabilities_is_registered_and_reports_no_native_runtime tests/unit/test_mcp_server.py::test_tg_mcp_capabilities_registry_covers_public_tools tests/unit/test_mcp_server.py::test_tg_session_mcp_tools_wrap_session_store tests/integration/test_harness_adoption.py::test_public_mcp_tools_roundtrip_against_native_binary -q
- local CI-equivalent pip-audit command: No known vulnerabilities found, 1 ignored
- git diff --check