### PR TITLE
feat: docs-coverage --fix emits a paste-ready Markdown table of undocumented files (dogfood 1.23.0)

### DIFF
--- a/src/tensor_grep/cli/docs_coverage.py
+++ b/src/tensor_grep/cli/docs_coverage.py
@@ -112,8 +112,39 @@ def _relative_posix(path: Path, root: Path) -> str:
         return path.as_posix()
 
 
+def _human_size(num_bytes: int) -> str:
+    size = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{num_bytes} B"
+
+
+def _uncovered_file_detail(path: Path, root: Path) -> dict[str, Any]:
+    """path + size + first non-blank line, for the --fix paste-ready table (bounded reads)."""
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    first_line = ""
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for raw in handle:
+                stripped = raw.strip()
+                if stripped:
+                    first_line = stripped[:100]
+                    break
+    except OSError:
+        first_line = ""
+    return {"path": _relative_posix(path, root), "size_bytes": int(size), "first_line": first_line}
+
+
 def build_docs_coverage(
-    path: str = ".", *, max_files: int = DEFAULT_MAX_INVENTORY_FILES
+    path: str = ".",
+    *,
+    max_files: int = DEFAULT_MAX_INVENTORY_FILES,
+    include_details: bool = False,
 ) -> dict[str, Any]:
     """Report which source files are not referenced by any governing doc under ``path``.
 
@@ -168,18 +199,19 @@ def build_docs_coverage(
             continue
     haystack = "\n".join(doc_texts)
 
-    uncovered: list[str] = []
+    uncovered_pairs: list[tuple[str, Path]] = []
     covered = 0
     for file_path in source_paths:
         rel = _relative_posix(file_path, resolved_root)
         if rel in haystack or file_path.name in haystack:
             covered += 1
         else:
-            uncovered.append(rel)
-    uncovered.sort()
+            uncovered_pairs.append((rel, file_path))
+    uncovered_pairs.sort(key=lambda item: item[0])
+    uncovered = [rel for rel, _ in uncovered_pairs]
 
     total = len(source_paths)
-    return {
+    payload: dict[str, Any] = {
         "path": str(resolved_root),
         "totals": {
             "source_files": total,
@@ -201,6 +233,30 @@ def build_docs_coverage(
             "excluded": "tests, fixtures, tool-state (.claude/.git/.tensor-grep), vendor, build/cache",
         },
     }
+    if include_details:
+        # --fix table source: path + size + first non-blank line per uncovered file.
+        payload["uncovered_details"] = [
+            _uncovered_file_detail(file_path, resolved_root) for _, file_path in uncovered_pairs
+        ]
+    return payload
+
+
+def render_docs_coverage_fix_markdown(payload: dict[str, Any]) -> str:
+    """Paste-ready Markdown table of undocumented source files (path/size/first line) -- the exact
+    manual step an agent otherwise hand-rolls to start closing the gaps (dogfood 1.23.0)."""
+    details = payload.get("uncovered_details") or []
+    if not details:
+        return "All source files are referenced by a governing doc. (Nothing to add.)"
+    lines = [
+        f"<!-- {len(details)} undocumented source file(s) under {payload['path']} -->",
+        "| File | Size | First line |",
+        "| --- | ---: | --- |",
+    ]
+    for detail in details:
+        # Escape the Markdown cell delimiter so a `|` in the first line can't break the table.
+        first = str(detail.get("first_line", "")).replace("|", "\\|")
+        lines.append(f"| `{detail['path']}` | {_human_size(int(detail['size_bytes']))} | {first} |")
+    return "\n".join(lines)
 
 
 def render_docs_coverage_text(payload: dict[str, Any]) -> str:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6730,14 +6730,23 @@ def docs_coverage(
         help="Maximum repo files to scan before truncating (walk-only; defaults to 50000).",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help="Emit a paste-ready Markdown table of undocumented files (path/size/first line).",
+    ),
 ) -> None:
     """List source files not referenced by any governing doc (CLAUDE.md/README/AGENTS.md)."""
     import json as _json
 
-    from tensor_grep.cli.docs_coverage import build_docs_coverage, render_docs_coverage_text
+    from tensor_grep.cli.docs_coverage import (
+        build_docs_coverage,
+        render_docs_coverage_fix_markdown,
+        render_docs_coverage_text,
+    )
 
     try:
-        payload = build_docs_coverage(path, max_files=max_repo_files)
+        payload = build_docs_coverage(path, max_files=max_repo_files, include_details=fix)
     except FileNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -6747,6 +6756,9 @@ def docs_coverage(
         return
     # Text output can embed a resolved filesystem path (non-English username -> non-ASCII); route
     # through the cp1252-safe writer, never bare typer.echo (the #346 crash class).
+    if fix:
+        _safe_stdout_line(render_docs_coverage_fix_markdown(payload))
+        return
     _safe_stdout_line(render_docs_coverage_text(payload))
 
 

--- a/tests/unit/test_docs_coverage.py
+++ b/tests/unit/test_docs_coverage.py
@@ -6,7 +6,39 @@ only (not semantic), lenient path-or-basename match so it under-reports gaps rat
 
 import pytest
 
-from tensor_grep.cli.docs_coverage import build_docs_coverage, render_docs_coverage_text
+from tensor_grep.cli.docs_coverage import (
+    build_docs_coverage,
+    render_docs_coverage_fix_markdown,
+    render_docs_coverage_text,
+)
+
+
+def test_fix_emits_paste_ready_markdown_table(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "src" / "bar.py").write_text(
+        "\ndef undocumented_thing():  # a | pipe to escape\n    return 1\n", encoding="utf-8"
+    )
+    (tmp_path / "CLAUDE.md").write_text("The main module is foo.py.\n", encoding="utf-8")
+
+    payload = build_docs_coverage(str(tmp_path), include_details=True)
+    details = payload["uncovered_details"]
+    assert [d["path"] for d in details] == ["src/bar.py"]
+    assert details[0]["size_bytes"] > 0
+    # first NON-BLANK line, not the leading blank line
+    assert details[0]["first_line"].startswith("def undocumented_thing()")
+
+    table = render_docs_coverage_fix_markdown(payload)
+    assert "| File | Size | First line |" in table
+    assert "`src/bar.py`" in table
+    assert "\\|" in table  # the pipe inside the first line is escaped so the table stays valid
+    assert "src/foo.py" not in table  # covered files are not in the fix table
+
+
+def test_details_absent_unless_requested(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "bar.py").write_text("y = 2\n", encoding="utf-8")
+    assert "uncovered_details" not in build_docs_coverage(str(tmp_path))
 
 
 def test_uncovered_source_file_flagged(tmp_path):


### PR DESCRIPTION
1.23.0 dogfood: `tg docs-coverage` found 18 real gaps, then the CEO **hand-rolled a Markdown table** of the uncovered files (path/size/first-line) to start closing them. `--fix` emits exactly that:

```
| File | Size | First line |
| --- | ---: | --- |
| `src/_index_lock.py` | 3.6 KB | from __future__ import annotations |
```

Sorted, pipe-escaped (a `|` in a first line can't break the table). `build_docs_coverage(include_details=True)` enriches each uncovered file with size + first non-blank line via bounded reads; `--json` carries `uncovered_details` too. Dogfooded on tensor-grep's own tree (33 files). 3 tests.

First of the docs-coverage upgrades (#48); --ignore/--stale/--daemon still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)