### PR TITLE
ci(security): SHA-pin all third-party GitHub Actions (supply-chain hardening)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -40,7 +40,7 @@ jobs:
         run: cargo deny check
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Create or update scheduled audit issue on failure
         if: needs.audit.result != 'success'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const title = "[Security Audit] Scheduled dependency audit failure";
@@ -150,7 +150,7 @@ jobs:
 
       - name: Close scheduled audit issue on success
         if: needs.audit.result == 'success'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const title = "[Security Audit] Scheduled dependency audit failure";

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.0.0
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - name: Setup Rust stable
@@ -75,7 +75,7 @@ jobs:
       - name: Throughput smoke benchmark
         run: uv run pytest tests/e2e/test_throughput.py -v --tb=short
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-artifacts
           path: artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Validate PR title for semantic release
         run: python scripts/validate_pr_title_semver.py
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Repo Hygiene Guard
         run: python scripts/check_repo_hygiene.py
@@ -47,13 +47,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -85,7 +85,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
         run: python -m pip install uv
@@ -108,13 +108,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -138,13 +138,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -178,13 +178,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -244,7 +244,7 @@ jobs:
         run: uv run python scripts/smoke_test_package_manager_bundle.py --bundle-dir artifacts/package-manager-bundle
 
       - name: Upload package-manager bundle artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: package-manager-bundle-${{ matrix.os }}
           path: artifacts/package-manager-bundle/
@@ -256,7 +256,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Setup Rust
         shell: bash
@@ -276,7 +276,7 @@ jobs:
         run: python -m pip install uv
         
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           
@@ -315,7 +315,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Install uv
         run: python -m pip install uv
@@ -380,7 +380,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         rust_channel: [stable, nightly]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Setup Rust ${{ matrix.rust_channel }}
         shell: bash
@@ -399,7 +399,7 @@ jobs:
           cargo --version
           
       - name: Setup Python for PyO3 Linker
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           
@@ -424,13 +424,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Python for PyO3 Linker
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -455,13 +455,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup Python for PyO3 Linker
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -509,13 +509,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Install uv
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
         
@@ -560,7 +560,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -602,7 +602,7 @@ jobs:
 
       - name: Checkout base revision for same-runner benchmark comparison
         if: github.event_name != 'schedule'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ steps.benchmark-base.outputs.base_sha }}
           path: base-revision
@@ -829,7 +829,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-artifacts-ci
           path: |
@@ -850,13 +850,13 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9
+        uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 # v9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -921,7 +921,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
       - name: Prefetch Rust dependencies for PyPI artifacts
@@ -941,7 +941,7 @@ jobs:
           done
           echo "Cargo dependency prefetch failed after 5 attempts."
           cargo fetch --manifest-path rust_core/Cargo.toml
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
           args: --release --out dist
@@ -950,7 +950,7 @@ jobs:
           CARGO_NET_RETRY: "10"
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pypi-wheels-${{ matrix.os }}
           path: dist
@@ -963,7 +963,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
       - name: Prefetch Rust dependencies for PyPI artifacts
@@ -983,7 +983,7 @@ jobs:
           done
           echo "Cargo dependency prefetch failed after 5 attempts."
           cargo fetch --manifest-path rust_core/Cargo.toml
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist
@@ -992,7 +992,7 @@ jobs:
           CARGO_NET_RETRY: "10"
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
       - name: Upload sdist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pypi-sdist
           path: dist
@@ -1005,9 +1005,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Download all distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: pypi-*
           path: dist
@@ -1059,7 +1059,7 @@ jobs:
             cargo_args: --no-default-features
             asset_name: tg-macos-amd64-cpu
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: matrix.acceleration == 'cpu' || env.RELEASE_NATIVE_ASSET_PROFILE == 'native-frontdoor-gpu'
         with:
           ref: v${{ needs.release.outputs.release_version }}
@@ -1070,7 +1070,7 @@ jobs:
 
       - name: Setup Python for PyO3 Linker
         if: matrix.acceleration == 'cpu' || env.RELEASE_NATIVE_ASSET_PROFILE == 'native-frontdoor-gpu'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -1118,7 +1118,7 @@ jobs:
 
       - name: Upload native release front door
         if: matrix.acceleration == 'cpu' || env.RELEASE_NATIVE_ASSET_PROFILE == 'native-frontdoor-gpu'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-native-${{ matrix.os }}-${{ matrix.acceleration }}
           path: dist-native/
