### PR TITLE
feat: LSP readiness gate — wait for the server index to settle before querying (moat P0-2)

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -369,6 +369,15 @@ class ExternalLSPClient:
         self.disabled_until_monotonic = 0.0
         self.initialized = False
         self.lsp_provider_response = False
+        # P0-2 readiness gate (warm-LSP moat): track server indexing via workDoneProgress tokens
+        # so the first references/definitions per (root,language) can wait for the index to
+        # settle instead of answering from a half-built index (the 2-of-14 under-return).
+        # Guarded by _lock. _index_ready is the cached "settled" verdict; any new
+        # create/begin re-invalidates it (server re-indexing after file churn).
+        self._active_progress_tokens: set[str] = set()
+        self._progress_end_count = 0
+        self._progress_activity_seen = False
+        self._index_ready = False
 
     def enable_debug_trace(self) -> None:
         self._debug_trace_enabled = True
@@ -837,8 +846,15 @@ class ExternalLSPClient:
             elif method in {
                 "client/registerCapability",
                 "client/unregisterCapability",
-                "window/workDoneProgress/create",
             }:
+                result = None
+            elif method == "window/workDoneProgress/create":
+                # P0-2: register the token as an in-flight indexing round (not just ACK it) so
+                # wait_until_ready blocks until its $/progress end arrives. A created-but-not-yet-
+                # begun token counts as active: the create->begin window must not read as "ready".
+                token = (message.get("params") or {}).get("token")
+                if token is not None:
+                    self._note_progress_started(str(token))
                 result = None
             else:
                 with self._lock:
@@ -889,8 +905,97 @@ class ExternalLSPClient:
             self._record_debug_trace(event="reader_error", detail={"message": str(exc)})
             self._broadcast_closed()
 
+    def _note_progress_started(self, token: str) -> None:
+        with self._lock:
+            self._active_progress_tokens.add(token)
+            self._progress_activity_seen = True
+            self._index_ready = False  # a new indexing round re-invalidates readiness
+
+    def _note_progress_ended(self, token: str) -> None:
+        with self._lock:
+            self._active_progress_tokens.discard(token)
+            self._progress_activity_seen = True
+            self._progress_end_count += 1
+
+    def _handle_progress_notification(self, message: dict[str, Any]) -> bool:
+        """P0-2: consume $/progress begin/report/end (previously dropped as id-less noise)."""
+        if message.get("method") != "$/progress":
+            return False
+        params = message.get("params") or {}
+        token = params.get("token")
+        kind = (params.get("value") or {}).get("kind")
+        if token is None:
+            return True
+        if kind == "begin":
+            self._note_progress_started(str(token))
+        elif kind == "end":
+            self._note_progress_ended(str(token))
+        # "report" -> in-flight; activity noted at begin. Nothing to do.
+        return True
+
+    def wait_until_ready(
+        self,
+        deadline_monotonic: float,
+        *,
+        probe: Any = None,
+        no_progress_grace_seconds: float = 1.0,
+        poll_interval_seconds: float = 0.05,
+    ) -> bool:
+        """Block until the server's workspace index has settled, or the deadline passes.
+
+        Ready means: at least one workDoneProgress round has ENDED and none is active. For
+        servers that never advertise progress, ``probe`` (a callable returning the current
+        workspace/symbol hit count) is polled until stable across two consecutive polls; with
+        no probe, we proceed best-effort after ``no_progress_grace_seconds`` of silence rather
+        than burning the whole deadline. Returns False ONLY on a genuine timeout while indexing
+        is demonstrably still in flight — and a timeout must NEVER arm
+        ``disabled_until_monotonic`` (that cooldown is reserved for real initialize failures;
+        arming it here would blackball the language for 30s of daemon uptime after one slow
+        first index).
+        """
+        started_monotonic = time.monotonic()
+        previous_probe_value: Any = None
+        while True:
+            with self._lock:
+                if self._index_ready:
+                    return True
+                active = bool(self._active_progress_tokens)
+                ended = self._progress_end_count > 0
+                activity = self._progress_activity_seen
+            if ended and not active:
+                with self._lock:
+                    self._index_ready = True
+                return True
+            now = time.monotonic()
+            if now >= deadline_monotonic:
+                return False
+            if not activity:
+                # No progress signal from this server (some don't emit workDoneProgress).
+                if probe is not None:
+                    try:
+                        current_probe_value = probe()
+                    except Exception:
+                        current_probe_value = None
+                    if (
+                        current_probe_value is not None
+                        and current_probe_value == previous_probe_value
+                    ):
+                        # Two consecutive stable polls -> index settled.
+                        with self._lock:
+                            self._index_ready = True
+                        return True
+                    previous_probe_value = current_probe_value
+                elif now - started_monotonic >= max(no_progress_grace_seconds, 0.0):
+                    # Silent server, no probe: best-effort after the grace window.
+                    with self._lock:
+                        self._index_ready = True
+                    return True
+            time.sleep(max(0.0, min(poll_interval_seconds, deadline_monotonic - now)))
+
     def _dispatch_response(self, message: dict[str, Any]) -> None:
         """Route a response message to the correct per-id slot (audit B12)."""
