### PR TITLE
fix: confine MCP audit_manifest to cwd + consume-resolved + in-process O_NOFOLLOW (round-5 Q3, parts A+B)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4534,6 +4534,37 @@ def _suppression_entry_matches(
     return True
 
 
+def _write_json_refuse_symlink(write_path: Path, data: object) -> None:
+    """Write JSON to ``write_path`` refusing to follow a symlink at the final component.
+
+    Round-5 security: closes the check->write symlink-swap race for the two in-process
+    ruleset-scan writers (baseline/suppressions). O_TRUNC (not O_EXCL) preserves the
+    documented create-or-overwrite semantics -- a re-run must still succeed and refresh
+    the file.
+
+    Two layers, because ``os.O_NOFOLLOW`` is unavailable on Windows (mirrors cpython's
+    own tempfile module: ``getattr(os, "O_NOFOLLOW", 0)``, not a hard import-time
+    dependency):
+      1. An explicit ``is_symlink()`` pre-check -- the authoritative guard on Windows,
+         and works there without elevated privileges (only *creating* a Windows symlink
+         needs privilege; checking for one does not).
+      2. ``O_NOFOLLOW`` on the actual open -- the authoritative guard on POSIX, closing
+         the narrow race between step 1's check and the open() call.
+    """
+    if write_path.is_symlink():
+        raise ValueError(f"Refusing to write through symlink at {write_path}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(str(write_path), flags, 0o600)
+    except OSError as exc:
+        raise ValueError(f"Refusing to write {write_path}: {exc}") from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, indent=2))
+    except OSError as exc:
+        raise ValueError(f"Refusing to write {write_path}: {exc}") from exc
+
+
 def _apply_ruleset_baseline(
     payload: dict[str, object],
     *,
@@ -4585,7 +4616,7 @@ def _apply_ruleset_baseline(
             "language": payload.get("language"),
             "fingerprints": matched_fingerprints,
         }
-        write_path.write_text(json.dumps(baseline_payload, indent=2), encoding="utf-8")
+        _write_json_refuse_symlink(write_path, baseline_payload)
         payload["baseline_written"] = {
             "path": str(write_path),
             "fingerprints": matched_fingerprints,
@@ -4719,7 +4750,7 @@ def _apply_ruleset_baseline(
                 for fingerprint in matched_fingerprints
             ],
         }
-        write_path.write_text(json.dumps(suppressions_payload, indent=2), encoding="utf-8")
+        _write_json_refuse_symlink(write_path, suppressions_payload)
         payload["suppressions_written"] = {
             "path": str(write_path),
             "fingerprints": matched_fingerprints,

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1126,6 +1126,48 @@ def execute_rewrite_apply_json(
     pattern = _restore_variadic_metavar_escaping(pattern)
     replacement = _restore_variadic_metavar_escaping(replacement)
 
+    # round-5 security: confine audit_manifest to cwd (the sibling precedent for a general
+    # audit artifact — tg_review_bundle_create's output_path, not the rewrite scan root) and
+    # consume the RESOLVED absolute path so the native subprocess argv (see
+    # _build_rewrite_command below) carries the anchor-validated location, not the raw
+    # candidate. Without this the validated path is discarded (TOCTOU) and the native binary
+    # independently re-resolves the unconfined raw string against its own cwd.
+    # NOTE (tracked follow-up, Part C of this fix): this Python-side confinement closes the
+    # anchor-mismatch/discard TOCTOU (validated-location == written-location) and refuses an
+    # escaping path before the native subprocess is ever spawned. It does NOT close the
+    # narrower cross-process symlink-swap window: between this resolve() and the moment the
+    # native Rust binary's write_audit_manifest_for_plan actually opens the resolved path
+    # (rust_core/src/main.rs, ~6746-6838), a symlink could in principle be swapped in at the
+    # final path component. Closing that residual window requires the Rust side to refuse via
+    # symlink_metadata()+O_NOFOLLOW at the point the bytes hit disk (rust_core/src/main.rs is
+    # explicitly out of scope for this PR — see deviations). This Python confinement is
+    # defense-in-depth and the user-facing early error, not a full closure on its own.
+    if audit_manifest is not None:
+        try:
+            audit_manifest = str(
+                _confine_write_path(audit_manifest, Path.cwd(), label="audit_manifest")
+            )
+        except ValueError as exc:
+            return _rewrite_error(str(exc), code="invalid_input"), 1
+
+    # round-5 security: audit_signing_key is a READ of secret HMAC material that operators
+    # legitimately keep OUTSIDE the repo (~/.config, CI-injected) — confining it to cwd would
+    # be a regression. Instead gate it default-OFF behind an explicit opt-in env var, mirroring
+    # the lint_cmd/test_cmd -> TG_MCP_ALLOW_VALIDATION_COMMANDS posture, closing the
+    # arbitrary-read-as-HMAC-key primitive without over-restricting a legit out-of-tree key.
+    if (
+        audit_signing_key is not None
+        and os.environ.get("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ") != "1"
+    ):
+        return (
+            _rewrite_error(
+                "audit_signing_key read requires TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1",
+                code="unsupported_option",
+                retryable=False,
+            ),
+            1,
+        )
+
     # audit A1: plan-bound apply. When the caller pins the previously reviewed plan
     # via expected_plan_digest/expected_match_count, recompute the plan against the
     # CURRENT tree and refuse the apply (no files written) if reality has drifted.
@@ -1544,14 +1586,21 @@ def tg_ruleset_scan(
         "test_dirs": [],
         "language": ruleset_meta["language"],
     }
-    # round-4 security: confine the two write paths to the scan root before any scan/write —
+    # round-4/5 security: confine the two write paths to the scan root before any scan/write —
     # unconfined, they are an arbitrary-file-write primitive reachable from any MCP client.
+    # round-5: consume the RESOLVED absolute path (not the raw candidate) below so the
+    # downstream writer (_run_ast_scan_payload -> ... re-resolves once) sees the same
+    # anchor-validated location this check validated (closes the discard/TOCTOU class).
     scan_root = Path(path).expanduser().resolve()
     try:
         if write_baseline is not None:
-            _confine_write_path(write_baseline, scan_root, label="write_baseline")
+            write_baseline = str(
+                _confine_write_path(write_baseline, scan_root, label="write_baseline")
+            )
         if write_suppressions is not None:
-            _confine_write_path(write_suppressions, scan_root, label="write_suppressions")
+            write_suppressions = str(
+                _confine_write_path(write_suppressions, scan_root, label="write_suppressions")
+            )
     except ValueError as exc:
         return _ruleset_scan_error(str(exc), code="invalid_input", ruleset=ruleset, path=path)
     try:
@@ -3328,11 +3377,14 @@ def tg_review_bundle_create(
             routing_reason="review-bundle-create",
         )
 
-    # round-4 security: confine the bundle output to the project (cwd) — unconfined it is an
-    # arbitrary-file-write primitive reachable from any MCP client.
+    # round-4/5 security: confine the bundle output to the project (cwd) — unconfined it is an
+    # arbitrary-file-write primitive reachable from any MCP client. round-5: consume the
+    # RESOLVED absolute path (not the raw candidate) below so create_review_bundle_json's own
+    # re-resolve in audit_manifest.py sees the same anchor-validated location this check
+    # validated (closes the discard/TOCTOU class).
     if output_path is not None:
         try:
-            _confine_write_path(output_path, Path.cwd(), label="output_path")
+            output_path = str(_confine_write_path(output_path, Path.cwd(), label="output_path"))
         except ValueError as exc:
             return _review_bundle_error(
                 str(exc),

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1749,15 +1749,13 @@ def test_tg_rewrite_apply_supports_optional_policy_parameter(tmp_path):
 
     policy_path = tmp_path / "apply-policy.json"
     policy_path.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "lint_cmd": None,
-                "test_cmd": None,
-                "ruleset_scan": None,
-                "on_failure": "warn",
-            }
-        ),
+        json.dumps({
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": None,
+            "ruleset_scan": None,
+            "on_failure": "warn",
+        }),
         encoding="utf-8",
     )
 
@@ -1807,15 +1805,13 @@ def test_tg_rewrite_apply_gates_policy_file_validation_commands(tmp_path, monkey
 
     policy_path = tmp_path / "apply-policy.json"
     policy_path.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "lint_cmd": "echo pwned",
-                "test_cmd": None,
-                "ruleset_scan": None,
-                "on_failure": "warn",
-            }
-        ),
+        json.dumps({
+            "version": 1,
+            "lint_cmd": "echo pwned",
+            "test_cmd": None,
+            "ruleset_scan": None,
+            "on_failure": "warn",
+        }),
         encoding="utf-8",
     )
 
