### PR TITLE
fix: harden upgrade daemon and lsp diagnostics

### DIFF
--- a/docs/FIX_PLAN_1_13_21.md
+++ b/docs/FIX_PLAN_1_13_21.md
@@ -1,0 +1,89 @@
+# v1.13.21 Dogfood Fix Plan
+
+## Goal
+
+Clear the two v1.13.20 dogfood carry-overs without changing the raw search,
+cache, map, edit-plan, or MCP contracts that held in v1.13.20.
+
+## Findings
+
+1. `tg upgrade` can leave a previously running session daemon absent after the
+   package/native-front-door refresh. Explicit `tg session daemon start .` works,
+   so the daemon runtime is healthy; the missing piece is upgrade handoff.
+2. Successful hybrid/LSP proof payloads still surface historical Pyright
+   `AssertionError: SRE module mismatch` lines in `provider_status.*.stderr_tail`.
+   External evidence points to this class of traceback as a Python environment
+   / stdlib mismatch, especially when a child process inherits interpreter
+   variables such as `PYTHONHOME`.
+
+Research anchor:
+
+- CPython issue `python/cpython#124114` and uv PR `astral-sh/uv#17821` both tie
+  `SRE module mismatch` to mismatched Python runtime/stdlib state or inherited
+  Python environment.
+
+## Implementation Plan
+
+### 1. Upgrade Daemon Handoff
+
+Files:
+
+- `src/tensor_grep/cli/main.py`
+- `tests/unit/test_cli_modes.py`
+
+Steps:
+
+1. Add a failing test that simulates a running daemon before `tg upgrade`, a
+   stopped/stale daemon after the package/native refresh, and asserts upgrade
+   calls `start_session_daemon()` for the pre-upgrade status `root` value. This
+   matters because daemon status can discover a nearby child/parent root.
+2. Implement a small helper that snapshots `get_session_daemon_status(".")`
+   before upgrade and, after a successful upgrade, restarts the daemon only when
+   it had been running and no live daemon is visible.
+3. Add a negative test and do not start a daemon for users who did not already
+   have one.
+4. Carry the same pre-upgrade daemon root into the scheduled Windows
+   self-upgrade helper so locked `tg.exe` upgrades can restart a daemon after
+   the background install completes.
+
+### 2. LSP SRE Mismatch Hygiene
+
+Files:
+
+- `src/tensor_grep/cli/lsp_provider_setup.py`
+- `src/tensor_grep/cli/lsp_external_provider.py`
+- `tests/unit/test_lsp_provider_setup.py`
+- `tests/unit/test_lsp_external_provider.py`
+
+Steps:
+
+1. Add a failing test proving managed LSP provider launches strip inherited
+   `PYTHONHOME`, `PYTHONPATH`, `VIRTUAL_ENV`, and `__PYVENV_LAUNCHER__` while
+   preserving the managed Node/bin PATH entries.
+2. Update `managed_provider_env()` to remove those interpreter-specific
+   variables for managed providers only. Add a companion test proving path or
+   custom providers keep those variables unchanged.
+3. Change successful LSP-proof status handling so SRE/ABI mismatch diagnostics
+   move to `provider_warnings` and remediation metadata, while `stderr_tail`
+   remains empty/suppressed for the successful current proof payload. Preserve
+   unrelated non-SRE stderr in `provider_recent_stderr` so non-current
+   diagnostics are not silently dropped.
+4. Keep failed/unhealthy provider statuses explicit; do not hide current
+   request errors or stderr when proof is false.
+
+## Validation
+
+Targeted local gates:
+
+- `uv run pytest tests/unit/test_cli_modes.py::<upgrade test> -q`
+- `uv run pytest tests/unit/test_lsp_provider_setup.py::<env test> tests/unit/test_lsp_external_provider.py::<stderr test> -q`
+- `uv run ruff format --check --preview <touched files>`
+- `uv run ruff check <touched files>`
+- `uv run mypy src/tensor_grep`
+
+Release gates:
+
+- Open a PR and let GitHub CI run.
+- Merge only after CI is green.
+- Verify the next semantic-release tag and public install proof before updating
+  repo/skill release docs.

