### PR TITLE
fix: native delegation line-number + rust passthrough exit status + drop dead scanner path (audit #1/#2/#4)

### DIFF
--- a/src/tensor_grep/backends/rust_backend.py
+++ b/src/tensor_grep/backends/rust_backend.py
@@ -233,11 +233,14 @@ class RustCoreBackend(ComputeBackend):
                     pcre2,
                     max_filesize,
                 )
-                # Results are emitted directly to stdout by ripgrep binary
+                # Results are emitted directly to stdout by the ripgrep binary, so the exact match
+                # count is unknowable here. Reflect FOUND-vs-NOT-FOUND via rg's exit code (0 = at
+                # least one match) so the CLI reports the correct exit status / is_empty instead of
+                # treating a non-empty passthrough result as empty (and exiting 1 on a real match).
                 return SearchResult(
                     matches=[],
                     total_files=1 if exit_code == 0 else 0,
-                    total_matches=0,  # Unknown without parsing
+                    total_matches=1 if exit_code == 0 else 0,
                     routing_backend="RustCoreBackend",
                     routing_reason="rust_pcre2_passthrough" if pcre2 else "rust_limit_passthrough",
                     routing_distributed=False,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3277,6 +3277,11 @@ def _build_native_tg_search_command(
         command.append("-v")
     if config.count:
         command.append("-c")
+    # Forward an EXPLICIT line-number choice only. The native subprocess inherits tg's stdout, so its
+    # own tty heuristic already matches tg's auto decision; we only need to forward when the user
+    # explicitly set --line-number/-n or --no-line-number/-N (otherwise that choice is dropped).
+    if config.line_number_explicit:
+        command.append("-n" if config.line_number else "-N")
     if config.column:
         command.append("--column")
     if config.context is not None:
@@ -5837,6 +5842,9 @@ def search_command(
                     )
                 sys.exit(2)
 
+    # Capture whether the user explicitly chose a line-number mode BEFORE auto-resolving (so native
+    # delegation can forward only an explicit -n/-N and leave the auto case to the native binary).
+    line_number_explicit = bool(no_line_number) or line_number is True
     if no_line_number:
         line_number = False
     elif line_number is None:
@@ -5967,6 +5975,7 @@ def search_command(
         line_buffered=line_buffered,
         no_line_buffered=no_line_buffered,
         line_number=line_number,
+        line_number_explicit=line_number_explicit,
         max_columns=max_columns,
         max_columns_preview=max_columns_preview,
         no_max_columns_preview=no_max_columns_preview,

--- a/src/tensor_grep/core/config.py
+++ b/src/tensor_grep/core/config.py
@@ -114,6 +114,10 @@ class SearchConfig:
     line_buffered: bool = False
     no_line_buffered: bool = False
     line_number: bool = True
+    # True when the user explicitly set --line-number/-n or --no-line-number/-N (vs tty-auto). Used by
+    # native delegation to forward the explicit choice; the auto case is left to the native binary's
+    # own (inherited-stdout) tty heuristic.
+    line_number_explicit: bool = False
     max_columns: int | None = None
     max_columns_preview: bool = False
     no_max_columns_preview: bool = False

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -1,6 +1,5 @@
 import fnmatch
 import os
-import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -28,17 +27,12 @@ _GENERATED_RELATIVE_DIRS = {
     ".claude/context",
 }
 
-# Attempt to load the blazing fast Rust PyO3 gitignore scanner
-try:
-    if "pytest" not in sys.modules:
-        from tensor_grep.rust_core import RustDirectoryScanner
-
-        HAS_RUST_SCANNER = True
-    else:
-        # Avoid linking errors in mocked test environments
-        HAS_RUST_SCANNER = False
-except (ImportError, ModuleNotFoundError):
-    HAS_RUST_SCANNER = False
+# The Rust PyO3 directory scanner (`RustDirectoryScanner`) is NOT exported by the `rust_core`
+# extension (only `RustBackend` + functions are), so the old `from rust_core import
+# RustDirectoryScanner` always raised and this flag was permanently False — the Python walk below was
+# always the only scan path. Kept as a documented flag so a future native scanner can re-enable a
+# fast path (which must also export the class) without re-plumbing the call site.
+HAS_RUST_SCANNER = False
 
 
 class DirectoryScanner:
@@ -91,23 +85,8 @@ class DirectoryScanner:
                 yield str(base_path)
             return
 
-        # Use the highly-optimized Rust PyO3 `ignore` crate if available
-        if (
-            HAS_RUST_SCANNER
-            and not self.config.glob
-            and not self.config.file_type
-            and not self.config.type_not
-            and not self._requires_python_guardrails(base_path)
-        ):
-            # Keep Python-side walking only for direct files or Python-only filters.
-            scanner = RustDirectoryScanner(
-                hidden=self.config.hidden, max_depth=self.config.max_depth
-            )
-            for file_path in scanner.walk(path_str):
-                yield file_path
-            return
-
-        # Python Fallback Path
+        # Python scan path (the only path — the native RustDirectoryScanner fast path was never
+        # exported by rust_core; see HAS_RUST_SCANNER above).
         max_depth = self.config.max_depth
         base_depth = len(base_path.parts)
         ignore_spec = self._load_ignore_spec(base_path)

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2837,6 +2837,35 @@ def test_cli_should_delegate_native_rg_output_flags(monkeypatch):
     assert seen["check"] is False
 
 
+def test_native_delegation_forwards_resolved_line_number():
+    """The native argv builder must forward the resolved line-number decision (-n when shown, -N when
+    suppressed). Otherwise an explicit --line-number/--no-line-number is silently dropped: the native
+    subprocess re-derives line numbers from its own tty heuristic and ignores tg's resolved choice."""
+    from tensor_grep.cli.main import _build_native_tg_search_command
+    from tensor_grep.core.config import SearchConfig
+
+    def _cmd(line_number: bool) -> list[str]:
+        return _build_native_tg_search_command(
+            Path("tg.exe"),
+            pattern="needle",
+            paths=["file.txt"],
+            config=SearchConfig(force_cpu=True, line_number=line_number, line_number_explicit=True),
+            ndjson=False,
+        )
+
+    assert "-n" in _cmd(True) and "-N" not in _cmd(True)
+    assert "-N" in _cmd(False) and "-n" not in _cmd(False)
+    # auto (non-explicit) must NOT forward — the native binary inherits tg's tty heuristic
+    auto_cmd = _build_native_tg_search_command(
+        Path("tg.exe"),
+        pattern="needle",
+        paths=["file.txt"],
+        config=SearchConfig(force_cpu=True, line_number=False),
+        ndjson=False,
+    )
+    assert "-n" not in auto_cmd and "-N" not in auto_cmd
+
+
 def test_search_help_should_describe_json_as_aggregate_json() -> None:
     result = CliRunner().invoke(app, ["search", "--help"])
 

--- a/tests/unit/test_directory_scanner.py
+++ b/tests/unit/test_directory_scanner.py
@@ -3,34 +3,6 @@ from tensor_grep.io.directory_scanner import DirectoryScanner
 
 
 class TestDirectoryScanner:
-    def test_should_delegate_directory_walks_to_rust_scanner_when_available(
-        self, tmp_path, monkeypatch
-    ):
-        seen: dict[str, object] = {}
-        rust_file = tmp_path / "from_rust.py"
-        rust_file.write_text("ok", encoding="utf-8")
-
-        class _FakeRustDirectoryScanner:
-            def __init__(self, *, hidden, max_depth):
-                seen["hidden"] = hidden
-                seen["max_depth"] = max_depth
-
-            def walk(self, path_str):
-                seen["path_str"] = path_str
-                yield str(rust_file)
-
-        monkeypatch.setattr("tensor_grep.io.directory_scanner.HAS_RUST_SCANNER", True)
-        monkeypatch.setattr(
-            "tensor_grep.io.directory_scanner.RustDirectoryScanner",
-            _FakeRustDirectoryScanner,
-            raising=False,
-        )
-
-        files = list(DirectoryScanner(SearchConfig()).walk(str(tmp_path)))
-
-        assert files == [str(rust_file)]
-        assert seen == {"hidden": False, "max_depth": None, "path_str": str(tmp_path)}
-
     def test_should_skip_gitignored_directories_by_default(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tensor_grep.io.directory_scanner.HAS_RUST_SCANNER", False)
 

--- a/tests/unit/test_rust_core.py
+++ b/tests/unit/test_rust_core.py
@@ -107,6 +107,39 @@ def test_rust_backend_skips_file_over_max_filesize(monkeypatch, tmp_path: Path):
     assert result.routing_reason == "rust_max_filesize_skipped"
 
 
+def test_rust_backend_limit_passthrough_reports_found_via_exit_code(monkeypatch, tmp_path: Path):
+    """The limit/pcre2 passthrough streams matches straight to stdout, so the exact count is
+    unknowable; it must still report non-empty via rg's exit code (0 = matched). Otherwise the CLI's
+    `is_empty` check treats a real match as empty and exits 1 with the wrong status. Audit #2."""
+    from tensor_grep.backends import rust_backend as rb
+    from tensor_grep.core.config import SearchConfig
+
+    exit_code = {"value": 0}
+
+    class FakeNativeRustBackend:
+        def execute_ripgrep(self, *args, **kwargs):
+            return exit_code["value"]
+
+    monkeypatch.setattr(rb, "HAVE_RUST", True)
+    monkeypatch.setattr(rb, "NativeRustBackend", FakeNativeRustBackend)
+
+    backend = rb.RustCoreBackend()
+    log_file = tmp_path / "app.log"
+    log_file.write_text("ERROR boom\n", encoding="utf-8")
+    config = SearchConfig(no_ignore_vcs=True)
+
+    exit_code["value"] = 0  # ripgrep emitted at least one match
+    found = backend.search(str(log_file), "ERROR", config=config)
+    assert found.routing_reason == "rust_limit_passthrough"
+    assert found.total_matches > 0
+    assert not found.is_empty
+
+    exit_code["value"] = 1  # ripgrep matched nothing
+    empty = backend.search(str(log_file), "ERROR", config=config)
+    assert empty.total_matches == 0
+    assert empty.is_empty
+
+
 def test_rust_backend_returns_binary_notice_unless_text_or_binary_flag_is_set(
     monkeypatch, tmp_path: Path
 ):


### PR DESCRIPTION
Addresses the 2026-06-30 audit. **Three findings fixed + verified; two assessed as follow-ups.**

## Fixed + verified

**#1 (MEDIUM) — native delegation dropped explicit `-n`/`-N`.** The guard couldn''t work (the CLI resolves `line_number` to a tty-auto bool that never matches the default), so I forward the flag only when the user explicitly set it — capturing `line_number_explicit` before resolution. Auto case unchanged, zero command churn. New builder test.

**#2 (MEDIUM) — pcre2/limit passthrough reported zero matches.** `rust_backend.py` streams matches straight to stdout via embedded ripgrep, so the count is unknowable in Python; it returned `total_matches=0` regardless, so `main.py:6456` (`is_empty → exit 1`) treated a real match as empty. Fix: reflect rg''s exit code (0 = matched) so `is_empty`/exit status are correct. (Reachable via `--max-filesize`/`--no-ignore-vcs`; explicit `--pcre2` routes to the rg backend in `pipeline.py:188` or raises — so the finding''s pcre2 framing is narrower in practice.) New exit-code test.

**#4 (LOW/MEDIUM) — dead Rust directory-scanner fast path.** `RustDirectoryScanner` is never exported by `rust_core`, so the import always raised and `HAS_RUST_SCANNER` was permanently False. Removed the broken import, the unreachable path, and the test that mocked it (false confidence).

Verification: 460+ backend/delegation/scanner tests pass; ruff + mypy clean.

## Assessed — follow-ups (not in this PR)

**#3 (MEDIUM) — `execute_ripgrep` PyO3 wrapper hardcodes flags** (`lib.rs:270-280`: `path_separator/vimgrep/sort_files/max_depth/null/null_data`). Fix is a Rust signature change + native rebuild; the local Rust build hangs, so it needs CI-side build verification (separate PR).

**#5 (MEDIUM) — GPU install surfaces are experimental/sidecar.** The tracked managed-native-GPU program (roadmap), not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)