### PR TITLE
fix: resolve apply-policy lint/test executables against PATH (round-4 CWE-427, HIGH)

### DIFF
--- a/src/tensor_grep/cli/apply_policy.py
+++ b/src/tensor_grep/cli/apply_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -359,6 +360,18 @@ def _run_policy_command(name: str, command: str, cwd: Path, timeout: int) -> dic
             passed=False,
             detail=f"{name} command could not be parsed: {exc}.",
         )
+
+    # CWE-427: resolve argv[0] against PATH to an absolute path BEFORE spawning. subprocess.run
+    # with a relative argv[0] and cwd=<target repo> lets a shadow executable planted in the
+    # untrusted repo (which Windows CreateProcess searches) pre-empt the real tool. Passing an
+    # absolute PATH-resolved binary removes the cwd search; fail closed if the tool is not on PATH.
+    resolved_executable = shutil.which(argv[0]) if argv else None
+    if resolved_executable is None:
+        return _command_result(
+            passed=False,
+            detail=f"{name} command executable {(argv[0] if argv else command)!r} was not found on PATH.",
+        )
+    argv = [resolved_executable, *argv[1:]]
 
     try:
         completed = subprocess.run(

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -951,3 +951,42 @@ def test_ast_workflow_main_entry_preserves_nonzero_exit_for_policy_failures(
     payload = json.loads(capsys.readouterr().out)
     assert payload["policy_result"] == {"all_passed": False}
     assert payload["mode"] == "apply"
+
+
+def test_run_policy_command_fails_closed_when_executable_missing_from_path(
+    tmp_path: Path,
+) -> None:
+    # CWE-427: a policy command whose executable is not on PATH must fail closed, never run.
+    from tensor_grep.cli.apply_policy import _run_policy_command
+
+    result = _run_policy_command(
+        "lint", "tg-definitely-nonexistent-tool-xyz --check", tmp_path, timeout=10
+    )
+    assert result["passed"] is False
+    assert "not found on PATH" in str(result["detail"])
+
+
+def test_run_policy_command_resolves_relative_executable_to_absolute(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # CWE-427: a relative argv[0] must be resolved to an absolute PATH binary before spawning,
+    # so Windows CreateProcess never searches the untrusted target-repo cwd for a shadow tool.
+    from tensor_grep.cli import apply_policy
+
+    fake_abs = str(tmp_path / "trusted-bin" / "ruff")
+    monkeypatch.setattr(
+        apply_policy.shutil, "which", lambda cmd: fake_abs if cmd == "ruff" else None
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_run(argv, **kwargs):
+        captured["argv"] = list(argv)
+        import subprocess as _sp
+
+        return _sp.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(apply_policy.subprocess, "run", _fake_run)
+    result = apply_policy._run_policy_command("lint", "ruff check .", tmp_path, timeout=10)
+
+    assert captured["argv"][0] == fake_abs  # absolute, PATH-resolved — not a cwd search
+    assert result["passed"] is True


### PR DESCRIPTION
## The bug (HIGH, CWE-427)
`_run_policy_command` (`apply_policy.py:364`) ran `policy.lint_cmd` / `policy.test_cmd` via `subprocess.run(argv, shell=False, cwd=<target repo root>)` where `argv[0]` could be **relative**. On Windows, `CreateProcess` searches the cwd — so an **untrusted target repo can plant a shadow `pytest.exe` / `ruff.exe` in its root** that pre-empts the real tool on PATH → arbitrary code execution during an apply/validate. Uncontrolled search path element.

## The fix
Resolve `argv[0]` with `shutil.which()` to an **absolute PATH binary** before spawning, so `CreateProcess` uses that exact path and never searches the target-repo cwd. **Fail closed** (`"<exe> not found on PATH"`) if unresolved. An already-absolute `argv[0]` (e.g. the `sys.executable` path the existing tests use) resolves to itself — no behavior change for legit configs.

## Tests
- **TDD:** 2 new tests — fail-closed when the executable is missing from PATH; a relative `argv[0]` is substituted with the absolute PATH-resolved path (each genuinely fails without the fix).
- Full `tests/unit/test_apply_policy.py`: **36 passed**; `ruff` + `mypy` clean.

Round-4 #31 (first of the apply-LSP HIGH pair; the managed-LSP `.cmd`-shim `node` hijack is the follow-up). Release-bearing (`fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
