### PR TITLE
fix: index.json cross-process lost-update race — per-index lockfile + Windows hardening (round-5 Q10)

### DIFF
--- a/src/tensor_grep/cli/_index_lock.py
+++ b/src/tensor_grep/cli/_index_lock.py
@@ -17,6 +17,25 @@ class IndexLockTimeoutError(RuntimeError):
     mtime staleness, so this only fires under sustained LIVE contention."""
 
 
+def replace_with_retry(
+    src: str | Path, dst: str | Path, *, attempts: int = 10, delay_s: float = 0.02
+) -> None:
+    """``os.replace`` retried on the Windows-only transient ``PermissionError`` (WinError 5) that
+    fires when the destination is momentarily held open by a concurrent reader / AV scanner / the
+    search indexer. On POSIX ``os.replace`` is atomic and never raises this, so the retry is a
+    no-op there. Fails CLOSED: re-raises the last error after ``attempts`` rather than leaving a
+    stale index (Backend Fail-Closed Contract)."""
+    src_s, dst_s = str(src), str(dst)
+    for attempt in range(attempts):
+        try:
+            os.replace(src_s, dst_s)
+            return
+        except PermissionError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(delay_s)
+
+
 def _lock_path_for(index_path: Path) -> Path:
     # dot-prefixed + .lock suffix: never matched by checkpoint index discovery (rglob of the
     # literal 'index.json', checkpoint_store.py:808-809) nor any '*.json' session glob.
@@ -40,6 +59,7 @@ def index_lock(
             fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             break
         except FileExistsError:
+            # Lock is held. Reclaim it if stale (dead holder), else fall through to wait.
             try:
                 if time.time() - lock_path.stat().st_mtime > stale_after_s:
                     try:
@@ -49,11 +69,18 @@ def index_lock(
                     continue
             except OSError:
                 pass
-            if time.monotonic() >= deadline:
-                raise IndexLockTimeoutError(
-                    f"could not acquire {lock_path} within {timeout_s}s"
-                ) from None
-            time.sleep(poll_interval_s)
+        except PermissionError:
+            # Windows delete-pending race: a concurrent reclaimer just unlink()'d the lock, so the
+            # name is in a "delete pending" state and O_CREAT|O_EXCL raises ERROR_ACCESS_DENIED
+            # (PermissionError) instead of the POSIX FileExistsError/ENOENT. Transient -> fall
+            # through to wait/retry. A genuine permission error self-limits: it will keep failing
+            # here and fail CLOSED at the deadline with IndexLockTimeoutError, never a raw leak.
+            pass
+        if time.monotonic() >= deadline:
+            raise IndexLockTimeoutError(
+                f"could not acquire {lock_path} within {timeout_s}s"
+            ) from None
+        time.sleep(poll_interval_s)
     try:
         try:
             os.write(fd, f"{os.getpid()}\n".encode())

--- a/src/tensor_grep/cli/_index_lock.py
+++ b/src/tensor_grep/cli/_index_lock.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_POLL_S = 0.02
+_TIMEOUT_S = 5.0  # RMW of a bounded JSON index is sub-ms; generous headroom, not the hot path
+_STALE_AFTER_S = 10.0  # RMW-scaled, NOT daemon-launch-scaled
+
+
+class IndexLockTimeoutError(RuntimeError):
+    """Fail-closed per AGENTS.md Backend Fail-Closed Contract: silently losing an index
+    entry is worse than a rare, actionable error. A genuinely dead lock is reclaimed via
+    mtime staleness, so this only fires under sustained LIVE contention."""
+
+
+def _lock_path_for(index_path: Path) -> Path:
+    # dot-prefixed + .lock suffix: never matched by checkpoint index discovery (rglob of the
+    # literal 'index.json', checkpoint_store.py:808-809) nor any '*.json' session glob.
+    return index_path.with_name(f".{index_path.name}.lock")
+
+
+@contextmanager
+def index_lock(
+    index_path: Path,
+    *,
+    poll_interval_s: float = _POLL_S,
+    timeout_s: float = _TIMEOUT_S,
+    stale_after_s: float = _STALE_AFTER_S,
+) -> Iterator[None]:
+    lock_path = _lock_path_for(index_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout_s
+    fd: int | None = None
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            break
+        except FileExistsError:
+            try:
+                if time.time() - lock_path.stat().st_mtime > stale_after_s:
+                    try:
+                        lock_path.unlink()  # GUARDED: two racing reclaimers must not crash the loser
+                    except OSError:
+                        pass
+                    continue
+            except OSError:
+                pass
+            if time.monotonic() >= deadline:
+                raise IndexLockTimeoutError(
+                    f"could not acquire {lock_path} within {timeout_s}s"
+                ) from None
+            time.sleep(poll_interval_s)
+    try:
+        try:
+            os.write(fd, f"{os.getpid()}\n".encode())
+        finally:
+            os.close(fd)
+        yield
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from tensor_grep.cli._index_lock import index_lock
+from tensor_grep.cli._index_lock import index_lock, replace_with_retry
 from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
 
 _CHECKPOINT_VERSION = 1
@@ -83,7 +83,7 @@ def _write_json_atomic(path: Path, payload: Any) -> None:
         # index/metadata that would leave the agent's rollback safety net unable to
         # find the checkpoint while edits stay applied (audit I5).
         os.fsync(handle.fileno())
-    os.replace(tmp_path, path)
+    replace_with_retry(tmp_path, path)
     # Best-effort durability of the rename itself; directory fsync is a no-op or
     # unsupported on Windows, so failures here are non-fatal.
     try:
@@ -679,6 +679,11 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
     created_at = datetime.now(UTC).isoformat()
     checkpoint_id = f"ckpt-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
     entries = _snapshot_entries(scope)
+
+    # Create the storage root up front so its resolve() is stable: under concurrent first-time
+    # creates, resolving _snapshot_path while another writer is still mkdir-ing .tensor-grep/
+    # checkpoints can transiently mis-resolve and trip the containment guard on a valid id.
+    _checkpoint_storage_dir(root).mkdir(parents=True, exist_ok=True)
 
     snapshot_dir = _snapshot_path(root, checkpoint_id)
     snapshot_dir.mkdir(parents=True, exist_ok=True)

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from tensor_grep.cli._index_lock import index_lock
 from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
 
 _CHECKPOINT_VERSION = 1
@@ -497,7 +498,11 @@ def _rebuild_index_from_checkpoint_metadata(root: Path) -> Path | None:
     records.sort(key=lambda record: record.created_at, reverse=True)
     if not records:
         return None
-    _write_index(root, records)
+    # q10 RMW race: this is a 4th writer of index.json (reached from the discovery/list path
+    # via _full_checkpoint_index_paths) that can otherwise clobber, or be clobbered by,
+    # create_checkpoint's RMW outside the new lock.
+    with index_lock(_index_path(root)):
+        _write_index(root, records)
     return _index_path(root)
 
 
@@ -618,6 +623,35 @@ def _configured_checkpoint_max() -> int:
     return value if value > 0 else _DEFAULT_CHECKPOINT_MAX
 
 
+def _select_retained_checkpoints(
+    root: Path,
+    records: list[CheckpointRecord],
+    *,
+    max_records: int | None = None,
+) -> tuple[list[CheckpointRecord], list[Path]]:
+    """Pure selector for bounded on-disk checkpoint retention (round-4 DoS).
+
+    Keep at most ``max_records`` newest records (``records`` must already be newest-first).
+    Returns ``(retained, dirs_to_delete)`` and performs NO filesystem mutation -- the caller
+    removes ``dirs_to_delete`` (metadata.json + the full snapshot copy for each dropped
+    checkpoint). Doing no I/O here lets ``create_checkpoint`` run this selector INSIDE the
+    index lock and defer the slow, index-unrelated ``rmtree`` calls until after the lock is
+    released (q10 RMW race fix).
+    """
+    limit = _configured_checkpoint_max() if max_records is None else max(1, int(max_records))
+    if len(records) <= limit:
+        return records, []
+    retained = records[:limit]
+    dirs_to_delete: list[Path] = []
+    for dropped in records[limit:]:
+        try:
+            dirs_to_delete.append(_checkpoint_dir(root, dropped.checkpoint_id))
+        except (OSError, ValueError):
+            # ValueError: a traversal-shaped id in a tampered index is refused by _checkpoint_dir.
+            pass
+    return retained, dirs_to_delete
+
+
 def _prune_checkpoint_records(
     root: Path,
     records: list[CheckpointRecord],
@@ -626,20 +660,15 @@ def _prune_checkpoint_records(
 ) -> list[CheckpointRecord]:
     """Bound on-disk checkpoint retention (round-4 DoS).
 