@@ -1837,14 +1833,12 @@ def test_tg_rewrite_apply_returns_structured_invalid_policy_error(tmp_path):
 
     policy_path = tmp_path / "apply-policy.json"
     policy_path.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "lint_cmd": None,
-                "test_cmd": None,
-                "ruleset_scan": None,
-            }
-        ),
+        json.dumps({
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": None,
+            "ruleset_scan": None,
+        }),
         encoding="utf-8",
     )
 
@@ -1895,12 +1889,10 @@ def test_tg_rewrite_apply_supports_optional_checkpoint_flag():
                 returncode=0,
                 # pass the unix-timestamp form to simulate what the native binary emits;
                 # the MCP layer must convert it to ISO-8601 before returning
-                stdout=json.dumps(
-                    {
-                        **payload,
-                        "checkpoint": {**payload["checkpoint"], "created_at": "1234567890"},
-                    }
-                ),
+                stdout=json.dumps({
+                    **payload,
+                    "checkpoint": {**payload["checkpoint"], "created_at": "1234567890"},
+                }),
                 stderr="",
             ),
         ) as mock_run,
@@ -2744,18 +2736,14 @@ def test_session_serve_render_commands_include_enriched_edit_plan_seed(tmp_path)
 
     session_id = session_store.open_session(str(project)).session_id
     stdin = StringIO(
-        "\n".join(
-            [
-                json.dumps({"command": "context_render", "query": "create invoice"}),
-                json.dumps(
-                    {
-                        "command": "blast_radius_render",
-                        "symbol": "create_invoice",
-                        "max_depth": 1,
-                    }
-                ),
-            ]
-        )
+        "\n".join([
+            json.dumps({"command": "context_render", "query": "create invoice"}),
+            json.dumps({
+                "command": "blast_radius_render",
+                "symbol": "create_invoice",
+                "max_depth": 1,
+            }),
+        ])
         + "\n"
     )
     stdout = StringIO()
