### PR TITLE
fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface)

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -588,6 +588,13 @@ def extract_windows_rg_bundle(benchmarks_dir: Path) -> Path | None:
         rg_member = next((name for name in bundle.namelist() if name.endswith("/rg.exe")), None)
         if rg_member is None:
             return None
+        # Zip-slip guard: validate every member stays within benchmarks_dir before extracting,
+        # so a crafted rg.zip cannot write outside the directory via "../" or absolute paths.
+        dest_root = benchmarks_dir.resolve()
+        for name in bundle.namelist():
+            target = (benchmarks_dir / name).resolve()
+            if target != dest_root and dest_root not in target.parents:
+                raise RuntimeError(f"rg.zip member escapes destination: {name}")
         bundle.extractall(benchmarks_dir)
 
     extracted = benchmarks_dir / Path(rg_member)

--- a/benchmarks/run_compat_checks.py
+++ b/benchmarks/run_compat_checks.py
@@ -69,6 +69,13 @@ def extract_windows_rg_bundle(benchmarks_dir: Path) -> Path | None:
         rg_member = next((name for name in bundle.namelist() if name.endswith("/rg.exe")), None)
         if rg_member is None:
             return None
+        # Zip-slip guard: validate every member stays within benchmarks_dir before extracting,
+        # so a crafted rg.zip cannot write outside the directory via "../" or absolute paths.
+        dest_root = benchmarks_dir.resolve()
+        for name in bundle.namelist():
+            target = (benchmarks_dir / name).resolve()
+            if target != dest_root and dest_root not in target.parents:
+                raise RuntimeError(f"rg.zip member escapes destination: {name}")
         bundle.extractall(benchmarks_dir)
 
     extracted = benchmarks_dir / Path(rg_member)

--- a/benchmarks/run_patch_bakeoff.py
+++ b/benchmarks/run_patch_bakeoff.py
@@ -28,6 +28,10 @@ Scenario = dict[str, Any]
 Prediction = dict[str, Any]
 ResultRow = dict[str, Any]
 
+# Bound each scenario validation command so a hung command can't stall the bakeoff (the harness
+# API docs promise a 60s validation timeout).
+_VALIDATION_COMMAND_TIMEOUT_S = 60
+
 _REQUIRED_SCENARIO_FIELDS = (
     "instance_id",
     "repo_fixture",
@@ -270,21 +274,31 @@ def evaluate_prediction(scenario: Scenario, prediction: Prediction) -> ResultRow
                 reason = "ok"
                 validation_passed = True
                 for command in validation_commands:
-                    completed = subprocess.run(
-                        command,
-                        cwd=worktree,
-                        env=_validation_subprocess_env(),
-                        shell=True,
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                    )
-                    passed = completed.returncode == 0
+                    try:
+                        completed = subprocess.run(
+                            command,
+                            cwd=worktree,
+                            env=_validation_subprocess_env(),
+                            # Scenarios are trusted, maintainer-authored benchmark fixtures (not
+                            # untrusted input), so shell syntax is allowed; the timeout bounds a
+                            # hung validation command so the bakeoff cannot stall indefinitely
+                            # (docs/harness_api.md promises a 60s validation timeout).
+                            shell=True,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                            timeout=_VALIDATION_COMMAND_TIMEOUT_S,
+                        )
+                        passed = completed.returncode == 0
+                        returncode: int | None = completed.returncode
+                    except subprocess.TimeoutExpired:
+                        passed = False
+                        returncode = None
                     validation_passed = validation_passed and passed
                     validation_results.append({
                         "command": command,
                         "passed": passed,
-                        "returncode": completed.returncode,
+                        "returncode": returncode,
                     })
                 if not validation_passed:
                     reason = "validation failed"

--- a/npm/install.js
+++ b/npm/install.js
@@ -25,6 +25,11 @@ function isAllowedHost(hostname) {
   );
 }
 
