### PR TITLE
feat: disambiguate blast-radius* help + doctor warm-cache/GPU hints (real-use discoverability bundle)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -155,7 +155,7 @@ persisted repeated-query acceleration, and optional GPU routing.
 - `tg context-render PATH "invoice flow"`
 - `tg edit-plan PATH "add retry with tests"`
 - `tg agent PATH "change behavior" --json`
-- `tg blast-radius-render PATH create_invoice`
+- `tg blast-radius PATH create_invoice --json`  (caller graph; `blast-radius-render` = prose bundle)
 - `tg session open PATH`
 - `tg session daemon start PATH`
 
@@ -2693,6 +2693,13 @@ def _doctor_ast_cache_status(root_path: str, config_path: str) -> dict[str, Any]
         except Exception:
             pass
         status["stale"] = stale
+    if not status["exists"]:
+        # Round-5 UX: a cold cache silently costs ~20-30s on the first query over a large tree.
+        # Surface a self-service remediation (agents read this via `doctor --json`).
+        status["remediation"] = (
+            "run `tg map .` once to warm the AST cache "
+            "(avoids ~20-30s first-query latency on large trees)"
+        )
     return status
 
 
@@ -2889,6 +2896,13 @@ def _build_doctor_payload(
     gpu_status["search_ready"] = (
         cast(dict[str, Any], gpu_status["search_runtime_probe"]).get("status") == "supported"
     )
+    if gpu_status.get("available") and not gpu_status["search_ready"]:
+        # Round-5 UX: `available=True search_ready=False` reads as "GPU is broken". It is not —
+        # GPU search is experimental/opt-in. State that so agents/users don't chase a non-bug.
+        gpu_status["search_ready_note"] = (
+            "GPU search is experimental/opt-in; search_ready=False is expected and not a "
+            "failure -- text and AST search are unaffected"
+        )
     # Complete the promotion_proof tier now that the runtime probe result is available.
     # This is the highest tier: GPU search actually routed through NativeGpuBackend.
     cast(dict[str, Any], gpu_status["tier"])["promotion_proof"] = gpu_status["search_ready"]
@@ -3141,6 +3155,11 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
         f"gpu: available={gpu_payload.get('available', False)} "
         f"search_ready={gpu_payload.get('search_ready', False)}"
     )
