### PR TITLE
fix: force UTF-8 stdout/stderr at CLI entry — root fix for the typer.echo cp1252 crash class (Q7)

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -817,7 +817,31 @@ def _run_requires_ast_workflow(run_args: list[str]) -> bool:
     )
 
 
+def _force_utf8_streams() -> None:
+    """Make stdout/stderr UTF-8 with ``errors="replace"`` so non-ASCII CLI output never raises
+    ``UnicodeEncodeError`` on a legacy cp1252 Windows console (the #346 / #42 crash class: a
+    filesystem path with a non-English username, a U+2028 in a match, an emoji marker, ...). The
+    root fix for the whole ``typer.echo``/``print`` sweep -- one reconfigure at the entry point
+    covers every command instead of routing each site through ``_safe_stdout_line``. No-op where the
+    stream is already UTF-8 or cannot be reconfigured (a pipe with pending bytes, a non-TextIO
+    stream); ``errors="replace"`` guarantees it can never itself raise on write.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        if "utf" in (getattr(stream, "encoding", None) or "").lower():
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            # Stream already has buffered output or is detached -- degrade to the per-line
+            # _safe_stdout_line fallback still in place at the call sites; do not crash startup.
+            pass
+
+
 def main_entry() -> None:
+    _force_utf8_streams()
     argv = sys.argv[1:]
     if argv and argv[0] in {"--version", "-V"}:
         _print_version()

--- a/tests/unit/test_force_utf8_streams.py
+++ b/tests/unit/test_force_utf8_streams.py
@@ -1,0 +1,47 @@
+"""Q7 root fix: main_entry forces UTF-8 stdout/stderr so non-ASCII CLI output never crashes on a
+cp1252 Windows console (the #346/#42 typer.echo crash class). One reconfigure covers every command."""
+
+import sys
+from unittest.mock import MagicMock
+
+from tensor_grep.cli.bootstrap import _force_utf8_streams
+
+
+def _fake_stream(encoding: str, *, raises: bool = False) -> MagicMock:
+    stream = MagicMock()
+    stream.encoding = encoding
+    if raises:
+        stream.reconfigure.side_effect = ValueError("stream has buffered output")
+    return stream
+
+
+def test_reconfigures_a_cp1252_stream(monkeypatch):
+    out, err = _fake_stream("cp1252"), _fake_stream("cp1252")
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    _force_utf8_streams()
+    out.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+    err.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+
+
+def test_noop_when_already_utf8(monkeypatch):
+    out = _fake_stream("utf-8")
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", _fake_stream("UTF-8"))
+    _force_utf8_streams()
+    out.reconfigure.assert_not_called()
+
+
+def test_survives_reconfigure_error(monkeypatch):
+    monkeypatch.setattr(sys, "stdout", _fake_stream("cp1252", raises=True))
+    monkeypatch.setattr(sys, "stderr", _fake_stream("cp1252", raises=True))
+    _force_utf8_streams()  # must not propagate — startup never crashes on this
+
+
+def test_survives_stream_without_reconfigure(monkeypatch):
+    class _Bare:
+        encoding = "cp1252"  # no reconfigure attribute at all
+
+    monkeypatch.setattr(sys, "stdout", _Bare())
+    monkeypatch.setattr(sys, "stderr", _Bare())
+    _force_utf8_streams()  # must not raise


### PR DESCRIPTION
The recurring #346/#42 crash class: `typer.echo`/`print` raises `UnicodeEncodeError` on a legacy cp1252 Windows console for **any** non-ASCII output (a path with a non-English username, U+2028 in a match, an emoji marker). Round-4 fixed sites one-by-one via `_safe_stdout_line` — whack-a-mole across ~25 echo sites.

**Root fix:** `_force_utf8_streams()` at `bootstrap.main_entry()` reconfigures stdout/stderr to UTF-8 `errors="replace"` **once**, before any command runs — covering every output path. Guarded (no-op if already UTF-8 / non-reconfigurable), and `errors="replace"` means it can never itself raise.

Verified: 4 unit tests + the **full unit suite (3122 passed)**; the one agent-capsule ranking failure was a local stale-worktree corpus-pollution artifact (passes clean, unrelated). Also cleaned 8 stale worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)