### PR TITLE
perf: blast-radius ~4.8x faster (memoize _module_aliases_for_path)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -5174,7 +5174,13 @@ def _source_tokens(source_files: list[str]) -> set[str]:
     return tokens
 
 
-def _module_aliases_for_path(path: str) -> set[str]:
+@lru_cache(maxsize=16384)
+def _module_aliases_for_path(path: str) -> frozenset[str]:
+    # Pure function of the path STRING (no file I/O) — safe to cache unconditionally, no mtime
+    # key needed. The reverse-import graph / PageRank calls this in tight loops (~1.4M calls for
+    # ~unique-file inputs on a depth-2 blast-radius), so memoization collapses it to one build
+    # per distinct path. frozenset return keeps the cached value immutable (all callers iterate
+    # it or .update() FROM it; none mutate it).
     current = Path(path)
     aliases = {current.stem.lower()}
     parts = [part.lower() for part in current.with_suffix("").parts]
@@ -5182,7 +5188,7 @@ def _module_aliases_for_path(path: str) -> set[str]:
         aliases.add(".".join(parts))
     if len(parts) > 1:
         aliases.add(".".join(parts[-2:]))
-    return {alias for alias in aliases if alias}
+    return frozenset(alias for alias in aliases if alias)
 
 
 def _import_alias_candidates(import_name: str) -> set[str]:
@@ -5201,7 +5207,7 @@ def _import_alias_candidates(import_name: str) -> set[str]:
 
 def _import_graph_bonus(
     file_path: str,
-    dependency_aliases: dict[str, set[str]],
+    dependency_aliases: dict[str, frozenset[str]],
     imports_by_file: dict[str, list[str]],
 ) -> int:
     bonus = 0

--- a/tests/unit/test_module_aliases_cache.py
+++ b/tests/unit/test_module_aliases_cache.py
@@ -1,0 +1,33 @@
+"""_module_aliases_for_path memoization (blast-radius perf, 2026-07-03).
+
+Found by profile-at-scale: on a depth-2 blast-radius this pure path->aliases function was
+called ~1.4M times for ~unique-file inputs (the reverse-import graph / PageRank loops),
+dominating a 62s run. It has no file I/O, so caching by the path string is unconditionally
+correct. This locks in the memoization + immutability without changing the alias contents.
+"""
+
+from tensor_grep.cli.repo_map import _module_aliases_for_path
+
+
+def test_returns_frozenset_and_is_cached() -> None:
+    _module_aliases_for_path.cache_clear()
+    a1 = _module_aliases_for_path("src/tensor_grep/core/config.py")
+    a2 = _module_aliases_for_path("src/tensor_grep/core/config.py")
+    assert isinstance(a1, frozenset)
+    assert a1 is a2  # identical cached object -> the hot loop pays one build per path
+    assert _module_aliases_for_path.cache_info().hits >= 1
+
+
+def test_alias_contents_unchanged() -> None:
+    # Parity: the memoized frozenset must contain exactly the aliases the old set did.
+    aliases = _module_aliases_for_path("a/b/mymod.py")
+    assert "mymod" in aliases  # stem
+    assert "a.b.mymod" in aliases  # full dotted path
+    assert "b.mymod" in aliases  # last-two dotted
+    assert "" not in aliases  # empties filtered
+
+
+def test_immutable_result_cannot_corrupt_cache() -> None:
+    aliases = _module_aliases_for_path("x/y.py")
+    # frozenset has no mutating API — a stray .add() would raise, not silently poison the cache.
+    assert not hasattr(aliases, "add")


### PR DESCRIPTION
## The AI-user's #1 complaint: blast-radius is slow (~4 min). This makes it ~5× faster.

**Profile-at-scale** of `tg blast-radius` (depth-2, high-fan-in symbol) found the dominant cost was **not** the AST parse (`compile` = 3.6% of runtime) but **`_module_aliases_for_path`, called ~1.4M times** for ~1000 unique-path inputs in the reverse-import graph / PageRank loops (6.1s self / **38s cumulative** of a 62s run).

It's a **pure function of the path string** (no file I/O), so it is unconditionally safe to memoize — no mtime key needed.

## Fix
`@lru_cache(maxsize=16384)` + `frozenset` return:
- blast-radius(`SearchConfig`, depth=2): **61.7s → 12.8s** on this repo (**4.8×**).
- cache: **1,431,341 hits / 1,002 misses** — the 1.4M calls collapse to one build per distinct path.
- **Output identical** (`affected=62`; **231 blast-radius/callers/pagerank parity tests unchanged**).
- `frozenset` keeps the cached value immutable (all callers iterate it or `.update()` *from* it; none mutate).

## Process note
This corrects the regression-hunt synthesis, which *guessed* AST-parse caching (would have saved ~3%) — the real hotspot only appeared under measurement. Textbook "measure before promoting." The reported +33% "regression" was separately proven **environmental noise** (the plain callers path is byte-identical v1.17.31→HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)