+// Time-bound each request and cap the response size so a stalled or oversized release
+// response can't hang the install or exhaust memory before the checksum comparison runs.
+const DOWNLOAD_TIMEOUT_MS = 60000;
+const MAX_DOWNLOAD_BYTES = 256 * 1024 * 1024; // generous for a release binary; rejects abuse
+
 // Download a URL to a Buffer, following a bounded number of redirects, enforcing HTTPS,
 // a trusted host, and a final 200 status before returning any bytes.
 function download(url, redirectsLeft = 5) {
@@ -44,34 +49,46 @@ function download(url, redirectsLeft = 5) {
       reject(new Error(`Refusing download from untrusted host: ${parsed.hostname}`));
       return;
     }
-    https
-      .get(url, (response) => {
-        const { statusCode } = response;
-        if ([301, 302, 303, 307, 308].includes(statusCode)) {
-          response.resume();
-          if (redirectsLeft <= 0) {
-            reject(new Error('Too many redirects'));
-            return;
-          }
-          const location = response.headers.location;
-          if (!location) {
-            reject(new Error('Redirect response without a location header'));
-            return;
-          }
-          resolve(download(new URL(location, url).toString(), redirectsLeft - 1));
+    const req = https.get(url, { timeout: DOWNLOAD_TIMEOUT_MS }, (response) => {
+      const { statusCode } = response;
+      if ([301, 302, 303, 307, 308].includes(statusCode)) {
+        response.resume();
+        if (redirectsLeft <= 0) {
+          reject(new Error('Too many redirects'));
           return;
         }
-        if (statusCode !== 200) {
-          response.resume();
-          reject(new Error(`Download failed with status code ${statusCode}`));
+        const location = response.headers.location;
+        if (!location) {
+          reject(new Error('Redirect response without a location header'));
           return;
         }
-        const chunks = [];
-        response.on('data', (chunk) => chunks.push(chunk));
-        response.on('end', () => resolve(Buffer.concat(chunks)));
-        response.on('error', reject);
-      })
-      .on('error', reject);
+        resolve(download(new URL(location, url).toString(), redirectsLeft - 1));
+        return;
+      }
+      if (statusCode !== 200) {
+        response.resume();
+        reject(new Error(`Download failed with status code ${statusCode}`));
+        return;
+      }
+      const chunks = [];
+      let total = 0;
+      response.on('data', (chunk) => {
+        total += chunk.length;
+        if (total > MAX_DOWNLOAD_BYTES) {
+          response.destroy();
+          req.destroy();
+          reject(new Error(`Download exceeded ${MAX_DOWNLOAD_BYTES} bytes`));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      response.on('end', () => resolve(Buffer.concat(chunks)));
+      response.on('error', reject);
+    });
+    req.on('timeout', () => {
+      req.destroy(new Error(`Download timed out after ${DOWNLOAD_TIMEOUT_MS}ms`));
+    });
+    req.on('error', reject);
   });
 }
 

--- a/src/tensor_grep/core/semantic_index.py
+++ b/src/tensor_grep/core/semantic_index.py
@@ -8,6 +8,12 @@ Layout under the index dir (default ``<root>/.tg_semantic_index/``, overridable 
 Staleness mirrors (does not duplicate) the Rust index.rs mtime semantics: a fingerprint over the
 indexed files' paths + mtimes is stored at build time and re-checked at load; a mismatch warns and
 returns ``None`` so the caller falls back to the unranked path rather than serving stale results.
+
+NOTE: this persisted-index acceleration is NOT yet wired into the CLI. The live ``tg search --rank``
+path ranks in-memory via :mod:`tensor_grep.core.reranker`; there is intentionally no ``tg index``
+command yet. These helpers are the building blocks for a future indexed-acceleration command — the
+stderr messages therefore describe the in-memory fallback rather than instructing a command that
+does not exist.
 """
 
 from __future__ import annotations
@@ -88,8 +94,7 @@ def load_or_warn(index_dir: Path) -> Bm25Index | None:
     meta_path = index_dir / _META_NAME
     if not chunks_path.is_file() or not meta_path.is_file():
         print(
-            f"tg: no semantic index at {index_dir} (run 'tg index --rank' first); "
-            "falling back to unranked results.",
+            f"tg: no persisted semantic index at {index_dir}; falling back to in-memory ranking.",
             file=sys.stderr,
         )
         return None
@@ -99,7 +104,7 @@ def load_or_warn(index_dir: Path) -> Bm25Index | None:
     if current != meta.get("fingerprint"):
         print(
             f"tg: semantic index at {index_dir} is stale (files changed since indexing); "
-            "re-run 'tg index --rank'. Falling back to unranked results.",
+            "falling back to in-memory ranking.",
             file=sys.stderr,
         )
         return None

--- a/tests/unit/test_benchmark_scripts.py
+++ b/tests/unit/test_benchmark_scripts.py
@@ -184,6 +184,28 @@ def _passing_many_pattern_payload(module):
     return payload
 
 
+@pytest.mark.parametrize(
+    "name,rel_path",
+    [
+        ("run_compat_checks_zipslip", "benchmarks/run_compat_checks.py"),
+        ("run_benchmarks_zipslip", "benchmarks/run_benchmarks.py"),
+    ],
+)
+def test_extract_windows_rg_bundle_rejects_zip_slip(name, rel_path, tmp_path):
+    # A crafted rg.zip with a member that escapes the destination (zip-slip) must be REFUSED
+    # before extraction, not written outside benchmarks_dir.
+    module = _load_script_module(name, rel_path)
+    bench_dir = tmp_path / name
+    bench_dir.mkdir()
+    archive = bench_dir / "rg.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("ripgrep/rg.exe", b"binary")
+        zf.writestr("../escape.exe", b"evil")  # escapes benchmarks_dir
+    with pytest.raises(RuntimeError, match="escapes destination"):
+        module.extract_windows_rg_bundle(bench_dir)
+    assert not (tmp_path / "escape.exe").exists(), "zip-slip member was written outside the dir"
+
+
 def test_run_gpu_native_benchmarks_gpu_proof_summary_reports_unsupported_route():
     module = _load_script_module(
         "run_gpu_native_benchmarks_script_gpu_proof_summary",


### PR DESCRIPTION
## Why
The contained, adversarially-verified slice of the supply-chain audit wave — everything that is NOT tamper-prevention code (which lands separately in batch 2 with extra review).

## Fixes
- **#4 SECURITY — zip-slip:** both benchmark `rg.zip` extractors called `extractall()` with no member-path validation → a crafted archive could write outside `benchmarks_dir`. Added the proven member-path guard (mirrors `_safe_extract_zip`). **TDD:** rejects an escaping member, both scripts.
- **#3 — patch-bakeoff:** scenario validation commands ran with no timeout (docs promise 60s) → a hung command stalled the bakeoff. Added a 60s timeout + `TimeoutExpired` handling. `shell=True` kept deliberately — scenarios are trusted, maintainer-authored fixtures (documented inline).
- **#5 — npm/install.js:** `download()` had no request timeout and buffered the full response unbounded. Added a 60s socket timeout + 256 MiB byte cap (still fail-closed checksum-verifies after download).
- **#6 LOW — dead surface:** `semantic_index` told users to run a nonexistent `tg index --rank`; messages now describe the real in-memory fallback, and a docstring documents that the persisted path is not yet CLI-wired.

## Validation
- ruff format `--preview` + lint + mypy clean; 8 affected tests pass (zip-slip ×2, semantic-index ×4, +existing).

## Scope
HIGH items deferred to **batch 2** (with adversarial review): checksum verification in the two native-refresh generated helpers (main.py:1451/:1517 + :10253/:10263) and fail-closed LSP toolchain integrity (Node/rust-analyzer/gopls SHAs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)