### PR TITLE
fix: registration-check comment/string-aware parser + flip gate to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,10 +311,10 @@ jobs:
         run: uv run mypy src/tensor_grep
 
       # Registration-completeness gate (catches "added X, missed front-door site N" — the v1.15.0
-      # --rank class). WARN-ONLY for one release to confirm zero false positives on real PRs, then
-      # remove continue-on-error to make it blocking.
-      - name: Registration completeness (warn-only)
-        continue-on-error: true
+      # --rank class). Blocking as of v1.17 after a clean warn-only release cycle (zero false
+      # positives through v1.16); the parser is string/comment-aware so a commented-out entry
+      # cannot false-pass. To re-soften, restore `continue-on-error: true`.
+      - name: Registration completeness
         run: |
           set -uo pipefail
           if [ -f .tg-registration.toml ]; then

--- a/src/tensor_grep/core/registration_check.py
+++ b/src/tensor_grep/core/registration_check.py
@@ -22,7 +22,46 @@ from pathlib import Path
 from typing import Any
 
 _OPEN_TO_CLOSE = {"{": "}", "[": "]", "(": ")"}
-_STRING_RE = re.compile(r'"([^"\\]*)"|\'([^\'\\]*)\'')
+_DECL_RE_CACHE: dict[str, re.Pattern[str]] = {}
+
+
+def _declaration_re(symbol: str) -> re.Pattern[str]:
+    """Anchor for `symbol`'s assignment line (cached).
+
+    Matches `SYMBOL ... =` on a single line where the `=` is a real assignment — not a
+    comparison (`==`/`!=`/`<=`/`>=`) and not separated from the symbol by a `#` comment — so a
+    mention of the symbol in a comment or docstring is never mistaken for the declaration.
+    """
+    pattern = _DECL_RE_CACHE.get(symbol)
+    if pattern is None:
+        pattern = re.compile(rf"(?<![\w]){re.escape(symbol)}\b[^\n=#]*(?<![!<>=])=(?!=)")
+        _DECL_RE_CACHE[symbol] = pattern
+    return pattern
+
+
+def _consume_string(text: str, index: int) -> tuple[str | None, int]:
+    """Consume a quoted string starting at `index` (a quote char); return (content, next_index).
+
+    Honors backslash escapes; returns (None, ...) for an unterminated single-line string (a
+    newline before the close), so a stray quote cannot run the scanner away.
+    """
+    quote = text[index]
+    parts: list[str] = []
+    j = index + 1
+    n = len(text)
+    while j < n:
+        ch = text[j]
+        if ch == "\\" and j + 1 < n:
+            parts.append(text[j + 1])
+            j += 2
+            continue
+        if ch == quote:
+            return "".join(parts), j + 1
+        if ch == "\n":
+            return None, j
+        parts.append(ch)
+        j += 1
+    return None, j
 
 
 @dataclass(frozen=True)
@@ -59,33 +98,44 @@ def extract_members(file_path: str, symbol: str) -> set[str]:
         text = Path(file_path).read_text(encoding="utf-8")
     except OSError:
         return set()
-    decl = re.search(rf"(?<![\w]){re.escape(symbol)}\b", text)
-    if decl is None:
+    match = _declaration_re(symbol).search(text)
+    if match is None:
         return set()
-    eq = text.find("=", decl.end())
-    if eq == -1:
-        return set()
-    index = eq + 1
-    while index < len(text) and text[index] not in "{[(":
+    index = match.end()
+    n = len(text)
+    # Skip whitespace and Rust reference/array prefixes (`&`) to the value's opening bracket. A
+    # scalar value (e.g. `X = 5`) has no opening bracket here -> no members.
+    while index < n and text[index] in " \t\r\n&":
         index += 1
-    if index >= len(text):
+    if index >= n or text[index] not in "{[(":
         return set()
     open_ch = text[index]
     close_ch = _OPEN_TO_CLOSE[open_ch]
+    members: set[str] = set()
     depth = 0