+        if self._handle_progress_notification(message):
+            return
         raw_id = message.get("id")
         if raw_id is None:
             # Notification from server with no id — drop (already handled upstream).

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -10585,6 +10585,26 @@ def _configured_lsp_operation_budget_seconds() -> float:
         return _DEFAULT_LSP_OPERATION_BUDGET_SECONDS
 
 
+def _wait_for_lsp_readiness(
+    client: Any,
+    deadline_monotonic: float,
+    *,
+    probe: Any = None,
+    no_progress_grace_seconds: float = 1.0,
+) -> None:
+    """Best-effort P0-2 readiness gate. Tolerates clients without wait_until_ready (duck-typed
+    fakes/third-party stubs) — the gate is a pre-step that improves first-query completeness;
+    it must never be a new failure mode for the query itself."""
+    waiter = getattr(client, "wait_until_ready", None)
+    if waiter is None:
+        return
+    waiter(
+        deadline_monotonic,
+        probe=probe,
+        no_progress_grace_seconds=no_progress_grace_seconds,
+    )
+
+
 def _lsp_operation_deadline() -> float:
     return time.monotonic() + _configured_lsp_operation_budget_seconds()
 
@@ -10768,6 +10788,10 @@ def _external_workspace_symbols(
             client = _EXTERNAL_LSP_PROVIDER_MANAGER.get_client(
                 language=language, workspace_root=repo_root
             )
+
+            # P0-2 (zero-grace variant): wait out an advertised indexing round; silent servers
+            # proceed instantly.
+            _wait_for_lsp_readiness(client, deadline_monotonic, no_progress_grace_seconds=0.0)
 
             def _request_symbols(
                 *,
@@ -10985,6 +11009,10 @@ def _external_definitions(
 
             _run_lsp_with_operation_budget(client, deadline_monotonic, _ensure_document)
 
+            # P0-2 (zero-grace variant): progress-advertising servers wait for their indexing
+            # round to end; silent servers proceed instantly (no latency tax on the 2s budget).
+            _wait_for_lsp_readiness(client, deadline_monotonic, no_progress_grace_seconds=0.0)
+
             def _request_definition(
                 *,
                 current_client: Any = client,
@@ -11069,6 +11097,28 @@ def _external_references(
                 deadline_monotonic,
                 _ensure_document,
             )
+
+            # P0-2 readiness gate: wait for the server's workspace index to settle before the
+            # references query — firing immediately answers from a half-built index (the 2-of-14
+            # under-return). Probe = workspace/symbol hit-count stability for servers that never
+            # emit workDoneProgress. A timeout here is honest-partial territory (the P0-1 union +
+            # diverged stamps make the result truthful); it must NOT read as a provider failure.
+            def _symbol_count_probe(
+                *, current_client: Any = client, query: str = symbol
+            ) -> int | None:
+                hits = current_client.request("workspace/symbol", {"query": query})
+                return len(hits) if isinstance(hits, list) else 0
+
+            def _bounded_probe(
+                *,
+                current_client: Any = client,
+                deadline: float = deadline_monotonic,
+                probe_fn: Any = _symbol_count_probe,
+            ) -> int | None:
+                probed = _run_lsp_with_operation_budget(current_client, deadline, probe_fn)
+                return probed if isinstance(probed, int) else None
+
+            _wait_for_lsp_readiness(client, deadline_monotonic, probe=_bounded_probe)
 
             def _request_references(
                 *,

--- a/tests/unit/test_lsp_readiness_gate.py
+++ b/tests/unit/test_lsp_readiness_gate.py
@@ -1,0 +1,122 @@
+"""P0-2 (warm-LSP moat): readiness gate in ExternalLSPClient.
+
+The 2-of-14 under-return happens because `textDocument/references` fires immediately after one
+didOpen while the server is still building its workspace index: `window/workDoneProgress/create`
+was a bare no-op ACK and `$/progress` notifications were dropped at `_dispatch_response`
+(id-less -> return). The client must track progress tokens and expose
+`wait_until_ready(deadline_monotonic)` so the first query per (root,language) waits for the index
+to settle. A readiness TIMEOUT must NOT arm the 30s `disabled_until_monotonic` cooldown -- only a
+real `initialize` failure may do that (otherwise one slow first index blackballs the language for
+30s of daemon uptime).
+
+Messages are driven directly through `_handle_server_request` / `_dispatch_response` -- the exact
+entry points `_reader_loop` feeds parsed messages into.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import lsp_external_provider as provider_module
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> provider_module.ExternalLSPClient:
+    monkeypatch.setattr(provider_module, "_provider_command", lambda language: ["fake-server"])
+    made = provider_module.ExternalLSPClient(language="typescript", workspace_root=tmp_path)
+    # Neutralize the response write path (no real process): server-request handling ACKs via
+    # _write_response, which must not require live stdin in these unit tests.
+    monkeypatch.setattr(made, "_write_response", lambda *a, **k: None)
+    return made
+
+
+def _create_progress(client: provider_module.ExternalLSPClient, token: str) -> None:
+    client._handle_server_request({
+        "id": 99,
+        "method": "window/workDoneProgress/create",
+        "params": {"token": token},
+    })
+
+
+def _progress(client: provider_module.ExternalLSPClient, token: str, kind: str) -> None:
+    client._dispatch_response({
+        "method": "$/progress",
+        "params": {"token": token, "value": {"kind": kind}},
+    })
+
+
+def test_progress_create_then_end_marks_ready(client) -> None:
+    _create_progress(client, "idx-1")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is False  # created, never ended
+    _progress(client, "idx-1", "begin")
+    _progress(client, "idx-1", "report")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is False  # still in flight
+    _progress(client, "idx-1", "end")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is True
+
+
+def test_server_initiated_begin_without_create_still_tracked(client) -> None:
+    _progress(client, "anon-token", "begin")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is False
+    _progress(client, "anon-token", "end")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is True
+
+
+def test_readiness_timeout_does_not_arm_cooldown(client) -> None:
+    _progress(client, "never-ends", "begin")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is False
+    # The load-bearing assertion: a slow index is NOT an initialize failure.
+    assert client.disabled_until_monotonic == 0.0
+
+
+def test_no_progress_server_uses_stability_probe(client) -> None:
+    # Server emits no progress at all; a probe (workspace/symbol hit count) that returns the
+    # same value on consecutive polls means the index has settled.
+    counts = iter([3, 5, 7, 7])
+    assert (
+        client.wait_until_ready(
+            time.monotonic() + 5.0,
+            probe=lambda: next(counts),
+            no_progress_grace_seconds=0.01,
+            poll_interval_seconds=0.01,
+        )
+        is True
+    )
+
+
+def test_no_progress_no_probe_returns_ready_after_grace(client) -> None:
+    # A server that never advertises progress and has no probe: after the grace window we
+    # proceed best-effort (True) rather than burning the whole deadline on silence.
+    start = time.monotonic()
+    assert (
+        client.wait_until_ready(
+            start + 5.0, no_progress_grace_seconds=0.02, poll_interval_seconds=0.01
+        )
+        is True
+    )
+    assert time.monotonic() - start < 2.0  # did not burn the full deadline
+
+
+def test_ready_is_cached_and_new_begin_reinvalidates(client) -> None:
+    _progress(client, "t", "begin")
+    _progress(client, "t", "end")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is True
+    # cached: an already-ready client answers instantly even with an expired deadline
+    assert client.wait_until_ready(time.monotonic() - 1.0) is True
+    # a NEW indexing round (e.g. file churn) re-invalidates readiness
+    _progress(client, "t2", "begin")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is False
+    _progress(client, "t2", "end")
+    assert client.wait_until_ready(time.monotonic() + 0.05) is True
+
+
+def test_plain_responses_still_dispatch_to_slots(client) -> None:
+    # The $/progress consumer must not break normal response demultiplexing.
+    import queue as queue_module
+
+    slot: queue_module.Queue = queue_module.Queue(maxsize=1)
+    with client._lock:
+        client._pending_requests[7] = slot
+    client._dispatch_response({"id": 7, "result": {"ok": True}})
+    assert slot.get_nowait()["result"] == {"ok": True}


### PR DESCRIPTION
Second slice of the warm-LSP moat (#45). P0-1 (#362) made a partial LSP answer *honest*; P0-2 makes it *complete*: the client now tracks `workDoneProgress`/`$/progress` (previously dropped as id-less noise) and exposes **`wait_until_ready(deadline)`** — so the first `references` per (root,language) waits for the server's index to settle instead of answering from a half-built index (the 2-of-14 root cause).

- Ready = a progress round ENDED and none active; `workspace/symbol` stability probe for silent servers; bounded grace; readiness cached (warm daemon ⇒ 2nd+ calls skip free) and re-invalidated on a new indexing round.
- **A readiness timeout does NOT arm the 30s cooldown** (reserved for real initialize failures — else one slow first index blackballs a language for 30s of daemon uptime).
- All 3 external query sites gated in repo_map (references = probe gate; defs/workspace-symbols = zero-grace, no latency tax).

TDD: 7 new tests; **wide regression 683 passed/1 skipped**; ruff/mypy clean. Next per the staged plan: P0-3/4 (daemon routing + provider threading — seams being re-verified by the round-6 plan-audit workflow), P0-5 (Job Object reaper), P0-6 (unified deadline → `--deadline` + partials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)