### PR TITLE
fix: accept opt-in GPU no-match timing rows

### DIFF
--- a/benchmarks/run_gpu_benchmarks.py
+++ b/benchmarks/run_gpu_benchmarks.py
@@ -125,19 +125,15 @@ def resolve_gpu_sidecar_python(raw: str | None = None) -> Path | None:
 
     candidates = []
     if os.name == "nt":
-        candidates.extend(
-            [
-                ROOT_DIR / ".venv_cuda" / "Scripts" / "python.exe",
-                ROOT_DIR / ".venv" / "Scripts" / "python.exe",
-            ]
-        )
+        candidates.extend([
+            ROOT_DIR / ".venv_cuda" / "Scripts" / "python.exe",
+            ROOT_DIR / ".venv" / "Scripts" / "python.exe",
+        ])
     else:
-        candidates.extend(
-            [
-                ROOT_DIR / ".venv_cuda" / "bin" / "python",
-                ROOT_DIR / ".venv" / "bin" / "python",
-            ]
-        )
+        candidates.extend([
+            ROOT_DIR / ".venv_cuda" / "bin" / "python",
+            ROOT_DIR / ".venv" / "bin" / "python",
+        ])
 
     for candidate in candidates:
         if candidate.exists():
@@ -1105,15 +1101,13 @@ def analyze_gpu_auto_recommendation(
                 winning_sizes_by_device.setdefault(str(device_id), set()).add(
                     int(row.get("size_bytes", 0))
                 )
-                winners.append(
-                    {
-                        "device_id": device_id,
-                        "size_label": row.get("size_label"),
-                        "size_bytes": row.get("size_bytes"),
-                        "speedup_vs_rg_pct": speedup_vs_rg_pct,
-                        "speedup_vs_tg_cpu_pct": speedup_vs_tg_cpu_pct,
-                    }
-                )
+                winners.append({
+                    "device_id": device_id,
+                    "size_label": row.get("size_label"),
+                    "size_bytes": row.get("size_bytes"),
+                    "speedup_vs_rg_pct": speedup_vs_rg_pct,
+                    "speedup_vs_tg_cpu_pct": speedup_vs_tg_cpu_pct,
+                })
 
     qualifying_devices = {
         device_id
@@ -1547,40 +1541,36 @@ def run_gpu_scale_benchmarks(
                 "tg_runtime_sidecar_used": device.get("tg_runtime_sidecar_used"),
             }
             if not device.get("operational", False):
-                entry.update(
-                    {
-                        "status": "UNSUPPORTED",
-                        "median_s": None,
-                        "samples_s": [],
-                        "stderr": device.get("error", "device probe failed"),
-                        "promotion_evidence": False,
-                        "not_gpu_proof_reason": _not_gpu_proof_reason(
-                            backend=device.get("tg_runtime_backend"),
-                            sidecar_used=device.get("tg_runtime_sidecar_used"),
-                        ),
-                    }
-                )
+                entry.update({
+                    "status": "UNSUPPORTED",
+                    "median_s": None,
+                    "samples_s": [],
+                    "stderr": device.get("error", "device probe failed"),
+                    "promotion_evidence": False,
+                    "not_gpu_proof_reason": _not_gpu_proof_reason(
+                        backend=device.get("tg_runtime_backend"),
+                        sidecar_used=device.get("tg_runtime_sidecar_used"),
+                    ),
+                })
             elif not _uses_native_cuda_runtime(device):
                 runtime_probe = runtime_probes.get(int(device["device_id"]), {})
-                entry.update(
-                    {
-                        "status": "UNSUPPORTED",
-                        "median_s": None,
-                        "samples_s": [],
-                        "stderr": (
-                            "GPU scale benchmark requires a CUDA-enabled native tg binary; "
-                            f"runtime probe routed to "
-                            f"{runtime_probe.get('routing_backend') or 'unknown'} "
-                            f"(sidecar_used={bool(runtime_probe.get('sidecar_used'))})."
-                        ),
-                        "command": runtime_probe.get("command"),
-                        "promotion_evidence": False,
-                        "not_gpu_proof_reason": _not_gpu_proof_reason(
-                            backend=runtime_probe.get("routing_backend"),
-                            sidecar_used=runtime_probe.get("sidecar_used"),
-                        ),
-                    }
-                )
+                entry.update({
+                    "status": "UNSUPPORTED",
+                    "median_s": None,
+                    "samples_s": [],
+                    "stderr": (
+                        "GPU scale benchmark requires a CUDA-enabled native tg binary; "
+                        f"runtime probe routed to "
+                        f"{runtime_probe.get('routing_backend') or 'unknown'} "
+                        f"(sidecar_used={bool(runtime_probe.get('sidecar_used'))})."
+                    ),
+                    "command": runtime_probe.get("command"),
+                    "promotion_evidence": False,
+                    "not_gpu_proof_reason": _not_gpu_proof_reason(
+                        backend=runtime_probe.get("routing_backend"),
+                        sidecar_used=runtime_probe.get("sidecar_used"),
+                    ),
+                })
             else:
                 result = benchmark_search_command(
                     build_tg_gpu_search_command(
@@ -1822,24 +1812,22 @@ def main() -> int:
             "winning_rows": [],
         }
         gpu_bottleneck_summary = summarize_gpu_pipeline_bottlenecks([])
-        payload.update(
-            {
-                "errors": [f"tg binary not found: {tg_binary}"],
-                "warnings": [],
-                "rows": [],
-                "correctness_checks": [],
-                "corpus_sizes": [],
-                "devices": [],
-                "gpu_auto_recommendation": recommendation,
-                "gpu_bottleneck_summary": gpu_bottleneck_summary,
-                "gpu_readiness_next_steps": build_gpu_readiness_next_steps(gpu_bottleneck_summary),
-                "scale_gate_summary": build_scale_gate_summary(
-                    devices=[],
-                    correctness_checks=[],
-                    gpu_auto_recommendation=recommendation,
-                ),
-            }
-        )
+        payload.update({
+            "errors": [f"tg binary not found: {tg_binary}"],
+            "warnings": [],
+            "rows": [],
+            "correctness_checks": [],
+            "corpus_sizes": [],
+            "devices": [],
+            "gpu_auto_recommendation": recommendation,
+            "gpu_bottleneck_summary": gpu_bottleneck_summary,
+            "gpu_readiness_next_steps": build_gpu_readiness_next_steps(gpu_bottleneck_summary),
+            "scale_gate_summary": build_scale_gate_summary(
+                devices=[],
+                correctness_checks=[],
+                gpu_auto_recommendation=recommendation,
+            ),
+        })
         output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return 1
 

--- a/benchmarks/run_gpu_benchmarks.py
+++ b/benchmarks/run_gpu_benchmarks.py
@@ -125,15 +125,19 @@ def resolve_gpu_sidecar_python(raw: str | None = None) -> Path | None:
 
     candidates = []
     if os.name == "nt":
-        candidates.extend([
-            ROOT_DIR / ".venv_cuda" / "Scripts" / "python.exe",
-            ROOT_DIR / ".venv" / "Scripts" / "python.exe",
-        ])
+        candidates.extend(
+            [
+                ROOT_DIR / ".venv_cuda" / "Scripts" / "python.exe",
+                ROOT_DIR / ".venv" / "Scripts" / "python.exe",
+            ]
+        )
     else:
-        candidates.extend([
-            ROOT_DIR / ".venv_cuda" / "bin" / "python",
-            ROOT_DIR / ".venv" / "bin" / "python",
-        ])
+        candidates.extend(
+            [
+                ROOT_DIR / ".venv_cuda" / "bin" / "python",
+                ROOT_DIR / ".venv" / "bin" / "python",
+            ]
+        )
 
     for candidate in candidates:
         if candidate.exists():
@@ -528,16 +532,26 @@ def benchmark_search_command(
     env: dict[str, str],
     runs: int,
     warmup: int,
+    allow_no_match: bool = False,
 ) -> dict[str, object]:
+    no_match_exit_accepted = False
     for _ in range(warmup):
         warmup_result = _run_command(command, env=env, capture_output=False)
-        if warmup_result.returncode != 0:
+        if (
+            warmup_result.returncode == 1
+            and allow_no_match
+            and not (warmup_result.stderr or "").strip()
+        ):
+            no_match_exit_accepted = True
+        elif warmup_result.returncode != 0:
             return {
                 "status": "FAIL",
                 "median_s": None,
                 "samples_s": [],
                 "stderr": (warmup_result.stderr or "").strip(),
                 "command": _command_display(command),
+                "allow_no_match": allow_no_match,
+                "no_match_exit_accepted": no_match_exit_accepted,
             }
 
     samples: list[float] = []
@@ -546,13 +560,17 @@ def benchmark_search_command(
         start = time.perf_counter()
         result = _run_command(command, env=env, capture_output=False)
         elapsed = time.perf_counter() - start
-        if result.returncode != 0:
+        if result.returncode == 1 and allow_no_match and not (result.stderr or "").strip():
+            no_match_exit_accepted = True
+        elif result.returncode != 0:
             return {
                 "status": "FAIL",
                 "median_s": None,
                 "samples_s": [round(sample, 6) for sample in samples],
                 "stderr": (result.stderr or "").strip(),
                 "command": _command_display(command),
+                "allow_no_match": allow_no_match,
+                "no_match_exit_accepted": no_match_exit_accepted,
             }
         samples.append(round(elapsed, 6))
         last_stderr = (result.stderr or "").strip()
@@ -563,6 +581,8 @@ def benchmark_search_command(
         "samples_s": samples,
         "stderr": last_stderr,
         "command": _command_display(command),
+        "allow_no_match": allow_no_match,
+        "no_match_exit_accepted": no_match_exit_accepted,
     }
 
 
@@ -1085,13 +1105,15 @@ def analyze_gpu_auto_recommendation(
                 winning_sizes_by_device.setdefault(str(device_id), set()).add(
                     int(row.get("size_bytes", 0))
                 )
-                winners.append({
-                    "device_id": device_id,
-                    "size_label": row.get("size_label"),
-                    "size_bytes": row.get("size_bytes"),
-                    "speedup_vs_rg_pct": speedup_vs_rg_pct,
-                    "speedup_vs_tg_cpu_pct": speedup_vs_tg_cpu_pct,
-                })
+                winners.append(
+                    {
+                        "device_id": device_id,
+                        "size_label": row.get("size_label"),
+                        "size_bytes": row.get("size_bytes"),
+                        "speedup_vs_rg_pct": speedup_vs_rg_pct,
+                        "speedup_vs_tg_cpu_pct": speedup_vs_tg_cpu_pct,
+                    }
+                )
 
     qualifying_devices = {
         device_id
@@ -1490,18 +1512,27 @@ def run_gpu_scale_benchmarks(
             shard_count=shard_count,
         )
         generated_corpora[size_bytes] = corpus_dir
+        pattern_counts = corpus_info.get("pattern_counts")
+        expected_matches = (
+            int(pattern_counts.get(benchmark_pattern, 0)) > 0
+            if isinstance(pattern_counts, dict)
+            else True
+        )
+        allow_no_match = not expected_matches
 
         rg_result = benchmark_search_command(
             build_rg_search_command(rg_binary, benchmark_pattern, corpus_dir),
             env=command_env,
             runs=runs,
             warmup=warmup,
+            allow_no_match=allow_no_match,
         )
         tg_cpu_result = benchmark_search_command(
             build_tg_cpu_search_command(tg_binary, benchmark_pattern, corpus_dir),
             env=command_env,
             runs=runs,
             warmup=warmup,
+            allow_no_match=allow_no_match,
         )
 
         gpu_results: list[dict[str, object]] = []
@@ -1516,36 +1547,40 @@ def run_gpu_scale_benchmarks(
                 "tg_runtime_sidecar_used": device.get("tg_runtime_sidecar_used"),
             }
             if not device.get("operational", False):
-                entry.update({
-                    "status": "UNSUPPORTED",
-                    "median_s": None,
-                    "samples_s": [],
-                    "stderr": device.get("error", "device probe failed"),
-                    "promotion_evidence": False,
-                    "not_gpu_proof_reason": _not_gpu_proof_reason(
-                        backend=device.get("tg_runtime_backend"),
-                        sidecar_used=device.get("tg_runtime_sidecar_used"),
-                    ),
-                })
+                entry.update(
+                    {
+                        "status": "UNSUPPORTED",
+                        "median_s": None,
+                        "samples_s": [],
+                        "stderr": device.get("error", "device probe failed"),
+                        "promotion_evidence": False,
+                        "not_gpu_proof_reason": _not_gpu_proof_reason(
+                            backend=device.get("tg_runtime_backend"),
+                            sidecar_used=device.get("tg_runtime_sidecar_used"),
+                        ),
+                    }
+                )
             elif not _uses_native_cuda_runtime(device):
                 runtime_probe = runtime_probes.get(int(device["device_id"]), {})
-                entry.update({
-                    "status": "UNSUPPORTED",
-                    "median_s": None,
-                    "samples_s": [],
-                    "stderr": (
-                        "GPU scale benchmark requires a CUDA-enabled native tg binary; "
-                        f"runtime probe routed to "
-                        f"{runtime_probe.get('routing_backend') or 'unknown'} "
-                        f"(sidecar_used={bool(runtime_probe.get('sidecar_used'))})."
-                    ),
-                    "command": runtime_probe.get("command"),
-                    "promotion_evidence": False,
-                    "not_gpu_proof_reason": _not_gpu_proof_reason(
-                        backend=runtime_probe.get("routing_backend"),
-                        sidecar_used=runtime_probe.get("sidecar_used"),
-                    ),
-                })
+                entry.update(
+                    {
+                        "status": "UNSUPPORTED",
+                        "median_s": None,
+                        "samples_s": [],
+                        "stderr": (
+                            "GPU scale benchmark requires a CUDA-enabled native tg binary; "
+                            f"runtime probe routed to "
+                            f"{runtime_probe.get('routing_backend') or 'unknown'} "
+                            f"(sidecar_used={bool(runtime_probe.get('sidecar_used'))})."
+                        ),
+                        "command": runtime_probe.get("command"),
+                        "promotion_evidence": False,
+                        "not_gpu_proof_reason": _not_gpu_proof_reason(
+                            backend=runtime_probe.get("routing_backend"),
+                            sidecar_used=runtime_probe.get("sidecar_used"),
+                        ),
+                    }
+                )
             else:
                 result = benchmark_search_command(
                     build_tg_gpu_search_command(
@@ -1557,6 +1592,7 @@ def run_gpu_scale_benchmarks(
                     env=command_env,
                     runs=runs,
                     warmup=warmup,
+                    allow_no_match=allow_no_match,
                 )
                 result["stderr"] = _clean_selected_gpu_stderr(
                     result.get("stderr"),
@@ -1594,6 +1630,7 @@ def run_gpu_scale_benchmarks(
             "file_count": corpus_info["file_count"],
             "total_lines": corpus_info["total_lines"],
             "pattern_counts": corpus_info["pattern_counts"],
+            "expected_match": expected_matches,
             "rg": rg_result,
             "tg_cpu": tg_cpu_result,
             "gpu": gpu_results,
@@ -1785,22 +1822,24 @@ def main() -> int:
             "winning_rows": [],
         }
         gpu_bottleneck_summary = summarize_gpu_pipeline_bottlenecks([])
-        payload.update({
-            "errors": [f"tg binary not found: {tg_binary}"],
-            "warnings": [],
-            "rows": [],
-            "correctness_checks": [],
-            "corpus_sizes": [],
-            "devices": [],
-            "gpu_auto_recommendation": recommendation,
-            "gpu_bottleneck_summary": gpu_bottleneck_summary,
-            "gpu_readiness_next_steps": build_gpu_readiness_next_steps(gpu_bottleneck_summary),
-            "scale_gate_summary": build_scale_gate_summary(
-                devices=[],
-                correctness_checks=[],
-                gpu_auto_recommendation=recommendation,
-            ),
-        })
+        payload.update(
+            {
+                "errors": [f"tg binary not found: {tg_binary}"],
+                "warnings": [],
+                "rows": [],
+                "correctness_checks": [],
+                "corpus_sizes": [],
+                "devices": [],
+                "gpu_auto_recommendation": recommendation,
+                "gpu_bottleneck_summary": gpu_bottleneck_summary,
+                "gpu_readiness_next_steps": build_gpu_readiness_next_steps(gpu_bottleneck_summary),
+                "scale_gate_summary": build_scale_gate_summary(
+                    devices=[],
+                    correctness_checks=[],
+                    gpu_auto_recommendation=recommendation,
+                ),
+            }
+        )
         output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return 1
 

--- a/benchmarks/run_gpu_native_benchmarks.py
+++ b/benchmarks/run_gpu_native_benchmarks.py
@@ -317,7 +317,9 @@ def benchmark_search_command(
     warmup: int,
     timeout_s: int,
     corpus_bytes: int,
+    allow_no_match: bool = False,
 ) -> dict[str, object]:
+    no_match_exit_accepted = False
     for _ in range(warmup):
         warmup_result = _run_command(command, env=env, capture_output=False, timeout_s=timeout_s)
         if isinstance(warmup_result, subprocess.TimeoutExpired):
@@ -328,8 +330,16 @@ def benchmark_search_command(
                 "stderr": f"command timed out after {timeout_s}s",
                 "command": _command_display(command),
                 "throughput_bytes_s": None,
+                "allow_no_match": allow_no_match,
+                "no_match_exit_accepted": no_match_exit_accepted,
             }
-        if warmup_result.returncode != 0:
+        if (
+            warmup_result.returncode == 1
+            and allow_no_match
+            and not (warmup_result.stderr or "").strip()
+        ):
+            no_match_exit_accepted = True
+        elif warmup_result.returncode != 0:
             return {
                 "status": "FAIL",
                 "median_s": None,
@@ -337,6 +347,8 @@ def benchmark_search_command(
                 "stderr": (warmup_result.stderr or "").strip(),
                 "command": _command_display(command),
                 "throughput_bytes_s": None,
+                "allow_no_match": allow_no_match,
+                "no_match_exit_accepted": no_match_exit_accepted,
             }
 
     samples: list[float] = []
@@ -353,8 +365,12 @@ def benchmark_search_command(
                 "stderr": f"command timed out after {timeout_s}s",
                 "command": _command_display(command),
                 "throughput_bytes_s": None,
+                "allow_no_match": allow_no_match,
+                "no_match_exit_accepted": no_match_exit_accepted,
             }
-        if result.returncode != 0:
+        if result.returncode == 1 and allow_no_match and not (result.stderr or "").strip():
+            no_match_exit_accepted = True
+        elif result.returncode != 0:
             return {
                 "status": "FAIL",
                 "median_s": None,
@@ -362,6 +378,8 @@ def benchmark_search_command(
                 "stderr": (result.stderr or "").strip(),
                 "command": _command_display(command),
                 "throughput_bytes_s": None,
+                "allow_no_match": allow_no_match,
+                "no_match_exit_accepted": no_match_exit_accepted,
             }
         samples.append(elapsed)
         last_stderr = (result.stderr or "").strip()
@@ -375,6 +393,8 @@ def benchmark_search_command(
         "stderr": last_stderr,
         "command": _command_display(command),
         "throughput_bytes_s": throughput,
+        "allow_no_match": allow_no_match,
+        "no_match_exit_accepted": no_match_exit_accepted,
     }
 
 
@@ -404,11 +424,13 @@ def _extract_tg_match_signatures(payload: dict[str, object]) -> list[tuple[str, 
         line_number = match.get("line_number")
         if not isinstance(line_number, int):
             line_number = 0
-        signatures.append((
-            _normalized_match_path(match.get("file")),
-            line_number,
-            _normalized_match_text(match.get("text")),
-        ))
+        signatures.append(
+            (
+                _normalized_match_path(match.get("file")),
+                line_number,
+                _normalized_match_text(match.get("text")),
+            )
+        )
     return sorted(signatures)
 
 
@@ -430,11 +452,13 @@ def _extract_rg_json_match_signatures(stdout: str) -> list[tuple[str, int, str]]
             line_number = 0
         lines = data.get("lines")
         line_text = lines.get("text") if isinstance(lines, dict) else ""
-        signatures.append((
-            _normalized_match_path(path_text),
-            line_number,
-            _normalized_match_text(line_text),
-        ))
+        signatures.append(
+            (
+                _normalized_match_path(path_text),
+                line_number,
+                _normalized_match_text(line_text),
+            )
+        )
     return sorted(signatures)
 
 
@@ -672,7 +696,9 @@ def benchmark_command_group(
     warmup: int,
     timeout_s: int,
     workload_bytes: int,
+    allow_no_match: bool = False,
 ) -> dict[str, object]:
+    no_match_exit_accepted = False
     for _ in range(warmup):
         for command in commands:
             warmup_result = _run_command(
@@ -686,8 +712,16 @@ def benchmark_command_group(
                     "stderr": f"command timed out after {timeout_s}s",
                     "command_group": [_command_display(candidate) for candidate in commands],
                     "throughput_bytes_s": None,
+                    "allow_no_match": allow_no_match,
+                    "no_match_exit_accepted": no_match_exit_accepted,
                 }
-            if warmup_result.returncode != 0:
+            if (
+                warmup_result.returncode == 1
+                and allow_no_match
+                and not (warmup_result.stderr or "").strip()
+            ):
+                no_match_exit_accepted = True
+            elif warmup_result.returncode != 0:
                 return {
                     "status": "FAIL",
                     "median_s": None,
@@ -695,6 +729,8 @@ def benchmark_command_group(
                     "stderr": (warmup_result.stderr or "").strip(),
                     "command_group": [_command_display(candidate) for candidate in commands],
                     "throughput_bytes_s": None,
+                    "allow_no_match": allow_no_match,
+                    "no_match_exit_accepted": no_match_exit_accepted,
                 }
 
     samples: list[float] = []
@@ -711,8 +747,12 @@ def benchmark_command_group(
                     "stderr": f"command timed out after {timeout_s}s",
                     "command_group": [_command_display(candidate) for candidate in commands],
                     "throughput_bytes_s": None,
+                    "allow_no_match": allow_no_match,
+                    "no_match_exit_accepted": no_match_exit_accepted,
                 }
-            if result.returncode != 0:
+            if result.returncode == 1 and allow_no_match and not (result.stderr or "").strip():
+                no_match_exit_accepted = True
+            elif result.returncode != 0:
                 return {
                     "status": "FAIL",
                     "median_s": None,
@@ -720,6 +760,8 @@ def benchmark_command_group(
                     "stderr": (result.stderr or "").strip(),
                     "command_group": [_command_display(candidate) for candidate in commands],
                     "throughput_bytes_s": None,
+                    "allow_no_match": allow_no_match,
+                    "no_match_exit_accepted": no_match_exit_accepted,
                 }
             last_stderr = (result.stderr or "").strip()
         elapsed = round(time.perf_counter() - started_at, 6)
@@ -734,6 +776,8 @@ def benchmark_command_group(
         "stderr": last_stderr,
         "command_group": [_command_display(candidate) for candidate in commands],
         "throughput_bytes_s": throughput,
+        "allow_no_match": allow_no_match,
+        "no_match_exit_accepted": no_match_exit_accepted,
     }
 
 
@@ -1075,9 +1119,9 @@ def run_gpu_error_tests(
             else "FAIL"
         )
 
-    nvrtc_env = _build_command_env({
-        "TG_TEST_CUDA_BEHAVIOR": "nvrtc-failure:simulated NVRTC compile error"
-    })
+    nvrtc_env = _build_command_env(
+        {"TG_TEST_CUDA_BEHAVIOR": "nvrtc-failure:simulated NVRTC compile error"}
+    )
     nvrtc_failure = _run_command(
         build_tg_gpu_search_command(tg_binary, pattern, corpus_dir, device_id),
         env=nvrtc_env,
@@ -1098,9 +1142,9 @@ def run_gpu_error_tests(
             else "FAIL"
         )
 
-    timeout_env = _build_command_env({
-        "TG_TEST_CUDA_BEHAVIOR": f"timeout:{timeout_simulation_ms}ms"
-    })
+    timeout_env = _build_command_env(
+        {"TG_TEST_CUDA_BEHAVIOR": f"timeout:{timeout_simulation_ms}ms"}
+    )
     timeout_result = _run_command(
         build_tg_gpu_search_command(tg_binary, pattern, corpus_dir, device_id),
         env=timeout_env,
@@ -1230,10 +1274,12 @@ def analyze_crossover(rows: list[dict[str, object]]) -> dict[str, object]:
         if ratio is None:
             continue
         if ratio < 1.0:
-            winners.append({
-                "size_label": row["size_label"],
-                "gpu_rg_ratio": ratio,
-            })
+            winners.append(
+                {
+                    "size_label": row["size_label"],
+                    "gpu_rg_ratio": ratio,
+                }
+            )
         if best_gap is None or ratio < best_gap["gpu_rg_ratio"]:
             best_gap = {
                 "size_label": row["size_label"],
@@ -1972,6 +2018,13 @@ def run_gpu_native_benchmarks(
             shard_count=shard_count,
         )
         actual_bytes = int(corpus_info["actual_bytes"])
+        pattern_counts = corpus_info.get("pattern_counts")
+        expected_matches = (
+            int(pattern_counts.get(benchmark_pattern, 0)) > 0
+            if isinstance(pattern_counts, dict)
+            else True
+        )
+        allow_no_match = not expected_matches
 
         rg_result = benchmark_search_command(
             build_rg_search_command(rg_binary, benchmark_pattern, corpus_dir),
@@ -1980,6 +2033,7 @@ def run_gpu_native_benchmarks(
             warmup=warmup,
             timeout_s=command_timeout_s,
             corpus_bytes=actual_bytes,
+            allow_no_match=allow_no_match,
         )
         tg_cpu_result = benchmark_search_command(
             build_tg_cpu_search_command(tg_binary, benchmark_pattern, corpus_dir),
@@ -1988,6 +2042,7 @@ def run_gpu_native_benchmarks(
             warmup=warmup,
             timeout_s=command_timeout_s,
             corpus_bytes=actual_bytes,
+            allow_no_match=allow_no_match,
         )
         if runtime_probe.get("status") == "PASS":
             tg_gpu_result = benchmark_search_command(
@@ -1997,6 +2052,7 @@ def run_gpu_native_benchmarks(
                 warmup=warmup,
                 timeout_s=command_timeout_s,
                 corpus_bytes=actual_bytes,
+                allow_no_match=allow_no_match,
             )
             tg_gpu_result["routing_backend"] = runtime_probe.get("routing_backend")
             tg_gpu_result["routing_reason"] = runtime_probe.get("routing_reason")
@@ -2077,6 +2133,7 @@ def run_gpu_native_benchmarks(
             "file_count": corpus_info["file_count"],
             "total_lines": corpus_info["total_lines"],
             "pattern_counts": corpus_info["pattern_counts"],
+            "expected_match": expected_matches,
             "rg": rg_result,
             "tg_cpu": tg_cpu_result,
             "tg_gpu": tg_gpu_result,
@@ -2521,18 +2578,20 @@ def run_advanced_gpu_native_benchmarks(
         else:
             gpu_group["ratio_vs_rg"] = None
             gpu_group["speedup_vs_rg"] = None
-        throughput_rows.append({
-            "size_label": size_label,
-            "size_bytes": size_bytes,
-            "actual_bytes": actual_bytes,
-            "pattern_count": len(throughput_patterns),
-            "file_count": throughput_info["file_count"],
-            "total_lines": throughput_info["total_lines"],
-            "line_bytes": throughput_info["line_bytes"],
-            "rg": rg_group,
-            "tg_gpu": gpu_group,
-            "gpu_stats": gpu_stats,
-        })
+        throughput_rows.append(
+            {
+                "size_label": size_label,
+                "size_bytes": size_bytes,
+                "actual_bytes": actual_bytes,
+                "pattern_count": len(throughput_patterns),
+                "file_count": throughput_info["file_count"],
+                "total_lines": throughput_info["total_lines"],
+                "line_bytes": throughput_info["line_bytes"],
+                "rg": rg_group,
+                "tg_gpu": gpu_group,
+                "gpu_stats": gpu_stats,
+            }
+        )
 
     advanced["throughput_rows"] = throughput_rows
     advanced["throughput_workload"] = {
@@ -2953,31 +3012,33 @@ def main() -> int:
     }
 
     if not tg_binary.exists():
-        payload.update({
-            "errors": [f"tg binary not found: {tg_binary}"],
-            "warnings": [],
-            "rows": [],
-            "correctness_checks": [],
-            "error_tests": {},
-            "corpus_sizes": [],
-            "throughput_target": {
-                "met": False,
-                "winning_rows": [],
-                "best_attempt": None,
-                "summary": "Benchmark did not run because the tg binary was missing.",
-            },
-            "scale_gate_summary": build_native_scale_gate_summary(
-                [],
-                correctness_checks=[],
-            ),
-            "advanced": {"enabled": args.advanced},
-            "crossover": {
-                "exists": False,
-                "first_gpu_faster_than_rg": None,
-                "summary": "Benchmark did not run because the tg binary was missing.",
-                "recommended_optimizations": GPU_TIMEOUT_OPTIMIZATIONS,
-            },
-        })
+        payload.update(
+            {
+                "errors": [f"tg binary not found: {tg_binary}"],
+                "warnings": [],
+                "rows": [],
+                "correctness_checks": [],
+                "error_tests": {},
+                "corpus_sizes": [],
+                "throughput_target": {
+                    "met": False,
+                    "winning_rows": [],
+                    "best_attempt": None,
+                    "summary": "Benchmark did not run because the tg binary was missing.",
+                },
+                "scale_gate_summary": build_native_scale_gate_summary(
+                    [],
+                    correctness_checks=[],
+                ),
+                "advanced": {"enabled": args.advanced},
+                "crossover": {
+                    "exists": False,
+                    "first_gpu_faster_than_rg": None,
+                    "summary": "Benchmark did not run because the tg binary was missing.",
+                    "recommended_optimizations": GPU_TIMEOUT_OPTIMIZATIONS,
+                },
+            }
+        )
         public_gate = build_public_managed_gpu_proof_gate(
             tg_binary_metadata=tg_binary_metadata,
             scale_gate_summary=payload["scale_gate_summary"]

--- a/benchmarks/run_gpu_native_benchmarks.py
+++ b/benchmarks/run_gpu_native_benchmarks.py
@@ -424,13 +424,11 @@ def _extract_tg_match_signatures(payload: dict[str, object]) -> list[tuple[str, 
         line_number = match.get("line_number")
         if not isinstance(line_number, int):
             line_number = 0
-        signatures.append(
-            (
-                _normalized_match_path(match.get("file")),
-                line_number,
-                _normalized_match_text(match.get("text")),
-            )
-        )
+        signatures.append((
+            _normalized_match_path(match.get("file")),
+            line_number,
+            _normalized_match_text(match.get("text")),
+        ))
     return sorted(signatures)
 
 
@@ -452,13 +450,11 @@ def _extract_rg_json_match_signatures(stdout: str) -> list[tuple[str, int, str]]
             line_number = 0
         lines = data.get("lines")
         line_text = lines.get("text") if isinstance(lines, dict) else ""
-        signatures.append(
-            (
-                _normalized_match_path(path_text),
-                line_number,
-                _normalized_match_text(line_text),
-            )
-        )
+        signatures.append((
+            _normalized_match_path(path_text),
+            line_number,
+            _normalized_match_text(line_text),
+        ))
     return sorted(signatures)
 
 
@@ -1119,9 +1115,9 @@ def run_gpu_error_tests(
             else "FAIL"
         )
 
-    nvrtc_env = _build_command_env(
-        {"TG_TEST_CUDA_BEHAVIOR": "nvrtc-failure:simulated NVRTC compile error"}
-    )
+    nvrtc_env = _build_command_env({
+        "TG_TEST_CUDA_BEHAVIOR": "nvrtc-failure:simulated NVRTC compile error"
+    })
     nvrtc_failure = _run_command(
         build_tg_gpu_search_command(tg_binary, pattern, corpus_dir, device_id),
         env=nvrtc_env,
@@ -1142,9 +1138,9 @@ def run_gpu_error_tests(
             else "FAIL"
         )
 
-    timeout_env = _build_command_env(
-        {"TG_TEST_CUDA_BEHAVIOR": f"timeout:{timeout_simulation_ms}ms"}
-    )
+    timeout_env = _build_command_env({
+        "TG_TEST_CUDA_BEHAVIOR": f"timeout:{timeout_simulation_ms}ms"
+    })
     timeout_result = _run_command(
         build_tg_gpu_search_command(tg_binary, pattern, corpus_dir, device_id),
         env=timeout_env,
@@ -1274,12 +1270,10 @@ def analyze_crossover(rows: list[dict[str, object]]) -> dict[str, object]:
         if ratio is None:
             continue
         if ratio < 1.0:
-            winners.append(
-                {
-                    "size_label": row["size_label"],
-                    "gpu_rg_ratio": ratio,
-                }
-            )
+            winners.append({
+                "size_label": row["size_label"],
+                "gpu_rg_ratio": ratio,
+            })
         if best_gap is None or ratio < best_gap["gpu_rg_ratio"]:
             best_gap = {
                 "size_label": row["size_label"],
@@ -2578,20 +2572,18 @@ def run_advanced_gpu_native_benchmarks(
         else:
             gpu_group["ratio_vs_rg"] = None
             gpu_group["speedup_vs_rg"] = None
-        throughput_rows.append(
-            {
-                "size_label": size_label,
-                "size_bytes": size_bytes,
-                "actual_bytes": actual_bytes,
-                "pattern_count": len(throughput_patterns),
-                "file_count": throughput_info["file_count"],
-                "total_lines": throughput_info["total_lines"],
-                "line_bytes": throughput_info["line_bytes"],
-                "rg": rg_group,
-                "tg_gpu": gpu_group,
-                "gpu_stats": gpu_stats,
-            }
-        )
+        throughput_rows.append({
+            "size_label": size_label,
+            "size_bytes": size_bytes,
+            "actual_bytes": actual_bytes,
+            "pattern_count": len(throughput_patterns),
+            "file_count": throughput_info["file_count"],
+            "total_lines": throughput_info["total_lines"],
+            "line_bytes": throughput_info["line_bytes"],
+            "rg": rg_group,
+            "tg_gpu": gpu_group,
+            "gpu_stats": gpu_stats,
+        })
 
     advanced["throughput_rows"] = throughput_rows
     advanced["throughput_workload"] = {
@@ -3012,33 +3004,31 @@ def main() -> int:
     }
 
     if not tg_binary.exists():
-        payload.update(
-            {
-                "errors": [f"tg binary not found: {tg_binary}"],
-                "warnings": [],
-                "rows": [],
-                "correctness_checks": [],
-                "error_tests": {},
-                "corpus_sizes": [],
-                "throughput_target": {
-                    "met": False,
-                    "winning_rows": [],
-                    "best_attempt": None,
-                    "summary": "Benchmark did not run because the tg binary was missing.",
-                },
-                "scale_gate_summary": build_native_scale_gate_summary(
-                    [],
-                    correctness_checks=[],
-                ),
-                "advanced": {"enabled": args.advanced},
-                "crossover": {
-                    "exists": False,
-                    "first_gpu_faster_than_rg": None,
-                    "summary": "Benchmark did not run because the tg binary was missing.",
-                    "recommended_optimizations": GPU_TIMEOUT_OPTIMIZATIONS,
-                },
-            }
-        )
+        payload.update({
+            "errors": [f"tg binary not found: {tg_binary}"],
+            "warnings": [],
+            "rows": [],
+            "correctness_checks": [],
+            "error_tests": {},
+            "corpus_sizes": [],
+            "throughput_target": {
+                "met": False,
+                "winning_rows": [],
+                "best_attempt": None,
+                "summary": "Benchmark did not run because the tg binary was missing.",
+            },
+            "scale_gate_summary": build_native_scale_gate_summary(
+                [],
+                correctness_checks=[],
+            ),
+            "advanced": {"enabled": args.advanced},
+            "crossover": {
+                "exists": False,
+                "first_gpu_faster_than_rg": None,
+                "summary": "Benchmark did not run because the tg binary was missing.",
+                "recommended_optimizations": GPU_TIMEOUT_OPTIMIZATIONS,
+            },
+        })
         public_gate = build_public_managed_gpu_proof_gate(
             tg_binary_metadata=tg_binary_metadata,
             scale_gate_summary=payload["scale_gate_summary"]

--- a/tests/unit/test_gpu_benchmark_scale_contracts.py
+++ b/tests/unit/test_gpu_benchmark_scale_contracts.py
@@ -1987,20 +1987,18 @@ def test_gpu_bottleneck_advisory_should_not_change_promotion_summary():
         }
         for size_label in ("1GB", "5GB")
     ]
-    advisory_summary = module.summarize_gpu_pipeline_bottlenecks(
-        [
-            module.extract_gpu_pipeline_breakdown(
-                {
-                    "pipeline": {
-                        "host_file_read_time_ms": 1000.0,
-                        "kernel_time_ms": 1.0,
-                        "wall_time_ms": 1001.0,
-                    }
-                },
-                source="scale_native_stats",
-            )
-        ]
-    )
+    advisory_summary = module.summarize_gpu_pipeline_bottlenecks([
+        module.extract_gpu_pipeline_breakdown(
+            {
+                "pipeline": {
+                    "host_file_read_time_ms": 1000.0,
+                    "kernel_time_ms": 1.0,
+                    "wall_time_ms": 1001.0,
+                }
+            },
+            source="scale_native_stats",
+        )
+    ])
 
     recommendation = module.analyze_gpu_auto_recommendation(
         rows,

--- a/tests/unit/test_gpu_benchmark_scale_contracts.py
+++ b/tests/unit/test_gpu_benchmark_scale_contracts.py
@@ -1542,6 +1542,142 @@ def test_run_gpu_native_correctness_should_compare_direct_rg_identity(monkeypatc
     assert result["gpu_total_matches"] == 1
 
 
+def test_run_gpu_native_correctness_should_accept_direct_rg_no_match_identity(
+    monkeypatch, tmp_path
+):
+    module = _load_script_module(
+        "run_gpu_native_benchmarks_rg_identity_no_match_correctness",
+        "benchmarks/run_gpu_native_benchmarks.py",
+    )
+    tg_binary = tmp_path / "tg.exe"
+    corpus_dir = tmp_path / "corpus"
+    tg_binary.write_text("binary", encoding="utf-8")
+    corpus_dir.mkdir()
+
+    def _fake_run_command(command, **_kwargs):
+        command_text = " ".join(str(part) for part in command)
+        if "--json" in command_text and "--cpu" in command_text:
+            stdout = (
+                '{"routing_backend":"NativeCpuBackend","sidecar_used":false,'
+                '"total_matches":0,"total_files":0,"matches":[]}'
+            )
+            return module.subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+        if "--json" in command_text and "--gpu-device-ids" in command_text:
+            stdout = (
+                '{"routing_backend":"NativeGpuBackend","sidecar_used":false,'
+                '"total_matches":0,"total_files":0,"matches":[]}'
+            )
+            return module.subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+        return module.subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run_command", _fake_run_command)
+
+    result = module.run_correctness_check(
+        tg_binary=tg_binary,
+        rg_binary="rg",
+        corpus_dir=corpus_dir,
+        pattern="NO_MATCH_SENTINEL",
+        device_id=0,
+        env={},
+        timeout_s=5,
+    )
+
+    assert result["status"] == "PASS"
+    assert result["matches_equal"] is True
+    assert result["files_equal"] is True
+    assert result["rg_matches_equal"] is True
+    assert result["rg_files_equal"] is True
+    assert result["rg_match_identity_equal"] is True
+    assert result["rg_total_matches"] == 0
+    assert result["gpu_total_matches"] == 0
+
+
+def test_run_gpu_native_benchmark_search_command_accepts_opt_in_no_match(monkeypatch, tmp_path):
+    module = _load_script_module(
+        "run_gpu_native_benchmarks_no_match_timing",
+        "benchmarks/run_gpu_native_benchmarks.py",
+    )
+
+    def _fake_run_command(command, **_kwargs):
+        return module.subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run_command", _fake_run_command)
+
+    strict = module.benchmark_search_command(
+        ["rg", "NO_MATCH", str(tmp_path)],
+        env={},
+        runs=1,
+        warmup=0,
+        timeout_s=5,
+        corpus_bytes=100,
+    )
+    allowed = module.benchmark_search_command(
+        ["rg", "NO_MATCH", str(tmp_path)],
+        env={},
+        runs=1,
+        warmup=1,
+        timeout_s=5,
+        corpus_bytes=100,
+        allow_no_match=True,
+    )
+
+    assert strict["status"] == "FAIL"
+    assert strict["allow_no_match"] is False
+    assert allowed["status"] == "PASS"
+    assert allowed["allow_no_match"] is True
+    assert allowed["no_match_exit_accepted"] is True
+
+
+def test_run_gpu_native_benchmark_command_group_accepts_opt_in_no_match(monkeypatch, tmp_path):
+    module = _load_script_module(
+        "run_gpu_native_benchmarks_no_match_group_timing",
+        "benchmarks/run_gpu_native_benchmarks.py",
+    )
+
+    def _fake_run_command(command, **_kwargs):
+        return module.subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run_command", _fake_run_command)
+
+    result = module.benchmark_command_group(
+        [["rg", "NO_MATCH", str(tmp_path)]],
+        env={},
+        runs=1,
+        warmup=1,
+        timeout_s=5,
+        workload_bytes=100,
+        allow_no_match=True,
+    )
+
+    assert result["status"] == "PASS"
+    assert result["allow_no_match"] is True
+    assert result["no_match_exit_accepted"] is True
+
+
+def test_python_gpu_benchmark_search_command_accepts_opt_in_no_match(monkeypatch, tmp_path):
+    module = _load_script_module(
+        "run_gpu_benchmarks_no_match_timing",
+        "benchmarks/run_gpu_benchmarks.py",
+    )
+
+    def _fake_run_command(command, **_kwargs):
+        return module.subprocess.CompletedProcess(command, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_run_command", _fake_run_command)
+
+    result = module.benchmark_search_command(
+        ["rg", "NO_MATCH", str(tmp_path)],
+        env={},
+        runs=1,
+        warmup=1,
+        allow_no_match=True,
+    )
+
+    assert result["status"] == "PASS"
+    assert result["allow_no_match"] is True
+    assert result["no_match_exit_accepted"] is True
+
+
 def test_run_gpu_native_benchmarks_should_not_time_sidecar_routed_gpu_rows(monkeypatch, tmp_path):
     module = _load_script_module(
         "run_gpu_native_benchmarks_sidecar_rows",
@@ -1851,18 +1987,20 @@ def test_gpu_bottleneck_advisory_should_not_change_promotion_summary():
         }
         for size_label in ("1GB", "5GB")
     ]
-    advisory_summary = module.summarize_gpu_pipeline_bottlenecks([
-        module.extract_gpu_pipeline_breakdown(
-            {
-                "pipeline": {
-                    "host_file_read_time_ms": 1000.0,
-                    "kernel_time_ms": 1.0,
-                    "wall_time_ms": 1001.0,
-                }
-            },
-            source="scale_native_stats",
-        )
-    ])
+    advisory_summary = module.summarize_gpu_pipeline_bottlenecks(
+        [
+            module.extract_gpu_pipeline_breakdown(
+                {
+                    "pipeline": {
+                        "host_file_read_time_ms": 1000.0,
+                        "kernel_time_ms": 1.0,
+                        "wall_time_ms": 1001.0,
+                    }
+                },
+                source="scale_native_stats",
+            )
+        ]
+    )
 
     recommendation = module.analyze_gpu_auto_recommendation(
         rows,


### PR DESCRIPTION
## Summary
- accept exit 1 only for benchmark timing rows that explicitly opt into no-match semantics
- record allow_no_match and no_match_exit_accepted in GPU benchmark artifacts
- add native direct-rg no-match identity coverage and helper tests for native/Python GPU benchmark timing

## Tests
- uv run ruff check benchmarks/run_gpu_native_benchmarks.py benchmarks/run_gpu_benchmarks.py tests/unit/test_gpu_benchmark_scale_contracts.py
- uv run pytest tests/unit/test_gpu_benchmark_correctness.py tests/unit/test_gpu_benchmark_scale_contracts.py -q