### PR TITLE
fix: silent-output + scope correctness in backends/sidecar (audit MED batch)

### DIFF
--- a/src/tensor_grep/backends/ast_backend.py
+++ b/src/tensor_grep/backends/ast_backend.py
@@ -11,7 +11,7 @@ import os
 import re
 from pathlib import Path
 
-from tensor_grep.backends.base import ComputeBackend
+from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
 
@@ -696,14 +696,15 @@ class AstBackend(ComputeBackend):
 
         try:
             query = self._get_query(parser, lang, pattern)
-        except Exception:
-            return SearchResult(
-                matches=[],
-                total_files=0,
-                total_matches=0,
-                routing_backend="AstBackend",
-                routing_reason="ast-native",
-            )
+        except Exception as exc:
+            # Audit MED: a broad `except Exception` here converted a malformed/misspelled AST
+            # node-type pattern into a look-alike 0-match result with zero logging — a
+            # silent false negative (sibling of the SILENT-FALLBACK class). Raise per base.py's
+            # contract so run_command's except-BackendExecutionError handler reports a real
+            # "invalid pattern" error instead of "0 matches".
+            raise BackendExecutionError(
+                f"AST query compilation failed (invalid pattern for language {lang!r}?): {exc}"
+            ) from exc
 
         matches = []
         seen_lines = set()

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -53,6 +53,20 @@ class RipgrepBackend(ComputeBackend):
     def search(
         self, file_path: str | list[str], pattern: str, config: SearchConfig | None = None
     ) -> SearchResult:
+        # Audit MED: an explicitly-empty file_path list means "no candidate files" and must
+        # yield no matches. Without this guard, _append_search_paths no-ops on the empty list,
+        # leaving rg with zero path args -> rg defaults to a full recursive CWD scan (a
+        # scope-widening footgun + misleading --stats), instead of an empty search.
+        if isinstance(file_path, list) and not file_path:
+            return SearchResult(
+                matches=[],
+                matched_file_paths=[],
+                match_counts_by_file={},
+                total_files=0,
+                total_matches=0,
+                routing_backend="RipgrepBackend",
+                routing_reason="rg_empty_paths",
+            )
         if config and (config.count or config.count_matches):
             return self._search_counts(file_path=file_path, pattern=pattern, config=config)
         if config and config.files_with_matches:
@@ -504,11 +518,16 @@ class RipgrepBackend(ComputeBackend):
                 cmd.append("--max-columns-preview")
             if config.no_max_columns_preview and not json_mode:
                 cmd.append("--no-max-columns-preview")
-            if config.sort_by != "none" and not json_mode:
+            # Audit MED: --sort/--sortr/--sort-files change the RESULT ORDER (unlike
+            # --max-columns/--trim, which only affect text rendering and are legitimately
+            # json-gated), and rg honors them with --json. Forward unconditionally so the
+            # default search() (always json_mode) and --json callers get the requested
+            # ordering instead of silently dropping it.
+            if config.sort_by != "none":
                 cmd.extend(["--sort", config.sort_by])
-            if config.sort_files and not json_mode:
+            if config.sort_files:
                 cmd.append("--sort-files")
-            if config.sort_by_reverse != "none" and not json_mode:
+            if config.sort_by_reverse != "none":
                 cmd.extend(["--sortr", config.sort_by_reverse])
             if config.trim and not json_mode:
                 cmd.append("--trim")

--- a/src/tensor_grep/sidecar.py
+++ b/src/tensor_grep/sidecar.py
@@ -261,7 +261,10 @@ def _classify_payload(args: Sequence[str], payload: dict[str, Any] | None) -> tu
     if content and not lines:
         lines = [content]
     if not lines:
-        return "", "", 1
+        # Audit MED: this branch (empty content, e.g. a zero-byte file) previously returned
+        # exit 1 with NO stdout AND no stderr — a silent failure, unlike every other
+        # early-return in this function. Populate stderr with an explanatory message.
+        return "", "no content to classify (input is empty)\n", 1
 
     budgeted_lines, line_budget = _apply_classify_line_budget(lines, max_lines)
     results, classification_backend = _classify_lines_with_metadata(budgeted_lines)

--- a/tests/unit/test_ast_backend.py
+++ b/tests/unit/test_ast_backend.py
@@ -115,8 +115,13 @@ class TestAstBackend:
         assert result is not None
         assert isinstance(result.total_matches, int)
 
-    def test_should_return_empty_result_on_invalid_ast_query(self, tmp_path, mocker):
+    def test_should_raise_on_invalid_ast_query(self, tmp_path, mocker):
+        """Audit MED: a broad `except Exception` around tree-sitter query compilation
+        silently converted an invalid/malformed AST pattern into a look-alike 0-match
+        result. It must raise BackendExecutionError so run_command surfaces a real
+        'invalid pattern' error instead of a silent 0-match (a silent-fallback sibling)."""
         from tensor_grep.backends.ast_backend import AstBackend
+        from tensor_grep.backends.base import BackendExecutionError
 
         backend = AstBackend()
         mocker.patch.object(backend, "is_available", return_value=True)
@@ -144,12 +149,10 @@ class TestAstBackend:
         file_path = tmp_path / "test.py"
         file_path.write_text("def hello():\n    print('world')\n", encoding="utf-8")
 
