### PR TITLE
docs: issue-template version + dtolnay action-pin honesty (audit #4/#6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: tensor-grep version
       description: Run `tg --version` or `python -m tensor_grep --version`.
-      placeholder: "tensor-grep 1.13.26"
+      placeholder: "output of tg --version (e.g. tensor-grep 1.17.x)"
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: tensor-grep version
-      placeholder: "tensor-grep 1.13.26"
+      placeholder: "output of tg --version (e.g. tensor-grep 1.17.x)"
     validations:
       required: false
   - type: dropdown

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,7 @@ Recent v1.13.40-v1.13.42 hardening (newest behavior agents should rely on):
 - **MCP apply safety:** the `tg_rewrite_apply` MCP tool refuses free-form `lint_cmd` / `test_cmd` (which shell-execute on the host) unless the operator opts in with `TG_MCP_ALLOW_VALIDATION_COMMANDS=1`; otherwise it returns `code="unsupported_option"`.
 - **grep parity:** `tg search --cpu -v` now includes blank lines, and `--json` / `--vimgrep` columns are byte offsets (ripgrep-accurate on non-ASCII lines).
 - **Agentic-edit integrity:** the audit-manifest chain records only verified manifests (a tampered manifest is no longer folded into the tamper-evident history), and the trigram index deserializer is hardened against a preallocation/OOM DoS from a crafted `.tensor-grep` index.
-- **Supply chain:** the `[tool.uv].constraint-dependencies` security floors track the latest patched releases, all third-party GitHub Actions are SHA-pinned, and the `Dependency & License Audit` gate is green.
+- **Supply chain:** the `[tool.uv].constraint-dependencies` security floors track the latest patched releases, third-party GitHub Actions are SHA-pinned (the one allow-listed exception is `dtolnay/rust-toolchain@stable`, intentionally channel-pinned — see the validator exemption in `scripts/validate_release_assets.py`), and the `Dependency & License Audit` gate is green.
 
 Current release facts:
 


### PR DESCRIPTION
**Draft** — the two cleanly-scoped MEDIUM/LOW doc findings from the 2026-06-29 audit (conflict-free with PR #303, which touches `.claude/skills/` not these files).

- **#6 [LOW]** — issue templates hard-coded `tensor-grep 1.13.26` (vs current v1.17.11). Now a generic `output of tg --version (e.g. tensor-grep 1.17.x)` in both `bug_report.yml` + `question.yml` so they don't drift each release.
- **#4 [MEDIUM]** — repo `SKILL.md:20` claimed *all* third-party Actions are SHA-pinned, but `dtolnay/rust-toolchain@stable` is an intentional, validator-allow-listed exception. Doc now states the exception honestly (points at `scripts/validate_release_assets.py`).

Verified: 64 doc/issue-governance tests pass.

## Deferred (tracked in Task #5)
- **#3a / #5** both edit AGENTS.md in the same supply-chain area PR #303 touches — handling them after #303 merges to avoid a merge conflict. #3b (de-pipe rustup) + #5-systemic (proof auto-update governance) are release-workflow-attended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)