### PR TITLE
fix: ASCII marker in tg inventory truncation notice (Windows cp1252 crash)

### DIFF
--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -274,7 +274,7 @@ def render_inventory_text(inventory: dict[str, Any]) -> str:
     scan = inventory["scan_limit"]
     if scan["possibly_truncated"]:
         lines.append(
-            f"  ⚠ truncated at max_files={scan['max_files']} "
+            f"  [!] truncated at max_files={scan['max_files']} "
             f"(cause={scan['truncation_cause']}); counts are a floor, not complete."
         )
     return "\n".join(lines)


### PR DESCRIPTION
`render_inventory_text` emitted `⚠` (U+26A0), which `typer.echo` **cannot encode on a Windows cp1252 console** — `tg inventory` crashes with `UnicodeEncodeError` on the truncation path (repo > `max_files`). Verified: `typer.echo('⚠')` raises on this console, tg does **not** reconfigure stdout to UTF-8, and no other command emits non-ASCII — so it's a real latent crash. Replaced with an ASCII `[!]` marker.

Found while dogfooding the (deferred) `tg diff-docs` command on this repo.

Tests + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)