### PR TITLE
fix: harden upgrade PyPI version probe

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -346,6 +346,48 @@ def _candidate_versions_from_pypi_simple_index(simple_index: str) -> list[str]:
     return candidates
 
 
+def _candidate_versions_from_pip_index_output(output: str) -> list[str]:
+    candidates: list[str] = []
+    version_pattern = r"[0-9]+(?:\.[0-9]+)*(?:(?:a|b|rc|dev|post)[0-9]+)?"
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        package_match = re.search(rf"\btensor-grep\s+\(({version_pattern})\)", line, re.IGNORECASE)
+        if package_match:
+            candidates.append(package_match.group(1))
+        if re.match(r"(?i)^(?:available versions|latest)\s*:", line):
+            candidates.extend(re.findall(version_pattern, line))
+    return candidates
+
+
+def _candidate_versions_from_pip_index(timeout_seconds: float) -> list[str]:
+    env = os.environ.copy()
+    env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "index",
+                "versions",
+                "tensor-grep",
+                "--no-cache-dir",
+                "--index-url",
+                "https://pypi.org/simple",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+            env=env,
+        )
+    except Exception:
+        return []
+    return _candidate_versions_from_pip_index_output(
+        "\n".join(part for part in (result.stdout, result.stderr) if part)
+    )
+
+
 def _latest_pypi_tensor_grep_version(timeout_seconds: float = 15.0) -> str | None:
     """Best-effort latest-version probe that avoids trusting one stale PyPI cache surface."""
     import urllib.request
@@ -373,6 +415,8 @@ def _latest_pypi_tensor_grep_version(timeout_seconds: float = 15.0) -> str | Non
         candidates.extend(_candidate_versions_from_pypi_simple_index(simple_index))
     except Exception:
         pass
+
+    candidates.extend(_candidate_versions_from_pip_index(timeout_seconds))
 
     return _highest_tensor_grep_version(candidates)
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -19,6 +19,7 @@ from typer.testing import CliRunner
 from tensor_grep.cli import agent_capsule, repo_map
 from tensor_grep.cli import main as cli_main
 from tensor_grep.cli.main import (
+    _candidate_versions_from_pip_index_output,
     _candidate_versions_from_pypi_json,
     _candidate_versions_from_pypi_simple_index,
     _highest_tensor_grep_version,
@@ -7972,6 +7973,76 @@ def test_upgrade_latest_version_candidates_skip_yanked_pypi_releases():
     ]
 
     assert _highest_tensor_grep_version(candidates) == "0.33.0"
+
+
+def test_upgrade_latest_version_candidates_include_pip_index_output():
+    pip_output = """
+    tensor-grep (0.34.0)
+    Available versions: 0.34.0, 0.33.0, 0.32.0
+      INSTALLED: 0.32.0
+      LATEST:    0.34.0
+    """
+
+    assert (
+        _highest_tensor_grep_version(_candidate_versions_from_pip_index_output(pip_output))
+        == "0.34.0"
+    )
+
+
+def test_latest_pypi_probe_uses_pip_index_when_json_and_simple_are_stale(monkeypatch):
+    class _FakeResponse:
+        def __init__(self, body: str) -> None:
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self) -> bytes:
+            return self.body.encode("utf-8")
+
+    stale_json = json.dumps({
+        "info": {"version": "0.33.0"},
+        "releases": {
+            "0.32.0": [{"yanked": False}],
+            "0.33.0": [{"yanked": False}],
+        },
+    })
+    stale_simple = """
+    <a href="tensor_grep-0.33.0-py3-none-any.whl">tensor_grep-0.33.0-py3-none-any.whl</a>
+    """
+    calls: list[list[str]] = []
+
+    def _fake_urlopen(request, timeout=None):
+        url = request.get_full_url()
+        if url.endswith("/json"):
+            return _FakeResponse(stale_json)
+        if url.endswith("/simple/tensor-grep/"):
+            return _FakeResponse(stale_simple)
+        raise AssertionError(f"unexpected url: {url}")
+
+    def _fake_run(cmd, **_kwargs):
+        calls.append([str(part) for part in cmd])
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=(
+                "tensor-grep (0.34.0)\n"
+                "Available versions: 0.34.0, 0.33.0, 0.32.0\n"
+                "  LATEST:    0.34.0\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr(cli_main.subprocess, "run", _fake_run)
+
+    assert cli_main._latest_pypi_tensor_grep_version(timeout_seconds=1.0) == "0.34.0"
+    assert calls
+    assert calls[0][1:5] == ["-m", "pip", "index", "versions"]
+    assert "--no-cache-dir" in calls[0]
 
 
 def test_upgrade_reports_latest_pypi_version_when_verified_version_matches_latest(monkeypatch):


### PR DESCRIPTION
## Summary
- add a no-cache `pip index versions tensor-grep` probe to `tg upgrade` latest-version discovery
- keep existing PyPI JSON/simple probes and select the highest valid candidate across all surfaces
- add regressions for stale JSON/simple metadata when pip index already sees the newer release

## Validation
- `uv run pytest tests/unit/test_cli_modes.py -k "upgrade or latest_pypi" -q`
- `uv run ruff check .`
- `uv run ruff format --check --preview .`
- `uv run mypy src/tensor_grep`
- `git diff --check`

## Dogfood context
Post-v1.13.28 dogfood saw `tg upgrade` initially report `1.13.27` as latest while PyPI/uvx soon resolved `1.13.28`. A second `tg upgrade` succeeded after propagation and refreshed the native front door to `tg 1.13.28`, but this patch makes future upgrades less dependent on a single stale PyPI metadata surface.