### PR TITLE
fix: verify a PATH-resident uv against the pinned version before trusting it (round-4 H6)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -464,8 +464,33 @@ try {
         "aarch64" = "40d65c29c4d97db6a0993df665d3727700bb799b3618992ce9a4dc533c6d1a31"
     }
     $uvPath = "uv"
-    if (!(Get-Command "uv" -ErrorAction SilentlyContinue)) {
+    # H6 hardening: a uv already on PATH is trusted ONLY if it reports EXACTLY the pinned version.
+    # Any mismatch/unparsable/error falls CLOSED into the checksum-verified download below, so a
+    # stale/incompatible/hijacked PATH uv can no longer bypass the pinned-uv supply-chain gate.
+    $uvTrusted = $false
+    $existingUv = Get-Command "uv" -ErrorAction SilentlyContinue
+    if ($existingUv) {
+        try {
+            $uvVersionOutput = & $existingUv.Source --version 2>$null
+            # EXACT regex-captured match (never substring/-like) so "0.11.253" cannot false-match "0.11.25".
+            if ($LASTEXITCODE -eq 0 -and $uvVersionOutput -match "^uv (?<v>\d+\.\d+\.\d+)" -and $Matches.v -eq $uvVersion) {
+                $uvTrusted = $true
+            } else {
+                Write-Warning "Existing PATH uv reports '$uvVersionOutput', not pinned $uvVersion; ignoring it and downloading the pinned, checksum-verified release instead."
+            }
+        } catch {
+            Write-Warning "Existing PATH uv version check failed ($_); ignoring it and downloading the pinned, checksum-verified release instead."
+        }
+    }
+    if ($uvTrusted) {
+        Write-Host "[1/4] Found existing uv $uvVersion on PATH (matches pinned version)."
+        $uvPath = $existingUv.Source
+    } else {
         Write-Host "[1/4] Downloading uv package manager (pinned $uvVersion)..."
+        # Residual risk (accepted): a version-string gate catches stale/accidental/incompatible uv but
+        # does NOT stop a determined PATH-hijack attacker who hardcodes --version to print the pin.
+        # Closing that needs a committed hash of the resident binary, which does not exist today (only
+        # the release zip is hashed). This closes the accidental/stale-uv hole; fake binary out of scope.
         # Detect CPU architecture to pick the correct release artifact.
         $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
         $uvArch = switch ($osArch) {
@@ -503,8 +528,6 @@ try {
             throw "uv.exe not found in extracted zip at $uvExtractDir."
         }
         $uvPath = $uvExePath
-    } else {
-        Write-Host "[1/4] Found existing uv installation."
     }
 
     # 2. Detect GPU Configuration

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,8 +114,26 @@ echo "=========================================================="
 # which executes an unverified remote script (audit: bring Linux/macOS to install.ps1 parity;
 # see https://github.com/astral-sh/uv/issues/13074). Bump UV_VERSION + every checksum together.
 UV_VERSION="0.11.25"
-if ! command -v uv &> /dev/null; then
+# H6 hardening: trust a uv already on PATH ONLY if it reports EXACTLY the pinned version; any
+# mismatch/unparsable value falls CLOSED into the checksum-verified download below, so a stale or
+# hijacked PATH uv can no longer bypass the pinned-uv supply-chain gate. (Mirror of install.ps1.)
+uv_trusted=0
+if command -v uv &> /dev/null; then
+    uv_ver="$(uv --version 2>/dev/null | awk '{print $2}')"
+    # Shell string equality is EXACT, never a glob, so "0.11.253" cannot false-match "0.11.25".
+    if [ "${uv_ver}" = "${UV_VERSION}" ]; then
+        uv_trusted=1
+    else
+        echo "Existing PATH uv reports '${uv_ver:-unknown}', not pinned ${UV_VERSION}; ignoring it and downloading the pinned, checksum-verified release instead." >&2
+    fi
+fi
+if [ "${uv_trusted}" = "1" ]; then
+    echo "[1/4] Found existing uv ${UV_VERSION} on PATH (matches pinned version)."
+else
     echo "[1/4] Downloading uv package manager (pinned ${UV_VERSION}, checksum-verified)..."
+    # Residual risk (accepted): a version-string gate catches stale/accidental uv but not a
+    # deliberate PATH-hijack that hardcodes --version to print the pin (no committed resident-binary
+    # hash exists; only the release archive is hashed). Fake binary is explicitly out of scope.
     uv_os="$(uname -s)"
     uv_machine="$(uname -m)"
     case "${uv_os}-${uv_machine}" in
@@ -165,8 +183,6 @@ if ! command -v uv &> /dev/null; then
         echo "ERROR: uv install completed but 'uv' is not on PATH ($HOME/.local/bin)." >&2
         exit 1
     fi
-else
-    echo "[1/4] Found existing uv installation."
 fi
 
 # 2. Detect GPU Configuration

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -622,3 +622,32 @@ def test_install_sh_notes_self_verification_of_astral_installer():
     # The comment should reference the self-verification property and contrast with install.ps1.
     assert "self-verif" in content
     assert "uv_checksums.json" in content or "install.ps1" in content
+
+
+def test_install_ps1_verifies_path_uv_version_before_trusting_it():
+    # H6 (round-4): a uv already on PATH must be trusted only after an EXACT pinned-version check;
+    # any mismatch must fall closed into the checksum-verified download, not silently reuse PATH uv.
+    content = _read_script("scripts/install.ps1")
+    idx = content.index('Get-Command "uv"')
+    end = content.index("[2/4]", idx)
+    branch = content[idx:end]
+    assert "--version" in branch  # the version probe
+    assert "$uvVersion" in branch  # compared against the pin
+    assert "$uvTrusted" in branch  # fail-closed marker gating reuse vs download
+    # The bare unconditional "Found existing uv installation." trust message must be gone.
+    assert "Found existing uv installation." not in content
+    # Exact regex-captured comparison (never -like/substring), so 0.11.253 cannot match 0.11.25.
+    assert "-eq $uvVersion" in branch
+
+
+def test_install_sh_verifies_path_uv_version_before_trusting_it():
+    content = _read_script("scripts/install.sh")
+    idx = content.index("command -v uv")
+    end = content.index("[2/4]", idx)
+    branch = content[idx:end]
+    assert "uv --version" in branch  # the version probe
+    assert "${UV_VERSION}" in branch  # compared against the pin
+    assert "uv_trusted" in branch  # fail-closed marker gating reuse vs download
+    assert "Found existing uv installation." not in content
+    # Exact shell string equality, never a glob match.
+    assert '[ "${uv_ver}" = "${UV_VERSION}" ]' in branch


### PR DESCRIPTION
## The bug (round-4, supply-chain H6)
Both installers, on finding a `uv` already on PATH, printed *"Found existing uv installation."* and used that binary — with **zero** version or checksum check — for every subsequent privileged step (`uv venv`, `uv pip install` of torch + tensor-grep itself). The committed-checksum pinned-uv hardening (H6) only guarded the **download** branch, so a stale/incompatible/hijacked PATH uv **completely bypassed** it.

## The fix (fix-approach-council-vetted)
Trust a PATH uv **only** if it reports **exactly** the pinned version; any mismatch, unparsable output, nonzero exit, or thrown probe error **fails closed** into the existing checksum-verified download block (left **byte-for-byte unchanged**) as the sole trusted source.
- `install.ps1`: regex-captured exact match (`$Matches.v -eq $uvVersion`), never `-like`/substring → `0.11.253` cannot false-match `0.11.25`.
- `install.sh`: shell string equality (`[ "${uv_ver}" = "${UV_VERSION}" ]`), exact not glob.

The council **dropped the finding's "or committed checksum" option as a no-op**: `uv_checksums.json` hashes the release **archive**, not a resident binary — there's no reference to hash a PATH uv against, so exact-version-match is the only deliverable verification. Offline/CI fast path preserved (an exact-pin match still skips the download). **Residual, documented in-code:** a version-string gate doesn't stop a deliberate PATH-hijack that hardcodes `--version` to print the pin — closing that needs a committed resident-binary hash that doesn't exist today; explicitly out of scope.

## Tests
2 static-content tests (ps1 + sh) asserting the PATH branch gates on `--version` vs the pin with a fail-closed marker and no bare unconditional-trust message. **44 install-script tests pass**; `bash -n` + PowerShell parser both clean; ruff clean.

Round-4 batch #34 (PR-D of 5 — **completes the batch**), task #24. Release-bearing (`fix:`). **Merge after #332 (v1.17.31) publishes** — one-merge-per-tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
