### PR TITLE
docs: capture v1.14-v1.15 features + session dev-process learnings

### DIFF
--- a/.claude/skills/tensor-grep/REFERENCE.md
+++ b/.claude/skills/tensor-grep/REFERENCE.md
@@ -15,6 +15,9 @@ tg refs REPO_PATH SYMBOL
 tg callers REPO_PATH SYMBOL
 tg blast-radius REPO_PATH SYMBOL
 tg blast-radius-plan REPO_PATH SYMBOL
+tg search PATTERN PATH
+tg search PATTERN PATH --rank
+tg orient REPO_PATH
 ```
 
 ## Useful Variants
@@ -25,6 +28,11 @@ tg defs REPO_PATH SYMBOL --provider native --json
 tg refs REPO_PATH SYMBOL --provider lsp --json
 tg blast-radius REPO_PATH SYMBOL --provider hybrid --json
 tg blast-radius-plan REPO_PATH SYMBOL --provider native --json
+tg search PATTERN PATH --rank
+tg search PATTERN PATH --rank --json
+tg orient REPO_PATH
+tg orient REPO_PATH --json
+tg orient REPO_PATH --max-tokens 6000 --max-central-files 15
 ```
 
 ## Practical Sequence
@@ -36,3 +44,22 @@ tg blast-radius-plan C:\repo open_file
 ```
 
 Use the top-ranked file/span first. Only broaden to refs/callers if the primary file is still ambiguous.
+
+## Orient-First Sequence (unfamiliar repo)
+
+```powershell
+tg orient C:\repo
+tg source C:\repo <symbol-from-orient-output>
+tg blast-radius C:\repo <symbol-from-orient-output>
+```
+
+Use `tg orient` when you do not yet know which files or symbols matter. The capsule gives you central files (import in-degree), entry points, and a symbol map — pick the right symbol, then proceed with source/blast-radius.
+
+## Search-Then-Source Sequence (unknown symbol name)
+
+```powershell
+tg search "pattern" C:\repo --rank
+tg source C:\repo <symbol-from-top-hit>
+```
+
+Use when the symbol name is unknown but the concept or text is known. `--rank` (alias `--bm25`) re-ranks ripgrep hits by BM25 content relevance — pure Python, no API key, no GPU.

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -13,6 +13,8 @@ Use this skill when you need to locate code precisely, understand likely edit im
 - You need references or likely callers before editing code.
 - You need an edit plan, blast radius, or validation target instead of ad hoc grep loops.
 - You are preparing a patch and want a smaller, more accurate context bundle.
+- You need a fast codebase orientation capsule (central files, entry points, symbol map) before diving into symbol lookup.
+- You need to find code by text/content relevance rather than an exact symbol name.
 
 ## Argument Order
 
@@ -25,8 +27,15 @@ prefer the canonical path-first form.
 
 1. Confirm the installed CLI is available:
    - `tg --version`
+0. (Unfamiliar repo) Orient before searching:
+   - `tg orient REPO_PATH`
+   Returns central files (by import in-degree), entry points, symbol map, and AST snippets in one call.
 2. Start with direct source lookup:
    - `tg source REPO_PATH SYMBOL`
+2a. If the symbol name is unknown, find it by content first:
+   - `tg search PATTERN REPO_PATH --rank`
+   BM25 re-ranks results by per-chunk relevance — no API key, no GPU required.
+   Then feed the top hit into `tg source`.
 3. If you need symbol navigation:
    - `tg defs REPO_PATH SYMBOL`
    - `tg refs REPO_PATH SYMBOL`
@@ -46,6 +55,8 @@ prefer the canonical path-first form.
 ## Rules
 
 - Prefer `tg` over repeated manual grep loops when working inside a real repository.
+- Run `tg orient REPO_PATH` first when entering an unfamiliar repo — it gives centrality, entry points, and a symbol map in one call, and costs no API key or GPU.
+- Use `tg search PATTERN PATH --rank` for content/text search; prefer it over raw grep loops when relevance ranking matters. The `--bm25` flag is an alias for `--rank`.
 - Keep edits narrow and grounded in the files `tg` ranks highest.
 - Do not expand context blindly if `tg` already identified the primary file and span.
 - Use provider-backed modes only when a task is clearly about semantic ambiguity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,46 @@ Known current weak spots:
 6. Do not change workflow, release, or docs contracts without updating the validator-backed tests.
 7. Do not run `wsl --shutdown`, restart WSL, stop Docker/WSL services, kill WSL processes, or reboot/restart the host as memory cleanup without explicit user approval. Other agents use WSL. If memory pressure is observed, first collect read-only process/memory evidence, stop only tensor-grep-owned processes you started, and ask before touching unrelated processes.
 
+## Adding a Command or Flag
+
+Adding a top-level `tg COMMAND` requires four registration points or the new command silently misroutes:
+
+1. `KNOWN_COMMANDS` in `src/tensor_grep/cli/commands.py` — the Python-side known-command registry.
+2. A `Commands::X` passthrough variant and a matching dispatch arm in `rust_core/src/main.rs` — the native front door must know about it.
+3. `PUBLIC_TOP_LEVEL_COMMANDS` in `tests/e2e/test_routing_parity.py` — the contract test that enforces parity between Python and native.
+4. A `@app.command` function in `main.py` — the Typer app entry point.
+
+Adding a search flag (e.g. `tg search --myflag`) requires two front doors or the flag leaks to ripgrep and causes an `rg: unrecognized flag` crash at runtime:
+
+1. `SEARCH_PYTHON_PASSTHROUGH_FLAGS` in `rust_core/src/main.rs` — the native binary's allowlist.
+2. `bootstrap._TG_ONLY_SEARCH_FLAGS` in `src/tensor_grep/cli/bootstrap.py` — the Python bootstrap's allowlist (the Python front door runs before the Typer app and forwards plain searches to rg).
+
+Missing either slot lets the flag reach ripgrep for users who install the published binary while your CliRunner tests pass cleanly — exactly how the `--rank` crash shipped undetected.
+
+## Dogfood the Real Binary, Not CliRunner
+
+The `tg` entry point is `tensor_grep.cli.bootstrap:main_entry`. It intercepts plain text searches and forwards them to ripgrep **before** the Typer app sees the argv. `CliRunner` invokes the Typer app directly and bypasses this front door entirely — so bugs in the bootstrap routing layer are invisible to unit tests.
+
+After adding or changing a search flag or command, dogfood the **installed published binary** using the harness at `scripts/dogfood/` (Dockerfile + `dogfood_features.py`). The harness installs the real PyPI wheel and runs every public command shape through the actual `tg` binary. Do not rely on `CliRunner` alone for routing coverage.
+
+## Verify AI-Drafted Plans Against the Real Code Before Building
+
+Before implementing a plan produced by an AI subagent or any external planning pass, check every factual claim in the plan against the real source files by citing `file:line`. A claim with no citation should be treated as a hypothesis, not a fact.
+
+This matters because AI-generated plans have a consistent failure mode: they identify plausible-sounding edit locations that do not match the actual code structure (dead code paths, renamed symbols, already-fixed lines). A verification pass that reads the real files before implementation is not overhead — it is the gate that prevents wasted cycles. A council or read-only review that cites file:line evidence caught 5 blockers in two unverified plans in a single session.
+
+## Skills
+
+Two kinds of skills apply to this repo; load the relevant one before non-trivial work.
+
+- **Using `tg` itself** — `.claude/skills/tensor-grep/SKILL.md` (+ `REFERENCE.md`): the agent-usage skill for the command surface (`search`, `search --rank`, `orient`, `map`, `agent`, `session`, AST, blast-radius). Keep it in sync whenever commands/flags change.
+- **Working ON `tg` (build + release discipline)** — reusable global skills at `~/.claude/skills/`:
+  - `dogfood-the-shipped-artifact` — after a release, install the published wheel in clean Docker and run the REAL `tg` binary across every feature; never trust CliRunner (it bypasses the bootstrap front door). Harness: `scripts/dogfood/`.
+  - `verify-plan-against-code` — before building an AI/subagent-drafted plan, verify every seam claim (file paths, the command/flag registration sites above, routing) against the real code with `file:line` citations; bake corrections in first.
+
+These encode the "Adding a Command or Flag", "Dogfood the Real Binary", and "Verify AI-Drafted Plans" sections above as reusable, project-independent skills.
+
+
 ## Dogfood follow-up workflow
 
 When public dogfood identifies multiple independent fixes, preserve the process that has been working:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+Claude Code guidance for the **tensor-grep** repository.
+
+> **All agent + contributor guidance lives in [AGENTS.md](AGENTS.md) — read it first.**
+> Claude Code auto-loads this `CLAUDE.md`; `AGENTS.md` (read by other agents) holds the full rules, so
+> this file points there to keep them DRY.
+
+`AGENTS.md` covers, among other things:
+
+- **Adding a Command or Flag** — the four registration sites for a new `tg` command and the two front
+  doors for a new search flag (miss one and it silently misroutes to ripgrep).
+- **Dogfood the Real Binary, Not CliRunner** — `CliRunner` bypasses the `bootstrap` front door; verify
+  the shipped binary.
+- **Verify AI-Drafted Plans Against the Real Code** — cite `file:line` for every seam claim before
+  building.
+- The ruff `--preview` (format only, not lint), line-ending, decode-the-structured-CI-failure-first,
+  and release rules.
+
+## Skills that apply here
+
+- **Using `tg`**: `.claude/skills/tensor-grep/SKILL.md` (+ `REFERENCE.md`).
+- **Build/release discipline** (global, `~/.claude/skills/`): `dogfood-the-shipped-artifact`,
+  `verify-plan-against-code`.
+- **Post-release dogfood harness**: `scripts/dogfood/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Run these before proposing a change:
 
 ```bash
 uv run ruff check .
+uv run ruff format --preview .
 uv run mypy src/tensor_grep
 uv run pytest -q
 ```
