### PR TITLE
fix: harden v1.13.14 dogfood contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Current positioning:
 - The public native front door is now the performance-critical shell entrypoint. Advertised CLI flags must either execute there or route to the Python sidecar intentionally; help text that advertises flags the native parser rejects is a release blocker.
 - Root search shortcuts are part of that native-front-door contract. `tg PATTERN PATH`, `tg -t js PATTERN PATH`, and `tg --count-matches PATTERN PATH` must behave as `tg search ...`, preserving the common rg-compatible flags instead of falling into positional-only parsing.
 - `tg new project NAME` creates a named AST project directory; `--base-dir DIR` acts as the parent directory. Bare `tg new` and `tg new project` still initialize the current or configured `--base-dir` directly.
-- `tg agent --query ... --json` is the first Actionable Context Capsule surface: a bounded, deterministic work packet with primary files/functions, alternative targets, route rationale, snippets with line maps, validation evidence, rollback/checkpoint metadata, omissions, confidence, optional native GPU route evidence, unresolved equal-confidence tie metadata, and an ask-before-editing recommendation. It is an opt-in agent command, not a mutation of raw `--format rg`, `--json`, or `--ndjson`.
-- `tg agent --gpu-device-ids 0,1 --query ... --json` runs an opt-in batched GPU evidence scan for the selected devices and records `gpu_acceleration`; sidecar-routed or CPU-fallback results are reported as unsupported instead of being counted as GPU proof.
+- `tg agent PATH "query" --json` is the Actionable Context Capsule surface: a bounded, deterministic work packet with primary files/functions, alternative targets, route rationale, snippets with line maps, validation evidence, rollback/checkpoint metadata, omissions, confidence, optional native GPU route evidence, unresolved equal-confidence tie metadata, and an ask-before-editing recommendation. It is an opt-in agent command, not a mutation of raw `--format rg`, `--json`, or `--ndjson`.
+- `tg agent PATH "query" --gpu-device-ids 0,1 --json` runs an opt-in batched GPU evidence scan for the selected devices and records `gpu_acceleration`; sidecar-routed or CPU-fallback results are reported as unsupported instead of being counted as GPU proof.
 - Capsule confidence must be honest when query language hints, primary target language, selected snippets, and validation commands disagree. Mixed-language agent workflows use `validation_alignment` and ask-before-editing metadata instead of silently pairing a TypeScript target with pytest-only validation.
 - Long-lived agent-loop memory surfaces are operationally bounded: session response caches report byte usage, LSP providers cap workspace clients and opened documents, and search/repo-context caches have environment-overridable entry caps. These controls do not change raw search output contracts.
 
@@ -336,7 +336,7 @@ What `v1.9.1` closed:
 
 What `v1.9.0` closed:
 
-- `tg agent --query ... --json` is released as the first Actionable Context Capsule surface for agent workflows, with primary target metadata, route rationale, bounded snippets with line maps, validation evidence, edit order, rollback/checkpoint metadata, omissions, confidence, and ask-before-editing recommendations
+- `tg agent PATH "query" --json` is released as the Actionable Context Capsule surface for agent workflows, with primary target metadata, route rationale, bounded snippets with line maps, validation evidence, edit order, rollback/checkpoint metadata, omissions, confidence, and ask-before-editing recommendations
 - the native front door sidecar-routes `tg agent` intentionally so public installs expose the same capsule contract as the Python CLI
 - stable managed install scripts now prefer the matching release-native CPU `tg` front door when the GitHub release asset exists, while keeping the managed Python environment as the sidecar/fallback for Python-backed commands
 - main CI builds, uploads, and verifies release-native CPU assets before PyPI publish, so `v1.9.0` includes `tg-windows-amd64-cpu.exe`, `tg-linux-amd64-cpu`, `tg-macos-amd64-cpu`, checksums, and package-manager bundle assets on the GitHub release
@@ -358,8 +358,10 @@ What `v1.9.0` closed:
 
 Active post-`v1.13.14` follow-up:
 
-- harden the new dogfood paper cuts before the next patch release: bounded checkpoint discovery must find tensor-grep checkpoint scopes under `artifacts/`, path-first `tg defs PATH SYMBOL` deprecation guidance must not imply the failing symbol-first form, LSP-tied capsule alternatives must preserve proof evidence honestly, and raw-search/session performance work must remain measurement-first until a concrete regression cause is proven
-- bound long-lived agent-loop memory growth in source: CPU/StringZilla/AST/repo-context caches should evict by entry caps, session serve/daemon response caches should evict by byte caps and report byte usage, and optional LSP providers should close evicted documents and stop evicted workspace clients
+- harden the `v1.13.14` dogfood contract bugs before the next patch release: `--no-ignore` / `--format rg` search shapes must preserve ripgrep-compatible scope and path output, MCP `tg_search` counts must agree with CLI aggregate search counts, and context rows must not inflate match totals
+- keep optional LSP proof honest: top-level `lsp_proof` must be derived from final rows or explicit provider responses, provider-status proof must not contradict result rows, and provider stderr such as Python SRE/ABI mismatch warnings must remain visible when it can explain degraded proof
+- keep agent-facing repo maps bounded by default: `tg map --json`, `tg session open`, MCP `tg_repo_map`, and MCP `tg_session_open` should default to the agent-safe 512-file cap, report `scan_limit`, skip generated/vendor roots such as `.venv`, `bench_data`, `gpu_bench_data`, `many_files`, and `.tmp_*`, and expose daemon response-cache byte stats
+- populate headline JSON aliases for agent consumers: `edit-plan` should expose top-level `plan`, `primary_target`, and `edit_order`; `blast-radius` should expose `blast_radius_score` and `affected_files`; deprecated `--query` and `--symbol` forms stay accepted during 1.13.x but current help/docs should show positional query and symbol forms
 - harden the `v1.12.33` dogfood edge cases without broadening claims: native/root search accepts the rg config-override sequence `--column --no-column`, readiness now reports a stale repo-local `uv run tg` warmup as an unsynchronized entrypoint with a refresh command, and the ripgrep-binary-resolution natural-language hardcase stays pinned as a capsule regression test
 - harden `v1.12.15` dogfood contract gaps: public native `tg search` must accept editor-facing `--vimgrep` and `--path-separator`, native-regex hot-query gates use absolute jitter for millisecond-scale rows, benchmark scripts refuse stale in-tree native binaries by default unless `--allow-claim-unsafe-launcher` marks the run as exploratory, and optional LSP provider routes must expose `lsp_proof` / fallback status instead of treating provider availability as proof of semantic navigation
 - continue hardening `tg agent` / Actionable Context Capsule ranking for ambiguous multi-language queries, token economy, follow-up reads, call-site evidence, and validation evidence as an opt-in agent workflow, not a replacement for raw search output
@@ -453,7 +455,7 @@ Release proof:
 - main CodeQL run `25601232120` passed on the release-bearing merge commit
 - GitHub release assets for `v1.9.0` include native CPU front doors, checksums, winget manifest, Homebrew formula, and publish instructions
 - PyPI reports `tensor-grep 1.9.0`; `tensor-grep==1.9.0` resolves from PyPI
-- Public `tg agent src/tensor_grep/cli --query "agent context capsule" --json` returned a capsule with primary target, snippets, omissions/follow-up reads, confidence, rollback, and ask-before-editing metadata
+- Public `tg agent src/tensor_grep/cli "agent context capsule" --json` returned a capsule with primary target, snippets, omissions/follow-up reads, confidence, rollback, and ask-before-editing metadata
 - Public launcher dogfood verified `cmd /c tg`, direct `tg.cmd`, native `tg.exe`, and Python `subprocess.run([...])` return exit `1` with no stdout for a fresh quoted no-match phrase
 - Public `tg classify --format json tests\conftest.py` completed in 0.206s with local deterministic classifications
 
@@ -495,11 +497,11 @@ For large internal-library roots, `tensor-grep` supports a bounded context-rende
 Agent-facing broad-scan commands now default to bounded repo-map scans and report that boundary in JSON via `scan_limit`:
 
 ```powershell
-tg context-render . --query "how auth routing works" --render-profile llm --max-repo-files 512 --json
-tg defs . --symbol runCursorWorker --max-repo-files 512 --json
-tg source . --symbol safeParseJSON --max-repo-files 512 --json
-tg refs . --symbol prepareCursorWorkerInvocation --max-repo-files 512 --json
-tg blast-radius . --symbol prepareCursorWorkerInvocation --max-repo-files 512 --json
+tg context-render . "how auth routing works" --render-profile llm --max-repo-files 512 --json
+tg defs . runCursorWorker --max-repo-files 512 --json
+tg source . safeParseJSON --max-repo-files 512 --json
+tg refs . prepareCursorWorkerInvocation --max-repo-files 512 --json
+tg blast-radius . prepareCursorWorkerInvocation --max-repo-files 512 --json
 ```
 
 The agent-facing command surface also accepts positional aliases when typing at a shell:

--- a/docs/DOGFOOD_1_13_14_ISSUES.md
+++ b/docs/DOGFOOD_1_13_14_ISSUES.md
@@ -1,0 +1,149 @@
+# v1.13.14 Dogfood Issue Ledger
+
+Date: 2026-05-25
+
+This ledger consolidates the supplied v1.13.14 dogfood reports. It separates
+confirmed release-blocking contracts from UX notes and longer roadmap items.
+
+## Research Anchors
+
+- Ripgrep ignore semantics: `--no-ignore` disables standard ignore-file
+  filtering, while hidden-file filtering remains controlled separately by
+  `--hidden`; `-u/-uu/-uuu` are layered shortcuts. Sources:
+  <https://github.com/BurntSushi/ripgrep/blob/14.1.0/doc/rg.1.txt.tpl> and
+  <https://iepathos.github.io/ripgrep/common-options/file-filtering/>.
+- Ripgrep JSON compatibility is JSON Lines event output. Tensor-grep aggregate
+  JSON is a different contract and must not be conflated with
+  `--format rg --json`. Source:
+  <https://iepathos.github.io/ripgrep/output-formats/>.
+- LSP proof requires completed provider requests, not provider availability
+  alone. LSP initialization and document sync are explicit lifecycle/request
+  contracts. Source:
+  <https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/lsp/3.18/specification.md>.
+- MCP initializes first, then tools are listed/called through explicit tool
+  schemas. Tool metadata calls should be deterministic and bounded. Sources:
+  <https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle>
+  and <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>.
+- Typer/Click help text is derived from command docstrings or explicit `help=`;
+  passthrough/native front doors need equivalent command descriptions. Sources:
+  <https://typer.tiangolo.com/tutorial/subcommands/name-and-help/> and
+  <https://typer.tiangolo.com/tutorial/options/help/>.
+- Pyright environment and command-line behavior depends on configured Python
+  paths and import resolution. SRE/ABI mismatch stderr should be surfaced as
+  provider health noise, not hidden behind a proof marker. Sources:
+  <https://github.com/microsoft/pyright/blob/main/docs/command-line.md> and
+  <https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md>.
+
+## Must Fix for v1.13.15
+
+1. Search/ripgrep parity edges
+   - Reports: one dogfood run counted zero stdout for
+     `tg search --no-ignore -l "tensor-grep"`, while `rg --no-ignore` found
+     thousands. A subagent reproduced that the current native command exits 2
+     with the broad generated-root guard on this repo, so the user-visible bug
+     is ambiguous: the command is not a silent no-match, but the guard message
+     is easy to miss if a harness only counts stdout.
+   - Confirmed edge: native `--format rg` treats an implicit no-path search as
+     explicit `.`, so it prints `.\AGENTS.md` where rg and the Python front door
+     print `AGENTS.md`.
+   - Confirmed edge: MCP `tg_search` counts ripgrep JSON context rows as matches
+     through `RipgrepBackend`, which explains MCP vs CLI count drift for
+     context-bearing searches.
+   - Recommendation: preserve implicit-path state in native rg passthrough,
+     count only `match` events as matches in `RipgrepBackend`, and improve the
+     generated-root refusal text so harnesses and humans do not interpret an
+     exit-2 guard as zero-result parity.
+
+2. Hybrid/LSP proof consistency
+   - Reports: `refs` / `callers` / `blast-radius` can return top-level
+     `lsp_proof=true` while final rows or provider status report no provider
+     response, and pyright stderr_tail can include repeated SRE mismatch traces.
+   - Root cause: proof counts are taken from intermediate external rows before
+     final hybrid merge/dedupe; normal successful navigation rows do not always
+     update provider status.
+   - Recommendation: prefer marker-backed LSP rows during hybrid merge, compute
+     top-level proof from final emitted rows, and mark provider response only
+     after usable navigation responses.
+
+3. Map/session cold scan bounds and exclusions
+   - Reports: `tg map . --json` emitted 91-115 MB and took several minutes on
+     Windows; one report observed `.venv`-class scope leakage. `tg session open`
+     also had multi-minute cold setup.
+   - Root cause: `tg map` and `tg session open` default to uncapped
+     `max_repo_files=None`; repo-map exclusions do not cover local generated
+     names such as `.venv_cuda`, `bench_data`, `gpu_bench_data`, `.tmp_*`,
+     `many_files`, `group2_many_files`, and `site`.
+   - Recommendation: default agent-facing map/session entry points to the
+     existing 512-file budget unless callers opt into a larger cap, widen
+     generated-directory exclusions, and surface `scan_limit`/truncation.
+
+4. Edit-plan headline fields
+   - Reports: `tg edit-plan ... --json` returns useful
+     `candidate_edit_targets`, `edit_plan_seed`, and `navigation_pack`, but
+     top-level `plan`, `primary_target`, and `edit_order` are null or empty.
+   - Recommendation: add additive top-level aliases derived from existing
+     nested data; do not remove the nested schema.
+
+5. Blast-radius headline fields
+   - Reports: `blast_radius_score=null` and `affected_files=[]` while
+     `files`, `file_matches`, and `caller_tree` are populated.
+   - Recommendation: add `affected_files` as a compatibility alias over ranked
+     radius files and compute a simple bounded score from existing file/caller
+     evidence. Keep the formula documented and deterministic.
+
+6. Daemon status observability
+   - Reports: `tg session daemon status --json` lacks
+     `response_cache_size_bytes`, max bytes, hits, misses, and skip counters,
+     even though daemon internals already track them.
+   - Recommendation: merge live daemon `stats` into `status` when available;
+     keep current behavior if stats cannot be fetched.
+
+7. Help/deprecation accuracy
+   - Reports: native root help shows blank descriptions for passthrough
+     commands; examples still advertise `--query` and `--symbol` while commands
+     warn that those forms are deprecated.
+   - Recommendation: add native command doc comments/help strings, update root
+     examples to positional forms, hide deprecated Typer options from normal
+     help while preserving parsing/warnings, and document PowerShell single
+     quotes for AST patterns.
+
+## Should Fix if Low Risk
+
+8. Checkpoint undo PATH UX
+   - Reports: `tg checkpoint undo <PATH>` is parsed as a checkpoint id and
+     fails with a generic "Checkpoint not found"; the supported latest-path form
+     is hard to infer.
+   - Recommendation: clarify help and error text, and keep `checkpoint undo
+     --last PATH` discoverable. A path-first shortcut can be considered if it
+     does not collide with checkpoint ids.
+
+9. Parser-backed definition confidence
+   - Reports: `defs` rows have `confidence=null`.
+   - Recommendation: set confidence for parser-backed/native definitions where
+     the code already knows the provenance.
+
+10. MCP capabilities latency
+   - Reports conflict: one saw `tg_mcp_capabilities` take more than 30 seconds,
+     another saw instant response.
+   - Recommendation: avoid expensive probes inside metadata-only tool calls and
+     add a timeout-smoke test if the local behavior reproduces.
+
+11. Duplicate launcher clutter
+   - Reports: multiple `tg`, `tg.cmd`, `tg.exe`, and `tg.ps1` launchers exist
+     across user bin dirs.
+   - Recommendation: keep doctor reporting explicit; avoid destructive pruning
+     in this PR unless there is a confirmed tensor-grep-owned stale launcher.
+
+## Defer to Roadmap
+
+- Strict `--rg-compat` mode for byte-equivalent rg behavior across every public
+  flag combination.
+- Published JSON schemas plus fixture validation for agent-facing payloads.
+- Persistent daemon query-result cache, implicit daemon routing, fast degraded
+  session open, and progress-phase streaming for slow commands.
+- Fuzzy AST matching / ignore type annotations / AST pattern-from-file.
+- Blast-radius TUI.
+- Native "bare metal" grep bypass beyond the current native front door.
+- Production GPU acceleration and public GPU promotion claims.
+- Full duplicate-launcher repair/pruning workflow.
+

