### PR TITLE
feat: docs-coverage --check exits non-zero on drift (CI doc-drift gate, dogfood 1.26.0)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6747,6 +6747,12 @@ def docs_coverage(
         "--stale",
         help="Inverse mode: report governing-doc references to files that no longer exist.",
     ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Exit non-zero when any file is uncovered (or, with --stale, any reference is stale) "
+        "-- turns docs-coverage into a CI doc-drift gate. Respects --ignore.",
+    ),
 ) -> None:
     """List source files not referenced by any governing doc (CLAUDE.md/README/AGENTS.md)."""
     import json as _json
@@ -6766,6 +6772,9 @@ def docs_coverage(
                 typer.echo(_json.dumps(stale_payload))
             else:
                 _safe_stdout_line(render_docs_stale_text(stale_payload))
+            # --check exits AFTER emitting the report, so CI shows what failed AND fails the job.
+            if check and stale_payload["totals"]["stale"] > 0:
+                raise typer.Exit(1)
             return
         payload = build_docs_coverage(
             path, max_files=max_repo_files, include_details=fix, ignore=tuple(ignore)
@@ -6776,13 +6785,14 @@ def docs_coverage(
 
     if json_output:
         typer.echo(_json.dumps(payload))
-        return
     # Text output can embed a resolved filesystem path (non-English username -> non-ASCII); route
     # through the cp1252-safe writer, never bare typer.echo (the #346 crash class).
-    if fix:
+    elif fix:
         _safe_stdout_line(render_docs_coverage_fix_markdown(payload))
-        return
-    _safe_stdout_line(render_docs_coverage_text(payload))
+    else:
+        _safe_stdout_line(render_docs_coverage_text(payload))
+    if check and payload["totals"]["uncovered"] > 0:
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/tests/unit/test_docs_coverage.py
+++ b/tests/unit/test_docs_coverage.py
@@ -5,6 +5,7 @@ only (not semantic), lenient path-or-basename match so it under-reports gaps rat
 """
 
 import pytest
+from typer.testing import CliRunner
 
 from tensor_grep.cli.docs_coverage import (
     build_docs_coverage,
@@ -13,6 +14,7 @@ from tensor_grep.cli.docs_coverage import (
     render_docs_coverage_text,
     render_docs_stale_text,
 )
+from tensor_grep.cli.main import app
 
 
 def test_stale_reference_flagged_when_cited_file_deleted(tmp_path):
@@ -42,6 +44,39 @@ def test_stale_ignores_bare_basenames_and_urls(tmp_path):
     )
     # bare basename (no separator) + a URL are never treated as repo paths
     assert build_docs_stale_references(str(tmp_path))["stale_references"] == []
+
+
+def test_check_exits_nonzero_on_uncovered_and_prints_report(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "bar.py").write_text("y = 2\n", encoding="utf-8")  # no doc -> uncovered
+    result = CliRunner().invoke(app, ["docs-coverage", str(tmp_path), "--check"])
+    assert result.exit_code == 1
+    assert "bar.py" in result.output  # the report is still emitted before the non-zero exit
+
+
+def test_check_exits_zero_when_all_covered(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "bar.py").write_text("y = 2\n", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("bar.py is the module.\n", encoding="utf-8")
+    result = CliRunner().invoke(app, ["docs-coverage", str(tmp_path), "--check"])
+    assert result.exit_code == 0
+
+
+def test_check_respects_ignore(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.stub.py").write_text("y = 2\n", encoding="utf-8")  # only an ignored stub
+    result = CliRunner().invoke(
+        app, ["docs-coverage", str(tmp_path), "--check", "--ignore", "*.stub.py"]
+    )
+    assert result.exit_code == 0  # ignored -> nothing uncovered -> gate passes
+
+
+def test_check_stale_exits_nonzero(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "exists.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("See `src/gone.py`.\n", encoding="utf-8")
+    result = CliRunner().invoke(app, ["docs-coverage", str(tmp_path), "--stale", "--check"])
+    assert result.exit_code == 1
 
 
 def test_fix_emits_paste_ready_markdown_table(tmp_path):


### PR DESCRIPTION
Dogfood suggestion #5: **`--check`** makes `docs-coverage` exit 1 on drift (any uncovered file, or with `--stale` any stale reference), 0 when clean — so `tg docs-coverage --check` / `--stale --check` becomes a **CI doc-drift gate** that fails the job. Report is printed before the exit so CI shows what failed. Respects `--ignore`. 4 CliRunner tests.

Also this turn: verified orient `score` IS correctly emitted in v1.26.0 (`score: 37.0`) — the reporter's 'hidden score' is a stale binary (version-soup, #47), not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)