-    start = index
-    while index < len(text):
-        if text[index] == open_ch:
+    # Bracket-match the value while skipping string literals and `#` / `//` comments, so a bracket
+    # or quoted string *inside* a literal or comment cannot corrupt the depth count or inject a
+    # spurious member (a `#`-commented entry is the realistic false-NEGATIVE vector: it would read
+    # as a registered member and mask a genuine registration gap).
+    while index < n:
+        ch = text[index]
+        if ch in "\"'":
+            literal, index = _consume_string(text, index)
+            if literal is not None:
+                members.add(literal)
+            continue
+        if ch == "#" or (ch == "/" and index + 1 < n and text[index + 1] == "/"):
+            while index < n and text[index] != "\n":
+                index += 1
+            continue
+        if ch == open_ch:
             depth += 1
-        elif text[index] == close_ch:
+        elif ch == close_ch:
             depth -= 1
             if depth == 0:
                 break
         index += 1
-    block = text[start : index + 1]
-    return {
-        (m.group(1) if m.group(1) is not None else m.group(2)) for m in _STRING_RE.finditer(block)
-    }
+    return members
 
 
 def check_group(group: RegistrationGroup, *, repo_root: str | Path = ".") -> dict[str, Any]:
@@ -101,11 +151,13 @@ def check_group(group: RegistrationGroup, *, repo_root: str | Path = ".") -> dic
         present_in = [k for k, members in members_by_site.items() if entity in members]
         missing_from = [k for k, members in members_by_site.items() if entity not in members]
         if missing_from:  # present in some sites but not all
