### PR TITLE
fix(license): declare Apache-2.0 consistently (Cargo + npm)

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tensor-grep",
       "version": "1.4.3",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "bin": {
         "tensor-grep": "bin/tg.js",
         "tg": "bin/tg.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -23,5 +23,5 @@
     "cli"
   ],
   "author": "tensor-grep team",
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/rust_core/Cargo.toml
+++ b/rust_core/Cargo.toml
@@ -3,7 +3,7 @@ name = "tensor_grep_rs"
 version = "1.13.43"
 edition = "2021"
 description = "Rust core engine for tensor-grep"
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/oimiragieo/tensor-grep"
 readme = "README.md"
 


### PR DESCRIPTION
The bundled `LICENSE` is **Apache-2.0** and the README badge says Apache-2.0, but `rust_core/Cargo.toml` and `npm/package.json`/`package-lock.json` still declared **MIT**. This aligns all package metadata to Apache-2.0 (CEO confirmed canonical).

Merge **after #270** (the sdist LICENSE-bundling fix) so the release actually publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)