### PR TITLE
feat: composite orient centrality — demote leaf data files, surface real hubs (dogfood)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -20,6 +20,11 @@ _CHARS_PER_TOKEN = 3.5
 # otherwise dominate the graph and bury the real architecture.
 _CENTRAL_DOC_SUFFIXES = frozenset({".md", ".markdown", ".rst", ".adoc", ".txt"})
 
+# Composite-centrality tuning (see _central_files_from_map): cap in-degree so a widely-imported data
+# sink can't dominate, and bound symbol density so one giant file can't either.
+_CENTRAL_FAN_IN_CAP = 12
+_CENTRAL_SYMBOL_DENSITY_CAP = 25
+
 _ENTRY_NAMES = {
     "main.py",
     "__main__.py",
@@ -31,6 +36,12 @@ _ENTRY_NAMES = {
     "index.js",
     "main.js",
     "app.ts",
+    # .tsx entrypoints (React/Ink CLIs): a real CLI entry is often main.tsx/app.tsx, not just the
+    # index.ts barrel (dogfood 2026-07-03 — orient listed index.ts barrels, missed main.tsx).
+    "main.tsx",
+    "app.tsx",
+    "cli.tsx",
+    "index.tsx",
     "main.rs",
     "lib.rs",
 }
@@ -69,10 +80,24 @@ def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> li
                 targets.append(candidate)
         resolved_imports[source] = targets
     reverse_importers = _repo_map._reverse_importers(code_files, resolved_imports)
-    # Centrality = in-degree (how many files import this one). NOTE: the reused reverse-import
-    # PageRank, seeded by all files, ranks IMPORTERS above the imported -- backwards for "show me the
-    # core files" -- so we rank by import in-degree directly.
-    centrality = {source: float(len(reverse_importers.get(source, ()))) for source in code_files}
+    # Composite centrality (dogfood 2026-07-03, v1.19.9): pure import in-degree surfaced LEAF data
+    # files (constants.ts / figures.ts / barrel index.ts imported by many) at the top and buried the
+    # real hubs (QueryEngine.ts, state.ts). A real architectural hub both RECEIVES and SENDS import
+    # edges AND has substance (many symbols); a data sink only receives. So: cap the in-degree
+    # contribution (a file imported by 50 is not proportionally more central than one imported by 12
+    # -- past that it is a common utility/constant, not a hub), and ADD fan-out (imports others) +
+    # symbol density. This demotes pure sinks without a fragile name/leaf heuristic.
+    symbol_counts: dict[str, int] = {}
+    for symbol in rm.get("symbols", []):
+        symbol_file = str(symbol.get("file"))
+        if symbol_file in code_file_set:
+            symbol_counts[symbol_file] = symbol_counts.get(symbol_file, 0) + 1
+    centrality: dict[str, float] = {}
+    for source in code_files:
+        fan_in = min(len(reverse_importers.get(source, ())), _CENTRAL_FAN_IN_CAP)
+        fan_out = len(resolved_imports.get(source, []))
+        density = min(symbol_counts.get(source, 0), _CENTRAL_SYMBOL_DENSITY_CAP)
+        centrality[source] = float(fan_in + fan_out + density)
     ranked = sorted(code_files, key=lambda source: (-centrality[source], source))
     result: list[dict[str, Any]] = []
     for file_path in ranked[:max_central_files]:

--- a/tests/unit/test_orient_central_excludes_docs.py
+++ b/tests/unit/test_orient_central_excludes_docs.py
@@ -21,9 +21,31 @@ def test_docs_are_never_central_and_code_wins_stem_collision() -> None:
     files = [c["file"] for c in central]
     assert not any(f.endswith((".md", ".rst", ".txt", ".adoc")) for f in files)  # no docs
     assert "src/config.py" in files
-    # the `import config` resolved to config.py (code), NOT config.md — in-degree 2 on the code file.
+    # the `import config` resolved to config.py (code), NOT config.md. Composite score =
+    # min(fan_in=2, cap) + fan_out=0 + symbol_density=1 (the Config class) = 3.0.
     cfg = next(c for c in central if c["file"] == "src/config.py")
-    assert cfg["graph_score"] == 2.0
+    assert cfg["graph_score"] == 3.0
+
+
+def test_hub_outranks_leaf_constant() -> None:
+    # A data SINK (constants.py: imported by 20, imports nothing, 1 symbol) must NOT outrank a real
+    # HUB (hub.py: imported by 3, imports 6 modules, 20 symbols). Pure import in-degree ranked the
+    # sink first (20 > 3); the composite (capped fan-in + fan-out + symbol density) fixes it.
+    files = ["src/constants.py", "src/hub.py"]
+    files += [f"src/u{i}.py" for i in range(6)]  # hub's import targets
+    files += [f"src/imp_c{i}.py" for i in range(20)]  # constants' importers (huge fan-in)
+    files += [f"src/imp_h{i}.py" for i in range(3)]  # hub's importers
+    imports = [{"file": f"src/imp_c{i}.py", "imports": ["constants"]} for i in range(20)]
+    imports += [{"file": f"src/imp_h{i}.py", "imports": ["hub"]} for i in range(3)]
+    imports.append({"file": "src/hub.py", "imports": [f"u{i}" for i in range(6)]})
+    symbols = [{"name": "C", "kind": "class", "file": "src/constants.py"}]
+    symbols += [{"name": f"h{i}", "kind": "function", "file": "src/hub.py"} for i in range(20)]
+    central = _central_files_from_map(
+        {"files": files, "imports": imports, "symbols": symbols}, max_central_files=10
+    )
+    order = [c["file"] for c in central]
+    assert "src/hub.py" in order and "src/constants.py" in order
+    assert order.index("src/hub.py") < order.index("src/constants.py")
 
 
 def test_pure_docs_repo_falls_back_not_empty() -> None:


### PR DESCRIPTION
Dogfood (v1.19.9, ~1900-file TS repo): orient ranked leaf data files (constants.ts/figures.ts/barrel index.ts) as the top "central files" while real hubs (QueryEngine.ts/state.ts/tools.ts) were absent — pure import **in-degree** ranks a widely-imported data *sink* above a real hub.

**Fix:** composite centrality = `min(fan_in, 12) + fan_out + min(symbol_density, 25)`. A hub both receives *and* sends import edges *and* has substance; capping in-degree + adding fan-out + symbol density demotes pure sinks — **no fragile filename/leaf heuristic**. Plus main.tsx/app.tsx/cli.tsx/index.tsx added to entrypoint detection.

On this repo the composite now ranks the real hubs (repo_map.py/main.py/mcp_server.py) top, main.py/main.rs appear in entry_points. TDD RED→GREEN (sink no longer outranks hub); docs still excluded (#352).

**Honest scope** (fixture-green lesson): validated on a fixture + this repo's non-regression, NOT on the reporter's TS corpus — a principled ranking improvement, not proven on the exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)