### PR TITLE
fix: expose Windows LSP doctor timeout budget

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -52,6 +52,8 @@ _DEFAULT_AGENT_REPO_SCAN_LIMIT = 512
 _DEFAULT_BLAST_RADIUS_JSON_MAX_CALLERS = 25
 _DEFAULT_BLAST_RADIUS_JSON_MAX_FILES = 25
 _DOCTOR_LSP_PROBE_TIMEOUT_SECONDS = 1.0
+_DOCTOR_LSP_WINDOWS_PROBE_TIMEOUT_SECONDS = 3.0
+_DOCTOR_LSP_PROBE_TIMEOUT_ENV = "TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS"
 _GUARDED_BROAD_SEARCH_ROOTS = {".claude", ".claude/context"}
 _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "__pycache__",
@@ -1612,18 +1614,33 @@ def _doctor_lsp_languages() -> list[str]:
     return supported_lsp_languages()
 
 
+def _doctor_lsp_probe_timeout_seconds() -> float:
+    raw_timeout = os.environ.get(_DOCTOR_LSP_PROBE_TIMEOUT_ENV)
+    if raw_timeout:
+        try:
+            parsed_timeout = float(raw_timeout)
+        except ValueError:
+            parsed_timeout = 0.0
+        if parsed_timeout > 0:
+            return parsed_timeout
+    if sys.platform.startswith("win"):
+        return _DOCTOR_LSP_WINDOWS_PROBE_TIMEOUT_SECONDS
+    return _DOCTOR_LSP_PROBE_TIMEOUT_SECONDS
+
+
 def _doctor_lsp_provider_statuses(path: str) -> list[dict[str, Any]]:
     from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager
 
     manager = ExternalLSPProviderManager()
     workspace_root = Path(path).resolve()
+    probe_timeout_seconds = _doctor_lsp_probe_timeout_seconds()
     try:
         return [
             manager.provider_status(
                 language=language,
                 workspace_root=workspace_root,
                 verify_health=True,
-                probe_timeout_seconds=_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS,
+                probe_timeout_seconds=probe_timeout_seconds,
             )
             for language in _doctor_lsp_languages()
         ]
@@ -2278,6 +2295,7 @@ def _build_doctor_payload(
         "TENSOR_GREP_LSP_REQUEST_TIMEOUT_SECONDS",
         "TENSOR_GREP_LSP_INITIALIZE_TIMEOUT_SECONDS",
         "TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS",
+        _DOCTOR_LSP_PROBE_TIMEOUT_ENV,
     ]
     installed_version = _doctor_installed_version()
     rust_binary_version = _doctor_rust_binary_version(native_tg_binary)
