### PR TITLE
fix: harden agent symbol dogfood contracts

### DIFF
--- a/.claude/skills/tensor-grep/REFERENCE.md
+++ b/.claude/skills/tensor-grep/REFERENCE.md
@@ -1,33 +1,38 @@
 # Tensor-Grep Reference
 
+> Argument order is **path-first**: `tg <command> <REPO_PATH> <SYMBOL>`.
+> If you reverse them (`<SYMBOL> <REPO_PATH>`) tensor-grep auto-corrects and
+> prints a hint, but write path-first to avoid the extra round trip. A bare
+> `tg <command> <SYMBOL>` resolves the symbol against the current directory.
+
 ## Core Commands
 
 ```powershell
 tg --version
-tg source SYMBOL REPO_PATH
-tg defs SYMBOL REPO_PATH
-tg refs SYMBOL REPO_PATH
-tg callers SYMBOL REPO_PATH
-tg blast-radius SYMBOL REPO_PATH
-tg blast-radius-plan SYMBOL REPO_PATH
+tg source REPO_PATH SYMBOL
+tg defs REPO_PATH SYMBOL
+tg refs REPO_PATH SYMBOL
+tg callers REPO_PATH SYMBOL
+tg blast-radius REPO_PATH SYMBOL
+tg blast-radius-plan REPO_PATH SYMBOL
 ```
 
 ## Useful Variants
 
 ```powershell
-tg source SYMBOL REPO_PATH --json
-tg defs SYMBOL REPO_PATH --provider native --json
-tg refs SYMBOL REPO_PATH --provider lsp --json
-tg blast-radius SYMBOL REPO_PATH --provider hybrid --json
-tg blast-radius-plan SYMBOL REPO_PATH --provider native --json
+tg source REPO_PATH SYMBOL --json
+tg defs REPO_PATH SYMBOL --provider native --json
+tg refs REPO_PATH SYMBOL --provider lsp --json
+tg blast-radius REPO_PATH SYMBOL --provider hybrid --json
+tg blast-radius-plan REPO_PATH SYMBOL --provider native --json
 ```
 
 ## Practical Sequence
 
 ```powershell
-tg source open_file C:\repo
-tg blast-radius open_file C:\repo
-tg blast-radius-plan open_file C:\repo
+tg source C:\repo open_file
+tg blast-radius C:\repo open_file
+tg blast-radius-plan C:\repo open_file
 ```
 
 Use the top-ranked file/span first. Only broaden to refs/callers if the primary file is still ambiguous.

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -14,18 +14,25 @@ Use this skill when you need to locate code precisely, understand likely edit im
 - You need an edit plan, blast radius, or validation target instead of ad hoc grep loops.
 - You are preparing a patch and want a smaller, more accurate context bundle.
 
+## Argument Order
+
+All symbol commands are **path-first**: `tg <command> <REPO_PATH> <SYMBOL>`.
+A reversed `<SYMBOL> <REPO_PATH>` call is auto-corrected with a stderr hint, and
+a single `tg <command> <SYMBOL>` resolves against the current directory — but
+prefer the canonical path-first form.
+
 ## Default Workflow
 
 1. Confirm the installed CLI is available:
    - `tg --version`
 2. Start with direct source lookup:
-   - `tg source SYMBOL REPO_PATH`
+   - `tg source REPO_PATH SYMBOL`
 3. If you need symbol navigation:
-   - `tg defs SYMBOL REPO_PATH`
-   - `tg refs SYMBOL REPO_PATH`
+   - `tg defs REPO_PATH SYMBOL`
+   - `tg refs REPO_PATH SYMBOL`
 4. If you need edit planning:
-   - `tg blast-radius SYMBOL REPO_PATH`
-   - `tg blast-radius-plan SYMBOL REPO_PATH`
+   - `tg blast-radius REPO_PATH SYMBOL`
+   - `tg blast-radius-plan REPO_PATH SYMBOL`
 5. Use the returned file/span candidates to make the smallest correct edit.
 6. Run only the most relevant validation commands after the edit.
 
