### PR TITLE
fix: harden cold path attribution evidence

### DIFF
--- a/benchmarks/run_cold_path_attribution.py
+++ b/benchmarks/run_cold_path_attribution.py
@@ -19,8 +19,13 @@ if str(BENCHMARKS_DIR) not in sys.path:
 
 from run_benchmarks import (  # noqa: E402
     SCENARIOS,
+    benchmark_binary_warnings,
+    benchmark_claim_blockers,
+    benchmark_launcher_warnings,
     build_tg_benchmark_cmd_with_mode,
+    classify_tg_launcher_command,
     collect_timing_samples,
+    emit_benchmark_claim_blockers,
     generate_test_data,
     resolve_rg_binary,
     resolve_tg_binary_with_source,
@@ -47,8 +52,10 @@ def _scenario_commands(
     bench_dir: Path,
     tg_binary: Path,
     launcher_modes: list[str],
-) -> list[dict[str, object]]:
+) -> tuple[list[dict[str, object]], dict[str, str], list[str]]:
     rows: list[dict[str, object]] = []
+    launcher_command_kinds: dict[str, str] = {}
+    warnings: list[str] = []
     rg_binary = resolve_rg_binary()
 
     for scenario in SCENARIOS:
@@ -69,6 +76,15 @@ def _scenario_commands(
                 return_mode=True,
                 launcher_mode=launcher_mode,
             )
+            command_kind = classify_tg_launcher_command(tg_cmd)
+            launcher_command_kinds[resolved_mode] = command_kind
+            row_warnings = benchmark_launcher_warnings(
+                command_kind=command_kind,
+                launcher_mode=resolved_mode,
+            )
+            for warning in row_warnings:
+                if warning not in warnings:
+                    warnings.append(warning)
             tg_time_s, tg_samples_s = collect_timing_samples(tg_cmd)
             trace_path = (
                 bench_dir / f"{scenario['name'].replace(' ', '_').lower()}-{launcher_mode}.json"
@@ -87,14 +103,16 @@ def _scenario_commands(
                 "scenario": scenario["name"],
                 "launcher_mode": launcher_mode,
                 "resolved_launcher_mode": resolved_mode,
+                "tg_launcher_command_kind": command_kind,
                 "rg_time_s": rg_time_s,
                 "rg_samples_s": rg_samples_s,
                 "tg_time_s": tg_time_s,
                 "tg_samples_s": tg_samples_s,
                 "phase_trace": phase_trace,
+                "warnings": row_warnings,
             })
 
-    return rows
+    return rows, launcher_command_kinds, warnings
 
 
 def _parse_phase_trace(stdout: str, trace_path: Path | None = None) -> object | None:
@@ -144,19 +162,39 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Launcher mode to compare. May be repeated. Defaults to the full cold-path set.",
     )
+    parser.add_argument(
+        "--allow-claim-unsafe-launcher",
+        action="store_true",
+        help=(
+            "Allow exploratory attribution runs even when launcher provenance is unsafe "
+            "for benchmark claims, such as a stale in-tree native tg binary."
+        ),
+    )
     args = parser.parse_args(argv)
 
     tg_binary, tg_binary_source = resolve_tg_binary_with_source(args.binary)
+    warnings = benchmark_binary_warnings(tg_binary)
+    for warning in warnings:
+        print(f"[warning] {warning}", file=sys.stderr)
+    blockers = benchmark_claim_blockers(warnings)
+    if blockers and not args.allow_claim_unsafe_launcher:
+        emit_benchmark_claim_blockers(blockers)
+        return 2
+
     bench_dir = resolve_bench_data_dir()
     bench_dir.mkdir(parents=True, exist_ok=True)
     generate_test_data(str(bench_dir), num_files=2, lines_per_file=2_000_000)
 
     launcher_modes = _unique_launcher_modes(args.launcher_mode)