@@ -2491,11 +2509,16 @@ def _build_doctor_payload(
         lsp_providers = _doctor_lsp_provider_statuses(str(root))
         payload["lsp"] = {
             "enabled": True,
+            "probe_timeout_seconds": _doctor_lsp_probe_timeout_seconds(),
             "providers": lsp_providers,
         }
     else:
         lsp_providers = []
-        payload["lsp"] = {"enabled": False, "providers": lsp_providers}
+        payload["lsp"] = {
+            "enabled": False,
+            "probe_timeout_seconds": None,
+            "providers": lsp_providers,
+        }
     payload["lsp_providers"] = lsp_providers
     return payload
 
@@ -2647,6 +2670,8 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
     lsp_payload = cast(dict[str, Any], payload.get("lsp", {}))
     if lsp_payload.get("enabled"):
         lines.append("lsp_providers:")
+        if lsp_payload.get("probe_timeout_seconds") is not None:
+            lines.append(f"lsp_probe_timeout_seconds: {lsp_payload['probe_timeout_seconds']}")
         for current in cast(list[dict[str, Any]], lsp_payload.get("providers", [])):
             command = current.get("command") or []
             command_str = " ".join(str(part) for part in command) if command else "missing"

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1009,6 +1009,34 @@ def test_doctor_help_mentions_lsp_and_json() -> None:
     assert "literal patterns" in normalized_help
 
 
+def test_doctor_lsp_probe_timeout_defaults_to_windows_budget(monkeypatch) -> None:
+    monkeypatch.delenv("TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+
+    assert cli_main._doctor_lsp_probe_timeout_seconds() == pytest.approx(3.0)
+
+
+def test_doctor_lsp_probe_timeout_keeps_short_posix_default(monkeypatch) -> None:
+    monkeypatch.delenv("TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setattr(cli_main.sys, "platform", "linux")
+
+    assert cli_main._doctor_lsp_probe_timeout_seconds() == pytest.approx(1.0)
+
+
+def test_doctor_lsp_probe_timeout_allows_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS", "7.5")
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+
+    assert cli_main._doctor_lsp_probe_timeout_seconds() == pytest.approx(7.5)
+
+
+def test_doctor_lsp_probe_timeout_ignores_invalid_env(monkeypatch) -> None:
+    monkeypatch.setenv("TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS", "slow")
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+
+    assert cli_main._doctor_lsp_probe_timeout_seconds() == pytest.approx(3.0)
+
+
 def test_doctor_json_includes_runtime_session_and_lsp(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
     monkeypatch.setattr(
@@ -1040,6 +1068,7 @@ def test_doctor_json_includes_runtime_session_and_lsp(monkeypatch, tmp_path: Pat
     monkeypatch.setenv("TG_RUST_EARLY_POSITIONAL_RG", "1")
     monkeypatch.setenv("TG_FORCE_CPU", "1")
     monkeypatch.setenv("TG_RESIDENT_AST", "1")
+    monkeypatch.setenv("TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS", "6.5")
 
     runner = CliRunner()
     result = runner.invoke(app, ["doctor", str(tmp_path), "--json"])
@@ -1055,6 +1084,7 @@ def test_doctor_json_includes_runtime_session_and_lsp(monkeypatch, tmp_path: Pat
     assert payload["env"]["TG_RESIDENT_AST"] == "1"
     assert payload["session_daemon"]["running"] is True
     assert payload["lsp"]["enabled"] is True
+    assert payload["lsp"]["probe_timeout_seconds"] == pytest.approx(6.5)
     assert payload["lsp"]["providers"][0]["language"] == "python"
     assert payload["lsp"]["providers"][0]["command_source"] == "managed"
     assert payload["lsp"]["providers"][0]["managed_provider_root"] == str(tmp_path / "providers")
@@ -1882,6 +1912,7 @@ def test_doctor_text_reports_lsp_health_and_proof_fields(monkeypatch, tmp_path: 
         "tensor_grep.cli.main._doctor_session_daemon_status",
         lambda path: {"running": False},
     )
+    monkeypatch.setenv("TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS", "4.5")
     monkeypatch.setattr(
         "tensor_grep.cli.main._doctor_lsp_provider_statuses",
         lambda path: [
@@ -1904,6 +1935,7 @@ def test_doctor_text_reports_lsp_health_and_proof_fields(monkeypatch, tmp_path: 
     result = CliRunner().invoke(app, ["doctor", str(tmp_path)])
 
     assert result.exit_code == 0
+    assert "lsp_probe_timeout_seconds: 4.5" in result.stdout
     assert "health=available_unverified" in result.stdout
     assert "health_check=not_run" in result.stdout
     assert "lsp_proof=False" in result.stdout


### PR DESCRIPTION
Summary: add a Windows-specific tg doctor --with-lsp probe budget so provider initialize checks get 3s instead of the POSIX 1s fast probe; expose lsp.probe_timeout_seconds in doctor JSON and lsp_probe_timeout_seconds in text output; allow override with TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS without changing LSP proof semantics. Research/planning: Exa reviewed LSP/MCP startup timeout examples; thinktank consensus was keep LSP experimental and improve diagnostics only; Gemini read-only review returned RESULT: PASS and I added its suggested fallback tests. Validation: focused doctor timeout tests passed; pytest tests/unit/test_cli_modes.py -k doctor passed; ruff check passed; git diff --check passed.