@@ -1131,18 +1131,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
 
       - name: Download native release front doors
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: release-native-*
           path: artifacts/native
@@ -1174,7 +1174,7 @@ jobs:
             --expected-version "${{ needs.release.outputs.release_version }}"
 
       - name: Upload GitHub release native assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           tag_name: v${{ needs.release.outputs.release_version }}
           fail_on_unmatched_files: true
@@ -1210,18 +1210,18 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
 
       - name: Download all distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: pypi-*
           path: dist
           merge-multiple: true
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: true
 
@@ -1248,14 +1248,14 @@ jobs:
         run: |
           echo "No semantic-release release for this commit; skipping publish parity gate."
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: needs.release.outputs.released == 'true'
         with:
           ref: v${{ needs.release.outputs.release_version }}
 
       - name: Download all distributions
         if: needs.release.outputs.released == 'true' && needs.release.outputs.publish_pypi == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: pypi-*
           path: dist
@@ -1323,7 +1323,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: v${{ needs.release.outputs.release_version }}
 
@@ -1331,7 +1331,7 @@ jobs:
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.issue.pull_request == null }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -89,7 +89,7 @@ jobs:
           PY
 
       - name: Apply triage labels and comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           TRIAGE_OUTPUT: ${{ runner.temp }}/issue-triage.json
         with:

--- a/.github/workflows/public-gpu-proof.yml
+++ b/.github/workflows/public-gpu-proof.yml
@@ -47,7 +47,7 @@ jobs:
           PY
           echo "TG_PUBLIC_GPU_PROOF_RELEASE_VERSION=${TG_PUBLIC_GPU_PROOF_RELEASE_TAG#v}" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.release_tag }}
 
@@ -56,7 +56,7 @@ jobs:
         run: python -m pip install uv
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload public GPU proof artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: public-gpu-proof-${{ inputs.release_tag }}
           path: artifacts/public-gpu-proof/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - name: Setup Python
         run: uv python install 3.12
       - name: Validate release/package asset consistency
@@ -30,10 +30,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Validate Homebrew formula syntax
         if: runner.os == 'Linux'
@@ -122,10 +122,10 @@ jobs:
             gpu: cpu
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -179,7 +179,7 @@ jobs:
           ./tg-macos-amd64-${{ matrix.gpu }} --version
         
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: binary-${{ runner.os }}-${{ matrix.gpu }}
           path: tg-*
@@ -192,15 +192,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -234,7 +234,7 @@ jobs:
             --expected-version "${GITHUB_REF#refs/tags/v}"
 
       - name: Install cargo-cyclonedx
-        uses: taiki-e/install-action@cargo-cyclonedx
+        uses: taiki-e/install-action@a93ce23109958ad177ba6918b4318226aad5bc24 # cargo-cyclonedx
 
       - name: Generate Rust SBOM
         working-directory: rust_core
@@ -249,7 +249,7 @@ jobs:
           uv run cyclonedx-py environment --outfile artifacts/sbom-python.json
 
       - name: Sign artifacts with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
         with:
           inputs: >-
             artifacts/**/tg-*
@@ -257,12 +257,12 @@ jobs:
             artifacts/sbom-*.json
 
       - name: Generate SLSA Provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: artifacts/**
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             artifacts/**/tg-*
@@ -278,7 +278,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Verify uploaded release assets and checksum coverage
         run: |
@@ -293,10 +293,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -314,10 +314,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -338,7 +338,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12
@@ -358,10 +358,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
           
