### PR TITLE
docs(gpu): label Dockerfile.gpu experimental + clarify gpu extras vs managed installer (audit MED #2/#3)

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,3 +1,9 @@
+# EXPERIMENTAL — cuDF GPU *sidecar* image, NOT the production native-GPU front door.
+# This builds the Python cuDF/Torch sidecar path (CUDA 12.4 runtime, no `--features cuda`),
+# which routes as GpuSidecar (sidecar_used=true), NOT NativeGpuBackend. The production
+# "public managed NVIDIA front door" proof path is the native CUDA build (rust_core / cudarc
+# cuda-13010) + the public-gpu-proof workflow — see docs/gpu_crossover.md and docs/CONTRACTS.md.
+# A successful build of this image is NOT native-GPU promotion proof.
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS builder
 
 # Set up non-interactive build environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# NOTE: these `gpu`/`gpu-win` extras are UNPINNED convenience deps and may resolve to a CPU-only
+# or CUDA-mismatched torch. The SUPPORTED GPU runtime path is the managed installer
+# (scripts/install.sh / install.ps1), which deliberately installs pinned CUDA 12.8 wheels.
+# `pip install tensor-grep[gpu]` is best-effort experimental, not the supported managed GPU path.
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "torch_geometric>=2.5.0"]
 gpu-win = ["torch>=2.0", "torch_geometric>=2.5.0"]
 nlp = ["transformers>=4.40", "tritonclient[http]"]


### PR DESCRIPTION
**Draft** — two MEDIUM GPU-packaging clarity findings from the 2nd 2026-06-29 audit. Doc/comment-only, no behavior change.

- **#2** — `Dockerfile.gpu` (CUDA 12.4, no `--features cuda`) is stale vs the native CUDA proof path (cudarc cuda-13010). Added a header making explicit it's the **experimental cuDF *sidecar* image** (routes GpuSidecar / sidecar_used=true), **not** the production native-GPU front door, and a successful build is not native-GPU promotion proof.
- **#3** — `pyproject.toml` `[gpu]`/`[gpu-win]` extras are unpinned (`torch>=2.0`) and can resolve CPU-only/CUDA-mismatched. Added a note that the **supported** GPU runtime is the managed installer (pinned CUDA 12.8 wheels); `pip install tensor-grep[gpu]` is best-effort experimental.

Verified: pyproject.toml parses; 58 docs-governance tests pass.

Part of the audit-#2 batch (Task #6). Sibling fixes: cuDF line-delimiter parity (#4) pushed to PR #302; release.yml gating (HIGH #1) + cuDF chunk-boundary (#5, GPU-gated) tracked next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)