### PR TITLE
fix: cap checkpoint retention to bound unbounded disk growth (round-4 DoS)

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -26,6 +26,10 @@ _DISCOVERY_CACHE_VERSION = 2
 _DISCOVERY_MAX_DEPTH = 6
 _DISCOVERY_MAX_DIRECTORIES = 10_000
 _DISCOVERY_CACHE_TTL_SECONDS = 300.0
+# round-4 DoS: bound on-disk checkpoint retention. Each checkpoint copies the WHOLE scope into a
+# new snapshot dir, so an uncapped store grows without limit. Keep only the newest N.
+_CHECKPOINT_MAX_ENV = "TG_CHECKPOINT_MAX"
+_DEFAULT_CHECKPOINT_MAX = 64
 _NON_GIT_IGNORED_DIRS = {
     ".git",
     ".hg",
@@ -603,6 +607,42 @@ def _write_checkpoint_metadata(
     _write_json_atomic(_metadata_path(root, result.checkpoint_id), payload)
 
 
+def _configured_checkpoint_max() -> int:
+    raw = os.environ.get(_CHECKPOINT_MAX_ENV)
+    if raw is None:
+        return _DEFAULT_CHECKPOINT_MAX
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_CHECKPOINT_MAX
+    return value if value > 0 else _DEFAULT_CHECKPOINT_MAX
+
+
+def _prune_checkpoint_records(
+    root: Path,
+    records: list[CheckpointRecord],
+    *,
+    max_records: int | None = None,
+) -> list[CheckpointRecord]:
+    """Bound on-disk checkpoint retention (round-4 DoS).
+
+    Keep at most ``max_records`` newest records (``records`` must already be newest-first). Each
+    dropped checkpoint's entire directory (metadata.json + the full snapshot copy) is removed so
+    disk usage stays bounded — an uncapped store grows by ~one full scope copy per checkpoint.
+    """
+    limit = _configured_checkpoint_max() if max_records is None else max(1, int(max_records))
+    if len(records) <= limit:
+        return records
+    retained = records[:limit]
+    for dropped in records[limit:]:
+        try:
+            shutil.rmtree(_checkpoint_dir(root, dropped.checkpoint_id), ignore_errors=True)
+        except (OSError, ValueError):
+            # ValueError: a traversal-shaped id in a tampered index is refused by _checkpoint_dir.
+            pass
+    return retained
+
+
 def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
     scope = _detect_checkpoint_scope(Path(path))
     root = scope.root
@@ -653,6 +693,7 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
             file_count=len(entries),
         ),
     )
+    records = _prune_checkpoint_records(root, records)
     _write_index(root, records)
     _prime_bounded_discovery_caches_for_root(root)
     return result

--- a/tests/unit/test_checkpoint_containment.py
+++ b/tests/unit/test_checkpoint_containment.py
@@ -157,3 +157,27 @@ def test_create_checkpoint_does_not_disclose_symlink_target(tmp_path: Path) -> N
     for path in snapshot.rglob("*"):
         if path.is_file() and not path.is_symlink():
             assert "SECRET-OUT-OF-ROOT" not in path.read_text(encoding="utf-8", errors="ignore")
+
+
+def test_create_checkpoint_prunes_to_retention_cap(tmp_path: Path, monkeypatch) -> None:
+    """Round-4 DoS: the checkpoint store had no retention cap, so every `tg checkpoint create`
+    copied the whole scope into a new snapshot dir with unbounded disk growth. Retain only the
+    newest TG_CHECKPOINT_MAX; drop older checkpoints (metadata + snapshot) entirely."""
+    monkeypatch.setenv("TG_CHECKPOINT_MAX", "3")
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "f.py").write_text("x\n", encoding="utf-8")
+
+    ids: list[str] = []
+    for i in range(6):
+        (root / "f.py").write_text(f"x{i}\n", encoding="utf-8")
+        ids.append(checkpoint_store.create_checkpoint(str(root)).checkpoint_id)
+
+    records = checkpoint_store._load_index(root)
+    assert len(records) == 3, "index must be bounded to TG_CHECKPOINT_MAX"
+    assert {r.checkpoint_id for r in records} == set(ids[-3:]), "keep the 3 newest"
+
+    for dropped in ids[:-3]:
+        assert not checkpoint_store._checkpoint_dir(root, dropped).exists()  # snapshot removed
+    for kept in ids[-3:]:
+        assert checkpoint_store._checkpoint_dir(root, kept).exists()


### PR DESCRIPTION
## The bug (round-4)
`create_checkpoint` (`checkpoint_store.py`) copies the **whole scope** into a new snapshot dir and appends to the index with **no cap and no pruning**. Each `tg checkpoint create` is ~one full copy of every tracked/untracked file, so repeated checkpoints grow disk **without limit**. The session store already bounds retention (`TG_SESSION_MAX`); checkpoints never got the same fix.

## The fix
Mirror the session-store pattern: `TG_CHECKPOINT_MAX` (default 64) + `_prune_checkpoint_records()`. After inserting the new record, keep the newest N and `shutil.rmtree` each dropped checkpoint's **whole directory** (metadata + full snapshot).

## Tests
- **TDD:** create 6 checkpoints with `TG_CHECKPOINT_MAX=3` → only the 3 newest survive (index records + snapshot dirs); older dirs removed.
- Full checkpoint suites (`atomic_undo` + `cli` + `containment`): **53 passed**; ruff + mypy clean.

Round-4 session-remainder HIGH (tracked in #32). Release-bearing (`fix:`); merges after #328 publishes (one-merge-per-tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