@@ -380,10 +380,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Setup Python
         run: uv python install 3.12

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -30,6 +30,38 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _normalize_pinned_actions(content: str) -> str:
+    """Rewrite SHA-pinned action refs (``owner/repo@<40hex> # vX``) back to their logical tag
+    (``owner/repo@vX``) for VALIDATION ONLY, so the workflow-content checks keep asserting against
+    the version comment rather than the (intentionally pinned) commit SHA. The raw workflow files
+    stay SHA-pinned; ``validate_actions_sha_pinned`` separately enforces that they ARE pinned.
+    """
+    return re.sub(r"@[0-9a-f]{40} # (\S+)", r"@\1", content)
+
+
+def validate_actions_sha_pinned() -> list[str]:
+    """Every third-party GitHub Action ``uses:`` must be pinned to a full 40-hex commit SHA
+    (supply-chain hardening — tags/branches are mutable). Exempt: ``dtolnay/rust-toolchain``
+    (``@stable`` is a moving ref by design that resolves to the latest Rust toolchain) and local
+    reusable workflows (``./...``). The ``# vX`` version comment keeps Dependabot updating the pins.
+    """
+    errors: list[str] = []
+    exempt_prefixes = ("dtolnay/rust-toolchain",)
+    workflows_dir = ROOT / ".github" / "workflows"
+    for workflow in sorted(workflows_dir.glob("*.yml")):
+        content = workflow.read_text(encoding="utf-8")
+        for match in re.finditer(r"uses:\s*([^\s@]+)@([^\s#]+)", content):
+            action, ref = match.group(1), match.group(2)
+            if action.startswith("./") or any(action.startswith(p) for p in exempt_prefixes):
+                continue
+            if not re.fullmatch(r"[0-9a-f]{40}", ref):
+                errors.append(
+                    f"{workflow.name}: third-party action `{action}@{ref}` must be pinned to a "
+                    "full 40-hex commit SHA (add `# vX` so Dependabot keeps it updated)"
+                )
+    return errors
+
+
 def _version_from_pyproject() -> str:
     data = tomllib.loads(_read(ROOT / "pyproject.toml"))
     return str(data["project"]["version"])
