### PR TITLE
feat: add 'tg orient' — one-call codebase orientation capsule

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -916,6 +916,12 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Emit a one-call codebase orientation capsule (central files, entry points, AST snippets)
+    #[command(name = "orient", disable_help_flag = true)]
+    Orient {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Open, query, and manage cached edit-loop sessions
     #[command(name = "session", disable_help_flag = true)]
     Session {
@@ -2651,6 +2657,14 @@ mod tests {
     }
 
     #[test]
+    fn orient_is_a_known_python_command_not_a_search_pattern() {
+        // `tg orient PATH` must be recognized as a passthrough command so the native front door
+        // delegates to the Python `orient` handler instead of treating "orient" as a ripgrep
+        // pattern via run_positional_cli().
+        assert!(is_known_python_command("orient"));
+    }
+
+    #[test]
     fn top_level_search_format_python_passthrough_args_detects_non_rg_formats() {
         let raw_args = ["tg", "--format=json", "ERROR", "bench_data"]
             .iter()
@@ -3555,6 +3569,7 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         #[cfg(feature = "cuda")]
         Commands::GpuOomProbe(args) => handle_gpu_oom_probe_command(args),
         Commands::Map { args } => handle_python_passthrough("map", args),
+        Commands::Orient { args } => handle_python_passthrough("orient", args),
         Commands::Session { args } => handle_python_passthrough("session", args),
         Commands::Doctor { args } => handle_python_passthrough("doctor", args),
         Commands::RepairLauncher { args } => handle_python_passthrough("repair-launcher", args),

--- a/src/tensor_grep/cli/commands.py
+++ b/src/tensor_grep/cli/commands.py
@@ -46,6 +46,7 @@ KNOWN_COMMANDS = {
     "__gpu-cuda-graphs",
     "__gpu-oom-probe",
     "map",
+    "orient",
     "session",
     "doctor",
     "checkpoint",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6518,6 +6518,36 @@ def map(
 
 
 @app.command()
+def orient(
+    path: str = typer.Argument(".", help="File or directory to orient on"),
+    max_tokens: int = typer.Option(3000, "--max-tokens", help="Snippet token budget", min=1),
+    max_central_files: int = typer.Option(
+        10, "--max-central-files", help="Number of top central files to surface", min=1
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit the capsule as JSON"),
+) -> None:
+    """Emit a one-call codebase orientation capsule (central files, entry points, AST snippets)."""
+    from tensor_grep.cli.orient_capsule import build_orient_capsule, build_orient_capsule_json
+
+    if json_output:
+        typer.echo(
+            build_orient_capsule_json(
+                path, max_tokens=max_tokens, max_central_files=max_central_files
+            )
+        )
+        return
+    payload = build_orient_capsule(path, max_tokens=max_tokens, max_central_files=max_central_files)
+    typer.echo(f"# Codebase orientation: {payload['path']}")
+    typer.echo(f"central files ({len(payload['central_files'])}):")
+    for cf in payload["central_files"]:
+        typer.echo(f"  {cf['file']}  (in-degree={cf['graph_score']})")
+    typer.echo(
+        f"entry_points={len(payload['entry_points'])} "
+        f"snippets={len(payload['snippets'])} ~{payload['token_estimate']} tokens"
+    )
+
+
+@app.command()
 def context(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     query_arg: str | None = typer.Argument(

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -94,6 +94,8 @@ def _ast_chunked_snippet(path_str: str, symbols: list[dict[str, Any]]) -> str | 
         if not sources:
             sources = _repo_map._js_ts_parser_symbol_sources(path, name)
         if not sources:
+            sources = _repo_map._rust_parser_symbol_sources(path, name)
+        if not sources:
             sources = _repo_map._regex_symbol_sources(path, name)
         if sources:
             return str(sources[0].get("source", ""))

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -1,0 +1,199 @@
+"""One-call codebase orientation capsule (`tg orient`).
+
+Reuses repo_map's import graph (in-degree centrality) + AST symbol-source chunkers to produce a
+bounded, AI-readable "explain this repo" capsule: the most central files, entry points, a symbol
+map, and AST-boundary snippets within a token budget. Pure-CPU, no API key, no GPU.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli import repo_map as _repo_map
+
+_CHARS_PER_TOKEN = 3.5
+
+_ENTRY_NAMES = {
+    "main.py",
+    "__main__.py",
+    "cli.py",
+    "app.py",
+    "server.py",
+    "main.ts",
+    "index.ts",
+    "index.js",
+    "main.js",
+    "app.ts",
+    "main.rs",
+    "lib.rs",
+}
+
+
+def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> list[dict[str, Any]]:
+    """Rank source files by import in-degree (foundational = imported-by-many); top-N with symbols."""
+    all_files = [str(f) for f in rm.get("files", [])]
+    if not all_files:
+        return []
+    imports_by_file: dict[str, list[str]] = {
+        str(entry["file"]): [str(i) for i in entry.get("imports", [])]
+        for entry in rm.get("imports", [])
+    }
+    # build_repo_map records imports as module names ("hub"), not file paths ("hub.py"); resolve them
+    # to files by stem so the import graph has real edges.
+    by_stem: dict[str, str] = {}
+    for source in all_files:
+        by_stem.setdefault(Path(source).stem, source)
+    resolved_imports: dict[str, list[str]] = {}
+    for source, modules in imports_by_file.items():
+        targets: list[str] = []
+        for module in modules:
+            candidate = by_stem.get(module) or by_stem.get(module.split(".")[-1])
+            if candidate and candidate != source:
+                targets.append(candidate)
+        resolved_imports[source] = targets
+    reverse_importers = _repo_map._reverse_importers(all_files, resolved_imports)
+    # Centrality = in-degree (how many files import this one). NOTE: the reused reverse-import
+    # PageRank, seeded by all files, ranks IMPORTERS above the imported -- backwards for "show me the
+    # core files" -- so we rank by import in-degree directly.
+    centrality = {source: float(len(reverse_importers.get(source, ()))) for source in all_files}
+    ranked = sorted(all_files, key=lambda source: (-centrality[source], source))
+    result: list[dict[str, Any]] = []
+    for file_path in ranked[:max_central_files]:
+        file_symbols = [
+            {"name": str(s["name"]), "kind": str(s["kind"])}
+            for s in rm.get("symbols", [])
+            if str(s.get("file")) == file_path
+        ][:6]
+        result.append({
+            "file": file_path,
+            "graph_score": round(centrality[file_path], 6),
+            "symbols": file_symbols,
+        })
+    return result
+
+
+def _detect_entry_points(rm: dict[str, Any]) -> list[dict[str, Any]]:
+    """Heuristic: files named main.py / cli.py / index.ts / lib.rs etc."""
+    result: list[dict[str, Any]] = []
+    for file_path in rm.get("files", []):
+        if Path(str(file_path)).name.lower() in _ENTRY_NAMES:
+            result.append({"file": str(file_path), "reason": "entry-name-heuristic"})
+    return result
+
+
+def _ast_chunked_snippet(path_str: str, symbols: list[dict[str, Any]]) -> str | None:
+    """Return the source of the first resolvable symbol via the AST/regex symbol-source chunkers."""
+    path = Path(path_str)
+    for sym in symbols:
+        name = str(sym.get("name", ""))
+        if not name:
+            continue
+        sources = _repo_map._python_symbol_sources(path, name)
+        if not sources:
+            sources = _repo_map._js_ts_parser_symbol_sources(path, name)
+        if not sources:
+            sources = _repo_map._regex_symbol_sources(path, name)
+        if sources:
+            return str(sources[0].get("source", ""))
+    return None
+
+
+def build_orient_capsule(
+    path: str | Path = ".",
+    *,
+    max_central_files: int = 10,
+    max_snippet_files: int = 5,
+    max_tokens: int = 3000,
+    max_repo_files: int | None = None,
+    render_profile: str = "compact",
+) -> dict[str, Any]:
+    """Build a bounded codebase orientation capsule (no API key, no GPU)."""
+    from tensor_grep.cli.repo_map import DEFAULT_AGENT_REPO_MAP_LIMIT
+
+    effective_max_repo_files = (
+        max_repo_files if max_repo_files is not None else DEFAULT_AGENT_REPO_MAP_LIMIT
+    )
+    rm = _repo_map.build_repo_map(path, max_repo_files=effective_max_repo_files)
+
+    central_files = _central_files_from_map(rm, max_central_files=max_central_files)
+    entry_points = _detect_entry_points(rm)
+
+    symbol_map: dict[str, list[dict[str, Any]]] = {}
+    for cf in central_files:
+        file_path = cf["file"]
+        syms = [
+            {
+                "name": str(s["name"]),
+                "kind": str(s["kind"]),
+                "line": int(s.get("line", s.get("start_line", 0)) or 0),
+            }
+            for s in rm.get("symbols", [])
+            if str(s.get("file")) == file_path
+        ][:8]
+        if syms:
+            symbol_map[file_path] = syms
+
+    snippets: list[dict[str, Any]] = []
+    token_budget_used = 0
+    for cf in central_files[:max_snippet_files]:
+        file_path = cf["file"]
+        snippet_text = _ast_chunked_snippet(file_path, symbol_map.get(file_path, []))
+        if not snippet_text:
+            continue
+        snippet_tokens = _repo_map._estimate_tokens(snippet_text)
+        if token_budget_used + snippet_tokens > max_tokens:
+            remaining_chars = int((max_tokens - token_budget_used) * _CHARS_PER_TOKEN)
+            if remaining_chars < 80:
+                break
+            snippets.append({
+                "file": file_path,
+                "source": snippet_text[:remaining_chars],
+                "truncated": True,
+            })
+            token_budget_used = max_tokens
+            break
+        snippets.append({"file": file_path, "source": snippet_text, "truncated": False})
+        token_budget_used += snippet_tokens
+
+    lines: list[str] = [f"# Codebase orientation: {rm['path']}"]
+    lines.append("\n## Central files (by import-graph centrality)")
+    for cf in central_files:
+        lines.append(f"- {cf['file']}  graph_score={cf['graph_score']}")
+    if entry_points:
+        lines.append("\n## Entry points (heuristic name detection)")
+        for ep in entry_points:
+            lines.append(f"- {ep['file']}  ({ep['reason']})")
+    lines.append("\n## Symbol map (top symbols per central file)")
+    for file_path, syms in symbol_map.items():
+        sym_list = ", ".join(f"{s['kind']} {s['name']}" for s in syms)
+        lines.append(f"- {file_path}: {sym_list}")
+    if snippets:
+        lines.append("\n## Key snippets (AST-boundary chunks)")
+        for snip in snippets:
+            lines.append(f"\n### {snip['file']}")
+            lines.append(f"```\n{snip['source'].rstrip()}\n```")
+
+    total_token_estimate = _repo_map._estimate_tokens("\n".join(lines))
+    truncated = any(s.get("truncated") for s in snippets) or token_budget_used >= max_tokens
+
+    return {
+        "path": rm["path"],
+        "central_files": central_files,
+        "entry_points": entry_points,
+        "symbol_map": symbol_map,
+        "snippets": snippets,
+        "token_estimate": total_token_estimate,
+        "token_budget_label": (
+            f"~{total_token_estimate} tokens (heuristic len/3.5); snippet budget {max_tokens}"
+        ),
+        "truncated": truncated,
+        "scan_limit": effective_max_repo_files,
+        "routing_reason": "orient",
+    }
+
+
+def build_orient_capsule_json(path: str | Path = ".", **kwargs: Any) -> str:
+    """JSON form of :func:`build_orient_capsule`."""
+    return json.dumps(build_orient_capsule(path, **kwargs), indent=2)

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -49,6 +49,7 @@ PUBLIC_TOP_LEVEL_COMMANDS = {
     "lsp",
     "lsp-setup",
     "map",
+    "orient",
     "session",
     "doctor",
     "checkpoint",

--- a/tests/integration/test_orient_command.py
+++ b/tests/integration/test_orient_command.py
@@ -1,0 +1,32 @@
+"""Integration tests for the `tg orient` CLI command (Plan 2 Task 2)."""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from tensor_grep.cli.main import app
+
+runner = CliRunner()
+
+
+def test_orient_command_outputs_human_capsule(tmp_path: Path) -> None:
+    (tmp_path / "hub.py").write_text("def hub():\n    pass\n", encoding="utf-8")
+    (tmp_path / "leaf.py").write_text("import hub\n\n\ndef leaf():\n    pass\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["orient", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Codebase orientation" in result.output
+    assert "central files" in result.output
+
+
+def test_orient_command_json_is_parseable(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["orient", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["routing_reason"] == "orient"
+    assert "central_files" in payload

--- a/tests/unit/test_orient_capsule.py
+++ b/tests/unit/test_orient_capsule.py
@@ -1,0 +1,74 @@
+"""Tests for build_orient_capsule -- the one-call codebase orientation capsule."""
+
+import json
+from pathlib import Path
+
+from tensor_grep.cli.orient_capsule import build_orient_capsule, build_orient_capsule_json
+
+
+def test_central_files_ranked_by_graph_score(tmp_path: Path) -> None:
+    # hub.py is imported by two files; leaf/other import it -> hub is most central.
+    (tmp_path / "hub.py").write_text("def hub_fn():\n    pass\n", encoding="utf-8")
+    (tmp_path / "leaf.py").write_text(
+        "import hub\n\n\ndef leaf_fn():\n    pass\n", encoding="utf-8"
+    )
+    (tmp_path / "other.py").write_text(
+        "import hub\n\n\ndef other_fn():\n    pass\n", encoding="utf-8"
+    )
+
+    payload = build_orient_capsule(
+        tmp_path, max_central_files=5, max_snippet_files=1, max_tokens=500
+    )
+
+    central = payload["central_files"]
+    assert len(central) >= 1
+    assert central[0]["file"].endswith("hub.py")
+    assert "graph_score" in central[0]
+    assert central[0]["graph_score"] > 0.0
+
+
+def test_capsule_has_required_keys_and_routing(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+    for key in (
+        "path",
+        "central_files",
+        "entry_points",
+        "symbol_map",
+        "snippets",
+        "token_estimate",
+        "token_budget_label",
+        "truncated",
+        "scan_limit",
+        "routing_reason",
+    ):
+        assert key in payload, f"missing capsule key: {key}"
+    assert payload["routing_reason"] == "orient"
+    assert isinstance(payload["token_estimate"], int)
+
+
+def test_entry_points_detected_by_name(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (tmp_path / "helper.py").write_text("def helper():\n    pass\n", encoding="utf-8")
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+    entry_files = [e["file"] for e in payload["entry_points"]]
+    assert any(f.endswith("main.py") for f in entry_files)
+    assert not any(f.endswith("helper.py") for f in entry_files)
+
+
+def test_token_budget_respected(tmp_path: Path) -> None:
+    # A big file should not blow the snippet token budget.
+    big = "\n".join(f"def fn_{i}():\n    return {i}" for i in range(200))
+    (tmp_path / "big.py").write_text(big, encoding="utf-8")
+    payload = build_orient_capsule(
+        tmp_path, max_central_files=3, max_snippet_files=3, max_tokens=120
+    )
+    snippet_tokens = sum(len(s["source"]) / 3.5 for s in payload["snippets"])
+    assert snippet_tokens <= 120 + 50  # within budget (+ slack for the final truncated chunk)
+
+
+def test_json_output_is_parseable(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    text = build_orient_capsule_json(tmp_path, max_tokens=500)
+    parsed = json.loads(text)
+    assert parsed["routing_reason"] == "orient"


### PR DESCRIPTION
## What
Adds `tg orient [PATH]` — a one-call, bounded, AI-readable codebase orientation capsule: the most central files (by import in-degree), entry points, a symbol map, and AST-boundary snippets within a token budget. Pure-CPU, no API key, no GPU. Human output + `--json`.

```
$ tg orient src/tensor_grep/core --max-central-files 3
# Codebase orientation: .../core
central files (3):
  .../retrieval_chunker.py  (in-degree=3.0)
  .../hardware/device_detect.py  (in-degree=2.0)
  .../retrieval_bm25.py  (in-degree=2.0)
entry_points=0 snippets=3 ~1007 tokens
```

## How (design-verification-driven)
This was built against a **design-verification council** that audited the (subagent-drafted) plan and caught real blockers before coding:
- **Native registration (blocker):** `orient` is a real top-level command — added to `KNOWN_COMMANDS` + a `Commands::Orient` passthrough variant/dispatch + routing test in `main.rs`. Without this the native front door would silently route `tg orient .` as a *ripgrep search for "orient"*.
- **Centrality (corrected):** ranks by import **in-degree**, not the reused reverse-import PageRank (which ranks importers *above* the imported — backwards for "core files" — and also has a 64-seed cap).
- **Rust snippets:** `.rs` files use `_rust_parser_symbol_sources` (tree-sitter), not the regex fallback.

## Tests
- 5 unit (`test_orient_capsule.py`) + 2 CLI integration (`test_orient_command.py`) + 1 Rust routing test — all green; ruff `--preview` + mypy clean.

## Follow-ups (not blocking)
- Task 4: token-efficiency benchmark (capsule vs full-dump).
- Task 5: user-facing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)