### PR TITLE
fix(lsp): pin gopls + csharp-ls versions + fix csharp-ls silent-accept

### DIFF
--- a/src/tensor_grep/cli/lsp_provider_setup.py
+++ b/src/tensor_grep/cli/lsp_provider_setup.py
@@ -42,6 +42,12 @@ _RUST_ANALYZER_SHA256: dict[str, str] = {
     "darwin/arm64": "",
 }
 
+# Pin gopls + csharp-ls to exact versions instead of "latest"/unversioned. Once the version is
+# pinned, integrity is enforced fail-closed by each ecosystem's checksum DB: Go's GOSUMDB
+# (sum.golang.org) for `go install gopls@vX`, and NuGet package signing for the dotnet tool.
+_GOPLS_VERSION = "v0.22.0"
+_CSHARP_LS_VERSION = "0.25.0"
+
 _LANGUAGE_ALIASES = {
     "python": "python",
     "javascript": "javascript",
@@ -475,7 +481,7 @@ def _ensure_gopls(root: Path) -> Path:
     go = shutil.which("go")
     if not go:
         raise RuntimeError("Go toolchain not found; unable to install gopls")
-    _run_checked([go, "install", "golang.org/x/tools/gopls@latest"])
+    _run_checked([go, "install", f"golang.org/x/tools/gopls@{_GOPLS_VERSION}"])
     built = _find_go_binary_name(root, "gopls")
     if built is None:
         raise RuntimeError("Go install completed without a discoverable gopls binary")
@@ -494,11 +500,33 @@ def _ensure_csharp_ls(root: Path) -> Path:
         raise RuntimeError("dotnet not found; unable to install csharp-ls")
     tool_dir = _managed_bin_dir(root)
     tool_dir.mkdir(parents=True, exist_ok=True)
-    install_cmd = [dotnet, "tool", "install", "--tool-path", str(tool_dir), "csharp-ls"]
+    install_cmd = [
+        dotnet,
+        "tool",
+        "install",
+        "--tool-path",
+        str(tool_dir),
+        "--version",
+        _CSHARP_LS_VERSION,
+        "csharp-ls",
+    ]
     completed = subprocess.run(install_cmd, check=False, capture_output=True, text=True)
-    if completed.returncode != 0 and "already installed" not in completed.stderr.lower():
-        update_cmd = [dotnet, "tool", "update", "--tool-path", str(tool_dir), "csharp-ls"]
-        _run_checked(update_cmd)
+    if completed.returncode != 0:
+        if "already installed" in completed.stderr.lower():
+            # A different version may already be on the tool-path; converge it to the pinned
+            # version rather than silently accepting whatever happens to be installed.
+            _run_checked([
+                dotnet,
+                "tool",
+                "update",
+                "--tool-path",
+                str(tool_dir),
+                "--version",
+                _CSHARP_LS_VERSION,
+                "csharp-ls",
+            ])
+        else:
+            raise RuntimeError(f"dotnet tool install csharp-ls failed: {completed.stderr.strip()}")
     if not destination.is_file():
         raise RuntimeError(f"dotnet tool install completed without {destination.name}")
     return destination

--- a/tests/unit/test_lsp_provider_setup.py
+++ b/tests/unit/test_lsp_provider_setup.py
@@ -44,6 +44,92 @@ def test_wrap_windows_batch_command_leaves_real_exe_and_posix_untouched(
     assert provider_setup.wrap_windows_batch_command([]) == []
 
 
+def test_gopls_install_pins_exact_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "providers"
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        provider_setup.shutil, "which", lambda c: None if c == "gopls" else "/usr/bin/go"
+    )
+    monkeypatch.setattr(provider_setup, "_run_checked", lambda cmd, **kw: captured.update(cmd=cmd))
+    built = tmp_path / "gopls"
+    built.write_text("", encoding="utf-8")
+    monkeypatch.setattr(provider_setup, "_find_go_binary_name", lambda *a: built)
+    monkeypatch.setattr(provider_setup, "_copy_binary_to_managed", lambda _b, dest: dest)
+
+    provider_setup._ensure_gopls(root)
+
+    assert f"golang.org/x/tools/gopls@{provider_setup._GOPLS_VERSION}" in captured["cmd"]
+    assert "golang.org/x/tools/gopls@latest" not in captured["cmd"]
+
+
+def test_csharp_ls_install_pins_exact_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "providers"
+    captured: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        provider_setup.shutil, "which", lambda c: None if c == "csharp-ls" else "/usr/bin/dotnet"
+    )
+
+    def _fake_run(cmd, **_kw):
+        captured["cmd"] = cmd
+        dest = provider_setup._managed_bin_binary(root, "csharp-ls")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("", encoding="utf-8")
+        return type("R", (), {"returncode": 0, "stderr": ""})()
+
+    monkeypatch.setattr(provider_setup.subprocess, "run", _fake_run)
+
+    provider_setup._ensure_csharp_ls(root)
+
+    assert "--version" in captured["cmd"]
+    assert provider_setup._CSHARP_LS_VERSION in captured["cmd"]
+
+
+def test_csharp_ls_already_installed_converges_to_pinned_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "providers"
+    update: dict[str, list[str]] = {}
+    monkeypatch.setattr(
+        provider_setup.shutil, "which", lambda c: None if c == "csharp-ls" else "/usr/bin/dotnet"
+    )
+    monkeypatch.setattr(
+        provider_setup.subprocess,
+        "run",
+        lambda cmd, **_kw: type(
+            "R", (), {"returncode": 1, "stderr": "Tool 'csharp-ls' is already installed."}
+        )(),
+    )
+
+    def _fake_run_checked(cmd, **_kw):
+        update["cmd"] = cmd
+        dest = provider_setup._managed_bin_binary(root, "csharp-ls")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(provider_setup, "_run_checked", _fake_run_checked)
+
+    provider_setup._ensure_csharp_ls(root)
+
+    assert "update" in update["cmd"]
+    assert provider_setup._CSHARP_LS_VERSION in update["cmd"]
+
+
+def test_csharp_ls_install_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "providers"
+    monkeypatch.setattr(
+        provider_setup.shutil, "which", lambda c: None if c == "csharp-ls" else "/usr/bin/dotnet"
+    )
+    monkeypatch.setattr(
+        provider_setup.subprocess,
+        "run",
+        lambda cmd, **_kw: type("R", (), {"returncode": 1, "stderr": "network error"})(),
+    )
+    with pytest.raises(RuntimeError, match="csharp-ls failed"):
+        provider_setup._ensure_csharp_ls(root)
+
+
 def test_supported_lsp_languages_should_include_managed_provider_matrix() -> None:
     assert provider_setup.supported_lsp_languages() == [
         "python",


### PR DESCRIPTION
## Why (LSP integrity Phase 2c — audit HIGH #2, final piece)
gopls was installed `@latest` and csharp-ls **unversioned** — a mutated upstream "latest" silently changes the installed binary. Pinning the version makes each ecosystem's checksum DB enforce integrity fail-closed (Go **GOSUMDB**/sum.golang.org for `go install gopls@vX`; **NuGet** package signing for the dotnet tool).

## Fix
- **gopls** `@latest` → **`@v0.22.0`** (`_GOPLS_VERSION`).
- **csharp-ls** gains **`--version 0.25.0`** (`_CSHARP_LS_VERSION`).
- **csharp-ls silent-accept fix:** the "already installed" branch previously did **nothing** (accepting *any* pre-existing version) and only ran `update` on *other* failures. Now it **converges to the pinned version** on already-installed and **raises** on any other install failure (was silently swallowed).

## Validation
20 tests pass (gopls pins exact version / csharp-ls pins `--version` / already-installed converges / other-failure raises); ruff format `--preview` + lint + mypy clean.

## Completes the HIGH
Final piece of the fail-closed LSP toolchain integrity solution alongside **#290** (npm `--ignore-scripts`) and **#291** (Node + rust-analyzer + the broken-Windows fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)