### PR TITLE
fix: tolerate ast scan access warnings

### DIFF
--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -1,6 +1,8 @@
 import json
 import os
+import re
 import subprocess
+import sys
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -10,6 +12,38 @@ from tensor_grep.backends.ast_backend import normalize_ast_language
 from tensor_grep.backends.base import ComputeBackend
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
+
+# Per-path I/O problems ast-grep reports while still scanning the rest of the
+# tree (a permission-denied system directory, a locked or vanished file, etc.).
+# These are non-fatal warnings, NOT a failed run; ripgrep logs them and keeps
+# going with a successful exit, and tensor-grep must do the same so one
+# unreadable path cannot abort an otherwise-complete scan.
+_PATH_ACCESS_WARNING_PATTERN = re.compile(
+    r"access is denied"
+    r"|permission denied"
+    r"|os error (?:5|13)"
+    r"|no such file or directory"
+    r"|cannot (?:open|read|access)"
+    r"|the system cannot find",
+    re.IGNORECASE,
+)
+
+
+def _stderr_is_only_path_access_warnings(stderr: str) -> bool:
+    lines = [line.strip() for line in stderr.splitlines() if line.strip()]
+    if not lines:
+        return False
+    return all(_PATH_ACCESS_WARNING_PATTERN.search(line) for line in lines)
+
+
+def _stdout_is_json_payload(stdout: str) -> bool:
+    if not stdout:
+        return False
+    try:
+        return isinstance(json.loads(stdout), list)
+    except json.JSONDecodeError:
+        return False
+
 
 _DEFAULT_AST_GREP_COMMAND_TIMEOUT_SECONDS = 60.0
 _AST_GREP_COMMAND_TIMEOUT_ENV = "TG_AST_GREP_TIMEOUT_SECONDS"
@@ -124,6 +158,20 @@ class AstGrepWrapperBackend(ComputeBackend):
         stderr = (result.stderr or "").strip()
         stdout = (result.stdout or "").strip()
         if not stderr and stdout.startswith("["):
+            return
+
+        # ast-grep exits nonzero when it cannot read an individual path (a
+        # permission-denied directory, a locked/vanished file) even though it
+        # successfully scanned everything else and emitted findings on stdout.
+        # Treat that as a non-fatal partial scan: keep the results and forward
+        # the warning to stderr instead of aborting. A genuine failure (bad
+        # config/rule, invalid language) does not match the access-warning
+        # shape, so it still raises below.
+        if _stdout_is_json_payload(stdout) and _stderr_is_only_path_access_warnings(stderr):
+            print(
+                f"tg: warning: skipped unreadable paths during ast scan: {stderr.splitlines()[0]}",
+                file=sys.stderr,
+            )
             return
 
         detail = stderr or stdout or "no error output"

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -441,3 +442,34 @@ def test_ast_wrapper_backend_should_surface_nonzero_project_scan_errors():
         pytest.raises(RuntimeError, match="failed to parse config"),
     ):
         backend.search_project("project", "sgconfig.yml")
+
+
+def test_ast_wrapper_backend_tolerates_per_path_access_warnings_with_findings(capsys):
+    # Regression: a single permission-denied / unreadable path in the scan tree
+    # makes ast-grep exit nonzero with a warning on stderr while still emitting
+    # findings on stdout. tensor-grep must keep the findings (not abort) and
+    # forward the warning to stderr, the way ripgrep does.
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = json.dumps([
+        {"file": "example.py", "text": "print(x)", "range": {"start": {"line": 0}}}
+    ])
+    mock_result.stderr = (
+        "ERROR: C:\\Users\\me\\AppData\\Local\\Temp\\WinSAT: Access is denied. (os error 5)"
+    )
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+    ):
+        result = backend.search_many(
+            ["example.py"],
+            "print($A)",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+    assert result.total_matches == 1
+    assert "skipped unreadable paths" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- tolerate ast-grep per-path access warnings when stdout contains valid JSON findings
- preserve partial scan findings instead of aborting the whole `tg scan`/AST wrapper run
- add regression coverage for a Windows `Access is denied. (os error 5)` warning with findings on stdout

## Validation
- `uv run pytest tests/unit/test_ast_wrapper_backend.py tests/unit/test_ast_workflows.py tests/unit/test_cli_modes.py -q` -> 453 passed
- `uv run ruff check .` -> pass
- `uv run ruff format --check --preview .` -> pass
- `uv run mypy src/tensor_grep` -> pass
- `uv run pytest -q --basetemp C:\dev\tg-pytest-isolated-<guid>` -> 2562 passed, 24 skipped

Note: a normal local `uv run pytest -q` hit pre-existing dogfood checkpoint state under `%TEMP%\.tensor-grep` in `test_checkpoint_list_explains_empty_scope`; rerunning with a temp base outside that contaminated tree passed. No repo source outside the AST wrapper fix was changed for that local-state issue.