### PR TITLE
fix: reject --json + render flags in the native binary (C3 self-sufficiency)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1221,6 +1221,29 @@ fn main_inner() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // C3: plain `--json` combined with a render-only flag (e.g. -b/--passthru/--heading)
+    // cannot be honored by the aggregate JSON path and must be rejected by the native
+    // binary itself — NEVER delegated to the Python sidecar, which deadlocks/fork-bombs
+    // the native<->python re-exec chain when the resolved Python is a stale tensor-grep
+    // lacking the launcher guard. Fail fast and deterministically before spawning anything.
+    let json_render_conflicts = json_aggregate_render_flag_conflicts(&raw_args);
+    if !json_render_conflicts.is_empty() {
+        let detail = format!(
+            "flag(s) {} not supported with plain --json; use --format rg --json for ripgrep \
+             JSON Lines that carry render metadata, or drop the flag(s).",
+            json_render_conflicts.join(", ")
+        );
+        let payload = serde_json::json!({
+            "version": 1,
+            "schema_version": 1,
+            "ok": false,
+            "error": "unsupported_flag",
+            "detail": detail,
+        });
+        println!("{payload}");
+        std::process::exit(2);
+    }
+
     if let Some(exit_code) = try_early_ripgrep_passthrough(&raw_args)? {
         if exit_code != 0 {
             std::process::exit(exit_code.max(1));
@@ -1503,6 +1526,68 @@ fn search_format_python_passthrough_args(raw_args: &[OsString]) -> Option<Vec<St
         index += 1;
     }
     None
+}
+
+/// Render-only flags the aggregate plain-`--json` path cannot honor. Mirrors
+/// `_PLAIN_JSON_INCOMPATIBLE_RENDER_FLAGS` / `_JSON_INCOMPATIBLE_RENDER_FLAGS` in the
+/// Python CLI/launcher (canonical spelling first in each group).
+const JSON_INCOMPATIBLE_RENDER_FLAGS: &[&[&str]] = &[
+    &["--passthru", "--passthrough"],
+    &["--heading", "--no-heading"],
+    &["--trim", "--no-trim"],
+    &["-b", "--byte-offset", "--no-byte-offset"],
+    &["-M", "--max-columns"],
+    &["--max-columns-preview", "--no-max-columns-preview"],
+    &["--context-separator", "--no-context-separator"],
+    &["--field-context-separator"],
+    &["--field-match-separator"],
+    &["-p", "--pretty"],
+];
+
+/// Return the canonical spellings of render-only flags the user combined with plain
+/// `--json` (not `--format rg`). Such a combination must be rejected by the NATIVE binary
+/// directly — never delegated to the Python sidecar — because delegating to a stale/older
+/// tensor-grep Python (one lacking the launcher guard) deadlocks and can fork-bomb the
+/// native<->python re-exec chain (audit C3). Mirrors the Python guard so the native front
+/// door is self-sufficient regardless of which Python it resolves.
+fn json_aggregate_render_flag_conflicts(raw_args: &[OsString]) -> Vec<String> {
+    let Some(search_args) = normalize_top_level_search_args(raw_args) else {
+        return Vec::new();
+    };
+    let args = search_args
+        .iter()
+        .skip(2)
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    if !args.iter().any(|arg| arg == "--json") {
+        return Vec::new();
+    }
+    // `--format rg` emits ripgrep JSON Lines, which carry render metadata — allowed.
+    let mut index = 0usize;
+    while index < args.len() {
+        if args[index] == "--format" {
+            if args.get(index + 1).map(String::as_str) == Some("rg") {
+                return Vec::new();
+            }
+        } else if args[index] == "--format=rg" {
+            return Vec::new();
+        }
+        index += 1;
+    }
+    let mut flagged: Vec<String> = Vec::new();
+    for arg in &args {
+        if arg == "--" {
+            break;
+        }
+        let base = arg.split('=').next().unwrap_or(arg);
+        for group in JSON_INCOMPATIBLE_RENDER_FLAGS {
+            let canonical = group[0].to_string();
+            if group.contains(&base) && !flagged.contains(&canonical) {
+                flagged.push(canonical);
+            }
+        }
+    }
+    flagged
 }
 
 fn normalize_top_level_search_args(raw_args: &[OsString]) -> Option<Vec<OsString>> {
@@ -2048,6 +2133,60 @@ mod tests {
             Commands::Search(args) => args,
             _ => panic!("expected search command"),
         }
+    }
+
+    fn json_conflicts(tokens: &[&str]) -> Vec<String> {
+        let raw_args = tokens.iter().map(OsString::from).collect::<Vec<_>>();
+        json_aggregate_render_flag_conflicts(&raw_args)
+    }
+
+    #[test]
+    fn json_aggregate_flags_incompatible_render_flags() {
+        // audit C3: plain --json + a render-only flag must be flagged so the native binary
+        // rejects it directly instead of delegating to (and deadlocking via) a stale Python
+        // sidecar in the native<->python re-exec chain.
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "-b", "foo", "f.py"]),
+            vec!["-b".to_string()]
+        );
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "--heading", "foo", "f.py"]),
+            vec!["--heading".to_string()]
+        );
+        // Option-first form (no explicit `search` subcommand) flags trigger flags too:
+        // `-b` is in SEARCH_PYTHON_PASSTHROUGH_FLAGS so it is recognized as a search.
+        assert_eq!(
+            json_conflicts(&["tg", "--json", "-b", "foo", "f.py"]),
+            vec!["-b".to_string()]
+        );
+        // `tg search --json --passthru` (explicit search) delegates via the --passthru gate,
+        // so the native guard must reject it directly.
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "--passthru", "foo", "f.py"]),
+            vec!["--passthru".to_string()]
+        );
+        // --byte-offset is an alias of -b and normalizes to the canonical spelling.
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "--byte-offset", "foo", "f.py"]),
+            vec!["-b".to_string()]
+        );
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "--passthru", "-b", "foo", "f.py"]),
+            vec!["--passthru".to_string(), "-b".to_string()]
+        );
+    }
+
+    #[test]
+    fn json_aggregate_allows_plain_json_and_rg_format() {
+        // plain --json (no render flag) is the native aggregate path — allowed.
+        assert!(json_conflicts(&["tg", "search", "--json", "foo", "f.py"]).is_empty());
+        // --format rg --json carries render metadata via ripgrep JSON Lines — allowed.
+        assert!(
+            json_conflicts(&["tg", "search", "--format", "rg", "--json", "-b", "foo", "f.py"])
+                .is_empty()
+        );
+        // a literal render-flag-looking pattern after `--` is not a flag.
+        assert!(json_conflicts(&["tg", "search", "--json", "--", "--passthru"]).is_empty());
     }
 
     #[cfg(feature = "cuda")]


