### PR TITLE
fix: --provider lsp refs must not discard native truth or mask a partial as lsp-only (moat P0-1)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -10696,7 +10696,17 @@ def _merge_agreement_status(
     elif fallback_used and lsp_count == 0:
         agreement_status = "fallback-native"
     elif normalized_provider == "lsp":
-        agreement_status = "lsp-only" if lsp_count > 0 else "native-fallback"
+        if lsp_count == 0:
+            agreement_status = "native-fallback"
+        elif native_count > lsp_count:
+            # native found strictly MORE refs than the LSP index proved -> the LSP result is
+            # incomplete. Report the divergence honestly instead of a clean lsp-only proof (P0-1:
+            # dogfood's 2-of-14 partial was masked as authoritative lsp-only). "diverged" was
+            # structurally unreachable in lsp mode before this. When native<=lsp (they agree, or LSP
+            # proved everything native saw) it stays lsp-only.
+            agreement_status = "diverged"
+        else:
+            agreement_status = "lsp-only"
     elif native_count > 0 and lsp_count > 0 and merged_count == native_count == lsp_count:
         agreement_status = "agreed"
     elif native_count > 0 and lsp_count > 0:
@@ -11827,6 +11837,9 @@ def build_symbol_refs_from_map(
     normalized_provider = _normalize_semantic_provider(semantic_provider)
     external_refs: list[dict[str, Any]] = []
     fallback_used = False
+    # Native ref count captured BEFORE any lsp/hybrid merge -> the divergence signal for
+    # provider_agreement (a partial LSP result must surface as diverged, not a clean lsp-only proof).
+    native_reference_count = len(references)
     if normalized_provider != "native":
         external_refs = [
             dict(current)
@@ -11835,29 +11848,33 @@ def build_symbol_refs_from_map(
             )
             if str(Path(str(current.get("file", ""))).expanduser().resolve()) in bounded_file_set
         ]
-        if normalized_provider == "lsp":
-            proof_refs = [dict(current) for current in external_refs if _is_lsp_proof_row(current)]
-            fallback_used = not bool(proof_refs)
-            references = proof_refs or references
-        else:
-            merged_refs: dict[tuple[str, int, int], dict[str, Any]] = {}
-            for current_ref in [*external_refs, *references]:
-                key = (
-                    str(current_ref["file"]),
-                    int(current_ref["line"]),
-                    int(current_ref.get("end_line", current_ref["line"])),
-                )
-                if key in merged_refs:
-                    merged_refs[key] = _merge_navigation_duplicate(
-                        merged_refs[key],
-                        dict(current_ref),
-                    )
-                else:
-                    merged_refs[key] = dict(current_ref)
-            references = list(merged_refs.values())
-            references.sort(
-                key=lambda item: (str(item["file"]), int(item["line"]), str(item.get("text", "")))
+        # Merge (union) native + external refs for BOTH lsp and hybrid. A partial / under-indexed
+        # LSP result must NEVER discard the correct native answer: the old `references = proof_refs
+        # or references` REPLACED the native rows with the LSP rows, then recomputed native_count
+        # from the replaced list -> always 0 -> falsely reported lsp-only / lsp_proof:True (dogfood
+        # v1.20.0: `tg refs --provider lsp` returned 2 of 14, marked authoritative -- a silent
+        # wrong-output / fail-closed-contract violation). Union keeps the native truth; the
+        # provider_agreement + lsp_proof below are then stamped honestly (native>lsp -> diverged).
+        proof_refs = [dict(current) for current in external_refs if _is_lsp_proof_row(current)]
+        merged_refs: dict[tuple[str, int, int], dict[str, Any]] = {}
+        for current_ref in [*external_refs, *references]:
+            key = (
+                str(current_ref["file"]),
+                int(current_ref["line"]),
+                int(current_ref.get("end_line", current_ref["line"])),
             )
+            if key in merged_refs:
+                merged_refs[key] = _merge_navigation_duplicate(merged_refs[key], dict(current_ref))
+            else:
+                merged_refs[key] = dict(current_ref)
+        references = list(merged_refs.values())
+        references.sort(
+            key=lambda item: (str(item["file"]), int(item["line"]), str(item.get("text", "")))
+        )
+        if normalized_provider == "lsp" and len(proof_refs) < native_reference_count:
+            # LSP proved fewer refs than the native scan -> its index is incomplete for this symbol;
+            # flag a fallback so the partial is not mis-reported as a clean lsp-only proof.
+            fallback_used = True
 
     references = _dedupe_symbol_references(references)
     for reference in references:
@@ -11897,7 +11914,7 @@ def build_symbol_refs_from_map(
         fallback_used = True
     payload["provider_agreement"] = _merge_agreement_status(
         semantic_provider=normalized_provider,
-        native_count=len([current for current in references if not _is_lsp_proof_row(current)]),
+        native_count=native_reference_count,
         lsp_count=lsp_proof_count,
         merged_count=len(references),
         fallback_used=fallback_used,

--- a/tests/unit/test_refs_lsp_no_masking.py
+++ b/tests/unit/test_refs_lsp_no_masking.py
@@ -1,0 +1,55 @@
+"""P0-1 of the warm-LSP moat: a partial / under-indexed `--provider lsp` references result must NOT
+discard the correct native answer (dogfood v1.20.0: `tg refs --provider lsp` returned 2 of 14 and
+marked it authoritative -- a silent wrong-output / fail-closed-contract violation)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import repo_map
+
+
+def test_partial_lsp_refs_do_not_discard_native_truth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "module.py").write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "a.py").write_text(
+        "from module import create_invoice\n\n\ndef use_a():\n    return create_invoice()\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.py").write_text(
+        "from module import create_invoice\n\n\ndef use_b():\n    return create_invoice()\n",
+        encoding="utf-8",
+    )
+    # Keep definitions native (isolate the references path).
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", lambda root, symbol, **kwargs: [])
+    monkeypatch.setattr(
+        repo_map, "_external_definitions", lambda root, symbol, native_definitions, **kwargs: []
+    )
+    # LSP under-returns: only ONE of the two native call sites (the 2-of-14 shape).
+    monkeypatch.setattr(
+        repo_map,
+        "_external_references",
+        lambda root, symbol, definitions, **kwargs: [
+            {
+                "file": str((tmp_path / "a.py").resolve()),
+                "line": 5,
+                "end_line": 5,
+                "text": "create_invoice()",
+                "provenance": "lsp-python",
+                "lsp_provider_response": True,
+                "lsp_operation": "textDocument/references",
+            }
+        ],
+    )
+    rm = repo_map.build_repo_map(tmp_path)
+    payload = repo_map.build_symbol_refs_from_map(rm, "create_invoice", semantic_provider="lsp")
+
+    ref_files = {Path(r["file"]).name for r in payload["references"]}
+    # Native truth NOT discarded: BOTH caller files present (pre-fix only a.py survived the replace).
+    assert "a.py" in ref_files
+    assert "b.py" in ref_files, "a partial LSP result must not discard the native ref b.py"
+    # ...and the partial is NOT mis-reported as a clean lsp-only proof.
+    assert payload["provider_agreement"]["agreement_status"] != "lsp-only"


### PR DESCRIPTION
Dogfood v1.20.0: `tg refs --provider lsp` returned **2 of 14** refs and reported them authoritative. The warm-LSP design workflow found **two** defects (verified against code):

1. **Masking** (`repo_map.py`): `references = proof_refs or references` *replaced* the 14 native rows with 2 LSP rows — silent wrong output. **Fix: union** native + external for both lsp + hybrid.
2. **False proof** (`_merge_agreement_status`): lsp mode forced `lsp-only` whenever `lsp_count>0`, and `native_count` was recomputed from the replaced list (always 0), so `diverged` was unreachable. **Fix: pass the pre-merge native count; report `diverged` when native found strictly more than LSP proved.**

This is the **standalone, no-daemon slice** of the warm-LSP moat (cold-start latency + readiness gate are P0-2..P2, tracked in #45). TDD + 95 semantic-provider/agent-capsule/callers/blast regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)