@@ -48,8 +55,8 @@ Use this skill when you need to locate code precisely, understand likely edit im
 
 - Default: `native`
 - Optional:
-  - `tg defs SYMBOL REPO_PATH --provider lsp`
-  - `tg blast-radius SYMBOL REPO_PATH --provider hybrid`
+  - `tg defs REPO_PATH SYMBOL --provider lsp`
+  - `tg blast-radius REPO_PATH SYMBOL --provider hybrid`
 
 Use `lsp` or `hybrid` only if native lookup seems ambiguous or incomplete.
 

--- a/.gemini/skills/tensor-grep/REFERENCE.md
+++ b/.gemini/skills/tensor-grep/REFERENCE.md
@@ -11,22 +11,22 @@ tg search --format rg "PATTERN" REPO_PATH
 tg agent REPO_PATH --query "change behavior" --json
 tg edit-plan REPO_PATH --query "change behavior" --json
 tg context-render REPO_PATH --query "feature flow" --json
-tg source --symbol SYMBOL REPO_PATH
-tg defs --symbol SYMBOL REPO_PATH
-tg refs --symbol SYMBOL REPO_PATH
-tg callers --symbol SYMBOL REPO_PATH
-tg blast-radius --symbol SYMBOL REPO_PATH
-tg blast-radius-plan --symbol SYMBOL REPO_PATH
+tg source REPO_PATH SYMBOL
+tg defs REPO_PATH SYMBOL
+tg refs REPO_PATH SYMBOL
+tg callers REPO_PATH SYMBOL
+tg blast-radius REPO_PATH SYMBOL
+tg blast-radius-plan REPO_PATH SYMBOL
 ```
 
 ## Useful Variants
 
 ```powershell
-tg source --symbol SYMBOL REPO_PATH --json
-tg defs --symbol SYMBOL REPO_PATH --provider native --json
-tg refs --symbol SYMBOL REPO_PATH --provider lsp --json
-tg blast-radius --symbol SYMBOL REPO_PATH --provider hybrid --json
-tg blast-radius-plan --symbol SYMBOL REPO_PATH --provider native --json
+tg source REPO_PATH SYMBOL --json
+tg defs REPO_PATH SYMBOL --provider native --json
+tg refs REPO_PATH SYMBOL --provider lsp --json
+tg blast-radius REPO_PATH SYMBOL --provider hybrid --json
+tg blast-radius-plan REPO_PATH SYMBOL --provider native --json
 tg search --format rg --sort path "PATTERN" REPO_PATH
 tg search --json "PATTERN" REPO_PATH
 tg search --format rg --json "PATTERN" REPO_PATH
@@ -37,15 +37,15 @@ tg session edit-plan SESSION_ID REPO_PATH --query "change behavior" --daemon --j
 ## Practical Sequence
 
 ```powershell
-tg source --symbol open_file C:\repo --json
-tg blast-radius --symbol open_file C:\repo --json
-tg blast-radius-plan --symbol open_file C:\repo --json
+tg source C:\repo open_file --json
+tg blast-radius C:\repo open_file --json
+tg blast-radius-plan C:\repo open_file --json
 ```
 
 Use the top-ranked file/span first. Only broaden to refs/callers if the primary file is still ambiguous.
 
 Notes:
 
-- Symbol commands use `--symbol`; do not pass the symbol positionally.
+- Symbol commands use path-first positional order: `tg <command> REPO_PATH SYMBOL`.
 - `tg search --format rg --json` emits ripgrep JSON Lines. Plain `tg search --json` is tensor-grep aggregate JSON.
 - LSP and GPU surfaces are experimental until their proof fields say otherwise.

--- a/.gemini/skills/tensor-grep/SKILL.md
+++ b/.gemini/skills/tensor-grep/SKILL.md
@@ -26,13 +26,13 @@ Use this skill when you need to locate code precisely, understand likely edit im
    - `tg agent REPO_PATH --query "change invoice tax" --json`
    - `tg edit-plan REPO_PATH --query "change invoice tax" --json`
    - `tg context-render REPO_PATH --query "invoice flow" --json`
