### PR TITLE
ci: pin uv in public-gpu-proof workflow + reject unpinned uv in its validator

### DIFF
--- a/.github/workflows/public-gpu-proof.yml
+++ b/.github/workflows/public-gpu-proof.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install uv
         shell: bash
-        run: python -m pip install uv
+        run: python -m pip install uv==0.11.25
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -1458,6 +1458,15 @@ def validate_dependabot_config(*, dependabot_content: str) -> list[str]:
 def validate_public_gpu_proof_workflow_content(*, workflow_content: str) -> list[str]:
     workflow_content = _normalize_pinned_actions(workflow_content)
     errors: list[str] = []
+
+    # Supply-chain: pin uv like the main CI bootstrap (audit MEDIUM). The lookahead allows
+    # `uv==<version>` and unrelated packages (uvloop) while rejecting a bare `uv`.
+    if re.search(r"pip install uv(?![=\w])", workflow_content):
+        errors.append(
+            "Public GPU proof workflow must pin uv (`pip install uv==<version>`); unpinned uv "
+            "is not allowed"
+        )
+
     try:
         parsed = yaml.safe_load(workflow_content) or {}
     except yaml.YAMLError as exc:

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -546,6 +546,26 @@ def test_should_reject_unpinned_uv_bootstrap_in_ci():
     )
 
 
+def test_should_reject_unpinned_uv_in_public_gpu_proof_workflow():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    unpinned = "steps:\n  - run: python -m pip install uv\n"
+    assert any(
+        "pin uv" in err
+        for err in module.validate_public_gpu_proof_workflow_content(workflow_content=unpinned)
+    )
+    pinned = "steps:\n  - run: python -m pip install uv==0.11.25\n"
+    assert not any(
+        "pin uv" in err
+        for err in module.validate_public_gpu_proof_workflow_content(workflow_content=pinned)
+    )
+
+
 def test_should_require_dependabot_config_targets_and_branch_separator():
     root = Path(__file__).resolve().parents[2]
     script_path = root / "scripts" / "validate_release_assets.py"


### PR DESCRIPTION
## Why (audit MEDIUM, follow-up to #298)
#298 pinned uv in `ci.yml` but **missed `public-gpu-proof.yml`**, which still ran bare `python -m pip install uv`, and `validate_public_gpu_proof_workflow_content` passed regardless.

## Fix
- `public-gpu-proof.yml`: `python -m pip install uv` → **`uv==0.11.25`**.
- `validate_public_gpu_proof_workflow_content`: add the same reject-unpinned-uv check used for `ci.yml` (regex `pip install uv(?![=\w])`).

## Validation
Regression test added; the real `public-gpu-proof.yml` validates clean (0 errors). 5 related validator tests pass; ruff `--preview` + lint clean. `ci:` → no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)