### PR TITLE
fix: prime checkpoint discovery caches

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -261,16 +261,76 @@ def _write_cached_checkpoint_index_paths(
     cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
-def _invalidate_discovery_caches_for_root(root: Path) -> None:
-    candidates = [root, *root.parents[: _DISCOVERY_MAX_DEPTH + 1]]
-    for candidate in candidates:
-        cache_path = _discovery_cache_path(candidate)
+def _valid_cached_checkpoint_index_paths_from_entry(entry: Any) -> set[Path]:
+    if not isinstance(entry, dict):
+        return set()
+    fingerprints = entry.get("index_paths")
+    if not isinstance(fingerprints, list):
+        return set()
+
+    index_paths: set[Path] = set()
+    for fingerprint in fingerprints:
+        if not isinstance(fingerprint, dict):
+            continue
+        raw_path = fingerprint.get("path")
+        if not isinstance(raw_path, str):
+            continue
+        index_path = Path(raw_path)
+        if _fingerprint_index_path(index_path) is not None:
+            index_paths.add(index_path)
+    return index_paths
+
+
+def _bounded_discovery_cache_roots_for_checkpoint(root: Path) -> list[Path]:
+    cache_roots = [root]
+    for candidate in root.parents:
+        if candidate.parent == candidate:
+            break
         try:
-            cache_path.unlink()
-        except FileNotFoundError:
+            distance = len(root.relative_to(candidate).parts)
+        except ValueError:
             continue
-        except OSError:
-            continue
+        if distance > _DISCOVERY_MAX_DEPTH:
+            break
+        cache_roots.append(candidate)
+    return cache_roots
+
+
+def _prime_bounded_discovery_caches_for_root(root: Path) -> None:
+    index_path = _index_path(root)
+    if not index_path.exists():
+        return
+    key = _discovery_cache_key(full=False, max_depth=_DISCOVERY_MAX_DEPTH)
+    for search_root in _bounded_discovery_cache_roots_for_checkpoint(root):
+        cache_path = _discovery_cache_path(search_root)
+        payload: dict[str, Any] = {"version": _DISCOVERY_CACHE_VERSION, "entries": {}}
+        try:
+            existing = json.loads(cache_path.read_text(encoding="utf-8"))
+            if isinstance(existing, dict) and existing.get("version") == _DISCOVERY_CACHE_VERSION:
+                payload = existing
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            pass
+
+        entries = payload.get("entries")
+        if not isinstance(entries, dict):
+            entries = {}
+            payload["entries"] = entries
+
+        index_paths = _valid_cached_checkpoint_index_paths_from_entry(entries.get(key))
+        index_paths.add(index_path)
+        entries[key] = {
+            "created_at_epoch_s": time.time(),
+            "index_paths": [
+                fingerprint
+                for cached_index_path in sorted(index_paths)
+                if (fingerprint := _fingerprint_index_path(cached_index_path)) is not None
+            ],
+        }
+        for entry_key in list(entries):
+            if isinstance(entry_key, str) and entry_key.startswith("full:"):
+                del entries[entry_key]
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
 def _load_index(root: Path) -> list[CheckpointRecord]:
@@ -426,7 +486,7 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
         ),
     )
     _write_index(root, records)
-    _invalidate_discovery_caches_for_root(root)
+    _prime_bounded_discovery_caches_for_root(root)
     return result
 
 
