### PR TITLE
fix: tg search --rank crashed in plain-text mode (dogfood finding)

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -38,6 +38,8 @@ _TG_ONLY_SEARCH_FLAGS = {
     "--pcre2-version",
     "--lang",
     "--ltl",
+    "--rank",
+    "--bm25",
     "--replace",
     "--stats",
     "--type-list",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3664,6 +3664,7 @@ def _can_passthrough_rg(
         not config.ast
         and not config.ltl
         and not config.force_cpu
+        and not config.rank_bm25
         and format_type == "rg"
         and (not json_mode or rg_json_passthrough)
         and not ndjson_mode

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -1066,3 +1066,13 @@ def test_python_module_help_should_use_public_tg_program_name() -> None:
     assert result.returncode == 0
     assert "Usage: tg " in result.stdout
     assert "python -m tensor_grep" not in result.stdout
+
+
+def test_rank_flags_route_to_full_cli_not_ripgrep() -> None:
+    # Regression (dogfood): `tg search --rank PATTERN PATH` (plain text) must route to the full
+    # Python CLI, which owns the BM25 re-rank. If --rank/--bm25 are not treated as tg-only flags,
+    # bootstrap forwards them to ripgrep, which dies with "rg: unrecognized flag --rank".
+    assert bootstrap._requires_full_cli(["--rank", "invoice", "src"])
+    assert bootstrap._requires_full_cli(["--bm25", "invoice", "src"])
+    # A plain rg-compatible search (no tg-only flags) still passes through to ripgrep.
+    assert not bootstrap._requires_full_cli(["invoice", "src"])


### PR DESCRIPTION
## The bug (found by dogfooding shipped v1.15.0)
\`tg search --rank "query" path\` — the **natural** way to use the v1.14.0 reranking feature — died with:
\`\`\`
rg: unrecognized flag --rank
\`\`\`
(exit 2). It only worked if you *also* passed \`--json\`. So the headline v1.14.0 feature was broken for the common case.

## Root cause
The \`tg\` entry point is \`tensor_grep.cli.bootstrap:main_entry\` — a front door that forwards plain-text searches to ripgrep. \`--rank\`/\`--bm25\` were **not** in \`bootstrap._TG_ONLY_SEARCH_FLAGS\`, so bootstrap treated them as rg-compatible and leaked them to ripgrep. The v1.14.0 unit/integration tests used \`CliRunner\`, which invokes the typer app **directly and bypasses bootstrap** — so they never exercised the real \`tg\` routing. Classic dogfood catch.

## Fix
- **`bootstrap.py`**: add \`--rank\`/\`--bm25\` to \`_TG_ONLY_SEARCH_FLAGS\` → routes to the Python CLI that owns the re-rank (primary fix).
- **`main.py`**: guard \`_can_passthrough_rg\` against \`rank_bm25\` (defense in depth — reranking needs full result collection, incompatible with rg streaming anyway).
- **Regression test**: \`_requires_full_cli(["--rank", ...])\` must be True.

## Verification
Patched into the **installed shipped artifact** and ran the real \`tg.exe\`: \`tg search "rerank" src/tensor_grep --rank\` (plain) now → exit 0 with reranked output. 16 tests green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)