### PR TITLE
fix: close 4 silent-wrong-output findings in search backends (audit ranks 4-6 + sidecar)

### DIFF
--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -158,7 +158,12 @@ class AstGrepWrapperBackend(ComputeBackend):
 
         stderr = (result.stderr or "").strip()
         stdout = (result.stdout or "").strip()
-        if not stderr and stdout.startswith("["):
+        # Audit HIGH: `stdout.startswith("[")` waived ANY nonzero exit whose stdout merely
+        # began with `[`, so a killed/OOM'd sg subprocess emitting TRUNCATED JSON was masked
+        # as a clean 0-match scan (the later json.loads then raised and was swallowed
+        # downstream). Require a COMPLETE, parseable JSON list before waiving — a truncated
+        # payload fails the parse and falls through to raise BackendExecutionError.
+        if not stderr and _stdout_is_json_payload(stdout):
             return
 
         # ast-grep exits nonzero when it cannot read an individual path (a

--- a/src/tensor_grep/backends/cybert_backend.py
+++ b/src/tensor_grep/backends/cybert_backend.py
@@ -8,7 +8,7 @@ import urllib.parse
 from dataclasses import replace
 from typing import Any
 
-from tensor_grep.backends.base import ComputeBackend
+from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
 from tensor_grep.io.reader_fallback import FallbackReader
@@ -246,10 +246,19 @@ class CybertBackend(ComputeBackend):
         if config is not None and threshold > 0.0:
             classify_config = replace(config, nlp_threshold=0.0)
 
+        # Audit HIGH (silent-fallback): the old `try: classify() except Exception:
+        # heuristic()` swallowed EVERY failure (Triton down, tokenization/inference error,
+        # or an unvalidated logits-shape IndexError) into keyword-heuristic hits labeled as
+        # real CyBERT output with no signal. Use classify_with_metadata so an EXPECTED
+        # provider outage degrades gracefully WITH a fallback_reason we surface below, and
+        # re-raise a genuinely unexpected error as BackendExecutionError (per base.py's
+        # contract) so the search loop falls back to CPU visibly instead of faking success.
         try:
-            classifications = self.classify(lines, config=classify_config)
-        except Exception:
-            classifications = self._heuristic_classify(lines)
+            classifications, classify_metadata = self.classify_with_metadata(
+                lines, config=classify_config
+            )
+        except Exception as exc:
+            raise BackendExecutionError(f"CyBERT classification failed: {exc}") from exc
 
         matches: list[MatchLine] = []
         for line_number, (line, classification) in enumerate(
@@ -269,6 +278,15 @@ class CybertBackend(ComputeBackend):
             )
 
         matched_file_paths = [file_path] if matches else []
+        fallback_reason: str | None = None
+        routing_reason = "nlp_cybert"
+        if classify_metadata.get("provider_status") != "provider":
+            # Results came from the keyword heuristic, not the CyBERT model — signal the
+            # engine swap so a JSON/CLI consumer never trusts these as model confidences.
+            routing_reason = "nlp_cybert_heuristic_fallback"
+            fallback_reason = str(
+                classify_metadata.get("fallback_reason") or "CyBERT provider unavailable"
+            )
         return SearchResult(
             matches=matches,
             matched_file_paths=matched_file_paths,
@@ -276,7 +294,8 @@ class CybertBackend(ComputeBackend):
             total_files=1 if matches else 0,
             total_matches=len(matches),
             routing_backend="CybertBackend",
-            routing_reason="nlp_cybert",
+            routing_reason=routing_reason,
+            fallback_reason=fallback_reason,
         )
 
     def classify_with_metadata(
@@ -377,11 +396,30 @@ class CybertBackend(ComputeBackend):
             # Using mock np if actual np fails here
             pass
 
+        # Audit HIGH: `self.labels` is a fixed 3-entry list; a Triton model swapped for one
+        # with a different class count made `self.labels[idx]` raise an UNCAUGHT IndexError
+        # (this loop sits outside every try/except in this method). Validate the shape and
+        # degrade to the heuristic (or raise, per the caller's contract) before indexing.
+        n_labels = len(self.labels)
+        probs_shape = getattr(probs, "shape", None)
+        if probs_shape is not None and len(probs_shape) >= 1 and probs_shape[-1] != n_labels:
+            reason = (
+                f"CyBERT model returned {probs_shape[-1]} classes but "
+                f"{n_labels} labels are configured"
+            )
+            if not raise_on_provider_error:
+                return self._heuristic_classify(lines), {
+                    "provider_used": "heuristic",
+                    "provider_status": "fallback",
+                    "fallback_reason": reason,
+                }
+            raise RuntimeError(reason)
+
         for prob in probs:
             idx = int(np.argmax(prob))
             confidence = float(prob[idx])
 
-            if confidence >= threshold:
+            if confidence >= threshold and idx < n_labels:
                 results.append({"label": self.labels[idx], "confidence": confidence})
 
         return results, {

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -203,11 +203,16 @@ class RipgrepBackend(ComputeBackend):
                     and Path(file_path[0]).is_dir()
                 )
             )
