### PR TITLE
fix: fail loud on explicit --gpu-device-ids for all non-GPU routes (round-4, council-vetted)

### DIFF
--- a/src/tensor_grep/core/pipeline.py
+++ b/src/tensor_grep/core/pipeline.py
@@ -200,6 +200,12 @@ class Pipeline:
                 else:
                     self.backend = CPUBackend()
                     selected_backend_reason = "force_cpu_python_cpu"
+            elif config and config.ast and config.gpu_device_ids:
+                # round-4: AST search has no GPU backend, but _should_honor_explicit_gpu_ids
+                # excludes ast, so an explicit --gpu-device-ids request silently fell through.
+                self._raise_explicit_gpu_configuration_error(
+                    config, "AST search has no GPU backend"
+                )
             elif config and config.ast:
                 try:
                     from tensor_grep.backends.ast_backend import AstBackend
@@ -239,9 +245,21 @@ class Pipeline:
                 if cybert_backend.is_available():
                     self.backend = cybert_backend
                     selected_backend_reason = "nlp_cybert"
+                elif config and config.gpu_device_ids:
+                    # round-4: cybert (the only GPU-capable NLP path) is unavailable; an explicit
+                    # --gpu-device-ids request must not silently fall back to a non-GPU backend.
+                    self._raise_explicit_gpu_configuration_error(
+                        config, "NLP classification backend (cybert) is unavailable"
+                    )
                 else:
                     self.backend = fallback_backend
                     selected_backend_reason = "nlp_backend_unavailable_fallback"
+            elif config and config.count and config.gpu_device_ids:
+                # round-4: count (-c) search has no GPU backend; fail loud rather than silently
+                # taking the rust/rg count fast path and dropping the explicit GPU request.
+                self._raise_explicit_gpu_configuration_error(
+                    config, "count (-c) search has no GPU backend"
+                )
             elif config and config.count and rust_available:
                 # For pure counting, our Rust backend beats rg and everything else
                 self.backend = rust_backend
@@ -266,6 +284,13 @@ class Pipeline:
                 # For literal string searches without context boundaries, StringZilla's SIMD destroys C
                 self.backend = sz_backend
                 selected_backend_reason = "fixed_strings_stringzilla_fast_path"
+            elif config and config.gpu_device_ids and needs_python_cpu:
+                # round-4: context/line-regexp/word-regexp/LTL routes have no GPU backend
+                # (_should_honor_explicit_gpu_ids excludes needs_python_cpu); fail loud instead
+                # of silently taking the rg/CPU semantics path and dropping the GPU request.
+                self._raise_explicit_gpu_configuration_error(
+                    config, "context/line-regexp/word-regexp/LTL search has no GPU backend"
+                )
             elif config and (
                 config.context
                 or config.before_context

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -56,6 +56,35 @@ class TestPipeline:
 
     @patch("tensor_grep.core.pipeline.RipgrepBackend")
     @patch("tensor_grep.core.pipeline.RustCoreBackend")
+    def test_explicit_gpu_device_ids_with_count_fails_loud_not_silent_cpu(self, mock_rust, mock_rg):
+        """Round-4: --gpu-device-ids + --count has no GPU backend, but count silently won
+        via count_rust_fast_path, dropping the explicit GPU intent with no diagnostic. It
+        must fail loud (ConfigurationError), like fixed-strings/pcre2/AST already do."""
+        mock_rg.return_value.is_available.return_value = True
+        mock_rust.return_value.is_available.return_value = True
+        with pytest.raises(ConfigurationError):
+            Pipeline(
+                force_cpu=False,
+                config=SearchConfig(query_pattern="ERROR", count=True, gpu_device_ids=[0]),
+            )
+
+    @patch("tensor_grep.core.pipeline.RipgrepBackend")
+    @patch("tensor_grep.core.pipeline.RustCoreBackend")
+    def test_explicit_gpu_device_ids_with_context_fails_loud_not_silent_cpu(
+        self, mock_rust, mock_rg
+    ):
+        """Round-4: --gpu-device-ids + context (-C) has no GPU backend, but the semantics
+        branch silently routed to rg_semantics_fast_path, dropping the GPU intent."""
+        mock_rg.return_value.is_available.return_value = True
+        mock_rust.return_value.is_available.return_value = True
+        with pytest.raises(ConfigurationError):
+            Pipeline(
+                force_cpu=False,
+                config=SearchConfig(query_pattern="ERROR", context=3, gpu_device_ids=[0]),
+            )
+
+    @patch("tensor_grep.core.pipeline.RipgrepBackend")
+    @patch("tensor_grep.core.pipeline.RustCoreBackend")
     @patch("tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend")
     @patch("tensor_grep.backends.ast_backend.AstBackend")
     def test_should_prefer_ast_wrapper_by_default_when_both_ast_backends_are_available(


### PR DESCRIPTION
## The bug (round-4, HIGH)
The shipped #9b fix only guarded `fixed_strings + --gpu-device-ids`. The **fix-approach-council** verified **3 more sibling silent-drop branches**: an explicit `--gpu-device-ids` combined with **AST**, **count (`-c`)**, **context/line-regexp/word-regexp/LTL**, or an **unavailable-cybert NLP** route was silently routed to a non-GPU backend with **no error, no warning** — the explicit GPU intent dropped.

The council also caught that the single-location fix the finding *cited* (`pipeline.py:203`) is a **no-op**: `_should_honor_explicit_gpu_ids` excludes these routes, so those branches are reached *before* the explicit-GPU branch.

## The fix (council-vetted)
**4 per-branch guards**, each gated **strictly on `config.gpu_device_ids` truthiness**, mirroring the shipped `_raise_explicit_gpu_configuration_error` (#9b). Rejected the "centralize before the elif chain" variant (would break `force_cpu` precedence). Plain no-GPU paths and the explicit-GPU happy path are unchanged; pcre2/force_cpu untouched.

## Tests
- **TDD:** 2 new tests (count+gpu, context+gpu → `ConfigurationError`) watched fail; **3 existing tripwires** (count-no-gpu, ast-no-gpu, explicit-gpu-happy-path) stay green.
- `test_pipeline.py` **38 passed**, cross_backend **39 passed/6 skipped**; ruff + mypy clean.

Round-4 batch #34 (PR-C of 5). Release-bearing (`fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
