### PR TITLE
feat: tg blast-radius --mermaid renders the caller graph as a Mermaid diagram (TG-6)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7781,6 +7781,63 @@ def callers(
     )
 
 
+def _mermaid_label(text: str) -> str:
+    """Neutralize characters that would break a quoted Mermaid node/edge label."""
+    return text.replace("\\", "/").replace('"', "'")
+
+
+def _mermaid_relpath(file_path: str, root: str) -> str:
+    """A short forward-slashed path for a Mermaid node (relative to root when it stays inside)."""
+    forward = file_path.replace("\\", "/")
+    try:
+        rel = os.path.relpath(file_path, root).replace("\\", "/")
+        if rel and not rel.startswith(".."):
+            return rel
+    except (ValueError, OSError):
+        pass
+    return os.path.basename(forward) or forward
+
+
+def _render_blast_radius_mermaid(payload: dict[str, Any]) -> str:
+    """Render a blast-radius payload's exact call sites (``callers[]``) as a Mermaid ``graph TD``.
+
+    Only DIRECT callers are drawn (each unique caller file --> the symbol), because they carry
+    exact file+line evidence. The depth-layered ``caller_tree`` has no exact file-to-file edges,
+    so inventing them would lie to the reader (the agent-native contract). Output is deterministic
+    (sorted nodes) so it is diff-friendly for doc generators.
+    """
+    symbol = str(payload.get("symbol", "symbol"))
+    root = str(payload.get("path") or ".")
+    callers = cast(list[dict[str, Any]], payload.get("callers") or [])
+    grouped: dict[str, list[int]] = {}
+    for caller in callers:
+        raw = caller.get("file")
+        if not raw:
+            continue
+        entry = grouped.setdefault(_mermaid_relpath(str(raw), root), [])
+        line_no = caller.get("line")
+        if isinstance(line_no, int):
+            entry.append(line_no)
+    lines = ["graph TD", f'  target["{_mermaid_label(symbol)}"]']
+    for idx, rel in enumerate(sorted(grouped)):
+        node = f"n{idx}"
+        lines.append(f'  {node}["{_mermaid_label(rel)}"]')
+        call_lines = sorted(grouped[rel])
+        if len(call_lines) == 1:
+            lines.append(f"  {node} -->|L{call_lines[0]}| target")
+        elif call_lines:
+            lines.append(f"  {node} -->|{len(call_lines)} calls| target")
+        else:
+            lines.append(f"  {node} --> target")
+    if not grouped:
+        lines.append(f"  %% no callers found for {symbol}")
+    if payload.get("result_incomplete"):
+        lines.append(
+            "  %% note: result truncated -- raise --max-callers/--max-files for the full graph"
+        )
+    return "\n".join(lines)
+
+
 @app.command(name="blast-radius")
 def blast_radius(
     path: str = typer.Argument(".", help="File or directory to inventory"),
@@ -7819,6 +7876,11 @@ def blast_radius(
         help="Maximum impacted files to include in output; raise for fuller broad impact analysis.",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+    mermaid_output: bool = typer.Option(
+        False,
+        "--mermaid",
+        help="Render the direct-caller graph as a Mermaid `graph TD` (doc/agent-friendly).",
+    ),
 ) -> None:
     """Return exact callers plus a transitive file/test blast radius for a symbol."""
     from tensor_grep.cli.repo_map import build_symbol_blast_radius
@@ -7842,6 +7904,12 @@ def blast_radius(
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
+
+    if mermaid_output:
+        # Faithful diagram of the exact call sites (no truncation caveat needed — the
+        # renderer emits a `%% truncated` comment from payload.result_incomplete itself).
+        typer.echo(_render_blast_radius_mermaid(payload))
+        return
 
     # Surface output-cap truncation (callers_truncated/files_truncated) so a capped blast radius
     # can never look complete — the same false-confidence vector as a truncated callers=0.

--- a/tests/unit/test_blast_radius_mermaid.py
+++ b/tests/unit/test_blast_radius_mermaid.py
@@ -1,0 +1,99 @@
+"""TG-6 (real-AI-use feedback): `tg blast-radius --mermaid` renders the EXISTING caller graph
+as a Mermaid `graph TD` diagram. An AI doing a doc audit wanted a visual/agent-consumable graph;
+the data already exists (blast-radius --json), so this is a faithful formatter over `callers[]`
+(exact file+line call sites) -- no fabricated transitive edges.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+import tensor_grep.cli.repo_map as repo_map
+from tensor_grep.cli.main import _render_blast_radius_mermaid, app
+
+runner = CliRunner()
+
+
+def _payload(symbol: str, callers: list[dict[str, Any]], path: str = "/repo", **extra: Any) -> dict:
+    p: dict[str, Any] = {"symbol": symbol, "path": path, "callers": callers}
+    p.update(extra)
+    return p
+
+
+def test_mermaid_renders_graph_td_with_caller_edges_to_the_symbol() -> None:
+    out = _render_blast_radius_mermaid(
+        _payload(
+            "SearchConfig",
+            [
+                {"file": "/repo/a/config.py", "line": 10},
+                {"file": "/repo/b/sidecar.py", "line": 431},
+            ],
+        )
+    )
+    lines = out.splitlines()
+    assert lines[0] == "graph TD"
+    assert "SearchConfig" in out
+    # both caller files appear (as forward-slashed relpaths) and point at the symbol node.
+    assert "a/config.py" in out
+    assert "b/sidecar.py" in out
+    assert out.count("-->") == 2  # one edge per unique caller file
+    assert "target" in out  # edges point at the symbol node
+    assert "\\" not in out  # never emit Windows backslashes into a mermaid label
+
+
+def test_mermaid_dedups_multiple_call_sites_in_one_file_into_one_node() -> None:
+    out = _render_blast_radius_mermaid(
+        _payload("Foo", [{"file": "/repo/x.py", "line": 1}, {"file": "/repo/x.py", "line": 9}])
+    )
+    assert out.count('x.py"]') == 1  # single node for the file
+    assert "2 calls" in out  # edge annotated with the call count
+    assert out.count("-->") == 1
+
+
+def test_mermaid_is_deterministic_and_escapes_quotes() -> None:
+    callers = [{"file": "/repo/z.py", "line": 2}, {"file": "/repo/a.py", "line": 1}]
+    first = _render_blast_radius_mermaid(_payload('Sym"quote', callers))
+    second = _render_blast_radius_mermaid(_payload('Sym"quote', callers))
+    assert first == second  # stable output (sorted nodes) -> diff-friendly
+    assert "Sym'quote" in first  # the raw double-quote is neutralized to a single-quote
+    assert 'Sym"quote' not in first  # no raw double-quote that would break the mermaid label
+
+
+def test_mermaid_handles_no_callers_without_fabricating_edges() -> None:
+    out = _render_blast_radius_mermaid(_payload("Lonely", []))
+    assert out.splitlines()[0] == "graph TD"
+    assert "Lonely" in out
+    assert "no callers" in out.lower()
+    assert "-->" not in out  # no invented edges
+
+
+def test_mermaid_notes_truncation_when_result_incomplete() -> None:
+    out = _render_blast_radius_mermaid(
+        _payload("Big", [{"file": "/repo/a.py", "line": 1}], result_incomplete=True)
+    )
+    assert "truncated" in out.lower()
+
+
+def test_blast_radius_command_supports_mermaid_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        repo_map,
+        "build_symbol_blast_radius",
+        lambda *a, **k: {
+            "symbol": "Sym",
+            "path": str(tmp_path),
+            "definitions": [],
+            "callers": [{"file": str(tmp_path / "c.py"), "line": 3}],
+            "files": [],
+            "tests": [],
+        },
+    )
+    result = runner.invoke(app, ["blast-radius", str(tmp_path), "Sym", "--mermaid"])
+    assert result.exit_code == 0, result.stdout
+    assert "graph TD" in result.stdout
+    assert "-->" in result.stdout


### PR DESCRIPTION
## From real AI-user feedback
An AI doing a Claude Code doc audit wanted a **visual, agent-consumable caller graph**. The data already exists — `tg blast-radius --json` returns `callers[]` with exact `file`+`line` in ~3s — so this adds a **`--mermaid`** flag that formats those exact call sites as a `graph TD`: one node per unique caller file, one edge to the symbol labeled with the line (or `N calls`).

## Faithful by construction
Only **direct** callers are drawn (they carry exact file+line evidence). The depth-layered `caller_tree` has no exact file-to-file edges, so inventing transitive edges would **lie to the agent** (the agent-native contract) — omitted, with a `%% truncated` comment from `result_incomplete` instead. Output is **deterministic** (sorted nodes) → diff-friendly for doc generators. Native command flag (no rg passthrough / bootstrap allowlist); `--json`/text paths unchanged.

## Real dogfood (python -m, not CliRunner)
```
tg blast-radius src/tensor_grep SearchConfig --mermaid
graph TD
  target["SearchConfig"]
  n0["backends/cpu_backend.py"]
  n0 -->|L248| target
  n2["cli/ast_workflows.py"]
  n2 -->|6 calls| target
  ...  (8 caller files)
```

## Tests
6 new (`test_blast_radius_mermaid.py`): graph-TD shape + per-file edges, multi-call-site dedup with count label, deterministic + quote-escaping, empty-callers with **no fabricated edges**, truncation note, and a command-level `--mermaid` smoke via a mocked builder. ruff + mypy clean; **69 blast-radius/CLI tests green**.

Task #35 (TG-6). Release-bearing (`feat:`). **Merge after #334 (v1.18.0) publishes.** Follow-ups: `--direction callees` (TG-5, the downstream half), then `tg inventory` / `tg diff-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
