### PR TITLE
fix: harden MCP/session/checkpoint security boundaries (audit ranks 1-3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,7 +342,7 @@ dependencies = [
 # `pip install tensor-grep[gpu]` is best-effort experimental, not the supported managed GPU path.
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "torch_geometric>=2.5.0"]
 gpu-win = ["torch>=2.0", "torch_geometric>=2.5.0"]
-nlp = ["transformers>=4.40", "tritonclient[http]"]
+nlp = ["transformers>=5.3.0", "tritonclient[http]"]
 ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "pygls>=1.3.0"]
 dev = [
   "pytest>=9.0.3", "pytest-cov>=5.0", "pytest-mock>=3.14",

--- a/src/tensor_grep/cli/apply_policy.py
+++ b/src/tensor_grep/cli/apply_policy.py
@@ -36,6 +36,25 @@ class PolicyValidationError(ValueError):
         self.details = details
 
 
+class PolicyCommandsNotAllowedError(PolicyValidationError):
+    """A policy file defines ``lint_cmd``/``test_cmd`` (a shell-exec sink) but the
+    caller has not opted into running validation commands.
+
+    Audit HIGH (RCE): the MCP ``TG_MCP_ALLOW_VALIDATION_COMMANDS`` gate previously
+    lived only in the ``tg_rewrite_apply`` wrapper and checked the *direct* lint_cmd/
+    test_cmd arguments, so a policy JSON file that carried those commands slipped
+    past it and reached ``subprocess`` in the default (gate-off) posture. Enforcement
+    now lives here at the module boundary so every caller — not just the MCP wrapper
+    — fails closed. Trusted callers (the local CLI apply path) opt in explicitly.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+            details=[{"field": "lint_cmd/test_cmd", "message": message}],
+        )
+
+
 CommandRunner = Callable[[str, str, Path, int], dict[str, object]]
 ScanRunner = Callable[[RulesetScanPolicy, Path, Path], dict[str, object]]
 
@@ -166,7 +185,18 @@ def load_apply_policy(
     *,
     legacy_lint_cmd: str | None = None,
     legacy_test_cmd: str | None = None,
+    allow_validation_commands: bool = True,
 ) -> ApplyPolicy:
+    """Load and validate an apply policy JSON file.
+
+    ``allow_validation_commands`` gates the shell-exec sink: when False, a policy
+    that defines ``lint_cmd``/``test_cmd`` fails closed with
+    :class:`PolicyCommandsNotAllowedError` before any command can run. It defaults
+    to True for the trusted local CLI path (a user who typed ``tg run --policy`` is
+    trusted). Untrusted callers — the MCP surface — MUST pass the operator's opt-in
+    (``_mcp_validation_commands_allowed()``); ``execute_rewrite_apply_json`` defaults
+    this to False so a forgetful future caller also fails closed.
+    """
     path = _resolved_path(policy_path)
     if not path.exists():
         raise FileNotFoundError(f"Policy file not found: {path}")
@@ -187,6 +217,17 @@ def load_apply_policy(
 
     lint_cmd = _coerce_optional_string(payload.get("lint_cmd"), field="lint_cmd") or legacy_lint_cmd
     test_cmd = _coerce_optional_string(payload.get("test_cmd"), field="test_cmd") or legacy_test_cmd
+
+    # Audit HIGH (RCE): fail closed before any command can run. A policy that only
+    # performs a (safe) ruleset scan / rollback has lint_cmd == test_cmd == None and
+    # is intentionally NOT blocked here — only the shell-exec sink is gated.
+    if not allow_validation_commands and (lint_cmd is not None or test_cmd is not None):
+        raise PolicyCommandsNotAllowedError(
+            "This apply policy defines lint_cmd/test_cmd, which execute a shell "
+            "command. That capability is disabled for this caller by default. On the "
+            "MCP surface, set TG_MCP_ALLOW_VALIDATION_COMMANDS=1 in the server "
+            "environment to opt in (the agent-safe edit loop does not require it)."
+        )
 
     on_failure = payload.get("on_failure")
     if not isinstance(on_failure, str) or on_failure not in _FAILURE_ACTIONS:

--- a/src/tensor_grep/cli/ast_workflows.py
+++ b/src/tensor_grep/cli/ast_workflows.py
@@ -682,6 +682,9 @@ def run_command(
             lint_cmd=lint_cmd,
             test_cmd=test_cmd,
             policy=policy,
+            # Trusted local CLI: a user who typed `tg run --apply --policy` is trusted
+            # to run its lint_cmd/test_cmd (unlike the agent-steerable MCP surface).
+            allow_validation_commands=True,
         )
         _safe_stdout_line(_inject_run_json_fields(rewrite_json, "apply"))
         return exit_code
@@ -821,6 +824,9 @@ def run_command(
                 lint_cmd=lint_cmd,
                 test_cmd=test_cmd,
                 policy=policy,
+                # Trusted local CLI (interactive apply): user-invoked, so validation
+                # commands are permitted here — the MCP boundary is gated separately.
+                allow_validation_commands=True,
             )
             if exit_code != 0:
                 apply_failed = True

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -556,7 +556,14 @@ def _snapshot_entries(scope: _CheckpointScope) -> dict[str, bool]:
 
 
 def _checkpoint_dir(root: Path, checkpoint_id: str) -> Path:
-    return _checkpoint_storage_dir(root) / checkpoint_id
+    # Audit HIGH (path traversal): checkpoint_id reaches here from the CLI, the MCP
+    # tg_checkpoint_undo tool, and policy rollback. An absolute or `..`-shaped id would
+    # escape the checkpoint store — arbitrary metadata.json read (load_checkpoint_metadata)
+    # and, on undo, an attacker-controlled snapshot SOURCE dir. Reuse the entry-key
+    # containment guard so the id can never leave the store. Generated ids
+    # (`ckpt-<ts>-<hex>`) are plain segments and always pass.
+    storage_dir = _checkpoint_storage_dir(root)
+    return _resolve_within_root(storage_dir, storage_dir.resolve(), checkpoint_id)
 
 
 def _snapshot_path(root: Path, checkpoint_id: str) -> Path:

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1106,8 +1106,10 @@ def execute_rewrite_apply_json(
     policy: str | None = None,
     expected_plan_digest: str | None = None,
     expected_match_count: int | None = None,
+    allow_validation_commands: bool = False,
 ) -> tuple[str, int]:
     from tensor_grep.cli.apply_policy import (
+        PolicyCommandsNotAllowedError,
         PolicyValidationError,
         evaluate_apply_policy,
         load_apply_policy,
@@ -1141,7 +1143,13 @@ def execute_rewrite_apply_json(
                 policy,
                 legacy_lint_cmd=lint_cmd,
                 legacy_test_cmd=test_cmd,
+                allow_validation_commands=allow_validation_commands,
             )
+        except PolicyCommandsNotAllowedError as exc:
+            # Audit HIGH (RCE): a policy file that carries lint_cmd/test_cmd is refused
+            # on the gate-off surface with the same code as the direct-param rejection,
+            # BEFORE any native binary or subprocess is reached.
+            return _rewrite_error(str(exc), code="unsupported_option", retryable=False), 1
         except FileNotFoundError as exc:
             return _rewrite_error(str(exc), code="not_found"), 1
         except PolicyValidationError as exc:
@@ -3160,6 +3168,10 @@ def tg_rewrite_apply(
         policy=policy,
         expected_plan_digest=expected_plan_digest,
         expected_match_count=expected_match_count,
+        # Audit HIGH (RCE): a policy file's lint_cmd/test_cmd is a shell-exec sink on
+        # the (agent-steerable) MCP boundary; gate it on the same operator opt-in as
+        # the direct lint_cmd/test_cmd params above.
+        allow_validation_commands=_mcp_validation_commands_allowed(),
     )
     return payload
 

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -711,7 +711,9 @@ def _remove_implicit_session_payload(path: str, session_id: str) -> None:
         _session_payload_path(root, session_id).unlink(missing_ok=True)
         records = [record for record in _load_index(root) if record.session_id != session_id]
         _write_index(root, records)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: a traversal-shaped session_id is refused by _session_payload_path;
+        # treat implicit cleanup as best-effort (fails closed) rather than raising.
         pass
 
 

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -428,7 +428,9 @@ def _prune_session_records(
     for dropped in records[limit:]:
         try:
             _session_payload_path(root, dropped.session_id).unlink(missing_ok=True)
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError: a locally-tampered index.json record with a traversal-shaped
+            # id is refused by _session_payload_path — skip it rather than break pruning.
             pass
     return retained
 

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -326,7 +326,21 @@ def _index_path(root: Path) -> Path:
 
 
 def _session_payload_path(root: Path, session_id: str) -> Path:
-    return _sessions_dir(root) / f"{session_id}.json"
+    # Audit HIGH (path traversal): session_id reaches this join from the CLI, the MCP
+    # tg_session_show/refresh tools, and the token-authenticated daemon. An absolute or
+    # `..`-shaped id resets pathlib's join and escapes the sessions dir — arbitrary .json
+    # read via get_session, destructive overwrite via refresh_session. Refuse absolute /
+    # `..` ids and assert the resolved payload path stays inside the sessions dir before
+    # any read/write. Generated ids (`session-<ts>-<root>-<hex>`) always pass.
+    candidate = Path(session_id)
+    if candidate.is_absolute() or any(part == ".." for part in candidate.parts):
+        raise ValueError(f"Refusing session id outside sessions dir: {session_id!r}")
+    sessions_dir = _sessions_dir(root)
+    sessions_dir_resolved = sessions_dir.resolve()
+    resolved = (sessions_dir / f"{session_id}.json").resolve()
+    if resolved != sessions_dir_resolved and sessions_dir_resolved not in resolved.parents:
+        raise ValueError(f"Refusing session id outside sessions dir: {session_id!r}")
+    return resolved
 
 
 def _session_root_for_payload(session_id: str, path: str = ".") -> Path:

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -161,6 +161,101 @@ def test_load_apply_policy_rejects_missing_required_keys(
     assert any(detail["field"] == field for detail in excinfo.value.details)
 
 
+def test_load_apply_policy_rejects_policy_lint_cmd_when_not_allowed(
+    tmp_path: Path,
+) -> None:
+    """Audit HIGH (RCE): a policy FILE carrying lint_cmd/test_cmd bypassed the MCP
+    TG_MCP_ALLOW_VALIDATION_COMMANDS gate because enforcement lived only in the MCP
+    wrapper, never in load_apply_policy. With allow_validation_commands=False the
+    module must FAIL CLOSED before any command can run."""
+    from tensor_grep.cli.apply_policy import (
+        PolicyCommandsNotAllowedError,
+        load_apply_policy,
+    )
+
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "version": 1,
+            "lint_cmd": "echo pwned",
+            "test_cmd": None,
+            "ruleset_scan": None,
+            "on_failure": "warn",
+        },
+    )
+
+    with pytest.raises(PolicyCommandsNotAllowedError):
+        load_apply_policy(str(policy_path), allow_validation_commands=False)
+
+
+def test_load_apply_policy_rejects_policy_test_cmd_when_not_allowed(
+    tmp_path: Path,
+) -> None:
+    from tensor_grep.cli.apply_policy import (
+        PolicyCommandsNotAllowedError,
+        load_apply_policy,
+    )
+
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": "echo pwned",
+            "ruleset_scan": None,
+            "on_failure": "warn",
+        },
+    )
+
+    with pytest.raises(PolicyCommandsNotAllowedError):
+        load_apply_policy(str(policy_path), allow_validation_commands=False)
+
+
+def test_load_apply_policy_allows_validation_commands_when_permitted(
+    tmp_path: Path,
+) -> None:
+    from tensor_grep.cli.apply_policy import load_apply_policy
+
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "version": 1,
+            "lint_cmd": "echo ok",
+            "test_cmd": None,
+            "ruleset_scan": None,
+            "on_failure": "warn",
+        },
+    )
+
+    policy = load_apply_policy(str(policy_path), allow_validation_commands=True)
+    assert policy.lint_cmd == "echo ok"
+
+
+def test_load_apply_policy_permits_ruleset_only_policy_without_validation_commands(
+    tmp_path: Path,
+) -> None:
+    """A policy that runs only a (safe) ruleset scan + rollback must NOT be
+    over-blocked when validation commands are disabled — only lint_cmd/test_cmd are
+    the shell-exec sink, so a blanket ``policy is not None`` rejection would regress
+    the safe rollback/scan-only use case."""
+    from tensor_grep.cli.apply_policy import load_apply_policy
+
+    policy_path = _write_policy(
+        tmp_path,
+        {
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": None,
+            "ruleset_scan": {"enabled": False},
+            "on_failure": "rollback",
+        },
+    )
+
+    policy = load_apply_policy(str(policy_path), allow_validation_commands=False)
+    assert policy.lint_cmd is None
+    assert policy.test_cmd is None
+
+
 @pytest.mark.parametrize(
     ("payload", "field"),
     [

--- a/tests/unit/test_checkpoint_containment.py
+++ b/tests/unit/test_checkpoint_containment.py
@@ -12,6 +12,7 @@ policy rollback).
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -98,3 +99,38 @@ def test_undo_refuses_absolute_entries(tmp_path: Path) -> None:
 
     assert victim.exists()
     assert victim.read_text(encoding="utf-8") == "SECRET\n"
+
+
+@pytest.mark.parametrize(
+    "evil_id",
+    ["../escape", "../../escape", "sub/../../escape", ".."],
+)
+def test_checkpoint_dir_refuses_traversal_id(tmp_path: Path, evil_id: str) -> None:
+    """Audit HIGH: checkpoint_id itself (not just entry keys) was joined to the store
+    with no validation, so an absolute/`..` id escaped the checkpoint store."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        checkpoint_store._checkpoint_dir(root, evil_id)
+
+
+def test_load_metadata_refuses_traversal_to_external_file(tmp_path: Path) -> None:
+    """Audit HIGH: an unvalidated checkpoint_id let load_checkpoint_metadata read a
+    metadata.json OUTSIDE the checkpoint store (arbitrary metadata disclosure)."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    external = tmp_path / "external_store"
+    external.mkdir()
+    (external / "metadata.json").write_text(json.dumps({"secret": "leak"}), encoding="utf-8")
+
+    storage = checkpoint_store._checkpoint_storage_dir(root)
+    evil_id = os.path.relpath(external, storage)  # ..(/..)+/external_store
+    with pytest.raises(ValueError):
+        checkpoint_store.load_checkpoint_metadata(evil_id, str(root))
+
+
+def test_undo_refuses_traversal_checkpoint_id(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        checkpoint_store.undo_checkpoint("../../evil-ckpt", str(root))

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1786,6 +1786,42 @@ def test_tg_rewrite_apply_supports_optional_policy_parameter(tmp_path):
     assert mock_execute.call_args.kwargs["policy"] == str(policy_path)
 
 
+def test_tg_rewrite_apply_gates_policy_file_validation_commands(tmp_path, monkeypatch):
+    """Audit HIGH (RCE): a policy FILE carrying lint_cmd bypassed the
+    TG_MCP_ALLOW_VALIDATION_COMMANDS gate — the 3141 guard only checked the direct
+    lint_cmd/test_cmd params, not a policy path that loads them from JSON. With the
+    gate OFF the policy's lint_cmd must be refused (code=unsupported_option) BEFORE
+    any command runs (load_apply_policy fails closed before native/command execution).
+    """
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.delenv("TG_MCP_ALLOW_VALIDATION_COMMANDS", raising=False)
+
+    policy_path = tmp_path / "apply-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "version": 1,
+            "lint_cmd": "echo pwned",
+            "test_cmd": None,
+            "ruleset_scan": None,
+            "on_failure": "warn",
+        }),
+        encoding="utf-8",
+    )
+
+    out = mcp_server.tg_rewrite_apply(
+        pattern="def $F($$$ARGS): return $EXPR",
+        replacement="lambda $$$ARGS: $EXPR",
+        lang="python",
+        path=str(tmp_path),
+        policy=str(policy_path),
+    )
+
+    parsed = json.loads(out)
+    assert parsed["error"]["code"] == "unsupported_option"
+    assert parsed["error"]["retryable"] is False
+
+
 def test_tg_rewrite_apply_returns_structured_invalid_policy_error(tmp_path):
     from tensor_grep.cli import mcp_server
 

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -16,7 +16,7 @@ def _optional_dependencies() -> dict[str, list[str]]:
 
 def test_nlp_extra_should_use_http_triton_client_not_all() -> None:
     deps = _optional_dependencies()["nlp"]
-    assert "transformers>=4.40" in deps
+    assert "transformers>=5.3.0" in deps  # CVE-2026-4372 fixed in 5.3.0
     assert "tritonclient[http]" in deps
     assert "tritonclient[all]" not in deps
 

--- a/tests/unit/test_session_containment.py
+++ b/tests/unit/test_session_containment.py
@@ -1,0 +1,63 @@
+"""Path-containment regression tests for the session store (audit HIGH).
+
+``session_id`` reached ``_session_payload_path`` from the CLI, the MCP
+``tg_session_show`` / ``tg_session_refresh`` tools, and the token-authenticated
+session daemon with no validation. An absolute or ``..``-shaped id resets pathlib's
+join and escapes the sessions dir, giving arbitrary ``.json`` read via ``get_session``
+and destructive overwrite via ``refresh_session``. These import ONLY ``session_store``
+so they run standalone in CI, mirroring ``test_checkpoint_containment.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import session_store
+
+
+@pytest.mark.parametrize(
+    "evil_id",
+    ["../escape", "../../escape", "sub/../../escape", ".."],
+)
+def test_session_payload_path_refuses_traversal(tmp_path: Path, evil_id: str) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        session_store._session_payload_path(root, evil_id)
+
+
+def test_session_payload_path_refuses_absolute(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    victim = tmp_path / "victim"
+    with pytest.raises(ValueError):
+        session_store._session_payload_path(root, str(victim))
+
+
+def test_get_session_refuses_traversal_to_external_file(tmp_path: Path) -> None:
+    """An unvalidated session_id let get_session read a .json OUTSIDE the sessions dir."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "leak.json").write_text(json.dumps({"secret": "x"}), encoding="utf-8")
+
+    sessions_dir = session_store._sessions_dir(root)
+    # id such that f"{id}.json" resolves to external/leak.json
+    evil_id = os.path.relpath(external / "leak", sessions_dir)
+    with pytest.raises(ValueError):
+        session_store.get_session(evil_id, str(root))
+
+
+def test_session_payload_path_allows_legit_id(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    payload_path = session_store._session_payload_path(
+        root, "session-20260101000000000000-repo-deadbeef"
+    )
+    sessions_dir_resolved = session_store._sessions_dir(root).resolve()
+    assert sessions_dir_resolved in payload_path.parents

--- a/tests/unit/test_session_containment.py
+++ b/tests/unit/test_session_containment.py
@@ -61,3 +61,32 @@ def test_session_payload_path_allows_legit_id(tmp_path: Path) -> None:
     )
     sessions_dir_resolved = session_store._sessions_dir(root).resolve()
     assert sessions_dir_resolved in payload_path.parents
+
+
+def test_cleanup_paths_tolerate_traversal_id_without_raising(tmp_path: Path) -> None:
+    """The traversal guard raises ValueError, so cleanup paths that only caught OSError
+    would crash on a locally-tampered index.json record instead of skipping it. Both the
+    session-store prune and the daemon implicit-cleanup must degrade gracefully."""
+    from tensor_grep.cli.session_daemon import _remove_implicit_session_payload
+
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    # Must not raise even though "../../evil" is refused by _session_payload_path.
+    _remove_implicit_session_payload(str(root), "../../evil")
+
+    def _record(session_id: str) -> session_store.SessionRecord:
+        return session_store.SessionRecord(
+            version=1,
+            session_id=session_id,
+            root=str(root),
+            created_at="2026-01-01T00:00:00+00:00",
+            file_count=0,
+            symbol_count=0,
+        )
+
+    # Two records so the traversal-shaped one lands in the dropped tail and its payload
+    # unlink is attempted (records are newest-first; max_records clamps to a minimum of 1).
+    records = [_record("session-keep"), _record("../../evil")]
+    retained = session_store._prune_session_records(root, records, max_records=1)
+    assert [r.session_id for r in retained] == ["session-keep"]

--- a/uv.lock
+++ b/uv.lock
@@ -433,14 +433,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -623,8 +623,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pywin32", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/75/0814c3ca505d5fb1986e381b4967cc1d0d62c6d5f52d271546f51cd4991c/cuda_bindings-12.9.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b65cbe73aa657daf8cc0137da2223e1858e4057056aad727aae5f839f35a724c", size = 12515235, upload-time = "2025-08-18T15:47:27.748Z" },
@@ -649,8 +649,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -678,7 +678,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/a5/e9d37c10f6c27c9c65d53c6cd6d9763e1df99c004780585fc2ad9041fbe3/cuda_bindings-12.9.6-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2662f59db67d9aeaf8959c593c91f600792c2970cf02cae2814387fc687b115a", size = 7090971, upload-time = "2026-03-11T14:47:29.526Z" },
@@ -697,7 +697,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/62/ed3039d866879872099fc855f8ad8b5e2ae9010b5e30d702fde3d66f23df/cuda_core-0.6.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07df8dd46494bd53943759232051facd4372104f2997732e0d39c5bc12a616d5", size = 21790662, upload-time = "2026-02-23T18:59:27.064Z" },
@@ -726,8 +726,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/83/03139c7d9c0425ec4824d6269cfd9e1ac8ae1cc88f12540578a405113083/cuda_core-0.7.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69946d1d5e2d96fc65b7bb36164d26c328cca75d9482b74ee7d61b2c1e1d33a7", size = 30374690, upload-time = "2026-04-08T17:03:08.962Z" },
@@ -790,7 +790,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/3c/4475aebeaab9651f2e61000fbe76f91a476d371dbfbf0a1cf46e689af253/cuda_python-12.9.0-py3-none-any.whl", hash = "sha256:926acba49b2c0a0374c61b7c98f337c085199cf51cdfe4d6423c4129c20547a7", size = 7532, upload-time = "2025-05-06T19:14:07.771Z" },
@@ -807,7 +807,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
@@ -824,7 +824,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/69/4a79126959ad6f1653504122ee1eb22d089dd6272d3fa37694dcdeb78ba5/cuda_python-12.9.6-py3-none-any.whl", hash = "sha256:ed5cf30e1129729eecf4605dff6e8bce84f2d30c17b17c7e5ac4b76448de35d2", size = 7596, upload-time = "2026-03-11T15:35:17.282Z" },
@@ -846,19 +846,19 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -877,16 +877,16 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -900,24 +900,24 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"] },
-    { name = "numpy" },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pynvjitlink-cu12" },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cachetools", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pandas", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pynvjitlink-cu12", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rich", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/d3/1686e1a2d6187bf8cc248b7d0a8efbea6eb20784a707176dfdd881529149/cudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:888641383ee908b820a7acafec028e8bd9851b8884009c61281d19b312c15ca9", size = 2630152, upload-time = "2025-08-07T12:23:36.002Z" },
@@ -943,25 +943,25 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
     { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "numba-cuda", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
-    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version < '3.14' or platform_machine != 'x86_64'" },
-    { name = "numpy" },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pandas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pyarrow", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rich", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/36/5caed16456ce318abb32ce66717231d5ce7b9713047ac4ae315d3f9b179e/cudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:43cbc0175e5016fa94ae96de83355c578dc149b644961301b47c6e28d5f61f49", size = 2715406, upload-time = "2026-04-09T09:42:26.382Z" },
@@ -993,7 +993,7 @@ name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
@@ -1405,34 +1405,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.3.1"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/d0/73454ef7ca885598a3194d07d5c517d91a840753c5b35d272600d7907f64/hf_xet-1.3.1.tar.gz", hash = "sha256:513aa75f8dc39a63cc44dbc8d635ccf6b449e07cdbd8b2e2d006320d2e4be9bb", size = 641393, upload-time = "2026-02-25T00:57:56.701Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/9b6a5614230d7a871442d8d8e1c270496821638ba3a9baac16a5b9166200/hf_xet-1.3.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:08b231260c68172c866f7aa7257c165d0c87887491aafc5efeee782731725366", size = 3759716, upload-time = "2026-02-25T00:57:41.052Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/de/72acb8d7702b3cf9b36a68e8380f3114bf04f9f21cf9e25317457fe31f00/hf_xet-1.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0810b69c64e96dee849036193848007f665dca2311879c9ea8693f4fc37f1795", size = 3518075, upload-time = "2026-02-25T00:57:39.605Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/5c/ed728d8530fec28da88ee882b522fccf00dc98e9d7bae4cdb0493070cb17/hf_xet-1.3.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ecd38f98e7f0f41108e30fd4a9a5553ec30cf726df7473dd3e75a1b6d56728c2", size = 4174369, upload-time = "2026-02-25T00:57:32.697Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/db/785a0e20aa3086948a26573f1d4ff5c090e63564bf0a52d32eb5b4d82e8d/hf_xet-1.3.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:65411867d46700765018b1990eb1604c3bf0bf576d9e65fc57fdcc10797a2eb9", size = 3953249, upload-time = "2026-02-25T00:57:30.096Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/6a/51b669c1e3dbd9374b61356f554e8726b9e1c1d6a7bee5d727d3913b10ad/hf_xet-1.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1684c840c60da12d76c2a031ba40e4b154fdbf9593836fcf5ff090d95a033c61", size = 4152989, upload-time = "2026-02-25T00:57:48.308Z" },
-    { url = "https://files.pythonhosted.org/packages/df/31/de07e26e396f46d13a09251df69df9444190e93e06a9d30d639e96c8a0ed/hf_xet-1.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b3012c0f2ce1f0863338491a2bc0fd3f84aded0e147ab25f230da1f5249547fd", size = 4390709, upload-time = "2026-02-25T00:57:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/c1/fcb010b54488c2c112224f55b71f80e44d1706d9b764a0966310b283f86e/hf_xet-1.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:4eb432e1aa707a65a7e1f8455e40c5b47431d44fe0fb1b0c5d53848c27469398", size = 3634142, upload-time = "2026-02-25T00:57:59.063Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/9ef49cc601c68209979661b3e0b6659fc5a47bfb40f3ebf29eae9ee09e5c/hf_xet-1.3.1-cp313-cp313t-win_arm64.whl", hash = "sha256:e56104c84b2a88b9c7b23ba11a2d7ed0ccbe96886b3f985a50cedd2f0e99853f", size = 3494918, upload-time = "2026-02-25T00:57:57.654Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f5/66adbb1f54a1b3c6da002fa36d4405901ddbcb7d927d780db17ce18ab99d/hf_xet-1.3.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:6517a245e41df3eae5adc5f9e8c86fa52abd548de798cbcd989f0082152860aa", size = 3759781, upload-time = "2026-02-25T00:57:47.017Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/75/189d91a90480c142cc710c1baa35ece20e8652d5fe5c9b2364a13573d827/hf_xet-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4a322d506c513f98fdc1aa2aaa825daefd535b686e80ca789e6d33fcb146f524", size = 3517533, upload-time = "2026-02-25T00:57:45.812Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/52/52dd1ab6c29661e29585f3c10d14572e2535a3a472f27a0a46215b0f4659/hf_xet-1.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f16ec9d26badec46334a798e01b5d86af536924789c95b1a1ec6a05f26523e0", size = 4174082, upload-time = "2026-02-25T00:57:38.171Z" },
-    { url = "https://files.pythonhosted.org/packages/14/03/460add181c79e2ea1527d2ad27788ecccaee1d5a82563f9402e25ee627e4/hf_xet-1.3.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e1f5d72bd5b73e61530fff573bcff34bdb64af2bf4862cdd516e6c1dab4dc75b", size = 3952874, upload-time = "2026-02-25T00:57:36.942Z" },
-    { url = "https://files.pythonhosted.org/packages/01/56/bf78f18890dfc8caa907830e95424dce0887d5c45efde13f23c9ebbaa8ef/hf_xet-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4bc71afd853508b2ddf123b8fc9de71b0afa4c956ec730b69fb76103781e94cd", size = 4152325, upload-time = "2026-02-25T00:57:54.081Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/94/91685c6a4a7f513097a6a73b1e879024304cd0eae78080e3d737622f2fd9/hf_xet-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:541b4b00ed294ae6cfd9416de9506e58971013714d7316189c9638ed54e362d4", size = 4390499, upload-time = "2026-02-25T00:57:55.258Z" },
-    { url = "https://files.pythonhosted.org/packages/79/1b/1e72c8ea1f31ef94640d1f265630d35b97b2ef31fe12696bbcc32dbcdc95/hf_xet-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f85480b4fe3e8e4cdbc59ef1d235152b732fd57ca439cc983c291892945ae818", size = 3634352, upload-time = "2026-02-25T00:58:04.749Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/61/b59e87a7a10b95c4578a6ce555339b2f002035569dfd366662b9f59975a8/hf_xet-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:83a8830160392ef4bea78d443ea2cf1febe65783b3843a8f12c64b368981e7e2", size = 3494371, upload-time = "2026-02-25T00:58:03.422Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f8/c2da4352c0335df6ae41750cf5bab09fdbfc30d3b4deeed9d621811aa835/hf_xet-1.3.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:581d1809a016f7881069d86a072168a8199a46c839cf394ff53970a47e4f1ca1", size = 3761755, upload-time = "2026-02-25T00:57:43.621Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/e5/a2f3eaae09da57deceb16a96ebe9ae1f6f7b9b94145a9cd3c3f994e7782a/hf_xet-1.3.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:329c80c86f2dda776bafd2e4813a46a3ee648dce3ac0c84625902c70d7a6ddba", size = 3523677, upload-time = "2026-02-25T00:57:42.3Z" },
-    { url = "https://files.pythonhosted.org/packages/61/cd/acbbf9e51f17d8cef2630e61741228e12d4050716619353efc1ac119f902/hf_xet-1.3.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2973c3ff594c3a8da890836308cae1444c8af113c6f10fe6824575ddbc37eca7", size = 4178557, upload-time = "2026-02-25T00:57:35.399Z" },
-    { url = "https://files.pythonhosted.org/packages/df/4f/014c14c4ae3461d9919008d0bed2f6f35ba1741e28b31e095746e8dac66f/hf_xet-1.3.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ed4bfd2e6d10cb86c9b0f3483df1d7dd2d0220f75f27166925253bacbc1c2dbe", size = 3958975, upload-time = "2026-02-25T00:57:34.004Z" },
-    { url = "https://files.pythonhosted.org/packages/86/50/043f5c5a26f3831c3fa2509c17fcd468fd02f1f24d363adc7745fbe661cb/hf_xet-1.3.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:713913387cc76e300116030705d843a9f15aee86158337eeffb9eb8d26f47fcd", size = 4158298, upload-time = "2026-02-25T00:57:51.14Z" },
-    { url = "https://files.pythonhosted.org/packages/08/9c/b667098a636a88358dbeb2caf90e3cb9e4b961f61f6c55bb312793424def/hf_xet-1.3.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e5063789c9d21f51e9ed4edbee8539655d3486e9cad37e96b7af967da20e8b16", size = 4395743, upload-time = "2026-02-25T00:57:52.783Z" },
-    { url = "https://files.pythonhosted.org/packages/70/37/4db0e4e1534270800cfffd5a7e0b338f2137f8ceb5768000147650d34ea9/hf_xet-1.3.1-cp37-abi3-win_amd64.whl", hash = "sha256:607d5bbc2730274516714e2e442a26e40e3330673ac0d0173004461409147dee", size = 3638145, upload-time = "2026-02-25T00:58:02.167Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/46/1ba8d36f8290a4b98f78898bdce2b0e8fe6d9a59df34a1399eb61a8d877f/hf_xet-1.3.1-cp37-abi3-win_arm64.whl", hash = "sha256:851b1be6597a87036fe7258ce7578d5df3c08176283b989c3b165f94125c5097", size = 3500490, upload-time = "2026-02-25T00:58:00.667Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
 ]
 
 [[package]]
@@ -1474,23 +1474,23 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.4.1"
+version = "1.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "shellingham" },
     { name = "tqdm" },
-    { name = "typer-slim" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/77/ce3331f40cb2d021fe9b24c46c41e72faf74493621138e5eddac12bf5e1c/huggingface_hub-1.21.0.tar.gz", hash = "sha256:a44f222cd8f2f7c2eade30b5e7a04cac984a3235fa61ea87a0a5a31db77d561f", size = 861572, upload-time = "2026-06-25T13:09:26.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/85/b505a99a133d9f99d21af182af416e9baef70bdeef019983479651e494c2/huggingface_hub-1.21.0-py3-none-any.whl", hash = "sha256:eadaa3678c512c82aea69e8675d90a184861e68de32f1105668628b4dce0e7cd", size = 721078, upload-time = "2026-06-25T13:09:24.402Z" },
 ]
 
 [[package]]
@@ -1524,7 +1524,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5", size = 54320, upload-time = "2024-08-20T17:11:42.348Z" }
 wheels = [
@@ -1547,7 +1547,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1613,12 +1613,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "zarr" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "zarr", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/b7/fbc1968592c92396efd3dc68f330d0e3da98a1150bfae414029bea9f9fe1/kvikio_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51094df8e0793485ae5021174b65bcd2bc584853cd832c142e6b463380bf4109", size = 672337, upload-time = "2025-08-07T13:50:13.422Z" },
@@ -1644,10 +1644,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/24/95abc4335e8db5b8e140dbe7bdaa9bd7c8620cc087b33ccf748f474c43b0/kvikio_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72cf92d7786b9cb34c60d616a25ef1c802ee465ebc20dd4b5ca2a365b409be16", size = 587150, upload-time = "2026-04-09T11:38:07.743Z" },
@@ -1725,9 +1725,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/69/529bd3a5b6d8edac3e530a0b71c3a8f620a544248c9e22d509852be269a7/libcudf_cu12-25.8.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2ae790b881a67511b414451821ec894f014e4c49d3c62e8f230c45b56cfce0cb", size = 521220643, upload-time = "2025-08-07T11:49:07.039Z" },
@@ -1749,10 +1749,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-libnvcomp-cu12" },
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-libnvcomp-cu12", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/26/f0ae0915b0efac09de00229a205912e25691163e3a6cb51d5327b75d2119/libcudf_cu12-26.4.0-py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2448f34ec63ef9bca6ec47b2089fb331826a834e5e256ae9e0f21a5a7e56df", size = 674674052, upload-time = "2026-04-20T17:52:44.693Z" },
@@ -1804,7 +1804,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fe/35789d6aed0df9336ca07fcb57e756f0f91df4136c5c3087ffa97f912f4e/librmm_cu12-25.8.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18381166e7d855d1ee9ab4684d2ab8af67a115e2015753f1ce91b8ef1ad06013", size = 3539813, upload-time = "2025-08-07T11:22:46.099Z" },
@@ -1826,7 +1826,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/dc/04009da12d0ebccee9c7319929194839d1b3c0f306877c32e85ae1778fb3/librmm_cu12-26.4.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7fa86af3cf2fdd956c5906f8bd9c2a139ddcbb1a5e4c9c4aa33f391623be6c3", size = 3969220, upload-time = "2026-04-09T12:45:21.77Z" },
@@ -2329,7 +2329,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "numba" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/94/63e54c690f093869c5ed3e811ff440554e87085e4301ba9fe37953a6dd80/numba_cuda-0.14.1.tar.gz", hash = "sha256:2e23bc9f5946e850f21f42cb2dcd24a2cb8ea84b60ad020b6e3b357830a9a697", size = 491974, upload-time = "2025-08-22T16:40:43.58Z" }
 wheels = [
@@ -2338,11 +2338,11 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 
 [[package]]
@@ -2353,10 +2353,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "numba", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/51/8935ff9ae5150e1ffed945bf1b95002a6a5e1f9256aeb1143e1c159b68c5/numba_cuda-0.24.0.tar.gz", hash = "sha256:f15a11a8d224e160e9cb2345049c5fa0bbd49eb255b2e8f661086746a7feb378", size = 1347749, upload-time = "2026-01-12T22:38:08.289Z" }
 wheels = [
@@ -2370,9 +2370,9 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"] },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2389,11 +2389,11 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numba", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/aa/78ba931a3ddce12d0948302ae46b6fd7a5fe9009cf0e0add84d8f7ad9197/numba_cuda-0.28.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:733ca2823c208baab10d5d67107c267c248bca11ad94eee14c5a90cb57041b33", size = 1838625, upload-time = "2026-03-03T18:17:37.461Z" },
@@ -2412,12 +2412,12 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 
 [[package]]
@@ -2425,8 +2425,8 @@ name = "numcodecs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
 wheels = [
@@ -2657,7 +2657,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2668,7 +2668,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2695,9 +2695,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2708,7 +2708,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3370,12 +3370,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/12/023332074131122d839be397fe78195eb51eae131a82004438933e9ffbbc/pylibcudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18d7032242d2b8a136f226b7ae4fd8e631e526cbc886186cb7571eb1c25fbcef", size = 28162734, upload-time = "2025-08-07T11:45:56.918Z" },
@@ -3402,10 +3402,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ad/d2a1961ae8b194ce33a9d8269dd046629fb556147aca74223cabc632a07b/pylibcudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0b191096b574cff4d709bb0880d2f0a346120493090cc8103098de9abead71", size = 8009026, upload-time = "2026-04-09T13:28:51.019Z" },
@@ -3887,9 +3887,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/2c/3363bbf6f5ee3699e28f5a3c525a165bedfa496b5a2a426777648a0297d6/rmm_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:856c38c22e8e1ea8a7216ff9c55d902a9a59b0a18a7affd426338743781f6725", size = 1139163, upload-time = "2025-08-07T11:18:37.215Z" },
@@ -3916,9 +3916,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c1/6c3a3c0e14ccd1f92e43dd90d1137bd3d0592794c02e871bbcc6cdbf2888/rmm_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be5e54e32bfac027803a658e1ee41d0c0c4fd89849a77c5ed148c3edcdc0269d", size = 1197307, upload-time = "2026-04-09T14:23:55.527Z" },
@@ -4389,7 +4389,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'gpu-win'", specifier = ">=2.0" },
     { name = "torch-geometric", marker = "extra == 'gpu'", specifier = ">=2.5.0" },
     { name = "torch-geometric", marker = "extra == 'gpu-win'", specifier = ">=2.5.0" },
-    { name = "transformers", marker = "extra == 'nlp'", specifier = ">=4.40" },
+    { name = "transformers", marker = "extra == 'nlp'", specifier = ">=5.3.0" },
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'bench'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'dev'", specifier = ">=0.22" },
@@ -4608,7 +4608,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.2.0"
+version = "5.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4619,11 +4619,11 @@ dependencies = [
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer-slim" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/7e/8a0c57d562015e5b16c97c1f0b8e0e92ead2c7c20513225dc12c2043ba9f/transformers-5.2.0.tar.gz", hash = "sha256:0088b8b46ccc9eff1a1dca72b5d618a5ee3b1befc3e418c9512b35dea9f9a650", size = 8618176, upload-time = "2026-02-16T18:54:02.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/93/79754b0ca486e556c2b95d4f5afc66aaf4b260694f3d6e1b51da2d036691/transformers-5.2.0-py3-none-any.whl", hash = "sha256:9ecaf243dc45bee11a7d93f8caf03746accc0cb069181bbf4ad8566c53e854b4", size = 10403304, upload-time = "2026-02-16T18:53:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
 ]
 
 [[package]]
@@ -4774,18 +4774,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]
@@ -5076,12 +5064,12 @@ name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "google-crc32c", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Fixes the three **HIGH** findings from an edge-case audit of subsystems the batch A/B audits never touched (session / apply-edit / MCP boundary). Each was adversarially verified against the real code, then fixed with TDD. Security-sensitive, so isolated into its own PR.

| # | Severity | Issue |
|---|---|---|
| 1 | HIGH | MCP `policy`-file RCE bypassing the validation-command gate |
| 2 | HIGH | `session_id` path traversal → arbitrary `.json` read/overwrite |
| 3 | HIGH | `checkpoint_id` path traversal → arbitrary read + injected-content undo |

## Rank 1 — MCP policy-file RCE

`tg_rewrite_apply(policy=...)` loaded `lint_cmd`/`test_cmd` from a caller-supplied JSON file and ran them via subprocess. The `TG_MCP_ALLOW_VALIDATION_COMMANDS` gate only checked the **direct** `lint_cmd`/`test_cmd` params, so a policy file slipped past it — arbitrary command execution over the (agent-steerable) MCP surface in the default gate-off posture.

- Enforcement moved to the `apply_policy` **module boundary**: `load_apply_policy(..., allow_validation_commands=False)` fails closed with `PolicyCommandsNotAllowedError` when a policy carries validation commands.
- `execute_rewrite_apply_json` defaults the flag to **False** (secure). The MCP tool passes the operator opt-in; the trusted local CLI (`ast_workflows`) passes `True`.
- **Not over-blocked:** a policy that only runs a ruleset scan / rollback (`lint_cmd == test_cmd == None`) still loads with the gate off — a blanket `policy is not None` rejection would have regressed that safe path.

## Ranks 2+3 — path traversal

`session_id` and `checkpoint_id` were joined straight into filesystem paths, so an absolute or `..`-shaped id escaped the store: arbitrary `.json` disclosure + destructive overwrite (session), and arbitrary metadata read + **attacker-controlled snapshot source** on `tg checkpoint undo` (checkpoint). Reachable via CLI, MCP (`tg_session_show/refresh`, `tg_checkpoint_undo`), and the token-authenticated daemon.

- `_session_payload_path` and `_checkpoint_dir` now resolve-and-assert containment; checkpoint reuses the existing `_resolve_within_root` guard.
- Generated ids (`session-<ts>-<root>-<hex>`, `ckpt-<ts>-<hex>`) always pass.

## Tests

- `test_apply_policy.py`: policy-file RCE gate at the module boundary; safe ruleset/rollback-only policies still load; opt-in path.
- `test_mcp_server.py`: end-to-end through `tg_rewrite_apply` — gate-off policy returns `code=unsupported_option` before any command runs.
- `test_session_containment.py` (new) + `test_checkpoint_containment.py`: traversal refusal incl. the external-file **read** and **overwrite** vectors; legit ids round-trip.

All affected suites green; `ruff check` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
