### PR TITLE
fix: keep + surface rg exit-2 partial results (rg-parity exit code) — PR-A slice 3 (rg-parse moat complete)

### DIFF
--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -111,12 +111,6 @@ class RipgrepBackend(ComputeBackend):
                 encoding="utf-8",
                 timeout_seconds=configured_ripgrep_timeout_seconds(),
             )
-            if result.returncode > 1:
-                stderr = result.stderr.strip()
-                raise RuntimeError(
-                    f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
-                )
-
             import json
 
             matches = []
@@ -166,7 +160,18 @@ class RipgrepBackend(ComputeBackend):
                 except json.JSONDecodeError:
                     pass
 
-            return SearchResult(
+            # Parse-first, THEN branch on the exit code. rg exit 2 = a SOFT per-file error (e.g.
+            # one unreadable/missing path among many); if it still emitted matches for the readable
+            # files, KEEP them + flag incomplete so we exit 2 like rg AND surface a "suppression !=
+            # absence" marker. Only a genuine total failure (exit >2, or exit 2 with nothing parsed)
+            # stays fail-closed with the byte-identical RuntimeError message.
+            partial = result.returncode == 2 and total_matches > 0
+            if result.returncode > 1 and not partial:
+                stderr = result.stderr.strip()
+                raise RuntimeError(
+                    f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
+                )
+            search_result = SearchResult(
                 matches=matches,
                 matched_file_paths=matched_file_paths,
                 match_counts_by_file=match_counts_by_file,
@@ -177,6 +182,12 @@ class RipgrepBackend(ComputeBackend):
                 routing_distributed=False,
                 routing_worker_count=1,
             )
+            if partial:
+                reason = result.stderr.strip() or "rg exit 2 (partial results)"
+                sys.stderr.write(f"tg: rg exited 2, keeping partial results: {reason}\n")
+                search_result.result_incomplete = True
+                search_result.incomplete_reason = reason
+            return search_result
 
         except Exception as e:
             raise RuntimeError(f"Ripgrep backend failed: {e}") from e
@@ -194,15 +205,16 @@ class RipgrepBackend(ComputeBackend):
                 encoding="utf-8",
                 timeout_seconds=configured_ripgrep_timeout_seconds(),
             )
-            if result.returncode > 1:
+            path_parts = result.stdout.split("\0") if config.null else result.stdout.splitlines()
+            matched_file_paths = [path for path in path_parts if path]
+            # rg exit 2 with some matched files = soft partial error: keep them, flag incomplete.
+            partial = result.returncode == 2 and bool(matched_file_paths)
+            if result.returncode > 1 and not partial:
                 stderr = result.stderr.strip()
                 raise RuntimeError(
                     f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
                 )
-
-            path_parts = result.stdout.split("\0") if config.null else result.stdout.splitlines()
-            matched_file_paths = [path for path in path_parts if path]
-            return SearchResult(
+            search_result = SearchResult(
                 matches=[],
                 matched_file_paths=matched_file_paths,
                 match_counts_by_file=dict.fromkeys(matched_file_paths, 1),
@@ -213,6 +225,12 @@ class RipgrepBackend(ComputeBackend):
                 routing_distributed=False,
                 routing_worker_count=1,
             )
+            if partial:
+                reason = result.stderr.strip() or "rg exit 2 (partial results)"
+                sys.stderr.write(f"tg: rg exited 2, keeping partial results: {reason}\n")
+                search_result.result_incomplete = True
+                search_result.incomplete_reason = reason
+            return search_result
         except Exception as e:
             raise RuntimeError(f"Ripgrep backend failed: {e}") from e
 
@@ -229,12 +247,6 @@ class RipgrepBackend(ComputeBackend):
                 encoding="utf-8",
                 timeout_seconds=configured_ripgrep_timeout_seconds(),
             )
-            if result.returncode > 1:
-                stderr = result.stderr.strip()
-                raise RuntimeError(
-                    f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
-                )
-
             lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
             total_matches = 0
             total_files = 0
@@ -277,8 +289,14 @@ class RipgrepBackend(ComputeBackend):
                         matched_file_paths.append(file_path)
                         match_counts_by_file[file_path] = count_value
 
+            partial = result.returncode == 2 and total_matches > 0
+            if result.returncode > 1 and not partial:
+                stderr = result.stderr.strip()
+                raise RuntimeError(
+                    f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
+                )
             routing_reason = "rg_count_matches" if config.count_matches else "rg_count"
