### PR TITLE
chore: post-release Docker dogfood harness (all features, real binary)

### DIFF
--- a/scripts/dogfood/Dockerfile
+++ b/scripts/dogfood/Dockerfile
@@ -1,0 +1,27 @@
+# Post-release dogfood: install the PUBLISHED tensor-grep from PyPI into a clean image and run the
+# full-feature battery against the REAL `tg` binary (the customer path — catches install + front-door
+# routing regressions that CliRunner-based tests cannot see).
+#
+# Usage (run after a release confirms on PyPI):
+#   docker build --build-arg TG_VERSION=1.15.1 -f scripts/dogfood/Dockerfile -t tg-dogfood scripts/dogfood
+#   docker run --rm tg-dogfood
+# Exit 0 = shipped artifact installs + every feature works. Exit 1 = a regression (failing command shown).
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
+
+ARG TG_VERSION
+RUN test -n "$TG_VERSION" || (echo "ERROR: pass --build-arg TG_VERSION=<published version>" >&2 && exit 1)
+
+# ripgrep backs tg's text-search passthrough; install it so the real plain-text search path is exercised.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install exactly what a customer gets: the published wheel from PyPI.
+RUN pip install --no-cache-dir "tensor-grep==${TG_VERSION}"
+
+# Install sanity — fail the build early if the artifact didn't resolve or `tg` isn't on PATH.
+RUN tg --version
+
+COPY dogfood_features.py /dogfood/dogfood_features.py
+ENTRYPOINT ["python", "/dogfood/dogfood_features.py"]

--- a/scripts/dogfood/README.md
+++ b/scripts/dogfood/README.md
@@ -1,0 +1,47 @@
+# Post-release Docker dogfood
+
+**Run this after every release confirms on PyPI.** It installs the *published* `tensor-grep` into a
+clean container and runs the real `tg` binary across every user-facing feature, asserting no
+regression.
+
+## Why
+
+Our unit/integration tests use Typer's `CliRunner`, which invokes the `app` object **directly and
+bypasses the real `tg` front door** (`tensor_grep.cli.bootstrap:main_entry`, which forwards plain
+text searches to ripgrep). v1.14.0's `tg search --rank` shipped broken in plain-text mode
+(`rg: unrecognized flag --rank`) and no test caught it — because none ran the installed binary the way
+a customer does. This harness closes that blind spot: a clean install + the real binary + every
+feature.
+
+## Run it
+
+```bash
+# After e.g. v1.15.1 publishes:
+docker build --build-arg TG_VERSION=1.15.1 -f scripts/dogfood/Dockerfile -t tg-dogfood scripts/dogfood
+docker run --rm tg-dogfood
+```
+
+- **Exit 0** — the shipped artifact installs and every feature works.
+- **Exit 1** — a regression; the failing `tg <command>` and its output are printed.
+
+The `RUN tg --version` line in the Dockerfile also fails the *build* early if the wheel didn't resolve
+or `tg` isn't on `PATH` (an install/packaging regression).
+
+### Without Docker
+
+The battery is environment-agnostic — point it at any installed `tg`:
+
+```bash
+pip install "tensor-grep==<version>"
+python scripts/dogfood/dogfood_features.py      # or TG_BIN=/path/to/tg python scripts/dogfood/dogfood_features.py
+```
+
+## Coverage & extending
+
+`dogfood_features.py` generates a tiny multi-file fixture (a hub imported by two modules, plus a Rust
+file) and exercises: `--version`, plain `search`, **`search --rank` (plain AND `--json`)**, `search
+--json`, `orient` (+ `--json` + empty-dir), `map`, and `agent --json`.
+
+**When you ship a new feature, add a `check(...)` line** so the battery grows with the product. The
+`search --rank (PLAIN)` check is a permanent regression guard for the v1.14.0/v1.15.1 bug — it asserts
+the output never contains `unrecognized flag`.

