### PR TITLE
fix: prevent Windows GPU probe launcher recursion

### DIFF
--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -42,8 +42,15 @@ def _looks_like_python_scripts_launcher(candidate: Path) -> bool:
         return True
 
     if sys.platform.startswith("win") and candidate.parent.name.lower() == "scripts":
-        python_root = candidate.parent.parent
-        return (python_root / "python.exe").is_file() or (python_root / "pythonw.exe").is_file()
+        scripts_dir = candidate.parent
+        python_root = scripts_dir.parent
+        return (
+            (scripts_dir / "python.exe").is_file()
+            or (scripts_dir / "pythonw.exe").is_file()
+            or (python_root / "python.exe").is_file()
+            or (python_root / "pythonw.exe").is_file()
+            or (python_root / "pyvenv.cfg").is_file()
+        )
 
     return False
 

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -367,6 +367,47 @@ def test_resolve_native_tg_binary_ignores_foreign_python_install_scripts_launche
     assert resolve_native_tg_binary() is None
 
 
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows launcher layout")
+def test_resolve_native_tg_binary_ignores_venv_scripts_launcher_when_python_is_adjacent(
+    monkeypatch, tmp_path
+):
+    repo_root = tmp_path / "repo"
+    runtime_file = repo_root / "src" / "tensor_grep" / "cli" / "runtime_paths.py"
+    runtime_file.parent.mkdir(parents=True, exist_ok=True)
+    runtime_file.write_text("# stub\n", encoding="utf-8")
+
+    host_python_dir = tmp_path / "host-python"
+    host_python_dir.mkdir(parents=True, exist_ok=True)
+    host_python = host_python_dir / "python.exe"
+    host_python.write_text("python\n", encoding="utf-8")
+
+    cached_venv_root = tmp_path / "uv-cache" / "archive-v0" / "tool-env"
+    scripts_dir = cached_venv_root / "Scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (cached_venv_root / "pyvenv.cfg").write_text("home = C:/Python312\n", encoding="utf-8")
+    (scripts_dir / "python.exe").write_text("python\n", encoding="utf-8")
+    cached_launcher = scripts_dir / "tg.exe"
+    cached_launcher.write_text("python console entrypoint\n", encoding="utf-8")
+
+    monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
+    monkeypatch.setattr(runtime_paths.sys, "executable", str(host_python))
+    monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
+    monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
+    monkeypatch.setenv("PATH", str(scripts_dir))
+    monkeypatch.setattr(runtime_paths, "_in_tree_native_tg_candidates", lambda **_kwargs: [])
+    monkeypatch.setattr(runtime_paths, "_expected_tg_version", lambda: "1.13.2")
+    monkeypatch.setattr(
+        runtime_paths,
+        "_native_candidate_matches_current_package",
+        lambda candidate, *, expected_version: (
+            Path(candidate).resolve() == cached_launcher.resolve()
+        ),
+    )
+    resolve_native_tg_binary.cache_clear()
+
+    assert resolve_native_tg_binary() is None
+
+
 def test_resolve_ripgrep_binary_env_override(tmp_path):
     rg_path = tmp_path / ("rg.exe" if sys.platform.startswith("win") else "rg")
     rg_path.touch()


### PR DESCRIPTION
## Summary
- reject Windows venv/uvx Scripts tg.exe launchers as native front doors when python.exe is adjacent or pyvenv.cfg marks the root
- add a Windows resolver regression test for the uvx/venv launcher layout that caused recursive GPU doctor probes

## Verification
- uv run ruff check .
- uv run ruff format --check --preview .
- uv run mypy src/tensor_grep
- uv run pytest tests/unit/test_runtime_paths.py -q
- uv run --no-sync tg doctor --json --no-lsp (exit 0, zero leftover tg-doctor-gpu-probe processes)
- uv run --no-sync tg dogfood --json --no-shell-probes --no-wsl-probe --output artifacts/dogfood_readiness_v1133_release_commit.json (PASS, 13/13)
- uv run pytest -q (2401 passed, 18 skipped)
- C:\\Users\\oimir\\.cargo\\bin\\cargo.exe test --manifest-path rust_core/Cargo.toml