-            return SearchResult(
+            search_result = SearchResult(
                 matches=[],
                 matched_file_paths=matched_file_paths,
                 match_counts_by_file=match_counts_by_file,
@@ -289,6 +307,12 @@ class RipgrepBackend(ComputeBackend):
                 routing_distributed=False,
                 routing_worker_count=1,
             )
+            if partial:
+                reason = result.stderr.strip() or "rg exit 2 (partial results)"
+                sys.stderr.write(f"tg: rg exited 2, keeping partial results: {reason}\n")
+                search_result.result_incomplete = True
+                search_result.incomplete_reason = reason
+            return search_result
         except Exception as e:
             raise RuntimeError(f"Ripgrep backend failed: {e}") from e
 

--- a/src/tensor_grep/cli/formatters/json_fmt.py
+++ b/src/tensor_grep/cli/formatters/json_fmt.py
@@ -105,6 +105,12 @@ def _routing_envelope(result: SearchResult) -> dict[str, object]:
         envelope["staging_bytes"] = result.staging_bytes
     if result.fallback_reason is not None:
         envelope["fallback_reason"] = result.fallback_reason
+    # Partial results (rg exit 2) — a machine-visible "suppression != absence" marker so --json/
+    # --ndjson agents don't read a truncated result as complete. Emitted only when incomplete, so
+    # the envelope shape is byte-identical for normal (complete) results.
+    if result.result_incomplete:
+        envelope["result_incomplete"] = True
+        envelope["incomplete_reason"] = result.incomplete_reason
     return envelope
 
 
@@ -164,6 +170,8 @@ class JsonFormatter(OutputFormatter):
             "transfer_time_ms",
             "staging_bytes",
             "fallback_reason",
+            "result_incomplete",
+            "incomplete_reason",
         ):
             if key in envelope:
                 data[key] = envelope[key]

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6468,9 +6468,9 @@ def search_command(
                 config,
             )
             _write_path_list(output_paths, use_nul=null)
-            sys.exit(0)
+            sys.exit(2 if all_results.result_incomplete else 0)
         _emit_stats()
-        sys.exit(1)
+        sys.exit(2 if all_results.result_incomplete else 1)
 
     if files_without_match:
         unmatched_candidates = candidate_files_set - matched_files
