### PR TITLE
chore: refresh stale release-proof fields + add test-side zip-slip guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,13 @@ release_docs_current_tag: v1.17.4
 
 As of 2026-06-26, the current tagged release state is `v1.17.4`, and the latest complete public PyPI/release-asset distribution is also `v1.17.4`. The stable installer, release-native asset publication, managed-native `tg upgrade` refresh path, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity fixes, Windows `.cmd` quoted-pattern launcher fix, native-first Windows PATH ordering, top-level validation-command contract, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, explicit language/file-name agent ranking, Windows validation-command quoting, docs/version governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternative-target surfacing, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, agent capsule hardcase routing, Windows subprocess bridge ranking hardening, and long-lived agent-loop memory/cache caps are released through `v1.17.4` GitHub assets and PyPI. Follow-up work should focus on context/session latency, GPU production viability, token economy, call-site evidence, AST parity roadmap, classify provider/cache UX, and keeping docs synchronized with release proof.
 
-- Latest verified release proof PR: #275 `fix(search): tg search --rank errored in plain-text mode`
-- Latest verified release proof merge commit: `a840cd4 fix(search): tg search --rank errored in plain-text mode (#275)`
-- Latest verified release proof commit: `3169980 chore(release): v1.15.1 [skip ci]`
-- Latest verified proof public release PR: #275 `fix(search): tg search --rank errored in plain-text mode`
-- Latest verified proof public release commit: `3169980 chore(release): v1.15.1 [skip ci]`
-- Latest merged fix commit: `a840cd4 fix(search): tg search --rank errored in plain-text mode (#275)`
-- Latest merged feature commit: `5689779 feat: add 'tg orient' — one-call codebase orientation capsule (#274)`
+- Latest verified release proof PR: #285 `fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface)`
+- Latest verified release proof merge commit: `e186aa4 fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface) (#285)`
+- Latest verified release proof commit: `2bf4211 chore(release): v1.17.4 [skip ci]`
+- Latest verified proof public release PR: #285 `fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface)`
+- Latest verified proof public release commit: `2bf4211 chore(release): v1.17.4 [skip ci]`
+- Latest merged fix commit: `e186aa4 fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface) (#285)`
+- Latest merged feature commit: `3a022ec feat: agent-contract completeness signals + Windows LSP / routing / BM25 fixes (#281)`
 - Recent fix commits:
   - `a840cd4 fix(search): tg search --rank errored in plain-text mode (#275)`
   - `1137537 fix(license): declare Apache-2.0 consistently across Cargo.toml + npm (#271)`

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 # tensor-grep Session Handoff
 
-Last updated: 2026-05-26
+Last updated: 2026-06-28
 
 ## Current Release State
 
@@ -8,13 +8,13 @@ release_docs_current_tag: v1.17.4
 
 - Latest tagged version: `v1.17.4`
 - Latest complete PyPI version: `v1.17.4`
-- Latest verified release proof PR: #236 `fix: repair owned python launchers`
-- Latest verified release proof merge commit: `3c0c213 fix: repair owned python launchers`
-- Latest verified release proof commit: `bd7035c chore(release): v1.13.23 [skip ci]`
-- Latest verified proof public release PR: #236 `fix: repair owned python launchers`
-- Latest verified proof public release commit: `bd7035c chore(release): v1.13.23 [skip ci]`
-- Latest fix commit: `3c0c213 fix: repair owned python launchers`
-- Latest feature commit: `a518cc6 feat: add agent success harness`
+- Latest verified release proof PR: #285 `fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface)`
+- Latest verified release proof merge commit: `e186aa4 fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface) (#285)`
+- Latest verified release proof commit: `2bf4211 chore(release): v1.17.4 [skip ci]`
+- Latest verified proof public release PR: #285 `fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface)`
+- Latest verified proof public release commit: `2bf4211 chore(release): v1.17.4 [skip ci]`
+- Latest fix commit: `e186aa4 fix: supply-chain hardening batch 1 (zip-slip, download timeouts/cap, dead surface) (#285)`
+- Latest feature commit: `3a022ec feat: agent-contract completeness signals + Windows LSP / routing / BM25 fixes (#281)`
 - GitHub release: <https://github.com/oimiragieo/tensor-grep/releases/tag/v1.17.4>
 - `v1.11.0` publication caveat: main CI run `25834508800` passed the pre-release matrix and semantic-release, but release-native asset publication was cancelled; `publish-success-gate` failed, `publish-github-release-assets` / `publish-pypi` did not complete, and PyPI latest remains `1.10.10`.
 - Main CI run `26513809791`: passed the pre-release matrix, semantic-release, `publish-github-release-assets`, `publish-pypi`, and `publish-success-gate`

--- a/tests/helpers/rg_parity.py
+++ b/tests/helpers/rg_parity.py
@@ -289,7 +289,10 @@ def resolve_pinned_rg_binary() -> Path | None:
         member = next((name for name in bundle.namelist() if name.endswith("/rg.exe")), None)
         if member is None:
             return None
-        bundle.extractall(benchmarks_dir)
+        # Reuse the production zip-slip guard so a crafted benchmarks/rg.zip can't escape the dir.
+        from tensor_grep.cli.lsp_provider_setup import _safe_extract_zip
+
+        _safe_extract_zip(bundle, benchmarks_dir)
 
     if dev_candidate.is_file():
         return dev_candidate.resolve()

--- a/tests/integration/test_cross_backend.py
+++ b/tests/integration/test_cross_backend.py
@@ -67,7 +67,10 @@ def _resolve_rg_binary() -> Path | None:
                 None,
             )
             if member is not None:
-                bundle.extractall(REPO_ROOT / "benchmarks")
+                # Reuse the production zip-slip guard (a crafted rg.zip must not escape the dir).
+                from tensor_grep.cli.lsp_provider_setup import _safe_extract_zip
+
+                _safe_extract_zip(bundle, REPO_ROOT / "benchmarks")
                 if dev_candidate.exists():
                     return dev_candidate
 


### PR DESCRIPTION
## Why
Two audit follow-ups, both **non-shipped-code** (so `chore:` → no release bump):

- **#5 (test-side zip-slip):** batch 1 added the zip-slip guard to the *benchmark* `rg.zip` extractors, but the **test helpers** (`tests/helpers/rg_parity.py`, `tests/integration/test_cross_backend.py`) still called `extractall()` directly — so CI could regress around a crafted `benchmarks/rg.zip`. Both now reuse the production `_safe_extract_zip` (true DRY, the auditor's suggested fix).
- **#4 (stale release-proof docs):** the headline tag was current (v1.17.4) but the "verified proof" fields pointed at **v1.15.1** (AGENTS.md) and **v1.13.23** (SESSION_HANDOFF.md). Refreshed every proof field to the real v1.17.4 state (#285 / `e186aa4` / `2bf4211`; latest feature `3a022ec`/#281).

## Validation
- ruff format `--preview` + lint clean; 43 docs-governance tests pass (proof edits consistent).

## Follow-up (noted, not in this PR)
Make `stamp_release_assets.py` own the proof fields + add governance validation for proof↔tag consistency — today only `release_docs_current_tag` is checked, which is exactly why the proof fields drifted unnoticed. (Overlaps the intent of the long-open #267.)

The two **HIGH** items — native-refresh checksum (two generated helpers) + LSP toolchain integrity — land in batch 2b with the review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)