--- a/docs/FIX_PLAN_1_13_15.md
+++ b/docs/FIX_PLAN_1_13_15.md
@@ -1,0 +1,182 @@
+# Fix Plan: v1.13.15 Dogfood Contracts
+
+Date: 2026-05-25
+
+Goal: repair the v1.13.14 dogfood contract failures without broad refactors or
+new positioning claims. This plan is intentionally PR-sized but covers the
+release blockers that affect agent trust, rg compatibility, and agent-loop
+resource bounds.
+
+## Scope
+
+### P0: Search and MCP Count Contracts
+
+1. Add failing tests:
+   - Native rg-format no-path files-with-matches output should match direct rg
+     (`AGENTS.md`, not `.\AGENTS.md`) for both `tg search --format rg ...`
+     and root-option forwarding (`tg --format rg ...`).
+   - `RipgrepBackend` should count only ripgrep JSON `match` events as
+     `total_matches`; context events may remain rendered rows but must not
+     inflate match totals.
+   - MCP `tg_search(..., context=1)` should render context rows without
+     inflating the header count, and a CLI/MCP fixture should agree on actual
+     match count.
+   - Native `tg search --json -C 1 PATTERN PATH` should remain tensor-grep
+     aggregate JSON, with `total_matches` counting true matches rather than
+     context rows; `--format rg --json` remains raw rg JSON Lines.
+   - Broad generated-root refusal for `--hidden --no-ignore` should explicitly
+     mention `--allow-broad-generated-scan`, exit 2, and make clear this is a
+     safety refusal rather than a zero-match result.
+2. Fix:
+   - Preserve implicit-path vs explicit-`.` through native rg passthrough with
+     an explicit `path_was_implicit` / equivalent request field. Use it only
+     when building rg passthrough argv; keep `primary_path()` as `.` for native,
+     index, and GPU internal routing.
+   - Adjust Python `RipgrepBackend.search` to track match-event count and
+     matched files separately from context rows.
+   - Improve generated-root refusal text.
+
+### P0: LSP Proof Consistency
+
+1. Add failing tests in semantic provider navigation coverage:
+   - Hybrid refs/callers duplicate native+LSP rows should preserve the
+     marker-backed LSP row.
+   - Top-level `lsp_proof` should be computed from final emitted rows, not
+     intermediate external rows, after merge, dedupe, and definition-location
+     filtering.
+   - Fallback/alias-only rows with `lsp-*` provenance but no
+     `lsp_provider_response` must not count as proof.
+   - Successful workspace-symbol, definition, and references requests should
+     mark cached provider status as response-backed, while fallback/alias rows
+     must not.
+   - Pyright SRE/ABI mismatch stderr should remain visible as bounded provider
+     warning/noise even when proof is true.
+2. Fix:
+   - Prefer `_is_lsp_proof_row()` rows in hybrid merge.
+   - Compute `lsp_count`, `native_count`, `provider_agreement`,
+     `lsp_evidence_status`, and top-level `lsp_proof` from final `references`
+     / `callers`.
+   - Mark cached provider status as response-backed after successful usable
+     navigation responses. Keep proof true while surfacing bounded SRE/ABI
+     stderr as provider warnings rather than suppressing it behind proof.
+
+### P1: Agent Output Bounds and Daemon Observability
+
+1. Add failing tests:
+   - `build_repo_map` / `tg map --json` should skip generated local dirs such as
+     `.venv_cuda`, `bench_data`, `gpu_bench_data`, `.tmp_*`, `many_files`,
+     `group2_many_files`, and `site`, across `files`, `tests`, `symbols`,
+     `imports`, `related_paths`, and session snapshots.
+   - `tg map --json`, text `tg map`, MCP `tg_repo_map`, CLI
+     `tg session open --json`, and MCP `tg_session_open` should default to the
+     existing 512-file agent scan cap and emit `scan_limit`; explicit
+     `--max-repo-files` / MCP `max_repo_files` overrides it.
+   - Session refresh and `--refresh-on-stale` rebuilds should preserve the
+     stored effective scan cap unless an explicit override is added.
+   - `tg session daemon status --json` should expose response-cache stats when
+     the daemon is alive, including direct-root status, discovered-root status,
+     and stats-fetch failure fallback.
+2. Fix:
+   - Widen repo-map generated directory exclusions.
+   - Default agent-facing CLI and MCP map/session-open surfaces to the existing
+     agent-loop scan cap without changing the low-level `build_repo_map()`
+     default globally.
+   - Persist the effective session `max_repo_files` / `scan_limit` and reuse it
+     for refreshes.
+   - Merge daemon `stats` fields into daemon `status`.
+
+### P1: Agent JSON Headline Fields
+
+1. Add failing tests:
+   - `edit-plan --json` exposes top-level `primary_target`, `edit_order`, and a
+     compact `plan` object when existing nested data identifies a target, across
+     CLI, MCP, and session surfaces.
+   - `blast-radius --json` exposes non-empty `affected_files` and a non-null
+     deterministic `blast_radius_score` when radius files exist, across CLI and
+     MCP surfaces.
+   - Existing nested `edit_plan_seed`, `navigation_pack`, `files`,
+     `file_matches`, and `caller_tree` payloads remain unchanged except for
+     additive aliases.
+2. Fix:
+   - Add compatibility aliases derived from `navigation_pack`,
+     `edit_plan_seed`, `candidate_edit_targets`, `files`, and `file_matches`.
+     Define `primary_target == navigation_pack.primary_target`; derive
+     `edit_order` from `edit_plan_seed.edit_ordering`; keep `plan` compact,
+     source-free metadata.
+   - Define `affected_files` after output limiting from ranked files/file
+     matches, and make `blast_radius_score` deterministic, documented, and
+     bounded.
+   - Keep nested fields unchanged.
+
+### P1: Help and UX Accuracy
+
+1. Add failing tests:
+   - Native root help descriptions for passthrough commands are non-empty.
+   - Root examples no longer recommend deprecated `--query` / `--symbol`.
+   - `context-render --help`, `agent --help`, `edit-plan --help`, and
+     navigation help hide deprecated forms while still accepting them.
+   - `tg run --help` includes PowerShell single-quote guidance for `$` AST
+     captures.
+   - `checkpoint undo <existing PATH>` returns an actionable hint to use
+     `tg checkpoint undo --last PATH` instead of a generic checkpoint-not-found
+     error; no path-first shortcut ships in this release.
+2. Fix:
+   - Add native passthrough command doc comments.
+   - Update Python root examples and command help strings.
+   - Set deprecated Typer options to hidden where Typer supports it.
+   - Improve checkpoint undo help/error text only.
+
+### P2: Low-Risk Contract Polish
+
+1. Add MCP capabilities latency regression coverage only if local reproduction
+   shows a slow path.
+2. Keep parser-backed definition confidence, duplicate launcher cleanup, and any
+   path-first checkpoint shortcut deferred.
+
+## Out of Scope
+
+- Full JSON schema publication/validator CLI.
+- Persistent daemon query cache and implicit daemon routing.
+- AST fuzzy matching and pattern-from-file.
+- Launcher pruning/repair beyond existing doctor diagnostics.
+- GPU production promotion or new GPU performance claims.
+
+## Local Gates
+
+Run before push:
+
+```powershell
+uv run ruff format --check --preview .
+uv run ruff check .
+uv run mypy src/tensor_grep
+uv run pytest -q
+cargo fmt --manifest-path rust_core/Cargo.toml --check
+cargo clippy --manifest-path rust_core/Cargo.toml --all-targets -- -D warnings
+cargo test --manifest-path rust_core/Cargo.toml
+uv run python scripts/agent_readiness.py
+git diff --check
+```
+
+If the Rust suite is too long for iteration, run targeted Rust tests while
+developing, then the full Rust and Python gates before PR push.
+
+## Release Process
+
+1. Push branch `codex/v1-13-15-dogfood-contracts`.
+2. Open a PR with a `fix:` title so semantic-release increments to v1.13.15
+   after merge.
+3. Do not bypass CI. Fix PR CI failures in-branch.
+4. Squash-merge only after PR checks pass.
+5. Watch main CI through release asset publication, PyPI publication, and
+   publish-success-gate. Also check main CodeQL / dependency graph runs.
+6. Verify release assets and public install:
+
+```powershell
+gh release view v1.13.15 --json tagName,assets
+uvx --refresh-package tensor-grep --from tensor-grep==1.13.15 tg --version
+tg upgrade
+cmd /c tg --version
+pwsh -NoProfile -Command "tg --version"
+python -c "import subprocess; print(subprocess.run(['tg','--version'], capture_output=True, text=True).stdout.strip())"
+tg doctor --json
+```

--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -28,10 +28,10 @@ These top-level fields are shared across every JSON shape documented here.
 | Rulesets JSON | `tg.exe rulesets --json` | [`examples/rulesets.json`](examples/rulesets.json) |
 | Ruleset scan JSON | `tg.exe scan --ruleset <name> --json ...` | [`examples/ruleset_scan.json`](examples/ruleset_scan.json) |
 | Repo map JSON | `tg.exe map --json ...` | [`examples/repo_map.json`](examples/repo_map.json) |
-| Context pack JSON | `tg.exe context --query ... --json ...` | [`examples/context_pack.json`](examples/context_pack.json) |
-| Edit plan JSON | `tg.exe edit-plan --query ... --json ...` | [`examples/edit_plan.json`](examples/edit_plan.json) |
-| Context render JSON | `tg.exe context-render --query ... --json ...` | [`examples/context_render.json`](examples/context_render.json) |
-| Agent capsule JSON | `tg.exe agent --query ... --json ...` | Schema documented in Agent Capsule JSON below. |
+| Context pack JSON | `tg.exe context <path> <query> --json` | [`examples/context_pack.json`](examples/context_pack.json) |
+| Edit plan JSON | `tg.exe edit-plan <path> <query> --json` | [`examples/edit_plan.json`](examples/edit_plan.json) |
+| Context render JSON | `tg.exe context-render <path> <query> --json` | [`examples/context_render.json`](examples/context_render.json) |
+| Agent capsule JSON | `tg.exe agent <path> <query> --json` | Schema documented in Agent Capsule JSON below. |
 | Rewrite plan JSON | `tg.exe run --rewrite ...` | [`examples/rewrite_plan.json`](examples/rewrite_plan.json) |
 | Apply + verify JSON | `tg.exe run --rewrite ... --apply --verify --json ...` | [`examples/rewrite_apply_verify.json`](examples/rewrite_apply_verify.json) |
 | Attempt ledger JSON | multi-attempt harness/replay ledger | [`examples/attempt_ledger.json`](examples/attempt_ledger.json) |
@@ -42,16 +42,16 @@ These top-level fields are shared across every JSON shape documented here.
 | GPU sidecar JSON | `tg.exe search --gpu-device-ids ... --json ...` | [`examples/gpu_sidecar_search.json`](examples/gpu_sidecar_search.json) |
 | Calibrate JSON | `tg.exe calibrate` | [`examples/calibrate.json`](examples/calibrate.json) |
 | Search NDJSON | `tg.exe search --ndjson ...` | [`examples/search.ndjson`](examples/search.ndjson) |
-| Symbol defs JSON | `tg.exe defs --symbol <name> --json ...` | [`examples/defs.json`](examples/defs.json) |
-| Symbol source JSON | `tg.exe source --symbol <name> --json ...` | [`examples/source.json`](examples/source.json) |
-| Symbol impact JSON | `tg.exe impact --symbol <name> --json ...` | [`examples/impact.json`](examples/impact.json) |
-| Symbol refs JSON | `tg.exe refs --symbol <name> --json ...` | [`examples/refs.json`](examples/refs.json) |
-| Symbol callers JSON | `tg.exe callers --symbol <name> --json ...` | [`examples/callers.json`](examples/callers.json) |
-| Symbol blast radius JSON | `tg.exe blast-radius --symbol <name> --json ...` | [`examples/blast_radius.json`](examples/blast_radius.json) |
-| Symbol blast radius plan JSON | `tg.exe blast-radius-plan --symbol <name> --json ...` | [`examples/blast_radius_plan.json`](examples/blast_radius_plan.json) |
-| Symbol blast radius render JSON | `tg.exe blast-radius-render --symbol <name> --json ...` | [`examples/blast_radius_render.json`](examples/blast_radius_render.json) |
+| Symbol defs JSON | `tg.exe defs <path> <symbol> --json` | [`examples/defs.json`](examples/defs.json) |
+| Symbol source JSON | `tg.exe source <path> <symbol> --json` | [`examples/source.json`](examples/source.json) |
+| Symbol impact JSON | `tg.exe impact <path> <symbol> --json` | [`examples/impact.json`](examples/impact.json) |
+| Symbol refs JSON | `tg.exe refs <path> <symbol> --json` | [`examples/refs.json`](examples/refs.json) |
+| Symbol callers JSON | `tg.exe callers <path> <symbol> --json` | [`examples/callers.json`](examples/callers.json) |
+| Symbol blast radius JSON | `tg.exe blast-radius <path> <symbol> --json` | [`examples/blast_radius.json`](examples/blast_radius.json) |
+| Symbol blast radius plan JSON | `tg.exe blast-radius-plan <path> <symbol> --json` | [`examples/blast_radius_plan.json`](examples/blast_radius_plan.json) |
+| Symbol blast radius render JSON | `tg.exe blast-radius-render <path> <symbol> --json` | [`examples/blast_radius_render.json`](examples/blast_radius_render.json) |
 | Session open JSON | `tg.exe session open ... --json` | [`examples/session_open.json`](examples/session_open.json) |
