### PR TITLE
fix: fail loud on explicit --gpu-device-ids with fixed-string search (audit #9b)

### DIFF
--- a/src/tensor_grep/core/pipeline.py
+++ b/src/tensor_grep/core/pipeline.py
@@ -246,6 +246,17 @@ class Pipeline:
                 # For pure counting, our Rust backend beats rg and everything else
                 self.backend = rust_backend
                 selected_backend_reason = "count_rust_fast_path"
+            elif config and config.fixed_strings and config.gpu_device_ids:
+                # Audit MED: `--gpu-device-ids` with fixed-string (-F) search is a user-explicit
+                # GPU request, but _should_honor_explicit_gpu_ids excludes fixed_strings (no GPU
+                # fixed-string backend exists yet), so without this guard the request silently
+                # falls through to the StringZilla/CPU fast path below — dropping the explicit GPU
+                # intent with no diagnostic. Fail loud, as pcre2/AST already do. Revisit to route
+                # to GPU once a fixed-string GPU kernel ships.
+                self._raise_explicit_gpu_configuration_error(
+                    config,
+                    "fixed-string (-F) search has no GPU backend",
+                )
             elif (
                 config
                 and config.fixed_strings

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -33,6 +33,27 @@ class TestPipeline:
         assert pipeline.backend == mock_ast_backend.return_value
         assert pipeline.selected_backend_reason == "ast_backend_available"
 
+    @patch("tensor_grep.core.pipeline.StringZillaBackend")
+    @patch("tensor_grep.core.pipeline.RipgrepBackend")
+    @patch("tensor_grep.core.pipeline.RustCoreBackend")
+    def test_explicit_gpu_device_ids_with_fixed_strings_fails_loud_not_silent_cpu(
+        self, mock_rust, mock_rg, mock_sz
+    ):
+        """Audit MED: `--gpu-device-ids` + fixed-string (-F) search is an explicit GPU
+        request, but `_should_honor_explicit_gpu_ids` excludes fixed_strings (no GPU
+        fixed-string backend exists yet), so the request silently fell through to the
+        StringZilla/CPU fast path — dropping the explicit GPU intent with no diagnostic.
+        It must fail loud (ConfigurationError), like pcre2/AST already do."""
+        mock_rg.return_value.is_available.return_value = True
+        mock_rust.return_value.is_available.return_value = True
+        mock_sz.return_value.is_available.return_value = True  # sz would win before the fix
+
+        with pytest.raises(ConfigurationError):
+            Pipeline(
+                force_cpu=False,
+                config=SearchConfig(fixed_strings=True, gpu_device_ids=[0]),
+            )
+
     @patch("tensor_grep.core.pipeline.RipgrepBackend")
     @patch("tensor_grep.core.pipeline.RustCoreBackend")
     @patch("tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend")


### PR DESCRIPTION
An explicit `--gpu-device-ids` request with fixed-string (`-F`) search silently fell through to the StringZilla/CPU fast path — `_should_honor_explicit_gpu_ids` excludes `fixed_strings` (no GPU fixed-string backend yet), so the explicit GPU intent was dropped with no diagnostic. Now raises `ConfigurationError` (like pcre2/AST), rather than silently routing to CPU. TDD; full pipeline suite + lint + mypy green. Revisit to route to GPU once a fixed-string GPU kernel ships.