### PR TITLE
ci(release): gate release.yml behind workflow_dispatch (audit HIGH)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Release
+# Manual/backfill release-asset pipeline ONLY. The authoritative release path is ci.yml
+# semantic-release on `main`. This is workflow_dispatch (NOT tag-push) so a manually-pushed
+# v* tag can no longer bypass semantic-release and auto-publish npm/assets (audit HIGH).
+# To backfill a published tag's assets, dispatch this workflow TARGETING that tag ref
+# (`gh workflow run release.yml --ref vX.Y.Z`); GITHUB_REF then resolves to refs/tags/vX.Y.Z
+# and every `${GITHUB_REF#refs/tags/...}` step below works unchanged.
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 jobs:
   validate-release-assets:

--- a/docs/CI_PIPELINE.md
+++ b/docs/CI_PIPELINE.md
@@ -46,7 +46,7 @@ Benchmark behavior:
 
 ### `release.yml`
 
-Manual/backfill release artifact pipeline for tag refs. Do not rely on it for the normal semantic-release path: tags created with the default `GITHUB_TOKEN` do not trigger a separate tag-push workflow run. The authoritative release-bearing path is now `ci.yml` on `main`: semantic-release creates the tag/release, main CI checks the action's `released` output, builds release-native CPU front-door assets from that tag, uploads them to the GitHub release, verifies checksum/package-manager coverage, then allows PyPI publish and `publish-success-gate` to complete.
+Manual/backfill release artifact pipeline, dispatched via `workflow_dispatch` TARGETING a published tag ref (`gh workflow run release.yml --ref vX.Y.Z`; `GITHUB_REF` then resolves to that tag). It is NOT triggered by a tag push, so a manually-pushed `v*` tag can no longer bypass semantic-release to auto-publish npm/assets (audit HIGH, hardened 2026-06-29). Do not rely on it for the normal semantic-release path. The authoritative release-bearing path is now `ci.yml` on `main`: semantic-release creates the tag/release, main CI checks the action's `released` output, builds release-native CPU front-door assets from that tag, uploads them to the GitHub release, verifies checksum/package-manager coverage, then allows PyPI publish and `publish-success-gate` to complete.
 
 ### `benchmark.yml` (Benchmarks)
 

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -2351,8 +2351,10 @@ def validate_release_workflow_content(*, release_workflow: str) -> list[str]:
     errors: list[str] = []
     for expected in (
         "on:",
-        "tags:",
-        "- 'v*'",
+        # release.yml is workflow_dispatch-only (NOT tag-push) so a manually-pushed v* tag
+        # cannot bypass semantic-release and auto-publish (audit HIGH, 2026-06-29). Backfill is
+        # via `gh workflow run release.yml --ref vX.Y.Z`; the body still uses ${GITHUB_REF#refs/tags/}.
+        "workflow_dispatch:",
         "validate-release-assets:",
         "validate-package-managers:",
         "build-binaries:",


### PR DESCRIPTION
**Draft** — fixes the HIGH finding from the 2nd 2026-06-29 audit.

## Problem
`release.yml` ran on `on: push: tags: v*` and creates GitHub release assets + publishes npm with `NPM_TOKEN` — but docs say it is only the manual/backfill path (authoritative path = `ci.yml` semantic-release on `main`). A manually-pushed `v*` tag could therefore bypass semantic-release and auto-publish.

## Fix (minimal, body unchanged)
Swap the trigger `on: push: tags: v*` → `on: workflow_dispatch:`. The body uses `${GITHUB_REF#refs/tags/...}` in 11 places; when the workflow is **dispatched targeting a tag ref** (`gh workflow run release.yml --ref vX.Y.Z`), `GITHUB_REF` resolves to `refs/tags/vX.Y.Z`, so every step works **unchanged** — only the auto-trigger-on-tag-push is removed. CI_PIPELINE.md updated to document the dispatch usage.

This matches the workflow's already-documented "manual/backfill" intent and closes the bypass.

## Verified
release.yml parses (`on = workflow_dispatch`); 69 workflow-config + docs-governance tests pass (they assert the `GITHUB_REF` body, which is unchanged). YAML-only change — can't runtime-test a workflow, validated structurally.

Further hardening (a protected `environment:` on the publish jobs) requires repo-settings config → left for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)