### PR TITLE
fix(sidecar): runtime-routing merge + GPU proof contract fields (audit HIGH 1&2)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6103,7 +6103,7 @@ def search_command(
     config.input_total_bytes = _sum_total_bytes(candidate_files_ordered)
 
     from tensor_grep.core.pipeline import Pipeline
-    from tensor_grep.core.result import SearchResult
+    from tensor_grep.core.result import SearchResult, merge_runtime_routing
 
     pipeline = Pipeline(force_cpu=effective_force_cpu, config=config)
     backend = pipeline.get_backend()
@@ -6166,23 +6166,7 @@ def search_command(
         matched_file_paths_ordered.append(file_path)
 
     def _merge_runtime_routing(result: SearchResult) -> None:
-        # Runtime routing metadata is authoritative when a backend internally
-        # falls back (for example Torch -> CPU for unsupported regex paths).
-        if result.routing_backend:
-            all_results.routing_backend = result.routing_backend
-            all_results.routing_gpu_device_ids = list(result.routing_gpu_device_ids)
-            all_results.routing_gpu_chunk_plan_mb = list(result.routing_gpu_chunk_plan_mb)
-        elif result.routing_gpu_device_ids or result.routing_gpu_chunk_plan_mb:
-            all_results.routing_gpu_device_ids = list(result.routing_gpu_device_ids)
-            all_results.routing_gpu_chunk_plan_mb = list(result.routing_gpu_chunk_plan_mb)
-        if result.routing_reason:
-            all_results.routing_reason = result.routing_reason
-        all_results.routing_distributed = (
-            all_results.routing_distributed or result.routing_distributed
-        )
-        all_results.routing_worker_count = max(
-            all_results.routing_worker_count, result.routing_worker_count
-        )
+        merge_runtime_routing(all_results, result)
 
     def _merge_count_metadata(result: SearchResult) -> None:
         for file_path, count in result.match_counts_by_file.items():

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -39,7 +39,7 @@ from tensor_grep.cli.scan_guardrails import BroadScanRefusedError
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.hardware.device_inventory import collect_device_inventory
 from tensor_grep.core.pipeline import Pipeline
-from tensor_grep.core.result import SearchResult
+from tensor_grep.core.result import SearchResult, merge_runtime_routing
 from tensor_grep.io.directory_scanner import DirectoryScanner
 
 
@@ -1389,19 +1389,7 @@ def _selected_gpu_execution_defaults(
 
 
 def _merge_runtime_routing(all_results: SearchResult, result: SearchResult) -> None:
-    if result.routing_backend:
-        all_results.routing_backend = result.routing_backend
-        all_results.routing_gpu_device_ids = list(result.routing_gpu_device_ids)
-        all_results.routing_gpu_chunk_plan_mb = list(result.routing_gpu_chunk_plan_mb)
-    elif result.routing_gpu_device_ids or result.routing_gpu_chunk_plan_mb:
-        all_results.routing_gpu_device_ids = list(result.routing_gpu_device_ids)
-        all_results.routing_gpu_chunk_plan_mb = list(result.routing_gpu_chunk_plan_mb)
-    if result.routing_reason:
-        all_results.routing_reason = result.routing_reason
-    all_results.routing_distributed = all_results.routing_distributed or result.routing_distributed
-    all_results.routing_worker_count = max(
-        all_results.routing_worker_count, result.routing_worker_count
-    )
+    merge_runtime_routing(all_results, result)
 
 
 def _merge_count_metadata(all_results: SearchResult, result: SearchResult) -> None:

--- a/src/tensor_grep/core/result.py
+++ b/src/tensor_grep/core/result.py
@@ -29,3 +29,26 @@ class SearchResult:
     @property
     def is_empty(self) -> bool:
         return self.total_matches == 0
+
+
+def merge_runtime_routing(aggregate: SearchResult, result: SearchResult) -> None:
+    """Merge a backend's runtime routing metadata into an aggregate result.
+
+    Runtime routing is authoritative when a backend internally falls back (for example
+    Torch -> CPU for unsupported regex paths), so an aggregate seeded from the *selected*
+    backend must adopt the runtime values rather than keep reporting the planned route.
+    Shared by the CLI, MCP, and GPU-sidecar paths so the merge semantics cannot drift.
+    """
+    if result.routing_backend:
+        aggregate.routing_backend = result.routing_backend
+        aggregate.routing_gpu_device_ids = list(result.routing_gpu_device_ids)
+        aggregate.routing_gpu_chunk_plan_mb = list(result.routing_gpu_chunk_plan_mb)
+    elif result.routing_gpu_device_ids or result.routing_gpu_chunk_plan_mb:
+        aggregate.routing_gpu_device_ids = list(result.routing_gpu_device_ids)
+        aggregate.routing_gpu_chunk_plan_mb = list(result.routing_gpu_chunk_plan_mb)
+    if result.routing_reason:
+        aggregate.routing_reason = result.routing_reason
+    aggregate.routing_distributed = aggregate.routing_distributed or result.routing_distributed
+    aggregate.routing_worker_count = max(
+        aggregate.routing_worker_count, result.routing_worker_count
+    )

--- a/src/tensor_grep/sidecar.py
+++ b/src/tensor_grep/sidecar.py
@@ -361,7 +361,7 @@ def _gpu_runtime_error(requested_ids: Sequence[int], exc: Exception) -> str:
 def _gpu_search(payload: dict[str, Any]) -> tuple[str, str, int]:
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.pipeline import ConfigurationError, Pipeline
-    from tensor_grep.core.result import SearchResult
+    from tensor_grep.core.result import SearchResult, merge_runtime_routing
     from tensor_grep.io.directory_scanner import DirectoryScanner
 
     pattern = payload.get("pattern", "")
@@ -454,6 +454,7 @@ def _gpu_search(payload: dict[str, Any]) -> tuple[str, str, int]:
         candidate_files = list(scanner.walk(path))
 
         all_results = SearchResult(matches=[], total_files=0, total_matches=0)
+        all_results.sidecar_used = True
         all_results.requested_gpu_device_ids = list(requested_gpu_device_ids)
         all_results.routing_backend = getattr(
             pipeline, "selected_backend_name", backend.__class__.__name__
@@ -469,6 +470,7 @@ def _gpu_search(payload: dict[str, Any]) -> tuple[str, str, int]:
         for current_file in candidate_files:
             for pattern_id, current_pattern in enumerate(search_patterns):
                 result = backend.search(current_file, current_pattern, config=config)
+                merge_runtime_routing(all_results, result)
                 all_results.matches.extend(result.matches)
                 all_results.total_matches += result.total_matches
                 for fp, count in result.match_counts_by_file.items():
@@ -495,13 +497,16 @@ def _gpu_search(payload: dict[str, Any]) -> tuple[str, str, int]:
     if payload.get("json"):
         import json as json_mod
 
+        from tensor_grep.cli.formatters.json_fmt import _routing_envelope
+
+        # Reuse the canonical routing envelope so the sidecar emits the SAME routing +
+        # GPU proof/unsupported contract fields as the CLI/MCP JSON path (sidecar_used,
+        # gpu_evidence_status, gpu_proof, native_gpu_unavailable, not_gpu_proof_reason)
+        # instead of a hand-built subset that silently drifts from docs/CONTRACTS.md.
         response = {
+            **_routing_envelope(all_results),
             "total_matches": all_results.total_matches,
             "total_files": all_results.total_files,
-            "routing_backend": all_results.routing_backend,
-            "routing_reason": all_results.routing_reason,
-            "requested_gpu_device_ids": all_results.requested_gpu_device_ids,
-            "routing_gpu_device_ids": all_results.routing_gpu_device_ids,
             "matches": serialized_matches,
         }
         return json_mod.dumps(response) + "\n", "", 0

--- a/tests/unit/test_gpu_sidecar_routing.py
+++ b/tests/unit/test_gpu_sidecar_routing.py
@@ -199,3 +199,71 @@ class TestSidecarGpuSearchDispatch:
         assert payload["routing_gpu_device_ids"] == [0]
         assert payload["matches"][0]["file"].endswith("keep.txt")
         assert captured_configs[0].glob == ["*.txt"]
+
+    def test_gpu_search_json_reports_runtime_cpu_fallback_and_contract_fields(
+        self, tmp_path, monkeypatch
+    ):
+        """Audit HIGH #1+#2: when the backend falls back to CPU at runtime, the sidecar JSON
+        must report the RUNTIME routing (not the selected GPU route) and expose the GPU
+        proof/unsupported contract fields (docs/CONTRACTS.md) — not a hand-built subset."""
+        from tensor_grep import sidecar as sidecar_mod
+        from tensor_grep.core.result import MatchLine, SearchResult
+
+        corpus_dir = tmp_path / "corpus"
+        corpus_dir.mkdir()
+        (corpus_dir / "a.log").write_text("ERROR boom\n", encoding="utf-8")
+
+        class CpuFallbackBackend:
+            def search(self, current_file: str, current_pattern: str, config=None):
+                return SearchResult(
+                    matches=[MatchLine(line_number=1, text="ERROR boom", file=current_file)],
+                    total_files=1,
+                    total_matches=1,
+                    routing_backend="NativeCpuBackend",
+                    routing_reason="gpu-auto-fallback-cpu",
+                )
+
+        class FakePipeline:
+            def __init__(self, config):
+                self.selected_backend_name = "FakeGpuBackend"
+                self.selected_backend_reason = "gpu-device-ids-explicit"
+                self.selected_gpu_device_ids = [0]
+                self._backend = CpuFallbackBackend()
+
+            def get_backend(self):
+                return self._backend
+
+        monkeypatch.setattr(sidecar_mod, "_detect_available_gpu_device_ids", lambda: [0])
+        monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", FakePipeline)
+
+        request: dict[str, Any] = {
+            "command": "gpu_search",
+            "args": [],
+            "payload": {
+                "pattern": "ERROR",
+                "path": str(corpus_dir),
+                "gpu_device_ids": [0],
+                "ignore_case": False,
+                "fixed_strings": False,
+                "invert_match": False,
+                "count": False,
+                "word_regexp": False,
+                "no_ignore": False,
+                "json": True,
+            },
+        }
+
+        stdout, stderr, exit_code = sidecar_mod._dispatch_request(request)
+
+        assert exit_code == 0, stderr
+        payload = json.loads(stdout)
+        # #1: runtime routing is authoritative over the selected GPU route
+        assert payload["routing_backend"] == "NativeCpuBackend"
+        assert payload["routing_reason"] == "gpu-auto-fallback-cpu"
+        # #2: GPU proof/unsupported contract fields are present and correct
+        assert payload["sidecar_used"] is True
+        assert payload["gpu_evidence_status"] == "unsupported"
+        assert payload["gpu_proof"] is False
+        assert payload["native_gpu_unavailable"] is True
+        assert payload["not_gpu_proof_reason"]
+        assert payload["requested_gpu_device_ids"] == [0]


### PR DESCRIPTION
**Draft** — fixes the two HIGH findings from the 2026-06-29 read-only audit. The GPU sidecar diverged from the CLI/MCP JSON path: it reported the *selected* route even on a runtime CPU fallback, and hand-built a JSON subset missing the GPU proof/unsupported contract fields.

## Fixes
- **HIGH #1 — runtime routing now authoritative in the sidecar.** Extracted a single shared `merge_runtime_routing(aggregate, result)` into `core/result.py`; the CLI (`main.py`) and MCP (`mcp_server.py`) nested/duplicate closures now call it, and the sidecar loop calls it after each `backend.search()`. So a Torch→CPU fallback is reported as `NativeCpuBackend`, not the selected GPU route. (No more drift between the three paths — the finding's explicit ask.)
- **HIGH #2 — sidecar JSON now uses the canonical envelope.** `_gpu_search` builds its JSON via `json_fmt._routing_envelope(all_results)` + sets `sidecar_used=True`, so it emits `sidecar_used`, `gpu_evidence_status`, `gpu_proof`, `native_gpu_unavailable`, `not_gpu_proof_reason` per docs/CONTRACTS.md — instead of a hand-built subset.

## Verification
- New regression test `test_gpu_search_json_reports_runtime_cpu_fallback_and_contract_fields` proves the fallback case (the existing test used an empty-routing fake, so it never exercised the merge).
- 140 sidecar+MCP tests pass; 16 CLI routing/fallback tests pass; ruff `--preview` + mypy clean on all changed files.

## Not in this PR (remaining audit findings, triaged separately)
#3 pipe-to-shell bootstrap (posture/trust-boundary), #4 dtolnay action-pin doc honesty, #5 release-proof staleness (release-workflow-attended per prior memory), #6 issue-template version placeholders — doc/governance items handled as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)