### PR TITLE
ci: pin uv + Rust toolchain in CI jobs + reject unpinned uv in validator (audit MEDIUM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Build Rust core
         working-directory: rust_core
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         run: uv python install 3.12
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -275,13 +275,13 @@ jobs:
             echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
             export PATH="$HOME/.cargo/bin:$PATH"
           fi
-          rustup default stable
+          rustup default 1.96.0
           rustup component add rustfmt clippy
           rustc --version
           cargo --version
           
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
         
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
         
       - name: Setup Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -353,7 +353,7 @@ jobs:
             echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
             export PATH="$HOME/.cargo/bin:$PATH"
           fi
-          rustup default stable
+          rustup default 1.96.0
           rustc --version
           cargo --version
         
@@ -533,7 +533,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -549,7 +549,7 @@ jobs:
             echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
             export PATH="$HOME/.cargo/bin:$PATH"
           fi
-          rustup default stable
+          rustup default 1.96.0
           rustc --version
           cargo --version
         
@@ -586,7 +586,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         run: uv python install 3.12
@@ -1349,7 +1349,7 @@ jobs:
           ref: v${{ needs.release.outputs.release_version }}
 
       - name: Install uv
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -277,6 +277,15 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
     if uv_bootstrap_count < 2:
         errors.append("CI workflow should bootstrap uv in package-manager/release validation paths")
 
+    # Supply-chain: every `pip install uv` must pin an exact version. An unpinned install pulls a
+    # moving "latest" uv into release-sensitive CI jobs (audit MEDIUM). The lookahead allows
+    # `uv==<version>` and unrelated packages like `uvloop` while rejecting a bare `uv`.
+    if re.search(r"pip install uv(?![=\w])", ci_workflow):
+        errors.append(
+            "CI workflow must pin uv (`pip install uv==<version>`); unpinned `pip install uv` "
+            "is not allowed in release-sensitive jobs"
+        )
+
     if "--pypi-wait-seconds" not in ci_workflow:
         errors.append("CI workflow must pass --pypi-wait-seconds to release parity validation")
 

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -515,6 +515,37 @@ def test_should_require_ci_pypi_parity_retry_arguments():
     assert any("--pypi-poll-interval-seconds" in err for err in errors)
 
 
+def test_should_reject_unpinned_uv_bootstrap_in_ci():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    unpinned = """
+    jobs:
+      x:
+        steps:
+          - run: python -m pip install uv
+          - run: python -m pip install uv
+    """
+    assert any(
+        "must pin uv" in err for err in module.validate_ci_workflow_content(ci_workflow=unpinned)
+    )
+
+    pinned = """
+    jobs:
+      x:
+        steps:
+          - run: python -m pip install uv==0.11.25
+          - run: python -m pip install uv==0.11.25
+    """
+    assert not any(
+        "must pin uv" in err for err in module.validate_ci_workflow_content(ci_workflow=pinned)
+    )
+
+
 def test_should_require_dependabot_config_targets_and_branch_separator():
     root = Path(__file__).resolve().parents[2]
     script_path = root / "scripts" / "validate_release_assets.py"


### PR DESCRIPTION
## Why (audit MEDIUM)
CI/release bootstrap was partly **moving-source**: 10× bare `python -m pip install uv` and 3× `rustup default stable` in `ci.yml` pulled "latest" uv/Rust into release-sensitive jobs, and `validate_release_assets.py` only checked uv was *bootstrapped*, not *pinned*.

## Fix
- **`ci.yml`**: `python -m pip install uv` → **`uv==0.11.25`** (10×, matches the installer pin #293 + release-build pin #295); `rustup default stable` → **`rustup default 1.96.0`** (3×, matches `rust_core/rust-toolchain.toml` from #295). The PR's own CI matrix validates the pinned bootstrap.
- **Validator**: `validate_ci_workflow_content` now **rejects** any unpinned `pip install uv` (regex `pip install uv(?![=\w])` — allows `uv==<ver>` and unrelated `uvloop`, rejects a bare `uv`). Regression test added.

## Validation
135 release-assets validator tests pass; ruff `--preview` + lint clean. (2 pre-existing mypy nits in the script are untouched + not CI-gated.) `ci:` → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)