--- a/scripts/dogfood/dogfood_features.py
+++ b/scripts/dogfood/dogfood_features.py
@@ -31,9 +31,7 @@ _RESULTS: list[tuple[bool, str, int, str]] = []
 
 
 def _run(args: list[str]) -> tuple[int, str, str]:
-    proc = subprocess.run(
-        [TG, *args], capture_output=True, text=True, timeout=120, check=False
-    )
+    proc = subprocess.run([TG, *args], capture_output=True, text=True, timeout=120, check=False)
     return proc.returncode, proc.stdout, proc.stderr
 
 

--- a/scripts/dogfood/dogfood_features.py
+++ b/scripts/dogfood/dogfood_features.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Full-feature dogfood: run the REAL installed ``tg`` binary across every user-facing feature on a
+generated fixture repo, asserting exit codes + output shape.
+
+Why this exists: our unit/integration tests use ``CliRunner``, which invokes the typer ``app``
+DIRECTLY and BYPASSES the real ``tg`` front door (``tensor_grep.cli.bootstrap:main_entry``, which
+forwards plain searches to ripgrep). v1.14.0's ``tg search --rank`` shipped broken in plain-text mode
+(``rg: unrecognized flag --rank``) precisely because no test ran the real binary. This script does —
+it is meant to run post-release in a clean Docker container / venv against the PUBLISHED artifact:
+
+    pip install "tensor-grep==<version>"
+    python dogfood_features.py            # uses the `tg` on PATH
+
+Exit 0 = the shipped CLI installs and every feature works. Exit 1 = a regression (with the failing
+command + output). Add a new ``check(...)`` line whenever a feature ships so the battery grows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# In Docker/venv `tg` is on PATH; TG_BIN lets you point at a specific binary for local verification.
+TG = os.environ.get("TG_BIN") or shutil.which("tg") or "tg"
+_RESULTS: list[tuple[bool, str, int, str]] = []
+
+
+def _run(args: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [TG, *args], capture_output=True, text=True, timeout=120, check=False
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check(
+    desc: str,
+    args: list[str],
+    *,
+    want_exit: int = 0,
+    must_contain: str | None = None,
+    must_not_contain: str | None = None,
+    json_key: str | None = None,
+) -> None:
+    """Run ``tg <args>`` and record pass/fail against the given expectations."""
+    code, out, err = _run(args)
+    combined = out + err
+    ok, detail = True, ""
+    if code != want_exit:
+        ok, detail = False, f"exit {code} != {want_exit}"
+    if ok and must_contain is not None and must_contain not in combined:
+        ok, detail = False, f"missing {must_contain!r}"
+    if ok and must_not_contain is not None and must_not_contain in combined:
+        ok, detail = False, f"contains forbidden {must_not_contain!r}"
+    if ok and json_key is not None:
+        try:
+            ok = json_key in json.loads(out)
+            detail = "" if ok else f"json missing key {json_key!r}"
+        except json.JSONDecodeError as exc:
+            ok, detail = False, f"invalid json: {exc}"
+    snippet = combined.strip().splitlines()[:2]
+    _RESULTS.append((ok, desc, code, detail))
+    status = "PASS" if ok else "FAIL"
+    print(f"[{status}] {desc}  (exit {code}){'  -> ' + detail if detail else ''}")
+    if not ok:
+        for line in snippet:
+            print(f"        | {line[:160]}")
+
+
+def _build_fixture(root: Path) -> None:
+    """A tiny multi-file repo: hub imported by two others (gives the import-graph features edges)."""
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "src" / "hub.py").write_text(
+        "def hub_fn(amount):\n    return amount * 2\n", encoding="utf-8"
+    )
+    (root / "src" / "leaf.py").write_text(
+        "import hub\n\n\ndef leaf_fn():\n    return hub.hub_fn(21)\n", encoding="utf-8"
+    )
+    (root / "src" / "other.py").write_text(
+        "import hub\n\n\ndef other_fn():\n    return hub.hub_fn(7)\n", encoding="utf-8"
+    )
+    (root / "main.py").write_text(
+        "from src.leaf import leaf_fn\n\n\ndef run():\n    return leaf_fn()\n", encoding="utf-8"
+    )
+    (root / "lib.rs").write_text(
+        "pub fn parse(input: &str) -> usize {\n    input.len()\n}\n", encoding="utf-8"
+    )
+
+
+def main() -> int:
+    print(f"=== tensor-grep full-feature dogfood (binary: {TG}) ===")
+    code, ver, _ = _run(["--version"])
+    print(f"version: {ver.strip()} (exit {code})\n")
+
+    with tempfile.TemporaryDirectory() as td:
+        fixture = Path(td) / "repo"
+        _build_fixture(fixture)
+        fx = str(fixture)
+        empty = Path(td) / "empty"
+        empty.mkdir()
+
+        check("version", ["--version"], must_contain="tensor-grep")
+        # --- text search (the ripgrep-compatible front door) ---
+        check("search (plain text)", ["search", "hub_fn", fx], must_contain="hub")
+        # REGRESSION GUARD (v1.14.0/v1.15.1): plain-text --rank must NOT leak to ripgrep.
+        check(
+            "search --rank (PLAIN -regression guard)",
+            ["search", "hub_fn", fx, "--rank"],
+            must_not_contain="unrecognized flag",
+        )
+        check(
+            "search --rank --json",
+            ["search", "hub_fn", fx, "--rank", "--json"],
+            json_key="matched_file_paths",
+        )
+        check("search --json", ["search", "hub_fn", fx, "--json"], json_key="matched_file_paths")
+        # --- orientation capsule (v1.15.0) ---
+        check("orient", ["orient", fx], must_contain="orientation")
+        check("orient --json", ["orient", fx, "--json"], json_key="routing_reason")
+        check("orient (empty dir -graceful)", ["orient", str(empty)], must_contain="orientation")
+        # --- repo map + agent context ---
+        check("map", ["map", fx])
+        check("agent --json", ["agent", "--query", "hub", "--json", fx], json_key="version")
+
+    failures = [r for r in _RESULTS if not r[0]]
+    print()
+    print(f"=== {len(_RESULTS) - len(failures)}/{len(_RESULTS)} checks passed ===")
+    if failures:
+        print("DOGFOOD FAILURES:")
+        for _, desc, code, detail in failures:
+            print(f"  - {desc} (exit {code}) {detail}")
+        return 1
+    print("ALL DOGFOOD CHECKS PASSED -shipped artifact installs and every feature works.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
A reusable post-release dogfood harness in `scripts/dogfood/`:
- **`dogfood_features.py`** — generates a fixture repo + runs the **real `tg` binary** across every user-facing feature (version, `search`, **`search --rank` plain AND `--json`**, `search --json`, `orient` +json +empty-dir, `map`, `agent --json`) with exit-code + output assertions. Environment-agnostic (`TG_BIN` override).
- **`Dockerfile`** — clean `python:3.12-slim` + ripgrep, `pip install tensor-grep==${TG_VERSION}`, `RUN tg --version` (fails the build early on a packaging regression), then runs the battery.
- **`README.md`** — the post-release process.

## Why
Our tests use `CliRunner`, which invokes the typer `app` directly and **bypasses the real `tg` front door** (`bootstrap`, which forwards plain searches to ripgrep). That's how v1.14.0's `tg search --rank` shipped broken in plain-text mode (`rg: unrecognized flag --rank`). This harness runs the customer path.

## Validation
Built + ran against shipped **v1.15.0** (which still has the bug) — the battery **correctly FAILED** the `--rank` regression guard (exit 1) in a clean Docker install:
```
[FAIL] search --rank (PLAIN) exit 2 -> rg: unrecognized flag --rank
=== 9/10 checks passed ===
```
Against the fixed binary it's 10/10. Run after each release: `docker build --build-arg TG_VERSION=<new> -f scripts/dogfood/Dockerfile -t tg-dogfood scripts/dogfood && docker run --rm tg-dogfood`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)