-4. Use symbol commands with explicit `--symbol`:
-   - `tg defs --symbol SYMBOL REPO_PATH --json`
-   - `tg source --symbol SYMBOL REPO_PATH --json`
-   - `tg refs --symbol SYMBOL REPO_PATH --json`
-   - `tg callers --symbol SYMBOL REPO_PATH --json`
-   - `tg blast-radius --symbol SYMBOL REPO_PATH --json`
-   - `tg blast-radius-plan --symbol SYMBOL REPO_PATH --json`
+4. Use symbol commands in path-first order:
+   - `tg defs REPO_PATH SYMBOL --json`
+   - `tg source REPO_PATH SYMBOL --json`
+   - `tg refs REPO_PATH SYMBOL --json`
+   - `tg callers REPO_PATH SYMBOL --json`
+   - `tg blast-radius REPO_PATH SYMBOL --json`
+   - `tg blast-radius-plan REPO_PATH SYMBOL --json`
 5. Use cached sessions for repeated edit loops:
    - `tg session open REPO_PATH --json`
    - `tg session edit-plan SESSION_ID REPO_PATH --query "change behavior" --json`
@@ -63,8 +63,8 @@ Use this skill when you need to locate code precisely, understand likely edit im
 
 - Default: `native`
 - Optional:
-  - `tg defs --symbol SYMBOL REPO_PATH --provider lsp --json`
-  - `tg blast-radius --symbol SYMBOL REPO_PATH --provider hybrid --json`
+  - `tg defs REPO_PATH SYMBOL --provider lsp --json`
+  - `tg blast-radius REPO_PATH SYMBOL --provider hybrid --json`
 
 Use `lsp` or `hybrid` only if native lookup seems ambiguous or incomplete. Provider availability is not semantic proof; check `health_status`, `lsp_proof`, and fallback fields.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -229,9 +229,9 @@ Only pass `--allow-broad-generated-scan` when the generated/cache/dependency tre
 | Files with matches | `tg search "pattern" src --files-with-matches` |
 | AST search | `tg run --lang python 'def $NAME($$$ARGS): $$$BODY' src --json` |
 | AST language identifiers | `tg ast-info --json` |
-| Source lookup | `tg source src --symbol someSymbol --json` |
-| Refs lookup | `tg refs src --symbol someSymbol --json` |
-| Blast radius | `tg blast-radius src --symbol someSymbol --json` |
+| Source lookup | `tg source src someSymbol --json` |
+| Refs lookup | `tg refs src someSymbol --json` |
+| Blast radius | `tg blast-radius src someSymbol --json` |
 | Context bundle | `tg context-render src --query "how routing works" --render-profile llm --json` |
 | Device inventory | `tg devices --json` |
 | MCP server | `tg mcp` |

--- a/docs/FIX_PLAN_1_13_12.md
+++ b/docs/FIX_PLAN_1_13_12.md
@@ -121,8 +121,9 @@ mode is 487 ms because it only checks current scope.
 | `tg session edit-plan` | **SESSION_ID** | `--query "..."` (PATH is 2nd positional) |
 | `tg run` | PATTERN_OR_PATH (positional, ambiguous) | `--pattern` flag alternative |
 
-Agents fail this constantly. `tg defs SYMBOL PATH` (intuitive) errors; `tg session edit-plan PATH ...`
-(intuitive after using non-session form) errors.
+Agents historically failed this constantly. `tg defs SYMBOL PATH` (intuitive) errored; `tg session edit-plan PATH ...`
+(intuitive after using non-session form) errored. The current hardening branch accepts those reversed forms
+conservatively and emits a canonical-order hint.
 
 **Proposed implementation (breaking change requires deprecation cycle)**
 

--- a/docs/planning/AI_ENTERPRISE_ACCELERATION_PLAN.md
+++ b/docs/planning/AI_ENTERPRISE_ACCELERATION_PLAN.md
@@ -113,7 +113,7 @@ Turn `defs` / `refs` / `callers` / `impact` into a stronger change-impact surfac
 
 ### Proposed features
 
