### PR TITLE
fix: spawn managed Windows LSP providers via trusted node+js argv, not the CWD-searchable .cmd shim (CWE-427)

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 
 from tensor_grep.cli.lsp_provider_setup import (
     canonical_language,
+    direct_managed_node_command,
     managed_provider_env,
     resolved_provider_command,
     wrap_windows_batch_command,
@@ -412,17 +413,36 @@ class ExternalLSPClient:
             raise LSPTransportError(self.last_error or "LSP provider temporarily unavailable")
         if self.process is not None:
             self.stop()
+        managed_root = _managed_provider_root()
+        try:
+            spawn_argv = direct_managed_node_command(list(self.command), root=managed_root)
+        except (ValueError, FileNotFoundError, OSError) as exc:
+            # Fail CLOSED (CWE-427): a managed Node cmd-shim whose trusted node.exe / JS
+            # entrypoint cannot be resolved must NOT fall back to the cmd.exe/.cmd path —
+            # that path's bare `node` resolves CWD-first against the attacker-controlled
+            # workspace_root. Silent fallback would re-open the exact hole we are closing.
+            raise LSPTransportError(
+                f"managed LSP provider could not be resolved to a trusted node runtime: {exc}"
+            ) from exc
+        if spawn_argv is None:
+            # External/PATH providers, managed native .exe binaries, and all POSIX are
+            # unchanged (wrap_windows_batch_command is a no-op except for a real .cmd/.bat).
+            spawn_argv = wrap_windows_batch_command(list(self.command))
+        # cwd stays workspace_root: the resolved argv contains zero CWD-searchable names, so
+        # this launch is safe. Residual (not exploitable here — these servers are
+        # worker-thread based): a server that itself spawns a bare-name grandchild at runtime
+        # could recur one level down.
         self.process = subprocess.Popen(
-            wrap_windows_batch_command(list(self.command)),
+            spawn_argv,
             cwd=str(self.workspace_root),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=managed_provider_env(self.command, managed_root=_managed_provider_root()),
+            env=managed_provider_env(self.command, managed_root=managed_root),
         )
         self._record_debug_trace(
             event="process_start",
-            detail={"command": list(self.command), "cwd": str(self.workspace_root)},
+            detail={"command": spawn_argv, "cwd": str(self.workspace_root)},
         )
         self._message_queue = queue.Queue()
         self._pending_requests = {}

--- a/src/tensor_grep/cli/lsp_provider_setup.py
+++ b/src/tensor_grep/cli/lsp_provider_setup.py
@@ -380,6 +380,74 @@ def wrap_windows_batch_command(command: list[str]) -> list[str]:
     return command
 
 
+# Managed Node LSP shim name -> npm package name. NOT 1:1: pyright-langserver ships in
+# the `pyright` package. Used to resolve the trusted JS entrypoint for the CWE-427 bypass.
+_MANAGED_NODE_BIN_TO_PACKAGE = {
+    "pyright-langserver": "pyright",
+    "typescript-language-server": "typescript-language-server",
+    "intelephense": "intelephense",
+}
+
+
+def managed_provider_js_entrypoint(binary_name: str, root: Path) -> Path:
+    """Resolve a managed Node LSP shim to its trusted absolute JS entrypoint.
+
+    Reads the package's ``package.json['bin']`` (the stable contract) rather than
+    text-parsing the generated ``.cmd`` cmd-shim (npm's cmd-shim template drifts across
+    versions with no stability guarantee). Fails CLOSED — raises on any resolution gap —
+    so the caller can never silently fall back to the CWD-searchable ``cmd.exe``/``.cmd``
+    launch path (CWE-427).
+    """
+    package = _MANAGED_NODE_BIN_TO_PACKAGE.get(binary_name)
+    if package is None:
+        raise ValueError(f"no managed npm package known for LSP shim {binary_name!r}")
+    package_dir = _node_packages_dir(root) / "node_modules" / package
+    data = json.loads((package_dir / "package.json").read_text(encoding="utf-8"))
+    bin_field = data.get("bin")
+    relative: str | None
+    if isinstance(bin_field, str):
+        relative = bin_field
+    elif isinstance(bin_field, dict):
+        relative = bin_field.get(binary_name)
+    else:
+        relative = None
+    if not relative:
+        raise ValueError(f"package.json for {package!r} has no bin entry for {binary_name!r}")
+    entry = (package_dir / relative).resolve()
+    if not entry.is_file():
+        raise FileNotFoundError(f"managed LSP entrypoint missing: {entry}")
+    return entry
+
+
+def direct_managed_node_command(command: list[str], *, root: Path) -> list[str] | None:
+    """Rewrite a MANAGED Node ``.cmd`` shim spawn into a direct, trusted-absolute
+    ``[node.exe, entry.js, *args]`` argv, bypassing the CWE-427-vulnerable cmd-shim.
+
+    The npm ``.cmd`` shim resolves a BARE ``node`` token, which ``cmd.exe`` searches
+    CWD-first — and for an LSP spawn CWD is the attacker-controlled analyzed workspace, so
+    a planted ``workspace_root\\node.exe`` hijacks the language server. Rewriting to the
+    trusted absolute node runtime + JS entrypoint removes every CWD-searchable name.
+
+    Returns ``None`` (caller keeps its existing ``wrap_windows_batch_command`` path) for
+    every case this bypass must NOT touch: non-Windows, non-managed/external providers, and
+    managed native ``.exe`` binaries (rust-analyzer/gopls/csharp-ls). Once the gate passes
+    (a managed Windows ``.cmd``/``.bat`` shim), any failure to resolve the trusted node
+    runtime or JS entrypoint RAISES (fail closed) — it never returns ``None``, so it can
+    never silently drop back to the vulnerable shim.
+    """
+    if not command or not is_windows():
+        return None
+    if _command_source(command, root) != "managed":
+        return None
+    if Path(command[0]).suffix.lower() not in {".cmd", ".bat"}:
+        return None
+    node_exe = _node_executable(root)
+    if not node_exe.is_file():
+        raise FileNotFoundError(f"managed node runtime missing: {node_exe}")
+    js_entry = managed_provider_js_entrypoint(Path(command[0]).stem, root)
+    return [str(node_exe), str(js_entry), *command[1:]]
+
+
 def _run_checked(command: list[str], *, cwd: Path | None = None) -> None:
     command = wrap_windows_batch_command(command)
     completed = subprocess.run(

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -134,6 +134,7 @@ def test_start_leaves_external_path_cmd_provider_unchanged(
     captured: dict[str, Any] = {}
     _install_spawn_capture(monkeypatch, captured)
 
+    monkeypatch.setattr(provider_module, "_provider_command", lambda _language: ["placeholder"])
     client = ExternalLSPClient(language="python", workspace_root=tmp_path)
     client.command = [str(external_cmd), "--stdio"]
     with pytest.raises(_CapturedSpawn):
@@ -152,6 +153,7 @@ def test_start_leaves_managed_native_exe_provider_unchanged(
     captured: dict[str, Any] = {}
     _install_spawn_capture(monkeypatch, captured)
 
+    monkeypatch.setattr(provider_module, "_provider_command", lambda _language: ["placeholder"])
     client = ExternalLSPClient(language="python", workspace_root=tmp_path)
     client.command = [str(fake["rust_exe"])]
     with pytest.raises(_CapturedSpawn):
@@ -169,6 +171,9 @@ def test_start_leaves_posix_command_unchanged(
     captured: dict[str, Any] = {}
     _install_spawn_capture(monkeypatch, captured)
 
+    # Stub command resolution so construction never depends on a real pyright on PATH (present on
+    # dev boxes, absent on clean CI); this test overrides client.command below regardless.
+    monkeypatch.setattr(provider_module, "_provider_command", lambda _language: ["placeholder"])
     client = ExternalLSPClient(language="python", workspace_root=tmp_path)
     client.command = ["/usr/bin/pyright-langserver", "--stdio"]
     with pytest.raises(_CapturedSpawn):

--- a/tests/unit/test_lsp_external_provider.py
+++ b/tests/unit/test_lsp_external_provider.py
@@ -11,11 +11,169 @@ from typing import Any
 import pytest
 
 import tensor_grep.cli.lsp_external_provider as provider_module
+import tensor_grep.cli.lsp_provider_setup as provider_setup
 from tensor_grep.cli.lsp_external_provider import (
     ExternalLSPClient,
     ExternalLSPProviderManager,
     LSPTransportError,
 )
+
+
+class _CapturedSpawn(Exception):
+    """Raised by the fake ``subprocess.Popen`` after recording argv so ``start()`` aborts
+    before touching real process I/O; the test inspects the captured argv."""
+
+
+def _install_spawn_capture(monkeypatch: pytest.MonkeyPatch, captured: dict[str, Any]) -> None:
+    def _fake_popen(argv: Any, **kwargs: Any) -> Any:
+        captured["argv"] = list(argv)
+        captured["cwd"] = kwargs.get("cwd")
+        raise _CapturedSpawn
+
+    monkeypatch.setattr(provider_module.subprocess, "Popen", _fake_popen)
+
+
+def _build_fake_managed_root(tmp_path: Path) -> dict[str, Path]:
+    """A managed-provider root with the REAL-shaped layout the CWE-427 bypass needs:
+    a node runtime, the ``.bin`` cmd-shim, and the resolvable ``package.json['bin']``
+    JS entrypoint. (The pre-existing managed-start fixtures stub only an empty ``.cmd``,
+    which cannot exercise the node/js rewrite — the mock-vs-real trap.)"""
+    root = tmp_path / "providers"
+    node_runtime = root / "node-runtime"
+    node_bin = root / "node-packages" / "node_modules" / ".bin"
+    pyright_pkg = root / "node-packages" / "node_modules" / "pyright"
+    managed_bin = root / "bin"
+    for directory in (node_runtime, node_bin, pyright_pkg, managed_bin):
+        directory.mkdir(parents=True, exist_ok=True)
+    node_exe = node_runtime / "node.exe"
+    node_exe.write_text("", encoding="utf-8")
+    cmd_shim = node_bin / "pyright-langserver.cmd"
+    cmd_shim.write_text("@node ... %*\n", encoding="utf-8")
+    (pyright_pkg / "package.json").write_text(
+        '{"bin": {"pyright-langserver": "langserver.js"}}', encoding="utf-8"
+    )
+    js_entry = pyright_pkg / "langserver.js"
+    js_entry.write_text("", encoding="utf-8")
+    rust_exe = managed_bin / "rust-analyzer.exe"
+    rust_exe.write_text("", encoding="utf-8")
+    return {
+        "root": root,
+        "node_exe": node_exe,
+        "cmd_shim": cmd_shim,
+        "js_entry": js_entry,
+        "rust_exe": rust_exe,
+    }
+
+
+def test_start_rewrites_managed_windows_cmd_shim_to_direct_node_js_argv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Round-4 CWE-427: the managed pyright ``.cmd`` shim resolves a BARE ``node`` which
+    ``cmd.exe`` searches CWD-first — and CWD is the attacker-controlled analyzed
+    ``workspace_root``. ``start()`` must spawn the trusted absolute
+    ``[node.exe, langserver.js, --stdio]`` argv instead, so no launch step performs a
+    CWD-relative search. TODAY it spawns ``[cmd.exe, /C, ...pyright-langserver.cmd, --stdio]``."""
+    fake = _build_fake_managed_root(tmp_path)
+    monkeypatch.setattr(provider_setup, "is_windows", lambda: True)
+    monkeypatch.setattr(provider_module, "_managed_provider_root", lambda *a, **k: fake["root"])
+    captured: dict[str, Any] = {}
+    _install_spawn_capture(monkeypatch, captured)
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    # Sanity: resolution yielded the managed .cmd shim (the vulnerable input).
+    assert client.command[0] == str(fake["cmd_shim"])
+    assert client.command[-1] == "--stdio"
+
+    with pytest.raises(_CapturedSpawn):
+        client.start()
+
+    expected_js = (
+        fake["root"] / "node-packages" / "node_modules" / "pyright" / "langserver.js"
+    ).resolve()
+    assert captured["argv"] == [str(fake["node_exe"]), str(expected_js), "--stdio"]
+    assert "cmd.exe" not in captured["argv"]
+    assert not any(part.lower().endswith(".cmd") for part in captured["argv"])
+    assert "node" not in captured["argv"]  # no BARE, CWD-searchable token
+
+
+def test_start_fails_closed_when_managed_js_entrypoint_unresolvable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If a managed shim's trusted JS entrypoint cannot be resolved (e.g. a future
+    ``package.json`` bin-layout change), ``start()`` must RAISE (fail closed), never
+    silently fall back to the CWD-searchable ``cmd.exe``/``.cmd`` path."""
+    fake = _build_fake_managed_root(tmp_path)
+    monkeypatch.setattr(provider_setup, "is_windows", lambda: True)
+    monkeypatch.setattr(provider_module, "_managed_provider_root", lambda *a, **k: fake["root"])
+
+    def _boom(_binary: str, _root: Path) -> Path:
+        raise ValueError("bin layout changed")
+
+    monkeypatch.setattr(provider_setup, "managed_provider_js_entrypoint", _boom)
+    captured: dict[str, Any] = {}
+    _install_spawn_capture(monkeypatch, captured)
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    with pytest.raises(LSPTransportError):
+        client.start()
+    assert "argv" not in captured  # never spawned the vulnerable shim
+
+
+def test_start_leaves_external_path_cmd_provider_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An external/PATH provider (a ``.cmd`` OUTSIDE the managed root, whose npm layout
+    tensor-grep does not own) must still route through ``cmd.exe`` unchanged — the
+    managed-only gate must not try to resolve a JS entry it does not own."""
+    fake = _build_fake_managed_root(tmp_path)
+    external_cmd = tmp_path / "external" / "pyright-langserver.cmd"
+    external_cmd.parent.mkdir(parents=True, exist_ok=True)
+    external_cmd.write_text("@node ...\n", encoding="utf-8")
+    monkeypatch.setattr(provider_setup, "is_windows", lambda: True)
+    monkeypatch.setattr(provider_module, "_managed_provider_root", lambda *a, **k: fake["root"])
+    captured: dict[str, Any] = {}
+    _install_spawn_capture(monkeypatch, captured)
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.command = [str(external_cmd), "--stdio"]
+    with pytest.raises(_CapturedSpawn):
+        client.start()
+    assert captured["argv"] == ["cmd.exe", "/C", str(external_cmd), "--stdio"]
+
+
+def test_start_leaves_managed_native_exe_provider_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A managed NATIVE ``.exe`` provider (rust-analyzer) has no cmd-shim and must never
+    be routed through the node/js rewrite — its suffix is ``.exe``, not ``.cmd``."""
+    fake = _build_fake_managed_root(tmp_path)
+    monkeypatch.setattr(provider_setup, "is_windows", lambda: True)
+    monkeypatch.setattr(provider_module, "_managed_provider_root", lambda *a, **k: fake["root"])
+    captured: dict[str, Any] = {}
+    _install_spawn_capture(monkeypatch, captured)
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.command = [str(fake["rust_exe"])]
+    with pytest.raises(_CapturedSpawn):
+        client.start()
+    assert captured["argv"] == [str(fake["rust_exe"])]
+
+
+def test_start_leaves_posix_command_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """POSIX: no cmd.exe wrap and no node/js rewrite — the command is spawned as-is."""
+    fake = _build_fake_managed_root(tmp_path)
+    monkeypatch.setattr(provider_setup, "is_windows", lambda: False)
+    monkeypatch.setattr(provider_module, "_managed_provider_root", lambda *a, **k: fake["root"])
+    captured: dict[str, Any] = {}
+    _install_spawn_capture(monkeypatch, captured)
+
+    client = ExternalLSPClient(language="python", workspace_root=tmp_path)
+    client.command = ["/usr/bin/pyright-langserver", "--stdio"]
+    with pytest.raises(_CapturedSpawn):
+        client.start()
+    assert captured["argv"] == ["/usr/bin/pyright-langserver", "--stdio"]
 
 
 def test_provider_status_reports_missing_binary(tmp_path: Path) -> None:
@@ -867,6 +1025,19 @@ def test_external_provider_client_starts_managed_provider_with_managed_runtime_e
     )
     binary.parent.mkdir(parents=True)
     binary.write_text("", encoding="utf-8")
+    if os.name == "nt":
+        # Real-shaped managed layout: once start() rewrites a managed Windows .cmd shim to
+        # the trusted [node.exe, entry.js] argv (CWE-427 fix), the bare .cmd stub alone is
+        # insufficient — the node runtime + package.json['bin'] entrypoint must resolve.
+        node_runtime = provider_root / "node-runtime"
+        node_runtime.mkdir(parents=True, exist_ok=True)
+        (node_runtime / "node.exe").write_text("", encoding="utf-8")
+        pyright_pkg = provider_root / "node-packages" / "node_modules" / "pyright"
+        pyright_pkg.mkdir(parents=True, exist_ok=True)
+        (pyright_pkg / "package.json").write_text(
+            '{"bin": {"pyright-langserver": "langserver.js"}}', encoding="utf-8"
+        )
+        (pyright_pkg / "langserver.js").write_text("", encoding="utf-8")
     monkeypatch.setenv("TENSOR_GREP_LSP_PROVIDER_HOME", str(provider_root))
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## The bug (round-4, HIGH — CWE-427)
`ExternalLSPClient.start()` spawns the managed Node LSP provider through its npm cmd-shim — `[cmd.exe, /C, ...\.bin\pyright-langserver.cmd, --stdio]` with `cwd=workspace_root`. The cmd-shim body resolves a **bare, unqualified `node`**, which `cmd.exe` searches **CWD-first** — and CWD is the **attacker-controlled analyzed repo**. A planted `workspace_root\node.exe` hijacks the language server. The managed PATH prepend doesn't help: CWD is searched before PATH. This is the sibling of the already-shipped `apply_policy` CWE-427 fix.

## The fix (fix-approach-council-vetted)
Resolve the shim to its trusted absolute `[node.exe, entry.js, *args]` **before** spawning:
- `direct_managed_node_command()` gates **strictly** to managed Windows `.cmd`/`.bat` shims. External/PATH providers, managed **native `.exe`** (rust-analyzer/gopls/csharp-ls), and **all POSIX** are byte-for-byte unchanged (still via `wrap_windows_batch_command`).
- JS entrypoint read from `package.json["bin"]` (the stable contract), **not** by text-parsing the version-drifting cmd-shim.
- Once the gate passes, any resolution failure **fails closed** (`LSPTransportError`) — never a silent fallback to the vulnerable shim (the recurring silent-fallback anti-pattern the council flagged).
- `self.command` (what `provider_status()`/doctor report) is never mutated; the rewrite is a local spawn-time argv only; `--stdio` preserved; debug trace logs the actual `spawn_argv`.

The council also confirmed the naive "apply to every `.cmd` unconditionally" would break external/chocolatey/pyenv shims — hence the managed-only gate.

## Tests
- **5 new** (`test_lsp_external_provider.py`): managed-shim rewrite (watched **RED** — today spawns `cmd.exe`); **fail-closed** on unresolvable entrypoint; **3 legit unchanged paths** (external/PATH `.cmd`, managed native `.exe`, POSIX).
- Upgraded the pre-existing managed-start env test to the **real-shaped layout** (`node.exe` + `package.json bin` + entry) — the empty-`.cmd` stub couldn't exercise the node/js rewrite (mock-vs-real trap).
- **106 LSP tests pass**; ruff + mypy clean.

Round-4 batch #34 (PR-E of 5), task #31. Release-bearing (`fix:`). **Merge after #330 (v1.17.29) publishes** — one-merge-per-tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