### PR DESCRIPTION
## Why

The C3 fork-bomb was fixed at the Python launcher layer in v1.13.36 — but the **native `tg.exe`** still delegated `--json` + a render-only flag (`-b`/`--passthru`/`--heading`/`--trim`/`-M`/`-p`/`--context-separator`/`--field-*`) to the Python sidecar. When the resolved Python is a **stale tensor-grep** lacking the launcher guard, that delegation deadlocks and fork-bombs the native↔python re-exec chain.

**Empirically reproduced:** with a stale `tensor-grep 1.13.21` Python on PATH, the native binary `tg --json -b` **hung at exit 124**. So the native binary was not self-sufficient — its safety depended on the Python version it happened to resolve.

## What

A native-level guard `json_aggregate_render_flag_conflicts()` (mirroring the Python `_json_aggregate_blocks_passthrough`) rejects these combinations **directly** with a structured `unsupported_flag` exit-2 error **before spawning any child** — so the native front door is safe regardless of which Python it resolves. Plain `--json` (native aggregate) and `--format rg --json` (ripgrep JSON Lines) are unaffected.

## Verification (under hard process-count + timeout guards)

Freshly-built native binary against the **stale 1.13.21 Python** (the case that hung before):

| invocation | before | after |
|---|---|---|
| `tg --json -b` | exit 124 (hang) | **exit 2, 0 procs** |
| `tg --json --heading / -p / --trim / -M` | hang / silent-ignore | **exit 2, 0 procs** |
| `tg --json` (plain) | works | works (exit 0) |
| `tg --format rg --json -b` | works | works (exit 0) |
| plain search | works | works |

Adds rust unit tests for the guard. `cargo fmt`/`clippy -D warnings`/`test` all green (sole failure is the pre-existing multi-python env-flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)