### PR TITLE
fix(search): fail-fast on slow searches (60s default, was 600s) + scope-a-path guidance

### DIFF
--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -264,8 +264,10 @@ class RipgrepBackend(ComputeBackend):
             # with the coreutils `timeout` convention instead of letting an uncaught
             # TimeoutExpired traceback abort the stream (audit B5/#10).
             sys.stderr.write(
-                "tensor-grep: ripgrep search exceeded the configured timeout and was "
-                "stopped (adjust TG_RG_TIMEOUT_SECONDS).\n"
+                "tensor-grep: search exceeded the "
+                f"{configured_ripgrep_timeout_seconds():g}s timeout and was stopped. For a large "
+                "repo, scope the search to a path (e.g. `tg search PATTERN src/`), or raise "
+                "TG_RG_TIMEOUT_SECONDS.\n"
             )
             return 124
         return int(result.returncode)

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -702,8 +702,9 @@ def _streaming_passthrough_returncode(
             return int(result.returncode)
         except subprocess.TimeoutExpired:
             sys.stderr.write(
-                "tensor-grep: search exceeded the configured timeout and was stopped "
-                "(adjust TG_RG_TIMEOUT_SECONDS / TG_SUBPROCESS_TIMEOUT_SECONDS).\n"
+                "tensor-grep: search exceeded the configured timeout and was stopped. For a "
+                "large repo, scope the search to a path (e.g. `tg search PATTERN src/`), or raise "
+                "TG_RG_TIMEOUT_SECONDS / TG_SUBPROCESS_TIMEOUT_SECONDS.\n"
             )
             return 124
     # --- end backward-compat shim -------------------------------------------------------

--- a/src/tensor_grep/cli/subprocess_policy.py
+++ b/src/tensor_grep/cli/subprocess_policy.py
@@ -38,7 +38,10 @@ def configured_ripgrep_timeout_seconds() -> float:
             parsed_ms = 0.0
         if parsed_ms > 0:
             return parsed_ms / 1000.0
-    return _configured_positive_float("TG_RG_TIMEOUT_SECONDS", 600.0)
+    # 60s (was 600s): ripgrep does GB/s, so a >60s search means something pathological (scanning
+    # an unexcluded huge/index dir). Fail FAST with guidance instead of a 10-minute hang; an agent
+    # cannot wait 10 minutes. Env-overridable for the rare legitimately-huge monorepo.
+    return _configured_positive_float("TG_RG_TIMEOUT_SECONDS", 60.0)
 
 
 def run_subprocess(

--- a/tests/unit/test_subprocess_policy.py
+++ b/tests/unit/test_subprocess_policy.py
@@ -5,6 +5,20 @@ import subprocess
 from tensor_grep.cli import subprocess_policy
 
 
+def test_ripgrep_timeout_defaults_to_60s(monkeypatch) -> None:
+    # Fail-fast default: ripgrep does GB/s, so a >60s search is pathological; an agent must never
+    # hang ~10 minutes (the old 600s default) before getting an actionable error.
+    monkeypatch.delenv("TG_RG_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("TG_SIDECAR_TIMEOUT_MS", raising=False)
+    assert subprocess_policy.configured_ripgrep_timeout_seconds() == 60.0
+
+
+def test_ripgrep_timeout_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("TG_RG_TIMEOUT_SECONDS", "120")
+    monkeypatch.delenv("TG_SIDECAR_TIMEOUT_MS", raising=False)
+    assert subprocess_policy.configured_ripgrep_timeout_seconds() == 120.0
+
+
 def test_run_subprocess_honors_timeout(monkeypatch) -> None:
     monkeypatch.setenv("TG_SUBPROCESS_TIMEOUT_SECONDS", "1")
 


### PR DESCRIPTION
## Why (dogfood-found)
A whole-repo `tg search --glob "*.py" -l` (no path) **hung ~600s then errored** — the default `TG_RG_TIMEOUT_SECONDS` was **600** (10 minutes). An agent can't wait that long; ripgrep does GB/s, so a >60s search is pathological.

## Fix
- **`configured_ripgrep_timeout_seconds()`: 600 → 60** (env-overridable).
- **Actionable timeout message** in both the full-CLI (`ripgrep_backend`) and bootstrap passthrough paths: "scope the search to a path (e.g. `tg search PATTERN src/`), or raise `TG_RG_TIMEOUT_SECONDS`." The guidance now lives in the **tool's own error**, not in a skill workaround.
- Tests: default == 60.0; env override == 120.0.

## Honest scope
This converts a **10-minute hang into a 60s actionable fail-fast** — the thing that most matters for an agent. It is **not** a speed fix for whole-repo search on huge trees: excluding tg's own index dirs *and* `benchmarks/` did **not** resolve the slowness, so the root cause is deeper in the full-CLI `-l`/`--glob` execution path (globs aren't effectively filtering the walk). The real fix is the **trigram-hybrid index** (broad=index / scoped=rg) from the search-architecture research — tracked separately as the moat item. Workaround remains: scope to a path (now surfaced by the tool).

## Validation
ruff format `--preview` + lint + mypy clean; 29 tests pass (subprocess_policy + ripgrep_backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)