### PR TITLE
fix: docs-coverage excluded-dir check must match relative parts, not ancestor dirs (round-6 rank-2)

### DIFF
--- a/src/tensor_grep/cli/docs_coverage.py
+++ b/src/tensor_grep/cli/docs_coverage.py
@@ -142,6 +142,22 @@ def _uncovered_file_detail(path: Path, root: Path) -> dict[str, Any]:
     return {"path": _relative_posix(path, root), "size_bytes": int(size), "first_line": first_line}
 
 
+def _has_excluded_ancestor(file_path: Path, resolved_root: Path) -> bool:
+    """True if any directory component BELOW the scan root is a tool-state/vendor/build dir.
+
+    Match against the RELATIVE-to-root parts, never the absolute path: _iter_repo_files returns
+    resolved (absolute) paths, so checking `file_path.parts` would exclude the ENTIRE repo whenever
+    the checkout itself lives under an ancestor named build/venv/target/... (e.g. a CI path like
+    /build/tensor-grep) -> source_files=0 -> coverage_pct=100.0, a silent false-green. Mirrors
+    inventory._is_test_path's relative-parts handling.
+    """
+    try:
+        relative_parts = file_path.resolve().relative_to(resolved_root).parts
+    except ValueError:
+        relative_parts = file_path.parts
+    return any(part in _EXCLUDED_DIR_PARTS for part in relative_parts)
+
+
 def _matches_ignore(rel: str, name: str, ignore: tuple[str, ...]) -> bool:
     """True if a source file should be excluded via --ignore. Matches each glob against BOTH the
     repo-relative posix path (`commands/*/index.js`) and the bare basename (`*.stub.py`), so an
@@ -181,7 +197,7 @@ def build_docs_coverage(
     for file_path in walked:
         # Tool-state / vendor / build trees are never "documented source" -- skip them entirely so
         # they cannot flood either the doc set or the uncovered set.
-        if any(part in _EXCLUDED_DIR_PARTS for part in file_path.parts):
+        if _has_excluded_ancestor(file_path, resolved_root):
             continue
         if _is_governing_doc(file_path.name):
             doc_paths.append(file_path)
@@ -364,7 +380,7 @@ def build_docs_stale_references(
     doc_paths = [
         file_path
         for file_path in walked
-        if not any(part in _EXCLUDED_DIR_PARTS for part in file_path.parts)
+        if not _has_excluded_ancestor(file_path, resolved_root)
         and _is_governing_doc(file_path.name)
     ]
 

--- a/tests/unit/test_docs_coverage.py
+++ b/tests/unit/test_docs_coverage.py
@@ -79,6 +79,33 @@ def test_check_stale_exits_nonzero(tmp_path):
     assert result.exit_code == 1
 
 
+def test_exclusion_matches_relative_parts_not_ancestor_dirs(tmp_path):
+    # Round-6 rank-2: a project checked out UNDER a dir named build/venv/target/... must not have
+    # its whole tree excluded (source_files=0 -> coverage_pct=100.0 false green). Only dirs BELOW
+    # the scan root count as excluded.
+    proj = tmp_path / "build" / "proj"  # ancestor 'build' is an _EXCLUDED_DIR_PART
+    (proj / "src").mkdir(parents=True)
+    (proj / "src" / "real.py").write_text("x = 1\n", encoding="utf-8")
+    (proj / "build").mkdir()  # an INNER build/ that SHOULD still be excluded
+    (proj / "build" / "generated.py").write_text("y = 1\n", encoding="utf-8")
+    payload = build_docs_coverage(str(proj))
+    assert payload["totals"]["source_files"] == 1  # real.py counted, inner build/ excluded
+    assert "src/real.py" in payload["uncovered_files"]
+    assert "build/generated.py" not in payload["uncovered_files"]
+    assert payload["totals"]["coverage_pct"] != 100.0  # was a false 100% before the fix
+
+
+def test_stale_exclusion_matches_relative_parts(tmp_path):
+    proj = tmp_path / "target" / "proj"  # ancestor 'target' is an _EXCLUDED_DIR_PART
+    proj.mkdir(parents=True)
+    (proj / "src").mkdir()
+    (proj / "src" / "exists.py").write_text("x = 1\n", encoding="utf-8")
+    (proj / "CLAUDE.md").write_text("See `src/gone.py`.\n", encoding="utf-8")
+    payload = build_docs_stale_references(str(proj))
+    assert payload["totals"]["doc_files"] == 1  # doc under a 'target' ancestor is still scanned
+    assert any(s["reference"] == "src/gone.py" for s in payload["stale_references"])
+
+
 def test_fix_emits_paste_ready_markdown_table(tmp_path):
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "foo.py").write_text("x = 1\n", encoding="utf-8")


### PR DESCRIPTION
**Round-6 audit rank #2 (HIGH — silent false-green).** `_iter_repo_files` returns absolute paths, and the excluded-dir check matched `_EXCLUDED_DIR_PARTS` against the **absolute** `file_path.parts`. So a project checked out under an ancestor named `build`/`venv`/`target`/... (any CI path like `/build/proj`) matched the *ancestor* → every file excluded → `source_files=0` → `coverage_pct=100.0` / 0 stale. A tool the CEO runs daily silently reports "all covered."

Fix: match `_EXCLUDED_DIR_PARTS` against the **relative-to-root** parts only (mirrors `_is_test_path`). Verified a project under `build/` now counts real source AND still excludes an inner `build/`. 2 regression tests.

2nd of the round-6 fix queue (after #370 RCE). Remaining HIGHs queued: MCP context-cap on the agent surface, MCP stdio multibyte desync + unbounded header readline, index.json RMW race, start() spawn race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)