@@ -17,6 +18,12 @@ For release/workflow/package-manager changes, also run:
 ```bash
 uv run python scripts/validate_release_assets.py
 ```
+
+**Ruff preview split:** CI runs `ruff format --check --preview .` but only `ruff check .` (no `--preview`) for lint. Locally, always run `ruff format --preview` but never pass `--preview` to `ruff check` — preview lint rules such as RUF056 produce false failures that do not match CI.
+
+**Line endings:** `.gitattributes` pins `*.py` and `*.rs` to `eol=lf`. Use `git ls-files --eol` to audit actual on-disk endings; `git show` and `git cat-file -p` smudge the output and can report false CR.
+
+**Decode the structured CI failure first:** When a CI run fails, open the failing check's structured JSON output before reading rich tracebacks. Theorizing from tracebacks without identifying the exact failing check wastes cycles — the structured output names the precise gate and often the file and line. This rule saved multiple CI round-trips during the June 2026 README-rewrite incident.
 
 ## Public Issue Intake
 
@@ -50,6 +57,20 @@ New and edited public issues are classified by a deterministic triage workflow. 
 ## Documentation and Contract Changes
 
 If you change workflow, release behavior, docs contracts, or package-manager assets, update the validator-backed tests too.
+
+## Post-Release Docker Dogfood Gate
+
+After a release lands on PyPI, run the post-release dogfood harness to verify the published binary — not just the local source tree:
+
+```bash
+# Run the battery against a tg already on PATH (e.g. an installed wheel)
+python scripts/dogfood/dogfood_features.py
+# Or clean-room via Docker: install the PUBLISHED version, then run the real binary
+docker build --build-arg TG_VERSION=<version> -f scripts/dogfood/Dockerfile -t tg-dogfood scripts/dogfood \
+  && docker run --rm tg-dogfood
+```
+
+The harness at `scripts/dogfood/` installs the real PyPI wheel and runs every public `tg` command through the installed `tg` binary. This catches routing bugs that are invisible to `CliRunner`-based unit tests because the bootstrap front door (which forwards plain searches to ripgrep before the Typer app) is bypassed by `CliRunner`. A flag that works in unit tests can still crash with `rg: unrecognized flag` for real users if it is missing from the bootstrap or native front-door allowlists.
 
 Important surfaces include:
 - `tests/unit/test_release_assets_validation.py`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![PyPI](https://img.shields.io/pypi/v/tensor-grep)](https://pypi.org/project/tensor-grep/)
 [![CI](https://github.com/oimiragieo/tensor-grep/actions/workflows/ci.yml/badge.svg)](https://github.com/oimiragieo/tensor-grep/actions/workflows/ci.yml)
 
-**Fast text, AST, indexed, and GPU-aware search CLI.** One binary for ripgrep-compatible text search, native AST search and rewrite, indexed acceleration for repeated queries, machine-readable context for AI agents, symbol call-graph analysis, security and compliance rule packs, and an embedded MCP server.
+**Fast text, AST, indexed, and GPU-aware search CLI.** One binary for ripgrep-compatible text search, BM25 re-ranking, native AST search and rewrite, indexed acceleration for repeated queries, codebase orientation for agents, machine-readable context for AI agents, symbol call-graph analysis, security and compliance rule packs, and an embedded MCP server.
 
 ```bash
 pip install tensor-grep        # or: uvx tensor-grep
@@ -35,6 +35,7 @@ It ships as a native CLI on Windows, macOS, and Linux — no server required for
 ### Text search
 - **ripgrep-compatible subset** — supports the common `rg` flags (pattern, path, `-t`/`--type`, `--count-matches`, `--no-ignore`, `--sort path`, `--format rg`, `--json`, `--ndjson`). This is a validated compatible subset, not a full ripgrep replacement. Use `--format rg` for deterministic ripgrep-shaped stdout; `--format rg --json` for rg JSON Lines output.
 - Root-level shortcuts: `tg PATTERN [PATH]`, `tg -t js PATTERN PATH`, `tg --count-matches PATTERN PATH` all behave as `tg search ...`.
+- **`tg search PATTERN PATH --rank`** (alias `--bm25`) — local BM25 re-ranking of text-search results by per-chunk content relevance. Pure-Python, no API key, no GPU. Scores and re-orders results from the ripgrep-backed engine so the most content-relevant matches surface first. Works in plain text and `--json` output modes. Usage: `tg search PATTERN PATH --rank`.
 - Chunk-parallel native CPU engine for large files.
 
 ### AST search & rewrite
@@ -45,6 +46,7 @@ It ships as a native CLI on Windows, macOS, and Linux — no server required for
 
 ### AI-agent context
 - **`tg agent PATH "query" --json`** — Actionable Context Capsule: primary files/functions, alternative targets, snippets with line maps, validation commands, rollback/checkpoint metadata, confidence, and an ask-before-editing recommendation. Mixed-language queries report `validation_alignment` instead of silently pairing mismatched targets and validators.
+- **`tg orient [PATH]`** — one-call codebase orientation capsule for agents. Ranks files by import in-degree (imported-by-many = foundational), identifies entry points via main/cli/index/lib heuristics, produces a symbol map, and emits AST-boundary code snippets within a token budget. Pure-CPU, no API key, no GPU. Options: `--max-tokens` (default 3000; bounds the snippet budget only, not the whole capsule), `--max-central-files` (default 10), `--json`. JSON keys include `central_files[{file,graph_score,symbols}]`, `entry_points`, `symbol_map`, `snippets`, `token_estimate`, `token_budget_label`, `truncated`, `scan_limit`, `routing_reason="orient"`. Honest caveat: in-degree centrality is import-graph based and works best on Python; Rust/JS edges resolve fully only in whole-repo scans.
 - **`tg map`** — machine-readable file/symbol map of a codebase.
 - **`tg context PATH "query"`** — semantic context capsule for a natural-language question.
 - **`tg context-render`** / **`tg edit-plan`** — rendered context and structured edit plans with daemon response caching for sub-second warm calls.
@@ -128,6 +130,12 @@ tg callers src/ authenticate_user
 # AST structural search/rewrite
 tg scan --config sgconfig.yml
 
+# Local BM25 re-ranking — surface most-relevant matches first, no API key
+tg search "TODO" src/ --rank
+
+# One-call codebase orientation for agents — central files, entry points, symbol map
+tg orient src/
+
 # Start the built-in MCP server
 tg mcp
 
@@ -180,7 +188,7 @@ tg dogfood
 
 The `v1.x` line is feature-complete for the current native search, AST, and editor-plane surface. The remaining work is intentionally narrow:
 
-- add any lexical reranking or AST-shaped chunking only when it beats the accepted lexical-first repo-map line on both retrieval quality and editor-plane benchmarks
+- extend lexical (BM25) re-ranking with AST-shaped chunking or semantic re-ranking only when it demonstrably beats the shipped `tg search --rank` baseline on both retrieval quality and editor-plane benchmarks
 - add tighter multi-agent signal surfaces on top of the existing JSON/NDJSON, session, and MCP contracts instead of inventing another parallel agent protocol
 - publish a broader reproducible comparator pack for tools such as `ag`, `ack`, `ugrep`, and GNU `grep` alongside the current `rg` and `git grep` rows
 - graduate or retire the experimental resident AST worker based on benchmark-governed evidence, not intuition

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,3 +37,4 @@
 - `tensor-grep` is strongest on native AST workflows, repeated-query acceleration, machine-readable harness flows, and managed enterprise rollout.
 - Bounded heavy-root context renders can now include full edit-plan seed metadata without escaping the capped repo-map file universe.
 - GPU acceleration is benchmark-governed and hardware-specific, not a universal default.
+- **New in v1.14.0+:** `tg search PATTERN PATH --rank` adds local BM25 re-ranking of text-search results (pure-Python, no API key, no GPU). `tg orient [PATH]` produces a one-call codebase orientation capsule (most central files by import in-degree, entry points, symbol map, AST snippets — pure-CPU). See the [README](https://github.com/oimiragieo/tensor-grep/blob/main/README.md) for usage. The post-release dogfood harness at `scripts/dogfood/` verifies these and all other public command shapes against the installed binary.


### PR DESCRIPTION
Documents the two shipped features (`tg search --rank`, `tg orient`) — previously documented only in plan files — and records this session's dev-process learnings (command/flag registration recipe, dogfood-the-real-binary, verify-AI-plans-against-code, the ruff --preview split, line-endings, the post-release Docker dogfood gate). Adds a Skills-discovery pointer to AGENTS.md. Two reusable global skills were created alongside: `dogfood-the-shipped-artifact` and `verify-plan-against-code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)