### PR TITLE
fix: context-render bounds --max-tokens by default (dogfood 1.23.0 — was ~800KB unbounded)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6980,8 +6980,14 @@ def context_render(
     max_render_chars: int | None = typer.Option(
         None, "--max-render-chars", min=1, help="Maximum characters to emit in rendered_context."
     ),
-    max_tokens: int | None = typer.Option(
-        None, "--max-tokens", min=1, help="Approximate maximum tokens to emit in rendered_context."
+    max_tokens: int = typer.Option(
+        # Bound a prompt-ready render bundle by default, mirroring the `context` command (dogfood
+        # 1.23.0: context-render defaulted to ~800KB, too big for prompt injection). 0 = unbounded;
+        # downstream normalizes <=0 -> None (repo_map.py _normalize / _apply_context_token_budget).
+        16000,
+        "--max-tokens",
+        min=0,
+        help="Bound the rendered_context to ~N tokens for prompt injection (0 = unbounded).",
     ),
     model: str | None = typer.Option(
         None, "--model", help="Future tokenizer model selector; currently accepted but ignored."
@@ -8606,8 +8612,14 @@ def session_context_render_cmd(
     max_render_chars: int | None = typer.Option(
         None, "--max-render-chars", min=1, help="Maximum characters to emit in rendered_context."
     ),
-    max_tokens: int | None = typer.Option(
-        None, "--max-tokens", min=1, help="Approximate maximum tokens to emit in rendered_context."
+    max_tokens: int = typer.Option(
+        # Bound a prompt-ready render bundle by default, mirroring the `context` command (dogfood
+        # 1.23.0: context-render defaulted to ~800KB, too big for prompt injection). 0 = unbounded;
+        # downstream normalizes <=0 -> None (repo_map.py _normalize / _apply_context_token_budget).
+        16000,
+        "--max-tokens",
+        min=0,
+        help="Bound the rendered_context to ~N tokens for prompt injection (0 = unbounded).",
     ),
     model: str | None = typer.Option(
         None, "--model", help="Future tokenizer model selector; currently accepted but ignored."

--- a/tests/unit/test_context_render_default_cap.py
+++ b/tests/unit/test_context_render_default_cap.py
@@ -1,0 +1,38 @@
+"""Dogfood 1.23.0: `tg context-render` (and `tg session context-render`) defaulted --max-tokens to
+None -> an unbounded ~800KB prompt bundle. It must bound by default (mirroring `tg context`, which
+caps at 16000), with 0 as the explicit unbounded opt-out."""
+
+import json
+
+from typer.testing import CliRunner
+
+from tensor_grep.cli.main import app
+
+
+def _project(tmp_path):
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    (src / "payments.py").write_text(
+        "def create_invoice(total):\n    return total + 1\n", encoding="utf-8"
+    )
+    return project
+
+
+def test_context_render_bounds_by_default(tmp_path):
+    project = _project(tmp_path)
+    result = CliRunner().invoke(app, ["context-render", str(project), "create invoice", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    # default max_tokens is now the 16000 bound, not None (unbounded ~800KB).
+    assert payload["max_tokens"] == 16000
+
+
+def test_context_render_max_tokens_zero_is_unbounded(tmp_path):
+    project = _project(tmp_path)
+    result = CliRunner().invoke(
+        app, ["context-render", str(project), "create invoice", "--json", "--max-tokens", "0"]
+    )
+    assert result.exit_code == 0, result.output
+    # 0 = opt-out; normalized to None (unbounded) downstream.
+    assert json.loads(result.stdout)["max_tokens"] is None

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -1623,7 +1623,7 @@ def test_top_level_context_render_uses_running_daemon_response_cache(
             "max_sources": 5,
             "max_symbols_per_file": 6,
             "max_render_chars": None,
-            "max_tokens": None,
+            "max_tokens": 16000,
             "model": None,
             "optimize_context": False,
             "render_profile": "llm",


### PR DESCRIPTION
Dogfood 1.23.0: `tg context-render` / `tg session context-render` defaulted `--max-tokens` to `None` → a 'prompt-ready' bundle rendered ~800KB, too big to inject. Mirror `tg context` (#359): **default 16000, `min=0`, 0 = explicit unbounded opt-out**. Downstream already normalizes `<=0 → None`, so behavior stays correct. 2 CliRunner tests pin the default + the opt-out.

Part of the 1.23.0 dogfood follow-ups (the rest — persisted graph in daemon, --deadline partials, LSP-from-daemon, docs-coverage --fix/--ignore/--stale — tracked in #45/#35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)