-        result = backend.search(
-            str(file_path), "not a valid ast query", SearchConfig(ast=True, lang="python")
-        )
-
-        assert result.total_matches == 0
-        assert result.matches == []
+        with pytest.raises(BackendExecutionError):
+            backend.search(
+                str(file_path), "not a valid ast query", SearchConfig(ast=True, lang="python")
+            )
 
     def test_should_support_dict_capture_shape(self, tmp_path, mocker):
         from tensor_grep.backends.ast_backend import AstBackend

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -414,6 +414,44 @@ def test_count_single_file_without_filename_parses_bare_count():
     assert result.total_matches == 5
 
 
+def test_should_forward_sort_flags_in_json_mode():
+    """Audit MED: --sort/--sortr/--sort-files change RESULT ORDER and rg honors them with
+    --json, but they were gated behind `not json_mode` — and search() always uses json_mode,
+    so the requested ordering was silently dropped."""
+    backend = RipgrepBackend()
+    config = SearchConfig(sort_by="path")
+
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch(
+            "tensor_grep.backends.ripgrep_backend.run_subprocess", return_value=mock_result
+        ) as run,
+    ):
+        backend.search("test.log", "ERROR", config=config)
+
+    cmd = run.call_args[0][0]
+    assert "--sort" in cmd and "path" in cmd
+
+
+def test_empty_file_path_list_returns_empty_not_cwd_scan():
+    """Audit MED: an explicitly-empty file_path list means 'no candidate files'. Without a
+    guard, _append_search_paths no-ops and rg runs with zero path args -> a full recursive
+    CWD scan (scope-widening footgun), instead of an empty search."""
+    backend = RipgrepBackend()
+
+    with patch("tensor_grep.backends.ripgrep_backend.run_subprocess") as run:
+        result = backend.search([], "ERROR", config=SearchConfig())
+
+    run.assert_not_called()  # no path-less rg command emitted
+    assert result.total_matches == 0
+    assert result.total_files == 0
+
+
 def test_passthrough_should_forward_count_flag_and_exit_code():
     backend = RipgrepBackend()
     config = SearchConfig(count=True, no_ignore=True)

--- a/tests/unit/test_sidecar_classify.py
+++ b/tests/unit/test_sidecar_classify.py
@@ -5,6 +5,20 @@ import types
 from typer.testing import CliRunner
 
 
+def test_sidecar_classify_empty_content_reports_diagnostic(monkeypatch):
+    """Audit MED: classifying empty content returned exit 1 with NO stdout AND no stderr —
+    zero diagnostic, unlike every other early-return branch in _classify_payload. It must
+    populate stderr so a caller (e.g. classifying a zero-byte log) gets a real message."""
+    from tensor_grep.sidecar import _classify_payload
+
+    monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
+
+    stdout, stderr, exit_code = _classify_payload(["--format", "json"], {"content": ""})
+
+    assert exit_code == 1
+    assert stderr.strip()  # a non-empty explanatory message, not a silent failure
+
+
 def test_sidecar_classify_defaults_to_fast_local_heuristics(monkeypatch):
     from tensor_grep.sidecar import _classify_payload
 

--- a/tests/unit/test_sidecar_classify.py
+++ b/tests/unit/test_sidecar_classify.py
@@ -13,7 +13,7 @@ def test_sidecar_classify_empty_content_reports_diagnostic(monkeypatch):
 
     monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
 
-    stdout, stderr, exit_code = _classify_payload(["--format", "json"], {"content": ""})
+    _stdout, stderr, exit_code = _classify_payload(["--format", "json"], {"content": ""})
 
     assert exit_code == 1
     assert stderr.strip()  # a non-empty explanatory message, not a silent failure


### PR DESCRIPTION
## Summary

The first MED batch from the edge-case audit — silent-output and scope-correctness fixes in the search backends + sidecar. Each verified against the real code and fixed with TDD.

| Finding | Effect |
|---|---|
| rank 9 — rg sort dropped in json mode | `--sort`/`--sortr`/`--sort-files` gated behind `not json_mode`; `search()` always uses json_mode → requested ordering silently dropped |
| rank 13 — rg empty path list | an explicitly-empty `file_path` list left rg with zero path args → full recursive **CWD scan** instead of an empty search |
| rank 10 — ast invalid query | a broad `except` converted a malformed AST pattern into a silent 0-match (silent-fallback sibling) |
| sidecar:263 — empty-content classify | classifying empty content returned exit 1 with **no stdout AND no stderr** — a silent failure |

## Details

- **rank 9** — `--sort`/`--sortr`/`--sort-files` change result *order* and rg honors them with `--json`; forward them unconditionally (unlike `--max-columns`/`--trim`, which only affect text rendering and stay json-gated).
- **rank 13** — `search()` now returns an empty `SearchResult` (`routing_reason=rg_empty_paths`) for an explicitly-empty list instead of emitting a path-less rg command.
- **rank 10** — `AstBackend.search()` now raises `BackendExecutionError` on query-compile failure so `run_command` reports a real "invalid pattern" error; the test that asserted the old silent-empty behavior was flipped to assert the raise.
- **sidecar:263** — the empty-content branch of `_classify_payload` now populates stderr, matching every other early-return.

## Tests
New/updated TDD tests for each. All backend + sidecar suites green; `ruff` + `mypy` clean.

> Scope note: this is the first, high-signal slice of the MED/LOW audit batch. The remaining items (checkpoint retention cap, session fsync/rebuild, stringzilla flag exclusion, audit-manifest digest, session index race, gpu_search per-file isolation, and a few LOW defense-in-depth items) are tracked as a focused follow-up (they're either more involved or lower-value, and some overlap the queued SafeBackendMixin refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
