### PR TITLE
fix: bound session edit-plan repo map

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6953,6 +6953,12 @@ def session_edit_plan_cmd(
     max_symbols: int = typer.Option(
         5, "--max-symbols", min=1, help="Maximum ranked symbols to retain in the plan payload."
     ),
+    max_repo_files: int = typer.Option(
+        _DEFAULT_AGENT_REPO_SCAN_LIMIT,
+        "--max-repo-files",
+        min=1,
+        help="Maximum cached repo files to score before ranking warm edit-plan targets.",
+    ),
     refresh_on_stale: bool = typer.Option(
         False,
         "--refresh-on-stale",
@@ -6982,6 +6988,7 @@ def session_edit_plan_cmd(
                     "max_sources": max_sources,
                     "max_tokens": max_tokens,
                     "max_symbols": max_symbols,
+                    "max_repo_files": max_repo_files,
                     "refresh_on_stale": refresh_on_stale,
                 },
             )
@@ -6994,6 +7001,7 @@ def session_edit_plan_cmd(
                 max_sources=max_sources,
                 max_tokens=max_tokens,
                 max_symbols=max_symbols,
+                max_repo_files=max_repo_files,
                 refresh_on_stale=refresh_on_stale,
             )
     except Exception as exc:

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from tensor_grep.cli.repo_map import (
     _is_repo_context_file,
     _iter_repo_files,
+    apply_repo_map_output_limits,
     build_context_edit_plan_from_map,
     build_context_pack_from_map,
     build_context_render_from_map,
@@ -32,6 +33,7 @@ _TG_DIRNAME = ".tensor-grep"
 _SESSIONS_SUBDIR = "sessions"
 _INDEX_FILE = "index.json"
 _SESSION_SERVE_CACHE_MAX_ENTRIES = 32
+_DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT = 512
 
 
 @dataclass
@@ -537,13 +539,18 @@ def session_context_edit_plan(
     max_sources: int | None = None,
     max_tokens: int | None = None,
     max_symbols: int = 5,
+    max_repo_files: int | None = _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT,
     refresh_on_stale: bool = False,
 ) -> dict[str, Any]:
     started_at = monotonic()
     payload = _load_session_payload(session_id, path, refresh_on_stale=refresh_on_stale)
     loaded_at = monotonic()
+    repo_map = _session_edit_plan_repo_map(
+        cast(dict[str, Any], payload["repo_map"]),
+        max_repo_files=max_repo_files,
+    )
     context = build_context_edit_plan_from_map(
-        payload["repo_map"],
+        repo_map,
         query,
         max_files=max_files,
         max_sources=max_sources,
@@ -560,6 +567,16 @@ def session_context_edit_plan(
         "total_seconds": max(0.0, built_at - started_at),
     }
     return context
+
+
+def _session_edit_plan_repo_map(
+    repo_map: dict[str, Any],
+    *,
+    max_repo_files: int | None,
+) -> dict[str, Any]:
+    if max_repo_files is None:
+        return repo_map
+    return apply_repo_map_output_limits(repo_map, max_files=max(1, int(max_repo_files)))
 
 
 def session_context_render(
@@ -737,8 +754,15 @@ def _serve_session_request_from_payload(
         query = str(request.get("query", "")).strip()
         if not query:
             raise ValueError("context_edit_plan requests require a non-empty query")
-        response = build_context_edit_plan_from_map(
+        max_repo_files = request.get("max_repo_files", _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT)
+        scoped_repo_map = _session_edit_plan_repo_map(
             repo_map,
+            max_repo_files=(
+                None if max_repo_files in (None, "") else int(cast(int | str, max_repo_files))
+            ),
+        )
+        response = build_context_edit_plan_from_map(
+            scoped_repo_map,
             query,
             max_files=int(request.get("max_files", 3)),
             max_sources=(

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -210,6 +210,141 @@ def test_session_edit_plan_does_not_walk_repo_for_validation_discovery(
     assert timing["total_seconds"] >= 0
 
 
+def test_session_edit_plan_applies_repo_map_cap_before_building_plan(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from tensor_grep.cli import session_store
+
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    for index in range(6):
+        (src_dir / f"module_{index}.py").write_text(
+            f"def target_{index}():\n    return {index}\n",
+            encoding="utf-8",
+        )
+
+    runner = CliRunner()
+    opened = json.loads(runner.invoke(app, ["session", "open", str(project), "--json"]).stdout)
+    assert opened["file_count"] == 6
+
+    captured_repo_maps: list[dict] = []
+
+    def fake_build_context_edit_plan_from_map(
+        repo_map: dict,
+        query: str,
+        **_kwargs,
+    ) -> dict:
+        captured_repo_maps.append(repo_map)
+        return {
+            "query": query,
+            "files": list(repo_map.get("files", [])),
+            "tests": list(repo_map.get("tests", [])),
+            "symbols": list(repo_map.get("symbols", [])),
+            "output_limit": dict(repo_map.get("output_limit", {})),
+        }
+
+    monkeypatch.setattr(
+        session_store,
+        "build_context_edit_plan_from_map",
+        fake_build_context_edit_plan_from_map,
+    )
+
+    edit_plan = runner.invoke(
+        app,
+        [
+            "session",
+            "edit-plan",
+            opened["session_id"],
+            str(project),
+            "--query",
+            "target",
+            "--max-repo-files",
+            "2",
+            "--json",
+        ],
+    )
+
+    assert edit_plan.exit_code == 0, edit_plan.output
+    payload = json.loads(edit_plan.stdout)
+    assert payload["routing_reason"] == "session-context-edit-plan"
+    assert len(payload["files"]) == 2
+    assert payload["output_limit"]["max_files"] == 2
+    assert payload["output_limit"]["original_files"] == 6
+    assert payload["output_limit"]["possibly_truncated"] is True
+    assert len(captured_repo_maps) == 1
+    assert len(captured_repo_maps[0]["files"]) == 2
+
+    show_result = runner.invoke(
+        app, ["session", "show", opened["session_id"], str(project), "--json"]
+    )
+    assert show_result.exit_code == 0, show_result.output
+    shown = json.loads(show_result.stdout)
+    assert len(shown["repo_map"]["files"]) == 6
+
+
+def test_session_serve_edit_plan_applies_repo_map_cap_before_building_plan(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from tensor_grep.cli import session_store
+
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    for index in range(5):
+        (src_dir / f"module_{index}.py").write_text(
+            f"def target_{index}():\n    return {index}\n",
+            encoding="utf-8",
+        )
+
+    runner = CliRunner()
+    opened = json.loads(runner.invoke(app, ["session", "open", str(project), "--json"]).stdout)
+    session_payload = json.loads(
+        runner.invoke(app, ["session", "show", opened["session_id"], str(project), "--json"]).stdout
+    )
+
+    captured_repo_maps: list[dict] = []
+
+    def fake_build_context_edit_plan_from_map(
+        repo_map: dict,
+        query: str,
+        **_kwargs,
+    ) -> dict:
+        captured_repo_maps.append(repo_map)
+        return {
+            "query": query,
+            "files": list(repo_map.get("files", [])),
+            "tests": list(repo_map.get("tests", [])),
+            "symbols": list(repo_map.get("symbols", [])),
+            "output_limit": dict(repo_map.get("output_limit", {})),
+        }
+
+    monkeypatch.setattr(
+        session_store,
+        "build_context_edit_plan_from_map",
+        fake_build_context_edit_plan_from_map,
+    )
+
+    payload = session_store.serve_session_request(
+        opened["session_id"],
+        {
+            "command": "context_edit_plan",
+            "query": "target",
+            "max_repo_files": 2,
+        },
+        str(project),
+        payload=session_payload,
+    )
+
+    assert payload["routing_reason"] == "session-context-edit-plan"
+    assert len(payload["files"]) == 2
+    assert payload["output_limit"]["original_files"] == 5
+    assert len(captured_repo_maps) == 1
+    assert len(captured_repo_maps[0]["files"]) == 2
+
+
 def test_session_edit_plan_uses_cached_validation_evidence_after_open(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add --max-repo-files to session edit-plan and pass it through daemon requests
- cap cached session repo maps before edit-plan graph/ranking work
- verify direct and serve/daemon request paths receive bounded maps without mutating persisted sessions

## Validation
- uv run pytest tests/unit/test_session_cli.py -q
- uv run ruff check src/tensor_grep/cli/session_store.py src/tensor_grep/cli/main.py tests/unit/test_session_cli.py
- uv run ruff format --check --preview src/tensor_grep/cli/session_store.py src/tensor_grep/cli/main.py tests/unit/test_session_cli.py
- git diff --check
- Gemini read-only diff review: RESULT: PASS