### PR TITLE
fix: bound two round-2 DoS vectors — LTL O(n^2)->O(n) + reject rubber-stamp max_depth (#26)

### DIFF
--- a/src/tensor_grep/backends/cpu_backend.py
+++ b/src/tensor_grep/backends/cpu_backend.py
@@ -582,14 +582,24 @@ class CPUBackend(ComputeBackend):
         matches: list[MatchLine] = []
         sequence_count = 0
 
+        # DoS fix: the old inner "scan forward per left-match" was O(n^2) — a
+        # left-matches-often/right-rarely query (every line matches A, none matches B)
+        # scanned to EOF for each of the ~n left hits. Precompute, in ONE backward pass, the
+        # nearest right-match index at-or-after each position so each left hit resolves its
+        # "eventually B" in O(1). Total O(n) with identical results (still the FIRST right
+        # match strictly after the left line).
+        total_lines = len(lines)
+        next_right_at_or_after: list[int | None] = [None] * (total_lines + 1)
+        nearest_right: int | None = None
+        for probe in range(total_lines - 1, -1, -1):
+            if right_regex.search(lines[probe][1]) is not None:
+                nearest_right = probe
+            next_right_at_or_after[probe] = nearest_right
+
         for idx, (left_line_no, left_text) in enumerate(lines):
             if left_regex.search(left_text) is None:
                 continue
-            right_match_idx = None
-            for probe in range(idx + 1, len(lines)):
-                if right_regex.search(lines[probe][1]) is not None:
-                    right_match_idx = probe
-                    break
+            right_match_idx = next_right_at_or_after[idx + 1]  # first right STRICTLY after idx
             if right_match_idx is None:
                 continue
 

--- a/src/tensor_grep/cli/scan_guardrails.py
+++ b/src/tensor_grep/cli/scan_guardrails.py
@@ -174,13 +174,24 @@ def _workspace_project_child_names(paths: list[str]) -> list[str]:
     return sorted(found, key=lambda item: item.lower())
 
 
+# A max_depth only counts as a real traversal BOUND if it is modest. Treating any non-None
+# value as "bounded" let `--max-depth 1000000` rubber-stamp a hostile-root scan (defeating the
+# broad-scan refusal entirely). Deeper-than-this scans of a system/generated/workspace root must
+# opt in explicitly via --allow-broad-generated-scan.
+_MAX_REASONABLE_SCAN_DEPTH = 50
+
+
+def _is_bounded_depth(max_depth: int | None) -> bool:
+    return max_depth is not None and 0 <= max_depth <= _MAX_REASONABLE_SCAN_DEPTH
+
+
 def _has_scan_bound(
     *,
     globs: list[str] | None,
     file_types: list[str] | None,
     max_depth: int | None,
 ) -> bool:
-    return bool(max_depth is not None or globs or file_types)
+    return bool(_is_bounded_depth(max_depth) or globs or file_types)
 
 
 def find_broad_scan_refusal(
@@ -197,7 +208,7 @@ def find_broad_scan_refusal(
     # Direct system roots need a traversal-depth bound. A glob alone still asks
     # the scanner to walk hostile roots such as %TEMP%, AppData, or C:\.
     system_roots = _system_root_names(paths)
-    if system_roots and max_depth is None:
+    if system_roots and not _is_bounded_depth(max_depth):
         return BroadScanRefusal("system-root", system_roots)
 
     if _has_scan_bound(globs=globs, file_types=file_types, max_depth=max_depth):

--- a/tests/unit/test_r2_dos_batch.py
+++ b/tests/unit/test_r2_dos_batch.py
@@ -1,0 +1,83 @@
+"""Round-2 DoS/hardening batch (#26):
+1. CPUBackend._search_ltl was O(n^2) — a `A -> eventually B` query where A matches often and
+   B rarely re-scanned to EOF per left hit. Now a single backward pass makes it O(n).
+2. scan_guardrails treated ANY non-None max_depth as a sufficient traversal bound, so
+   `--max-depth 1000000` rubber-stamped a hostile-root scan (defeating the broad-scan refusal).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.backends.cpu_backend import CPUBackend
+from tensor_grep.cli.scan_guardrails import _has_scan_bound, _is_bounded_depth
+from tensor_grep.core.config import SearchConfig
+
+# --- LTL O(n^2) -> O(n), semantics preserved ---
+
+
+def test_ltl_finds_eventually_sequence(tmp_path: Path) -> None:
+    f = tmp_path / "seq.txt"
+    f.write_text("has A here\nnothing\nhas B here\n", encoding="utf-8")
+    result = CPUBackend()._search_ltl(f, "A -> eventually B", SearchConfig())
+    assert result.total_matches == 1
+    assert result.matches[0].line_number == 1  # the A line
+    assert result.matches[1].line_number == 3  # the first B strictly after it
+
+
+def test_ltl_no_right_match_returns_zero(tmp_path: Path) -> None:
+    f = tmp_path / "noright.txt"
+    f.write_text("A\nA\nA\n", encoding="utf-8")
+    result = CPUBackend()._search_ltl(f, "A -> eventually ZZZ", SearchConfig())
+    assert result.total_matches == 0
+
+
+def test_ltl_right_scan_is_linear_not_quadratic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    n = 400
+    f = tmp_path / "patho.txt"
+    f.write_text("A\n" * n, encoding="utf-8")  # every line matches left, none matches right
+    backend = CPUBackend()
+    calls = {"right": 0}
+    orig = CPUBackend._compile_ltl
+
+    def _spy(pattern: str, flags: int):
+        left, right = orig(pattern, flags)
+
+        class _Counting:
+            def search(self, text: str):
+                calls["right"] += 1
+                return right.search(text)
+
+        return left, _Counting()
+
+    monkeypatch.setattr(backend, "_compile_ltl", _spy)
+    result = backend._search_ltl(f, "A -> eventually ZZZ", SearchConfig())
+    assert result.total_matches == 0
+    # O(n): exactly one right-regex probe per line (the backward pass). The old nested scan
+    # was ~n*(n-1)/2 right probes (~80k for n=400) — a hang vector on large files.
+    assert calls["right"] <= n + 1
+
+
+# --- scan_guardrails: a huge max_depth no longer rubber-stamps a hostile-root scan ---
+
+
+def test_is_bounded_depth_rejects_rubber_stamp_values() -> None:
+    assert _is_bounded_depth(0) is True  # depth 0 = the given dir only, genuinely bounded
+    assert _is_bounded_depth(3) is True
+    assert _is_bounded_depth(50) is True
+    assert _is_bounded_depth(51) is False  # over the reasonable threshold
+    assert _is_bounded_depth(1_000_000) is False
+    assert _is_bounded_depth(None) is False
+
+
+def test_has_scan_bound_ignores_huge_depth_but_honors_glob() -> None:
+    # TODAY (pre-fix): max_depth=1_000_000 -> True (the bug). After: False.
+    assert _has_scan_bound(globs=None, file_types=None, max_depth=1_000_000) is False
+    assert _has_scan_bound(globs=None, file_types=None, max_depth=None) is False
+    assert _has_scan_bound(globs=None, file_types=None, max_depth=3) is True
+    # a glob is still a genuine bound regardless of depth.
+    assert _has_scan_bound(globs=["*.py"], file_types=None, max_depth=1_000_000) is True


### PR DESCRIPTION
## Two bounded resource/DoS hardening fixes (round-2 #26)

### 1. `CPUBackend._search_ltl` was O(n²)
The `A -> eventually B` matcher scanned **forward to EOF for every left hit**, so an adversarial/large file where A matches often and B rarely (every line matches A, none matches B) did ~`n*(n-1)/2` right-regex probes — a hang vector. **Fix:** one **backward pass** precomputes the nearest right-match index at-or-after each position, so each left hit resolves its "eventually B" in O(1). Total **O(n)**, **identical results** (still the first right match strictly after the left line; `max_count` break preserved).

### 2. `scan_guardrails` rubber-stamped any `max_depth`
It treated **any** non-None `max_depth` as a sufficient traversal bound, so `--max-depth 1000000` on a system/generated/workspace root walked right past the broad-scan refusal. **Fix:** a depth only counts as a bound when `0 <= depth <= 50` (`_MAX_REASONABLE_SCAN_DEPTH`); deeper hostile-root scans must opt in via `--allow-broad-generated-scan`. A glob / file-type still bounds regardless (unchanged). Existing tests use depths ≤ 5 — unaffected.

## Tests
5 new: LTL finds the eventually-sequence + returns 0 on no-right + **a spy proving the right-regex probe count is O(n) not O(n²)**; `_is_bounded_depth`/`_has_scan_bound` reject `1_000_000` and `None` (watched fail — was `True`) but accept ≤50 and any glob. **35 cpu + 18 broad-scan tests green**; ruff + mypy clean.

Task #26 (both remaining Python items). Release-bearing (`fix:`). Merge after #336 (PR-A slice). `lib.rs` GIL item defers with the #24 rust batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