-            missing.append({
-                "entity": entity,
-                "present_in": present_in,
-                "missing_from": missing_from,
-            })
+            missing.append(
+                {
+                    "entity": entity,
+                    "present_in": present_in,
+                    "missing_from": missing_from,
+                }
+            )
     return {
         "name": group.name,
         "complete": not missing,

--- a/src/tensor_grep/core/registration_check.py
+++ b/src/tensor_grep/core/registration_check.py
@@ -151,13 +151,11 @@ def check_group(group: RegistrationGroup, *, repo_root: str | Path = ".") -> dic
         present_in = [k for k, members in members_by_site.items() if entity in members]
         missing_from = [k for k, members in members_by_site.items() if entity not in members]
         if missing_from:  # present in some sites but not all
-            missing.append(
-                {
-                    "entity": entity,
-                    "present_in": present_in,
-                    "missing_from": missing_from,
-                }
-            )
+            missing.append({
+                "entity": entity,
+                "present_in": present_in,
+                "missing_from": missing_from,
+            })
     return {
         "name": group.name,
         "complete": not missing,

--- a/tests/unit/test_registration_check.py
+++ b/tests/unit/test_registration_check.py
@@ -204,19 +204,17 @@ def test_check_groups_aggregates_and_sets_overall(tmp_path: Path) -> None:
 def test_load_config_parses_groups(tmp_path: Path) -> None:
     cfg = tmp_path / "reg.json"
     cfg.write_text(
-        json.dumps(
-            {
-                "registration_groups": [
-                    {
-                        "name": "search-flag",
-                        "sites": [
-                            {"file": "a.py", "symbol": "FLAGS"},
-                            {"file": "b.rs", "symbol": "FLAGS"},
-                        ],
-                    }
-                ]
-            }
-        ),
+        json.dumps({
+            "registration_groups": [
+                {
+                    "name": "search-flag",
+                    "sites": [
+                        {"file": "a.py", "symbol": "FLAGS"},
+                        {"file": "b.rs", "symbol": "FLAGS"},
+                    ],
+                }
+            ]
+        }),
         encoding="utf-8",
     )
     groups = load_config(str(cfg))

--- a/tests/unit/test_registration_check.py
+++ b/tests/unit/test_registration_check.py
@@ -124,6 +124,44 @@ def test_extract_members_missing_symbol_returns_empty(tmp_path: Path) -> None:
     assert extract_members(str(f), "ABSENT") == set()
 
 
+def test_extract_members_skips_commented_out_entries(tmp_path: Path) -> None:
+    # A `#`-commented quoted string inside the block must NOT be collected — otherwise it reads as
+    # a registered member and masks a genuine registration gap (false negative defeats the tool).
+    f = tmp_path / "x.py"
+    f.write_text(
+        'FLAGS = {\n    "--a",\n    # "--ghost",  not registered yet\n    "--b",\n}\n',
+        encoding="utf-8",
+    )
+    assert extract_members(str(f), "FLAGS") == {"--a", "--b"}
+
+
+def test_extract_members_ignores_symbol_mention_in_preceding_comment(tmp_path: Path) -> None:
+    # A comment/docstring mentioning the symbol before its declaration must not be mistaken for it.
+    f = tmp_path / "x.py"
+    f.write_text(
+        "# FLAGS must list every front-door flag; see OTHER == FLAGS guards\n"
+        'FLAGS = {"--a", "--b"}\n',
+        encoding="utf-8",
+    )
+    assert extract_members(str(f), "FLAGS") == {"--a", "--b"}
+
+
+def test_extract_members_bracket_inside_string_does_not_overshoot(tmp_path: Path) -> None:
+    # A bracket inside a string literal must not corrupt the depth count and swallow later content.
+    f = tmp_path / "x.py"
+    f.write_text(
+        'FLAGS = ["route[v1", "/health"]\nGHOST = ["--should-not-appear"]\n',
+        encoding="utf-8",
+    )
+    assert extract_members(str(f), "FLAGS") == {"route[v1", "/health"}
+
+
+def test_extract_members_handles_escaped_quote_in_member(tmp_path: Path) -> None:
+    f = tmp_path / "x.py"
+    f.write_text('FLAGS = ["a\\"b", "c"]\n', encoding="utf-8")
+    assert extract_members(str(f), "FLAGS") == {'a"b', "c"}
+
+
 def test_check_group_flags_entity_missing_from_one_site(tmp_path: Path) -> None:
     a = tmp_path / "a.py"
     a.write_text('FLAGS = {"--x", "--y", "--rank"}\n', encoding="utf-8")
@@ -166,17 +204,19 @@ def test_check_groups_aggregates_and_sets_overall(tmp_path: Path) -> None:
 def test_load_config_parses_groups(tmp_path: Path) -> None:
     cfg = tmp_path / "reg.json"
     cfg.write_text(
-        json.dumps({
-            "registration_groups": [
-                {
-                    "name": "search-flag",
-                    "sites": [
-                        {"file": "a.py", "symbol": "FLAGS"},
-                        {"file": "b.rs", "symbol": "FLAGS"},
-                    ],
-                }
-            ]
-        }),
+        json.dumps(
+            {
+                "registration_groups": [
+                    {
+                        "name": "search-flag",
+                        "sites": [
+                            {"file": "a.py", "symbol": "FLAGS"},
+                            {"file": "b.rs", "symbol": "FLAGS"},
+                        ],
+                    }
+                ]
+            }
+        ),
         encoding="utf-8",
     )
     groups = load_config(str(cfg))


### PR DESCRIPTION
## Why
The registration-completeness detector (shipped v1.16, the CI guard for the "added X, missed front-door site N" / `--rank` class) used an approximate parser. The audit (adversarially verified) found a realistic **false-negative**: a `#`-commented-out entry inside a registration block was collected as a real member, so it read as registered and **masked a genuine registration gap** — defeating the tool's only job. With the gate about to become blocking, that had to be fixed first.

## Changes
- **`extract_members` is now string- and comment-aware.** It (a) anchors to a real same-line assignment (not a comparison `==`/`!=`/`<=`/`>=`, not a comment/docstring mention of the symbol), and (b) bracket-matches the value while skipping string literals and `#`/`//` comments — so a bracket or quoted string *inside* a literal or comment can no longer corrupt the depth count or inject a spurious member.
- **CI gate flipped warn-only → blocking.** It ran clean through the v1.16 release cycle (zero false positives), and the hardened parser can no longer false-pass on a commented-out entry. To re-soften: restore `continue-on-error: true`.

## Validation
- 17 registration tests pass (13 original + 4 new: commented-out entry, preceding-comment mention, bracket-in-string overshoot, escaped quote).
- Real-repo `.tg-registration.toml` check stays **2/2 groups complete** with the new parser.
- ruff format + lint + mypy clean.

Pairs with #281 (no file overlap). The remaining audit items (security/supply-chain: LSP toolchain checksums, MCP policy ACE, download timeouts, native-refresh integrity, installer bootstrap) follow as a council-verified wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)