### PR TITLE
fix(lsp): npm install --ignore-scripts (block lifecycle/binding.gyp exec vector)

### DIFF
--- a/src/tensor_grep/cli/lsp_provider_setup.py
+++ b/src/tensor_grep/cli/lsp_provider_setup.py
@@ -326,6 +326,11 @@ def _ensure_node_packages(root: Path) -> None:
             "install",
             "--no-fund",
             "--no-audit",
+            # --ignore-scripts blocks dependency lifecycle scripts (pre/postinstall) AND node-gyp
+            # binding.gyp execution — the #1 npm code-exec vector (the 2026 node-gyp worm). The
+            # managed providers (pyright / typescript-language-server / intelephense) are pure JS
+            # with no native build step, so disabling scripts is safe and needs no selective rebuild.
+            "--ignore-scripts",
             *list(_NODE_PACKAGE_SPECS),
         ],
         cwd=_node_packages_dir(root),

--- a/tests/unit/test_lsp_provider_setup.py
+++ b/tests/unit/test_lsp_provider_setup.py
@@ -242,6 +242,8 @@ def test_ensure_node_packages_should_install_pinned_package_specs(
     assert "typescript@6.0.3" in captured["command"]
     assert "typescript-language-server@5.1.3" in captured["command"]
     assert "intelephense@1.18.0" in captured["command"]
+    # Supply-chain: lifecycle/binding.gyp scripts must be disabled (pure-JS providers need none).
+    assert "--ignore-scripts" in captured["command"]
 
 
 def test_install_managed_lsp_providers_should_not_mutate_toolchains_by_default(


### PR DESCRIPTION
## Why (LSP integrity, Phase 1)
`tg lsp-setup`'s managed Node install ran `npm install` **without `--ignore-scripts`** — a compromised dependency could execute code at install time via `pre`/`postinstall` **or** a weaponized `binding.gyp` (the 2026 node-gyp npm worm, which bypasses lifecycle-script monitoring entirely). The managed providers (pyright / typescript-language-server / intelephense) are **pure JS** with no native build, so disabling scripts is safe and needs no selective rebuild; top-level specs are already version-pinned.

## Fix
Add `--ignore-scripts` to the managed `npm install`. Test asserts it's present.

## Context — thinktank + Exa solution
This is **Phase 1** of the fail-closed LSP toolchain integrity solution (Exa-researched → 4-seat citation-enforced council, unanimous endorse-with-modifications). It's the one no-external-data, zero-break-risk piece. **Phase 2** (separate PR, needs live-feed SHA/version data) lands the rest, in the council's mandated atomic order: committed Node + rust-analyzer SHA tables + a Node verify fn + the **atomic** rust-analyzer fail-open→raise (it currently `warn`s+`return`s on an all-empty SHA table = zero verification on every platform), gopls/csharp-ls version pins + the csharp-ls "already installed" silent-accept fix, a `TG_ALLOW_UNVERIFIED_TOOLCHAIN` opt-out, and a CI SHA-completeness gate.

## Validation
16 tests pass; ruff format `--preview` + lint + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)