### PR TITLE
fix: --vimgrep/--column emit one row per rg occurrence at its true byte column (PR-A slice 2)

### DIFF
--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -145,8 +145,18 @@ class RipgrepBackend(ComputeBackend):
                         if "text" not in _path_obj and isinstance(file_path, str):
                             path_str = file_path
 
-                        # Note: Ripgrep JSON also outputs absolute offsets, but MatchLine requires line_num/text
-                        matches.append(MatchLine(line_number=line_number, text=text, file=path_str))
+                        # Stash rg's per-occurrence byte offsets (submatches[]) for --vimgrep/
+                        # --column output shaping. Counting stays one-per-matching-line (below) so
+                        # total_matches / parity with the other backends is unchanged.
+                        _subs = data_match.get("submatches") or None
+                        matches.append(
+                            MatchLine(
+                                line_number=line_number,
+                                text=text,
+                                file=path_str,
+                                submatches=tuple(_subs) if _subs else None,
+                            )
+                        )
                         total_matches += 1
                         if path_str:
                             match_counts_by_file[path_str] = (

--- a/src/tensor_grep/cli/formatters/ripgrep_fmt.py
+++ b/src/tensor_grep/cli/formatters/ripgrep_fmt.py
@@ -73,6 +73,25 @@ class RipgrepFormatter(OutputFormatter):
         # by the UTF-8 width of the text before the match (audit MED parity).
         return len(match.text[:index].encode("utf-8")) + 1
 
+    def _submatch_columns(self, match: MatchLine) -> list[int] | None:
+        """rg's authoritative 1-based byte columns for every occurrence on this line.
+
+        rg submatch ``start`` is a 0-based BYTE offset into the line, so ``start + 1`` is rg's
+        1-based byte column directly — no Python regex, no first-occurrence-only guess. Returns
+        None for non-rg backends / context lines (no submatches) so those fall through to the
+        existing single-column path unchanged.
+        """
+        subs = match.submatches
+        if not subs:
+            return None
+        columns: list[int] = []
+        for sub in subs:
+            if isinstance(sub, dict):
+                start = sub.get("start")
+                if isinstance(start, int):
+                    columns.append(start + 1)
+        return columns or None
+
     def format(self, result: SearchResult) -> str:
         lines = []
 
@@ -128,30 +147,38 @@ class RipgrepFormatter(OutputFormatter):
             non_binary_matches = result.matches
 
         for match in non_binary_matches:
+            # rg supplies per-occurrence byte offsets; --vimgrep/--column emit ONE row per
+            # occurrence (matching real `rg --vimgrep`), not just the first. Non-rg backends /
+            # context lines have no submatches -> single row via _column_for_match, unchanged.
+            submatch_columns = self._submatch_columns(match)
             if self.config.vimgrep:
-                lines.append(
-                    ":".join([
-                        self._format_path(str(match.file)),
-                        str(match.line_number),
-                        str(self._column_for_match(match)),
-                        str(match.text),
-                    ])
-                )
+                columns = submatch_columns or [self._column_for_match(match)]
+                for column in columns:
+                    lines.append(
+                        ":".join([
+                            self._format_path(str(match.file)),
+                            str(match.line_number),
+                            str(column),
+                            str(match.text),
+                        ])
+                    )
                 continue
 
-            parts = []
+            prefix_parts = []
             if self.config.with_filename or (
                 self.config.file_patterns is None
                 and not self.config.no_filename
                 and result.total_files > 1
             ):
-                parts.append(self._format_path(str(match.file)))
+                prefix_parts.append(self._format_path(str(match.file)))
 
             if self.config.line_number:
-                parts.append(str(match.line_number))
-            if self.config.column:
-                parts.append(str(self._column_for_match(match)))
+                prefix_parts.append(str(match.line_number))
 
-            parts.append(str(match.text))
-            lines.append(":".join(parts))
+            if self.config.column:
+                columns = submatch_columns or [self._column_for_match(match)]
+                for column in columns:
+                    lines.append(":".join([*prefix_parts, str(column), str(match.text)]))
+            else:
+                lines.append(":".join([*prefix_parts, str(match.text)]))
         return "\n".join(lines)

--- a/src/tensor_grep/core/result.py
+++ b/src/tensor_grep/core/result.py
@@ -8,6 +8,11 @@ class MatchLine:
     file: str
     range: dict[str, object] | None = None
     meta_variables: dict[str, object] | None = None
+    # rg's authoritative per-occurrence byte offsets for a multi-match line (each entry is an rg
+    # submatch: {"match": {...}, "start": int, "end": int}). Populated only by RipgrepBackend;
+    # consumed by --vimgrep/--column output shaping. Tuple keeps the frozen dataclass hashable;
+    # None (the default) keeps every other backend byte-for-byte unchanged.
+    submatches: tuple[dict[str, object], ...] | None = None
 
 
 @dataclass

--- a/tests/unit/test_submatches_output_shaping.py
+++ b/tests/unit/test_submatches_output_shaping.py
@@ -1,0 +1,85 @@
+"""PR-A slice 2 (submatches output-shaping): rg supplies per-occurrence byte offsets, but the
+parser discarded them, so --vimgrep/--column reported only the FIRST occurrence's column and one
+row for a multi-match line. Fix: stash rg's submatches on MatchLine (counting unchanged — still
+one-per-matching-line) and emit one output row per occurrence in --vimgrep/--column, at each
+occurrence's true byte column. Non-rg backends / context lines (no submatches) are unchanged.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from types import SimpleNamespace
+
+import tensor_grep.backends.ripgrep_backend as rb
+from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+from tensor_grep.cli.formatters.ripgrep_fmt import RipgrepFormatter
+from tensor_grep.core.config import SearchConfig
+from tensor_grep.core.result import MatchLine, SearchResult
+
+
+def _multi_match_line() -> MatchLine:
+    # "foo bar foo baz foo": three occurrences of foo at 0-based byte offsets 0, 8, 16.
+    return MatchLine(
+        line_number=1,
+        text="foo bar foo baz foo",
+        file="a.log",
+        submatches=(
+            {"match": {"text": "foo"}, "start": 0, "end": 3},
+            {"match": {"text": "foo"}, "start": 8, "end": 11},
+            {"match": {"text": "foo"}, "start": 16, "end": 19},
+        ),
+    )
+
+
+def test_backend_stashes_submatches_without_inflating_count(monkeypatch) -> None:
+    record = {
+        "type": "match",
+        "data": {
+            "path": {"text": "a.log"},
+            "lines": {"text": "foo bar foo\n"},
+            "line_number": 1,
+            "submatches": [
+                {"match": {"text": "foo"}, "start": 0, "end": 3},
+                {"match": {"text": "foo"}, "start": 8, "end": 11},
+            ],
+        },
+    }
+    fake = SimpleNamespace(returncode=0, stdout=_json.dumps(record) + "\n", stderr="")
+    monkeypatch.setattr(rb, "run_subprocess", lambda *a, **k: fake)
+    monkeypatch.setattr(RipgrepBackend, "_get_binary_name", lambda self: "rg")
+
+    result = RipgrepBackend().search("a.log", "foo", SearchConfig())
+    assert result.total_matches == 1  # counting stays one-per-matching-LINE (parity preserved)
+    assert result.matches[0].submatches is not None
+    assert len(result.matches[0].submatches) == 2
+
+
+def test_vimgrep_emits_one_row_per_submatch_with_true_columns() -> None:
+    result = SearchResult(matches=[_multi_match_line()], total_files=1, total_matches=1)
+    rows = RipgrepFormatter(SearchConfig(vimgrep=True)).format(result).splitlines()
+    assert len(rows) == 3  # was 1 (first occurrence only)
+    # vimgrep row = path:line:COLUMN:text; columns are 1-based byte columns 0+1, 8+1, 16+1.
+    assert [r.split(":")[2] for r in rows] == ["1", "9", "17"]
+
+
+def test_column_emits_one_row_per_submatch() -> None:
+    result = SearchResult(matches=[_multi_match_line()], total_files=1, total_matches=1)
+    rows = RipgrepFormatter(SearchConfig(column=True, line_number=True)).format(result).splitlines()
+    assert len(rows) == 3
+    # row = line:COLUMN:text (no filename when total_files==1 and no with_filename)
+    assert [r.split(":")[1] for r in rows] == ["1", "9", "17"]
+
+
+def test_no_submatches_stays_single_row() -> None:
+    # Non-rg backend / context line: no submatches -> unchanged single-row behavior.
+    ml = MatchLine(line_number=1, text="foo bar foo", file="a.log")
+    result = SearchResult(matches=[ml], total_files=1, total_matches=1)
+    assert len(RipgrepFormatter(SearchConfig(vimgrep=True)).format(result).splitlines()) == 1
+    assert (
+        len(
+            RipgrepFormatter(SearchConfig(column=True, line_number=True))
+            .format(result)
+            .splitlines()
+        )
+        == 1
+    )


### PR DESCRIPTION
## The defect (round-4, PR-A slice 2)
rg's `--json` Match events carry `submatches[]` with **authoritative per-occurrence byte offsets**, but the parser discarded them. So for a **multi-match line**, `--vimgrep`/`--column` reported only the **first** occurrence's column and emitted **one** row — diverging from real `rg --vimgrep`, which emits N rows (one per occurrence at its true byte column).

## Council-vetted narrow fix
The council **rejected** the naive "iterate submatches → inflate `total_matches`" (every sibling backend + the GPU/CPU parity oracle would regress, and it mis-zeroes `-v` lines). Counting stays **one-per-matching-line**; only **output shaping** changes:
- **result.py** — `MatchLine` gains a frozen `submatches: tuple[...] | None = None` (default `None` keeps every other backend byte-for-byte unchanged).
- **ripgrep_backend.py** — the match branch additionally stashes submatches; `total_matches`/count `+= 1` **unchanged**; context branch untouched.
- **ripgrep_fmt.py** — `--vimgrep` and `--column` emit one row per submatch, `column = submatch.start + 1` (rg `start` is a 0-based byte offset → +1 is rg's 1-based byte column directly; no `re.search`, no first-occurrence guess). No submatches (non-rg backend / context) → single row via the existing path, unchanged.

## Tests
4 new: backend stashes 2 submatches while `total_matches` stays **1**; `--vimgrep` and `--column` emit **3** rows at cols 1/9/17 for `"foo bar foo baz foo"` (watched fail: 1 row); no-submatches stays single-row. **87 formatter/parity tests green (no regression)**; ruff + mypy clean.

Task #34 (PR-A **slice 2 of 3**). Release-bearing (`fix:`). Slice 3 (the `-o --pcre2` crash in main.py + json_fmt column mirror) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