@@ -6482,9 +6482,9 @@ def search_command(
         if unmatched:
             _emit_stats()
             _write_path_list(unmatched, use_nul=null)
-            sys.exit(0)
+            sys.exit(2 if all_results.result_incomplete else 0)
         _emit_stats()
-        sys.exit(1)
+        sys.exit(2 if all_results.result_incomplete else 1)
 
     if all_results.is_empty:
         _emit_stats()
@@ -6492,11 +6492,11 @@ def search_command(
             from tensor_grep.cli.formatters.json_fmt import JsonFormatter
 
             _safe_stdout_line(JsonFormatter().format(all_results))
-        sys.exit(1)
+        sys.exit(2 if all_results.result_incomplete else 1)
 
     if quiet:
         _emit_stats()
-        sys.exit(0)
+        sys.exit(2 if all_results.result_incomplete else 0)
 
     formatter: OutputFormatter
 
@@ -6525,6 +6525,10 @@ def search_command(
 
     _safe_stdout_line(formatter.format(all_results))
     _emit_stats()
+    if all_results.result_incomplete:
+        # rg-parity: partial results (rg exit 2, soft per-file error) exit 2 after a formatted
+        # success, not 0 — so a caller/agent sees the same incompleteness rg would signal.
+        sys.exit(2)
 
 
 @app.command()

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -2717,6 +2717,10 @@ def tg_search(
                     "truncated": truncated,
                     "omitted_matches": omitted_matches,
                     "omitted_files": omitted_files,
+                    # Partial results (rg exit 2 soft error) — top-level so an agent caller can't
+                    # read a truncated result as complete (suppression != absence).
+                    "result_incomplete": all_results.result_incomplete,
+                    "incomplete_reason": all_results.incomplete_reason,
                     "routing": _routing_payload(all_results),
                 },
                 indent=2,

--- a/src/tensor_grep/core/result.py
+++ b/src/tensor_grep/core/result.py
@@ -31,6 +31,13 @@ class SearchResult:
     transfer_time_ms: float | None = None
     staging_bytes: int | None = None
     fallback_reason: str | None = None
+    # Partial-results signal: the backend produced SOME output but a soft per-item error
+    # suppressed the rest (e.g. rg exit 2 with matches for the readable files). Distinct from
+    # fallback_reason (which means "the execution engine was swapped") — conflating them would
+    # emit a false "we fell back" signal to doctor/JSON. Drives the rg-parity exit code 2 and a
+    # machine-visible "suppression != absence" marker on the JSON/MCP envelopes.
+    result_incomplete: bool = False
+    incomplete_reason: str | None = None
 
     @property
     def is_empty(self) -> bool:
@@ -58,3 +65,8 @@ def merge_runtime_routing(aggregate: SearchResult, result: SearchResult) -> None
     aggregate.routing_worker_count = max(
         aggregate.routing_worker_count, result.routing_worker_count
     )
+    # Partial-results incompleteness is monotonic: any incomplete sub-result taints the aggregate,
+    # so ALL consumers (CLI, MCP, sidecar) inherit the rg-parity exit-2 + envelope marker uniformly.
+    aggregate.result_incomplete = aggregate.result_incomplete or result.result_incomplete
+    if result.incomplete_reason and not aggregate.incomplete_reason:
+        aggregate.incomplete_reason = result.incomplete_reason

--- a/tests/unit/test_rg_exit2_partial.py
+++ b/tests/unit/test_rg_exit2_partial.py
@@ -1,0 +1,114 @@
+"""PR-A slice 3 (rg-exit2-partial-results): rg exit 2 is a SOFT per-file error (e.g. one
+unreadable/missing path among many) AND rg still emits matches for the readable files. The old
+parser raised unconditionally on exit>1, discarding those partial results. Fix: parse-first, then
+keep partial results + flag result_incomplete (rg-parity exit 2 + a suppression!=absence marker);
+only a genuine total failure (exit>2, or exit 2 with nothing parsed) stays fail-closed.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from types import SimpleNamespace
+
+import pytest
+
+import tensor_grep.backends.ripgrep_backend as rb
+from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+from tensor_grep.core.config import SearchConfig
+from tensor_grep.core.result import SearchResult, merge_runtime_routing
+
+
+def _fake(returncode: int, stdout: str, stderr: str = ""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _match(path: str = "a.log", text: str = "ERROR", line: int = 1) -> str:
+    return _json.dumps({
+        "type": "match",
+        "data": {"path": {"text": path}, "lines": {"text": text + "\n"}, "line_number": line},
+    })
+
+
+def _patch_rg(monkeypatch, fake):
+    monkeypatch.setattr(rb, "run_subprocess", lambda *a, **k: fake)
+    monkeypatch.setattr(RipgrepBackend, "_get_binary_name", lambda self: "rg")
+
+
+def test_search_exit2_with_matches_keeps_partial_and_flags_incomplete(monkeypatch) -> None:
+    _patch_rg(monkeypatch, _fake(2, _match() + "\n", "rg: b.log: No such file or directory"))
+    result = RipgrepBackend().search("a.log", "ERROR", SearchConfig())
+    assert result.total_matches == 1  # partial results KEPT (was: discarded via raise)
+    assert result.result_incomplete is True
+    assert "No such file" in (result.incomplete_reason or "")
+
+
+def test_search_exit2_zero_parsed_still_fails_closed(monkeypatch) -> None:
+    # exit 2 with NOTHING parsed = a genuine failure (e.g. regex syntax) -> raise, byte-identical.
+    _patch_rg(monkeypatch, _fake(2, "", "regex parse error"))
+    with pytest.raises(RuntimeError, match="exit code 2"):
+        RipgrepBackend().search("a.log", "ERROR", SearchConfig())
+
+
+def test_search_exit_gt2_always_fails_closed_even_with_matches(monkeypatch) -> None:
+    _patch_rg(monkeypatch, _fake(3, _match() + "\n", "fatal"))
+    with pytest.raises(RuntimeError, match="exit code 3"):
+        RipgrepBackend().search("a.log", "ERROR", SearchConfig())
+
+
+def test_search_exit01_unchanged(monkeypatch) -> None:
+    _patch_rg(monkeypatch, _fake(0, _match() + "\n"))
+    result = RipgrepBackend().search("a.log", "ERROR", SearchConfig())
+    assert result.total_matches == 1
+    assert result.result_incomplete is False
+
+
+def test_files_with_matches_exit2_keeps_partial(monkeypatch) -> None:
+    _patch_rg(monkeypatch, _fake(2, "a.log\nc.log\n", "rg: b.log: No such file"))
+    result = RipgrepBackend()._search_files_with_matches(
+        "x", "ERROR", SearchConfig(files_with_matches=True)
+    )
+    assert result.matched_file_paths == ["a.log", "c.log"]
+    assert result.result_incomplete is True
+
+
+def test_counts_exit2_keeps_partial(monkeypatch) -> None:
+    _patch_rg(monkeypatch, _fake(2, "3\n", "rg: b.log: No such file"))
+    result = RipgrepBackend()._search_counts("a.log", "ERROR", SearchConfig(count=True))
+    assert result.total_matches == 3
+    assert result.result_incomplete is True
+
+
+def test_merge_runtime_routing_or_merges_incompleteness() -> None:
+    agg = SearchResult()
+    sub = SearchResult(result_incomplete=True, incomplete_reason="rg exit 2")
+    merge_runtime_routing(agg, sub)
+    assert agg.result_incomplete is True
+    assert agg.incomplete_reason == "rg exit 2"
+
+
+def test_json_formatter_emits_incompleteness_only_when_partial() -> None:
+    from tensor_grep.cli.formatters.json_fmt import JsonFormatter, NdjsonFormatter
+    from tensor_grep.core.result import MatchLine
+
+    incomplete = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR", file="a.log")],
+        total_matches=1,
+        total_files=1,
+        result_incomplete=True,
+        incomplete_reason="rg exit 2 (partial results)",
+    )
+    out = _json.loads(JsonFormatter().format(incomplete))
+    assert out["result_incomplete"] is True
+    assert out["incomplete_reason"] == "rg exit 2 (partial results)"
+    # NDJSON spreads the full envelope, so it carries it per row.
+    nd_row = _json.loads(NdjsonFormatter().format(incomplete).splitlines()[0])
+    assert nd_row["result_incomplete"] is True
+    # Complete result: byte-identical shape, no incompleteness keys.
+    complete = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR", file="a.log")],
+        total_matches=1,
+        total_files=1,
+    )
+    out2 = _json.loads(JsonFormatter().format(complete))
+    assert "result_incomplete" not in out2
+    assert "incomplete_reason" not in out2


### PR DESCRIPTION
## The defect (round-4, the rg-parse moat's final slice)
`rg` exit 2 is a **soft per-file error** (e.g. one unreadable/missing path among many) — and rg **still emits matches** for the readable files. The parser raised unconditionally on `exit>1`, **discarding** those partial matches. And had it merely returned them, tg would have silently exited **0 while rg exits 2** — a new parity break.

## Council-vetted 5-site coordinated fix
1. **result.py** — `SearchResult` gains `result_incomplete: bool` + `incomplete_reason: str|None` (deliberately *not* overloading `fallback_reason`, which means "engine swapped"); `merge_runtime_routing` OR-merges them so CLI/MCP/sidecar inherit uniformly.
2. **ripgrep_backend.py** (all 3 methods) — **parse-first, then branch**: exit 2 with a non-empty parse **keeps** the results + flags incomplete + a stderr note; exit >2, or exit 2 with nothing parsed, still raises the **byte-identical** `RuntimeError` (kept plain, *not* `BackendExecutionError`, to avoid the `--pcre2` CPU-fallback engine-swap the council flagged).
3. **main.py** — terminal exits now `sys.exit(2 if result_incomplete else …)` across files-with/without-matches, is_empty, quiet, post-format → **tg exits 2 like rg**.
4. **json_fmt.py** — `--json`/`--ndjson` envelopes emit the fields (only when incomplete → byte-identical shape for complete results).
5. **mcp_server.py** — the structured `tg_search` response carries them top-level (suppression ≠ absence for agents).

## Tests
7 backend tests (exit2+matches keeps partial + flags; exit2-zero-parse & exit>2 fail closed byte-identically; exit0/1 unchanged; files-with-matches + counts partial; merge OR-merge). **273 tests green** incl. the full **`test_rg_parity_edges`** exit-code suite + formatters + mcp + routing_parity — **zero regression**. ruff + mypy clean.

Task #34 — **PR-A slice 3 of 3; the rg-parse moat is now COMPLETE** (lines-bytes, `-u`, submatches, exit-2). Release-bearing (`fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
