### PR TITLE
fix: round-2 audit-manifest + LSP security/DoS batch (PR-A)

### DIFF
--- a/src/tensor_grep/cli/audit_manifest.py
+++ b/src/tensor_grep/cli/audit_manifest.py
@@ -316,6 +316,9 @@ def _audit_diff_index_path(parent: str, index: int) -> str:
     return f"{parent}[{index}]" if parent else f"[{index}]"
 
 
+_MAX_MANIFEST_DIFF_DEPTH = 64
+
+
 def _diff_manifest_values(
     previous: Any,
     current: Any,
@@ -324,7 +327,15 @@ def _diff_manifest_values(
     added: dict[str, Any],
     removed: dict[str, Any],
     changed: dict[str, dict[str, Any]],
+    _depth: int = 0,
 ) -> None:
+    # Audit LOW (DoS): bound recursion over attacker-supplied manifest JSON so a maliciously
+    # deep manifest raises a clean, bounded error instead of an uncaught RecursionError crashing
+    # `tg audit diff`. Real audit manifests are shallow; 64 is generous headroom.
+    if _depth > _MAX_MANIFEST_DIFF_DEPTH:
+        raise ValueError(
+            f"Audit manifest nesting exceeds the maximum diff depth ({_MAX_MANIFEST_DIFF_DEPTH})."
+        )
     if isinstance(previous, dict) and isinstance(current, dict):
         for key in sorted(set(previous) | set(current)):
             if key in _AUDIT_DIFF_IGNORED_KEYS:
@@ -343,6 +354,7 @@ def _diff_manifest_values(
                 added=added,
                 removed=removed,
                 changed=changed,
+                _depth=_depth + 1,
             )
         return
 
@@ -356,6 +368,7 @@ def _diff_manifest_values(
                 added=added,
                 removed=removed,
                 changed=changed,
+                _depth=_depth + 1,
             )
         for index in range(shared_length, len(current)):
             added[_audit_diff_index_path(path, index)] = current[index]

--- a/src/tensor_grep/cli/audit_manifest.py
+++ b/src/tensor_grep/cli/audit_manifest.py
@@ -226,7 +226,9 @@ def create_review_bundle_json(
     )
 
 
-def verify_review_bundle(bundle_path: str | Path) -> dict[str, Any]:
+def verify_review_bundle(
+    bundle_path: str | Path, *, signing_key: str | Path | None = None
+) -> dict[str, Any]:
     resolved_bundle = Path(bundle_path).expanduser().resolve()
     bundle = _read_review_bundle_object(resolved_bundle)
     raw_checksums = bundle.get("checksums")
@@ -257,18 +259,46 @@ def verify_review_bundle(bundle_path: str | Path) -> dict[str, Any]:
         and expected_bundle_sha256 == actual_bundle_sha256,
     }
 
+    # Audit HIGH (integrity bypass): the SHA256 checks above are KEYLESS and cosmetic against a
+    # recomputing adversary (an attacker with write access to the bundle just recomputes them).
+    # Verify the embedded audit_manifest's HMAC signature with an out-of-band signing key: a
+    # SIGNED bundle then reports valid only when the correct key is supplied, and a signed bundle
+    # verified without the key fails closed. (Unsigned bundles have no signature to check.)
+    manifest_signature_valid = True
+    manifest_signature_error: str | None = None
+    embedded_manifest = bundle.get("audit_manifest")
+    if isinstance(embedded_manifest, dict):
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="tg_bundle_verify_") as tmp_dir:
+            tmp_manifest = Path(tmp_dir) / "manifest.json"
+            tmp_manifest.write_text(json.dumps(embedded_manifest), encoding="utf-8")
+            manifest_result = verify_audit_manifest(tmp_manifest, signing_key=signing_key)
+        manifest_checks = manifest_result.get("checks", {})
+        manifest_signature_valid = bool(manifest_checks.get("signature_valid", False))
+        if not manifest_signature_valid:
+            errs = manifest_result.get("errors") or []
+            manifest_signature_error = errs[0] if errs else "Embedded manifest signature invalid."
+
     payload = _envelope(routing_reason="review-bundle-verify")
     payload["bundle_path"] = str(resolved_bundle)
