### PR TITLE
fix: time-bound native front-door downloads (no indefinite install/upgrade hang)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -575,9 +575,18 @@ def _managed_native_frontdoor_path() -> Path | None:
 
 
 def _download_native_frontdoor_asset(url: str, destination: Path) -> None:
+    import socket
     import urllib.request
 
-    urllib.request.urlretrieve(url, destination)
+    # urlretrieve has NO timeout param; bound it with a process socket timeout so a stalled read on
+    # the release CDN can't hang install/upgrade indefinitely (audit: reliability). Restore the
+    # prior default afterward so we don't leak a global timeout into the rest of the process.
+    previous_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(60)
+    try:
+        urllib.request.urlretrieve(url, destination)
+    finally:
+        socket.setdefaulttimeout(previous_timeout)
 
 
 def _native_frontdoor_checksums_url(version: str) -> str:
@@ -590,7 +599,7 @@ def _fetch_native_frontdoor_checksums(version: str) -> str | None:
 
     url = _native_frontdoor_checksums_url(version)
     try:
-        with urllib.request.urlopen(url) as response:
+        with urllib.request.urlopen(url, timeout=30) as response:
             raw: bytes = response.read()
             return raw.decode("utf-8")
     except Exception:

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -10179,6 +10179,49 @@ def test_upgrade_scheduled_windows_helper_refreshes_stale_com_bridge(monkeypatch
     assert json.loads(popen_calls[0][9]) == [str(bridge_tg)]
 
 
+def test_native_frontdoor_download_helpers_use_timeouts(monkeypatch, tmp_path):
+    # Reliability: the native front-door asset + CHECKSUMS downloads must be time-bounded, or a
+    # stalled CDN read hangs install/upgrade indefinitely. urlretrieve has NO timeout param, so the
+    # asset download is bounded by a process socket timeout instead.
+    import socket
+
+    import tensor_grep.cli.main as m
+
+    # CHECKSUMS fetch uses urlopen(timeout=...).
+    checksum_timeouts: list = []
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b"deadbeef  tg-x.exe\n"
+
+    def _fake_urlopen(url, timeout=None, *args, **kwargs):
+        checksum_timeouts.append(timeout)
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    assert m._fetch_native_frontdoor_checksums("9.9.9") is not None
+    assert checksum_timeouts and all(t is not None and t > 0 for t in checksum_timeouts)
+
+    # Asset download bounds urlretrieve with a socket timeout and restores the prior default.
+    seen_timeout: list = []
+
+    def _fake_urlretrieve(url, dest):
+        seen_timeout.append(socket.getdefaulttimeout())
+        Path(dest).write_bytes(b"x")
+
+    monkeypatch.setattr("urllib.request.urlretrieve", _fake_urlretrieve)
+    before = socket.getdefaulttimeout()
+    m._download_native_frontdoor_asset("https://example.test/tg-x.exe", tmp_path / "tg.exe")
+    assert seen_timeout == [60.0], f"download did not set a socket timeout: {seen_timeout}"
+    assert socket.getdefaulttimeout() == before, "socket default timeout leaked after download"
+
+
 def test_upgrade_schedules_windows_helper_for_realworld_uv_pip_ensurepip_lock(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Why
Audit (reliability, MEDIUM): the native front-door asset download uses `urlretrieve` — which has **no timeout parameter** — and the `CHECKSUMS.txt` fetch used `urlopen` with no timeout. A stalled CDN read could hang `tg` install/upgrade **indefinitely**, before any retry logic runs.

## Fix
- `_fetch_native_frontdoor_checksums`: `urlopen(url, timeout=30)`.
- `_download_native_frontdoor_asset`: bound `urlretrieve` with a **process socket timeout (60s)**, restored afterward so no global default leaks. `urlretrieve` is kept deliberately — the scheduled refresh helper and the existing upgrade tests assert on it; only the timeout is added.

## Validation
- New TDD test: CHECKSUMS fetch passes a positive `urlopen` timeout; asset download sets+restores a 60s socket default.
- All existing native-frontdoor upgrade tests pass (15/15 in the affected `-k` slice); ruff format `--preview` + lint + mypy clean.

## Scope note
This is the safe, self-contained slice of the supply-chain wave. The **HIGH** items — checksum verification inside the *generated detached* refresh helper (which replaces `tg.exe`) and fail-closed LSP toolchain integrity (Node/rust-analyzer/gopls SHAs) — are deliberately **not** in this PR: they touch tamper-prevention code + need real per-platform checksums and careful tracing, so they ship as a separately-reviewed PR (adversarial `silent-failure-hunter` + `code-reviewer` pass) rather than a rushed edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)