### PR TITLE
fix: align mcp server version and framing

### DIFF
--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -1386,6 +1386,12 @@ These examples reuse the existing public contracts above; they are not separate 
 
 The MCP server exposes stable tool contracts layered on top of the native CLI outputs.
 
+`serverInfo.name` is `tensor-grep` and `serverInfo.version` tracks the installed
+`tensor-grep` package version, not the bundled MCP SDK version. Stdio MCP messages
+are newline-delimited JSON-RPC per the MCP transport spec. The server also accepts
+legacy `Content-Length` JSON-RPC frames defensively and still writes newline-delimited
+JSON-RPC responses to stdout.
+
 PyPI wheel installs can serve simple `tg_rewrite_plan(...)` and `tg_rewrite_apply(...)` through the packaged PyO3 Rust extension even when a standalone native `tg` binary is unavailable. Rewrite diff, checkpoint, audit, validation, verify, and other native-only rewrite options still require a standalone native `tg` binary via `TG_NATIVE_TG_BINARY` or an in-tree/release build.
 
 Call `tg_mcp_capabilities()` first when a client might be running in a PyPI wheel, sandbox, or other runtime where the standalone native binary is uncertain.

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -2,11 +2,20 @@ import json
 import os
 import re
 import subprocess
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from functools import lru_cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+from io import TextIOWrapper
 from pathlib import Path
 from typing import Any
 
+import anyio
+from mcp import types
 from mcp.server.fastmcp import FastMCP
+from mcp.shared.message import SessionMessage
 
 from tensor_grep.cli.main import _build_rulesets_payload, _run_ast_scan_payload
 from tensor_grep.cli.repo_map import (
@@ -29,8 +38,21 @@ from tensor_grep.core.pipeline import Pipeline
 from tensor_grep.core.result import SearchResult
 from tensor_grep.io.directory_scanner import DirectoryScanner
 
+
+def _mcp_server_version() -> str:
+    try:
+        return package_version("tensor-grep")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def _apply_mcp_server_metadata(server: FastMCP) -> None:
+    server._mcp_server.version = _mcp_server_version()
+
+
 # Initialize the FastMCP server
 mcp = FastMCP("tensor-grep")
+_apply_mcp_server_metadata(mcp)
 
 _REWRITE_ROUTING_BACKEND = "AstBackend"
 _REWRITE_ROUTING_REASON = "ast-native"
@@ -2745,6 +2767,88 @@ def tg_rewrite_diff(pattern: str, replacement: str, lang: str, path: str = ".") 
     return _execute_rewrite_diff_command(command)
 
 
+async def _read_stdio_message_payload(stdin: anyio.AsyncFile[str]) -> str | None:
+    line = await stdin.readline()
+    if line == "":
+        return None
+    if not line.strip():
+        return ""
+    if not line.lower().startswith("content-length:"):
+        return line
+
+    try:
+        content_length = int(line.split(":", 1)[1].strip())
+    except (IndexError, ValueError):
+        return line
+    while True:
+        header = await stdin.readline()
+        if header == "":
+            return None
+        if not header.strip():
+            break
+    return await stdin.read(content_length)
+
+
+@asynccontextmanager
+async def _stdio_server_accepting_content_length(
+    stdin: anyio.AsyncFile[str] | None = None,
+    stdout: anyio.AsyncFile[str] | None = None,
+) -> AsyncIterator[tuple[Any, Any]]:
+    if not stdin:
+        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8"))
+    if not stdout:
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+    async def stdin_reader() -> None:
+        try:
+            async with read_stream_writer:
+                while True:
+                    payload = await _read_stdio_message_payload(stdin)
+                    if payload is None:
+                        break
+                    if not payload.strip():
+                        continue
+                    try:
+                        message = types.JSONRPCMessage.model_validate_json(payload)
+                    except Exception as exc:  # pragma: no cover
+                        await read_stream_writer.send(exc)
+                        continue
+                    await read_stream_writer.send(SessionMessage(message))
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+
+    async def stdout_writer() -> None:
+        try:
+            async with write_stream_reader:
+                async for session_message in write_stream_reader:
+                    payload = session_message.message.model_dump_json(
+                        by_alias=True,
+                        exclude_none=True,
+                    )
+                    await stdout.write(payload + "\n")
+                    await stdout.flush()
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(stdin_reader)
+        task_group.start_soon(stdout_writer)
+        yield read_stream, write_stream
+
+
+async def _run_mcp_stdio_async() -> None:
+    _apply_mcp_server_metadata(mcp)
+    async with _stdio_server_accepting_content_length() as (read_stream, write_stream):
+        await mcp._mcp_server.run(
+            read_stream,
+            write_stream,
+            mcp._mcp_server.create_initialization_options(),
+        )
+
+
 def run_mcp_server() -> None:
     """Entry point for the MCP server."""
-    mcp.run()
+    anyio.run(_run_mcp_stdio_async)

--- a/tests/integration/test_mcp_stdio_protocol.py
+++ b/tests/integration/test_mcp_stdio_protocol.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import sys
+from importlib.metadata import version
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,7 @@ async def _stdio_protocol_roundtrip() -> None:
         async with ClientSession(read_stream, write_stream) as session:
             initialized = await session.initialize()
             assert initialized.serverInfo.name == "tensor-grep"
+            assert initialized.serverInfo.version == version("tensor-grep")
 
             listed = await session.list_tools()
             tool_names = {tool.name for tool in listed.tools}
@@ -60,3 +62,63 @@ async def _stdio_protocol_roundtrip() -> None:
 
 def test_tg_mcp_stdio_initialize_tools_list_and_call_roundtrip() -> None:
     asyncio.run(_stdio_protocol_roundtrip())
+
+
+async def _read_jsonrpc_line(process: asyncio.subprocess.Process) -> dict[str, object]:
+    assert process.stdout is not None
+    raw = await asyncio.wait_for(process.stdout.readline(), timeout=10.0)
+    assert raw, "MCP server did not emit a JSON-RPC response"
+    return json.loads(raw.decode("utf-8"))
+
+
+async def _stdio_content_length_initialize_roundtrip() -> None:
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "tensor_grep",
+        "mcp",
+        cwd=REPO_ROOT,
+        env=_mcp_env(),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert process.stdin is not None
+    try:
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "raw-framed-test", "version": "1.0.0"},
+            },
+        }
+        body = json.dumps(initialize, separators=(",", ":"))
+        frame = f"Content-Length: {len(body.encode('utf-8'))}\r\n\r\n{body}"
+        process.stdin.write(frame.encode("utf-8"))
+        await process.stdin.drain()
+
+        response = await _read_jsonrpc_line(process)
+
+        assert response["id"] == 1
+        result = response["result"]
+        assert isinstance(result, dict)
+        server_info = result["serverInfo"]
+        assert isinstance(server_info, dict)
+        assert server_info["name"] == "tensor-grep"
+        assert server_info["version"] == version("tensor-grep")
+    finally:
+        if process.stdin is not None:
+            process.stdin.close()
+            await process.stdin.wait_closed()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5.0)
+        except TimeoutError:
+            process.terminate()
+            await process.wait()
+
+
+def test_tg_mcp_stdio_accepts_content_length_initialize_frame() -> None:
+    asyncio.run(_stdio_content_length_initialize_roundtrip())

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -4,6 +4,7 @@ import hmac
 import json
 import sys
 import types
