### PR TITLE
fix: confine MCP write-tool paths to a per-tool anchor (round-4 arbitrary write, HIGH)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1457,7 +1457,6 @@ def tg_rulesets() -> str:
     return _inject_mcp_contract_fields(json.dumps(_build_rulesets_payload(), indent=2))
 
 
-@mcp.tool()  # type: ignore
 def _confine_write_path(candidate: str, anchor: Path, *, label: str) -> Path:
     """Resolve an MCP-supplied write path and refuse anything outside ``anchor`` (round-4).
 
@@ -1476,6 +1475,7 @@ def _confine_write_path(candidate: str, anchor: Path, *, label: str) -> Path:
     return resolved
 
 
+@mcp.tool()  # type: ignore
 def tg_ruleset_scan(
     ruleset: str,
     path: str = ".",

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1458,6 +1458,24 @@ def tg_rulesets() -> str:
 
 
 @mcp.tool()  # type: ignore
+def _confine_write_path(candidate: str, anchor: Path, *, label: str) -> Path:
+    """Resolve an MCP-supplied write path and refuse anything outside ``anchor`` (round-4).
+
+    The MCP write tools (ruleset baseline/suppressions, review-bundle output) take a path
+    straight from the (LLM/attacker-influenceable) tool call. Without confinement that is an
+    arbitrary-file-write primitive. Resolve the candidate (relative paths join the anchor),
+    normalize ``..`` and parent symlinks, and require the result to be the anchor itself or a
+    descendant; raise ``ValueError`` otherwise (fail closed).
+    """
+    anchor_resolved = anchor.expanduser().resolve()
+    raw = Path(candidate).expanduser()
+    target = raw if raw.is_absolute() else (anchor_resolved / raw)
+    resolved = target.resolve()
+    if resolved != anchor_resolved and anchor_resolved not in resolved.parents:
+        raise ValueError(f"{label} must stay within {anchor_resolved} (refused: {resolved})")
+    return resolved
+
+
 def tg_ruleset_scan(
     ruleset: str,
     path: str = ".",
@@ -1526,6 +1544,16 @@ def tg_ruleset_scan(
         "test_dirs": [],
         "language": ruleset_meta["language"],
     }
+    # round-4 security: confine the two write paths to the scan root before any scan/write —
+    # unconfined, they are an arbitrary-file-write primitive reachable from any MCP client.
+    scan_root = Path(path).expanduser().resolve()
+    try:
+        if write_baseline is not None:
+            _confine_write_path(write_baseline, scan_root, label="write_baseline")
+        if write_suppressions is not None:
+            _confine_write_path(write_suppressions, scan_root, label="write_suppressions")
+    except ValueError as exc:
+        return _ruleset_scan_error(str(exc), code="invalid_input", ruleset=ruleset, path=path)
     try:
         payload = _run_ast_scan_payload(
             project_cfg,
@@ -3295,6 +3323,18 @@ def tg_review_bundle_create(
             code="invalid_input",
             routing_reason="review-bundle-create",
         )
+
+    # round-4 security: confine the bundle output to the project (cwd) — unconfined it is an
+    # arbitrary-file-write primitive reachable from any MCP client.
+    if output_path is not None:
+        try:
+            _confine_write_path(output_path, Path.cwd(), label="output_path")
+        except ValueError as exc:
+            return _review_bundle_error(
+                str(exc),
+                code="invalid_input",
+                routing_reason="review-bundle-create",
+            )
 
     try:
         return create_review_bundle_json(

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tensor_grep.core.hardware.device_detect import DeviceInfo
 from tensor_grep.core.hardware.device_inventory import DeviceInventory
 from tensor_grep.core.result import MatchLine, SearchResult
@@ -4792,3 +4794,56 @@ def test_rewrite_apply_command_still_sentinels_positionals() -> None:
 
     assert cmd[-3:] == ["--", "-rf", "/tmp/x"]
     assert "--apply" in cmd and "--json" in cmd
+
+
+# --- round-4 security: MCP write-path confinement (arbitrary file write) -----------
+#
+# tg_ruleset_scan (write_baseline/write_suppressions) and tg_review_bundle_create
+# (output_path) forwarded LLM-supplied paths straight to disk with no confinement —
+# an arbitrary-file-write primitive reachable from any MCP client. Writes must stay
+# within a per-tool anchor (scan root / cwd) and fail closed otherwise.
+
+
+def test_confine_write_path_refuses_escape(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    anchor = tmp_path / "proj"
+    anchor.mkdir()
+    with pytest.raises(ValueError):
+        mcp_server._confine_write_path("../evil.json", anchor, label="write_baseline")
+    with pytest.raises(ValueError):
+        mcp_server._confine_write_path(str(tmp_path / "evil.json"), anchor, label="write_baseline")
+    ok = mcp_server._confine_write_path("baseline.json", anchor, label="write_baseline")
+    assert ok == (anchor.resolve() / "baseline.json")
+    ok2 = mcp_server._confine_write_path("sub/dir/base.json", anchor, label="x")
+    assert ok2 == (anchor.resolve() / "sub" / "dir" / "base.json")
+
+
+def test_ruleset_scan_refuses_write_baseline_escape(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    (scan_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+    escape = tmp_path / "evil_baseline.json"
+    out = mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), write_baseline=str(escape)
+    )
+    parsed = json.loads(out)
+    assert parsed.get("error", {}).get("code") == "invalid_input"
+    assert not escape.exists()  # fail closed: nothing written outside the scan root
+
+
+def test_review_bundle_create_refuses_output_path_escape(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    manifest = proj / "manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    monkeypatch.chdir(proj)  # cwd = the project anchor
+    escape = tmp_path / "evil_bundle.json"
+    out = mcp_server.tg_review_bundle_create(manifest_path=str(manifest), output_path=str(escape))
+    parsed = json.loads(out)
+    assert parsed.get("error", {}).get("code") == "invalid_input"
+    assert not escape.exists()


### PR DESCRIPTION
## The bug (HIGH, round-4)
Two MCP write tools forwarded an **LLM/attacker-supplied path straight to disk with no confinement** — an arbitrary-file-write primitive reachable from any MCP client (prompt-injection reachable):
- `tg_ruleset_scan` — `write_baseline` / `write_suppressions`
- `tg_review_bundle_create` — `output_path`

An MCP tool call could write to `/etc/cron.d/*`, `~/.bashrc`, a startup script, etc.

## The fix
`_confine_write_path(candidate, anchor, label)` resolves the path (relative joins the anchor; `..` and parent symlinks normalized) and raises `ValueError` unless the result is the anchor or a descendant — **fail closed**, checked *before* any scan/write:
- `tg_ruleset_scan` → confined to the **scan root** (`path`).
- `tg_review_bundle_create` → confined to **cwd** (the project boundary).

An escaping path returns an `invalid_input` error and writes nothing.

## Tests
- **TDD:** 3 new tests — helper refuses relative + absolute escapes and allows within-anchor; each tool fails closed on an escaping path with **no file written outside**.
- 13/13 (incl. 10 existing ruleset/review-bundle tests); `ruff` + `mypy` clean.

Round-4 #29 slice-2. Release-bearing (`fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
