### PR TITLE
build: pin Rust toolchain (1.96.0) + uv (0.11.25) in the release pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ version_toml = [
     "rust_core/Cargo.toml:package.version",
 ]
 branch = "main"
-build_command = "python scripts/stamp_release_assets.py && git add AGENTS.md README.md SKILL.md docs/SESSION_HANDOFF.md docs/CONTINUATION_PLAN.md docs/CONTRACTS.md docs/benchmarks.md docs/gpu_crossover.md docs/PAPER.md && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && . $HOME/.cargo/env && rustup default stable && cargo generate-lockfile --manifest-path rust_core/Cargo.toml && git add rust_core/Cargo.lock && pip install uv && uv lock --upgrade-package tensor-grep && git add uv.lock && uv build"
+build_command = "python scripts/stamp_release_assets.py && git add AGENTS.md README.md SKILL.md docs/SESSION_HANDOFF.md docs/CONTINUATION_PLAN.md docs/CONTRACTS.md docs/benchmarks.md docs/gpu_crossover.md docs/PAPER.md && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && . $HOME/.cargo/env && rustup default 1.96.0 && cargo generate-lockfile --manifest-path rust_core/Cargo.toml && git add rust_core/Cargo.lock && pip install uv==0.11.25 && uv lock --upgrade-package tensor-grep && git add uv.lock && uv build"
 upload_to_pypi = false
 upload_to_release = true
 commit_message = "chore(release): v{version} [skip ci]"

--- a/rust_core/rust-toolchain.toml
+++ b/rust_core/rust-toolchain.toml
@@ -5,3 +5,7 @@
 # release's `cargo generate-lockfile`). Bump deliberately, in tandem with a green CI matrix.
 [toolchain]
 channel = "1.96.0"
+# Include the components CI uses, so pinning the channel doesn't drop rustfmt/clippy: the
+# "Check Rust Formatting" (cargo fmt) + clippy jobs need them, and a channel-only pin installs
+# the toolchain without them on minimal-profile runners.
+components = ["rustfmt", "clippy"]

--- a/rust_core/rust-toolchain.toml
+++ b/rust_core/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pin the Rust toolchain for reproducible, supply-chain-safe builds (audit MEDIUM). Without this,
+# `rustup default stable` (CI + the semantic-release build_command) picked up "whatever stable is
+# newest that day". 1.96.0 is the stable release the pipeline already builds with — pinning it
+# locks that in. cargo auto-applies this to every invocation in the crate (the CI matrix and the
+# release's `cargo generate-lockfile`). Bump deliberately, in tandem with a green CI matrix.
+[toolchain]
+channel = "1.96.0"


### PR DESCRIPTION
## Why (audit MEDIUM)
The semantic-release `build_command` bootstrapped **moving** toolchains — `rustup default stable` + `pip install uv` (latest) — so every release built against whatever was newest that day (non-reproducible + supply-chain-exposed).

## Fix
- **`rust_core/rust-toolchain.toml`** `channel = "1.96.0"` — the current stable the pipeline already builds with. cargo auto-applies it to **both** the CI matrix and the release's `cargo generate-lockfile`, so **this PR's CI matrix validates the pin** (the part I can't run locally).
- **build_command**: `rustup default stable` → `rustup default 1.96.0`; `pip install uv` → `pip install uv==0.11.25` (matches the installer pin from #293).

## Safety
Both pins are the **exact versions the pipeline already uses successfully** — this locks in known-good, not a version jump. `build:` → no release; the next routine release exercises the pinned commands (loud-fail + revert if ever wrong). 134 release-assets validation tests pass; pyproject TOML valid; validator contract intact (stamp / lockfiles / uv build all preserved).

## Scope
Half of the remaining audit tail (Task #2). The **proof-ledger post-publish automation** is the separate remaining item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)