-| Session context JSON | `tg.exe session context <id> --query ... --json` | [`examples/session_context.json`](examples/session_context.json) |
+| Session context JSON | `tg.exe session context <id> <path> <query> --json` | [`examples/session_context.json`](examples/session_context.json) |
 | Doctor JSON | `tg.exe doctor --json` | Operational diagnostics schema documented below. |
 | MCP rewrite diff JSON | `tg_rewrite_diff(...)` | [`examples/mcp_rewrite_diff.json`](examples/mcp_rewrite_diff.json) |
 
@@ -271,7 +271,7 @@ Current `coverage` values:
 
 ## Context Pack JSON
 
-Emitted by `tg.exe context --query <text> --json ...`.
+Emitted by `tg.exe context <path> <query> --json`.
 
 Example: [`examples/context_pack.json`](examples/context_pack.json)
 
@@ -342,7 +342,7 @@ Each ranked `imports[]` object extends the Repo Map JSON import shape with:
 
 ## Edit Plan JSON
 
-Emitted by `tg.exe edit-plan --query ... --json ...`.
+Emitted by `tg.exe edit-plan <path> <query> --json`.
 
 Example: [`examples/edit_plan.json`](examples/edit_plan.json)
 
@@ -431,7 +431,7 @@ Each `navigation_pack.primary_target` or `navigation_pack.follow_up_reads[]` obj
 
 ## Context Render JSON
 
-Emitted by `tg.exe context-render --query ... --json ...`.
+Emitted by `tg.exe context-render <path> <query> --json`.
 
 Example: [`examples/context_render.json`](examples/context_render.json)
 
@@ -511,7 +511,7 @@ For Python source blocks, compact and optimized `llm` profiles can strip:
 
 ## Agent Capsule JSON
 
-Emitted by `tg.exe agent --query ... --json ...`.
+Emitted by `tg.exe agent <path> <query> --json`.
 
 Use this shape when an agent needs the smallest actionable work packet before editing code. It composes context rendering, edit-plan evidence, validation hints, and rollback guidance without changing raw `search --format rg`, `search --json`, or `search --ndjson` output contracts.
 
@@ -965,7 +965,7 @@ This is the streaming variant of Search JSON. Each line is a standalone JSON obj
 
 ## Symbol Defs JSON
 
-Emitted by `tg.exe defs --symbol <name> --json ...`.
+Emitted by `tg.exe defs <path> <name> --json`.
 
 Example: [`examples/defs.json`](examples/defs.json)
 
@@ -1002,7 +1002,7 @@ Each `definitions[]` object contains `name`, `kind`, `file`, `line`, and may add
 
 ## Symbol Source JSON
 
-Emitted by `tg.exe source --symbol <name> --json ...`.
+Emitted by `tg.exe source <path> <name> --json`.
 
 Example: [`examples/source.json`](examples/source.json)
 
@@ -1033,7 +1033,7 @@ Each `sources[]` object contains `name`, `kind`, `file`, `start_line`, `end_line
 
 ## Symbol Impact JSON
 
-Emitted by `tg.exe impact --symbol <name> --json ...`.
+Emitted by `tg.exe impact <path> <name> --json`.
 
 Example: [`examples/impact.json`](examples/impact.json)
 
@@ -1067,7 +1067,7 @@ Each `imports[]` object may additionally include:
 
 ## Symbol Refs JSON
 
-Emitted by `tg.exe refs --symbol <name> --json ...`.
+Emitted by `tg.exe refs <path> <name> --json`.
 
 Example: [`examples/refs.json`](examples/refs.json)
 
@@ -1105,7 +1105,7 @@ Each `references[]` object contains `name`, `kind`, `file`, `line`, `text`, and 
 
 ## Symbol Callers JSON
 
-Emitted by `tg.exe callers --symbol <name> --json ...`.
+Emitted by `tg.exe callers <path> <name> --json`.
 
 Example: [`examples/callers.json`](examples/callers.json)
 
@@ -1137,7 +1137,7 @@ Each `callers[]` object may additionally include:
 
 ## Symbol Blast Radius JSON
 
-Emitted by `tg.exe blast-radius --symbol <name> --json ...`.
+Emitted by `tg.exe blast-radius <path> <name> --json`.
 
 Example: [`examples/blast_radius.json`](examples/blast_radius.json)
 
@@ -1191,7 +1191,7 @@ Each `caller_tree[]` object may additionally include:
 
 ## Symbol Blast Radius Plan JSON
 
-Emitted by `tg.exe blast-radius-plan --symbol <name> --json ...`.
+Emitted by `tg.exe blast-radius-plan <path> <name> --json`.
 
 Example: [`examples/blast_radius_plan.json`](examples/blast_radius_plan.json)
 
@@ -1215,7 +1215,7 @@ The shape matches Symbol Blast Radius JSON and additionally includes:
 
 ## Symbol Blast Radius Render JSON
 
-Emitted by `tg.exe blast-radius-render --symbol <name> --json ...`.
+Emitted by `tg.exe blast-radius-render <path> <name> --json`.
 
 Example: [`examples/blast_radius_render.json`](examples/blast_radius_render.json)
 
@@ -1294,7 +1294,7 @@ Stop responses additionally include:
 
 ## Session Context JSON
 
-Emitted by `tg.exe session context <id> --query ... --json`.
+Emitted by `tg.exe session context <id> <path> <query> --json`.
 
 Example: [`examples/session_context.json`](examples/session_context.json)
 
@@ -1481,7 +1481,7 @@ Response mapping:
 - `tg_index_search(...)` returns the same v1 envelope and payload shape as [`examples/index_search.json`](examples/index_search.json)
 - `tg_edit_plan(...)` returns the same v1 envelope and payload shape as [`examples/edit_plan.json`](examples/edit_plan.json)
 - `tg_context_render(...)` returns the same v1 envelope and payload shape as [`examples/context_render.json`](examples/context_render.json)
-- `tg_agent_capsule(...)` returns the same v1 capsule contract as `tg.exe agent --query ... --json ...`, with `routing_reason = "agent-context-capsule"`. Optional `gpu_device_ids` request native GPU evidence and populate `gpu_acceleration`; sidecar-routed GPU evidence is reported as unsupported.
+- `tg_agent_capsule(...)` returns the same v1 capsule contract as `tg.exe agent <path> <query> --json`, with `routing_reason = "agent-context-capsule"`. Optional `gpu_device_ids` request native GPU evidence and populate `gpu_acceleration`; sidecar-routed GPU evidence is reported as unsupported.
 - `tg_symbol_defs(...)` returns the same v1 envelope and payload shape as [`examples/defs.json`](examples/defs.json)
 - `tg_symbol_source(...)` returns the same v1 envelope and payload shape as [`examples/source.json`](examples/source.json)
 - `tg_symbol_impact(...)` returns the same v1 envelope and payload shape as [`examples/impact.json`](examples/impact.json)

--- a/docs/harness_cookbook.md
+++ b/docs/harness_cookbook.md
@@ -24,7 +24,10 @@ Expected top-level fields:
 - `"sidecar_used"`
 - `"query"`
 - `"path"`
+- `"total_files"`
 - `"total_matches"`
+- `"matched_file_paths"`
+- `"match_counts_by_file"`
 - `"matches"`
 
 Recommended consumer behavior:
@@ -87,7 +90,7 @@ Current coverage values describe the limits of this surface:
 Use context packs when the agent already has a task/query and wants a smaller ranked subset than the full repo map.
 
 ```powershell
-tg.exe context --query "invoice payment" --json .\src
+tg.exe context .\src "invoice payment" --json
 ```
 
 Expected top-level fields:
@@ -119,32 +122,38 @@ Before any autonomous edit, inspect the top-level `ambiguity` object. `ambiguity
 Resolve exact definitions:
 
 ```powershell
-tg defs --symbol create_invoice --max-repo-files 512 --json .\src
+tg defs .\src create_invoice --max-repo-files 512 --json
 ```
 
 Fetch the exact source block:
 
 ```powershell
-tg source --symbol create_invoice --max-repo-files 512 --json .\src
+tg source .\src create_invoice --max-repo-files 512 --json
 ```
 
 Estimate likely change impact:
 
 ```powershell
-tg impact --symbol create_invoice --max-repo-files 512 --json .
+tg impact . create_invoice --max-repo-files 512 --json
 ```
 
 Find reference sites:
 
 ```powershell
-tg refs --symbol create_invoice --max-repo-files 512 --json .
+tg refs . create_invoice --max-repo-files 512 --json
 ```
 
 Find call sites plus likely impacted tests:
 
 ```powershell
-tg callers --symbol create_invoice --max-repo-files 512 --json .
+tg callers . create_invoice --max-repo-files 512 --json
 ```
+
+For `tg blast-radius ... --json`, `blast_radius_score` is a bounded `0.0` to
+`1.0` evidence-density score derived from ranked files, direct callers, and
+related tests before output limiting. Use `affected_files` for the concrete
+file list and treat the score as a prioritization hint, not a correctness
+proof.
 
 For broad repo roots, read `scan_limit` before assuming the inventory is complete. If `no_match` is true on `defs` or `source`, treat the compact payload as a real miss and refine the symbol/query instead of scanning unrelated inventories.
 
@@ -169,7 +178,7 @@ tg session refresh session-20260320071200-rewrite . --json
 Reuse the cached repo map for another query:
 
 ```powershell
-tg session context session-20260320071200-rewrite . --query "invoice payment" --json
+tg session context session-20260320071200-rewrite . "invoice payment" --json
 tg session serve session-20260320071200-rewrite . < requests.jsonl
 tg session serve session-20260320071200-rewrite . --refresh-on-stale < requests.jsonl
 ```
