### PR TITLE
fix(build): bundle LICENSE/NOTICE in sdist (unblock PyPI publishing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ features = ["pyo3/extension-module"]
 python-source = "src"
 module-name = "tensor_grep.rust_core"
 manifest-path = "rust_core/Cargo.toml"
+# Bundle the license files referenced by the auto-emitted `License-File:` metadata. Without this,
+# maturin writes `License-File: LICENSE`/`NOTICE` into PKG-INFO but omits the actual files, and PyPI
+# rejects the upload: "400 License-File LICENSE does not exist in distribution file" (blocked v1.13.44).
+include = ["LICENSE", "NOTICE"]
 
 [tool.uv]
 cache-keys = [


### PR DESCRIPTION
**Fixes the publish-pypi 400 that blocked v1.13.44 (and every release).**

maturin emits `License-File: LICENSE`/`NOTICE` into the sdist PKG-INFO (auto-detected from the repo-root LICENSE the project recently gained) but does **not** bundle the files, so PyPI's Warehouse rejects the upload with `400 License-File LICENSE does not exist in distribution file`.

Fix: `[tool.maturin] include = ["LICENSE", "NOTICE"]`. **Verified locally** — the rebuilt sdist now contains `tensor_grep-*/LICENSE` and `/NOTICE`.

Note: separately, `rust_core/Cargo.toml` declares `license = "MIT"` while the bundled LICENSE is Apache-2.0 — a metadata inconsistency worth resolving (your call on which is canonical), but not the cause of the 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)