--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -1118,11 +1118,21 @@ def _attach_lsp_proof_fields(status: dict[str, Any]) -> dict[str, Any]:
             or "_sre" in item.lower()
             or "abi mismatch" in item.lower()
         ]
+        other_stderr = [item for item in stderr_tail if item not in provider_warnings]
         if provider_warnings:
             status["provider_warnings"] = provider_warnings[-3:]
-            status["stderr_tail"] = provider_warnings[-3:]
-            status["stderr_tail_suppressed"] = False
+            status["provider_warning_status"] = "non_current_diagnostic"
+            status["provider_warning_remediation"] = (
+                "Managed provider proof succeeded, but provider stderr previously reported a "
+                "Python runtime or stdlib mismatch. Re-run `tg lsp-setup` after clearing "
+                "inherited PYTHONHOME/PYTHONPATH or inspect `tg doctor --with-lsp --json`."
+            )
+            status["stderr_tail"] = []
+            status["stderr_tail_suppressed"] = True
+            if other_stderr:
+                status["provider_recent_stderr"] = other_stderr[-3:]
         elif stderr_tail:
+            status["provider_recent_stderr"] = stderr_tail[-3:]
             status["stderr_tail"] = []
             status["stderr_tail_suppressed"] = True
         return status

--- a/src/tensor_grep/cli/lsp_provider_setup.py
+++ b/src/tensor_grep/cli/lsp_provider_setup.py
@@ -516,6 +516,8 @@ def managed_provider_env(
     root = managed_provider_root(managed_root)
     if _command_source(command, root) != "managed":
         return env
+    for key in ("PYTHONHOME", "PYTHONPATH", "VIRTUAL_ENV", "__PYVENV_LAUNCHER__"):
+        env.pop(key, None)
     path_entries = [str(_node_runtime_path_entry(root)), str(_managed_bin_dir(root).resolve())]
     existing_path = env.get("PATH")
     if existing_path:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -1631,6 +1631,42 @@ def _doctor_session_daemon_status(path: str) -> dict[str, Any]:
     return get_session_daemon_status(path)
 
 
+def _upgrade_running_session_daemon_snapshot(path: str = ".") -> dict[str, Any] | None:
+    try:
+        status = _doctor_session_daemon_status(path)
+    except Exception:
+        return None
+    if status.get("running") is not True:
+        return None
+    root = str(status.get("root") or "").strip()
+    if not root:
+        return None
+    return {"root": root}
+
+
+def _restart_session_daemon_after_upgrade(snapshot: dict[str, Any] | None) -> str | None:
+    if not snapshot:
+        return None
+    root = str(snapshot.get("root") or "").strip()
+    if not root:
+        return None
+    try:
+        current = _doctor_session_daemon_status(root)
+    except Exception as exc:
+        current = {"running": False, "status_error": str(exc)}
+    if current.get("running") is True:
+        return None
+    try:
+        from tensor_grep.cli.session_daemon import start_session_daemon
+
+        started = start_session_daemon(root)
+    except Exception as exc:
+        return f"WARNING: session daemon was running before upgrade but restart failed for {root}: {exc}"
+    if started.get("running") is True:
+        return f"Session daemon restarted after upgrade for {root}."
+    return f"WARNING: session daemon was running before upgrade but did not restart for {root}."
+
+
 def _doctor_lsp_languages() -> list[str]:
     return supported_lsp_languages()
 
@@ -8947,6 +8983,7 @@ def upgrade() -> None:
         native_path: Path | None = None,
         native_assets: list[dict[str, str]] | None = None,
         bridge_paths: list[Path] | None = None,
+        daemon_root: str | None = None,
     ) -> Path:
         import textwrap
 
@@ -8971,6 +9008,7 @@ def upgrade() -> None:
             native_path_arg = sys.argv[5]
             native_assets = json.loads(sys.argv[6])
             bridge_paths = [Path(path) for path in json.loads(sys.argv[7])]
+            daemon_root = sys.argv[8] if len(sys.argv) > 8 else ""
             native_path = Path(native_path_arg) if native_path_arg else None
             log_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -9327,6 +9365,66 @@ def upgrade() -> None:
                     messages.append(cleanup_payload)
                 return "\\n".join(messages)
 