@@ -3499,12 +3487,10 @@ def test_tg_edit_plan_prefers_targeted_vitest_validation_commands(tmp_path):
     tests_dir.mkdir()
 
     (project / "package.json").write_text(
-        json.dumps(
-            {
-                "name": "vitest-project",
-                "devDependencies": {"vitest": "^1.0.0"},
-            }
-        ),
+        json.dumps({
+            "name": "vitest-project",
+            "devDependencies": {"vitest": "^1.0.0"},
+        }),
         encoding="utf-8",
     )
     module_path = src_dir / "payments.ts"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1749,13 +1749,15 @@ def test_tg_rewrite_apply_supports_optional_policy_parameter(tmp_path):
 
     policy_path = tmp_path / "apply-policy.json"
     policy_path.write_text(
-        json.dumps({
-            "version": 1,
-            "lint_cmd": None,
-            "test_cmd": None,
-            "ruleset_scan": None,
-            "on_failure": "warn",
-        }),
+        json.dumps(
+            {
+                "version": 1,
+                "lint_cmd": None,
+                "test_cmd": None,
+                "ruleset_scan": None,
+                "on_failure": "warn",
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -1805,13 +1807,15 @@ def test_tg_rewrite_apply_gates_policy_file_validation_commands(tmp_path, monkey
 
     policy_path = tmp_path / "apply-policy.json"
     policy_path.write_text(
-        json.dumps({
-            "version": 1,
-            "lint_cmd": "echo pwned",
-            "test_cmd": None,
-            "ruleset_scan": None,
-            "on_failure": "warn",
-        }),
+        json.dumps(
+            {
+                "version": 1,
+                "lint_cmd": "echo pwned",
+                "test_cmd": None,
+                "ruleset_scan": None,
+                "on_failure": "warn",
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -1833,12 +1837,14 @@ def test_tg_rewrite_apply_returns_structured_invalid_policy_error(tmp_path):
 
     policy_path = tmp_path / "apply-policy.json"
     policy_path.write_text(
-        json.dumps({
-            "version": 1,
-            "lint_cmd": None,
-            "test_cmd": None,
-            "ruleset_scan": None,
-        }),
+        json.dumps(
+            {
+                "version": 1,
+                "lint_cmd": None,
+                "test_cmd": None,
+                "ruleset_scan": None,
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -1889,10 +1895,12 @@ def test_tg_rewrite_apply_supports_optional_checkpoint_flag():
                 returncode=0,
                 # pass the unix-timestamp form to simulate what the native binary emits;
                 # the MCP layer must convert it to ISO-8601 before returning
-                stdout=json.dumps({
-                    **payload,
-                    "checkpoint": {**payload["checkpoint"], "created_at": "1234567890"},
-                }),
+                stdout=json.dumps(
+                    {
+                        **payload,
+                        "checkpoint": {**payload["checkpoint"], "created_at": "1234567890"},
+                    }
+                ),
                 stderr="",
             ),
         ) as mock_run,
@@ -1936,7 +1944,9 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag(tmp_path, monkey
     # and assert the RESOLVED absolute path is what reaches the native argv.
     cwd = tmp_path / "repo"
     cwd.mkdir()
-    (cwd / "src").mkdir()  # path="src" must exist under cwd or the pre-confinement existence check rejects it
+    (
+        cwd / "src"
+    ).mkdir()  # path="src" must exist under cwd or the pre-confinement existence check rejects it
     monkeypatch.chdir(cwd)
     resolved_manifest = cwd / "rewrite-audit.json"
 
@@ -2073,7 +2083,9 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag(tmp_path, mon
     # legitimate flag-forwarding path.
     cwd = tmp_path / "repo"
     cwd.mkdir()
-    (cwd / "src").mkdir()  # path="src" must exist under cwd or the pre-confinement existence check rejects it
+    (
+        cwd / "src"
+    ).mkdir()  # path="src" must exist under cwd or the pre-confinement existence check rejects it
     monkeypatch.chdir(cwd)
     monkeypatch.setenv("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ", "1")
     resolved_manifest = cwd / "rewrite-audit.json"
@@ -2732,14 +2744,18 @@ def test_session_serve_render_commands_include_enriched_edit_plan_seed(tmp_path)
 
     session_id = session_store.open_session(str(project)).session_id
     stdin = StringIO(
-        "\n".join([
-            json.dumps({"command": "context_render", "query": "create invoice"}),
-            json.dumps({
-                "command": "blast_radius_render",
-                "symbol": "create_invoice",
-                "max_depth": 1,
-            }),
-        ])
+        "\n".join(
+            [
+                json.dumps({"command": "context_render", "query": "create invoice"}),
+                json.dumps(
+                    {
+                        "command": "blast_radius_render",
+                        "symbol": "create_invoice",
+                        "max_depth": 1,
+                    }
+                ),
+            ]
+        )
         + "\n"
     )
     stdout = StringIO()
@@ -3483,10 +3499,12 @@ def test_tg_edit_plan_prefers_targeted_vitest_validation_commands(tmp_path):
     tests_dir.mkdir()
 
     (project / "package.json").write_text(
-        json.dumps({
-            "name": "vitest-project",
-            "devDependencies": {"vitest": "^1.0.0"},
-        }),
+        json.dumps(
+            {
+                "name": "vitest-project",
+                "devDependencies": {"vitest": "^1.0.0"},
+            }
+        ),
         encoding="utf-8",
     )
     module_path = src_dir / "payments.ts"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1936,6 +1936,7 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag(tmp_path, monkey
     # and assert the RESOLVED absolute path is what reaches the native argv.
     cwd = tmp_path / "repo"
     cwd.mkdir()
+    (cwd / "src").mkdir()  # path="src" must exist under cwd or the pre-confinement existence check rejects it
     monkeypatch.chdir(cwd)
     resolved_manifest = cwd / "rewrite-audit.json"
 
@@ -2072,6 +2073,7 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag(tmp_path, mon
     # legitimate flag-forwarding path.
     cwd = tmp_path / "repo"
     cwd.mkdir()
+    (cwd / "src").mkdir()  # path="src" must exist under cwd or the pre-confinement existence check rejects it
     monkeypatch.chdir(cwd)
     monkeypatch.setenv("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ", "1")
     resolved_manifest = cwd / "rewrite-audit.json"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1928,8 +1928,16 @@ def test_tg_rewrite_apply_supports_optional_checkpoint_flag():
     ]
 
 
-def test_tg_rewrite_apply_supports_optional_audit_manifest_flag():
+def test_tg_rewrite_apply_supports_optional_audit_manifest_flag(tmp_path, monkeypatch):
     from tensor_grep.cli import mcp_server
+
+    # round-5 security: audit_manifest is confined to cwd (see the round-5 confinement
+    # tests below), so this test's flag-support assertion must use a cwd-confined path
+    # and assert the RESOLVED absolute path is what reaches the native argv.
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    resolved_manifest = cwd / "rewrite-audit.json"
 
     payload = {
         "version": 1,
@@ -1938,7 +1946,7 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag():
         "routing_reason": "ast-native",
         "sidecar_used": False,
         "audit_manifest": {
-            "path": "C:/repo/rewrite-audit.json",
+            "path": str(resolved_manifest),
             "file_count": 1,
             "applied_edit_count": 1,
             "signed": False,
@@ -1966,7 +1974,7 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag():
             replacement="lambda $$$ARGS: $EXPR",
             lang="python",
             path="src",
-            audit_manifest="C:/repo/rewrite-audit.json",
+            audit_manifest="rewrite-audit.json",
         )
 
     parsed = json.loads(out)
@@ -1982,7 +1990,7 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag():
         "lambda $$$ARGS: $EXPR",
         "--apply",
         "--audit-manifest",
-        "C:/repo/rewrite-audit.json",
+        str(resolved_manifest),
         "--json",
         "--",
         "def $F($$$ARGS): return $EXPR",
@@ -1990,7 +1998,7 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag():
     ]
 
 
-def test_tg_rewrite_apply_records_generated_audit_manifest_in_history_index(tmp_path):
+def test_tg_rewrite_apply_records_generated_audit_manifest_in_history_index(tmp_path, monkeypatch):
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -1998,6 +2006,9 @@ def test_tg_rewrite_apply_records_generated_audit_manifest_in_history_index(tmp_
     audit_dir.mkdir(parents=True)
     manifest_path = audit_dir / "rewrite-audit.json"
     manifest_payload = _write_audit_manifest(manifest_path, project_root=project)
+    # round-5 security: audit_manifest is confined to cwd; the manifest already lives
+    # under `project`, so anchor cwd there.
+    monkeypatch.chdir(project)
     payload = {
         "version": 1,
         "schema_version": 1,
@@ -2053,8 +2064,17 @@ def test_tg_rewrite_apply_records_generated_audit_manifest_in_history_index(tmp_
     ]
 
 
-def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag():
+def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag(tmp_path, monkeypatch):
     from tensor_grep.cli import mcp_server
+
+    # round-5 security: audit_manifest is confined to cwd, and audit_signing_key (a secret
+    # READ) requires the explicit opt-in env var. Anchor cwd + opt in to exercise the
+    # legitimate flag-forwarding path.
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ", "1")
+    resolved_manifest = cwd / "rewrite-audit.json"
 
     payload = {
         "version": 1,
@@ -2063,7 +2083,7 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag():
         "routing_reason": "ast-native",
         "sidecar_used": False,
         "audit_manifest": {
-            "path": "C:/repo/rewrite-audit.json",
+            "path": str(resolved_manifest),
             "file_count": 1,
             "applied_edit_count": 1,
             "signed": True,
@@ -2091,7 +2111,7 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag():
             replacement="lambda $$$ARGS: $EXPR",
             lang="python",
             path="src",
-            audit_manifest="C:/repo/rewrite-audit.json",
+            audit_manifest="rewrite-audit.json",
             audit_signing_key="C:/repo/audit.key",
         )
 
@@ -2108,7 +2128,7 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag():
         "lambda $$$ARGS: $EXPR",
         "--apply",
         "--audit-manifest",
-        "C:/repo/rewrite-audit.json",
+        str(resolved_manifest),
         "--audit-signing-key",
         "C:/repo/audit.key",
         "--json",
@@ -4847,3 +4867,213 @@ def test_review_bundle_create_refuses_output_path_escape(tmp_path, monkeypatch):
     parsed = json.loads(out)
     assert parsed.get("error", {}).get("code") == "invalid_input"
     assert not escape.exists()
+
+
+# --- round-5 security: tg_rewrite_apply audit_manifest confinement + consume-resolved,
+# audit_signing_key opt-in gate, and O_NOFOLLOW-guarded in-process writes (TOCTOU fix) -----
+#
+# tg_rewrite_apply's audit_manifest was entirely unconfined (an arbitrary MCP-reachable
+# file-write primitive), and the round-4 write-path confinement that DID exist for
+# write_baseline/write_suppressions/output_path validated a resolved Path then discarded
+# it, forwarding the raw candidate string to the downstream consumer (TOCTOU: the
+# validated location and the written location could diverge). This block covers: (1) the
+# audit_manifest escape refusal, (2) the audit_signing_key opt-in gate, (3) a confined
+# audit_manifest is still written for a rewrite target in a different directory, and (4)
+# the O_NOFOLLOW symlink-swap refusal on the in-process ruleset-scan writers, guarding the
+# O_TRUNC-not-O_EXCL re-run/overwrite semantics.
+
+
+def test_rewrite_apply_refuses_audit_manifest_escape(tmp_path, monkeypatch):
+    """FAILS pre-fix (audit_manifest unconfined at _build_rewrite_command call site);
+    PASSES post-fix (Part A: confined to cwd, refused before any subprocess spawn)."""
+    from tensor_grep.cli import mcp_server
+
+    cwd = tmp_path / "proj"
+    (cwd / "sub").mkdir(parents=True)
+    (cwd / "sub" / "a.py").write_text("foo = 1\n", encoding="utf-8")
+    monkeypatch.chdir(cwd)  # cwd is the anchor
+    outside = tmp_path / "escape"
+    outside.mkdir()
+    escaped = outside / "pwned_manifest.json"  # absolute, outside cwd AND outside target
+    payload_json, exit_code = mcp_server.execute_rewrite_apply_json(
+        pattern="foo",
+        replacement="bar",
+        lang="python",
+        path=str(cwd / "sub"),
+        audit_manifest=str(escaped),
+    )
+    payload = json.loads(payload_json)
+    assert exit_code == 1
+    assert payload.get("error", {}).get("code") == "invalid_input"
+    assert not escaped.exists()  # subprocess never spawned
+
+
+def test_rewrite_apply_refuses_audit_signing_key_without_opt_in(tmp_path, monkeypatch):
+    """FAILS pre-fix (audit_signing_key forwarded to the native binary unconditionally,
+    an arbitrary-file-read-as-HMAC-key primitive); PASSES post-fix (Part A: refused with
+    code=unsupported_option unless TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1)."""
+    from tensor_grep.cli import mcp_server
+
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    (cwd / "a.py").write_text("foo = 1\n", encoding="utf-8")
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ", raising=False)
+    secret = tmp_path / "outside-secret.key"
+    secret.write_text("hmac-secret\n", encoding="utf-8")
+
+    with patch("tensor_grep.cli.mcp_server.subprocess.run") as mock_run:
+        payload_json, exit_code = mcp_server.execute_rewrite_apply_json(
+            pattern="foo",
+            replacement="bar",
+            lang="python",
+            path=str(cwd),
+            audit_signing_key=str(secret),
+        )
+        mock_run.assert_not_called()  # refused before any subprocess spawn
+
+    payload = json.loads(payload_json)
+    assert exit_code == 1
+    assert payload.get("error", {}).get("code") == "unsupported_option"
+
+
+def test_rewrite_apply_writes_confined_audit_manifest(tmp_path, monkeypatch):
+    """A confined audit_manifest under cwd must still be written for a rewrite target in
+    a DIFFERENT directory (guards the anchor from over-restricting to the rewrite path)."""
+    from tensor_grep.cli import mcp_server
+
+    cwd = tmp_path / "proj"
+    (cwd / "sub").mkdir(parents=True)
+    (cwd / "sub" / "a.py").write_text("foo = 1\n", encoding="utf-8")
+    monkeypatch.chdir(cwd)
+    audit_dir = cwd / "tg_audit"
+    audit_dir.mkdir()
+    manifest = audit_dir / "manifest.json"  # UNDER the cwd anchor
+    resolved_manifest = manifest.resolve()
+
+    payload = {
+        "version": 1,
+        "schema_version": 1,
+        "routing_backend": "AstBackend",
+        "routing_reason": "ast-native",
+        "sidecar_used": False,
+        "audit_manifest": {
+            "path": str(resolved_manifest),
+            "file_count": 1,
+            "applied_edit_count": 1,
+            "signed": False,
+            "signature_kind": None,
+        },
+        "plan": {"total_edits": 1},
+        "verification": None,
+        "validation": None,
+    }
+    with (
+        patch("tensor_grep.cli.mcp_server.resolve_native_tg_binary", return_value=Path("tg.exe")),
+        patch(
+            "tensor_grep.cli.mcp_server.subprocess.run",
+            return_value=CompletedProcess(
+                args=["tg.exe"], returncode=0, stdout=json.dumps(payload), stderr=""
+            ),
+        ) as mock_run,
+    ):
+        _payload_json, exit_code = mcp_server.execute_rewrite_apply_json(
+            pattern="foo",
+            replacement="bar",
+            lang="python",
+            path=str(cwd / "sub"),  # rewrite target != cwd, legit
+            audit_manifest=str(manifest),
+        )
+
+    assert exit_code == 0
+    # the RESOLVED absolute path reached the native argv, not the raw candidate string.
+    assert "--audit-manifest" in mock_run.call_args.args[0]
+    idx = mock_run.call_args.args[0].index("--audit-manifest")
+    assert mock_run.call_args.args[0][idx + 1] == str(resolved_manifest)
+
+
+def test_write_json_refuse_symlink_refuses_swap(tmp_path):
+    """Direct unit test of the Part-B in-process writer (main.py._write_json_refuse_symlink)
+    shared by write_baseline and write_suppressions. FAILS pre-fix (plain
+    write_path.write_text(...) blindly follows the symlink, silently overwriting whatever
+    it points at); PASSES post-fix (refused via the is_symlink() pre-check -- authoritative
+    on Windows, where os.O_NOFOLLOW is unavailable -- and via O_NOFOLLOW on POSIX; the
+    outside target is left completely unchanged, not written through)."""
+    from tensor_grep.cli import main as cli_main
+
+    outside_target = tmp_path / "outside.json"
+    outside_target.write_text("UNCHANGED\n", encoding="utf-8")
+    link_path = tmp_path / "baseline.json"
+    try:
+        link_path.symlink_to(outside_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted in this environment")
+
+    with pytest.raises(ValueError):
+        cli_main._write_json_refuse_symlink(link_path, {"fingerprints": ["x"]})
+    assert outside_target.read_text(encoding="utf-8") == "UNCHANGED\n"
+
+
+def test_ruleset_scan_write_baseline_refuses_symlink_swap_end_to_end(tmp_path, monkeypatch):
+    """End-to-end: a pre-planted symlink at a confined write_baseline target is refused
+    fail-closed through the full tg_ruleset_scan path (confinement resolve() +
+    Part-B is_symlink()/O_NOFOLLOW both refuse it), and the symlink's outside target is
+    left unchanged (not written through)."""
+    from tensor_grep.cli import mcp_server
+    from tests.unit.test_cli_modes import _FakeAstPipeline, _FakeAstScanner
+
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
+    monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    monkeypatch.chdir(scan_root)
+
+    (scan_root / "a.py").write_text("hashlib.md5($$$ARGS)\n", encoding="utf-8")
+    outside_target = tmp_path / "outside-baseline.json"  # sibling of scan_root, still in tmp_path
+    outside_target.write_text("UNCHANGED\n", encoding="utf-8")
+    link_path = scan_root / "baseline.json"
+    try:
+        link_path.symlink_to(outside_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted in this environment")
+
+    out = mcp_server.tg_ruleset_scan(
+        "crypto-safe",
+        path=".",
+        language="python",
+        write_baseline="baseline.json",
+    )
+    parsed = json.loads(out)
+    assert parsed.get("error", {}).get("code") == "invalid_input"
+    assert outside_target.read_text(encoding="utf-8") == "UNCHANGED\n"
+
+
+def test_ruleset_scan_write_baseline_overwrites_on_rerun(monkeypatch, tmp_path):
+    """A repeated write to the SAME write_baseline path must succeed and overwrite
+    (guards O_CREAT|O_TRUNC|O_NOFOLLOW, not O_EXCL, which would fail the second run)."""
+    from tensor_grep.cli import mcp_server
+    from tests.unit.test_cli_modes import _FakeAstPipeline, _FakeAstScanner
+
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
+    monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
+    monkeypatch.chdir(tmp_path)
+
+    Path("a.py").write_text("hashlib.md5($$$ARGS)\n", encoding="utf-8")
+
+    first = json.loads(
+        mcp_server.tg_ruleset_scan(
+            "crypto-safe", path=".", language="python", write_baseline="baseline.json"
+        )
+    )
+    assert first.get("error") is None
+    second = json.loads(
+        mcp_server.tg_ruleset_scan(
+            "crypto-safe", path=".", language="python", write_baseline="baseline.json"
+        )
+    )
+    assert second.get("error") is None
+    baseline_file = Path("baseline.json")
+    written = json.loads(baseline_file.read_text(encoding="utf-8"))
+    assert written["fingerprints"] == [first["findings"][0]["fingerprint"]]
+    # round-5: the write lands under the validated anchor (scan_root == cwd here, path=".").
+    assert baseline_file.resolve().parent == tmp_path.resolve()


### PR DESCRIPTION
Council-vetted fix for the MCP arbitrary-write TOCTOU: `tg_rewrite_apply`'s `audit_manifest` was unconfined (4th write param, missed by round-4's #327), and `_confine_write_path` validated a resolved Path then discarded it while callers forwarded the raw string (re-resolved downstream against a different anchor = TOCTOU).

**Parts A+B (Python, this PR):**
- Confine `audit_manifest` to **cwd** (the sibling precedent — review-bundle output_path — not the rewrite scan-root) and forward the **resolved absolute** path so validated-location == written-location.
- `audit_signing_key` (a secret READ operators keep out-of-tree) gated default-OFF behind `TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1` — not path-confined.
- Consume the resolved Path at the `write_baseline`/`write_suppressions`/review-bundle call sites.
- In-process writes use `O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW` (O_TRUNC not O_EXCL — preserves create-or-overwrite re-run semantics).

**The council earned its keep**: rejected anchoring to `path` (would re-introduce the mismatch), `O_EXCL` (breaks re-runs), and blanket-confining the signing-key read.

**Part C (Rust `main.rs` O_NOFOLLOW at the point bytes hit disk) is a tracked follow-up** — documented in-code; this PR closes the load-bearing Python arbitrary-write + anchor-mismatch, not the residual cross-process symlink-swap window.

Verification (real venv): 138 mcp tests green incl 7 new security tests; my 2 test fixes for the agent's chdir-without-src; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)