### PR TITLE
fix(packaging): verify the Homebrew binary via sha256 in the published formula (audit MED)

### DIFF
--- a/scripts/prepare_package_manager_release.py
+++ b/scripts/prepare_package_manager_release.py
@@ -13,6 +13,8 @@ except ModuleNotFoundError:  # pragma: no cover
 from pathlib import Path
 
 WINDOWS_NATIVE_ASSET = "tg-windows-amd64-cpu.exe"
+MACOS_NATIVE_ASSET = "tg-macos-amd64-cpu"
+LINUX_NATIVE_ASSET = "tg-linux-amd64-cpu"
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT = SCRIPT_DIR.parents[0]
@@ -165,6 +167,40 @@ def _stamp_winget_installer_sha(*, winget_content: str, installer_sha256: str) -
     )
 
 
+def _asset_sha_from_checksums(checksums_path: Path | None, asset_name: str) -> str | None:
+    """Return the lowercased SHA256 for ``asset_name`` from a ``<sha>  <asset>`` CHECKSUMS file."""
+    if checksums_path is None or not checksums_path.exists():
+        return None
+    for raw_line in checksums_path.read_text(encoding="utf-8").splitlines():
+        parts = raw_line.split()
+        if len(parts) == 2 and parts[1] == asset_name:
+            digest = parts[0]
+            if re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+                return digest.lower()
+            raise ValueError(f"Invalid SHA256 digest for {asset_name}")
+    raise ValueError(f"Missing {asset_name} entry in {checksums_path}")
+
+
+def _stamp_homebrew_sha256(*, brew_content: str, mac_sha256: str, linux_sha256: str) -> str:
+    """Insert a ``sha256 "<digest>"`` line after each per-OS ``url`` in the formula so the
+    published Homebrew formula verifies the downloaded binary (audit MED). The source template
+    carries no sha256 (the binary digests only exist post-build); they are stamped here at bundle
+    time from CHECKSUMS.txt, mirroring the winget InstallerSha256 stamping above.
+    """
+    content = brew_content
+    for asset, digest in ((MACOS_NATIVE_ASSET, mac_sha256), (LINUX_NATIVE_ASSET, linux_sha256)):
+        content = re.sub(
+            r'(?m)^(\s*)(url "https://github\.com/oimiragieo/tensor-grep/releases/download/'
+            rf'v[^"]+/{re.escape(asset)}")\s*$',
+            lambda match, d=digest: (
+                f'{match.group(1)}{match.group(2)}\n{match.group(1)}sha256 "{d}"'
+            ),
+            content,
+            count=1,
+        )
+    return content
+
+
 def prepare_bundle(
     *, output_dir: Path, check_only: bool, release_checksums: Path | None = None
 ) -> int:
@@ -181,6 +217,8 @@ def prepare_bundle(
 
     try:
         windows_installer_sha = _windows_installer_sha_from_checksums(release_checksums)
+        macos_native_sha = _asset_sha_from_checksums(release_checksums, MACOS_NATIVE_ASSET)
+        linux_native_sha = _asset_sha_from_checksums(release_checksums, LINUX_NATIVE_ASSET)
     except ValueError as exc:
         print(f"ERROR: {exc}")
         return 1
@@ -206,7 +244,14 @@ def prepare_bundle(
 
     brew_dest.parent.mkdir(parents=True, exist_ok=True)
     winget_dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(brew_src, brew_dest)
+    brew_content = _read(brew_src)
+    if macos_native_sha is not None and linux_native_sha is not None:
+        brew_content = _stamp_homebrew_sha256(
+            brew_content=brew_content,
+            mac_sha256=macos_native_sha,
+            linux_sha256=linux_native_sha,
+        )
+    brew_dest.write_text(brew_content, encoding="utf-8")
     if winget_src_dir.is_dir():
         for manifest_path in sorted(winget_src_dir.iterdir()):
             if manifest_path.is_file():

--- a/scripts/smoke_test_package_manager_bundle.py
+++ b/scripts/smoke_test_package_manager_bundle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import re
 
 try:
     import tomllib
@@ -32,7 +33,9 @@ def _version_from_pyproject() -> str:
     return str(data["project"]["version"])
 
 
-def smoke_test_package_manager_bundle(*, bundle_dir: Path, expected_version: str) -> list[str]:
+def smoke_test_package_manager_bundle(
+    *, bundle_dir: Path, expected_version: str, require_binary_sha256: bool = False
+) -> list[str]:
     errors: list[str] = []
     validators = _load_release_assets_module()
 
@@ -72,6 +75,17 @@ def smoke_test_package_manager_bundle(*, bundle_dir: Path, expected_version: str
             brew_content=brew_content, py_version=expected_version
         )
     )
+    # audit MED: at RELEASE/publish time (real binaries + CHECKSUMS exist, signalled by an explicit
+    # require_binary_sha256) the SHIPPED Homebrew formula must carry a 64-hex sha256 for each OS
+    # binary so `brew install` verifies the download. At PR-readiness time there are no binaries to
+    # checksum, so the formula is legitimately unstamped and the check is skipped.
+    brew_sha_digests = re.findall(r'(?m)^\s*sha256 "([0-9a-f]{64})"', brew_content)
+    if require_binary_sha256 and len(brew_sha_digests) < 2:
+        errors.append(
+            "Bundle Homebrew formula must carry a 64-hex sha256 for each OS binary "
+            f"(found {len(brew_sha_digests)}); expected the macOS and Linux digests stamped "
+            "from CHECKSUMS.txt"
+        )
     errors.extend(
         validators.validate_winget_manifest(
             winget_content=winget_content, py_version=expected_version
@@ -132,7 +146,11 @@ def main() -> int:
 
     expected_version = args.expected_version or _version_from_pyproject()
     errors = smoke_test_package_manager_bundle(
-        bundle_dir=args.bundle_dir, expected_version=expected_version
+        bundle_dir=args.bundle_dir,
+        expected_version=expected_version,
+        # The release/publish job supplies an explicit --expected-version (and real CHECKSUMS, so
+        # the formula is stamped); PR-readiness supplies neither, so the binary sha256 is not required.
+        require_binary_sha256=args.expected_version is not None,
     )
     if errors:
         for err in errors:

--- a/scripts/tensor-grep.rb
+++ b/scripts/tensor-grep.rb
@@ -7,6 +7,10 @@ class TensorGrep < Formula
   TENSOR_GREP_VERSION = "1.13.41"
   version TENSOR_GREP_VERSION
   
+  # NOTE: a `sha256 "<digest>"` line is stamped after each url into the PUBLISHED formula at
+  # release-bundle time from CHECKSUMS.txt (scripts/prepare_package_manager_release.py). This
+  # source template carries none on purpose: the binary digests only exist after the release
+  # builds them (the same post-build constraint as the winget InstallerSha256).
   if OS.mac?
     url "https://github.com/oimiragieo/tensor-grep/releases/download/v#{version}/tg-macos-amd64-cpu"
   elsif OS.linux?

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -3261,6 +3261,17 @@ def validate_homebrew_formula_contract(*, brew_content: str, py_version: str) ->
     if "version TENSOR_GREP_VERSION" not in brew_content:
         errors.append("Homebrew formula must declare `version TENSOR_GREP_VERSION`")
 
+    # audit MED: a Homebrew formula with a versioned URL must carry a 64-hex sha256 so `brew
+    # install` verifies the binary. The source template carries none (the binary digests only
+    # exist post-build; they are stamped into the published bundle formula from CHECKSUMS.txt).
+    # Validate IF-PRESENT: any sha256 that exists must be a lowercase 64-hex digest.
+    for match in re.finditer(r'(?m)^\s*sha256 "([^"]*)"', brew_content):
+        digest = match.group(1)
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            errors.append(
+                f"Homebrew formula sha256 must be a lowercase 64-hex digest, found '{digest}'"
+            )
+
     return errors
 
 

--- a/tests/unit/test_prepare_package_manager_release.py
+++ b/tests/unit/test_prepare_package_manager_release.py
@@ -130,3 +130,28 @@ def test_prepare_bundle_check_mode_fails_on_manifest_drift(tmp_path):
     module.ROOT = root
     rc = module.prepare_bundle(output_dir=root / "artifacts" / "bundle", check_only=True)
     assert rc == 1
+
+
+def test_stamp_homebrew_sha256_inserts_digest_after_each_os_url():
+    """audit MED: the Homebrew formula stamper inserts a sha256 after each per-OS url so the
+    published formula verifies the downloaded binary."""
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "prepare_package_manager_release.py"
+    spec = importlib.util.spec_from_file_location("prepare_package_manager_release", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    formula = (
+        "  if OS.mac?\n"
+        '    url "https://github.com/oimiragieo/tensor-grep/releases/download/'
+        'v#{version}/tg-macos-amd64-cpu"\n'
+        "  elsif OS.linux?\n"
+        '    url "https://github.com/oimiragieo/tensor-grep/releases/download/'
+        'v#{version}/tg-linux-amd64-cpu"\n'
+        "  end\n"
+    )
+    mac, lin = "a" * 64, "b" * 64
+    stamped = module._stamp_homebrew_sha256(brew_content=formula, mac_sha256=mac, linux_sha256=lin)
+    assert f'tg-macos-amd64-cpu"\n    sha256 "{mac}"' in stamped
+    assert f'tg-linux-amd64-cpu"\n    sha256 "{lin}"' in stamped

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -4870,3 +4870,37 @@ def test_validate_actions_sha_pinned_passes_and_exempts_rust_toolchain():
     assert module.validate_actions_sha_pinned() == []
     ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     assert "dtolnay/rust-toolchain@stable" in ci
+
+
+def test_validate_homebrew_formula_contract_validates_sha256_if_present():
+    """audit MED: a sha256 in the formula must be a lowercase 64-hex digest (validate IF-PRESENT;
+    the source template legitimately carries none until stamped from CHECKSUMS at bundle time)."""
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    base = (
+        "class TensorGrep < Formula\n"
+        '  TENSOR_GREP_VERSION = "1.2.3"\n'
+        "  version TENSOR_GREP_VERSION\n"
+    )
+    bad = base + '  sha256 "NOTAHEX"\nend\n'
+    assert any(
+        "64-hex" in e
+        for e in module.validate_homebrew_formula_contract(brew_content=bad, py_version="1.2.3")
+    )
+    good = base + '  sha256 "' + ("a" * 64) + '"\nend\n'
+    assert not any(
+        "sha256" in e
+        for e in module.validate_homebrew_formula_contract(brew_content=good, py_version="1.2.3")
+    )
+    # source template with NO sha256 must NOT error (chicken-and-egg).
+    assert not any(
+        "sha256" in e
+        for e in module.validate_homebrew_formula_contract(
+            brew_content=base + "end\n", py_version="1.2.3"
+        )
+    )

--- a/tests/unit/test_smoke_test_package_manager_bundle.py
+++ b/tests/unit/test_smoke_test_package_manager_bundle.py
@@ -37,6 +37,8 @@ def _write_bundle(tmp_path: Path, version: str) -> Path:
             "class TensorGrep < Formula\n"
             '  TENSOR_GREP_VERSION = "1.2.3"\n'
             "  version TENSOR_GREP_VERSION\n"
+            '  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n'
+            '  sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"\n'
             "end\n"
         ),
         encoding="utf-8",
@@ -130,3 +132,29 @@ def test_should_fail_when_summary_missing_required_paths(tmp_path: Path):
     assert any(
         "Bundle summary must include tg --version smoke verification" in err for err in errors
     )
+
+
+def test_smoke_test_requires_binary_sha256_only_at_release_time(tmp_path: Path):
+    """audit MED: the binary sha256 is required only when require_binary_sha256 is set (the
+    release/publish job, which has real binaries + CHECKSUMS). PR-readiness (no binaries -> the
+    formula is legitimately unstamped) must NOT fail."""
+    module = _load_module()
+    bundle = _write_bundle(tmp_path, "1.2.3")
+    brew = bundle / "homebrew-tap" / "Formula" / "tensor-grep.rb"
+    brew.write_text(
+        "class TensorGrep < Formula\n"
+        '  TENSOR_GREP_VERSION = "1.2.3"\n'
+        "  version TENSOR_GREP_VERSION\n"
+        "end\n",
+        encoding="utf-8",
+    )
+    # PR-readiness: unstamped formula tolerated.
+    readiness = module.smoke_test_package_manager_bundle(
+        bundle_dir=bundle, expected_version="1.2.3"
+    )
+    assert not any("sha256" in err for err in readiness)
+    # release-time: stamped per-OS sha256 required.
+    release = module.smoke_test_package_manager_bundle(
+        bundle_dir=bundle, expected_version="1.2.3", require_binary_sha256=True
+    )
+    assert any("must carry a 64-hex sha256" in err for err in release)


### PR DESCRIPTION
Closes the last install channel with **zero binary verification** — Homebrew. `brew install` downloaded the release binary with no checksum; now the published formula carries a per-OS `sha256`, on par with install.sh / install.ps1 / npm / winget (all hardened in audit S4).

## How (mirrors the existing winget stamping)
The council flagged the chicken-and-egg: the binary digests only exist **post-build**. So — exactly like the winget `InstallerSha256` — `prepare_package_manager_release.py` stamps the macOS + Linux `sha256` into the **bundle** formula from `CHECKSUMS.txt` (`_asset_sha_from_checksums` + `_stamp_homebrew_sha256`). The source template (`scripts/tensor-grep.rb`) intentionally carries none; `validate_homebrew_formula_contract` validates sha256 **if-present** (64-hex); the bundle smoke-test enforces the shipped formula carries one per OS.

## Verification
End-to-end locally: synthetic `CHECKSUMS.txt` → stamped formula (digests match) → bundle smoke-test green. Plus unit tests for the stamper + the if-present validator. **166 tests pass**, ruff clean. No new CI job / no `release.yml` change — uses the existing post-build bundle step.

## Notes
- **`fix:`** → cuts a customer release; v1.13.42's *brew formula* will carry the sha256 (pip/npm bits unchanged).
- **Authenticity follow-up (council):** `CHECKSUMS.txt` is same-channel, so this is integrity on par with other channels; verifying its Sigstore `.sig` (already produced in `release.yml`) is tracked for full authenticity.

Council-verified (3 lenses) before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)