### PR TITLE
feat: orient central_files expose a score alias (dogfood)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -106,9 +106,14 @@ def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> li
             for s in rm.get("symbols", [])
             if str(s.get("file")) == file_path
         ][:6]
+        rounded_score = round(centrality[file_path], 6)
         result.append({
             "file": file_path,
-            "graph_score": round(centrality[file_path], 6),
+            # `graph_score` is the composite centrality; `score` is a stable alias so agents that
+            # threshold on a generic `score` key find it populated (dogfood v1.20.0: "central_files
+            # JSON still has score: null — surface the score so agents can threshold").
+            "graph_score": rounded_score,
+            "score": rounded_score,
             "symbols": file_symbols,
         })
     return result

--- a/tests/unit/test_orient_central_excludes_docs.py
+++ b/tests/unit/test_orient_central_excludes_docs.py
@@ -27,6 +27,21 @@ def test_docs_are_never_central_and_code_wins_stem_collision() -> None:
     assert cfg["graph_score"] == 3.0
 
 
+def test_central_files_expose_score_alias() -> None:
+    # dogfood v1.20.0: agents thresholding on a generic `score` key found it null. `score` is a
+    # populated alias of `graph_score` so both work.
+    rm = {
+        "files": ["src/a.py", "src/b.py"],
+        "imports": [{"file": "src/b.py", "imports": ["a"]}],
+        "symbols": [{"name": "A", "kind": "class", "file": "src/a.py"}],
+    }
+    central = _central_files_from_map(rm, max_central_files=10)
+    assert central
+    for entry in central:
+        assert entry["score"] == entry["graph_score"]
+        assert entry["score"] is not None
+
+
 def test_hub_outranks_leaf_constant() -> None:
     # A data SINK (constants.py: imported by 20, imports nothing, 1 symbol) must NOT outrank a real
     # HUB (hub.py: imported by 3, imports 6 modules, 20 symbols). Pure import in-degree ranked the


### PR DESCRIPTION
Dogfood v1.20.0: "orient central_files JSON still has `score: null` — surface the score so agents can threshold." The composite centrality is emitted as `graph_score`; agents thresholding on a generic `score` key found it absent. Adds `score` as a populated alias of `graph_score` (both keys work). Trivial, additive, no ranking change. 9 orient tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)