+            def _restart_session_daemon_after_upgrade() -> str:
+                if not daemon_root:
+                    return ""
+                status_command = [
+                    sys.executable,
+                    "-m",
+                    "tensor_grep.cli.main",
+                    "session",
+                    "daemon",
+                    "status",
+                    daemon_root,
+                    "--json",
+                ]
+                start_command = [
+                    sys.executable,
+                    "-m",
+                    "tensor_grep.cli.main",
+                    "session",
+                    "daemon",
+                    "start",
+                    daemon_root,
+                    "--json",
+                ]
+                try:
+                    status = subprocess.run(
+                        status_command,
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    if status.returncode == 0:
+                        try:
+                            if json.loads(status.stdout).get("running") is True:
+                                return ""
+                        except json.JSONDecodeError:
+                            pass
+                    started = subprocess.run(
+                        start_command,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    if started.returncode == 0:
+                        return "Session daemon restarted after scheduled upgrade for " + daemon_root + "."
+                    error = (started.stderr or started.stdout or "").strip()
+                    return (
+                        "WARNING: session daemon was running before scheduled upgrade but "
+                        "restart failed for "
+                        + daemon_root
+                        + (": " + error if error else ".")
+                    )
+                except Exception as exc:
+                    return (
+                        "WARNING: session daemon was running before scheduled upgrade but "
+                        "restart failed for "
+                        + daemon_root
+                        + ": "
+                        + str(exc)
+                    )
+
             ok, method, payload = _run_attempts()
             if ok:
                 verified, version = _verify_installed_version(expected_version)
@@ -9350,6 +9448,9 @@ def upgrade() -> None:
                 text += "\\nVerified tensor-grep " + version + "."
                 if native_payload:
                     text += "\\n" + native_payload
+                daemon_payload = _restart_session_daemon_after_upgrade()
+                if daemon_payload:
+                    text += "\\n" + daemon_payload
                 if payload:
                     text += "\\n" + payload
                 log_path.write_text(text, encoding="utf-8")
@@ -9379,6 +9480,7 @@ def upgrade() -> None:
                 str(native_path) if native_path is not None else "",
                 native_asset_payload,
                 bridge_payload,
+                daemon_root or "",
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -9397,6 +9499,7 @@ def upgrade() -> None:
     typer.echo("Upgrading tensor-grep to the latest version...")
 
     try:
+        daemon_snapshot = _upgrade_running_session_daemon_snapshot()
         previous_version = _installed_version()
         latest_version = _latest_pypi_tensor_grep_version()
         exact_latest_requested = False
@@ -9452,6 +9555,9 @@ def upgrade() -> None:
                 typer.echo(output)
         if native_refresh_message:
             typer.echo(native_refresh_message)
+        daemon_restart_message = _restart_session_daemon_after_upgrade(daemon_snapshot)
+        if daemon_restart_message:
+            typer.echo(daemon_restart_message)
 
     except RuntimeError as e:
         if _looks_like_windows_self_update_lock(str(e)):
@@ -9492,6 +9598,11 @@ def upgrade() -> None:
                 native_path=native_path,
                 native_assets=native_assets,
                 bridge_paths=bridge_paths,
+                daemon_root=(
+                    str(daemon_snapshot.get("root"))
+                    if isinstance(daemon_snapshot, dict) and daemon_snapshot.get("root")
+                    else None
+                ),
             )
             typer.echo(
                 "Windows is still using tg.exe, so the upgrade was scheduled in the background."

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -7695,6 +7695,98 @@ def test_upgrade_uses_uv_when_available(monkeypatch):
     assert "Successfully upgraded tensor-grep via uv!" in result.stdout
 
 
+def test_upgrade_restarts_preexisting_session_daemon_after_handoff_loss(monkeypatch):
+    calls: list[list[str]] = []
+    daemon_statuses = iter([
+        {
+            "running": True,
+            "root": r"C:\dev\projects\tensor-grep",
+            "host": "127.0.0.1",
+            "port": 43123,
+            "pid": 9001,
+        },
+        {
+            "running": False,
+            "root": r"C:\dev\projects\tensor-grep",
+            "stale_metadata": True,
+        },
+    ])
+    restarted: list[str] = []
+
+    def _fake_run(cmd, capture_output=True, text=True, check=True):
+        calls.append(list(cmd))
+        if cmd[0] == "uv":
+            return subprocess.CompletedProcess(cmd, 0, stdout="Installed 1 package", stderr="")
+        if cmd[:2] == ["python", "-c"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="0.32.0\n", stderr="")
+        raise AssertionError("pip fallback should not be used when uv succeeds")
+
+    monkeypatch.setattr("sys.executable", "python")
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: "0.31.0")
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._latest_pypi_tensor_grep_version",
+        lambda: "0.32.0",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda _path: next(daemon_statuses),
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.session_daemon.start_session_daemon",
+        lambda path: (
+            restarted.append(path) or {"running": True, "root": path, "auto_started": True}
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert calls[0][0] == "uv"
+    assert restarted == [r"C:\dev\projects\tensor-grep"]
+    assert "Session daemon restarted after upgrade" in result.stdout
+
+
+def test_upgrade_does_not_start_session_daemon_when_none_was_running(monkeypatch):
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, capture_output=True, text=True, check=True):
+        calls.append(list(cmd))
+        if cmd[0] == "uv":
+            return subprocess.CompletedProcess(cmd, 0, stdout="Installed 1 package", stderr="")
+        if cmd[:2] == ["python", "-c"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="0.32.0\n", stderr="")
+        raise AssertionError("pip fallback should not be used when uv succeeds")
+
+    monkeypatch.setattr("sys.executable", "python")
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: "0.31.0")
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._latest_pypi_tensor_grep_version",
+        lambda: "0.32.0",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda _path: {"running": False, "root": r"C:\dev\projects\tensor-grep"},
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.session_daemon.start_session_daemon",
+        lambda _path: (_ for _ in ()).throw(
+            AssertionError("upgrade should not start a daemon that was not already running")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert calls[0][0] == "uv"
+    assert "Session daemon restarted after upgrade" not in result.stdout
+
+
 def test_upgrade_pins_exact_latest_pypi_version_when_local_metadata_is_stale(monkeypatch):
     calls: list[list[str]] = []
 
@@ -9455,6 +9547,67 @@ def test_upgrade_schedules_windows_helper_when_tg_exe_is_locked(monkeypatch, tmp
     assert "Windows is still using tg.exe" in result.output
     assert "Wait a few seconds, then run `tg --version` again." in result.output
     assert "Upgrade log:" in result.output
+
+
+def test_upgrade_scheduled_windows_helper_restarts_preexisting_session_daemon(
+    monkeypatch, tmp_path
+):
+    popen_calls: list[list[str]] = []
+    daemon_root = r"C:\dev\projects\tensor-grep"
+    locked_error = (
+        "failed to remove file `C:\\Users\\oimir\\.tensor-grep\\.venv\\Scripts\\tg.exe`: "
+        "The process cannot access the file because it is being used by another process. "
+        "(os error 32)"
+    )
+
+    def _fake_run(cmd, capture_output=True, text=True, check=True):
+        command = list(cmd)
+        if command[0] == "uv":
+            raise subprocess.CalledProcessError(returncode=1, cmd=command, stderr=locked_error)
+        if command[:3] == ["python", "-m", "pip"]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=command, stderr=locked_error)
+        raise AssertionError(f"unexpected command: {command}")
+
+    class _FakePopen:
+        def __init__(
+            self,
+            cmd,
+            stdout=None,
+            stderr=None,
+            stdin=None,
+            close_fds=None,
+            creationflags=0,
+        ):
+            popen_calls.append([str(part) for part in cmd])
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    monkeypatch.setattr("sys.executable", "python")
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: "0.31.0")
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._latest_pypi_tensor_grep_version",
+        lambda: "0.32.0",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda _path: {"running": True, "root": daemon_root},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0
+    assert popen_calls
+    helper_code = popen_calls[0][2]
+    compile(helper_code, "<scheduled-upgrade-helper>", "exec")
+    assert popen_calls[0][-1] == daemon_root
+    assert "def _restart_session_daemon_after_upgrade" in helper_code
+    assert '"daemon"' in helper_code
+    assert '"start"' in helper_code
+    assert "daemon_root" in helper_code
 
 
 def test_upgrade_scheduled_windows_helper_refreshes_stale_com_bridge(monkeypatch, tmp_path):

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -440,7 +440,7 @@ def test_provider_status_verify_health_success_reports_lsp_proof(
     assert "not_lsp_proof_reason" not in status
 
 
-def test_provider_status_verify_health_success_preserves_sre_stderr_warning(
+def test_provider_status_verify_health_success_suppresses_sre_stderr_tail(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -473,9 +473,82 @@ def test_provider_status_verify_health_success_preserves_sre_stderr_warning(
     assert status["health_status"] == "ready"
     assert status["lsp_proof"] is True
     assert status["last_error"] is None
-    assert status["stderr_tail"] == ["SRE module mismatch traceback"]
+    assert status["stderr_tail"] == []
     assert status["provider_warnings"] == ["SRE module mismatch traceback"]
-    assert status["stderr_tail_suppressed"] is False
+    assert status["provider_warning_status"] == "non_current_diagnostic"
+    assert "PYTHONHOME" in status["provider_warning_remediation"]
+    assert status["stderr_tail_suppressed"] is True
+
+
+def test_provider_status_verify_health_success_preserves_other_suppressed_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        self.capabilities = {"documentSymbolProvider": True}
+        self._stderr_tail = ["provider indexed workspace"]
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "ensure_document", lambda self, **_kwargs: None)
+    monkeypatch.setattr(
+        ExternalLSPClient,
+        "request",
+        lambda self, method, params: [{"name": "tg_lsp_health_probe", "kind": 12}],
+    )
+    monkeypatch.setattr(ExternalLSPClient, "stop", lambda self: None)
+
+    status = ExternalLSPProviderManager().provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.25,
+    )
+
+    assert status["lsp_proof"] is True
+    assert status["stderr_tail"] == []
+    assert status["provider_recent_stderr"] == ["provider indexed workspace"]
+    assert status["stderr_tail_suppressed"] is True
+
+
+def test_provider_status_verify_health_failure_preserves_sre_stderr_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        provider_module,
+        "_provider_command",
+        lambda _language: ["fake-lsp", "--stdio"],
+    )
+
+    def _fake_start(self: ExternalLSPClient) -> None:
+        self.capabilities = {"documentSymbolProvider": True}
+        self._stderr_tail = ["AssertionError: SRE module mismatch"]
+
+    def _fake_request(self: ExternalLSPClient, method: str, params: dict[str, Any]) -> object:
+        raise LSPTransportError("semantic probe failed")
+
+    monkeypatch.setattr(ExternalLSPClient, "start", _fake_start)
+    monkeypatch.setattr(ExternalLSPClient, "ensure_document", lambda self, **_kwargs: None)
+    monkeypatch.setattr(ExternalLSPClient, "request", _fake_request)
+    monkeypatch.setattr(ExternalLSPClient, "stop", lambda self: None)
+
+    status = ExternalLSPProviderManager().provider_status(
+        language="python",
+        workspace_root=tmp_path,
+        verify_health=True,
+        probe_timeout_seconds=0.25,
+    )
+
+    assert status["health_status"] == "unhealthy"
+    assert status["lsp_proof"] is False
+    assert status["stderr_tail"] == ["AssertionError: SRE module mismatch"]
+    assert "not_lsp_proof_reason" in status
 
 
 def test_provider_status_verify_health_applies_probe_budget_to_initialize(

--- a/tests/unit/test_lsp_provider_setup.py
+++ b/tests/unit/test_lsp_provider_setup.py
@@ -89,6 +89,55 @@ def test_managed_provider_env_should_prefix_managed_node_runtime_for_node_shims(
     assert env["PATH"].endswith("system-path")
 
 
+def test_managed_provider_env_should_strip_python_runtime_vars_for_managed_node_shims(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "providers"
+    node_bin = root / "node-packages" / "node_modules" / ".bin"
+    node_bin.mkdir(parents=True)
+    command = [str((node_bin / "pyright-langserver").resolve()), "--stdio"]
+
+    env = provider_setup.managed_provider_env(
+        command,
+        base_env={
+            "PATH": "system-path",
+            "PYTHONHOME": r"C:\stale-python",
+            "PYTHONPATH": r"C:\stale-python\Lib",
+            "VIRTUAL_ENV": r"C:\stale-venv",
+            "__PYVENV_LAUNCHER__": r"C:\stale-venv\python.exe",
+        },
+        managed_root=root,
+    )
+
+    assert "PYTHONHOME" not in env
+    assert "PYTHONPATH" not in env
+    assert "VIRTUAL_ENV" not in env
+    assert "__PYVENV_LAUNCHER__" not in env
+    assert env["PATH"].endswith("system-path")
+
+
+def test_managed_provider_env_should_preserve_python_runtime_vars_for_path_providers(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "providers"
+    command = [str((tmp_path / "path-provider" / "pyright-langserver").resolve()), "--stdio"]
+    base_env = {
+        "PATH": "system-path",
+        "PYTHONHOME": r"C:\custom-python",
+        "PYTHONPATH": r"C:\custom-python\Lib",
+        "VIRTUAL_ENV": r"C:\custom-venv",
+        "__PYVENV_LAUNCHER__": r"C:\custom-venv\python.exe",
+    }
+
+    env = provider_setup.managed_provider_env(
+        command,
+        base_env=base_env,
+        managed_root=root,
+    )
+
+    assert env == base_env
+
+
 @pytest.mark.parametrize(
     ("language", "binary_name", "expected_command"),
     [


### PR DESCRIPTION
## Summary
- restart a pre-existing session daemon after successful `tg upgrade`, including the scheduled Windows self-upgrade helper path
- scrub inherited Python runtime variables for managed LSP provider launches while preserving custom/path provider environments
- keep successful LSP proof `stderr_tail` clean by moving SRE/ABI diagnostics to provider warning fields and preserving other suppressed stderr under `provider_recent_stderr`
- add `docs/FIX_PLAN_1_13_21.md` with the dogfood plan and validation scope

## Validation
- `uv run pytest tests/unit/test_cli_modes.py::test_upgrade_restarts_preexisting_session_daemon_after_handoff_loss tests/unit/test_cli_modes.py::test_upgrade_does_not_start_session_daemon_when_none_was_running tests/unit/test_cli_modes.py::test_upgrade_scheduled_windows_helper_restarts_preexisting_session_daemon tests/unit/test_lsp_provider_setup.py::test_managed_provider_env_should_strip_python_runtime_vars_for_managed_node_shims tests/unit/test_lsp_provider_setup.py::test_managed_provider_env_should_preserve_python_runtime_vars_for_path_providers tests/unit/test_lsp_external_provider.py::test_provider_status_verify_health_success_suppresses_sre_stderr_tail tests/unit/test_lsp_external_provider.py::test_provider_status_verify_health_success_preserves_other_suppressed_stderr tests/unit/test_lsp_external_provider.py::test_provider_status_verify_health_failure_preserves_sre_stderr_tail -q`
- `uv run pytest tests/unit/test_lsp_provider_setup.py tests/unit/test_lsp_external_provider.py -q`
- `uv run pytest tests/unit/test_cli_modes.py::test_upgrade_uses_uv_when_available tests/unit/test_cli_modes.py::test_upgrade_pins_exact_latest_pypi_version_when_local_metadata_is_stale tests/unit/test_cli_modes.py::test_upgrade_reports_latest_pypi_version_when_verified_version_matches_latest tests/unit/test_cli_modes.py::test_upgrade_schedules_windows_helper_when_tg_exe_is_locked tests/unit/test_cli_modes.py::test_upgrade_scheduled_windows_helper_restarts_preexisting_session_daemon -q`
- `uv run ruff check .`
- `uv run ruff format --check --preview src tests scripts`
- `uv run mypy src/tensor_grep`
- `git diff --check`

## Review
- Exa research anchor: CPython/uv reports connect `AssertionError: SRE module mismatch` to Python runtime/stdlib environment mismatch.
- Read-only plan review subagents raised daemon-root and custom-provider-env concerns; both are covered by tests.
- Claude Opus read-only review returned PASS; low findings were addressed by scheduled-helper restart and `provider_recent_stderr`.