### PR TITLE
fix: rg NDJSON split on newline only + O(1) file-list membership (round-5 Q1/Q2)

### DIFF
--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -118,7 +118,10 @@ class RipgrepBackend(ComputeBackend):
             match_counts_by_file: dict[str, int] = {}
             total_matches = 0
 
-            for line in result.stdout.splitlines():
+            # split on rg's NDJSON record delimiter (\n) — NOT str.splitlines(), which also
+            # breaks on U+2028/U+2029/U+0085 that rg emits UNESCAPED inside a match's line text,
+            # fracturing the JSON record so it fails json.loads and is silently dropped.
+            for line in result.stdout.split("\n"):
                 if not line.strip():
                     continue
                 try:
@@ -153,10 +156,12 @@ class RipgrepBackend(ComputeBackend):
                         )
                         total_matches += 1
                         if path_str:
-                            match_counts_by_file[path_str] = (
-                                match_counts_by_file.get(path_str, 0) + 1
-                            )
-                            if path_str not in matched_file_paths:
+                            # O(1) first-seen detection via the counts dict — the previous
+                            # `path_str not in matched_file_paths` was an O(n) scan per match,
+                            # degrading a common-token search on a large repo to O(matches x files).
+                            new_count = match_counts_by_file.get(path_str, 0) + 1
+                            match_counts_by_file[path_str] = new_count
+                            if new_count == 1:
                                 matched_file_paths.append(path_str)
                     elif data.get("type") == "context":
                         data_match = data["data"]
@@ -215,7 +220,9 @@ class RipgrepBackend(ComputeBackend):
                 encoding="utf-8",
                 timeout_seconds=configured_ripgrep_timeout_seconds(),
             )
-            path_parts = result.stdout.split("\0") if config.null else result.stdout.splitlines()
+            # split on rg's \n path delimiter, not str.splitlines() (a filename may contain a
+            # literal U+2028/U+0085 that splitlines would fracture the path on).
+            path_parts = result.stdout.split("\0") if config.null else result.stdout.split("\n")
             matched_file_paths = [path for path in path_parts if path]
             # rg exit 2 with some matched files = soft partial error: keep them, flag incomplete.
             partial = result.returncode == 2 and bool(matched_file_paths)
@@ -257,7 +264,7 @@ class RipgrepBackend(ComputeBackend):
                 encoding="utf-8",
                 timeout_seconds=configured_ripgrep_timeout_seconds(),
             )
-            lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            lines = [line.strip() for line in result.stdout.split("\n") if line.strip()]
             total_matches = 0
             total_files = 0
             matched_file_paths: list[str] = []

--- a/tests/unit/test_rg_ndjson_split_and_membership.py
+++ b/tests/unit/test_rg_ndjson_split_and_membership.py
@@ -1,0 +1,78 @@
+"""Round-5 Q1+Q2: rg NDJSON must split on newline only (not str.splitlines, which also breaks on
+U+2028/U+2029/U+0085 that rg emits unescaped inside match text), and file-list membership must be
+O(1). CI-safe: mocks run_subprocess, never spawns real rg."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+from tensor_grep.core.config import SearchConfig
+
+U2028 = chr(0x2028)  # LINE SEPARATOR: str.splitlines() splits here; str.split(chr(10)) does not
+U0085 = chr(0x0085)  # NEXT LINE: same class of bug
+
+
+def _fake(returncode: int, stdout: str, stderr: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _search(stdout: str, config: SearchConfig | None = None):
+    be = RipgrepBackend()
+    with (
+        patch.object(be, "_get_binary_name", return_value="rg"),
+        patch(
+            "tensor_grep.backends.ripgrep_backend.run_subprocess",
+            return_value=_fake(0, stdout),
+        ),
+    ):
+        return be.search("a.py", "foo", config or SearchConfig())
+
+
+def _match(path: str, text: str = "x", line: int = 1) -> str:
+    # ensure_ascii=False replicates rg/serde_json emitting the raw separator (not a unicode escape).
+    return json.dumps(
+        {
+            "type": "match",
+            "data": {
+                "path": {"text": path},
+                "lines": {"text": text},
+                "line_number": line,
+                "submatches": [{"match": {"text": "foo"}, "start": 0, "end": 3}],
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+class TestQ1UnicodeLineBoundarySplit:
+    def test_u2028_in_match_text_is_not_dropped(self) -> None:
+        rec = _match("a.py", text="foo" + U2028 + "bar")
+        assert U2028 in rec and "\n" not in rec  # raw separator inside a single JSON record
+        res = _search(rec + "\n")
+        # str.splitlines() fractures this record at U+2028 into two invalid-JSON halves -> both
+        # fail json.loads -> silently dropped -> 0 matches. split on newline keeps it whole -> 1.
+        assert res.total_matches == 1
+        assert res.matches and res.matches[0].file == "a.py"
+
+    def test_u0085_next_line_char_is_not_dropped(self) -> None:
+        rec = _match("a.py", text="foo" + U0085 + "baz")
+        assert U0085 in rec and "\n" not in rec
+        res = _search(rec + "\n")
+        assert res.total_matches == 1
+
+
+class TestQ2MembershipOrderAndCounts:
+    def test_first_seen_order_preserved_no_dupes(self) -> None:
+        stdout = "\n".join([_match("z.py"), _match("a.py"), _match("z.py")]) + "\n"
+        res = _search(stdout)
+        assert res.matched_file_paths == ["z.py", "a.py"]  # first-seen order, z not duplicated
+        assert res.match_counts_by_file == {"z.py": 2, "a.py": 1}
+        assert res.total_matches == 3
+
+    def test_single_file_many_matches(self) -> None:
+        stdout = "\n".join(_match("a.py", line=i) for i in range(1, 6)) + "\n"
+        res = _search(stdout)
+        assert res.matched_file_paths == ["a.py"]
+        assert res.match_counts_by_file == {"a.py": 5}
+        assert res.total_matches == 5


### PR DESCRIPTION
Two round-5 audit findings (adversarially verified + live-reproduced).

**Q1 (correctness/silent-failure):** rg `--json`/`-l`/`--count` parsers used `str.splitlines()`, which also splits on U+2028/U+2029/U+0085 that rg emits **unescaped** inside a match's line text (or a filename). One such char fractured rg's single NDJSON record into invalid-JSON halves → both fail `json.loads` → match silently dropped (`total_matches:0`, no `result_incomplete`, no stderr). Fixed all 3 parse loops to `split("\n")`.

**Q2 (perf):** default path did an O(n) `not in matched_file_paths` list scan per match → O(matches×files) on a large repo. The counts dict already encodes first-seen → O(1).

**Tests:** 4 new (RED-proven: splitlines→2 fragments→dropped) + 30 parity/exit2/submatch green, zero regression. ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)