### PR TITLE
fix: MCP context tools bound max_tokens by default — #359 cap missed the agent surface (round-6 rank-4)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -74,6 +74,12 @@ _NATIVE_TG_REMEDIATION = (
     "Install a standalone native tg binary, put it on PATH, or set TG_NATIVE_TG_BINARY."
 )
 _DEFAULT_MCP_REPO_SCAN_LIMIT = 512
+# Bound the context payload on the AGENT surface by default (round-6 rank-4). The #359 cap only
+# reached the CLI (typer default 16000); the MCP tools an agent actually calls defaulted to None
+# (unbounded), so a context pack/render could balloon to ~800KB straight into a model's prompt.
+# Mirrors repo_map._DEFAULT_CONTEXT_MAX_TOKENS; 0/None = explicit unbounded opt-out (a guard test
+# pins them equal). Literal keeps the heavy repo_map import lazy.
+_DEFAULT_MCP_CONTEXT_MAX_TOKENS = 16000
 
 _PYTHON_LOCAL_MCP_TOOLS = (
     "tg_rulesets",
@@ -1716,16 +1722,21 @@ def tg_repo_map(path: str = ".", max_repo_files: int | None = 512) -> str:
 
 
 @mcp.tool()  # type: ignore
-def tg_context_pack(query: str, path: str = ".") -> str:
+def tg_context_pack(
+    query: str, path: str = ".", max_tokens: int | None = _DEFAULT_MCP_CONTEXT_MAX_TOKENS
+) -> str:
     """
     Return a ranked repository context pack for edit planning.
 
     Args:
         query: Query text used to rank relevant files, symbols, and tests.
         path: File or directory to inventory.
+        max_tokens: Bound the pack for prompt injection (default ~16000; 0/None = unbounded).
     """
     try:
-        return _inject_mcp_contract_fields(json.dumps(build_context_pack(query, path), indent=2))
+        return _inject_mcp_contract_fields(
+            json.dumps(build_context_pack(query, path, max_tokens=max_tokens), indent=2)
+        )
     except FileNotFoundError:
         payload = _envelope_base(
             routing_backend="RepoMap",
@@ -1806,7 +1817,7 @@ def tg_context_render(
     max_sources: int = 5,
     max_symbols_per_file: int = 6,
     max_render_chars: int | None = None,
-    max_tokens: int | None = None,
+    max_tokens: int | None = _DEFAULT_MCP_CONTEXT_MAX_TOKENS,
     model: str | None = None,
     optimize_context: bool = False,
     render_profile: str = "full",
@@ -1999,7 +2010,7 @@ def tg_session_context_render(
     max_sources: int = 5,
     max_symbols_per_file: int = 6,
     max_render_chars: int | None = None,
-    max_tokens: int | None = None,
+    max_tokens: int | None = _DEFAULT_MCP_CONTEXT_MAX_TOKENS,
     model: str | None = None,
     optimize_context: bool = False,
     render_profile: str = "full",

--- a/tests/unit/test_mcp_context_default_cap.py
+++ b/tests/unit/test_mcp_context_default_cap.py
@@ -1,0 +1,40 @@
+"""Round-6 rank-4: the MCP context tools (the surface agents actually call) must bound the context
+payload by default, like the CLI (#359). They defaulted to max_tokens=None (unbounded) -> a pack/
+render could balloon straight into a model prompt."""
+
+import json
+
+from tensor_grep.cli import mcp_server, repo_map
+
+
+def test_mcp_context_cap_constant_mirrors_the_library_constant():
+    # A drift guard: the MCP-surface literal must equal repo_map's canonical default.
+    assert mcp_server._DEFAULT_MCP_CONTEXT_MAX_TOKENS == repo_map._DEFAULT_CONTEXT_MAX_TOKENS
+
+
+def _project(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "payments.py").write_text(
+        "def create_invoice():\n    return 1\n", encoding="utf-8"
+    )
+    return str(tmp_path)
+
+
+def test_tg_context_render_bounds_by_default(tmp_path):
+    payload = json.loads(mcp_server.tg_context_render("create invoice", _project(tmp_path)))
+    assert payload["max_tokens"] == mcp_server._DEFAULT_MCP_CONTEXT_MAX_TOKENS
+
+
+def test_tg_context_render_zero_is_unbounded_opt_out(tmp_path):
+    payload = json.loads(
+        mcp_server.tg_context_render("create invoice", _project(tmp_path), max_tokens=0)
+    )
+    assert payload["max_tokens"] is None  # normalized <=0 -> unbounded
+
+
+def test_tg_context_pack_accepts_and_defaults_max_tokens(tmp_path):
+    # tg_context_pack had NO max_tokens param at all -> always unbounded. It now accepts one and
+    # defaults to the bound (call succeeds + emits the pack).
+    out = mcp_server.tg_context_pack("create invoice", _project(tmp_path))
+    payload = json.loads(out)
+    assert isinstance(payload, dict)  # bounded call still returns a valid pack


### PR DESCRIPTION
**Round-6 audit rank #4 (HIGH).** The context cap (#359) only reached the **CLI**; the MCP tools an agent actually calls (`tg_context_render`, `tg_session_context_render`) defaulted to `max_tokens=None` (unbounded), and `tg_context_pack` had no `max_tokens` param at all — so a context bundle could balloon ~800KB straight into a model prompt on the real surface.

Fix: default the three tools to `_DEFAULT_MCP_CONTEXT_MAX_TOKENS` (16000, mirrors the library constant; 0/None = unbounded opt-out). `tg_edit_plan` stays `None` (no rendered text). 4 tests incl. a constant-mirror drift guard.

4th of the round-6 fix queue. Remaining HIGHs (MCP Content-Length shim byte/char desync + unbounded header read — needs a binary-reader refactor; index.json RMW race; start() spawn race) tracked #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)