@@ -583,6 +643,19 @@ def discover_nearby_checkpoint_scopes(path: str = ".") -> list[CheckpointScopeRe
     return _scopes_from_index_paths(_nearby_checkpoint_index_paths(search_root))
 
 
+def discover_cached_checkpoint_scopes(path: str = ".") -> list[CheckpointScopeResult]:
+    resolved = Path(path).expanduser().resolve()
+    search_root = resolved if resolved.is_dir() else resolved.parent
+    index_paths = _read_cached_checkpoint_index_paths(
+        search_root,
+        full=False,
+        max_depth=_DISCOVERY_MAX_DEPTH,
+    )
+    if index_paths is None:
+        return []
+    return _scopes_from_index_paths(index_paths)
+
+
 def resolve_latest_checkpoint(path: str = ".") -> CheckpointLatestResult:
     scope = describe_checkpoint_scope(path)
     if scope.checkpoints:
@@ -595,9 +668,21 @@ def resolve_latest_checkpoint(path: str = ".") -> CheckpointLatestResult:
 
     discovered = [
         child_scope
-        for child_scope in discover_nearby_checkpoint_scopes(path)
+        for child_scope in [
+            *discover_nearby_checkpoint_scopes(path),
+            *discover_cached_checkpoint_scopes(path),
+        ]
         if child_scope.checkpoints
     ]
+    deduped: list[CheckpointScopeResult] = []
+    seen_roots: set[str] = set()
+    for child_scope in discovered:
+        key = child_scope.root.lower() if os.name == "nt" else child_scope.root
+        if key in seen_roots:
+            continue
+        seen_roots.add(key)
+        deduped.append(child_scope)
+    discovered = deduped
     if not discovered:
         resolved = Path(path).expanduser().resolve()
         raise FileNotFoundError(f"No checkpoints found under {resolved}.")
@@ -684,7 +769,6 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
             if not any(directory.iterdir()):
                 directory.rmdir()
 
-    _invalidate_discovery_caches_for_root(root)
     return CheckpointUndoResult(
         checkpoint_id=checkpoint_id,
         mode=mode,

--- a/tests/unit/test_checkpoint_cli.py
+++ b/tests/unit/test_checkpoint_cli.py
@@ -335,7 +335,47 @@ def test_checkpoint_discover_reuses_valid_index_cache(
     assert second[0].checkpoints[0].checkpoint_id == checkpoint.checkpoint_id
 
 
-def test_checkpoint_create_invalidates_parent_discovery_cache(tmp_path: Path) -> None:
+def test_checkpoint_create_primes_parent_discovery_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tensor_grep.cli import checkpoint_store
+
+    workspace = tmp_path / "workspace"
+    project = workspace / "group" / "project"
+    project.mkdir(parents=True)
+    (project / "sample.py").write_text("print('before')\n", encoding="utf-8")
+
+    checkpoint = checkpoint_store.create_checkpoint(str(project))
+    cache_path = checkpoint_store._discovery_cache_path(workspace.resolve())
+    assert cache_path.exists()
+
+    def fail_bounded_walk(*_args, **_kwargs):
+        raise AssertionError("primed checkpoint discovery should avoid tree walk")
+
+    monkeypatch.setattr(checkpoint_store, "_bounded_checkpoint_index_paths", fail_bounded_walk)
+
+    scopes = checkpoint_store.discover_checkpoint_scopes(str(workspace))
+
+    assert [scope.root for scope in scopes] == [str(project.resolve())]
+    assert scopes[0].checkpoints[0].checkpoint_id == checkpoint.checkpoint_id
+
+
+def test_checkpoint_discovery_cache_roots_never_include_filesystem_anchor(
+    tmp_path: Path,
+) -> None:
+    from tensor_grep.cli import checkpoint_store
+
+    anchor = Path(tmp_path.anchor)
+    shallow_root = anchor / "tg-cache-root-a" / "tg-cache-root-b" / "tg-cache-root-c"
+
+    cache_roots = checkpoint_store._bounded_discovery_cache_roots_for_checkpoint(shallow_root)
+
+    assert anchor not in cache_roots
+    assert all(candidate.parent != candidate for candidate in cache_roots)
+
+
+def test_checkpoint_create_merges_parent_discovery_cache(tmp_path: Path) -> None:
     from tensor_grep.cli import checkpoint_store
 
     workspace = tmp_path / "workspace"
@@ -351,9 +391,15 @@ def test_checkpoint_create_invalidates_parent_discovery_cache(tmp_path: Path) ->
     second_project = workspace / "second"
     second_project.mkdir()
     (second_project / "sample.py").write_text("print('second')\n", encoding="utf-8")
-    checkpoint_store.create_checkpoint(str(second_project))
+    second_checkpoint = checkpoint_store.create_checkpoint(str(second_project))
 
-    assert not cache_path.exists()
+    scopes = checkpoint_store.discover_checkpoint_scopes(str(workspace))
+    assert cache_path.exists()
+    assert [scope.root for scope in scopes] == [
+        str(project.resolve()),
+        str(second_project.resolve()),
+    ]
+    assert scopes[1].checkpoints[0].checkpoint_id == second_checkpoint.checkpoint_id
 
 
 def test_checkpoint_list_auto_discovery_does_not_use_unbounded_rglob(
@@ -503,6 +549,38 @@ def test_checkpoint_undo_last_restores_latest_child_scope_checkpoint(tmp_path: P
     assert restored["checkpoint_id"] == latest_checkpoint_id
     assert restored["root"] == str(project.resolve())
     assert source_file.read_text(encoding="utf-8") == "print('middle')\n"
+
+
+def test_checkpoint_undo_last_uses_cached_nested_scope_without_tree_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tensor_grep.cli import checkpoint_store
+
+    workspace = tmp_path / "workspace"
+    project = workspace / "group" / "project"
+    project.mkdir(parents=True)
+    source_file = project / "sample.py"
+    source_file.write_text("print('before')\n", encoding="utf-8")
+
+    runner = CliRunner()
+    create_result = runner.invoke(app, ["checkpoint", "create", str(project), "--json"])
+    assert create_result.exit_code == 0
+    checkpoint_id = json.loads(create_result.stdout)["checkpoint_id"]
+    source_file.write_text("print('after')\n", encoding="utf-8")
+
+    def fail_bounded_walk(*_args, **_kwargs):
+        raise AssertionError("undo --last should use cached discovery instead of tree walk")
+
+    monkeypatch.setattr(checkpoint_store, "_bounded_checkpoint_index_paths", fail_bounded_walk)
+
+    undo_result = runner.invoke(app, ["checkpoint", "undo", "--last", str(workspace), "--json"])
+
+    assert undo_result.exit_code == 0
+    restored = json.loads(undo_result.stdout)
+    assert restored["checkpoint_id"] == checkpoint_id
+    assert restored["root"] == str(project.resolve())
+    assert source_file.read_text(encoding="utf-8") == "print('before')\n"
 
 
 def test_checkpoint_undo_last_rejects_broad_path_with_multiple_child_scopes(


### PR DESCRIPTION
## Summary
- prime bounded parent checkpoint-discovery caches when a checkpoint is created
- merge cache entries so multiple child checkpoint scopes survive later creates
- make `checkpoint undo --last PATH` resolve direct, nearby, or cached scopes without triggering recursive discovery
- keep stale/nonexistent cached index paths filtered before reuse

## Evidence ledger
- Exa/doc research: Python pathlib docs warn recursive globbing visits every directory in large trees; PEP 471 notes reducing directory/stat calls is material on Windows, supporting cache-first discovery over repeated recursive walks
- Thinktank/subagent: Meitner recommended treating `--discover` and unscoped `undo --last` as cache/invalidator problems, not broader checkpoint architecture work
- Gemini: bounded read-only diff audit returned `GEMINI_AUDIT_RESULT: PASS`; only naming cleanup requested, applied before commit
- Local tests:
  - `uv run pytest tests/unit/test_checkpoint_cli.py -q -p no:cacheprovider` -> 23 passed
  - `uv run pytest tests/unit/test_checkpoint_cli.py tests/unit/test_apply_policy.py tests/unit/test_trust_parity.py -q -p no:cacheprovider` -> 59 passed
  - `uv run ruff check src/tensor_grep/cli/checkpoint_store.py tests/unit/test_checkpoint_cli.py` -> pass
  - `uv run ruff format --check --preview src/tensor_grep/cli/checkpoint_store.py tests/unit/test_checkpoint_cli.py` -> pass
  - `git diff --check` -> pass

## Scope notes
- This does not change checkpoint snapshot/restore semantics.
- `--discover-full` remains the explicit exhaustive path; the new priming targets the bounded default `--discover` and cached `undo --last` resolution.