### PR TITLE
fix(gpu): fail closed on invalid explicit --gpu-device-ids (audit HIGH)

### DIFF
--- a/src/tensor_grep/core/hardware/memory_manager.py
+++ b/src/tensor_grep/core/hardware/memory_manager.py
@@ -100,18 +100,21 @@ class MemoryManager:
             return detected_ids
 
         detected_set = set(detected_ids)
-        normalized: list[int] = []
+        # De-dup requested IDs, preserving order.
+        requested: list[int] = []
         seen: set[int] = set()
         for device_id in preferred_ids:
-            if device_id in seen:
-                continue
-            if device_id in detected_set:
-                normalized.append(device_id)
+            if device_id not in seen:
+                requested.append(device_id)
                 seen.add(device_id)
 
-        # Preserve backward-compatible behavior: if all requested IDs are invalid,
-        # fall back to the detected routable set instead of disabling GPU usage.
-        return normalized if normalized else detected_ids
+        # Fail closed (audit HIGH): explicit device IDs must ALL be routable. Returning the detected
+        # set — or a partial subset — when a requested ID is invalid would silently route work to a
+        # different GPU than asked (e.g. `--gpu-device-ids 9,11` running on `[3,5]`). Returning []
+        # makes the explicit-GPU pipeline raise a clear configuration error instead of mis-routing.
+        if any(device_id not in detected_set for device_id in requested):
+            return []
+        return requested
 
     def get_device_chunk_plan_mb(
         self, preferred_ids: list[int] | None = None

--- a/tests/unit/test_memory_manager.py
+++ b/tests/unit/test_memory_manager.py
@@ -109,17 +109,24 @@ class TestMemoryManager:
         mock_detect.return_value = mock_instance
 
         manager = MemoryManager()
-        assert manager.get_device_ids(preferred_ids=[7, 2, 2, 99]) == [7, 2]
+        # All-valid request is de-duplicated, order preserved.
+        assert manager.get_device_ids(preferred_ids=[7, 2, 2]) == [7, 2]
 
     @patch("tensor_grep.core.hardware.memory_manager.DeviceDetector")
-    def test_should_fallback_to_detected_device_ids_when_preferred_ids_invalid(self, mock_detect):
+    def test_should_fail_closed_when_any_preferred_id_is_invalid(self, mock_detect):
         mock_instance = MagicMock()
         mock_instance.has_gpu.return_value = True
         mock_instance.list_devices.return_value = [MagicMock(device_id=3), MagicMock(device_id=5)]
         mock_detect.return_value = mock_instance
 
         manager = MemoryManager()
-        assert manager.get_device_ids(preferred_ids=[9, 11]) == [3, 5]
+        # All requested IDs invalid -> [] (was the fail-OPEN bug: returned all detected [3, 5],
+        # silently routing `--gpu-device-ids 9,11` to GPUs 3 and 5).
+        assert manager.get_device_ids(preferred_ids=[9, 11]) == []
+        # ANY invalid -> [] (no silent partial routing).
+        assert manager.get_device_ids(preferred_ids=[3, 9]) == []
+        # All valid -> the exact requested set.
+        assert manager.get_device_ids(preferred_ids=[5, 3]) == [5, 3]
 
     @patch("tensor_grep.core.hardware.memory_manager.DeviceDetector")
     def test_should_prefer_public_device_id_enumeration_when_available(self, mock_detect):


### PR DESCRIPTION
## Why (audit HIGH)
`MemoryManager.get_device_ids()` fell back to **all** detected GPUs when every requested explicit ID was invalid (and silently dropped invalid IDs from a partial list). So `--gpu-device-ids 9,11` could route execution to `[3,5]` instead of failing — work runs on a different GPU than asked.

## Fix
Explicit IDs must **all** be routable. If any requested ID isn't in the detected set, `get_device_ids` returns **`[]`** (fail-closed). The explicit-GPU pipeline already turns an empty chunk plan into a clear configuration error (`_raise_explicit_gpu_configuration_error`), so the user gets a **visible error** rather than silent mis-routing. The auto-detect path (no explicit IDs) is unchanged.

## Tests
all-invalid → `[]`; any-invalid → `[]`; all-valid → exact requested set (de-duped). The former "preserve the fallback" test is flipped to assert fail-closed. 14 memory_manager + 6 device_detector + 8 explicit-GPU tests pass; ruff/mypy clean.

## Related
Part of the 2026-06-29 audit batch. The companion cuDF device-*binding* HIGH (reports selected IDs without binding the CUDA context) is the next fix; GPU production-readiness is the multi-week native-backend program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)