@@ -206,9 +215,9 @@ Minimal command chain:
 
 ```powershell
 tg.exe map --json .\src
-tg.exe context --query "invoice payment" --json .\src
-tg defs --symbol create_invoice --json .\src
-tg callers --symbol create_invoice --json .\src
+tg.exe context .\src "invoice payment" --json
+tg defs .\src create_invoice --json
+tg callers .\src create_invoice --json
 tg.exe run --lang python --rewrite 'lambda $$$ARGS: $EXPR' --json 'def $F($$$ARGS): return $EXPR' .\src\sample.py
 tg.exe run --lang python --rewrite 'lambda $$$ARGS: $EXPR' --apply --verify --checkpoint --lint-cmd "ruff check ." --test-cmd "pytest -q" --json 'def $F($$$ARGS): return $EXPR' .\src\sample.py
 python benchmarks/run_patch_bakeoff.py --scenarios benchmarks/patch_eval/real_patch_bakeoff_scenarios.json --predictions artifacts/patch_eval_demo/gemini_skill_ab_limit12_bakeoff.json --output artifacts/patch_eval_demo/gemini_skill_ab_limit12_bakeoff_scored.json

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -906,16 +906,19 @@ pub enum Commands {
     GpuOomProbe(GpuOomProbeArgs),
 
     // Editor-plane and Python passthrough commands:
+    /// Build a bounded repository map for agent context selection
     #[command(name = "map", disable_help_flag = true)]
     Map {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Open, query, and manage cached edit-loop sessions
     #[command(name = "session", disable_help_flag = true)]
     Session {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Diagnose launcher, GPU, cache, daemon, and LSP readiness
     #[command(name = "doctor", disable_help_flag = true)]
     Doctor {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -927,101 +930,121 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Create, list, and undo edit checkpoints
     #[command(name = "checkpoint", disable_help_flag = true)]
     Checkpoint {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Run tensor-grep self-check and dogfood diagnostics
     #[command(name = "dogfood", disable_help_flag = true)]
     Dogfood {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Print source snippets for a resolved symbol
     #[command(name = "source", disable_help_flag = true)]
     Source {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Estimate files impacted by a symbol or query
     #[command(name = "impact", disable_help_flag = true)]
     Impact {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Find direct callers of a symbol
     #[command(name = "callers", disable_help_flag = true)]
     Callers {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Build a transitive blast-radius graph for a symbol
     #[command(name = "blast-radius", disable_help_flag = true)]
     BlastRadius {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Render a human-readable symbol blast radius
     #[command(name = "blast-radius-render", disable_help_flag = true)]
     BlastRadiusRender {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Build a machine-readable blast-radius plan
     #[command(name = "blast-radius-plan", disable_help_flag = true)]
     BlastRadiusPlan {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Build a machine-readable edit plan without rendered source
     #[command(name = "edit-plan", disable_help_flag = true)]
     EditPlan {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Emit an actionable context capsule for agents
     #[command(name = "agent", disable_help_flag = true)]
     Agent {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Render bounded prompt-ready context for a task
     #[command(name = "context-render", disable_help_flag = true)]
     ContextRender {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Inspect AST language and parser support
     #[command(name = "ast-info", disable_help_flag = true)]
     AstInfo {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// List and inspect bundled scanning rulesets
     #[command(name = "rulesets", disable_help_flag = true)]
     Rulesets {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Show audit manifest history
     #[command(name = "audit-history", disable_help_flag = true)]
     AuditHistory {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Compare audit manifests
     #[command(name = "audit-diff", disable_help_flag = true)]
     AuditDiff {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Create and verify review bundles
     #[command(name = "review-bundle", disable_help_flag = true)]
     ReviewBundle {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// List GPU devices and routing readiness
     #[command(name = "devices", disable_help_flag = true)]
     Devices {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Find symbol definitions
     #[command(name = "defs", disable_help_flag = true)]
     Defs {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Find symbol references
     #[command(name = "refs", disable_help_flag = true)]
     Refs {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Build a ranked context pack for a task
     #[command(name = "context", disable_help_flag = true)]
     Context {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -1116,6 +1139,7 @@ pub struct GpuOomProbeArgs {
 struct ResolvedSearchRequest {
     patterns: Vec<String>,
     paths: Vec<String>,
+    path_was_implicit: bool,
 }
 
 impl ResolvedSearchRequest {
@@ -1146,6 +1170,16 @@ impl ResolvedSearchRequest {
 }
 
 fn main() -> anyhow::Result<()> {
+    let handle = std::thread::Builder::new()
+        .name("tg-main".to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(main_inner)?;
+    handle
+        .join()
+        .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+}
+
+fn main_inner() -> anyhow::Result<()> {
     let raw_args: Vec<OsString> = std::env::args_os().collect();
 
     if raw_args.len() <= 1 {
@@ -3671,11 +3705,13 @@ fn resolve_search_request_with_stdin(
     stdin_searches_implicit_path: bool,
 ) -> anyhow::Result<ResolvedSearchRequest> {
     let mut patterns = args.regexp.clone();
+    let mut path_was_implicit = false;
     let paths = if args.regexp.is_empty() {
         if let Some(pattern) = args.pattern.as_ref() {
             patterns.push(pattern.clone());
         }
         if args.path.is_empty() {
+            path_was_implicit = true;
             if stdin_searches_implicit_path {
                 Vec::new()
             } else {
@@ -3691,6 +3727,7 @@ fn resolve_search_request_with_stdin(
         }
         paths.extend(args.path.clone());
         if paths.is_empty() {
+            path_was_implicit = true;
             if stdin_searches_implicit_path {
                 Vec::new()
             } else {
@@ -3705,7 +3742,11 @@ fn resolve_search_request_with_stdin(
         anyhow::bail!("search requires a pattern or at least one -e/--regexp pattern");
     }
 
-    Ok(ResolvedSearchRequest { patterns, paths })
+    Ok(ResolvedSearchRequest {
+        patterns,
+        paths,
+        path_was_implicit,
+    })
 }
 
 fn detect_warm_index_state(
@@ -3997,7 +4038,11 @@ fn command_ripgrep_args(args: &SearchArgs, request: &ResolvedSearchRequest) -> R
         multiline_dotall: args.multiline_dotall,
         no_multiline_dotall: false,
         patterns: request.patterns.clone(),
-        paths: request.paths.clone(),
+        paths: if request.path_was_implicit {
+            Vec::new()
+        } else {
+            request.paths.clone()
+        },
         pcre2: args.pcre2,
         no_pcre2: false,
         pcre2_unicode: args.pcre2_unicode,
@@ -4788,7 +4833,10 @@ struct SearchResultJson<'a> {
     not_gpu_proof_reason: Option<String>,
     query: &'a str,
     path: &'a str,
+    total_files: usize,
     total_matches: usize,
+    matched_file_paths: Vec<String>,
+    match_counts_by_file: std::collections::BTreeMap<String, usize>,
     matches: Vec<SearchMatchJson>,
 }
 
@@ -7942,6 +7990,13 @@ fn emit_json_search_results(
         decision.routing_backend(),
         decision.sidecar_used(),
     );
+    let mut match_counts_by_file = std::collections::BTreeMap::<String, usize>::new();
+    for matched in &matches {
+        *match_counts_by_file
+            .entry(matched.file.clone())
+            .or_insert(0) += 1;
+    }
+    let matched_file_paths = match_counts_by_file.keys().cloned().collect::<Vec<_>>();
     let payload = SearchResultJson {
         version: JSON_OUTPUT_VERSION,
         routing_backend: decision.routing_backend(),
@@ -7955,7 +8010,10 @@ fn emit_json_search_results(
         not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
         query: pattern,
         path,
+        total_files: matched_file_paths.len(),
         total_matches: matches.len(),
+        matched_file_paths,
+        match_counts_by_file,
         matches,
     };
 

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -15,6 +15,7 @@ use rayon::prelude::*;
 use regex::RegexBuilder as OutputRegexBuilder;
 use serde::Serialize;
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -637,7 +638,10 @@ struct NativeJsonOutput<'a> {
     not_gpu_proof_reason: Option<String>,
     query: &'a str,
     path: String,
+    total_files: usize,
     total_matches: usize,
+    matched_file_paths: Vec<String>,
+    match_counts_by_file: BTreeMap<String, usize>,
     matches: Vec<NativeJsonMatch>,
 }
 
@@ -1893,6 +1897,12 @@ fn emit_json_matches(config: &NativeSearchConfig, stats: &SearchStats) -> Result
         config.routing_backend,
         config.sidecar_used,
     );
+    let mut match_counts_by_file: BTreeMap<String, usize> = BTreeMap::new();
+    for matched in &stats.matches {
+        let path = matched.path.to_string_lossy().into_owned();
+        *match_counts_by_file.entry(path).or_insert(0) += 1;
+    }
+    let matched_file_paths = match_counts_by_file.keys().cloned().collect::<Vec<_>>();
     let payload = NativeJsonOutput {
         version: JSON_OUTPUT_VERSION,
         routing_backend: config.routing_backend,
@@ -1906,7 +1916,10 @@ fn emit_json_matches(config: &NativeSearchConfig, stats: &SearchStats) -> Result
         not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
         query: &config.pattern,
         path: display_search_path(&config.paths),
+        total_files: stats.matched_files,
         total_matches: stats.total_matches,
+        matched_file_paths,
+        match_counts_by_file,
         matches: stats
             .matches
             .iter()

--- a/rust_core/src/python_sidecar.rs
+++ b/rust_core/src/python_sidecar.rs
@@ -1065,7 +1065,8 @@ mod tests {
         fs::write(&local_exe, b"local").unwrap();
 
         assert_eq!(
-            resolve_python_command_for_context(Some(&local_exe), &[home.clone()]).as_os_str(),
+            resolve_python_command_for_context(Some(&local_exe), std::slice::from_ref(&home))
+                .as_os_str(),
             OsStr::new("python")
         );
         assert_eq!(

--- a/rust_core/tests/test_public_native_cli_parity.rs
+++ b/rust_core/tests/test_public_native_cli_parity.rs
@@ -1088,6 +1088,96 @@ fn test_search_version_is_accepted_on_public_native_frontdoor() {
 }
 
 #[test]
+fn test_public_native_root_help_describes_python_passthrough_commands() {
+    let output = tg().arg("--help").output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected: &[(&str, &[&str])] = &[
+        (
+            "map",
+            &[
+                "Build a bounded repository map",
+                "Return a deterministic repository map",
+            ],
+        ),
+        (
+            "session",
+            &[
+                "Open, query, and manage cached",
+                "Open and reuse cached repository-map sessions",
+            ],
+        ),
+        (
+            "doctor",
+            &["Diagnose launcher, GPU, cache", "Print system, GPU, cache"],
+        ),
+        ("checkpoint", &["Create, list, and undo"]),
+        (
+            "edit-plan",
+            &[
+                "Build a machine-readable edit plan",
+                "Return a machine-readable edit-planning",
+            ],
+        ),
+        (
+            "agent",
+            &[
+                "Emit an actionable context capsule",
+                "Return an actionable context capsule",
+            ],
+        ),
+        (
+            "context-render",
+            &[
+                "Render bounded prompt-ready context",
+                "Return a prompt-ready repository context",
+            ],
+        ),
+        (
+            "defs",
+            &[
+                "Find symbol definitions",
+                "Return exact definition locations",
+            ],
+        ),
+        (
+            "refs",
+            &[
+                "Find symbol references",
+                "Return Python-first symbol references",
+            ],
+        ),
+        (
+            "callers",
+            &["Find direct callers", "Return Python-first call sites"],
+        ),
+        (
+            "blast-radius",
+            &[
+                "Build a transitive blast-radius graph",
+                "Return exact callers plus",
+            ],
+        ),
+    ];
+    for (command, descriptions) in expected {
+        assert!(
+            stdout.contains(command)
+                && descriptions
+                    .iter()
+                    .any(|description| stdout.contains(description)),
+            "missing help for {command}: {stdout}"
+        );
+    }
+}
+
+#[test]
 fn test_top_level_structured_search_accepts_no_ignore() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("ignored.log");
@@ -1117,6 +1207,12 @@ fn test_top_level_structured_search_accepts_no_ignore() {
     );
     let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(payload["total_matches"], 1);
+    assert_eq!(payload["total_files"], 1);
+    assert_eq!(payload["matched_file_paths"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        payload["match_counts_by_file"].as_object().unwrap().len(),
+        1
+    );
 }
 
 #[test]
@@ -1154,6 +1250,117 @@ fn test_top_level_format_rg_search_is_accepted_on_public_native_frontdoor() {
             String::from_utf8_lossy(&output.stderr)
         );
     }
+}
+
+#[test]
+fn test_format_rg_no_explicit_path_omits_dot_for_files_with_matches() {
+    let dir = tempdir().unwrap();
+    let fake_rg = fake_rg_exact_args_script(
+        dir.path(),
+        &["-l", "-g", "AGENTS.md", "-e", "tensor-grep"],
+        "AGENTS.md\n",
+    );
+    fs::write(dir.path().join("AGENTS.md"), "tensor-grep\n").unwrap();
+
+    for args in [
+        vec![
+            "search",
+            "--format",
+            "rg",
+            "-l",
+            "-g",
+            "AGENTS.md",
+            "tensor-grep",
+        ],
+        vec!["--format", "rg", "-l", "-g", "AGENTS.md", "tensor-grep"],
+    ] {
+        let output = tg()
+            .current_dir(dir.path())
+            .args(&args)
+            .env("TG_RG_PATH", &fake_rg)
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "args={args:?} status={:?}\nstdout={}\nstderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+            "AGENTS.md\n"
+        );
+    }
+}
+
+#[test]
+fn test_format_rg_explicit_dot_path_is_forwarded_for_files_with_matches() {
+    let dir = tempdir().unwrap();
+    let fake_rg = fake_rg_exact_args_script(
+        dir.path(),
+        &["-l", "-g", "AGENTS.md", "-e", "tensor-grep", "."],
+        "AGENTS.md\n",
+    );
+    fs::write(dir.path().join("AGENTS.md"), "tensor-grep\n").unwrap();
+
+    let output = tg()
+        .current_dir(dir.path())
+        .args([
+            "search",
+            "--format",
+            "rg",
+            "-l",
+            "-g",
+            "AGENTS.md",
+            "tensor-grep",
+            ".",
+        ])
+        .env("TG_RG_PATH", &fake_rg)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+        "AGENTS.md\n"
+    );
+}
+
+#[test]
+fn test_native_json_context_counts_only_real_matches() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("sample.txt"), "before\nneedle\nafter\n").unwrap();
+
+    let output = tg()
+        .current_dir(dir.path())
+        .args(["search", "--json", "-C", "1", "needle", "sample.txt"])
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["total_matches"], 1);
+    assert_eq!(payload["total_files"], 1);
+    assert_eq!(payload["matched_file_paths"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        payload["match_counts_by_file"].as_object().unwrap().len(),
+        1
+    );
 }
 
 #[test]

--- a/rust_core/tests/test_runtime_path_resolution.rs
+++ b/rust_core/tests/test_runtime_path_resolution.rs
@@ -212,8 +212,12 @@ fn test_help_documents_runtime_override_env_vars() {
         assert!(stdout.contains(expected), "stdout={stdout}");
     }
     assert!(stdout.contains("repair-launcher"), "stdout={stdout}");
-    assert!(stdout.contains("--allow-foreign-rename"), "stdout={stdout}");
     let normalized_stdout = stdout.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        stdout.contains("--allow-foreign-rename")
+            || normalized_stdout.contains("--allow- foreign-rename"),
+        "stdout={stdout}"
+    );
     let normalized_lower = normalized_stdout.to_lowercase();
     assert!(
         normalized_stdout.contains("native GPU falls back"),

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -772,7 +772,6 @@ def build_check_plan(
                 "tg",
                 "context-render",
                 "tests/unit/test_trust_planning.py",
-                "--query",
                 "invoice tax calculation",
                 "--json",
             ],

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -65,6 +65,9 @@ class RipgrepBackend(ComputeBackend):
             import json
 
             matches = []
+            matched_file_paths: list[str] = []
+            match_counts_by_file: dict[str, int] = {}
+            total_matches = 0
 
             for line in result.stdout.splitlines():
                 if not line.strip():
@@ -83,6 +86,13 @@ class RipgrepBackend(ComputeBackend):
 
                         # Note: Ripgrep JSON also outputs absolute offsets, but MatchLine requires line_num/text
                         matches.append(MatchLine(line_number=line_number, text=text, file=path_str))
+                        total_matches += 1
+                        if path_str:
+                            match_counts_by_file[path_str] = (
+                                match_counts_by_file.get(path_str, 0) + 1
+                            )
+                            if path_str not in matched_file_paths:
+                                matched_file_paths.append(path_str)
                     elif data.get("type") == "context":
                         data_match = data["data"]
                         line_number = data_match.get("line_number", 0)
@@ -94,12 +104,12 @@ class RipgrepBackend(ComputeBackend):
                 except json.JSONDecodeError:
                     pass
 
-            files_set = {m.file for m in matches}
-
             return SearchResult(
                 matches=matches,
-                total_files=len(files_set),
-                total_matches=len(matches),
+                matched_file_paths=matched_file_paths,
+                match_counts_by_file=match_counts_by_file,
+                total_files=len(matched_file_paths),
+                total_matches=total_matches,
                 routing_backend="RipgrepBackend",
                 routing_reason="rg_json",
                 routing_distributed=False,

--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -1110,7 +1110,19 @@ def _attach_lsp_proof_fields(status: dict[str, Any]) -> dict[str, Any]:
     status["lsp_proof"] = lsp_proof
     if lsp_proof:
         status.pop("not_lsp_proof_reason", None)
-        if status.get("stderr_tail"):
+        stderr_tail = [str(item) for item in status.get("stderr_tail", []) if str(item)]
+        provider_warnings = [
+            item
+            for item in stderr_tail
+            if "sre module mismatch" in item.lower()
+            or "_sre" in item.lower()
+            or "abi mismatch" in item.lower()
+        ]
+        if provider_warnings:
+            status["provider_warnings"] = provider_warnings[-3:]
+            status["stderr_tail"] = provider_warnings[-3:]
+            status["stderr_tail_suppressed"] = False
+        elif stderr_tail:
             status["stderr_tail"] = []
             status["stderr_tail_suppressed"] = True
         return status

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -139,7 +139,7 @@ persisted repeated-query acceleration, and optional GPU routing.
 - `tg PATTERN [PATH ...]`
 - `tg search [OPTIONS] PATTERN [PATH ...]`
 - `tg run PATTERN [PATH]`
-- `tg agent PATH --query "change invoice tax"`
+- `tg agent PATH "change invoice tax"`
 - `tg scan --config sgconfig.yml`
 - `tg doctor --with-lsp`
 - `tg dogfood --output artifacts/agent_readiness.json`
@@ -148,10 +148,10 @@ persisted repeated-query acceleration, and optional GPU routing.
 
 **AI workflows**
 - `tg map PATH`
-- `tg context-render PATH --query "invoice flow"`
-- `tg edit-plan PATH --query "add retry with tests"`
-- `tg agent PATH --query "change behavior" --json`
-- `tg blast-radius-render PATH --symbol create_invoice`
+- `tg context-render PATH "invoice flow"`
+- `tg edit-plan PATH "add retry with tests"`
+- `tg agent PATH "change behavior" --json`
+- `tg blast-radius-render PATH create_invoice`
 - `tg session open PATH`
 - `tg session daemon start PATH`
 
@@ -3163,7 +3163,8 @@ def _format_broad_generated_scan_error(generated_dirs: list[str]) -> str:
     if len(generated_dirs) > 8:
         visible_dirs = f"{visible_dirs}, ..."
     return (
-        "Error: broad generated-root scan refused: path contains generated, cache, "
+        "Error: broad generated-root scan refused as a safety guard, not a zero-match result: "
+        "path contains generated, cache, "
         f"or dependency directories ({visible_dirs}). Scope the path, add --glob, --type, "
         "or --max-depth, or pass --allow-broad-generated-scan to opt in.\n"
         "For bounded output:\n"
@@ -5851,29 +5852,34 @@ def map(
         None, "--max-files", min=1, help="Maximum source files to include in output."
     ),
     max_repo_files: int | None = typer.Option(
-        None, "--max-repo-files", min=1, help="Maximum repo files to scan before returning."
+        512,
+        "--max-repo-files",
+        min=1,
+        help="Maximum repo files to scan before returning. Defaults to the agent-safe 512-file cap.",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return a deterministic repository map for AI editing workflows."""
     from tensor_grep.cli.repo_map import (
+        DEFAULT_AGENT_REPO_MAP_LIMIT,
         apply_repo_map_output_limits,
         build_repo_map,
         build_repo_map_json,
     )
 
     try:
+        effective_max_repo_files = max_repo_files or DEFAULT_AGENT_REPO_MAP_LIMIT
         if json_output:
             typer.echo(
                 build_repo_map_json(
                     path,
                     max_files=max_files,
-                    max_repo_files=max_repo_files,
+                    max_repo_files=effective_max_repo_files,
                 )
             )
             return
 
-        payload = build_repo_map(path, max_repo_files=max_repo_files)
+        payload = build_repo_map(path, max_repo_files=effective_max_repo_files)
         payload = apply_repo_map_output_limits(payload, max_files=max_files)
     except FileNotFoundError as exc:
         typer.echo(str(exc), err=True)
@@ -5891,7 +5897,10 @@ def context(
         None, help="Query text used to rank relevant repo context."
     ),
     query: str | None = typer.Option(
-        None, "--query", help="Query text used to rank relevant repo context."
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
     ),
     max_files: int | None = typer.Option(
         None, "--max-files", min=1, help="Maximum ranked source files to include."
@@ -5945,7 +5954,10 @@ def context_render(
         None, help="Query text used to rank and render repo context."
     ),
     query: str | None = typer.Option(
-        None, "--query", help="Query text used to rank and render repo context."
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
     ),
     max_files: int = typer.Option(
         3, "--max-files", min=1, help="Maximum files to include in the render bundle."
@@ -6050,7 +6062,10 @@ def agent(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     query_arg: str | None = typer.Argument(None, help="Natural-language task or symbol query."),
     query: str | None = typer.Option(
-        None, "--query", help="Natural-language task or symbol query."
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
     ),
     max_files: int = typer.Option(
         3, "--max-files", min=1, help="Maximum files to include in the capsule."
@@ -6155,7 +6170,12 @@ def agent(
 def edit_plan(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     query_arg: str | None = typer.Argument(None, help="Query text used to rank edit targets."),
-    query: str | None = typer.Option(None, "--query", help="Query text used to rank edit targets."),
+    query: str | None = typer.Option(
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
+    ),
     max_files: int = typer.Option(
         3, "--max-files", min=1, help="Maximum files to include in the plan."
     ),
@@ -6336,7 +6356,12 @@ def _resolve_path_and_query(
 def defs(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6388,7 +6413,12 @@ def defs(
 def source(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6439,7 +6469,12 @@ def source(
 def impact(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to evaluate."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to evaluate."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6491,7 +6526,12 @@ def impact(
 def refs(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6543,7 +6583,12 @@ def refs(
 def callers(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6595,7 +6640,12 @@ def callers(
 def blast_radius(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6676,7 +6726,12 @@ def blast_radius(
 def blast_radius_render(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6778,7 +6833,12 @@ def blast_radius_render(
 def blast_radius_plan(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     provider: str = typer.Option(
         "native", "--provider", help="Semantic provider: native, lsp, or hybrid."
     ),
@@ -6852,12 +6912,12 @@ def blast_radius_plan(
 def session_open(
     path: str = typer.Argument(".", help="File or directory rooted at the session scope."),
     max_repo_files: int | None = typer.Option(
-        None,
+        512,
         "--max-repo-files",
         min=1,
         help=(
-            "Opt-in cap for files scanned into the initial session repo map. "
-            "Default keeps the complete session map."
+            "Maximum files scanned into the initial session repo map. "
+            "Defaults to the agent-safe 512-file cap."
         ),
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
@@ -7057,7 +7117,10 @@ def session_context_cmd(
         None, help="Query text used to rank relevant repo context."
     ),
     query: str | None = typer.Option(
-        None, "--query", help="Query text used to rank relevant repo context."
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
     ),
     refresh_on_stale: bool = typer.Option(
         False,
@@ -7121,7 +7184,10 @@ def session_context_render_cmd(
         None, help="Query text used to rank and render repo context."
     ),
     query: str | None = typer.Option(
-        None, "--query", help="Query text used to rank and render repo context."
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
     ),
     max_files: int = typer.Option(
         3, "--max-files", min=1, help="Maximum files to include in the render bundle."
@@ -7243,7 +7309,12 @@ def session_edit_plan_cmd(
     session_id: str = typer.Argument(..., help="Session ID to query."),
     path: str = typer.Argument(".", help="File or directory rooted at the session scope."),
     query_arg: str | None = typer.Argument(None, help="Query text used to rank edit targets."),
-    query: str | None = typer.Option(None, "--query", help="Query text used to rank edit targets."),
+    query: str | None = typer.Option(
+        None,
+        "--query",
+        help="Deprecated: use positional QUERY.",
+        hidden=True,
+    ),
     max_files: int = typer.Option(
         3, "--max-files", min=1, help="Maximum files to include in the plan."
     ),
@@ -7339,7 +7410,12 @@ def session_blast_radius_cmd(
     session_id: str = typer.Argument(..., help="Session ID to query."),
     path: str = typer.Argument(".", help="File or directory rooted at the session scope."),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     max_depth: int = typer.Option(
         3,
         "--max-depth",
@@ -7405,7 +7481,12 @@ def session_blast_radius_render_cmd(
     session_id: str = typer.Argument(..., help="Session ID to query."),
     path: str = typer.Argument(".", help="File or directory rooted at the session scope."),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     max_depth: int = typer.Option(
         3,
         "--max-depth",
@@ -7505,7 +7586,12 @@ def session_blast_radius_plan_cmd(
     session_id: str = typer.Argument(..., help="Session ID to query."),
     path: str = typer.Argument(".", help="File or directory rooted at the session scope."),
     symbol_arg: str | None = typer.Argument(None, help="Exact symbol name to resolve."),
-    symbol: str | None = typer.Option(None, "--symbol", help="Exact symbol name to resolve."),
+    symbol: str | None = typer.Option(
+        None,
+        "--symbol",
+        help="Deprecated: use positional SYMBOL.",
+        hidden=True,
+    ),
     max_depth: int = typer.Option(
         3,
         "--max-depth",
@@ -7800,6 +7886,10 @@ def checkpoint_undo(
     """Restore a checkpoint."""
     from tensor_grep.cli.checkpoint_store import resolve_latest_checkpoint, undo_checkpoint
 
+    if path == "--json":
+        json_output = True
+        path = "."
+
     try:
         if last:
             if checkpoint_id is not None and path != ".":
@@ -7820,7 +7910,33 @@ def checkpoint_undo(
                 raise typer.Exit(1)
             payload = undo_checkpoint(checkpoint_id, path)
     except Exception as exc:
-        typer.echo(str(exc), err=True)
+        message = str(exc)
+        if not last and checkpoint_id is not None:
+            candidate = Path(checkpoint_id).expanduser()
+            if candidate.exists():
+                message = (
+                    f"{message}. The first positional argument is parsed as CHECKPOINT_ID; "
+                    f"to restore the newest checkpoint for this path, use "
+                    f"`tg checkpoint undo --last {checkpoint_id}`."
+                )
+        if json_output:
+            typer.echo(
+                json.dumps(
+                    _with_schema_version(
+                        {
+                            "ok": False,
+                            "error": "checkpoint_not_found",
+                            "detail": message,
+                            "checkpoint_id": checkpoint_id,
+                            "path": path,
+                        },
+                        version=1,
+                    ),
+                    indent=2,
+                )
+            )
+            raise typer.Exit(1) from exc
+        typer.echo(message, err=True)
         raise typer.Exit(1) from exc
 
     if json_output:
@@ -9670,7 +9786,11 @@ def ast_info(
 
 @app.command(
     name="run",
-    help="Run a validated AST slice for structural search and guarded rewrites.",
+    help=(
+        "Run a validated AST slice for structural search and guarded rewrites. "
+        "PowerShell users should single-quote AST patterns containing $ captures, "
+        "for example 'def $NAME($$$ARGS): $$$BODY'."
+    ),
 )
 def run(
     arguments: list[str] | None = typer.Argument(

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1055,15 +1055,22 @@ def tg_ruleset_scan(
 
 
 @mcp.tool()  # type: ignore
-def tg_repo_map(path: str = ".") -> str:
+def tg_repo_map(path: str = ".", max_repo_files: int | None = 512) -> str:
     """
     Return a deterministic repository inventory for agent context selection.
 
     Args:
         path: File or directory to inventory.
+        max_repo_files: Maximum repo files to scan before returning. Defaults to 512.
     """
     try:
-        return json.dumps(build_repo_map(path), indent=2)
+        from tensor_grep.cli.repo_map import DEFAULT_AGENT_REPO_MAP_LIMIT
+
+        effective_max_repo_files = max_repo_files or DEFAULT_AGENT_REPO_MAP_LIMIT
+        return json.dumps(
+            build_repo_map(path, max_repo_files=effective_max_repo_files),
+            indent=2,
+        )
     except FileNotFoundError:
         payload = {
             "version": _json_output_version(),
@@ -2603,13 +2610,14 @@ def tg_checkpoint_undo(checkpoint_id: str, path: str = ".") -> str:
 
 
 @mcp.tool()  # type: ignore
-def tg_session_open(path: str = ".", max_repo_files: int | None = None) -> str:
+def tg_session_open(path: str = ".", max_repo_files: int | None = 512) -> str:
     """
     Create a cached repository-map session for repeated edit loops.
 
     Args:
         path: File or directory rooted at the session scope.
         max_repo_files: Optional cap for files scanned into the initial session repo map.
+            Defaults to 512 for agent-safe cold opens.
     """
     from tensor_grep.cli.session_store import open_session
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -24,6 +24,7 @@ from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 JSON_OUTPUT_VERSION = 1
 ROUTING_BACKEND = "RepoMap"
 ROUTING_REASON = "repo-map"
+DEFAULT_AGENT_REPO_MAP_LIMIT = 512
 _DEFAULT_LSP_OPERATION_BUDGET_SECONDS = 2.0
 _LSP_OPERATION_BUDGET_ENV_VAR = "TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS"
 _SKIP_DIR_NAMES = {
@@ -39,18 +40,24 @@ _SKIP_DIR_NAMES = {
     ".pytest_cache",
     ".ruff_cache",
     ".tmp",
+    ".venv_cuda",
     ".tox",
     ".turbo",
     ".vite",
     ".vitest",
     "__pycache__",
     "artifacts",
+    "bench_data",
     "build",
     "coverage",
     "dist",
+    "gpu_bench_data",
+    "group2_many_files",
     "htmlcov",
+    "many_files",
     "node_modules",
     "out",
+    "site",
     "target",
     "temp",
     "tmp",
@@ -398,7 +405,11 @@ def _should_skip_repo_dir(path: Path) -> bool:
         return True
     if name == "context" and path.parent.name.lower() == ".claude":
         return True
-    return name.startswith(("tg-agent-gpu-probe", "tg-doctor-gpu-probe"))
+    return name.startswith((
+        ".tmp_",
+        "tg-agent-gpu-probe",
+        "tg-doctor-gpu-probe",
+    ))
 
 
 def _iter_repo_bucket_files(root: Path) -> Iterator[Path]:
@@ -4150,6 +4161,8 @@ def build_repo_map(
 def build_repo_map_incremental(
     previous_map: dict[str, Any],
     changeset: dict[str, Any],
+    *,
+    max_repo_files: int | None = None,
 ) -> dict[str, Any]:
     root = Path(str(previous_map.get("path", "."))).expanduser().resolve()
     if not root.exists():
@@ -4177,11 +4190,13 @@ def build_repo_map_incremental(
         dict(symbol) for symbol in previous_map.get("symbols", [])
     ])
 
+    normalized_max_repo_files = max(1, int(max_repo_files)) if max_repo_files is not None else None
     all_files = [
         current
-        for current in _iter_repo_files(root)
+        for current in _iter_repo_files(root, max_files=normalized_max_repo_files)
         if _is_repo_context_file(current, context_root)
     ]
+    capped_file_count = len(all_files)
     current_files_by_path = {str(current): current for current in all_files}
     parsed_imports_by_file: dict[str, list[str]] = {}
     parsed_symbols_by_file: dict[str, list[dict[str, Any]]] = {}
@@ -4224,6 +4239,12 @@ def build_repo_map_incremental(
     payload["imports"] = imports
     payload["tests"] = tests
     payload["related_paths"] = sorted(dict.fromkeys([*source_files, *tests]))
+    if normalized_max_repo_files is not None:
+        payload["scan_limit"] = {
+            "max_repo_files": normalized_max_repo_files,
+            "scanned_files": capped_file_count,
+            "possibly_truncated": capped_file_count >= normalized_max_repo_files,
+        }
     return payload
 
 
@@ -8776,6 +8797,33 @@ def _sorted_ranked_symbols(symbols: list[dict[str, Any]]) -> list[dict[str, Any]
     return sorted(symbols, key=_symbol_rank_key)
 
 
+def _attach_edit_plan_headline_aliases(payload: dict[str, Any]) -> None:
+    navigation_pack = payload.get("navigation_pack")
+    edit_plan_seed = payload.get("edit_plan_seed")
+    if not isinstance(navigation_pack, dict) or not isinstance(edit_plan_seed, dict):
+        return
+    primary_target = navigation_pack.get("primary_target")
+    if isinstance(primary_target, dict) and primary_target:
+        payload["primary_target"] = dict(primary_target)
+    edit_order = edit_plan_seed.get("edit_ordering") or navigation_pack.get("edit_ordering")
+    if isinstance(edit_order, list):
+        payload["edit_order"] = [str(item) for item in edit_order]
+    payload["plan"] = {
+        "query": str(payload.get("query", "")),
+        "primary_file": edit_plan_seed.get("primary_file"),
+        "primary_symbol": dict(edit_plan_seed.get("primary_symbol", {}))
+        if isinstance(edit_plan_seed.get("primary_symbol"), dict)
+        else edit_plan_seed.get("primary_symbol"),
+        "primary_span": dict(edit_plan_seed.get("primary_span", {}))
+        if isinstance(edit_plan_seed.get("primary_span"), dict)
+        else edit_plan_seed.get("primary_span"),
+        "edit_order": list(payload.get("edit_order", [])),
+        "validation_commands": list(edit_plan_seed.get("validation_commands", [])),
+        "rollback_risk": edit_plan_seed.get("rollback_risk"),
+        "ranking_quality": str(payload.get("ranking_quality", "")),
+    }
+
+
 def _attach_edit_plan_metadata(
     repo_map: dict[str, Any],
     payload: dict[str, Any],
@@ -8911,6 +8959,7 @@ def _attach_edit_plan_metadata(
                 payload,
                 max_reads=max(max_files, max_symbols),
             )
+        _attach_edit_plan_headline_aliases(payload)
     return payload
 
 
@@ -9268,6 +9317,9 @@ _LLM_CONTEXT_RENDER_OMITTED_KEYS = (
     "file_matches",
     "file_summaries",
     "graph_trust_summary",
+    "edit_order",
+    "plan",
+    "primary_target",
     "test_matches",
 )
 
@@ -10047,6 +10099,23 @@ def _is_lsp_proof_row(row: dict[str, Any]) -> bool:
     )
 
 
+def _merge_navigation_duplicate(
+    existing: dict[str, Any],
+    candidate: dict[str, Any],
+) -> dict[str, Any]:
+    existing_is_lsp = _is_lsp_proof_row(existing)
+    candidate_is_lsp = _is_lsp_proof_row(candidate)
+    if candidate_is_lsp and not existing_is_lsp:
+        merged = {**existing, **candidate}
+    elif existing_is_lsp and not candidate_is_lsp:
+        merged = {**candidate, **existing}
+    else:
+        merged = {**existing, **candidate}
+    if _is_lsp_proof_row(merged):
+        merged["lsp_proof"] = True
+    return dict(merged)
+
+
 def _lsp_proof_row_count(rows: list[dict[str, Any]]) -> int:
     return sum(1 for row in rows if _is_lsp_proof_row(row))
 
@@ -10177,6 +10246,7 @@ def _external_workspace_symbols(
                 "lsp_provider_response": True,
                 "lsp_operation": "workspace/symbol",
             })
+            client.lsp_provider_response = True
     matches.sort(key=lambda item: (str(item["file"]), int(item["line"]), str(item["kind"])))
     deduped: list[dict[str, Any]] = []
     seen: set[tuple[str, int, int, str]] = set()
@@ -10395,6 +10465,7 @@ def _external_definitions(
                 "lsp_operation": "textDocument/definition",
                 "lsp_resolution_basis": "native-definition-anchor",
             })
+            client.lsp_provider_response = True
 
     return _dedupe_lsp_definition_rows(definitions) or workspace_matches
 
@@ -10490,8 +10561,10 @@ def _external_references(
                 "text": text,
                 "provenance": f"lsp-{language}",
                 "lsp_provider_response": True,
+                "lsp_proof": True,
                 "lsp_operation": "textDocument/references",
             })
+            client.lsp_provider_response = True
     references.sort(key=lambda item: (str(item["file"]), int(item["line"])))
     deduped: list[dict[str, Any]] = []
     seen_refs: set[tuple[str, int, int]] = set()
@@ -10591,7 +10664,10 @@ def build_symbol_defs_from_map(
     payload["related_paths"] = related_paths
     payload["graph_completeness"] = "strong"
     payload["semantic_provider"] = normalized_provider
-    lsp_proof_count = _lsp_proof_row_count(external_definitions)
+    for definition in definitions:
+        if _is_lsp_proof_row(definition):
+            definition["lsp_proof"] = True
+    lsp_proof_count = _lsp_proof_row_count(definitions)
     if normalized_provider != "native" and lsp_proof_count == 0 and native_definitions:
         fallback_used = True
     payload["provider_agreement"] = _merge_agreement_status(
@@ -11079,13 +11155,22 @@ def build_symbol_refs_from_map(
                     int(current_ref["line"]),
                     int(current_ref.get("end_line", current_ref["line"])),
                 )
-                merged_refs[key] = dict(current_ref)
+                if key in merged_refs:
+                    merged_refs[key] = _merge_navigation_duplicate(
+                        merged_refs[key],
+                        dict(current_ref),
+                    )
+                else:
+                    merged_refs[key] = dict(current_ref)
             references = list(merged_refs.values())
             references.sort(
                 key=lambda item: (str(item["file"]), int(item["line"]), str(item.get("text", "")))
             )
 
     references = _dedupe_symbol_references(references)
+    for reference in references:
+        if _is_lsp_proof_row(reference):
+            reference["lsp_proof"] = True
     referenced_files = sorted(dict.fromkeys(str(current["file"]) for current in references))
     related_paths: list[str] = []
     for current in [*payload["files"], *referenced_files, *payload["tests"]]:
@@ -11103,7 +11188,7 @@ def build_symbol_refs_from_map(
     )
     payload["coverage_summary"] = _coverage_summary(payload)
     payload["semantic_provider"] = normalized_provider
-    lsp_proof_count = _lsp_proof_row_count(external_refs)
+    lsp_proof_count = _lsp_proof_row_count(references)
     if normalized_provider != "native" and lsp_proof_count == 0 and references:
         fallback_used = True
     payload["provider_agreement"] = _merge_agreement_status(
@@ -11388,7 +11473,13 @@ def build_symbol_callers_from_map(
                     int(current_call_entry["line"]),
                     int(current_call_entry.get("end_line", current_call_entry["line"])),
                 )
-                merged_calls[key] = dict(current_call_entry)
+                if key in merged_calls:
+                    merged_calls[key] = _merge_navigation_duplicate(
+                        merged_calls[key],
+                        dict(current_call_entry),
+                    )
+                else:
+                    merged_calls[key] = dict(current_call_entry)
             calls = list(merged_calls.values())
             calls.sort(
                 key=lambda item: (str(item["file"]), int(item["line"]), str(item.get("text", "")))
@@ -11407,6 +11498,9 @@ def build_symbol_callers_from_map(
         for current in calls
         if (str(current["file"]), int(current.get("line", 0) or 0)) not in definition_locations
     ]
+    for call in calls:
+        if _is_lsp_proof_row(call):
+            call["lsp_proof"] = True
     caller_files = sorted(dict.fromkeys(str(current["file"]) for current in calls))
     context_payload = build_context_pack_from_map(
         repo_map,
@@ -11444,7 +11538,7 @@ def build_symbol_callers_from_map(
     )
     payload["coverage_summary"] = _coverage_summary(payload)
     payload["semantic_provider"] = normalized_provider
-    lsp_proof_count = _lsp_proof_row_count(external_calls)
+    lsp_proof_count = _lsp_proof_row_count(calls)
     if normalized_provider != "native" and lsp_proof_count == 0 and calls:
         fallback_used = True
     payload["provider_agreement"] = _merge_agreement_status(
@@ -11569,6 +11663,7 @@ def _apply_blast_radius_output_limits(
         selected_files = original_files[:normalized_max_files]
         selected_file_set = set(selected_files)
         limited["files"] = selected_files
+        limited["affected_files"] = list(selected_files)
         limited["file_matches"] = [
             current
             for current in _list_of_dicts(payload.get("file_matches"))
@@ -11625,6 +11720,8 @@ def _apply_blast_radius_output_limits(
             rendered_lines.append(f"Depth {current.get('depth')}:")
             rendered_lines.extend(f"- {path}" for path in _list_of_strings(current.get("files")))
         limited["rendered_caller_tree"] = "\n".join(rendered_lines)
+    elif "files" in limited:
+        limited["affected_files"] = _list_of_strings(limited.get("files"))
 
     limited["output_limit"] = {
         "max_callers": normalized_max_callers,
@@ -11668,6 +11765,8 @@ def build_symbol_blast_radius_from_map(
         payload["routing_reason"] = "symbol-blast-radius"
         payload["max_depth"] = max(0, int(max_depth))
         payload["callers"] = []
+        payload["affected_files"] = []
+        payload["blast_radius_score"] = 0.0
         payload["file_matches"] = []
         payload["file_summaries"] = []
         payload["test_matches"] = []
@@ -11961,6 +12060,13 @@ def build_symbol_blast_radius_from_map(
     payload["definitions"] = definitions
     payload["callers"] = direct_callers
     payload["files"] = radius_files
+    payload["affected_files"] = list(radius_files)
+    evidence_score = sum(min(10, max(0, int(item.get("score", 0)))) for item in ranked_files)
+    evidence_score += len(direct_callers) + len(related_tests)
+    evidence_denominator = max(
+        1, (10 * len(ranked_files)) + len(direct_callers) + len(related_tests)
+    )
+    payload["blast_radius_score"] = round(min(1.0, evidence_score / evidence_denominator), 3)
     payload["file_matches"] = ranked_files
     payload["file_summaries"] = _file_summaries(repo_map.get("symbols", []), radius_files)
     payload["tests"] = related_tests

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -148,6 +148,48 @@ def _probe_daemon(root: Path) -> dict[str, Any] | None:
     return metadata
 
 
+def _merge_live_daemon_stats(status: dict[str, Any]) -> dict[str, Any]:
+    if not status.get("running"):
+        return status
+    stat_fields = {
+        "version",
+        "cache_hits",
+        "cache_misses",
+        "refresh_count",
+        "root_count",
+        "session_count",
+        "sessions",
+        "cache_size_bytes",
+        "response_cache_size",
+        "response_cache_size_bytes",
+        "response_cache_max_size_bytes",
+        "response_cache_hits",
+        "response_cache_misses",
+        "response_cache_puts",
+        "response_cache_entries",
+        "response_cache_oversized_skips",
+        "uptime_seconds",
+        "inflight_requests",
+        "skipped_requests",
+        "last_full_rebuild_seconds",
+    }
+    try:
+        stats = _daemon_request(
+            str(status.get("host", _DAEMON_HOST)),
+            int(status["port"]),
+            {"command": "stats"},
+            response_timeout=_DAEMON_CONNECT_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        status["stats_unavailable"] = str(exc)
+        return status
+    for key, value in stats.items():
+        if key not in stat_fields:
+            continue
+        status[key] = value
+    return status
+
+
 def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
     root = _resolve_root(Path(path))
     metadata = _read_daemon_metadata(root)
@@ -158,7 +200,7 @@ def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
             live = _probe_daemon(discovered_root)
             if live is None:
                 continue
-            return {
+            return _merge_live_daemon_stats({
                 "version": _SESSION_VERSION,
                 "root": str(discovered_root),
                 "requested_root": str(root),
@@ -168,7 +210,7 @@ def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
                 "port": int(live["port"]),
                 "pid": int(live["pid"]),
                 "started_at": str(live["started_at"]),
-            }
+            })
         return {
             "version": _SESSION_VERSION,
             "root": str(root),
@@ -184,7 +226,7 @@ def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
             "running": False,
             "stale_metadata": True,
         }
-    return {
+    return _merge_live_daemon_stats({
         "version": _SESSION_VERSION,
         "root": str(root),
         "discovered": False,
@@ -193,7 +235,7 @@ def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
         "port": int(live["port"]),
         "pid": int(live["pid"]),
         "started_at": str(live["started_at"]),
-    }
+    })
 
 
 def start_session_daemon(path: str = ".") -> dict[str, Any]:

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -13,6 +13,7 @@ from typing import Any, TextIO, cast
 from uuid import uuid4
 
 from tensor_grep.cli.repo_map import (
+    DEFAULT_AGENT_REPO_MAP_LIMIT,
     _is_repo_context_file,
     _iter_repo_files,
     apply_repo_map_output_limits,
@@ -38,8 +39,8 @@ _SESSION_SERVE_CACHE_MAX_ENTRIES = 32
 _SESSION_SERVE_RESPONSE_CACHE_MAX_ENTRIES = 32
 _SESSION_SERVE_RESPONSE_CACHE_MAX_BYTES_ENV = "TENSOR_GREP_SESSION_RESPONSE_CACHE_MAX_BYTES"
 _DEFAULT_SESSION_SERVE_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024
-_DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT = 512
-_DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT = 512
+_DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
+_DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
 
 
 @dataclass
@@ -74,6 +75,7 @@ class SessionRefreshResult:
     symbol_count: int
     refresh_type: str
     changeset: dict[str, list[str]]
+    scan_limit: dict[str, Any] | None = None
 
 
 class SessionStaleError(RuntimeError):
@@ -447,10 +449,31 @@ def _new_session_id(root: Path) -> str:
     return f"session-{timestamp}-{root.name}-{uuid4().hex[:8]}"
 
 
-def open_session(path: str = ".", *, max_repo_files: int | None = None) -> SessionOpenResult:
+def _effective_session_max_repo_files(
+    requested: int | None,
+    payload: dict[str, Any] | None = None,
+) -> int | None:
+    if requested is not None:
+        return max(1, int(requested))
+    if payload is not None:
+        scan_limit = payload.get("scan_limit")
+        if isinstance(scan_limit, dict) and scan_limit.get("max_repo_files") is not None:
+            try:
+                return max(1, int(cast(int | str, scan_limit["max_repo_files"])))
+            except (TypeError, ValueError):
+                pass
+    return DEFAULT_AGENT_REPO_MAP_LIMIT
+
+
+def open_session(
+    path: str = ".",
+    *,
+    max_repo_files: int | None = DEFAULT_AGENT_REPO_MAP_LIMIT,
+) -> SessionOpenResult:
     root = _resolve_root(Path(path))
     started_at = monotonic()
-    repo_map = build_repo_map(root, max_repo_files=max_repo_files)
+    effective_max_repo_files = _effective_session_max_repo_files(max_repo_files)
+    repo_map = build_repo_map(root, max_repo_files=effective_max_repo_files)
     built_at = monotonic()
     created_at = datetime.now(UTC).isoformat()
     session_id = _new_session_id(root)
@@ -500,10 +523,12 @@ def refresh_session(
     session_id: str,
     path: str = ".",
     *,
+    max_repo_files: int | None = None,
     payload_cache: _SessionServeCache | None = None,
 ) -> SessionRefreshResult:
     root = _resolve_root(Path(path))
     existing = get_session(session_id, path)
+    effective_max_repo_files = _effective_session_max_repo_files(max_repo_files, existing)
     changeset = _stale_changeset(existing, detect_added_files=True)
     refresh_type = "full"
     if changeset is not None:
@@ -511,13 +536,14 @@ def refresh_session(
             repo_map = build_repo_map_incremental(
                 cast(dict[str, Any], existing["repo_map"]),
                 changeset,
+                max_repo_files=effective_max_repo_files,
             )
             refresh_type = "incremental"
         except Exception:
-            repo_map = build_repo_map(root)
+            repo_map = build_repo_map(root, max_repo_files=effective_max_repo_files)
             refresh_type = "full"
     else:
-        repo_map = build_repo_map(root)
+        repo_map = build_repo_map(root, max_repo_files=effective_max_repo_files)
         changeset = _empty_changeset()
     refreshed_at = datetime.now(UTC).isoformat()
     created_at = str(existing.get("created_at", refreshed_at))
@@ -531,6 +557,7 @@ def refresh_session(
         "snapshot": _capture_snapshot(repo_map["related_paths"]),
         "refresh_type": refresh_type,
         "changeset": changeset,
+        "scan_limit": cast(dict[str, Any] | None, repo_map.get("scan_limit")),
     }
     session_path = _session_payload_path(root, session_id)
     session_path.parent.mkdir(parents=True, exist_ok=True)
@@ -572,6 +599,7 @@ def refresh_session(
         symbol_count=len(repo_map["symbols"]),
         refresh_type=refresh_type,
         changeset=changeset,
+        scan_limit=cast(dict[str, Any] | None, repo_map.get("scan_limit")),
     )
 
 

--- a/tests/unit/test_benchmark_artifacts_schema.py
+++ b/tests/unit/test_benchmark_artifacts_schema.py
@@ -130,6 +130,8 @@ ARTIFACT_SCHEMAS: dict[str, tuple[str, ...]] = {
     ),
 }
 
+MAX_UNIT_TEST_ARTIFACT_BYTES = 64 * 1024 * 1024
+
 
 def test_benchmark_artifacts_should_exist_and_match_stable_top_level_shapes() -> None:
     artifacts_dir = Path("artifacts")
@@ -140,6 +142,11 @@ def test_benchmark_artifacts_should_exist_and_match_stable_top_level_shapes() ->
         path = artifacts_dir / file_name
         if not path.exists():
             pytest.skip(f"generated benchmark artifact missing: {path}")
+        if path.stat().st_size > MAX_UNIT_TEST_ARTIFACT_BYTES:
+            pytest.skip(
+                "generated benchmark artifact is too large for unit-test JSON loading: "
+                f"{path} ({path.stat().st_size} bytes)"
+            )
         payload = json.loads(path.read_text(encoding="utf-8"))
 
         for key in required_keys:

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -686,7 +686,7 @@ def test_root_help_should_surface_current_agent_gpu_launcher_and_validation_cont
     assert result.exit_code == 0
     help_text = result.stdout
     for expected in [
-        "tg agent PATH --query",
+        'tg agent PATH "change invoice tax"',
         "alternative targets",
         "validation_commands",
         "$file",

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -436,6 +436,7 @@ def test_files_mode_refuses_unbounded_broad_generated_root_scan(tmp_path: Path):
 
     assert result.exit_code == 2
     assert "broad generated-root scan refused" in result.output
+    assert "safety guard, not a zero-match result" in result.output
     assert "node_modules" in result.output
     assert "--glob" in result.output
     assert "--max-depth" in result.output
@@ -1005,9 +1006,10 @@ def test_session_context_help_mentions_daemon_flag() -> None:
     result = runner.invoke(app, ["session", "context", "--help"])
 
     assert result.exit_code == 0
-    normalized_output = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+    normalized_output = re.sub(r"\s+", " ", re.sub(r"\x1b\[[0-9;]*m", "", result.stdout))
     assert "-daemon" in normalized_output
-    assert "localhost session daemon" in normalized_output
+    assert "warm localhost" in normalized_output
+    assert "session daemon" in normalized_output
 
 
 def test_lsp_help_mentions_provider_modes() -> None:
@@ -3091,6 +3093,8 @@ def test_map_json_emits_repo_inventory_envelope(tmp_path):
     assert payload["routing_reason"] == "repo-map"
     assert payload["sidecar_used"] is False
     assert payload["path"] == str(project.resolve())
+    assert payload["scan_limit"]["max_repo_files"] == 512
+    assert payload["scan_limit"]["possibly_truncated"] is False
     assert str(module_path.resolve()) in payload["files"]
     assert str(test_path.resolve()) in payload["tests"]
     assert any(
@@ -3337,6 +3341,24 @@ def test_symbol_commands_warn_for_legacy_symbol_option(tmp_path):
         assert payload["routing_reason"] == routing_reason
         assert payload["symbol"] == "create_invoice"
         assert _has_expected_file(payload)
+
+
+def test_symbol_command_help_hides_legacy_symbol_option():
+    runner = CliRunner()
+
+    for command in (
+        "defs",
+        "source",
+        "impact",
+        "refs",
+        "callers",
+        "blast-radius",
+        "blast-radius-render",
+        "blast-radius-plan",
+    ):
+        result = runner.invoke(app, [command, "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--symbol" not in _strip_ansi(result.stdout)
 
 
 def test_symbol_commands_reject_positional_and_flag_symbol(tmp_path):
@@ -3741,6 +3763,9 @@ def test_blast_radius_json_returns_transitive_symbol_radius(tmp_path):
     assert payload["definitions"][0]["file"] == str(module_path.resolve())
     assert any(caller["file"] == str(service_path.resolve()) for caller in payload["callers"])
     assert payload["files"][0] == str(module_path.resolve())
+    assert payload["affected_files"] == payload["files"]
+    assert payload["blast_radius_score"] is not None
+    assert 0.0 <= payload["blast_radius_score"] <= 1.0
     assert str(service_path.resolve()) in payload["files"]
     assert str(api_path.resolve()) in payload["files"]
     assert payload["tests"][0] == str(test_path.resolve())
@@ -4087,6 +4112,15 @@ def test_agent_context_commands_warn_for_legacy_query_option(tmp_path):
         assert payload["routing_reason"] == routing_reason
         assert payload["query"] == "create invoice"
         assert _has_expected_file(payload)
+
+
+def test_agent_context_help_hides_legacy_query_option():
+    runner = CliRunner()
+
+    for command in ("context", "context-render", "agent", "edit-plan"):
+        result = runner.invoke(app, [command, "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--query" not in _strip_ansi(result.stdout)
 
 
 def test_agent_context_commands_reject_positional_and_flag_query(tmp_path):
@@ -6320,6 +6354,14 @@ def test_edit_plan_json_returns_machine_readable_plan_bundle(tmp_path):
     assert payload["candidate_edit_targets"]["spans"][0]["file"] == str(module_path.resolve())
     assert payload["candidate_edit_targets"]["spans"][0]["symbol"] == "create_invoice"
     assert payload["candidate_edit_targets"]["spans"][0]["depth"] == 0
+    assert payload["primary_target"] == payload["navigation_pack"]["primary_target"]
+    assert payload["primary_target"]["file"] == str(module_path.resolve())
+    assert payload["edit_order"] == payload["edit_plan_seed"]["edit_ordering"]
+    assert payload["plan"]["primary_file"] == str(module_path.resolve())
+    assert payload["plan"]["primary_symbol"]["name"] == "create_invoice"
+    assert payload["plan"]["edit_order"] == payload["edit_order"]
+    assert "rendered_context" not in payload["plan"]
+    assert "sources" not in payload["plan"]
     _assert_enriched_edit_plan_seed(
         payload["edit_plan_seed"],
         primary_file=module_path,
@@ -7368,6 +7410,7 @@ def test_tg_run_help_should_position_ast_as_validated_slice_not_ast_grep_parity(
     help_text = _strip_ansi(result.stdout)
     normalized_help = re.sub(r"\s+", " ", help_text)
     assert "validated AST slice" in normalized_help
+    assert "PowerShell users should single-quote AST patterns" in normalized_help
     assert "--selector" in help_text
     assert "--strictness" in help_text
     assert "--stdin" in help_text
@@ -12174,6 +12217,22 @@ def test_main_entry_should_not_rewrite_checkpoint_subcommand(monkeypatch):
     cli_main.main_entry()
 
     assert seen["argv"] == ["tg", "checkpoint", "list"]
+
+
+def test_checkpoint_undo_existing_path_reports_last_hint_json(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = CliRunner().invoke(app, ["checkpoint", "undo", str(project), "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "checkpoint_not_found"
+    assert payload["checkpoint_id"] == str(project)
+    assert payload["path"] == "."
+    assert "parsed as CHECKPOINT_ID" in payload["detail"]
+    assert "tg checkpoint undo --last" in payload["detail"]
 
 
 def test_main_entry_should_not_rewrite_dogfood_subcommand(monkeypatch):

--- a/tests/unit/test_harness_cookbook.py
+++ b/tests/unit/test_harness_cookbook.py
@@ -31,7 +31,7 @@ def test_harness_cookbook_covers_public_workflows() -> None:
     assert "tg.exe search --json" in doc
     assert "tg.exe search --index --json" in doc
     assert "tg.exe map --json" in doc
-    assert 'tg.exe context --query "invoice payment" --json' in doc
+    assert 'tg.exe context .\\src "invoice payment" --json' in doc
     assert "tg session open" in doc
     assert "tg session list" in doc
     assert "tg session show" in doc
@@ -40,7 +40,7 @@ def test_harness_cookbook_covers_public_workflows() -> None:
     assert "tg session serve" in doc
     assert "--refresh-on-stale" in doc
     assert "tg.exe map --json" in doc
-    assert "tg.exe context --query" in doc
+    assert "tg.exe context .\\src" in doc
     assert "tg.exe search --ndjson" in doc
     assert "tg.exe run --lang python --rewrite" in doc
     assert "--diff" in doc
@@ -63,11 +63,14 @@ def test_harness_cookbook_covers_public_workflows() -> None:
     assert "tg checkpoint create" in doc
     assert "tg checkpoint list" in doc
     assert "tg checkpoint undo" in doc
-    assert "tg defs --symbol" in doc
-    assert "tg source --symbol" in doc
-    assert "tg impact --symbol" in doc
-    assert "tg refs --symbol" in doc
-    assert "tg callers --symbol" in doc
+    assert "tg defs .\\src create_invoice" in doc
+    assert "tg source .\\src create_invoice" in doc
+    assert "tg impact . create_invoice" in doc
+    assert "tg refs . create_invoice" in doc
+    assert "tg callers . create_invoice" in doc
+    assert "blast_radius_score" in doc
+    assert "0.0` to" in doc
+    assert "affected_files" in doc
     assert "--checkpoint" in doc
     assert "--apply-edit-ids" in doc
     assert "--reject-edit-ids" in doc

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -317,14 +317,22 @@ def test_refresh_session_uses_incremental_builder_when_changeset_available(
     original_incremental = session_store.build_repo_map_incremental
 
     def tracking_incremental(
-        previous_map: dict[str, object], changeset: dict[str, list[str]]
+        previous_map: dict[str, object],
+        changeset: dict[str, list[str]],
+        *,
+        max_repo_files: int | None = None,
     ) -> dict[str, object]:
         incremental_calls["count"] += 1
-        return original_incremental(previous_map, changeset)
+        assert max_repo_files == session_store.DEFAULT_AGENT_REPO_MAP_LIMIT
+        return original_incremental(previous_map, changeset, max_repo_files=max_repo_files)
 
-    def unexpected_full_build(path: str | Path = ".") -> dict[str, object]:
+    def unexpected_full_build(
+        path: str | Path = ".",
+        *,
+        max_repo_files: int | None = None,
+    ) -> dict[str, object]:
         full_calls["count"] += 1
-        return repo_map.build_repo_map(path)
+        return repo_map.build_repo_map(path, max_repo_files=max_repo_files)
 
     monkeypatch.setattr(session_store, "build_repo_map_incremental", tracking_incremental)
     monkeypatch.setattr(session_store, "build_repo_map", unexpected_full_build)
@@ -349,13 +357,22 @@ def test_refresh_session_falls_back_to_full_rebuild_when_incremental_fails(
     full_calls = {"count": 0}
 
     def failing_incremental(
-        previous_map: dict[str, object], changeset: dict[str, list[str]]
+        previous_map: dict[str, object],
+        changeset: dict[str, list[str]],
+        *,
+        max_repo_files: int | None = None,
     ) -> dict[str, object]:
+        assert max_repo_files == session_store.DEFAULT_AGENT_REPO_MAP_LIMIT
         raise RuntimeError("boom")
 
-    def tracking_full_build(path: str | Path = ".") -> dict[str, object]:
+    def tracking_full_build(
+        path: str | Path = ".",
+        *,
+        max_repo_files: int | None = None,
+    ) -> dict[str, object]:
         full_calls["count"] += 1
-        return repo_map.build_repo_map(path)
+        assert max_repo_files == session_store.DEFAULT_AGENT_REPO_MAP_LIMIT
+        return repo_map.build_repo_map(path, max_repo_files=max_repo_files)
 
     monkeypatch.setattr(session_store, "build_repo_map_incremental", failing_incremental)
     monkeypatch.setattr(session_store, "build_repo_map", tracking_full_build)
@@ -411,7 +428,10 @@ def test_refresh_session_incremental_repo_map_matches_full_rebuild(tmp_path: Pat
     payload = _session_payload(paths["project"], session_id)
 
     assert refreshed.refresh_type == "incremental"
-    assert payload["repo_map"] == repo_map.build_repo_map(paths["project"])
+    assert payload["repo_map"] == repo_map.build_repo_map(
+        paths["project"],
+        max_repo_files=session_store.DEFAULT_AGENT_REPO_MAP_LIMIT,
+    )
 
 
 def test_session_context_raises_stale_error_with_changeset_summary(tmp_path: Path) -> None:

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -440,7 +440,7 @@ def test_provider_status_verify_health_success_reports_lsp_proof(
     assert "not_lsp_proof_reason" not in status
 
 
-def test_provider_status_verify_health_success_suppresses_stderr_tail(
+def test_provider_status_verify_health_success_preserves_sre_stderr_warning(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -473,8 +473,9 @@ def test_provider_status_verify_health_success_suppresses_stderr_tail(
     assert status["health_status"] == "ready"
     assert status["lsp_proof"] is True
     assert status["last_error"] is None
-    assert status["stderr_tail"] == []
-    assert status["stderr_tail_suppressed"] is True
+    assert status["stderr_tail"] == ["SRE module mismatch traceback"]
+    assert status["provider_warnings"] == ["SRE module mismatch traceback"]
+    assert status["stderr_tail_suppressed"] is False
 
 
 def test_provider_status_verify_health_applies_probe_budget_to_initialize(

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -289,6 +289,44 @@ def test_tg_search_includes_routing_summary_in_non_empty_output():
     assert "workers=2" in out
 
 
+def test_tg_search_context_rows_do_not_inflate_header_count():
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = MagicMock()
+    fake_backend.search.return_value = SearchResult(
+        matches=[
+            MatchLine(line_number=1, text="before", file="a.log"),
+            MatchLine(line_number=2, text="ERROR here", file="a.log"),
+            MatchLine(line_number=3, text="after", file="a.log"),
+        ],
+        matched_file_paths=["a.log"],
+        match_counts_by_file={"a.log": 1},
+        total_files=1,
+        total_matches=1,
+        routing_backend="RipgrepBackend",
+        routing_reason="rg_json",
+    )
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "RipgrepBackend"
+        pipeline.selected_backend_reason = "rg_json"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        out = mcp_server.tg_search("ERROR", ".", context=1)
+
+    assert "Found 1 matches across 1 files:" in out
+    assert "  1: before" in out
+    assert "  2: ERROR here" in out
+    assert "  3: after" in out
+
+
 def test_tg_search_should_report_runtime_routing_override_when_backend_falls_back():
     from tensor_grep.cli import mcp_server
 
@@ -669,6 +707,25 @@ def test_tg_session_open_accepts_initial_repo_map_cap(tmp_path: Path):
     assert payload["scan_limit"]["max_repo_files"] == 2
     assert payload["scan_limit"]["possibly_truncated"] is True
     assert payload["build_seconds"] >= 0
+
+
+def test_tg_session_open_defaults_to_agent_safe_repo_map_cap(tmp_path: Path):
+    from tensor_grep.cli import mcp_server
+
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    for index in range(520):
+        (src_dir / f"module_{index:03}.py").write_text(
+            f"def function_{index}():\n    return {index}\n",
+            encoding="utf-8",
+        )
+
+    payload = json.loads(mcp_server.tg_session_open(str(project)))
+
+    assert payload["file_count"] == 512
+    assert payload["scan_limit"]["max_repo_files"] == 512
+    assert payload["scan_limit"]["possibly_truncated"] is True
 
 
 def test_tg_rulesets_returns_builtin_ruleset_metadata():
@@ -2541,6 +2598,8 @@ def test_tg_repo_map_returns_json_inventory(tmp_path):
     assert payload["sidecar_used"] is False
     assert payload["coverage"]["language_scope"] == "python-js-ts-rust"
     assert payload["path"] == str(project.resolve())
+    assert payload["scan_limit"]["max_repo_files"] == 512
+    assert payload["scan_limit"]["possibly_truncated"] is False
     assert str(module_path.resolve()) in payload["files"]
     assert str(test_path.resolve()) in payload["tests"]
     assert any(
@@ -3008,6 +3067,11 @@ def test_tg_edit_plan_returns_machine_readable_plan_bundle(tmp_path):
         primary_file=module_path,
         primary_symbol_name="create_invoice",
     )
+    assert payload["primary_target"] == payload["navigation_pack"]["primary_target"]
+    assert payload["edit_order"] == payload["edit_plan_seed"]["edit_ordering"]
+    assert payload["plan"]["primary_file"] == str(module_path.resolve())
+    assert payload["plan"]["primary_symbol"]["name"] == "create_invoice"
+    assert "rendered_context" not in payload["plan"]
 
 
 def test_tg_edit_plan_prefers_targeted_vitest_validation_commands(tmp_path):

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -49,6 +49,34 @@ def test_should_forward_no_ignore_flag():
     assert "--no-ignore" in cmd
 
 
+def test_json_context_events_do_not_inflate_match_totals():
+    backend = RipgrepBackend()
+    config = SearchConfig(context=1)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stderr = ""
+    mock_result.stdout = "\n".join([
+        '{"type":"begin","data":{"path":{"text":"app.log"}}}',
+        '{"type":"context","data":{"path":{"text":"app.log"},"lines":{"text":"before\\n"},"line_number":1}}',
+        '{"type":"match","data":{"path":{"text":"app.log"},"lines":{"text":"ERROR here\\n"},"line_number":2}}',
+        '{"type":"context","data":{"path":{"text":"app.log"},"lines":{"text":"after\\n"},"line_number":3}}',
+        '{"type":"end","data":{"path":{"text":"app.log"},"binary_offset":null,"stats":{"matches":1}}}',
+    ])
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch("tensor_grep.backends.ripgrep_backend.subprocess.run", return_value=mock_result),
+    ):
+        result = backend.search("app.log", "ERROR", config=config)
+
+    assert len(result.matches) == 3
+    assert result.total_matches == 1
+    assert result.total_files == 1
+    assert result.matched_file_paths == ["app.log"]
+    assert result.match_counts_by_file == {"app.log": 1}
+
+
 def test_should_forward_rg_config_override_flags():
     backend = RipgrepBackend()
     config = SearchConfig(

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -1244,6 +1244,54 @@ def test_repo_map_callers_hybrid_deduplicates_external_and_native_same_call_site
     assert [(row["file"], row["line"], row["text"]) for row in payload["callers"]] == [
         (resolved_consumer, 3, "create_invoice()")
     ]
+    assert payload["callers"][0]["lsp_provider_response"] is True
+    assert payload["callers"][0]["lsp_proof"] is True
+    assert payload["lsp_proof"] is True
+    assert payload["lsp_evidence_status"] == "lsp_proof"
+
+
+def test_repo_map_refs_hybrid_deduplicates_external_and_native_same_reference_with_lsp_proof(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service_path = tmp_path / "service.py"
+    consumer_path = tmp_path / "consumer.py"
+    service_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+    consumer_path.write_text(
+        "from service import create_invoice\n\ncreate_invoice()\n",
+        encoding="utf-8",
+    )
+    resolved_consumer = str(consumer_path.resolve())
+    monkeypatch.setattr(
+        repo_map,
+        "_external_references",
+        lambda root, symbol, definitions: [
+            {
+                "name": symbol,
+                "kind": "reference",
+                "file": resolved_consumer,
+                "line": 3,
+                "end_line": 3,
+                "text": "create_invoice()",
+                "provenance": "lsp-python",
+                "lsp_provider_response": True,
+                "lsp_proof": True,
+                "lsp_operation": "textDocument/references",
+            }
+        ],
+    )
+
+    payload = repo_map.build_symbol_refs("create_invoice", tmp_path, semantic_provider="hybrid")
+    matching_refs = [
+        row
+        for row in payload["references"]
+        if row["file"] == resolved_consumer and row["line"] == 3
+    ]
+
+    assert len(matching_refs) == 1
+    assert matching_refs[0]["lsp_provider_response"] is True
+    assert matching_refs[0]["lsp_proof"] is True
+    assert payload["lsp_proof"] is True
+    assert payload["lsp_evidence_status"] == "lsp_proof"
 
 
 def test_repo_map_blast_radius_hybrid_can_include_js_ts_alias_wrapper_callers(

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -93,6 +93,49 @@ def test_session_open_can_cap_initial_repo_map(tmp_path: Path) -> None:
     assert len(shown["repo_map"]["files"]) == 2
     assert shown["scan_limit"] == opened["scan_limit"]
 
+    refresh_result = runner.invoke(
+        app,
+        ["session", "refresh", opened["session_id"], str(project), "--json"],
+    )
+
+    assert refresh_result.exit_code == 0, refresh_result.output
+    refreshed = json.loads(refresh_result.stdout)
+    assert refreshed["file_count"] == 2
+    assert refreshed["scan_limit"]["max_repo_files"] == 2
+
+
+def test_session_open_defaults_to_agent_safe_repo_map_cap(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    for index in range(520):
+        (src_dir / f"module_{index:03}.py").write_text(
+            f"def function_{index}():\n    return {index}\n",
+            encoding="utf-8",
+        )
+
+    runner = CliRunner()
+    open_result = runner.invoke(app, ["session", "open", str(project), "--json"])
+
+    assert open_result.exit_code == 0, open_result.output
+    opened = json.loads(open_result.stdout)
+    assert opened["file_count"] == 512
+    assert opened["scan_limit"] == {
+        "max_repo_files": 512,
+        "scanned_files": 512,
+        "possibly_truncated": True,
+    }
+
+    show_result = runner.invoke(
+        app,
+        ["session", "show", opened["session_id"], str(project), "--json"],
+    )
+
+    assert show_result.exit_code == 0, show_result.output
+    shown = json.loads(show_result.stdout)
+    assert len(shown["repo_map"]["files"]) == 512
+    assert shown["scan_limit"] == opened["scan_limit"]
+
 
 def test_session_edit_plan_and_blast_radius_plan_reuse_cached_repo_map(tmp_path: Path) -> None:
     project = tmp_path / "project"
@@ -1412,6 +1455,12 @@ def test_session_daemon_lifecycle(tmp_path: Path) -> None:
     status = session_daemon.get_session_daemon_status(str(project))
     assert status["running"] is True
     assert status["port"] == started["port"]
+    assert status["response_cache_hits"] == 0
+    assert status["response_cache_misses"] == 0
+    assert status["response_cache_entries"] == 0
+    assert status["response_cache_size_bytes"] == 0
+    assert status["response_cache_max_size_bytes"] > 0
+    assert status["response_cache_oversized_skips"] == 0
 
     stopped_payload = session_daemon.stop_session_daemon(str(project))
     assert stopped_payload["stopped"] is True
@@ -1439,6 +1488,8 @@ def test_session_daemon_status_discovers_child_scope_from_parent_cwd(
         assert payload["discovered"] is True
         assert payload["root"] == str(project.resolve())
         assert payload["port"] == started["port"]
+        assert "response_cache_size_bytes" in payload
+        assert "response_cache_max_size_bytes" in payload
     finally:
         session_daemon.stop_session_daemon(str(project))
 

--- a/tests/unit/test_trust_planning.py
+++ b/tests/unit/test_trust_planning.py
@@ -397,12 +397,23 @@ def test_repo_map_excludes_generated_hidden_binary_and_log_noise_by_default(
     node_modules = project / "node_modules" / "pkg"
     cache_dir = project / ".pytest_cache"
     artifacts_dir = project / "artifacts" / "debug"
+    extra_generated_dirs = [
+        project / ".venv_cuda" / "lib",
+        project / "bench_data" / "corpus",
+        project / "gpu_bench_data" / "corpus",
+        project / ".tmp_large" / "cache",
+        project / "many_files" / "generated",
+        project / "group2_many_files" / "generated",
+        project / "site" / "packages",
+    ]
     src_dir.mkdir(parents=True)
     hidden_dir.mkdir()
     git_dir.mkdir()
     node_modules.mkdir(parents=True)
     cache_dir.mkdir()
     artifacts_dir.mkdir(parents=True)
+    for generated_dir in extra_generated_dirs:
+        generated_dir.mkdir(parents=True)
 
     source_path = src_dir / "payments.py"
     source_path.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
@@ -415,16 +426,28 @@ def test_repo_map_excludes_generated_hidden_binary_and_log_noise_by_default(
         "def create_invoice_debug_probe():\n    return 'debug artifact'\n",
         encoding="utf-8",
     )
+    generated_probes = []
+    for index, generated_dir in enumerate(extra_generated_dirs):
+        generated_probe = generated_dir / f"generated_{index}.py"
+        generated_probe.write_text(
+            f"def generated_invoice_probe_{index}():\n    return {index}\n",
+            encoding="utf-8",
+        )
+        generated_probes.append(generated_probe)
     (project / "run.log").write_text("create invoice noisy log\n", encoding="utf-8")
     (project / "blob.bin").write_bytes(b"create invoice\0binary")
 
     payload = repo_map.build_context_render("create invoice", project)
     files = {Path(path).resolve() for path in payload["files"]}
+    serialized = json.dumps(payload)
 
     assert source_path.resolve() in files
     assert (hidden_dir / "notes.txt").resolve() not in files
     assert (node_modules / "dep.js").resolve() not in files
     assert artifact_probe.resolve() not in files
+    for generated_probe in generated_probes:
+        assert generated_probe.resolve() not in files
+        assert str(generated_probe.resolve()) not in serialized
     assert (project / "run.log").resolve() not in files
     assert (project / "blob.bin").resolve() not in files
 


### PR DESCRIPTION
## Summary

- Fix v1.13.14 dogfood contract regressions across search/MCP count parity, LSP proof reporting, bounded repo-map/session defaults, edit-plan/blast-radius headline fields, help/docs deprecation drift, and checkpoint undo path hints.
- Document the consolidated dogfood issues and the reviewed v1.13.15 implementation plan.
- Update README, harness docs, and the agent-readiness script to prefer positional query/symbol forms while keeping legacy flags accepted.

## Validation

- `uv run pytest -q` -> 2493 passed, 17 skipped
- `uv run ruff format --check --preview .`
- `uv run ruff check .`
- `uv run mypy src/tensor_grep`
- `C:/Users/oimir/.cargo/bin/cargo.exe fmt --manifest-path rust_core/Cargo.toml --check`
- `C:/Users/oimir/.cargo/bin/cargo.exe clippy --manifest-path rust_core/Cargo.toml --all-targets -- -D warnings`
- `C:/Users/oimir/.cargo/bin/cargo.exe test --manifest-path rust_core/Cargo.toml`
- `uv run python scripts/agent_readiness.py --no-shell-probes --no-wsl-probe --json --progress never` -> 13 passed, 0 failed
- `git diff --check`