+    if gpu_payload.get("available") and not gpu_payload.get("search_ready"):
+        lines.append(
+            "  note: search_ready=False is expected -- GPU search is experimental/opt-in, "
+            "not a failure; text and AST search are unaffected"
+        )
     if gpu_tier:
         lines.append(
             f"  tier: installed={gpu_tier.get('installed', False)} "
@@ -3158,6 +3177,11 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
         lines.append(f"  size: {ast_payload.get('size_bytes')} bytes")
         lines.append(f"  mtime: {ast_payload.get('mtime')}")
         lines.append(f"  stale: {ast_payload.get('stale')}")
+    else:
+        lines.append(
+            "  hint: cache cold -- run `tg map .` once to warm it "
+            "(avoids ~20-30s first-query latency on large trees)"
+        )
 
     ast_grep_payload = cast(dict[str, Any], payload.get("ast_grep", {}))
     ast_grep_options = "/".join(
@@ -7820,7 +7844,13 @@ def blast_radius(
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
-    """Return exact callers plus a transitive file/test blast radius for a symbol."""
+    """Return exact callers plus a transitive file/test blast radius for a symbol.
+
+    The machine-readable caller GRAPH. Pass --json for callers, caller_tree,
+    affected_files, blast_radius_score, imports, tests, and graph_trust_summary
+    (~3s on a mid-size repo). Use this, not blast-radius-render, when you want the
+    impact graph rather than a prose paste-in.
+    """
     from tensor_grep.cli.repo_map import build_symbol_blast_radius
 
     try:
@@ -7911,7 +7941,12 @@ def blast_radius_render(
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
-    """Return a prompt-ready blast-radius bundle for a symbol."""
+    """Return a prompt-ready blast-radius bundle for a symbol.
+
+    Emits PROSE for pasting into a prompt. For the machine-readable caller graph
+    (callers/caller_tree/affected_files/blast_radius_score), use
+    `tg blast-radius SYMBOL --json` instead -- it is faster and agent-consumable.
+    """
     from tensor_grep.cli.repo_map import (
         build_symbol_blast_radius_render,
         build_symbol_blast_radius_render_json,
@@ -7999,7 +8034,10 @@ def blast_radius_plan(
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
-    """Return a machine-readable blast-radius planning bundle without rendered source text."""
+    """Return a machine-readable blast-radius planning bundle without rendered source text.
+
+    Like `blast-radius --json` but shaped as an edit/action plan (no source snippets).
+    """
     from tensor_grep.cli.repo_map import (
         build_symbol_blast_radius_plan,
         build_symbol_blast_radius_plan_json,

--- a/tests/unit/test_feedback_ux_bundle.py
+++ b/tests/unit/test_feedback_ux_bundle.py
@@ -1,0 +1,102 @@
+"""Round-5 (real-AI-use feedback) discoverability/UX bundle: blast-radius command help
+disambiguation (an AI burned 3.5 min on `blast-radius-render` — a prose bundle — when the
+machine-readable caller graph it wanted is one flag away at `blast-radius --json`), plus doctor
+remediation hints for a cold AST cache and the GPU `search_ready=False` explainer.
+
+These assert help/output CONTRACTS (substring, so wording can still evolve), not exact text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from tensor_grep.cli.main import _doctor_ast_cache_status, _render_doctor_payload, app
+
+runner = CliRunner()
+
+
+def _strip(text: str) -> str:
+    # Typer/rich may wrap help across lines; collapse whitespace for robust substring checks.
+    return " ".join(text.split())
+
+
+def _minimal_doctor_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "version": "1.0.0",
+        "platform": "linux",
+        "python_executable": "/usr/bin/python",
+        "python_version": "3.12.0",
+        "invoked_as": "tg",
+        "root": "/repo",
+        "session_daemon": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --- TG-1 / TG-3: blast-radius* help disambiguation ---
+
+
+def test_blast_radius_render_help_routes_to_the_json_graph_command() -> None:
+    result = runner.invoke(app, ["blast-radius-render", "--help"])
+    assert result.exit_code == 0
+    text = _strip(result.stdout)
+    # The prose-render command must tell the reader the machine-readable graph is elsewhere.
+    assert "tg blast-radius" in text
+    assert "--json" in text
+
+
+def test_blast_radius_help_advertises_the_graph_keys_it_returns() -> None:
+    result = runner.invoke(app, ["blast-radius", "--help"])
+    assert result.exit_code == 0
+    text = _strip(result.stdout)
+    # Agents should learn from --help that the caller graph is already there under --json.
+    assert "caller_tree" in text
+    assert "blast_radius_score" in text
+
+
+def test_three_blast_radius_commands_have_distinguishing_when_to_use() -> None:
+    render = _strip(runner.invoke(app, ["blast-radius-render", "--help"]).stdout)
+    plan = _strip(runner.invoke(app, ["blast-radius-plan", "--help"]).stdout)
+    # -render is prose-for-a-prompt; -plan is a machine plan without source text.
+    assert "prose" in render.lower()
+    assert "plan" in plan.lower()
+
+
+# --- TG-2: doctor warms a cold AST cache ---
+
+
+def test_doctor_ast_cache_status_includes_remediation_when_cold(tmp_path: Path) -> None:
+    status = _doctor_ast_cache_status(str(tmp_path), str(tmp_path / "sgconfig.yml"))
+    assert status["exists"] is False
+    assert "remediation" in status
+    assert "tg map" in str(status["remediation"])
+
+
+def test_doctor_render_warns_to_warm_cold_ast_cache() -> None:
+    out = _render_doctor_payload(_minimal_doctor_payload(ast_cache={"exists": False}))
+    assert "tg map" in out
+    # The negative: a warm cache must NOT emit the warm hint.
+    warm = _render_doctor_payload(
+        _minimal_doctor_payload(
+            ast_cache={"exists": True, "size_bytes": 10, "mtime": 1.0, "stale": False}
+        )
+    )
+    assert "warm" not in warm.lower()
+
+
+# --- TG-13: doctor explains GPU available=True / search_ready=False ---
+
+
+def test_doctor_render_explains_gpu_search_ready_false() -> None:
+    out = _render_doctor_payload(
+        _minimal_doctor_payload(gpu={"available": True, "search_ready": False})
+    )
+    assert "experimental" in out.lower()
+    # The negative: when search actually routes on GPU, no "experimental" caveat.
+    ready = _render_doctor_payload(
+        _minimal_doctor_payload(gpu={"available": True, "search_ready": True})
+    )
+    assert "search_ready=False is expected" not in ready


### PR DESCRIPTION
## From real AI-user feedback
An AI ran a Claude Code doc audit (~1900 files) with `tg` and **burned 3.5 min on `tg blast-radius-render`** (a prose bundle) getting class-def-only output — when the caller **graph** it wanted (callers / caller_tree / affected_files / blast_radius_score / imports / tests) already ships via **`tg blast-radius --json` in ~3s**. It also hit `ast_cache exists=False` (20-30s cold first queries, no hint) and `gpu available=True search_ready=False` (reads as broken).

**Grounding reframe:** the "make blast-radius a real graph" P0 is largely a *discoverability* problem — the graph exists; the AI used the wrong command. This bundle fixes **4 of the 5 named gaps** with pure help/output strings — **no new command, no registration sites, no behavior risk.**

## Changes
- **TG-1 / TG-3** — docstrings on all three `blast-radius*` commands now state *when to use each*: `blast-radius` = machine-readable caller graph (lists the `--json` keys), `blast-radius-render` = **prose** for a prompt (explicitly points to `blast-radius --json`), `blast-radius-plan` = machine edit-plan. The top-of-file AI-workflows usage block now shows `blast-radius … --json` (the graph), not `-render`.
- **TG-2** — doctor emits a remediation when the AST cache is cold: a human `hint:` line **and** a `remediation` key in the `doctor --json` payload (agents read JSON) → run `tg map .` once to warm it.
- **TG-13** — doctor explains `available=True search_ready=False` as expected (GPU search is experimental/opt-in, not a failure): a human `note:` line **and** a `search_ready_note` JSON key.

## Tests
6 new (`test_feedback_ux_bundle.py`): help-contract via `CliRunner` for the 3 commands; doctor renderer + `_doctor_ast_cache_status` via synthetic payloads for the cold-cache hint and GPU explainer, each with a **negative** case (warm cache → no hint; search_ready=True → no caveat). ruff + mypy clean.

Task #35 (first PR of the roadmap). Release-bearing (`feat:`). **Merge after the round-4 batch (#331/#332/#333 → v1.17.32) publishes** — one-merge-per-tick. Follow-ups: `--direction callees` + `--format mermaid` (the genuine graph gaps), then `tg inventory` + `tg diff-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
