### PR TITLE
ci(dependabot): require manual review for github-actions updates (no auto-merge)

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -88,10 +88,12 @@ jobs:
           safe="false"
           reason="manual-review"
 
-          if [[ "$PACKAGE_ECOSYSTEM" == "github-actions" && "$UPDATE_TYPE" =~ ^version-update:semver-(minor|patch)$ ]]; then
-            safe="true"
-            reason="github-actions-safe"
-          elif [[ ( "$PACKAGE_ECOSYSTEM" == "uv" || "$PACKAGE_ECOSYSTEM" == "cargo" || "$PACKAGE_ECOSYSTEM" == "npm" ) \
+          # github-actions updates are deliberately NOT auto-merged (supply-chain hardening): an
+          # action/workflow bump changes code that runs in CI AND the release pipeline with repo
+          # write permissions. Even though actions are SHA-pinned, a Dependabot bump repoints the
+          # pin at a new commit, so it must get explicit human review. Direct:production library
+          # updates likewise fall through to manual-review below.
+          if [[ ( "$PACKAGE_ECOSYSTEM" == "uv" || "$PACKAGE_ECOSYSTEM" == "cargo" || "$PACKAGE_ECOSYSTEM" == "npm" ) \
                && ( "$DEPENDENCY_TYPE" == "direct:development" || "$DEPENDENCY_TYPE" == "indirect" ) \
                && "$UPDATE_TYPE" =~ ^version-update:semver-(minor|patch)$ ]]; then
             safe="true"


### PR DESCRIPTION
## Why (audit LOW/MEDIUM)
The Dependabot automation auto-approved + auto-merged **github-actions** semver-minor/patch bumps. A GitHub Actions update changes code that runs in CI **and the release pipeline** with repo write permissions — and even though actions are SHA-pinned, a Dependabot bump repoints the pin at a new commit. That should get **explicit human review** (the auditor's "require explicit review for GitHub Actions updates").

## Fix
Remove `github-actions` from the auto-merge-safe policy so those PRs route to `manual-review`. Unchanged: uv/cargo/npm **dev + indirect** semver-minor/patch still auto-merge (convenience, low risk); **direct:production** already required review.

## Validation
3 dependabot policy tests pass; the **real** `dependabot-automation.yml` passes `validate_dependabot_automation_workflow_content` (contract intact — both `automerge:eligible` and `manual-review` still present). No package change → `ci:` (no release bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)