@@ -175,6 +207,7 @@ def validate_winget_manifest(*, winget_content: str, py_version: str) -> list[st
 
 
 def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
+    ci_workflow = _normalize_pinned_actions(ci_workflow)
     errors: list[str] = []
     for expected in (
         "release-intent:",
@@ -1414,6 +1447,7 @@ def validate_dependabot_config(*, dependabot_content: str) -> list[str]:
 
 
 def validate_public_gpu_proof_workflow_content(*, workflow_content: str) -> list[str]:
+    workflow_content = _normalize_pinned_actions(workflow_content)
     errors: list[str] = []
     try:
         parsed = yaml.safe_load(workflow_content) or {}
@@ -1496,6 +1530,7 @@ def validate_public_gpu_proof_workflow_content(*, workflow_content: str) -> list
 
 
 def validate_dependabot_automation_workflow_content(*, workflow_content: str) -> list[str]:
+    workflow_content = _normalize_pinned_actions(workflow_content)
     errors: list[str] = []
     for expected in (
         "name: Dependabot Automation",
@@ -1632,6 +1667,7 @@ def validate_dependabot_automation_workflow_content(*, workflow_content: str) ->
 
 
 def validate_audit_workflow_content(*, workflow_content: str) -> list[str]:
+    workflow_content = _normalize_pinned_actions(workflow_content)
     errors: list[str] = []
     for expected in (
         "name: Security Audit",
@@ -2292,6 +2328,7 @@ def validate_benchmarks_docs(*, benchmarks_content: str) -> list[str]:
 
 
 def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
+    release_workflow = _normalize_pinned_actions(release_workflow)
     errors: list[str] = []
     for expected in (
         "on:",
@@ -3479,6 +3516,8 @@ def validate_all() -> list[str]:
     errors.extend(
         validate_dependabot_automation_workflow_content(workflow_content=dependabot_workflow)
     )
+
+    errors.extend(validate_actions_sha_pinned())
 
     package_manager_runbook = _read(ROOT / "docs" / "package_manager_publish.md")
     release_checklist = _read(ROOT / "docs" / "RELEASE_CHECKLIST.md")

--- a/tests/unit/test_audit_workflow_contract.py
+++ b/tests/unit/test_audit_workflow_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -17,7 +18,8 @@ def test_audit_workflow_checks_out_pull_request_head_ref() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     workflow = (repo_root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
 
-    assert "uses: actions/checkout@v6" in workflow
+    # checkout is SHA-pinned for supply-chain hardening; the `# v6` comment keeps Dependabot updating it.
+    assert re.search(r"uses: actions/checkout@[0-9a-f]{40} # v6", workflow)
     assert (
         "repository: ${{ github.event_name == 'pull_request' && "
         "github.event.pull_request.head.repo.full_name || github.repository }}"

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -1,6 +1,14 @@
 import importlib.util
+import re
 import textwrap
 from pathlib import Path
+
+
+def _detag(content: str) -> str:
+    """Restore SHA-pinned action refs (``@<sha> # vX``) to their logical tag (``@vX``) so
+    tests that assert or string-manipulate version strings keep working against the
+    SHA-pinned workflow files (supply-chain hardening)."""
+    return re.sub(r"@[0-9a-f]{40} # (\S+)", r"@\1", content)
 
 
 def test_should_validate_release_and_package_assets_consistency():
@@ -791,7 +799,7 @@ def test_should_require_audit_workflow_checkout_to_use_pr_head_ref():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+    workflow = _detag((root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8"))
     workflow = workflow.replace(
         "      - uses: actions/checkout@v6\n"
         "        with:\n"
@@ -904,7 +912,7 @@ def test_should_reject_audit_workflow_legacy_scanner_environment_steps():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+    workflow = _detag((root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8"))
     workflow = workflow.replace(
         "      - name: Export Python audit requirements\n",
         "      - name: Create Python audit environment\n"
@@ -1126,7 +1134,7 @@ def test_should_require_pypi_artifact_builds_to_prefetch_cargo_dependencies_with
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         "      - name: Prefetch Rust dependencies for PyPI artifacts\n",
         "      - name: Prefetch Rust dependencies without retry\n",
@@ -1856,7 +1864,7 @@ def test_should_require_ci_semantic_release_github_asset_jobs():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace("  build-release-native-assets:", "  old-assets:", 1)
     ci_workflow = ci_workflow.replace("  publish-github-release-assets:", "  old-upload:", 1)
 
@@ -1963,7 +1971,7 @@ def test_should_require_ci_release_assets_to_gate_on_semantic_release_released_o
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         "      released: ${{ steps.publish_check.outputs.released }}\n",
         "",
@@ -2006,7 +2014,7 @@ def test_should_require_ci_macos_native_frontdoor_to_use_intel_runner_label():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         "- os: macos-15-intel\n"
         "            acceleration: cpu\n"
@@ -2035,7 +2043,7 @@ def test_should_require_ci_native_build_smoke_to_use_intel_runner_label():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         "os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]",
         "os: [ubuntu-latest, windows-latest, macos-latest]",
@@ -2051,7 +2059,7 @@ def test_should_require_ci_native_build_smoke_to_use_intel_runner_label():
 
 def test_should_configure_semantic_release_native_assets_for_optional_gpu_profile():
     root = Path(__file__).resolve().parents[2]
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
 
     assert "TENSOR_GREP_RELEASE_NATIVE_ASSET_PROFILE" in ci_workflow
     assert "vars.TENSOR_GREP_RELEASE_NATIVE_ASSET_PROFILE || 'native-frontdoor'" in ci_workflow
@@ -2077,7 +2085,7 @@ def test_should_require_ci_release_asset_verifiers_to_use_selectable_native_prof
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         '--expected-profile "$RELEASE_NATIVE_ASSET_PROFILE"',
         "--expected-profile native-frontdoor",
@@ -2100,7 +2108,7 @@ def test_should_reject_ci_release_native_macos_nvidia_asset():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         "- os: macos-15-intel\n"
         "            acceleration: cpu\n"
@@ -3896,7 +3904,9 @@ def test_should_require_release_build_binaries_step_contracts():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     build_binaries_prefix, build_binaries_rest = release_workflow.split("  build-binaries:", 1)
     build_binaries_section, remainder = build_binaries_rest.split("  create-release:", 1)
     build_binaries_section = build_binaries_section.replace(
@@ -4033,7 +4043,9 @@ def test_should_require_create_release_download_artifacts_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     release_workflow = release_workflow.replace(
         "actions/download-artifact@v8",
         "actions/download-artifact@v3",
@@ -4062,7 +4074,9 @@ def test_should_require_create_release_setup_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     create_release_prefix, create_release_rest = release_workflow.split("  create-release:", 1)
     create_release_section, remainder = create_release_rest.split("  verify-release-assets:", 1)
     create_release_section = create_release_section.replace(
@@ -4101,7 +4115,9 @@ def test_should_require_create_release_artifact_validation_steps():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     create_release_prefix, create_release_rest = release_workflow.split("  create-release:", 1)
     create_release_section, remainder = create_release_rest.split("  verify-release-assets:", 1)
     create_release_section = create_release_section.replace(
@@ -4144,7 +4160,9 @@ def test_should_require_verify_release_assets_checkout_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     verify_prefix, verify_rest = release_workflow.split("  verify-release-assets:", 1)
     verify_section, remainder = verify_rest.split("  validate-tag-version-parity:", 1)
     verify_section = verify_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
@@ -4171,7 +4189,9 @@ def test_should_require_verify_release_assets_python_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     verify_prefix, verify_rest = release_workflow.split("  verify-release-assets:", 1)
     verify_section, remainder = verify_rest.split("  validate-tag-version-parity:", 1)
     verify_section = verify_section.replace(
@@ -4205,7 +4225,9 @@ def test_should_require_validate_tag_version_parity_setup_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     tag_prefix, tag_rest = release_workflow.split("  validate-tag-version-parity:", 1)
     tag_section, remainder = tag_rest.split("  publish-npm:", 1)
     tag_section = tag_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
@@ -4238,7 +4260,9 @@ def test_should_require_validate_tag_version_parity_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     tag_prefix, tag_rest = release_workflow.split("  validate-tag-version-parity:", 1)
     tag_section, remainder = tag_rest.split("  publish-npm:", 1)
     tag_section = tag_section.replace(
@@ -4268,7 +4292,9 @@ def test_should_require_publish_npm_checkout_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
@@ -4289,7 +4315,9 @@ def test_should_require_publish_npm_uv_python_setup_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace("astral-sh/setup-uv@v8.0.0", "astral-sh/setup-uv@v4.0.0", 1)
@@ -4312,7 +4340,9 @@ def test_should_require_publish_npm_node_version_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace("node-version: '22'", "node-version: '18'", 1)
@@ -4333,7 +4363,9 @@ def test_should_require_publish_npm_version_check_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace(
@@ -4361,7 +4393,9 @@ def test_should_require_publish_npm_registry_parity_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace(
@@ -4389,7 +4423,9 @@ def test_should_require_publish_npm_working_directory_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace("working-directory: npm", "working-directory: .", 1)
@@ -4413,7 +4449,9 @@ def test_should_require_publish_npm_auth_env_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     npm_prefix, npm_rest = release_workflow.split("  publish-npm:", 1)
     npm_section, remainder = npm_rest.split("  publish-docs:", 1)
     npm_section = npm_section.replace(
@@ -4441,7 +4479,9 @@ def test_should_require_publish_docs_checkout_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
     docs_section = docs_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
@@ -4464,7 +4504,9 @@ def test_should_require_publish_docs_python_setup_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
     docs_section = docs_section.replace("actions/setup-python@v6", "actions/setup-python@v4", 1)
@@ -4489,7 +4531,9 @@ def test_should_require_publish_docs_force_flag():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
     docs_section = docs_section.replace("mkdocs gh-deploy --force", "mkdocs gh-deploy", 1)
@@ -4512,7 +4556,9 @@ def test_should_require_publish_docs_build_step_with_strict_mode():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
     docs_section = docs_section.replace(
@@ -4548,7 +4594,9 @@ def test_should_require_publish_docs_install_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
     docs_section = docs_section.replace(
@@ -4576,7 +4624,7 @@ def test_should_require_ci_release_readiness_docs_build_step():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_workflow = _detag((root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
     ci_workflow = ci_workflow.replace(
         "      - name: Build docs site (strict)\n",
         "      - name: Build docs site\n",
@@ -4599,7 +4647,9 @@ def test_should_require_publish_docs_deploy_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     docs_prefix, docs_rest = release_workflow.split("  publish-docs:", 1)
     docs_section, remainder = docs_rest.split("  release-success-gate:", 1)
     docs_section = docs_section.replace(
@@ -4624,7 +4674,9 @@ def test_should_require_release_success_gate_setup_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     gate_prefix, gate_rest = release_workflow.split("  release-success-gate:", 1)
     gate_section = gate_rest
     gate_section = gate_section.replace("actions/checkout@v6", "actions/checkout@v3", 1)
@@ -4655,7 +4707,9 @@ def test_should_require_release_success_gate_confirm_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     gate_prefix, gate_rest = release_workflow.split("  release-success-gate:", 1)
     gate_section = gate_rest.replace(
         'echo "Release publication gates passed: parity, npm, docs."',
@@ -4682,7 +4736,9 @@ def test_should_require_release_success_gate_parity_script_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     gate_prefix, gate_rest = release_workflow.split("  release-success-gate:", 1)
     gate_section = gate_rest.replace(
         "python scripts/validate_release_version_parity.py",
@@ -4709,7 +4765,9 @@ def test_should_require_release_success_gate_parity_entrypoint_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    release_workflow = (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    release_workflow = _detag(
+        (root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    )
     gate_prefix, gate_rest = release_workflow.split("  release-success-gate:", 1)
     gate_section = gate_rest.replace(
         "python scripts/validate_release_version_parity.py",
@@ -4736,7 +4794,9 @@ def test_should_validate_public_gpu_proof_workflow_contract():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    workflow = (root / ".github" / "workflows" / "public-gpu-proof.yml").read_text(encoding="utf-8")
+    workflow = _detag(
+        (root / ".github" / "workflows" / "public-gpu-proof.yml").read_text(encoding="utf-8")
+    )
 
     assert module.validate_public_gpu_proof_workflow_content(workflow_content=workflow) == []
 
@@ -4794,3 +4854,19 @@ def test_should_reject_public_gpu_proof_workflow_without_dispatch_only_fixed_run
     assert "Public GPU proof workflow must request read-only contents permission" in joined_errors
     assert "Public GPU proof workflow must use fixed GPU runner labels" in joined_errors
     assert "Public GPU proof workflow must run with --public-managed-proof" in joined_errors
+
+
+def test_validate_actions_sha_pinned_passes_and_exempts_rust_toolchain():
+    """Supply-chain hardening: every third-party action in the repo's workflows must be
+    pinned to a 40-hex commit SHA, and dtolnay/rust-toolchain@stable must stay exempt
+    (its @stable is a moving ref by design)."""
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.validate_actions_sha_pinned() == []
+    ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "dtolnay/rust-toolchain@stable" in ci


### PR DESCRIPTION
Council-spec'd supply-chain hardening (the "lock down CI robots" backlog item).

## What
Pins **87** third-party action `uses:` across all workflow files to a full **40-hex commit SHA + `# vX` comment**. Tags/branches are mutable; a full SHA is the only immutable ref — this mitigates a compromised-upstream-action attack on the privileged publish/sign jobs (`id-token`/`contents`/`attestations: write`). The `# vX` comment keeps Dependabot updating the pins.

Includes the **highest-privilege previously-floating targets** an earlier scope missed: `taiki-e/install-action@cargo-cyclonedx`, `pypa/gh-action-pypi-publish` (was a *branch* alias), `PyO3/maturin-action`, `python-semantic-release`, `sigstore`, `attest-build-provenance`, `softprops/action-gh-release`, `astral-sh/setup-uv`, `actions/*`.

**Exempt:** `dtolnay/rust-toolchain@stable` — `@stable` is a moving ref by design; pinning would freeze the Rust toolchain.

## Validator + tests (the ship-blocker the council caught)
- `validate_release_assets.py` normalizes the pinned form back to the logical tag for its ~30 existing version assertions (`_normalize_pinned_actions`), and a new **`validate_actions_sha_pinned()`** enforces that every third-party action IS pinned (dtolnay exempt).
- Tests de-tag real-file reads so version-injection negatives still work; new regression test. **163 tests pass** locally; ruff/format/mypy clean.

## Release note
Conventional type **`ci:`** — this hardens the *build pipeline*, not the product, so semantic-release correctly cuts **no customer release**. It protects all future releases.

Council-verified (3 Claude lenses) before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)