### PR TITLE
feat: docs-coverage --ignore <glob> excludes intentional stub groups (dogfood 1.23.0)

### DIFF
--- a/src/tensor_grep/cli/docs_coverage.py
+++ b/src/tensor_grep/cli/docs_coverage.py
@@ -13,6 +13,7 @@ Pure-CPU, no AST parse, no API key.
 
 from __future__ import annotations
 
+import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -140,11 +141,19 @@ def _uncovered_file_detail(path: Path, root: Path) -> dict[str, Any]:
     return {"path": _relative_posix(path, root), "size_bytes": int(size), "first_line": first_line}
 
 
+def _matches_ignore(rel: str, name: str, ignore: tuple[str, ...]) -> bool:
+    """True if a source file should be excluded via --ignore. Matches each glob against BOTH the
+    repo-relative posix path (`commands/*/index.js`) and the bare basename (`*.stub.py`), so an
+    intentional stub group is easy to silence without re-flagging every run."""
+    return any(fnmatch.fnmatch(rel, glob) or fnmatch.fnmatch(name, glob) for glob in ignore)
+
+
 def build_docs_coverage(
     path: str = ".",
     *,
     max_files: int = DEFAULT_MAX_INVENTORY_FILES,
     include_details: bool = False,
+    ignore: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     """Report which source files are not referenced by any governing doc under ``path``.
 
@@ -182,6 +191,14 @@ def build_docs_coverage(
             )  # a governing doc documents source, not tests
             and not _is_fixture_path(file_path)
             and not _looks_like_binary_file(file_path)
+            # --ignore: an intentional stub group is excluded entirely (not counted as uncovered nor
+            # dragging coverage_pct). Only pay the relative-path cost when globs were actually given.
+            and not (
+                ignore
+                and _matches_ignore(
+                    _relative_posix(file_path, resolved_root), file_path.name, ignore
+                )
+            )
         ):
             source_paths.append(file_path)
 
@@ -222,6 +239,7 @@ def build_docs_coverage(
         },
         "doc_files": sorted(_relative_posix(d, resolved_root) for d in doc_paths),
         "uncovered_files": uncovered,
+        "applied_ignore": list(ignore),
         "scan_limit": {
             "max_files": max_files,
             "possibly_truncated": possibly_truncated,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6729,6 +6729,13 @@ def docs_coverage(
         min=1,
         help="Maximum repo files to scan before truncating (walk-only; defaults to 50000).",
     ),
+    ignore: list[str] = typer.Option(
+        [],
+        "--ignore",
+        help="Glob(s) of source files to exclude entirely (repeatable). Matched against the "
+        "repo-relative path and basename, e.g. --ignore 'commands/*/index.js' --ignore '*.stub.py'. "
+        "An intentional stub group stops being re-flagged and no longer drags coverage_pct.",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
     fix: bool = typer.Option(
         False,
@@ -6746,7 +6753,9 @@ def docs_coverage(
     )
 
     try:
-        payload = build_docs_coverage(path, max_files=max_repo_files, include_details=fix)
+        payload = build_docs_coverage(
+            path, max_files=max_repo_files, include_details=fix, ignore=tuple(ignore)
+        )
     except FileNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc

--- a/tests/unit/test_docs_coverage.py
+++ b/tests/unit/test_docs_coverage.py
@@ -41,6 +41,31 @@ def test_details_absent_unless_requested(tmp_path):
     assert "uncovered_details" not in build_docs_coverage(str(tmp_path))
 
 
+def test_ignore_glob_excludes_stub_group_entirely(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "real.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "src" / "a.stub.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "src" / "b.stub.py").write_text("x = 1\n", encoding="utf-8")
+    # no governing doc -> everything is uncovered by default
+    base = build_docs_coverage(str(tmp_path))
+    assert set(base["uncovered_files"]) == {"src/a.stub.py", "src/b.stub.py", "src/real.py"}
+    # --ignore drops the stub group: not flagged, and not counted (coverage_pct reflects real source)
+    filtered = build_docs_coverage(str(tmp_path), ignore=("*.stub.py",))
+    assert filtered["uncovered_files"] == ["src/real.py"]
+    assert filtered["totals"]["source_files"] == 1
+    assert filtered["applied_ignore"] == ["*.stub.py"]
+
+
+def test_ignore_matches_relative_path_glob(tmp_path):
+    (tmp_path / "commands" / "a").mkdir(parents=True)
+    (tmp_path / "commands" / "a" / "index.js").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "real.js").write_text("y = 2\n", encoding="utf-8")
+    filtered = build_docs_coverage(str(tmp_path), ignore=("commands/*/index.js",))
+    assert "commands/a/index.js" not in filtered["uncovered_files"]
+    assert "src/real.js" in filtered["uncovered_files"]
+
+
 def test_uncovered_source_file_flagged(tmp_path):
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "foo.py").write_text("x = 1\n", encoding="utf-8")


### PR DESCRIPTION
Second docs-coverage upgrade from the 1.23.0 dogfood. Intentional stub groups (disabled `commands/*/index.js`, generated `*.stub.py`) re-flagged every run and dragged `coverage_pct`. **`--ignore` (repeatable)** excludes matching source files *entirely* — not uncovered, not in the denominator. Each glob matches both the repo-relative path and the basename; payload carries `applied_ignore`. Short-circuits when unused. 2 tests + dogfooded.

Independent of #365 (--fix) — different option/param, merges cleanly. Remaining docs-coverage upgrades (--stale, --daemon) tracked #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)