-    payload["valid"] = bundle_integrity["valid"] and all(
-        bool(component_check["valid"]) for component_check in checks.values()
+    payload["valid"] = (
+        bundle_integrity["valid"]
+        and all(bool(component_check["valid"]) for component_check in checks.values())
+        and manifest_signature_valid
     )
     payload["checks"] = checks
     payload["bundle_integrity"] = bundle_integrity
+    payload["manifest_signature_valid"] = manifest_signature_valid
+    if manifest_signature_error is not None:
+        payload["manifest_signature_error"] = manifest_signature_error
     return payload
 
 
-def verify_review_bundle_json(bundle_path: str | Path) -> str:
-    return json.dumps(verify_review_bundle(bundle_path), indent=2)
+def verify_review_bundle_json(
+    bundle_path: str | Path, *, signing_key: str | Path | None = None
+) -> str:
+    return json.dumps(verify_review_bundle(bundle_path, signing_key=signing_key), indent=2)
 
 
 def _resolve_history_root(path: str | Path) -> Path:

--- a/src/tensor_grep/cli/audit_manifest.py
+++ b/src/tensor_grep/cli/audit_manifest.py
@@ -288,16 +288,24 @@ def _resolve_history_root(path: str | Path) -> Path:
 
 
 def _resolve_manifest_root(manifest_path: Path, manifest: dict[str, Any]) -> Path:
+    manifest_resolved = manifest_path.expanduser().resolve()
     manifest_root = _normalize_optional_str(manifest.get("path"))
     if manifest_root is not None:
         candidate = Path(manifest_root).expanduser().resolve()
-        if candidate.exists():
+        # Audit HIGH (path traversal): manifest["path"] is attacker-controlled JSON. Only honor it
+        # when the manifest file actually lives under the declared root (or IS that root) — a
+        # tampered manifest pointing `path` at any other existing directory must NOT redirect the
+        # audit-history writes / checkpoint reads there. Otherwise derive the root from the
+        # manifest file's own location.
+        if candidate.exists() and (
+            candidate == manifest_resolved or candidate in manifest_resolved.parents
+        ):
             return _resolve_root(candidate)
 
-    for ancestor in manifest_path.expanduser().resolve().parents:
+    for ancestor in manifest_resolved.parents:
         if ancestor.name == _AUDIT_SUBDIR and ancestor.parent.name == _TG_DIRNAME:
             return ancestor.parent.parent
-    return manifest_path.expanduser().resolve().parent
+    return manifest_resolved.parent
 
 
 def _audit_diff_field_path(parent: str, field: str) -> str:

--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -85,6 +85,11 @@ def _configured_positive_int(env_var: str, default: int) -> int:
     return value if value > 0 else default
 
 
+# Audit MED (DoS): cap the framed-message body size so a malicious or buggy external LSP
+# provider cannot declare a huge Content-Length and force an unbounded read/allocation.
+_MAX_LSP_MESSAGE_BYTES = 64 * 1024 * 1024
+
+
 def _read_message(stream: Any) -> dict[str, Any] | None:
     headers: dict[str, str] = {}
     while True:
@@ -99,8 +104,14 @@ def _read_message(stream: Any) -> dict[str, Any] | None:
             continue
         key, value = line.split(":", 1)
         headers[key.strip().lower()] = value.strip()
-    content_length = int(headers.get("content-length", "0"))
+    try:
+        content_length = int(headers.get("content-length", "0"))
+    except (TypeError, ValueError):
+        return None
     if content_length <= 0:
+        return None
+    if content_length > _MAX_LSP_MESSAGE_BYTES:
+        # Refuse an oversized frame rather than allocating/reading an unbounded body.
         return None
     body = stream.read(content_length)
     if not body:

--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -670,6 +670,12 @@ class ExternalLSPClient:
             self._notify_document_closed(evicted_uri)
 
     def _notify_document_closed(self, uri: str) -> None:
+        # Audit LOW (leak): evict the per-URI version counter on close, mirroring the
+        # _opened_documents cleanup. Both removal paths (open-eviction and close_document)
+        # funnel through here, so _doc_versions no longer grows unbounded across a
+        # long-lived client's lifetime. _doc_versions is _lock-guarded (see did_change).
+        with self._lock:
+            self._doc_versions.pop(uri, None)
         try:
             self.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
         except Exception:

--- a/src/tensor_grep/cli/lsp_server.py
+++ b/src/tensor_grep/cli/lsp_server.py
@@ -98,6 +98,40 @@ def _resolve_repo_root(path: Path) -> Path:
     return path.parent.resolve()
 
 
+def _path_within_root(path: str | Path, root: Path) -> bool:
+    """Whether ``path`` resolves inside (or is) ``root`` — used to confine LSP edits."""
+    try:
+        target = Path(path).resolve()
+    except (OSError, ValueError):
+        return False
+    root_resolved = root.resolve()
+    return target == root_resolved or root_resolved in target.parents
+
+
+def _uri_within_root(uri: str, root: Path) -> bool:
+    try:
+        return _path_within_root(_uri_to_path(uri), root)
+    except (OSError, ValueError):
+        return False
+
+
+def _workspace_edit_target_uris(result: dict[str, Any]) -> list[str]:
+    """Collect every edited document URI from an external provider's WorkspaceEdit response
+    (both the ``changes`` map and the ``documentChanges`` list) so they can be confined."""
+    uris: list[str] = []
+    changes = result.get("changes")
+    if isinstance(changes, dict):
+        uris.extend(str(key) for key in changes)
+    document_changes = result.get("documentChanges")
+    if isinstance(document_changes, list):
+        for entry in document_changes:
+            if isinstance(entry, dict):
+                text_document = entry.get("textDocument")
+                if isinstance(text_document, dict) and text_document.get("uri"):
+                    uris.append(str(text_document["uri"]))
+    return uris
+
+
 def _invalidate_repo_map_cache(ls: TensorGrepLSPServer, uri: str) -> None:
     try:
         repo_root = _resolve_repo_root(_uri_to_path(uri))
@@ -671,6 +705,9 @@ def _workspace_edit_for_symbol(
     if resolved is None:
         return None
     symbol, _ = resolved
+    # Audit MED (edit-outside-workspace): confine every rename edit — external provider OR
+    # native — to the resolved workspace root, so a rename can never write to a file outside it.
+    workspace_root = _resolve_repo_root(_uri_to_path(uri))
     if ls.provider_mode != "native":
         deadline_monotonic = repo_map._lsp_operation_deadline()
         client = _external_client_for_uri(ls, uri, deadline_monotonic=deadline_monotonic)
@@ -694,10 +731,14 @@ def _workspace_edit_for_symbol(
             except LSPTransportError:
                 result = None
             if isinstance(result, dict) and result:
-                try:
-                    return WorkspaceEdit(**result)
-                except Exception:
-                    pass
+                edit_uris = _workspace_edit_target_uris(result)
+                if edit_uris and all(
+                    _uri_within_root(edit_uri, workspace_root) for edit_uri in edit_uris
+                ):
+                    try:
+                        return WorkspaceEdit(**result)
+                    except Exception:
+                        pass
     current_repo_map = _get_repo_map(ls, uri)
     defs_payload = repo_map.build_symbol_defs_from_map(current_repo_map, symbol)
     refs_payload = repo_map.build_symbol_refs_from_map(current_repo_map, symbol)
@@ -707,6 +748,8 @@ def _workspace_edit_for_symbol(
 
     document_changes: list[TextDocumentEdit] = []
     for current_file, entries in sorted(entries_by_file.items()):
+        if not _path_within_root(current_file, workspace_root):
+            continue  # never emit an edit for a file outside the workspace root
         edits: list[TextEdit] = []
         seen_ranges: set[tuple[int, int, int, int]] = set()
         for entry in sorted(

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -11035,6 +11035,11 @@ def review_bundle_create(
 @review_bundle_app.command("verify")
 def review_bundle_verify(
     bundle_path: str = typer.Argument(..., help="Path to the review bundle JSON file."),
+    signing_key: str | None = typer.Option(
+        None,
+        "--signing-key",
+        help="Optional HMAC signing key path to verify the embedded manifest's signature.",
+    ),
     json_output: bool = typer.Option(
         False,
         "--json",
@@ -11046,14 +11051,14 @@ def review_bundle_verify(
 
     try:
         if json_output:
-            json_text = verify_review_bundle_json(bundle_path)
+            json_text = verify_review_bundle_json(bundle_path, signing_key=signing_key)
             typer.echo(json_text)
             # Mirror the text path: a tampered/invalid bundle must exit 1 even in
             # --json mode (audit H1) so callers can gate on the process status.
             if not json.loads(json_text).get("valid", False):
                 raise typer.Exit(code=1)
             return
-        payload = verify_review_bundle(bundle_path)
+        payload = verify_review_bundle(bundle_path, signing_key=signing_key)
     except typer.Exit:
         raise
     except FileNotFoundError as exc:

--- a/tests/unit/test_audit_manifest_root_containment.py
+++ b/tests/unit/test_audit_manifest_root_containment.py
@@ -12,11 +12,38 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tensor_grep.cli.audit_manifest import (
     _AUDIT_SUBDIR,
     _TG_DIRNAME,
+    _diff_manifest_values,
     _resolve_manifest_root,
 )
+
+
+def _deep_manifest(leaf: str, depth: int = 100) -> dict:
+    root: dict = {}
+    node = root
+    for _ in range(depth):
+        node["k"] = {}
+        node = node["k"]
+    node["v"] = leaf
+    return root
+
+
+def test_diff_manifest_values_bounds_recursion_depth() -> None:
+    """Audit LOW (DoS): a maliciously deep manifest must raise a clean bounded ValueError,
+    not crash `tg audit diff` with an uncaught RecursionError."""
+    with pytest.raises(ValueError):
+        _diff_manifest_values(
+            _deep_manifest("a"),
+            _deep_manifest("b"),
+            path="",
+            added={},
+            removed={},
+            changed={},
+        )
 
 
 def test_resolve_manifest_root_ignores_tampered_out_of_tree_path(tmp_path: Path) -> None:

--- a/tests/unit/test_audit_manifest_root_containment.py
+++ b/tests/unit/test_audit_manifest_root_containment.py
@@ -1,0 +1,49 @@
+"""Path-containment regression test for audit-manifest root resolution (audit HIGH).
+
+``_resolve_manifest_root`` honored the manifest's self-reported ``path`` field verbatim
+whenever it pointed at any *existing* directory, with no containment check. A tampered
+manifest (attacker-controlled JSON) could therefore redirect the filesystem root used for
+audit-history writes and checkpoint reads to any directory on disk. The root must instead
+be honored only when the manifest file actually lives under the declared root, else be
+derived from the manifest file's own location.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.audit_manifest import (
+    _AUDIT_SUBDIR,
+    _TG_DIRNAME,
+    _resolve_manifest_root,
+)
+
+
+def test_resolve_manifest_root_ignores_tampered_out_of_tree_path(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    audit_dir = repo / _TG_DIRNAME / _AUDIT_SUBDIR
+    audit_dir.mkdir(parents=True)
+    manifest_path = audit_dir / "manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+
+    # An attacker points the manifest's `path` at an unrelated existing directory.
+    victim = tmp_path / "victim"
+    victim.mkdir()
+
+    root = _resolve_manifest_root(manifest_path, {"path": str(victim)})
+
+    # The tampered path must NOT be honored; the root must derive from the manifest location.
+    assert root == repo.resolve()
+    assert root != victim.resolve()
+
+
+def test_resolve_manifest_root_honors_legit_containing_path(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    audit_dir = repo / _TG_DIRNAME / _AUDIT_SUBDIR
+    audit_dir.mkdir(parents=True)
+    manifest_path = audit_dir / "manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+
+    # A legit manifest declares the root it actually lives under.
+    root = _resolve_manifest_root(manifest_path, {"path": str(repo)})
+    assert root == repo.resolve()

--- a/tests/unit/test_audit_manifest_signing_key.py
+++ b/tests/unit/test_audit_manifest_signing_key.py
@@ -58,6 +58,43 @@ def test_signed_manifest_with_correct_out_of_band_key_is_valid(tmp_path: Path) -
     assert result["valid"] is True
 
 
+def _make_signed_bundle(tmp_path: Path, signing_key_bytes: bytes) -> tuple[Path, Path]:
+    key = tmp_path / "audit.key"
+    key.write_bytes(signing_key_bytes)
+    manifest = tmp_path / "rewrite-audit.json"
+    _write_signed_manifest(manifest, signing_key_bytes, embedded_key_path=str(key))
+    bundle = audit_manifest.create_review_bundle(str(manifest))
+    bundle_path = tmp_path / "bundle.json"
+    bundle_path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+    return key, bundle_path
+
+
+def test_review_bundle_valid_only_with_correct_signing_key(tmp_path: Path) -> None:
+    """Audit HIGH (integrity bypass): a signed review bundle reports valid only when the
+    correct out-of-band signing key is supplied. The keyless SHA256 self-checks alone are
+    cosmetic against a recomputing adversary."""
+    key, bundle_path = _make_signed_bundle(tmp_path, b"top-secret")
+
+    with_key = audit_manifest.verify_review_bundle(str(bundle_path), signing_key=key)
+    assert with_key["manifest_signature_valid"] is True
+    assert with_key["valid"] is True
+
+    # A SIGNED bundle verified WITHOUT the key must fail closed, not report valid.
+    no_key = audit_manifest.verify_review_bundle(str(bundle_path))
+    assert no_key["manifest_signature_valid"] is False
+    assert no_key["valid"] is False
+
+
+def test_review_bundle_rejects_wrong_signing_key(tmp_path: Path) -> None:
+    _key, bundle_path = _make_signed_bundle(tmp_path, b"top-secret")
+    wrong = tmp_path / "wrong.key"
+    wrong.write_bytes(b"not-the-key")
+
+    result = audit_manifest.verify_review_bundle(str(bundle_path), signing_key=wrong)
+    assert result["manifest_signature_valid"] is False
+    assert result["valid"] is False
+
+
 def test_signed_manifest_without_key_refuses_embedded_key_path(tmp_path: Path) -> None:
     # The attacker controls both the manifest AND the embedded key file it points at.
     attacker_key = tmp_path / "attacker.key"

--- a/tests/unit/test_lsp_external_provider_hardening.py
+++ b/tests/unit/test_lsp_external_provider_hardening.py
@@ -33,3 +33,17 @@ def test_read_message_refuses_malformed_content_length() -> None:
     stream = _FakeStream(["Content-Length: not-a-number\r\n", "\r\n"])
     assert _read_message(stream) is None
     assert stream.read_called_with is None
+
+
+def test_notify_document_closed_evicts_doc_version(tmp_path, monkeypatch) -> None:
+    """Audit LOW (leak): _doc_versions grew unbounded because closed URIs were never
+    evicted (unlike _opened_documents). Closing a document must drop its version entry."""
+    import tensor_grep.cli.lsp_external_provider as m
+
+    monkeypatch.setattr(m, "_provider_command", lambda language: ["dummy-lsp"])
+    client = m.ExternalLSPClient(language="python", workspace_root=tmp_path)
+
+    client._doc_versions["file:///x.py"] = 5
+    client._notify_document_closed("file:///x.py")
+
+    assert "file:///x.py" not in client._doc_versions

--- a/tests/unit/test_lsp_external_provider_hardening.py
+++ b/tests/unit/test_lsp_external_provider_hardening.py
@@ -1,0 +1,35 @@
+"""Hardening regression tests for the external-LSP-provider message reader (audit MED).
+
+``_read_message`` trusted the framed ``Content-Length`` header with no upper bound before
+allocating/reading the body from the provider subprocess's stdout, so a malicious or buggy
+provider could force an unbounded read. It must refuse oversized (and malformed) frames.
+"""
+
+from __future__ import annotations
+
+from tensor_grep.cli.lsp_external_provider import _MAX_LSP_MESSAGE_BYTES, _read_message
+
+
+class _FakeStream:
+    def __init__(self, header_lines: list[str]) -> None:
+        self._lines = list(header_lines)
+        self.read_called_with: int | None = None
+
+    def readline(self) -> str:
+        return self._lines.pop(0) if self._lines else ""
+
+    def read(self, n: int) -> str:
+        self.read_called_with = n
+        return ""
+
+
+def test_read_message_refuses_oversized_content_length() -> None:
+    stream = _FakeStream([f"Content-Length: {_MAX_LSP_MESSAGE_BYTES + 1}\r\n", "\r\n"])
+    assert _read_message(stream) is None
+    assert stream.read_called_with is None  # the oversized body read was never attempted
+
+
+def test_read_message_refuses_malformed_content_length() -> None:
+    stream = _FakeStream(["Content-Length: not-a-number\r\n", "\r\n"])
+    assert _read_message(stream) is None
+    assert stream.read_called_with is None

--- a/tests/unit/test_lsp_server_confinement.py
+++ b/tests/unit/test_lsp_server_confinement.py
@@ -1,0 +1,46 @@
+"""Workspace-root confinement tests for LSP rename edits (audit MED).
+
+An external LSP provider's rename response was applied verbatim (``WorkspaceEdit(**result)``)
+with no check that the edited document URIs stayed inside the resolved workspace root, so a
+malicious/buggy provider could drive an edit to a file outside the workspace. Both the
+external and native rename branches now confine every edit target to the workspace root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.lsp_server import (
+    _path_to_uri,
+    _path_within_root,
+    _uri_within_root,
+    _workspace_edit_target_uris,
+)
+
+
+def test_path_and_uri_within_root_confine_and_reject(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / "pkg").mkdir(parents=True)
+    inside = root / "pkg" / "mod.py"
+    inside.write_text("x", encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text("x", encoding="utf-8")
+
+    assert _path_within_root(inside, root) is True
+    assert _path_within_root(outside, root) is False
+    assert _uri_within_root(_path_to_uri(inside), root) is True
+    assert _uri_within_root(_path_to_uri(outside), root) is False
+
+
+def test_workspace_edit_target_uris_extracts_both_shapes() -> None:
+    result = {
+        "changes": {"file:///a.py": [], "file:///b.py": []},
+        "documentChanges": [
+            {"textDocument": {"uri": "file:///c.py"}, "edits": []},
+        ],
+    }
+    assert set(_workspace_edit_target_uris(result)) == {
+        "file:///a.py",
+        "file:///b.py",
+        "file:///c.py",
+    }


### PR DESCRIPTION
## Summary

Round-2 audit **PR-A** — the Python-side security + DoS fixes for the audit-manifest and LSP subsystems, thinktank-reviewed (it caught 2 fix-approach corrections, baked in). Single-owner of `audit_manifest.py` + the LSP files per the council's conflict-safe sequencing. Each fix is TDD (RED→GREEN), lint + mypy clean.

| # | Sev | Fix |
|---|---|---|
| 1 | HIGH | **Manifest path-traversal** — `manifest["path"]` (attacker JSON) redirected audit writes/reads to any dir; now contained to the manifest's actual location |
| 2 | HIGH | **Review-bundle integrity bypass** — keyless SHA256 self-checks were cosmetic; now verifies the embedded manifest's **HMAC** (with a `--signing-key`) and fails closed |
| 3 | MED | **LSP rename escape** — an external provider's `WorkspaceEdit` could edit files **outside the workspace**; both rename branches now confine every edit to the workspace root |
| 4 | MED | **LSP Content-Length** unbounded read; now capped at 64 MB + malformed-header guard |
| 5 | LOW | **Audit-diff recursion** crash on a deep manifest; now a clean bounded error |
| 6 | LOW | **LSP `_doc_versions`** memory leak; now evicted on document close |

## Notable details
- **#2 (integrity):** `verify_review_bundle(..., signing_key=)` writes the embedded `audit_manifest` to a temp file and reuses the existing `verify_audit_manifest` HMAC path (`hmac.compare_digest` over canonical bytes), folding `signature_valid` into `valid`. A **signed** bundle now reports valid only with the correct out-of-band key; verified without it, it fails closed. The `--signing-key` CLI option is threaded through `review-bundle verify`. (Exa-confirmed: `hmac.compare_digest` + canonical-bytes is the correct 2026 pattern; the path-containment fix in #1 keeps the temp-verify's record side-effect inside the temp dir.)
- **#3 (confinement):** new `_path_within_root`/`_uri_within_root`/`_workspace_edit_target_uris` helpers; the external branch rejects an edit whose targets escape the root, the native branch skips out-of-root files.

## Tests
New TDD tests for each: manifest-root containment, recursion cap, Content-Length cap + malformed guard, `_doc_versions` eviction, LSP confinement helpers, and signed-bundle-valid-only-with-key / rejects-wrong-key. All affected suites green; `ruff` + `mypy` clean.

> Part of the round-2 program (thinktank-audited, GO_WITH_FIXES). Sequenced next: PR-B (Rust `--` sentinel + BatBadBut `Command::new` + GIL) → PR-C (native-delegation deny-by-default + ReDoS + `*`-quantifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