-1. `tg blast-radius --symbol ... --json`
+1. `tg blast-radius REPO_PATH SYMBOL --json`
    - return downstream callers, importers, affected tests, and ranked related files
 
 2. graph depth controls

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -480,26 +480,6 @@ def _alternative_targets(
             ])
         alternatives.append(alternative)
 
-    for file_path in _as_list_of_strings(candidate_targets.get("files")):
-        if file_path == primary_file:
-            continue
-        key = (file_path, None)
-        if key in seen or any(item.get("file") == file_path for item in alternatives):
-            continue
-        seen.add(key)
-        match = file_matches.get(file_path, {})
-        score = int(match.get("score", 0) or 0)
-        alternatives.append({
-            "file": file_path,
-            "symbol": None,
-            "kind": "file",
-            "line": 1,
-            "language": repo_map._target_language_for_path(file_path),
-            "confidence": repo_map._confidence_from_score(score),
-            "reasons": list(match.get("reasons") or []),
-            "evidence": list(match.get("provenance") or ["heuristic"]),
-        })
-
     return alternatives[:limit]
 
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6555,6 +6555,73 @@ def _echo_symbol_location_rows(rows: list[dict[str, Any]]) -> None:
             typer.echo(rendered)
 
 
+def _maybe_swap_reversed_positionals(
+    *,
+    path: str,
+    value: str,
+    command_name: str,
+    value_label: str,
+) -> tuple[str, str]:
+    """Auto-correct a reversed ``<VALUE> <PATH>`` invocation.
+
+    Agents (and grep muscle memory, and older docs) frequently call these
+    commands as ``tg <command> <SYMBOL> <PATH>`` instead of the canonical
+    path-first ``tg <command> <PATH> <SYMBOL>``. When that happens the first
+    positional is not an existing path but the second one is, which previously
+    produced an opaque ``Path not found: <SYMBOL>`` error. Detect that exact
+    case and transparently swap, emitting a hint so the caller can learn the
+    canonical order. The swap only fires when the first arg is definitively not
+    a path AND the second arg definitively is, so a legitimate ``<PATH>
+    <VALUE>`` call (where the value happens to share a name with a real path)
+    is never disturbed.
+    """
+    if Path(path).expanduser().exists():
+        return path, value
+    if not Path(value).expanduser().exists():
+        return path, value
+    typer.echo(
+        f"Warning: '{path}' is not an existing path but '{value}' is; "
+        f"interpreting as `tg {command_name} <PATH> <{value_label}>` "
+        f"(path={value!r}, {value_label.lower()}={path!r}). "
+        f"Pass <PATH> before <{value_label}> to silence this hint.",
+        err=True,
+    )
+    return value, path
+
+
+def _maybe_swap_reversed_session_path(
+    *,
+    session_id: str,
+    path: str,
+    command_name: str,
+) -> tuple[str, str]:
+    """Auto-correct ``tg session <command> <PATH> <SESSION_ID> ...``.
+
+    Session commands are the one user-facing surface where the stable session
+    identifier must lead the path. Agents commonly transpose this after using
+    the path-first top-level commands. Only swap when the first positional is
+    an existing path and the second positional resolves to an existing session
+    under that path, so ordinary session-first calls remain untouched.
+    """
+    if not Path(session_id).expanduser().exists():
+        return session_id, path
+    if Path(path).expanduser().exists():
+        return session_id, path
+    try:
+        from tensor_grep.cli.session_store import get_session
+
+        get_session(path, session_id)
+    except Exception:
+        return session_id, path
+    typer.echo(
+        f"Warning: '{session_id}' is an existing path and '{path}' is an existing "
+        f"session for it; interpreting as `tg session {command_name} <SESSION_ID> "
+        f"<PATH> <QUERY>`. Pass <SESSION_ID> before <PATH> to silence this hint.",
+        err=True,
+    )
+    return path, session_id
+
+
 def _resolve_path_and_symbol(
     *,
     path: str,
@@ -6575,7 +6642,12 @@ def _resolve_path_and_symbol(
         )
         return path, symbol_option
     if symbol_arg is not None:
-        return path, symbol_arg
+        return _maybe_swap_reversed_positionals(
+            path=path,
+            value=symbol_arg,
+            command_name=command_name,
+            value_label="SYMBOL",
+        )
     if path != "." and not Path(path).expanduser().exists():
         return ".", path
     raise ValueError("Missing symbol. Use positional SYMBOL or --symbol SYMBOL.")
@@ -6600,7 +6672,12 @@ def _resolve_path_and_query(
         )
         return path, query_option
     if query_arg is not None:
-        return path, query_arg
+        return _maybe_swap_reversed_positionals(
+            path=path,
+            value=query_arg,
+            command_name=command_name,
+            value_label="QUERY",
+        )
     if path != "." and not Path(path).expanduser().exists():
         return ".", path
     raise ValueError("Missing query. Use positional QUERY or --query QUERY.")
@@ -7397,6 +7474,11 @@ def session_context_cmd(
     from tensor_grep.cli.session_store import session_context
 
     try:
+        session_id, path = _maybe_swap_reversed_session_path(
+            session_id=session_id,
+            path=path,
+            command_name="context",
+        )
         resolved_path, resolved_query = _resolve_path_and_query(
             path=path,
             query_arg=query_arg,
@@ -7498,6 +7580,11 @@ def session_context_render_cmd(
     from tensor_grep.cli.session_store import SessionStaleError, session_context_render
 
     try:
+        session_id, path = _maybe_swap_reversed_session_path(
+            session_id=session_id,
+            path=path,
+            command_name="context-render",
+        )
         resolved_path, resolved_query = _resolve_path_and_query(
             path=path,
             query_arg=query_arg,
@@ -7614,6 +7701,11 @@ def session_edit_plan_cmd(
     from tensor_grep.cli.session_store import session_context_edit_plan
 
     try:
+        session_id, path = _maybe_swap_reversed_session_path(
+            session_id=session_id,
+            path=path,
+            command_name="edit-plan",
+        )
         resolved_path, resolved_query = _resolve_path_and_query(
             path=path,
             query_arg=query_arg,

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4423,7 +4423,7 @@ def _symbol_span_length(symbol: dict[str, Any]) -> int:
     return max(1, end_line - start_line + 1)
 
 
-def _symbol_rank_key(symbol: dict[str, Any]) -> tuple[int, int, int, int, int, str, int, str]:
+def _symbol_rank_key(symbol: dict[str, Any]) -> tuple[int, int, int, int, str, int, str]:
     if bool(symbol.get("exact_query_match")):
         query_match_rank = 0
     elif bool(symbol.get("bridge_query_match")):

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4423,8 +4423,17 @@ def _symbol_span_length(symbol: dict[str, Any]) -> int:
     return max(1, end_line - start_line + 1)
 
 
-def _symbol_rank_key(symbol: dict[str, Any]) -> tuple[int, int, int, str, int, str]:
+def _symbol_rank_key(symbol: dict[str, Any]) -> tuple[int, int, int, int, int, str, int, str]:
+    if bool(symbol.get("exact_query_match")):
+        query_match_rank = 0
+    elif bool(symbol.get("bridge_query_match")):
+        query_match_rank = 1
+    elif bool(symbol.get("covered_query_match")):
+        query_match_rank = 2
+    else:
+        query_match_rank = 3
     return (
+        query_match_rank,
         -int(symbol.get("score", 0)),
         0 if str(symbol.get("kind")) == "function" else 1,
         -_symbol_span_length(symbol),

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -6866,8 +6866,10 @@ def test_gemini_project_context_and_skill_should_exist():
 
     assert "Use the `tensor-grep` skill" in context_text
     assert "Do not ask what task to perform" in context_text
-    assert "tg source --symbol SYMBOL REPO_PATH" in skill_text
-    assert "tg source --symbol SYMBOL REPO_PATH" in reference_text
+    assert "tg source REPO_PATH SYMBOL" in skill_text
+    assert "tg source REPO_PATH SYMBOL" in reference_text
+    assert "tg source --symbol SYMBOL REPO_PATH" not in skill_text
+    assert "tg source --symbol SYMBOL REPO_PATH" not in reference_text
     assert "tg source SYMBOL REPO_PATH" not in skill_text
     assert "tg source SYMBOL REPO_PATH" not in reference_text
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -3404,6 +3404,47 @@ def test_defs_text_lists_definition_locations(tmp_path):
     assert "create_invoice" in result.stdout
 
 
+def test_defs_auto_corrects_reversed_symbol_path_positionals(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    module_path = src_dir / "payments.py"
+    module_path.write_text(
+        "def create_invoice(total, tax):\n    return total + tax\n",
+        encoding="utf-8",
+    )
+
+    # Reversed `<SYMBOL> <PATH>` order (grep muscle memory / older docs): the
+    # first positional is not a path but the second one is, so it should be
+    # transparently swapped instead of failing with `Path not found`.
+    result = CliRunner().invoke(app, ["defs", "create_invoice", str(project)])
+
+    assert result.exit_code == 0, result.output
+    assert "Path not found" not in result.output
+    assert "interpreting as `tg defs <PATH> <SYMBOL>`" in result.output
+    assert "definitions=1" in result.stdout
+    assert f"{module_path.resolve()}:1" in result.stdout
+
+
+def test_defs_does_not_swap_when_first_positional_is_a_real_path(tmp_path):
+    # When the first positional is a real path we must honor the caller's
+    # explicit `<PATH> <SYMBOL>` request even if the symbol shares a name with
+    # an existing path; the anti-swap guard must not fire.
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "payments.py").write_text(
+        "def create_invoice(total, tax):\n    return total + tax\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["defs", str(project), "create_invoice"])
+
+    assert result.exit_code == 0, result.output
+    assert "interpreting as" not in result.output
+    assert "definitions=1" in result.stdout
+
+
 def test_impact_json_returns_ranked_files_and_tests_for_symbol(tmp_path):
     project = tmp_path / "project"
     src_dir = project / "src"
@@ -4840,6 +4881,96 @@ def test_agent_context_commands_prefer_invoice_implementation_over_service_menti
     assert agent_payload["primary_target"]["file"] == str(paths["payments"].resolve())
     assert agent_payload["primary_target"]["symbol"] == "create_invoice"
     assert agent_payload["ask_user_before_editing"]["required"] is False
+
+
+def test_agent_capsule_exact_symbol_query_prefers_exact_symbol_over_prefix(tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    module_path = src_dir / "native_search.py"
+    module_path.write_text(
+        "def run_native_search_files():\n"
+        "    total = 0\n"
+        "    total += 1\n"
+        "    total += 2\n"
+        "    return total\n\n"
+        "def run_native_search():\n"
+        "    return 1\n",
+        encoding="utf-8",
+    )
+
+    payload = _agent_capsule_payload_for_query(project, "run_native_search")
+
+    assert payload["primary_target"]["file"] == str(module_path.resolve())
+    assert payload["primary_target"]["symbol"] == "run_native_search"
+
+
+def test_agent_capsule_filters_file_only_alternative_targets(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    primary_path = src_dir / "payments.py"
+    alternative_path = src_dir / "notes.py"
+    primary_path.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+    alternative_path.write_text("invoice notes\n", encoding="utf-8")
+
+    def _fake_context_render(*_args, **_kwargs):
+        return {
+            "navigation_pack": {
+                "primary_target": {
+                    "file": str(primary_path),
+                    "symbol": "create_invoice",
+                    "kind": "function",
+                    "start_line": 1,
+                    "end_line": 2,
+                },
+                "follow_up_reads": [],
+                "validation_commands": [],
+            },
+            "edit_plan_seed": {
+                "primary_file": str(primary_path),
+                "primary_symbol": {"name": "create_invoice", "kind": "function"},
+                "primary_span": {"start_line": 1, "end_line": 2},
+                "confidence": {"overall": 0.9},
+                "validation_plan": [],
+                "validation_commands": [],
+                "edit_ordering": [str(primary_path)],
+            },
+            "candidate_edit_targets": {
+                "files": [str(alternative_path)],
+                "symbols": [],
+            },
+            "file_matches": [
+                {
+                    "path": str(alternative_path),
+                    "score": 80,
+                    "reasons": ["source"],
+                    "provenance": ["heuristic"],
+                }
+            ],
+            "validation_commands": [],
+            "sources": [
+                {
+                    "file": str(primary_path),
+                    "symbol": "create_invoice",
+                    "start_line": 1,
+                    "end_line": 2,
+                    "source": primary_path.read_text(encoding="utf-8"),
+                }
+            ],
+            "context_consistency": {"primary_file_included": True},
+        }
+
+    monkeypatch.setattr(agent_capsule.repo_map, "build_context_render", _fake_context_render)
+
+    payload = agent_capsule.build_agent_capsule(
+        "create_invoice",
+        project,
+        include_blast_radius=False,
+        max_tokens=400,
+    )
+
+    assert payload["alternative_targets"] == []
 
 
 def test_context_pack_uses_repo_map_imports_for_direct_validation_evidence(

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -291,6 +291,36 @@ def test_session_commands_accept_positional_query_and_symbol_aliases(tmp_path: P
         assert _has_string(payload, expected_service_file)
 
 
+def test_session_edit_plan_auto_corrects_reversed_path_session_order(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True)
+    module_path = src_dir / "payments.py"
+    module_path.write_text("def create_invoice(total):\n    return total + 1\n", encoding="utf-8")
+
+    runner = CliRunner()
+    opened = json.loads(runner.invoke(app, ["session", "open", str(project), "--json"]).stdout)
+
+    result = runner.invoke(
+        app,
+        [
+            "session",
+            "edit-plan",
+            str(project),
+            opened["session_id"],
+            "create invoice",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "interpreting as `tg session edit-plan <SESSION_ID> <PATH> <QUERY>`" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["session_id"] == opened["session_id"]
+    assert payload["routing_reason"] == "session-context-edit-plan"
+    assert payload["files"] == [str(module_path.resolve())]
+
+
 def test_session_commands_warn_for_legacy_query_and_symbol_options(tmp_path: Path) -> None:
     project = tmp_path / "project"
     src_dir = project / "src"


### PR DESCRIPTION
## Summary
- auto-correct reversed path/query and path/symbol positionals for agent-facing commands with actionable hints
- prefer exact symbol matches in agent capsule ranking and remove file-only alternative-target noise
- align Claude/Gemini/root tensor-grep skills and active docs on canonical path-first symbol commands

## Validation
- uv run pytest tests/unit/test_cli_modes.py tests/unit/test_session_cli.py tests/unit/test_agent_capsule_hardcases.py tests/unit/test_semantic_provider_navigation.py -q
- uv run pytest tests/unit/test_public_docs_governance.py tests/unit/test_benchmark_scripts.py -q
- uv run pytest tests/unit/test_cli_modes.py::test_agent_capsule_exact_symbol_query_prefers_exact_symbol_over_prefix tests/unit/test_cli_modes.py::test_agent_capsule_filters_file_only_alternative_targets tests/unit/test_session_cli.py::test_session_edit_plan_auto_corrects_reversed_path_session_order tests/unit/test_cli_modes.py::test_defs_auto_corrects_reversed_symbol_path_positionals tests/unit/test_cli_modes.py::test_defs_does_not_swap_when_first_positional_is_a_real_path -q
- uv run ruff check .
- uv run ruff format --check --preview .
- git diff --check
- uv run tg defs run_native_search rust_core
- uv run tg agent rust_core run_native_search --json
- uv run python -m tensor_grep --version