### PR TITLE
fix: --gpu-device-ids must not silently downgrade to CPU via rg-passthrough (round-5 Q9)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3790,6 +3790,10 @@ def _can_passthrough_rg(
         and not config.ltl
         and not config.force_cpu
         and not config.rank_bm25
+        # An explicit --gpu-device-ids request must reach Pipeline, which raises loudly when GPU
+        # can't be honored (the "never silently downgrade to CPU" contract). rg-passthrough would
+        # run plain CPU rg with exit 0 and no fallback_reason — a silent downgrade. (round-5 Q9)
+        and not config.gpu_device_ids
         and format_type == "rg"
         and (not json_mode or rg_json_passthrough)
         and not ndjson_mode

--- a/tests/unit/test_rg_passthrough_gpu_guard.py
+++ b/tests/unit/test_rg_passthrough_gpu_guard.py
@@ -1,0 +1,31 @@
+"""Round-5 Q9: an explicit --gpu-device-ids request must NOT take the rg-passthrough fast path
+(which runs plain CPU rg with exit 0 and no diagnostic) — it must reach Pipeline where the
+"never silently downgrade an explicit GPU request to CPU" fail-loud contract runs."""
+
+from tensor_grep.cli.main import _can_passthrough_rg
+from tensor_grep.core.config import SearchConfig
+
+
+def _passthrough(config: SearchConfig) -> bool:
+    return _can_passthrough_rg(
+        config,
+        format_type="rg",
+        explicit_rg_format=False,
+        json_mode=False,
+        ndjson_mode=False,
+        files_mode=False,
+        files_with_matches=False,
+        files_without_match=False,
+        only_matching=False,
+        stats_mode=False,
+    )
+
+
+def test_gpu_device_ids_request_is_not_passthrough() -> None:
+    # Was True (silent CPU downgrade); must be False so Pipeline can raise ConfigurationError.
+    assert _passthrough(SearchConfig(gpu_device_ids=[0])) is False
+
+
+def test_plain_search_still_passthrough() -> None:
+    # The default fast path must be preserved (no perf regression).
+    assert _passthrough(SearchConfig()) is True


### PR DESCRIPTION
`_can_passthrough_rg` didn't check `config.gpu_device_ids`, so an explicit `--gpu-device-ids` request took the plain-CPU-rg fast path (exit 0, no `fallback_reason`) — violating the documented *fail-loud, never-silent-downgrade* GPU contract Pipeline enforces. Added `not config.gpu_device_ids` to the guard (mirrors the stats-branch guard). Adversarially verified + live-reproduced by the round-5 audit; TDD + routing-parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)