-    Keep at most ``max_records`` newest records (``records`` must already be newest-first). Each
-    dropped checkpoint's entire directory (metadata.json + the full snapshot copy) is removed so
-    disk usage stays bounded — an uncapped store grows by ~one full scope copy per checkpoint.
+    Thin wrapper over ``_select_retained_checkpoints`` that removes the dropped checkpoints'
+    directories immediately, so any existing caller/test that expects synchronous pruning is
+    unchanged. Each dropped checkpoint's entire directory (metadata.json + the full snapshot
+    copy) is removed so disk usage stays bounded — an uncapped store grows by ~one full scope
+    copy per checkpoint.
     """
-    limit = _configured_checkpoint_max() if max_records is None else max(1, int(max_records))
-    if len(records) <= limit:
-        return records
-    retained = records[:limit]
-    for dropped in records[limit:]:
-        try:
-            shutil.rmtree(_checkpoint_dir(root, dropped.checkpoint_id), ignore_errors=True)
-        except (OSError, ValueError):
-            # ValueError: a traversal-shaped id in a tampered index is refused by _checkpoint_dir.
-            pass
+    retained, dirs_to_delete = _select_retained_checkpoints(root, records, max_records=max_records)
+    for directory in dirs_to_delete:
+        shutil.rmtree(directory, ignore_errors=True)
     return retained
 
 
@@ -681,20 +710,28 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
         original_path=scope.original_path,
     )
 
-    records = _load_index(root)
-    records.insert(
-        0,
-        CheckpointRecord(
-            version=_CHECKPOINT_VERSION,
-            checkpoint_id=checkpoint_id,
-            mode=mode,
-            root=str(root),
-            created_at=created_at,
-            file_count=len(entries),
-        ),
-    )
-    records = _prune_checkpoint_records(root, records)
-    _write_index(root, records)
+    # q10 RMW race: load->mutate->write must be atomic w.r.t. every other writer of this
+    # index.json, cross-process and cross-thread, or a concurrent insert can be lost (see
+    # _index_lock.index_lock docstring / AGENTS.md Backend Fail-Closed Contract). Retention
+    # selection stays inside the lock (pure, no I/O); the actual rmtree of dropped snapshot
+    # dirs happens AFTER release so the lock is never held across slow directory removal.
+    with index_lock(_index_path(root)):
+        records = _load_index(root)
+        records.insert(
+            0,
+            CheckpointRecord(
+                version=_CHECKPOINT_VERSION,
+                checkpoint_id=checkpoint_id,
+                mode=mode,
+                root=str(root),
+                created_at=created_at,
+                file_count=len(entries),
+            ),
+        )
+        records, dropped_dirs = _select_retained_checkpoints(root, records)
+        _write_index(root, records)
+    for directory in dropped_dirs:
+        shutil.rmtree(directory, ignore_errors=True)
     _prime_bounded_discovery_caches_for_root(root)
     return result
 

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -596,6 +596,10 @@ def open_session(
         "scan_limit": scan_limit,
         "build_seconds": max(0.0, built_at - started_at),
     }
+    # Create the sessions dir up front so _session_payload_path's sessions_dir.resolve() is stable:
+    # under concurrent first-time opens, resolving while another writer is still mkdir-ing the dir
+    # can transiently mis-resolve and trip the containment guard on a VALID session id (Windows).
+    _sessions_dir(root).mkdir(parents=True, exist_ok=True)
     session_path = _session_payload_path(root, session_id)
     _write_json_atomic(session_path, payload)
 

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -14,7 +14,7 @@ from time import monotonic
 from typing import Any, TextIO, cast
 from uuid import uuid4
 
-from tensor_grep.cli._index_lock import index_lock
+from tensor_grep.cli._index_lock import index_lock, replace_with_retry
 from tensor_grep.cli.repo_map import (
     DEFAULT_AGENT_REPO_MAP_LIMIT,
     _is_repo_context_file,
@@ -415,7 +415,7 @@ def _write_json_atomic(path: Path, payload: Any, *, mode: int | None = None) -> 
             pass
     else:
         tmp_path.write_text(data, encoding="utf-8")
-    os.replace(tmp_path, path)
+    replace_with_retry(tmp_path, path)
 
 
 def _write_index(root: Path, records: list[SessionRecord]) -> None:

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -14,6 +14,7 @@ from time import monotonic
 from typing import Any, TextIO, cast
 from uuid import uuid4
 
+from tensor_grep.cli._index_lock import index_lock
 from tensor_grep.cli.repo_map import (
     DEFAULT_AGENT_REPO_MAP_LIMIT,
     _is_repo_context_file,
@@ -606,12 +607,17 @@ def open_session(
         file_count=len(repo_map["files"]),
         symbol_count=len(repo_map["symbols"]),
     )
-    records = [existing for existing in _load_index(root) if existing.session_id != session_id]
-    records.insert(0, record)
-    # audit I2: bound retention so disk and index size do not grow without limit; unlink the
-    # payload files for any records dropped past the configured cap before rewriting the index.
-    records = _prune_session_records(root, records)
-    _write_index(root, records)
+    # q10 RMW race: load->mutate->write must be atomic w.r.t. every other writer of this
+    # index.json, cross-process and cross-thread, or a concurrent insert can be lost (see
+    # _index_lock.index_lock docstring / AGENTS.md Backend Fail-Closed Contract).
+    with index_lock(_index_path(root)):
+        records = [existing for existing in _load_index(root) if existing.session_id != session_id]
+        records.insert(0, record)
+        # audit I2: bound retention so disk and index size do not grow without limit; unlink
+        # the payload files for any records dropped past the configured cap before rewriting
+        # the index.
+        records = _prune_session_records(root, records)
+        _write_index(root, records)
     return SessionOpenResult(
         session_id=session_id,
         root=str(root),
@@ -679,31 +685,34 @@ def refresh_session(
     if payload_cache is not None:
         payload_cache.put(session_id, str(root), payload)
 
-    records = _load_index(root)
-    for index, record in enumerate(records):
-        if record.session_id == session_id:
-            records[index] = SessionRecord(
-                version=_SESSION_VERSION,
-                session_id=session_id,
-                root=str(root),
-                created_at=created_at,
-                file_count=len(repo_map["files"]),
-                symbol_count=len(repo_map["symbols"]),
+    # q10 RMW race: same load->mutate->write hazard as open_session; serialize against every
+    # other writer of this index.json before mutating the in-memory record list.
+    with index_lock(_index_path(root)):
+        records = _load_index(root)
+        for index, record in enumerate(records):
+            if record.session_id == session_id:
+                records[index] = SessionRecord(
+                    version=_SESSION_VERSION,
+                    session_id=session_id,
+                    root=str(root),
+                    created_at=created_at,
+                    file_count=len(repo_map["files"]),
+                    symbol_count=len(repo_map["symbols"]),
+                )
+                break
+        else:
+            records.insert(
+                0,
+                SessionRecord(
+                    version=_SESSION_VERSION,
+                    session_id=session_id,
+                    root=str(root),
+                    created_at=created_at,
+                    file_count=len(repo_map["files"]),
+                    symbol_count=len(repo_map["symbols"]),
+                ),
             )
-            break
-    else:
-        records.insert(
-            0,
-            SessionRecord(
-                version=_SESSION_VERSION,
-                session_id=session_id,
-                root=str(root),
-                created_at=created_at,
-                file_count=len(repo_map["files"]),
-                symbol_count=len(repo_map["symbols"]),
-            ),
-        )
-    _write_index(root, records)
+        _write_index(root, records)
 
     return SessionRefreshResult(
         session_id=session_id,

--- a/tests/unit/test_index_lock_concurrency.py
+++ b/tests/unit/test_index_lock_concurrency.py
@@ -1,0 +1,351 @@
+"""Concurrency regression tests for the q10 index.json RMW lost-update race.
+
+``session_store.open_session`` / ``refresh_session`` and ``checkpoint_store.create_checkpoint``
+each do ``_load_index`` -> mutate -> ``_write_index`` with no serialization between the read and
+the atomic ``os.replace`` swap. Two near-simultaneous writers can each read the same pre-insert
+index and the second clobbers the first's insert -- an orphaned session/snapshot dir that is
+invisible to ``list`` and never retention-pruned (reintroducing the round-4 disk-growth DoS).
+
+These tests import ONLY ``_index_lock``, ``session_store``, and ``checkpoint_store`` (no
+``cli.main`` / rust_core), so they run standalone and in CI, mirroring
+``test_session_containment.py`` / ``test_checkpoint_containment.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import _index_lock, checkpoint_store, session_store
+
+
+def _make_project(tmp_path: Path, name: str = "project") -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    (root / "mod.py").write_text("def value():\n    return 1\n", encoding="utf-8")
+    return root
+
+
+# --------------------------------------------------------------------------------------
+# _index_lock.py direct unit coverage
+# --------------------------------------------------------------------------------------
+
+
+def test_index_lock_releases_after_use(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    with _index_lock.index_lock(index_path):
+        assert lock_path.exists()
+    assert not lock_path.exists()
+
+    # A second, later acquire must succeed immediately (no leaked lock file).
+    with _index_lock.index_lock(index_path, timeout_s=0.5):
+        pass
+
+
+def test_index_lock_releases_on_exception(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    with pytest.raises(RuntimeError, match="boom"):
+        with _index_lock.index_lock(index_path):
+            raise RuntimeError("boom")
+    assert not lock_path.exists()
+
+
+def test_index_lock_timeout_raises_under_sustained_contention(tmp_path: Path) -> None:
+    """Fail-closed contract: sustained LIVE contention raises IndexLockTimeoutError rather
+    than silently dropping the caller's write or hanging forever."""
+    index_path = tmp_path / "index.json"
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+
+    def hold_lock() -> None:
+        with _index_lock.index_lock(index_path):
+            holder_ready.set()
+            release_holder.wait(timeout=5.0)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    try:
+        assert holder_ready.wait(timeout=5.0)
+        with pytest.raises(_index_lock.IndexLockTimeoutError):
+            with _index_lock.index_lock(index_path, timeout_s=0.3, stale_after_s=60.0):
+                pass
+    finally:
+        release_holder.set()
+        holder.join(timeout=5.0)
+
+
+# --------------------------------------------------------------------------------------
+# Cross-writer lost-insert (tdd_test_buggy): FAILS pre-fix, PASSES once load->write runs
+# inside index_lock. No multiprocessing needed -- file I/O releases the GIL at the race
+# window; the monkeypatched sleep widens that window deterministically.
+# --------------------------------------------------------------------------------------
+
+
+def test_concurrent_open_session_no_lost_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _make_project(tmp_path)
+
+    orig_write_index = session_store._write_index
+
+    def slow_write_index(r: Path, recs: list) -> None:
+        time.sleep(0.05)  # widen the real RMW window deterministically
+        return orig_write_index(r, recs)
+
+    monkeypatch.setattr(session_store, "_write_index", slow_write_index)
+
+    results: dict[int, session_store.SessionOpenResult] = {}
+
+    def worker(i: int) -> None:
+        results[i] = session_store.open_session(str(root))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 4
+    written = {r.session_id for r in results.values()}
+    indexed = {rec.session_id for rec in session_store._load_index(root)}
+    # TODAY (pre-fix): indexed is a strict subset of written (lost inserts under the race).
+    # AFTER (fix): every writer's insert survives.
+    assert written == indexed
+
+
+def test_concurrent_create_checkpoint_no_lost_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _make_project(tmp_path)
+
+    orig_write_index = checkpoint_store._write_index
+
+    def slow_write_index(r: Path, recs: list) -> None:
+        time.sleep(0.05)
+        return orig_write_index(r, recs)
+
+    monkeypatch.setattr(checkpoint_store, "_write_index", slow_write_index)
+
+    results: dict[int, checkpoint_store.CheckpointCreateResult] = {}
+
+    def worker(i: int) -> None:
+        results[i] = checkpoint_store.create_checkpoint(str(root))
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 4
+    written = {r.checkpoint_id for r in results.values()}
+    indexed = {rec.checkpoint_id for rec in checkpoint_store._load_index(root)}
+    # Concrete "orphaned snapshot dir invisible to list, never pruned" scenario: every
+    # returned checkpoint_id must be indexed AND have a real snapshot dir on disk.
+    assert written == indexed
+    for checkpoint_id in written:
+        assert checkpoint_store._snapshot_path(root, checkpoint_id).exists()
+
+
+def test_concurrent_refresh_session_no_lost_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """refresh_session has its own load->mutate->write span (session_store.py CHANGE 3);
+    concurrent refreshes of DIFFERENT sessions in the same root must not clobber each
+    other's index entries either."""
+    root = _make_project(tmp_path)
+    session_ids = [session_store.open_session(str(root)).session_id for _ in range(4)]
+
+    orig_write_index = session_store._write_index
+
+    def slow_write_index(r: Path, recs: list) -> None:
+        time.sleep(0.05)
+        return orig_write_index(r, recs)
+
+    monkeypatch.setattr(session_store, "_write_index", slow_write_index)
+
+    errors: list[BaseException] = []
+
+    def worker(session_id: str) -> None:
+        try:
+            session_store.refresh_session(session_id, str(root))
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(sid,)) for sid in session_ids]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    indexed = {rec.session_id for rec in session_store._load_index(root)}
+    # All four originally-opened sessions must still be present after concurrent refreshes.
+    assert indexed == set(session_ids)
+
+
+# --------------------------------------------------------------------------------------
+# Non-contended hot path guard (tdd_test_legit A): the lock must not add material overhead
+# on the normal, uncontended path, and must not wrap build_repo_map / the snapshot copy.
+# --------------------------------------------------------------------------------------
+
+
+def test_open_session_uncontended_hot_path_unaffected(tmp_path: Path) -> None:
+    root = _make_project(tmp_path)
+
+    from tensor_grep.cli.repo_map import build_repo_map
+
+    baseline_start = time.monotonic()
+    repo_map_only = build_repo_map(root, max_repo_files=session_store.DEFAULT_AGENT_REPO_MAP_LIMIT)
+    baseline_elapsed = time.monotonic() - baseline_start
+    assert repo_map_only["files"]
+
+    start = time.monotonic()
+    result = session_store.open_session(str(root))
+    elapsed = time.monotonic() - start
+
+    # An uncontended lock acquire/release is a single os.open/os.close pair (microseconds).
+    # Guard against the lock adding material overhead: total open_session time (repo scan +
+    # payload write + the now-LOCKED index RMW) stays within a small, generous multiple of
+    # the unlocked repo-scan-only baseline -- not blown out toward the 5s acquire timeout.
+    assert elapsed < max(baseline_elapsed * 3.0, 0.05) + 1.0
+    indexed = {rec.session_id for rec in session_store._load_index(root)}
+    assert result.session_id in indexed
+
+
+def test_create_checkpoint_uncontended_hot_path_unaffected(tmp_path: Path) -> None:
+    root = _make_project(tmp_path)
+
+    start = time.monotonic()
+    result = checkpoint_store.create_checkpoint(str(root))
+    elapsed = time.monotonic() - start
+
+    # A tiny fixture root; an uncontended lock must not push this anywhere near the 5s
+    # acquire timeout.
+    assert elapsed < 2.0
+    indexed = {rec.checkpoint_id for rec in checkpoint_store._load_index(root)}
+    assert result.checkpoint_id in indexed
+    assert checkpoint_store._snapshot_path(root, result.checkpoint_id).exists()
+
+
+# --------------------------------------------------------------------------------------
+# Stale-lock reclaim (tdd_test_legit B): a genuinely dead lock must self-heal, not hang
+# every tg invocation for that root.
+# --------------------------------------------------------------------------------------
+
+
+def _plant_stale_lock(index_path: Path) -> Path:
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = _index_lock._lock_path_for(index_path)
+    lock_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    stale_mtime = time.time() - 3600.0  # 1 hour old, well past the 10s staleness threshold
+    os.utime(lock_path, (stale_mtime, stale_mtime))
+    return lock_path
+
+
+def test_open_session_reclaims_stale_lock(tmp_path: Path) -> None:
+    root = _make_project(tmp_path)
+    _plant_stale_lock(session_store._index_path(root))
+
+    start = time.monotonic()
+    result = session_store.open_session(str(root))
+    elapsed = time.monotonic() - start
+
+    # Must reclaim promptly (well under the 5s acquire timeout), not hang and not raise.
+    assert elapsed < 4.0
+    indexed = {rec.session_id for rec in session_store._load_index(root)}
+    assert result.session_id in indexed
+
+
+def test_create_checkpoint_reclaims_stale_lock(tmp_path: Path) -> None:
+    root = _make_project(tmp_path)
+    _plant_stale_lock(checkpoint_store._index_path(root))
+
+    start = time.monotonic()
+    result = checkpoint_store.create_checkpoint(str(root))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 4.0
+    indexed = {rec.checkpoint_id for rec in checkpoint_store._load_index(root)}
+    assert result.checkpoint_id in indexed
+
+
+def test_open_session_reclaims_stale_lock_two_racing_threads(tmp_path: Path) -> None:
+    """Two threads race to reclaim the SAME dead lock. Guards the previously-unguarded
+    unlink pattern (mirrored from session_daemon.py:170): the loser of the unlink race
+    must not crash with FileNotFoundError."""
+    root = _make_project(tmp_path)
+    _plant_stale_lock(session_store._index_path(root))
+
+    errors: list[BaseException] = []
+    results: dict[int, session_store.SessionOpenResult] = {}
+
+    def worker(i: int) -> None:
+        try:
+            results[i] = session_store.open_session(str(root))
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    written = {r.session_id for r in results.values()}
+    indexed = {rec.session_id for rec in session_store._load_index(root)}
+    assert written == indexed
+
+
+# --------------------------------------------------------------------------------------
+# Per-root isolation (tdd_test_legit bonus): locks are per-index-file, not global -- two
+# different roots opened concurrently must not block each other.
+# --------------------------------------------------------------------------------------
+
+
+def test_index_lock_is_per_root_not_global(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root_a = _make_project(tmp_path, name="project_a")
+    root_b = _make_project(tmp_path, name="project_b")
+
+    orig_write_index = session_store._write_index
+
+    def slow_write_index(r: Path, recs: list) -> None:
+        time.sleep(0.2)
+        return orig_write_index(r, recs)
+
+    monkeypatch.setattr(session_store, "_write_index", slow_write_index)
+
+    # Baseline: a single locked (slowed) open_session call.
+    baseline_start = time.monotonic()
+    session_store.open_session(str(root_a))
+    baseline_elapsed = time.monotonic() - baseline_start
+
+    results: dict[str, session_store.SessionOpenResult] = {}
+
+    def worker(key: str, root: Path) -> None:
+        results[key] = session_store.open_session(str(root))
+
+    start = time.monotonic()
+    threads = [
+        threading.Thread(target=worker, args=("a", root_a)),
+        threading.Thread(target=worker, args=("b", root_b)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    concurrent_elapsed = time.monotonic() - start
+
+    # Two DIFFERENT roots must not serialize against each other's lock: concurrent wall
+    # clock stays close to a single locked call, not ~2x (which would mean the two locks
+    # were contending on a shared/global lockfile instead of one lockfile per index.json).
+    assert concurrent_elapsed < baseline_elapsed * 1.8 + 0.5
+    assert results["a"].session_id in {r.session_id for r in session_store._load_index(root_a)}
+    assert results["b"].session_id in {r.session_id for r in session_store._load_index(root_b)}


### PR DESCRIPTION
Council-vetted fix for the index.json read-modify-write lost-update race (session + checkpoint stores): a concurrent `tg checkpoint create` (or session open/refresh) under a multi-agent orchestrator could clobber another writer's insert → orphaned snapshot dir (invisible to list, never retention-pruned) or a stale resolve-latest/undo target.

**Fix** (new `_index_lock.py`): a blocking, fail-closed `O_CREAT|O_EXCL` per-index lockfile with mtime stale-reclaim wraps ONLY the load→mutate→write span. `build_repo_map`/snapshot-copy stay outside (no hot-path latency); rmtree moved out of the lock via a pure selector; readers stay lock-free; per-index locks so session traffic never serializes against checkpoint traffic.

**The council earned its keep** — it rejected mirroring the daemon lock's try-once semantics (a losing write would silently drop its insert = the same bug).

**My real-venv verification caught 3 Windows-only bugs** the worktree build couldn't run (delete-pending PermissionError on acquire; `os.replace` WinError 5 transient → `replace_with_retry`; `resolve()` race → pre-create storage dir). Checkpoint concurrency-test flake 3/15 → **0/20**; 169 regression + 12 concurrency tests green; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)