+            # Audit HIGH: rg emits `path:count` whenever it prints the filename, which is
+            # driven by -H/--no-filename (config.with_filename/no_filename), NOT only by the
+            # multi-file heuristic. A single-file `--count -H` yielded `path:count`, hit the
+            # bare-count branch, `int()` raised, and the line was silently dropped -> false 0.
+            path_prefixed = (multi_file or config.with_filename) and not config.no_filename
             for line in lines:
                 matched_path: str | None = None
                 if config.null and "\0" in line:
                     matched_path, count_text = line.rsplit("\0", 1)
-                elif multi_file and ":" in line:
+                elif path_prefixed and ":" in line:
                     matched_path, count_text = line.rsplit(":", 1)
                 else:
                     count_text = line

--- a/src/tensor_grep/core/registration_check.py
+++ b/src/tensor_grep/core/registration_check.py
@@ -34,7 +34,17 @@ def _declaration_re(symbol: str) -> re.Pattern[str]:
     """
     pattern = _DECL_RE_CACHE.get(symbol)
     if pattern is None:
-        pattern = re.compile(rf"(?<![\w]){re.escape(symbol)}\b[^\n=#]*(?<![!<>=])=(?!=)")
+        # Audit HIGH: the old pattern only forbade a `#` BETWEEN the symbol and the `=`, so
+        # a `# SYMBOL = ...` comment (or Rust `// SYMBOL = ...`) matched as the declaration
+        # and extract_members returned the comment's wrong member set — corrupting the very
+        # CI-gating registration tool. Anchor to line-start (re.MULTILINE) and require the
+        # line-prefix before the symbol to carry NO comment marker (`#` or `//`), while still
+        # allowing real declaration keywords (`const `/`pub `/type annotations), so a Rust
+        # `const SYMBOL: &[&str] =` — where the symbol is not the first token — still matches.
+        pattern = re.compile(
+            rf"^(?:[^\n#/]|/(?!/))*?(?<![\w]){re.escape(symbol)}\b[^\n=#]*(?<![!<>=])=(?!=)",
+            re.MULTILINE,
+        )
         _DECL_RE_CACHE[symbol] = pattern
     return pattern
 

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -5,7 +5,37 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tensor_grep.backends.ast_wrapper_backend import AstGrepWrapperBackend
+from tensor_grep.backends.base import BackendExecutionError
 from tensor_grep.core.config import SearchConfig
+
+
+def test_raise_for_nonzero_raises_on_truncated_json_from_killed_subprocess():
+    """Audit HIGH: a killed/OOM'd sg subprocess emits TRUNCATED JSON that still starts
+    with '[' with empty stderr. The old waiver (``stdout.startswith('[')``) masked that as
+    a clean 0-match scan; the later json.loads then failed and was swallowed downstream. A
+    FULL parse must be required before waiving the nonzero exit."""
+    backend = AstGrepWrapperBackend()
+    result = subprocess.CompletedProcess(
+        args=["sg", "scan"],
+        returncode=137,  # 128 + SIGKILL(9): OOM-killer / container memory limit
+        stdout='[{"file": "a.py", "range"',  # truncated, invalid JSON
+        stderr="",
+    )
+    with pytest.raises(BackendExecutionError):
+        backend._raise_for_nonzero(result)
+
+
+def test_raise_for_nonzero_waives_complete_json_with_nonzero_exit():
+    """A COMPLETE JSON payload with a nonzero exit and no stderr is a real (if quirky)
+    result and must still be waived — the fix must not over-raise on valid output."""
+    backend = AstGrepWrapperBackend()
+    result = subprocess.CompletedProcess(
+        args=["sg", "scan"],
+        returncode=1,
+        stdout="[]",
+        stderr="",
+    )
+    backend._raise_for_nonzero(result)  # must not raise
 
 
 def test_ast_wrapper_backend_should_use_resolved_binary_path():

--- a/tests/unit/test_cybert_backend.py
+++ b/tests/unit/test_cybert_backend.py
@@ -5,6 +5,25 @@ import numpy as np
 import pytest
 
 
+def test_search_surfaces_heuristic_fallback_reason(tmp_path):
+    """Audit HIGH: search() swallowed classify() failures with a bare `except Exception`
+    and returned keyword-heuristic matches labeled as real CyBERT output
+    (routing_reason='nlp_cybert', fallback_reason=None) — a silent engine downgrade. When
+    the CyBERT provider is unavailable it must surface the swap: a distinct routing_reason
+    plus a non-empty fallback_reason. (tritonclient is not installed in the test env, so the
+    classifier degrades to the keyword heuristic naturally.)"""
+    from tensor_grep.backends.cybert_backend import CybertBackend
+    from tensor_grep.core.config import SearchConfig
+
+    log = tmp_path / "app.log"
+    log.write_text("this is an error line\nall good here\n", encoding="utf-8")
+
+    result = CybertBackend().search(str(log), "error", config=SearchConfig())
+
+    assert result.routing_reason == "nlp_cybert_heuristic_fallback"
+    assert result.fallback_reason
+
+
 class TestCybertBackend:
     @patch.dict(
         "sys.modules",
@@ -380,13 +399,19 @@ class TestCybertBackend:
         log_path.write_text("warning: latency is high\ninfo: startup ok\n", encoding="utf-8")
 
         backend = CybertBackend()
+        # search() consumes classify_with_metadata (results + provider metadata) so it can
+        # surface a fallback signal; here the CyBERT model succeeds (provider_status=provider)
+        # so no fallback is reported and routing_reason stays "nlp_cybert".
         with patch.object(
             backend,
-            "classify",
-            return_value=[
-                {"label": "warn", "confidence": 0.85},
-                {"label": "info", "confidence": 0.20},
-            ],
+            "classify_with_metadata",
+            return_value=(
+                [
+                    {"label": "warn", "confidence": 0.85},
+                    {"label": "info", "confidence": 0.20},
+                ],
+                {"provider_used": "cybert", "provider_status": "provider", "fallback_reason": None},
+            ),
         ):
             result = backend.search(
                 str(log_path),
@@ -400,5 +425,6 @@ class TestCybertBackend:
         assert result.match_counts_by_file == {str(log_path): 1}
         assert result.routing_backend == "CybertBackend"
         assert result.routing_reason == "nlp_cybert"
+        assert result.fallback_reason is None
         assert result.matches[0].line_number == 1
         assert result.matches[0].text == "[warn 0.850] warning: latency is high"

--- a/tests/unit/test_registration_check.py
+++ b/tests/unit/test_registration_check.py
@@ -22,6 +22,31 @@ def _write_config(tmp_path: Path, group: dict) -> str:
     return str(cfg)
 
 
+def test_extract_members_ignores_symbol_in_python_comment_line(tmp_path: Path) -> None:
+    """Audit HIGH: `# _COMMANDS = {...}` in a comment matched the declaration regex (the
+    `[^\\n=#]*` only blocked a `#` BETWEEN symbol and `=`, not one starting the line), so
+    extract_members read the comment's (wrong) member set — a false result in the very
+    CI-gating registration tool this file exists to keep honest."""
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "# _COMMANDS = {'ghost'}\n_COMMANDS = {'real_a', 'real_b'}\n",
+        encoding="utf-8",
+    )
+    assert extract_members(str(f), "_COMMANDS") == {"real_a", "real_b"}
+
+
+def test_extract_members_ignores_symbol_in_rust_line_comment(tmp_path: Path) -> None:
+    """The fix must handle Rust `//` comments AND keep matching a `const SYMBOL: &[&str] =`
+    declaration whose symbol is NOT the first token — so a naive `^[ \\t]*SYMBOL` anchor is
+    insufficient (it would break real Rust registration sites)."""
+    f = tmp_path / "mod.rs"
+    f.write_text(
+        '// SYMBOLS = &["ghost"]\nconst SYMBOLS: &[&str] = &["real_a", "real_b"];\n',
+        encoding="utf-8",
+    )
+    assert extract_members(str(f), "SYMBOLS") == {"real_a", "real_b"}
+
+
 def test_entity_scoped_config_ignores_legit_asymmetry(tmp_path: Path) -> None:
     a = tmp_path / "a.py"
     a.write_text('FLAGS = {"--x", "--rank"}\n', encoding="utf-8")

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -371,6 +371,49 @@ def test_should_raise_on_rg_fatal_error():
             backend.search("test.log", "(")
 
 
+def test_count_with_filename_single_file_parses_path_prefixed_output():
+    """Audit HIGH: a single-file ``--count -H`` makes rg emit ``path:count``, but the
+    count parser only path-split on the list/dir heuristic (ignoring ``with_filename``),
+    so ``int('test.log:3')`` raised and the line was silently dropped -> false 0 matches.
+    """
+    backend = RipgrepBackend()
+    config = SearchConfig(count=True, with_filename=True)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "test.log:3\n"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch("tensor_grep.backends.ripgrep_backend.run_subprocess", return_value=mock_result),
+    ):
+        result = backend.search("test.log", "ERROR", config=config)
+
+    assert result.total_matches == 3
+    assert result.total_files == 1
+    assert result.match_counts_by_file == {"test.log": 3}
+
+
+def test_count_single_file_without_filename_parses_bare_count():
+    """Regression guard: the common single-file bare-count path must keep parsing."""
+    backend = RipgrepBackend()
+    config = SearchConfig(count=True)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "5\n"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch("tensor_grep.backends.ripgrep_backend.run_subprocess", return_value=mock_result),
+    ):
+        result = backend.search("test.log", "ERROR", config=config)
+
+    assert result.total_matches == 5
+
+
 def test_passthrough_should_forward_count_flag_and_exit_code():
     backend = RipgrepBackend()
     config = SearchConfig(count=True, no_ignore=True)


### PR DESCRIPTION
## Summary

Correctness batch from the same edge-case audit as #313 — four findings where a real failure or a wrong answer was returned **silently as a clean result**. Each was adversarially verified against the real code and fixed with TDD.

| Finding | Sev | Effect |
|---|---|---|
| ripgrep `_search_counts` ignores `with_filename` | HIGH | `--count -H` on a single file → silent **false 0 matches** |
| ast-grep `_raise_for_nonzero` OOM mask | HIGH | killed/OOM `sg` subprocess → masked as clean 0-match scan |
| `registration_check._declaration_re` comment match | HIGH | `# SYMBOL = ...` matched as the declaration — in the **CI-gating** tool itself |
| CyBERT `search()` silent fallback | HIGH | classifier failure → keyword-heuristic hits labeled as real model output |

## Details

- **ripgrep count** — rg prints `path:count` whenever it prints the filename (driven by `-H`/`--no-filename`), not just for multi-file. A single-file `--count -H` yielded `path:count`, `int()` raised, the line was dropped → false 0. Now `path_prefixed = (multi_file or with_filename) and not no_filename`.
- **ast-grep OOM** — the waiver keyed on `stdout.startswith("[")`, which truncated JSON from a killed process also satisfies. Now requires a full `json.loads` (via `_stdout_is_json_payload`); a truncated payload raises `BackendExecutionError`.
- **registration-check** — `[^\n=#]*` only blocked a `#` *between* the symbol and `=`. Now anchored to line-start with a comment-marker exclusion (`#`/`//`) *before* the symbol — while still allowing `const `/`pub ` so Rust `const SYMBOL: &[&str] =` (symbol not first token) keeps matching. A naive `^[ \t]*SYMBOL` anchor would have broken real Rust registration sites; there's a test guarding that.
- **CyBERT** — `search()` swallowed `classify()` failures with a bare except. Now uses `classify_with_metadata` (graceful degrade *with* a reason), surfaces `routing_reason=nlp_cybert_heuristic_fallback` + `fallback_reason` on the swap, re-raises unexpected errors as `BackendExecutionError` (per base.py's contract → visible CPU fallback), and validates the logits shape before indexing the fixed 3-label list (fixes a latent uncaught `IndexError`).

## Tests

New TDD tests for each: count `path:count` parse (+ bare-count regression guard); ast-grep truncated-JSON raises / complete-JSON waives; Python `#` and Rust `//` comment declarations ignored; CyBERT fallback surfaces `routing_reason`+`fallback_reason`. All backend suites green; `ruff` + `mypy` clean.

> Follow-up: this is the 4th/5th recurrence of the silent-fallback contract violation — a systemic `SafeBackendMixin` + conformance CI gate is queued to make it structurally impossible (per the session's innovation review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
