### PR TITLE
fix(security): native C3 guard bypass + index deserializer DoS clamp (audit batch 2)

### DIFF
--- a/rust_core/src/index.rs
+++ b/rust_core/src/index.rs
@@ -306,6 +306,14 @@ fn bincode_serialize(index: &TrigramIndex) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Cap a length-prefixed pre-allocation to the bytes actually remaining in the buffer.
+/// Every element consumes at least one byte, so a declared count larger than the remaining
+/// input is corrupt/hostile; clamping prevents a crafted index file from forcing a multi-GB
+/// Vec/HashMap allocation (OOM-abort DoS) before the read loop fails cleanly. audit MED.
+fn bounded_capacity(declared: usize, data: &[u8], pos: usize) -> usize {
+    declared.min(data.len().saturating_sub(pos))
+}
+
 fn bincode_deserialize(data: &[u8]) -> Result<TrigramIndex> {
     let mut pos = 0;
 
@@ -331,7 +339,7 @@ fn bincode_deserialize(data: &[u8]) -> Result<TrigramIndex> {
 
     let files_count = read_u32_le(data, &mut pos)? as usize;
 
-    let mut files = Vec::with_capacity(files_count);
+    let mut files = Vec::with_capacity(bounded_capacity(files_count, data, pos));
     for _ in 0..files_count {
         let path_len = read_u32_le(data, &mut pos)? as usize;
         let path_str = String::from_utf8_lossy(read_exact(data, &mut pos, path_len)?).to_string();
@@ -348,11 +356,11 @@ fn bincode_deserialize(data: &[u8]) -> Result<TrigramIndex> {
 
     let trigram_count = read_u32_le(data, &mut pos)? as usize;
 
-    let mut postings = HashMap::with_capacity(trigram_count);
+    let mut postings = HashMap::with_capacity(bounded_capacity(trigram_count, data, pos));
     for _ in 0..trigram_count {
         let trigram: [u8; 3] = read_exact(data, &mut pos, 3)?.try_into()?;
         let posting_count = read_u32_le(data, &mut pos)? as usize;
-        let mut entries = Vec::with_capacity(posting_count);
+        let mut entries = Vec::with_capacity(bounded_capacity(posting_count, data, pos));
         let mut previous_file_id = 0u32;
         let mut previous_line = 0u32;
         let mut first = true;
@@ -1115,6 +1123,23 @@ mod tests {
 
     fn write_test_file(dir: &Path, name: &str, content: &str) {
         fs::write(dir.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn bincode_deserialize_rejects_hostile_length_prefix_without_oom() {
+        // A crafted index declaring ~4 billion file entries but supplying no data must fail
+        // with a clean error, not pre-allocate a multi-GB Vec and OOM-abort. Without the
+        // bounded_capacity clamp this is Vec::with_capacity(u32::MAX) -> allocation abort;
+        // with it, the read loop fails on the first missing entry and returns Err (audit MED).
+        let mut data = Vec::new();
+        data.extend_from_slice(INDEX_MAGIC);
+        data.push(INDEX_FORMAT_VERSION);
+        data.extend_from_slice(&0u32.to_le_bytes()); // root_len = 0
+        data.extend_from_slice(&u32::MAX.to_le_bytes()); // files_count = hostile
+                                                         // no file data follows (truncated)
+
+        let result = bincode_deserialize(&data);
+        assert!(result.is_err(), "hostile length prefix must error, not OOM");
     }
 
     fn serialize_legacy_v1(index: &TrigramIndex) -> Vec<u8> {

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1563,8 +1563,14 @@ fn json_aggregate_render_flag_conflicts(raw_args: &[OsString]) -> Vec<String> {
         return Vec::new();
     }
     // `--format rg` emits ripgrep JSON Lines, which carry render metadata — allowed.
+    // Stop at the `--` end-of-options token (mirroring the conflict loop below): a
+    // literal `--format rg` smuggled AFTER `--` is a search pattern, not the flag, and
+    // must not suppress a genuine render-flag conflict that precedes `--` (audit MED).
     let mut index = 0usize;
     while index < args.len() {
+        if args[index] == "--" {
+            break;
+        }
         if args[index] == "--format" {
             if args.get(index + 1).map(String::as_str) == Some("rg") {
                 return Vec::new();
@@ -2187,6 +2193,23 @@ mod tests {
         );
         // a literal render-flag-looking pattern after `--` is not a flag.
         assert!(json_conflicts(&["tg", "search", "--json", "--", "--passthru"]).is_empty());
+    }
+
+    #[test]
+    fn json_aggregate_format_rg_after_double_dash_does_not_suppress_real_conflict() {
+        // Regression (audit MED): `--format rg` / `--format=rg` smuggled AFTER `--` is a
+        // literal search pattern, not the format flag, so it must NOT satisfy the rg-format
+        // allowance. The genuine `-b` render-flag conflict BEFORE `--` must still be reported
+        // (otherwise the native binary delegates the --json+render combo to the Python
+        // sidecar, re-opening the C3 fork-bomb against a guard-less Python).
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "-b", "--", "--format", "rg"]),
+            vec!["-b".to_string()]
+        );
+        assert_eq!(
+            json_conflicts(&["tg", "search", "--json", "-b", "--", "--format=rg"]),
+            vec!["-b".to_string()]
+        );
     }
 
     #[cfg(feature = "cuda")]


### PR DESCRIPTION
Second batch of audit fixes (v1.13.40 shipped the first 8). Two security MEDs, each TDD'd.

### `fix(native)` — C3 fork-bomb guard bypass
`json_aggregate_render_flag_conflicts`'s `--format rg` allow-check scanned all args without stopping at the `--` end-of-options token (unlike the conflict loop below it). So `tg search --json -b -- --format rg PATTERN` matched the literal `--format rg` *after* `--`, returned "no conflict", and suppressed the genuine `-b` conflict — delegating the `--json`+render combo to the Python sidecar and re-opening the C3 fork-bomb against a guard-less/stale Python. Fix: break the allow-check loop on `--`. Rust test asserts the smuggled-after-`--` case now reports `["-b"]`.

### `fix(index)` — index deserializer preallocation DoS
`bincode_deserialize` sized three containers (files Vec, postings HashMap, per-trigram entries Vec) from **unvalidated u32 counts**. A crafted `.tensor-grep` index declaring ~4 billion entries forced a multi-GB `Vec::with_capacity` → OOM-abort instead of the normal graceful corrupt-index recovery. Fix: `bounded_capacity()` clamps each preallocation to the bytes actually remaining. Rust test: hostile `u32::MAX` count + truncated data → clean `Err`, not OOM.

## Verification (local)
`cargo test` (index 25 + native guard 3 passing) · `cargo clippy -D warnings` clean · `cargo fmt --check` clean. Based on `main` (so it inherits the v1.13.40 mypy/audit gate fixes).

## Remaining backlog (next batches)
GPU `BackendExecutionError` fallback, nested `.gitignore` parity, supply-chain (Homebrew sha256, rust-analyzer/Node checksums), 38 LOWs, and the upstream-gated pyo3 0.29 bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)