+from importlib.metadata import version
 from io import StringIO
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -988,6 +989,16 @@ def test_tg_mcp_capabilities_is_registered_and_reports_no_native_runtime(monkeyp
     ]
     assert tools["tg_rewrite_diff"]["mode"] == "native-required"
     assert tools["tg_index_search"]["mode"] == "native-required"
+
+
+def test_mcp_server_initialization_version_tracks_tensor_grep_package() -> None:
+    from tensor_grep.cli import mcp_server
+
+    mcp_server._apply_mcp_server_metadata(mcp_server.mcp)
+    options = mcp_server.mcp._mcp_server.create_initialization_options()
+
+    assert options.server_name == "tensor-grep"
+    assert options.server_version == version("tensor-grep")
 
 
 def test_tg_mcp_capabilities_registry_covers_public_tools(monkeypatch):


### PR DESCRIPTION
## Summary
- set MCP initialize `serverInfo.version` to the installed `tensor-grep` package version instead of the MCP SDK version
- keep stdio output newline-delimited JSON-RPC while defensively accepting legacy `Content-Length` JSON-RPC input frames
- document the MCP version/framing contract in the harness API

## Evidence ledger
- Exa/doc research: MCP stdio transport specifies UTF-8 JSON-RPC messages delimited by newlines, with no non-MCP stdout; lifecycle docs define `serverInfo.version` as the server implementation version
- Thinktank/subagent: Meitner flagged the MCP version/framing rough edge as a small isolated protocol slice
- Gemini: bounded read-only diff audit returned `GEMINI_AUDIT_RESULT: PASS`
- Local tests:
  - `uv run pytest tests/unit/test_mcp_server.py tests/integration/test_mcp_stdio_protocol.py tests/unit/test_harness_api_docs.py -q -p no:cacheprovider` -> 125 passed
  - `uv run ruff check src/tensor_grep/cli/mcp_server.py tests/unit/test_mcp_server.py tests/integration/test_mcp_stdio_protocol.py` -> pass
  - `uv run ruff format --check --preview src/tensor_grep/cli/mcp_server.py tests/unit/test_mcp_server.py tests/integration/test_mcp_stdio_protocol.py` -> pass
  - `git diff --check` -> pass

## Scope notes
- This preserves the MCP spec newline transport as the emitted server format.
- Content-Length input support is defensive compatibility for probes/clients that accidentally use LSP-style framing.