### PR TITLE
fix: round-5 mechanical batch — inventory walk-cap, json submatches, MCP error sanitize, dir-scan DoS caps

### DIFF
--- a/src/tensor_grep/cli/formatters/json_fmt.py
+++ b/src/tensor_grep/cli/formatters/json_fmt.py
@@ -77,6 +77,15 @@ def _match_payload(match: MatchLine, config: SearchConfig | None = None) -> dict
         payload["range"] = match.range
     if match.meta_variables is not None:
         payload["metaVariables"] = match.meta_variables
+    # audit q6: mirror RipgrepFormatter._submatch_columns -- rg's per-occurrence byte offsets
+    # (match.submatches) were parsed onto MatchLine but never read here, so --json lost
+    # column/offset info and could not report multiple occurrences on one line. Emit the same
+    # dicts rg's own --json submatches use (keys: "match"/"start"/"end"); omit the key entirely
+    # (no null/empty noise) for non-rg backends / context lines that have none.
+    if match.submatches:
+        subs = [dict(sub) for sub in match.submatches if isinstance(sub, dict)]
+        if subs:
+            payload["submatches"] = subs
     return payload
 
 

--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -175,7 +175,13 @@ def build_inventory(
     if not root.exists():
         raise FileNotFoundError(f"inventory path does not exist: {path}")
 
-    walked = _iter_repo_files(root, max_files=None)
+    # Probe one file past the cap: _iter_repo_files' bucketed early-stop (repo_map.py)
+    # can honor a real max_files bound and stop walking once it has enough, so we thread
+    # the cap straight into the iterator instead of walking the whole tree and slicing
+    # afterward. Asking for max_files + 1 (not max_files) lets us still tell "exactly
+    # max_files files exist" apart from "more files exist" for the truncation notice,
+    # without ever walking further than one file past the cap.
+    walked = _iter_repo_files(root, max_files=max_files + 1)
     possibly_truncated = False
     truncation_cause: str | None = None
     if len(walked) > max_files:

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -210,6 +210,49 @@ def _envelope_base(
     return base
 
 
+def _log_tool_exception(tool_name: str, exc: BaseException) -> None:
+    """Log the full exception (message + traceback) server-side only.
+
+    q11: MCP tool responses are returned to the client over the protocol
+    stream (stdout); the raw exception text can contain absolute filesystem
+    paths, internal module structure, or a full stack trace and must never
+    be shipped there. The full detail is written to stderr instead, which
+    carries server-side diagnostics, not the MCP JSON-RPC channel.
+    """
+    import traceback
+
+    detail = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    print(f"[tensor-grep-mcp] {tool_name} failed: {detail}", file=sys.stderr, end="")
+
+
+def _sanitized_tool_error(tool_name: str, exc: BaseException) -> dict[str, Any]:
+    """Build a stable, sanitized error object for an MCP tool JSON response.
+
+    Logs the full exception server-side (see `_log_tool_exception`) and
+    returns only a short category + safe reason to the client -- never the
+    raw exception text or a stack trace. Still signals failure (the caller
+    keeps the call's error/non-empty-result contract); this only strips the
+    internals from what crosses the wire.
+    """
+    _log_tool_exception(tool_name, exc)
+    return {
+        "code": "internal_error",
+        "message": f"{tool_name} failed due to an internal error ({exc.__class__.__name__}).",
+        "retryable": False,
+    }
+
+
+def _sanitized_tool_error_text(tool_name: str, exc: BaseException) -> str:
+    """Plain-text counterpart of `_sanitized_tool_error` for tool response
+    modes that return free text instead of a JSON envelope.
+    """
+    _log_tool_exception(tool_name, exc)
+    return (
+        f"{tool_name} failed: internal error ({exc.__class__.__name__}). "
+        "See server logs for detail."
+    )
+
+
 def _rewrite_envelope() -> dict[str, Any]:
     return _envelope_base(
         routing_backend=_REWRITE_ROUTING_BACKEND,
@@ -2765,9 +2808,7 @@ def tg_search(
         return "\n".join(output)
 
     except Exception as e:
-        import traceback
-
-        return f"Search failed: {e!s}\n{traceback.format_exc()}"
+        return _sanitized_tool_error_text("tg_search", e)
 
 
 @mcp.tool()  # type: ignore
@@ -2936,23 +2977,17 @@ def tg_ast_search(pattern: str, lang: str, path: str = ".", structured_json: boo
         return "\n".join(output)
 
     except Exception as e:
-        import traceback
-
         if structured_json:
             return json.dumps(
                 {
                     "pattern": pattern,
                     "lang": lang,
                     "path": path,
-                    "error": {
-                        "code": "internal_error",
-                        "message": str(e),
-                        "detail": traceback.format_exc(),
-                    },
+                    "error": _sanitized_tool_error("tg_ast_search", e),
                 },
                 indent=2,
             )
-        return f"AST Search failed: {e!s}\n{traceback.format_exc()}"
+        return _sanitized_tool_error_text("tg_ast_search", e)
 
 
 @mcp.tool()  # type: ignore
@@ -3037,21 +3072,15 @@ def tg_classify_logs(file_path: str, structured_json: bool = True) -> str:
         return "\n".join(output)
 
     except Exception as e:
-        import traceback
-
         if structured_json:
             return json.dumps(
                 {
                     "file_path": file_path,
-                    "error": {
-                        "code": "internal_error",
-                        "message": str(e),
-                        "detail": traceback.format_exc(),
-                    },
+                    "error": _sanitized_tool_error("tg_classify_logs", e),
                 },
                 indent=2,
             )
-        return f"Log Classification failed: {e!s}\n{traceback.format_exc()}"
+        return _sanitized_tool_error_text("tg_classify_logs", e)
 
 
 @mcp.tool()  # type: ignore

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -34,10 +34,57 @@ _GENERATED_RELATIVE_DIRS = {
 # fast path (which must also export the class) without re-plumbing the call site.
 HAS_RUST_SCANNER = False
 
+# Defensive traversal budget (round-5 Q14 hardening): a pathological tree (very deep/wide fanout,
+# or a filesystem fan-bomb) must not make a single `walk()` call consume unbounded time/memory.
+# Counts total dir+file entries the walk touches; once the cap is exceeded the walk STOPS and
+# flags the truncation (never a silent drop) -- mirroring the `possibly_truncated` /
+# `truncation_cause` DoS-guard style used by `cli/inventory.py` and `cli/repo_map.py`.
+# Env-overridable for the rare legitimately-huge monorepo.
+_MAX_SCAN_ENTRIES_ENV = "TG_DIR_SCAN_MAX_ENTRIES"
+DEFAULT_MAX_SCAN_ENTRIES = 200_000
+
+# Defensive byte cap on `.gitignore` (round-5 Q15 hardening): a giant (crafted or accidental)
+# .gitignore must not be slurped into memory whole. Read at most this many bytes; the rest is
+# ignored and flagged via `gitignore_truncated` rather than silently swallowed.
+_GITIGNORE_MAX_BYTES_ENV = "TG_GITIGNORE_MAX_BYTES"
+DEFAULT_GITIGNORE_MAX_BYTES = 1024 * 1024  # 1 MiB is generous for a real .gitignore
+
+
+def _configured_positive_int(env_var: str, default: int) -> int:
+    raw_value = os.environ.get(env_var)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
 
 class DirectoryScanner:
-    def __init__(self, config: SearchConfig | None = None):
+    def __init__(
+        self,
+        config: SearchConfig | None = None,
+        *,
+        max_scan_entries: int | None = None,
+        gitignore_max_bytes: int | None = None,
+    ):
         self.config = config or SearchConfig()
+        self.max_scan_entries = (
+            max_scan_entries
+            if max_scan_entries is not None
+            else _configured_positive_int(_MAX_SCAN_ENTRIES_ENV, DEFAULT_MAX_SCAN_ENTRIES)
+        )
+        self.gitignore_max_bytes = (
+            gitignore_max_bytes
+            if gitignore_max_bytes is not None
+            else _configured_positive_int(_GITIGNORE_MAX_BYTES_ENV, DEFAULT_GITIGNORE_MAX_BYTES)
+        )
+        # Truncation signals -- sticky (never reset to False) so a scanner instance reused across
+        # multiple `walk()` calls (see `ast_workflows.py`) doesn't lose an earlier truncation.
+        self.scan_truncated = False
+        self.scan_truncation_cause: str | None = None
+        self.gitignore_truncated = False
 
     def _load_ignore_spec(self, base_path: Path) -> "GitIgnoreSpec | None":
         if self.config.no_ignore or self.config.no_ignore_vcs or self.config.no_ignore_files:
@@ -49,7 +96,20 @@ class DirectoryScanner:
 
         import pathspec
 
-        patterns = gitignore.read_text(encoding="utf-8").splitlines()
+        # Byte-cap the read (Q15): request one extra byte so we can tell whether the file
+        # actually exceeded the cap without loading it whole.
+        with gitignore.open("rb") as handle:
+            raw = handle.read(self.gitignore_max_bytes + 1)
+        if len(raw) > self.gitignore_max_bytes:
+            raw = raw[: self.gitignore_max_bytes]
+            self.gitignore_truncated = True
+            # Drop a dangling partial final line so a byte-boundary cut mid-pattern (e.g.
+            # "*.b") isn't fed to pathspec as a misleading glob.
+            last_newline = raw.rfind(b"\n")
+            if last_newline != -1:
+                raw = raw[:last_newline]
+
+        patterns = raw.decode("utf-8", errors="replace").splitlines()
         return pathspec.GitIgnoreSpec.from_lines(patterns)
 
     def _requires_python_guardrails(self, base_path: Path) -> bool:
@@ -94,7 +154,20 @@ class DirectoryScanner:
         def _relative_posix(path: Path) -> str:
             return path.relative_to(base_path).as_posix()
 
+        entries_visited = 0
+
         for root, dirs, files in os.walk(base_path):
+            # Traversal budget (Q14): count this root plus every dir/file entry it exposes
+            # BEFORE any filtering, since those are the entries the walk had to stat via
+            # readdir. Once the budget is exceeded, stop descending and surface truncation
+            # rather than silently dropping the rest of the tree.
+            entries_visited += 1 + len(dirs) + len(files)
+            if entries_visited > self.max_scan_entries:
+                self.scan_truncated = True
+                self.scan_truncation_cause = "max-scan-entries"
+                dirs.clear()
+                break
+
             current_depth = len(Path(root).parts) - base_depth
 
             if max_depth is not None and current_depth >= max_depth:

--- a/tests/unit/test_directory_scanner_hardening.py
+++ b/tests/unit/test_directory_scanner_hardening.py
@@ -1,0 +1,76 @@
+"""Round-5 Q14/Q15 hardening: DirectoryScanner traversal budget + .gitignore byte cap.
+
+Q14: an unbounded directory walk on a pathological tree (deep/wide fanout) must STOP once a
+defensive entry budget is exceeded, and must flag the truncation rather than silently dropping
+the remainder of the tree.
+
+Q15: reading `.gitignore` must be byte-capped so a giant file (crafted or accidental) cannot be
+slurped into memory whole; anything beyond the cap is ignored and flagged, without crashing.
+"""
+
+from tensor_grep.core.config import SearchConfig
+from tensor_grep.io.directory_scanner import DirectoryScanner
+
+
+class TestDirectoryScannerTraversalBudget:
+    def test_should_stop_and_flag_truncation_when_scan_budget_exceeded(self, tmp_path):
+        # 20 subdirectories each holding one file -> os.walk visits far more than a
+        # deliberately tiny budget can absorb.
+        for i in range(20):
+            sub = tmp_path / f"d{i}"
+            sub.mkdir()
+            (sub / "file.py").write_text("x", encoding="utf-8")
+
+        scanner = DirectoryScanner(SearchConfig(), max_scan_entries=5)
+        files = list(scanner.walk(str(tmp_path)))
+
+        # The walk must not silently drop -- it must both stop short AND flag truncation.
+        assert len(files) < 20
+        assert scanner.scan_truncated is True
+        assert scanner.scan_truncation_cause == "max-scan-entries"
+
+    def test_should_not_flag_truncation_when_budget_is_sufficient(self, tmp_path):
+        for i in range(5):
+            sub = tmp_path / f"d{i}"
+            sub.mkdir()
+            (sub / "file.py").write_text("x", encoding="utf-8")
+
+        scanner = DirectoryScanner(SearchConfig(), max_scan_entries=10_000)
+        files = list(scanner.walk(str(tmp_path)))
+
+        assert len(files) == 5
+        assert scanner.scan_truncated is False
+        assert scanner.scan_truncation_cause is None
+
+
+class TestDirectoryScannerGitignoreByteCap:
+    def test_should_cap_oversized_gitignore_without_crash(self, tmp_path):
+        # A .gitignore far larger than a small test cap; must not be read whole into memory.
+        huge_contents = "*.bin\n" * 200_000
+        (tmp_path / ".gitignore").write_text(huge_contents, encoding="utf-8")
+
+        keep = tmp_path / "keep.py"
+        keep.write_text("ok", encoding="utf-8")
+
+        scanner = DirectoryScanner(SearchConfig(), gitignore_max_bytes=64)
+
+        # Must not raise, and the legitimate file must still be returned (it is not a *.bin
+        # pattern, and the oversized ignore file is only partially honored, never crashes).
+        files = list(scanner.walk(str(tmp_path)))
+
+        assert str(keep) in files
+        assert scanner.gitignore_truncated is True
+
+    def test_should_not_flag_truncation_for_small_gitignore(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        keep = tmp_path / "keep.py"
+        keep.write_text("ok", encoding="utf-8")
+        ignored = tmp_path / "debug.log"
+        ignored.write_text("ok", encoding="utf-8")
+
+        scanner = DirectoryScanner(SearchConfig(), gitignore_max_bytes=64)
+        files = list(scanner.walk(str(tmp_path)))
+
+        assert str(keep) in files
+        assert str(ignored) not in files
+        assert scanner.gitignore_truncated is False

--- a/tests/unit/test_inventory_max_files.py
+++ b/tests/unit/test_inventory_max_files.py
@@ -1,0 +1,88 @@
+"""TDD regression: ``tg inventory`` must thread ``--max-repo-files`` INTO the walk.
+
+Bug (round-5 [q4]): ``build_inventory`` called ``_iter_repo_files(root, max_files=None)``
+-- walking the WHOLE tree -- then sliced the already-fully-walked list down to
+``max_files`` afterward. On a huge repo that is unbounded work despite the cap.
+
+The fix threads the real cap into the iterator (``_iter_repo_files`` supports a real
+bucketed early-stop, see ``repo_map.py::_iter_repo_files``) so the walk itself stops
+once it has enough files, while still honoring the "truncation is never silent"
+contract (``scan_limit.possibly_truncated`` / ``truncation_cause``).
+"""
+
+import os
+
+import tensor_grep.cli.inventory as inventory_module
+from tensor_grep.cli.inventory import build_inventory
+
+
+def _write(root, rel, content=b"x"):
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    path.write_bytes(content)
+    return path
+
+
+class TestWalkThreadsMaxFiles:
+    def test_iterator_receives_bounded_max_files_not_none(self, tmp_path, monkeypatch):
+        """The walker must be told the cap up front, not walked unbounded then sliced."""
+        for i in range(20):
+            _write(tmp_path, f"f{i:03d}.py", "x=1\n")
+
+        real_iter_repo_files = inventory_module._iter_repo_files
+        seen_max_files: list[int | None] = []
+
+        def spy_iter_repo_files(root, *, max_files=None, **kwargs):
+            seen_max_files.append(max_files)
+            return real_iter_repo_files(root, max_files=max_files, **kwargs)
+
+        monkeypatch.setattr(inventory_module, "_iter_repo_files", spy_iter_repo_files)
+
+        inv = build_inventory(str(tmp_path), max_files=5)
+
+        assert seen_max_files, "the walker was never called"
+        # The old bug called _iter_repo_files(root, max_files=None) -- an unbounded
+        # walk -- and truncated the already-fully-walked list afterward. The fix must
+        # pass a real, finite bound tied to the requested cap.
+        assert seen_max_files[0] is not None
+        assert seen_max_files[0] <= 5 + 1
+
+        assert inv["totals"]["files"] == 5
+        assert inv["scan_limit"]["possibly_truncated"] is True
+        assert inv["scan_limit"]["truncation_cause"] == "project-files"
+
+    def test_walk_stops_early_does_not_scandir_every_top_level_dir(self, tmp_path, monkeypatch):
+        """With N top-level dirs and max_files=k<N, only ~k dirs should ever be scanned.
+
+        A fully-walk-then-slice implementation must call os.scandir on every one of
+        the N top-level directories before it can slice the result down to k. A real
+        early-stop walk only advances as many bucket generators as needed to reach
+        the cap, so most of the N directories are never touched.
+        """
+        n_dirs = 40
+        for i in range(n_dirs):
+            _write(tmp_path, f"d{i:03d}/only.py", "x=1\n")
+
+        scanned_dirs: set[str] = set()
+        real_scandir = os.scandir
+
+        def counting_scandir(path="."):
+            scanned_dirs.add(os.fspath(path))
+            return real_scandir(path)
+
+        monkeypatch.setattr(os, "scandir", counting_scandir)
+
+        inv = build_inventory(str(tmp_path), max_files=3)
+
+        assert inv["totals"]["files"] == 3
+        assert inv["scan_limit"]["possibly_truncated"] is True
+
+        # +1 accounts for the root directory's own scandir call. A walk-everything
+        # implementation would scan all n_dirs subdirectories (plus root); the
+        # early-stop walk should touch only a handful near the cap.
+        assert len(scanned_dirs) < n_dirs, (
+            f"expected an early-stopped walk to skip most of {n_dirs} top-level dirs, "
+            f"but {len(scanned_dirs)} were scanned"
+        )

--- a/tests/unit/test_json_fmt_submatches.py
+++ b/tests/unit/test_json_fmt_submatches.py
@@ -1,0 +1,54 @@
+"""q6-jsonfmt-submatches: JsonFormatter._match_payload built each match dict from a hardcoded
+key tuple that never read MatchLine.submatches (per-occurrence byte offsets), unlike
+RipgrepFormatter (which reads match.submatches, see ripgrep_fmt.py::_submatch_columns). Result:
+--json lost column/offset info the vimgrep/column path relies on and could not report multiple
+occurrences on one line.
+
+Fix: mirror ripgrep_fmt.py -- when MatchLine.submatches is present, emit them (same shape/keys
+rg's own submatches use: "match"/"start"/"end") in the JSON match object; when absent, omit the
+key cleanly (no null/empty noise, no crash).
+"""
+
+from __future__ import annotations
+
+import json
+
+from tensor_grep.cli.formatters.json_fmt import JsonFormatter
+from tensor_grep.core.result import MatchLine, SearchResult
+
+
+def _multi_match_line() -> MatchLine:
+    # "foo bar foo baz foo": three occurrences of foo at 0-based byte offsets 0, 8, 16.
+    return MatchLine(
+        line_number=1,
+        text="foo bar foo baz foo",
+        file="a.log",
+        submatches=(
+            {"match": {"text": "foo"}, "start": 0, "end": 3},
+            {"match": {"text": "foo"}, "start": 8, "end": 11},
+            {"match": {"text": "foo"}, "start": 16, "end": 19},
+        ),
+    )
+
+
+def test_json_output_includes_submatches_with_correct_start_end() -> None:
+    result = SearchResult(matches=[_multi_match_line()], total_files=1, total_matches=1)
+
+    parsed = json.loads(JsonFormatter().format(result))
+
+    submatches = parsed["matches"][0]["submatches"]
+    assert submatches == [
+        {"match": {"text": "foo"}, "start": 0, "end": 3},
+        {"match": {"text": "foo"}, "start": 8, "end": 11},
+        {"match": {"text": "foo"}, "start": 16, "end": 19},
+    ]
+
+
+def test_json_output_omits_submatches_key_when_absent() -> None:
+    # Non-rg backend / context line: no submatches -> key must be omitted, not null.
+    ml = MatchLine(line_number=1, text="foo bar foo", file="a.log")
+    result = SearchResult(matches=[ml], total_files=1, total_matches=1)
+
+    parsed = json.loads(JsonFormatter().format(result))
+
+    assert "submatches" not in parsed["matches"][0]

--- a/tests/unit/test_mcp_error_sanitization.py
+++ b/tests/unit/test_mcp_error_sanitization.py
@@ -1,0 +1,225 @@
+"""q11-mcp-traceback-leak: MCP tool error responses must not leak raw
+exception text (absolute filesystem paths, internal module structure, or a
+stack trace) to the client. Failures must still be signaled -- never
+swallowed -- but the wire response gets a stable, sanitized message while
+the full detail goes to stderr for server-side debugging.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from tensor_grep.core.result import SearchResult
+
+# A message shaped like a real Python exception: an absolute filesystem path
+# plus internal module structure that must never reach the MCP client.
+_SECRET_PATH = r"C:\Users\oimir\secret_project\internal\credentials_loader.py"
+_LEAKY_MESSAGE = f"boom while reading {_SECRET_PATH} in module tensor_grep.internal.cache"
+
+
+def _raise_leaky_error(*_args, **_kwargs):
+    raise RuntimeError(_LEAKY_MESSAGE)
+
+
+def test_sanitized_tool_error_helper_strips_raw_exception_text(capsys):
+    """Unit-level: the new sanitization helper never echoes the raw message,
+    but does log full detail (incl. traceback) to stderr.
+    """
+    from tensor_grep.cli import mcp_server
+
+    try:
+        _raise_leaky_error()
+    except RuntimeError as exc:
+        payload = mcp_server._sanitized_tool_error("tg_probe", exc)
+
+    assert payload["code"] == "internal_error"
+    assert payload["retryable"] is False
+    assert _SECRET_PATH not in payload["message"]
+    assert "Traceback" not in payload["message"]
+    assert "credentials_loader" not in payload["message"]
+
+    captured = capsys.readouterr()
+    # Full detail (path + traceback) is preserved server-side on stderr...
+    assert _SECRET_PATH in captured.err
+    assert "Traceback" in captured.err
+    # ...and never printed to stdout (the MCP JSON-RPC channel).
+    assert _SECRET_PATH not in captured.out
+
+
+def test_sanitized_tool_error_text_helper_strips_raw_exception_text(capsys):
+    from tensor_grep.cli import mcp_server
+
+    try:
+        _raise_leaky_error()
+    except RuntimeError as exc:
+        text = mcp_server._sanitized_tool_error_text("tg_probe", exc)
+
+    assert _SECRET_PATH not in text
+    assert "Traceback" not in text
+    # Still clearly signals failure to the caller.
+    assert "failed" in text.lower()
+
+    captured = capsys.readouterr()
+    assert _SECRET_PATH in captured.err
+
+
+def test_tg_search_exception_path_does_not_leak_path_or_traceback(capsys):
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = MagicMock()
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "CuDFBackend"
+        pipeline.selected_backend_reason = "gpu_explicit_ids_cudf"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.side_effect = _raise_leaky_error
+
+        out = mcp_server.tg_search("ERROR", ".")
+
+    # Failure is still signaled to the caller (fail-closed, never swallowed).
+    assert "failed" in out.lower()
+    # But the raw path / module structure / traceback never crosses the wire.
+    assert _SECRET_PATH not in out
+    assert "credentials_loader" not in out
+    assert "Traceback" not in out
+    assert "internal.cache" not in out
+
+    # Full detail landed server-side on stderr instead.
+    captured = capsys.readouterr()
+    assert _SECRET_PATH in captured.err
+
+
+def test_tg_ast_search_exception_path_sanitizes_structured_json_error(capsys):
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = type("AstGrepWrapperBackend", (), {"search": MagicMock()})()
+    fake_backend.search.side_effect = _raise_leaky_error
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "AstGrepWrapperBackend"
+        pipeline.selected_backend_reason = "ast_grep_json"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.py"]
+
+        out = mcp_server.tg_ast_search("def $A():", "python", ".", structured_json=True)
+
+    payload = json.loads(out)
+    assert payload["error"]["code"] == "internal_error"
+    # The structured error still exists (contract preserved) but is sanitized.
+    assert _SECRET_PATH not in json.dumps(payload)
+    assert "Traceback" not in json.dumps(payload)
+    assert "detail" not in payload["error"]
+
+    captured = capsys.readouterr()
+    assert _SECRET_PATH in captured.err
+    assert "Traceback" in captured.err
+
+
+def test_tg_ast_search_exception_path_sanitizes_plain_text(capsys):
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = type("AstGrepWrapperBackend", (), {"search": MagicMock()})()
+    fake_backend.search.side_effect = _raise_leaky_error
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "AstGrepWrapperBackend"
+        pipeline.selected_backend_reason = "ast_grep_json"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.py"]
+
+        out = mcp_server.tg_ast_search("def $A():", "python", ".", structured_json=False)
+
+    assert "failed" in out.lower()
+    assert _SECRET_PATH not in out
+    assert "Traceback" not in out
+
+    captured = capsys.readouterr()
+    assert _SECRET_PATH in captured.err
+
+
+def test_tg_classify_logs_exception_path_does_not_leak_path_or_traceback(tmp_path, capsys):
+    from tensor_grep.cli import mcp_server
+
+    log_path = tmp_path / "app.log"
+    log_path.write_text("INFO startup ok\nERROR database failed\n", encoding="utf-8")
+
+    with patch(
+        "tensor_grep.sidecar._classify_lines_with_metadata",
+        side_effect=_raise_leaky_error,
+    ):
+        out = mcp_server.tg_classify_logs(str(log_path), structured_json=True)
+
+    payload = json.loads(out)
+    assert payload["error"]["code"] == "internal_error"
+    assert _SECRET_PATH not in json.dumps(payload)
+    assert "Traceback" not in json.dumps(payload)
+    assert "detail" not in payload["error"]
+
+    captured = capsys.readouterr()
+    assert _SECRET_PATH in captured.err
+
+
+def test_tg_classify_logs_exception_path_sanitizes_plain_text(tmp_path, capsys):
+    from tensor_grep.cli import mcp_server
+
+    log_path = tmp_path / "app.log"
+    log_path.write_text("INFO startup ok\nERROR database failed\n", encoding="utf-8")
+
+    with patch(
+        "tensor_grep.sidecar._classify_lines_with_metadata",
+        side_effect=_raise_leaky_error,
+    ):
+        out = mcp_server.tg_classify_logs(str(log_path), structured_json=False)
+
+    assert "failed" in out.lower()
+    assert _SECRET_PATH not in out
+    assert "Traceback" not in out
+
+    captured = capsys.readouterr()
+    assert _SECRET_PATH in captured.err
+
+
+# Sanity: unrelated code paths (e.g. a normal SearchResult) are unaffected by
+# the sanitization helpers -- this guards against a fix that accidentally
+# swallows success responses.
+def test_tg_search_success_path_is_unaffected_by_sanitization(capsys):
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = MagicMock()
+    fake_backend.search.return_value = SearchResult(matches=[], total_files=0, total_matches=0)
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "CuDFBackend"
+        pipeline.selected_backend_reason = "gpu_explicit_ids_cudf"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = []
+
+        out = mcp_server.tg_search("ERROR", ".")
+
+    payload = json.loads(out)
+    assert payload["total_matches"] == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""


### PR DESCRIPTION
Four adversarially-verified round-5 audit findings, built in parallel worktrees + **verified in the real venv** (16 new tests + 164 regression green, ruff/format/mypy clean, added lines ASCII-only).

- **Q4 (perf):** `tg inventory` threaded `--max-repo-files` into the *walk* (bucketed early-stop) instead of walking the whole tree then slicing — no more unbounded walk on a huge repo. Truncation-reporting contract unchanged.
- **Q6 (correctness):** `--json`/`--ndjson` now emit `MatchLine.submatches` (per-occurrence byte offsets), mirroring `ripgrep_fmt.py` — was silently dropping column/multi-occurrence info. Omitted cleanly when absent.
- **Q11 (security/info-disclosure):** MCP tool error responses are sanitized — no more raw traceback / absolute-path leak over the wire; full detail logged server-side. Still fails the call (not swallowed).
- **Q14+Q15 (DoS hardening):** `DirectoryScanner` gained a traversal-entry budget + a `.gitignore` read byte-cap, with truncation signals (never silent-drop).

Each fix is TDD (RED-proven) and touches a non-overlapping file. Ships behind v1.19.5/#352 one-merge-per-tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)