### PR TITLE
fix(release): stop the winget readiness gate freezing every release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,15 +205,30 @@ jobs:
             throw "Unable to resolve project version from pyproject.toml"
           }
           $version = $versionMatch.Matches[0].Groups['version'].Value
-          $manifestPath = "scripts\winget-pkgs\manifests\o\oimiragieo\tensor-grep\$version"
+          $manifestRoot = "scripts\winget-pkgs\manifests\o\oimiragieo\tensor-grep"
+          $manifestPath = Join-Path $manifestRoot $version
           if (-not (Test-Path -LiteralPath $manifestPath)) {
-            throw "Winget manifest directory not found: $manifestPath"
+            # A valid winget manifest needs the published release artifact's InstallerUrl
+            # + SHA256, which only exist AFTER the release. Demanding the current
+            # (just-bumped) version's manifest pre-release is unsatisfiable and froze
+            # every release after a version bump, so warn and validate the latest
+            # committed manifest for syntax instead of hard-failing.
+            Write-Host "::warning::Winget manifest for $version not yet generated (created post-release with the published InstallerUrl + SHA256); validating the latest committed manifest for syntax instead."
+            $latest = Get-ChildItem -LiteralPath $manifestRoot -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.Name -match '^\d+\.\d+\.\d+' } |
+              Sort-Object { [version]($_.Name -replace '[^0-9.].*$', '') } |
+              Select-Object -Last 1
+            $manifestPath = if ($latest) { $latest.FullName } else { $null }
           }
-          $wingetOutput = @(winget validate --manifest $manifestPath 2>&1)
-          $wingetExitCode = $LASTEXITCODE
-          $wingetOutput | ForEach-Object { Write-Host $_ }
-          if ($wingetExitCode -ne 0) {
-            throw "winget validate failed with exit code $wingetExitCode for $manifestPath"
+          if ($manifestPath) {
+            $wingetOutput = @(winget validate --manifest $manifestPath 2>&1)
+            $wingetExitCode = $LASTEXITCODE
+            $wingetOutput | ForEach-Object { Write-Host $_ }
+            if ($wingetExitCode -ne 0) {
+              throw "winget validate failed with exit code $wingetExitCode for $manifestPath"
+            }
+          } else {
+            Write-Host "::warning::No committed winget manifests under $manifestRoot; skipping winget syntax validation."
           }
 
       - name: Validate package-manager publish bundle source state

--- a/tests/unit/test_release_workflow_configuration.py
+++ b/tests/unit/test_release_workflow_configuration.py
@@ -220,9 +220,17 @@ def test_ci_workflow_should_not_cancel_in_progress_main_pushes() -> None:
 def test_ci_package_manager_readiness_should_require_direct_winget_validate() -> None:
     workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
     package_manager_section = _job_section(workflow, "package-manager-readiness")
-    assert "winget-pkgs\\manifests\\o\\oimiragieo\\tensor-grep\\$version" in package_manager_section
+    # The manifest path is built from the project version under the winget-pkgs tree and
+    # validated directly with winget.
+    assert "winget-pkgs\\manifests\\o\\oimiragieo\\tensor-grep" in package_manager_section
+    assert "Join-Path $manifestRoot $version" in package_manager_section
     assert "winget validate --manifest $manifestPath" in package_manager_section
-    assert "Winget manifest directory not found" in package_manager_section
+    # A missing current-version manifest must NOT hard-fail the release: a valid manifest
+    # needs the published artifact URL + SHA256, which only exist post-release, so the gate
+    # warns and validates the latest committed manifest for syntax instead of throwing
+    # "Winget manifest directory not found" (which froze every release after a version bump).
+    assert "Winget manifest directory not found" not in package_manager_section
+    assert "validating the latest committed manifest" in package_manager_section
     assert "Python release asset validator fallback" not in package_manager_section
 
 


### PR DESCRIPTION
## The bug

`package-manager-readiness (windows)` hard-fails whenever `scripts/winget-pkgs/manifests/.../<pyproject_version>/` is absent. But a valid winget manifest needs the **published artifact's InstallerUrl + SHA256**, which only exist **after** the release. So right after semantic-release bumps pyproject, the just-bumped version's manifest cannot exist yet → the gate `throw`s → CI fails → `Semantic Release` is skipped.

**This silently froze every release since the 1.13.35 bump (2026-06-05):**
- the deep-audit fixes (`29ac86b`) and the dogfood CRITICAL+HIGH fixes (`5bd3261`) merged to `main` but **never shipped** to PyPI/npm.
- committed manifests stop at 1.13.34; pyproject is at 1.13.35 → permanent failure.

## The fix

Validate the current version's manifest **if present** (still hard-failing on a *malformed* committed manifest — the real protection); otherwise **warn** and validate the latest committed manifest for syntax, or skip if none exist. The gate no longer blocks the release that must precede the manifest it was demanding.

## Test plan
- YAML parses; the `winget validate` syntax check still runs (and still fails CI) for any committed manifest that is malformed.
- Once merged, the next `main` CI should pass the gate → `Semantic Release` runs → the accumulated `fix:` commits publish a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)