-    rows = _scenario_commands(
+    rows, launcher_command_kinds, launcher_warnings = _scenario_commands(
         bench_dir=bench_dir,
         tg_binary=tg_binary,
         launcher_modes=launcher_modes,
     )
+    for warning in launcher_warnings:
+        if warning not in warnings:
+            warnings.append(warning)
+            print(f"[warning] {warning}", file=sys.stderr)
 
     payload = {
         "artifact": "bench_cold_path_attribution",
@@ -172,6 +210,7 @@ def main(argv: list[str] | None = None) -> int:
             "machine": platform.machine().lower(),
             "python_version": platform.python_version(),
             "tg_binary_source": tg_binary_source,
+            "tg_launcher_command_kinds": launcher_command_kinds,
         },
         "host_provenance": {
             "benchmark_host_key": benchmark_host_key({
@@ -183,8 +222,10 @@ def main(argv: list[str] | None = None) -> int:
             "machine": platform.machine().lower(),
             "python_version": platform.python_version(),
             "tg_binary_source": tg_binary_source,
+            "tg_launcher_command_kinds": launcher_command_kinds,
         },
         "launcher_modes": launcher_modes,
+        "warnings": warnings,
         "rows": rows,
     }
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,6 +9,7 @@ These scripts and artifact paths are the accepted benchmark surface for the curr
 | Surface | Script | Default artifact |
 | --- | --- | --- |
 | End-to-end CLI text search | `benchmarks/run_benchmarks.py` | `artifacts/bench_run_benchmarks.json` |
+| Cold-path startup/control-plane attribution | `benchmarks/run_cold_path_attribution.py` | `artifacts/bench_cold_path_attribution.json` |
 | Native CPU large-file / many-file search | `benchmarks/run_native_cpu_benchmarks.py` | `artifacts/bench_run_native_cpu_benchmarks.json` |
 | Host-local CLI tool comparison | `benchmarks/run_tool_comparison_benchmarks.py` | `artifacts/bench_tool_comparison.json` |
 | Repeated-query / hot-cache search | `benchmarks/run_hot_query_benchmarks.py` | `artifacts/bench_hot_query_benchmarks.json` |
@@ -46,6 +47,8 @@ Environment blocks should at minimum record:
 - `python_version` when Python orchestrates the benchmark
 
 For `run_benchmarks.py`, the environment block should also record `tg_launcher_mode` and `tg_launcher_command_kind` so cold-path comparisons stay tied to both the configured entrypoint experiment and the concrete command kind being timed. This prevents native-exe, `.cmd` shim, `uv`, or Python-module overhead from being combined into one search-speed claim. Benchmark artifacts should also record `tg_binary_kind`, `tg_binary_version`, `tg_binary_expected_version`, and `tg_binary_version_status` so stale in-tree native binaries are visible. A top-level `warnings` array is required when the timed `tg` entrypoint is a shim/interpreter route. A stale in-tree native tg binary blocks claim-quality benchmark scripts by default; pass `--allow-claim-unsafe-launcher` only for exploratory timing.
+
+For `run_cold_path_attribution.py`, every row should record the requested `launcher_mode`, `resolved_launcher_mode`, and `tg_launcher_command_kind`, plus row-local `warnings` when the timed command includes a shim/interpreter route. The top-level `environment.tg_launcher_command_kinds` map should summarize the concrete command kind for each resolved launcher mode, and the top-level `warnings` array should aggregate binary and launcher warnings. Stale in-tree native binaries block claim-quality cold-path attribution by default; pass `--allow-claim-unsafe-launcher` only when the output is explicitly exploratory.
 
 For `run_repo_retrieval_benchmarks.py`, the metrics block should expose retrieval-quality and context-efficiency keys explicitly:
 

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -10005,6 +10005,19 @@ def test_run_cold_path_attribution_should_write_output(monkeypatch, tmp_path):
         "resolve_tg_binary_with_source",
         lambda binary=None: (tmp_path / "tg.exe", "explicit_arg"),
     )
+
+    def fake_build_tg_cmd(tg_args, *, binary=None, return_mode=False, launcher_mode="auto"):
+        if launcher_mode == "python_module_launcher":
+            return [
+                str(tmp_path / "python.exe"),
+                "-m",
+                "tensor_grep",
+                "search",
+                *tg_args,
+            ], "python_module_launcher"
+        return [str(binary or tmp_path / "tg.exe"), "search", *tg_args], launcher_mode
+
+    monkeypatch.setattr(module, "build_tg_benchmark_cmd_with_mode", fake_build_tg_cmd)
     timing_cmds: list[list[str]] = []
     monkeypatch.setattr(
         module,
@@ -10032,8 +10045,17 @@ def test_run_cold_path_attribution_should_write_output(monkeypatch, tmp_path):
     assert exit_code == 0
     assert payload["artifact"] == "bench_cold_path_attribution"
     assert payload["suite"] == "cold_path_attribution"
+    assert payload["warnings"]
+    assert "python_module" in payload["warnings"][0]
+    assert payload["environment"]["tg_launcher_command_kinds"] == {
+        "explicit_binary": "native_exe",
+        "discovered_cli_binary": "native_exe",
+        "python_module_launcher": "python_module",
+    }
     assert {row["launcher_mode"] for row in payload["rows"]} == set(module.DEFAULT_LAUNCHER_MODES)
     assert payload["rows"][0]["name"] == "1. Simple String Match [explicit_binary]"
+    assert payload["rows"][0]["tg_launcher_command_kind"] == "native_exe"
+    assert payload["rows"][0]["warnings"] == []
     assert payload["rows"][0]["phase_trace"] == {"phase": "startup", "marker": "trace-file"}
     assert all(str(bench_dir) in cmd for cmd in timing_cmds)
     assert generated == [(str(bench_dir), 2, 2_000_000)]
@@ -10125,6 +10147,86 @@ def test_run_cold_path_attribution_should_drop_stale_trace_files(monkeypatch, tm
     assert payload["rows"][0]["phase_trace"] is None
 
 
+def test_run_cold_path_attribution_should_warn_for_non_native_launcher(monkeypatch, tmp_path):
+    module = _load_script_module(
+        "run_cold_path_attribution_launcher_warning_script",
+        "benchmarks/run_cold_path_attribution.py",
+    )
+
+    bench_dir = tmp_path / "bench_data_root"
+    python_launcher = tmp_path / "python.exe"
+    python_launcher.write_text("python\n", encoding="utf-8")
+    monkeypatch.setattr(module.sys, "executable", str(python_launcher))
+    monkeypatch.setattr(
+        module,
+        "SCENARIOS",
+        [
+            {
+                "name": "1. Simple String Match",
+                "rg_args": ["rg", "ERROR", "bench_data"],
+                "tg_args": ["tg", "search", "ERROR", "bench_data"],
+            }
+        ],
+    )
+    monkeypatch.setattr(module, "resolve_rg_binary", lambda: "rg")
+    monkeypatch.setattr(module, "resolve_bench_data_dir", lambda: bench_dir)
+    monkeypatch.setattr(module, "generate_test_data", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module,
+        "resolve_tg_binary_with_source",
+        lambda binary=None: (tmp_path / "tg.exe", "explicit_arg"),
+    )
+    monkeypatch.setattr(module, "collect_timing_samples", lambda *args, **kwargs: (0.1, [0.1]))
+    monkeypatch.setattr(module, "run_cmd_capture", lambda *args, **kwargs: (0, ""))
+
+    output_path = tmp_path / "cold-path.json"
+    exit_code = module.main([
+        "--output",
+        str(output_path),
+        "--launcher-mode",
+        "python_module_launcher",
+    ])
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert payload["environment"]["tg_launcher_command_kinds"] == {
+        "python_module_launcher": "python_module"
+    }
+    assert payload["warnings"]
+    assert "python_module" in payload["warnings"][0]
+    assert payload["rows"][0]["tg_launcher_command_kind"] == "python_module"
+    assert payload["rows"][0]["warnings"] == payload["warnings"]
+
+
+def test_run_cold_path_attribution_should_refuse_stale_binary_by_default(
+    monkeypatch, tmp_path, capsys
+):
+    module = _load_script_module(
+        "run_cold_path_attribution_stale_binary_script",
+        "benchmarks/run_cold_path_attribution.py",
+    )
+    tg_binary = tmp_path / "repo" / "rust_core" / "target" / "release" / "tg.exe"
+    tg_binary.parent.mkdir(parents=True, exist_ok=True)
+    tg_binary.write_text("stale\n", encoding="utf-8")
+    output_path = tmp_path / "cold-path.json"
+    monkeypatch.setattr(
+        module,
+        "resolve_tg_binary_with_source",
+        lambda binary=None: (tg_binary, "default_binary_path"),
+    )
+    monkeypatch.setattr(
+        module,
+        "benchmark_binary_warnings",
+        lambda _binary: ["tensor-grep benchmark warning: stale in-tree native tg binary"],
+    )
+
+    exit_code = module.main(["--output", str(output_path)])
+
+    assert exit_code == 2
+    assert not output_path.exists()
+    assert "refusing claim-quality benchmark" in capsys.readouterr().err
+
+
 def test_run_benchmarks_should_record_host_provenance(monkeypatch, tmp_path):
     module = _load_script_module(
         "run_benchmarks_script_host_provenance",
@@ -10186,18 +10288,24 @@ def test_run_cold_path_attribution_should_record_host_provenance(monkeypatch, tm
     monkeypatch.setattr(
         module,
         "_scenario_commands",
-        lambda **kwargs: [
-            {
-                "scenario": "1. Simple String Match",
-                "launcher_mode": "explicit_binary",
-                "resolved_launcher_mode": "explicit_binary",
-                "rg_time_s": 0.1,
-                "rg_samples_s": [0.1, 0.1, 0.1],
-                "tg_time_s": 0.1,
-                "tg_samples_s": [0.1, 0.1, 0.1],
-                "phase_trace": None,
-            }
-        ],
+        lambda **kwargs: (
+            [
+                {
+                    "scenario": "1. Simple String Match",
+                    "launcher_mode": "explicit_binary",
+                    "resolved_launcher_mode": "explicit_binary",
+                    "tg_launcher_command_kind": "native_exe",
+                    "rg_time_s": 0.1,
+                    "rg_samples_s": [0.1, 0.1, 0.1],
+                    "tg_time_s": 0.1,
+                    "tg_samples_s": [0.1, 0.1, 0.1],
+                    "phase_trace": None,
+                    "warnings": [],
+                }
+            ],
+            {"explicit_binary": "native_exe"},
+            [],
+        ),
     )
 
     output_path = tmp_path / "bench_cold.json"
@@ -10208,3 +10316,6 @@ def test_run_cold_path_attribution_should_record_host_provenance(monkeypatch, tm
     assert payload["benchmark_host_key"] == module.benchmark_host_key(payload["environment"])
     assert payload["host_provenance"]["benchmark_host_key"] == payload["benchmark_host_key"]
     assert payload["host_provenance"]["tg_binary_source"] == "explicit_arg"
+    assert payload["host_provenance"]["tg_launcher_command_kinds"] == {
+        "explicit_binary": "native_exe"
+    }


### PR DESCRIPTION
## Summary
- record launcher command kind per cold-path attribution row and in environment provenance
- aggregate shim/Python launcher warnings so startup claims cannot mix native and wrapper timing
- block stale in-tree native binaries by default unless the run is explicitly exploratory

## Research / planning
- Exa: Rust CLI startup/process-spawn research supports separating process/launcher overhead from search engine timing before making performance claims.
- Thinktank/subagents: recommended #48A as measurement and attribution guardrails before attempting startup optimization.

## Validation
- uv run ruff check benchmarks/run_cold_path_attribution.py tests/unit/test_benchmark_scripts.py
- uv run ruff format --check --preview benchmarks/run_cold_path_attribution.py tests/unit/test_benchmark_scripts.py
- uv run pytest tests/unit/test_benchmark_scripts.py tests/unit/test_benchmark_docs.py -q -k "cold_path_attribution or benchmark"

Refs #48
