### PR TITLE
fix(install): pin uv to an exact version in the installers (supply-chain)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -450,10 +450,13 @@ Write-Host "=========================================================="
 
 try {
     # 1. Install or locate uv
+    # Pin uv to an exact version for reproducible, supply-chain-safe installs: the versioned astral
+    # installer downloads that exact uv release and verifies its checksum. Bump deliberately.
+    $uvVersion = "0.11.25"
     $uvPath = "uv"
     if (!(Get-Command "uv" -ErrorAction SilentlyContinue)) {
-        Write-Host "[1/4] Downloading uv package manager..."
-        Invoke-WebRequest -Uri "https://astral.sh/uv/install.ps1" -OutFile "$env:TEMP\uv_install.ps1"
+        Write-Host "[1/4] Downloading uv package manager (pinned $uvVersion)..."
+        Invoke-WebRequest -Uri "https://astral.sh/uv/$uvVersion/install.ps1" -OutFile "$env:TEMP\uv_install.ps1"
         & "$env:TEMP\uv_install.ps1"
         $uvPath = "$env:USERPROFILE\.local\bin\uv.exe"
     } else {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -108,9 +108,12 @@ echo "           TENSOR-GREP LINUX/MACOS INSTALLER              "
 echo "=========================================================="
 
 # 1. Install or locate uv
+# Pin uv to an exact version for reproducible, supply-chain-safe installs: the versioned astral
+# installer downloads that exact uv release and verifies its checksum. Bump deliberately.
+UV_VERSION="0.11.25"
 if ! command -v uv &> /dev/null; then
-    echo "[1/4] Downloading uv package manager..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    echo "[1/4] Downloading uv package manager (pinned ${UV_VERSION})..."
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh
     export PATH="$HOME/.local/bin:$PATH"
 else
     echo "[1/4] Found existing uv installation."

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -456,6 +456,22 @@ def test_install_sh_should_refresh_tensor_grep_uv_cache_before_stable_install():
     )
 
 
+def test_install_sh_pins_uv_version():
+    # Supply-chain: bootstrap uv via the versioned (pinned) astral installer URL, never the
+    # unpinned "latest" URL. The versioned installer fetches that exact uv release + verifies it.
+    content = _read_script("scripts/install.sh")
+    assert "astral.sh/uv/install.sh" not in content
+    assert 'UV_VERSION="' in content
+    assert "astral.sh/uv/${UV_VERSION}/install.sh" in content
+
+
+def test_install_ps1_pins_uv_version():
+    content = _read_script("scripts/install.ps1")
+    assert "astral.sh/uv/install.ps1" not in content
+    assert '$uvVersion = "' in content
+    assert "astral.sh/uv/$uvVersion/install.ps1" in content
+
+
 def test_install_sh_should_stage_install_before_replacing_existing_managed_dir():
     content = _read_script("scripts/install.sh")
 


### PR DESCRIPTION
## Why (audit MEDIUM)
The installers bootstrapped uv via the **unpinned** astral URL (`curl https://astral.sh/uv/install.sh | sh`; `Invoke-WebRequest .../uv/install.ps1`) — every run fetched whatever "latest" uv was published, a moving supply-chain dependency.

## Fix
Use the **versioned** astral installer URL (`astral.sh/uv/0.11.25/install.{sh,ps1}`) via a single `UV_VERSION` / `$uvVersion` constant. The versioned installer downloads that exact uv release **and verifies its checksum** → reproducible, supply-chain-safe installs. Verified both versioned URLs resolve (200) before pinning.

## Tests
Regression tests assert both installers use the versioned (pinned) URL and not the bare "latest" one (170 existing install-script tests still pass).

## Deferred (separate, attended)
The semantic-release `build_command` (pyproject.toml:133) also bootstraps unpinned rustup + `pip install uv`. That path is **load-bearing for publishing and untestable locally**, so pinning it is handled separately/attended rather than risk reddening the release pipeline. Tracked with the proof-staleness systemic fix + dependabot policy as the remaining audit-MEDIUM tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)