### PR TITLE
fix: serialize ExternalLSPClient.start() check-then-spawn (round-6 r9 concurrency race)

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -321,6 +321,10 @@ class ExternalLSPClient:
         self.process: subprocess.Popen[Any] | None = None
         self._request_id = 0
         self._lock = threading.Lock()
+        # Serializes start()'s check-then-spawn so concurrent daemon worker threads sharing this
+        # cached client cannot both Popen (round-6 r9). SEPARATE from _lock: start()'s initialize
+        # handshake calls request() which takes _lock, so reusing it would re-entrant-deadlock.
+        self._start_lock = threading.Lock()
         self._max_open_documents = (
             _configured_positive_int(
                 _LSP_PROVIDER_OPEN_DOCUMENT_MAX_ENTRIES_ENV_VAR,
@@ -416,8 +420,18 @@ class ExternalLSPClient:
         self._debug_trace.append(entry)
 
     def start(self) -> None:
+        # Fast path (no lock): already running.
         if self.process is not None and self.process.poll() is None:
             return
+        # Serialize the check-then-spawn (round-6 r9): two daemon worker threads calling into the
+        # SAME cached client (get_client is shared per (root,language)) must not both pass the None
+        # check and both Popen, orphaning one child. Double-checked under _start_lock.
+        with self._start_lock:
+            if self.process is not None and self.process.poll() is None:
+                return
+            self._start_locked()
+
+    def _start_locked(self) -> None:
         if self.disabled_until_monotonic > time.monotonic():
             raise LSPTransportError(self.last_error or "LSP provider temporarily unavailable")
         if self.process is not None:

--- a/tests/unit/test_lsp_start_race.py
+++ b/tests/unit/test_lsp_start_race.py
@@ -1,0 +1,66 @@
+"""Round-6/7 r9: ExternalLSPClient.start() check-then-spawn must be serialized. Two daemon worker
+threads (ThreadingMixIn) calling into the SAME cached client (get_client is shared per
+(root,language)) previously both passed the `if self.process is not None` None-check and both
+Popen'd, orphaning one language-server child. A double-checked _start_lock guards the spawn."""
+
+import io
+import threading
+import time
+
+from tensor_grep.cli import lsp_external_provider as provider_module
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO()  # empty -> reader loop hits EOF cleanly
+        self.stderr = io.BytesIO()
+
+    def poll(self):
+        return None  # alive
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+
+def test_concurrent_start_spawns_exactly_one_process(tmp_path, monkeypatch):
+    monkeypatch.setattr(provider_module, "_provider_command", lambda language: ["fake-server"])
+    monkeypatch.setattr(provider_module, "direct_managed_node_command", lambda *a, **k: None)
+    monkeypatch.setattr(provider_module, "wrap_windows_batch_command", lambda cmd: list(cmd))
+    monkeypatch.setattr(provider_module, "managed_provider_env", lambda *a, **k: {})
+
+    client = provider_module.ExternalLSPClient(language="python", workspace_root=tmp_path)
+
+    spawns: list[int] = []
+
+    def _fake_popen(*_a, **_k):
+        spawns.append(1)
+        time.sleep(0.05)  # widen the race window so an unserialized start() would double-spawn
+        return _FakeProc()
+
+    monkeypatch.setattr(provider_module.subprocess, "Popen", _fake_popen)
+    # skip the real initialize handshake (which would need a live reader/stdio round-trip)
+    monkeypatch.setattr(client, "request", lambda *a, **k: {"capabilities": {}})
+
+    threads = [threading.Thread(target=client.start) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(spawns) == 1, (
+        f"start() double-spawned ({len(spawns)} Popen calls) — the race is open"
+    )
+
+
+def test_start_lock_and_lock_are_distinct(tmp_path, monkeypatch):
+    # Guards the anti-deadlock invariant: start() must not reuse _lock (its handshake takes _lock).
+    monkeypatch.setattr(provider_module, "_provider_command", lambda language: ["fake-server"])
+    client = provider_module.ExternalLSPClient(language="python", workspace_root=tmp_path)
+    assert client._start_lock is not client._lock


### PR DESCRIPTION
**Round-6/7 audit r9 (HIGH concurrency, P0-3 prerequisite).** `start()` did an unlocked check-then-spawn — two ThreadingMixIn daemon threads sharing the same cached client (`get_client` is per-(root,language)) both pass the `None` check and both `Popen`, orphaning one language-server child. Live once the warm daemon holds long-lived clients.

Fix: a **separate `_start_lock`** (not `_lock` — `start()`'s handshake takes `_lock`, reuse = re-entrant deadlock) with double-checked locking. 2 tests (6 concurrent `start()` → exactly 1 spawn). 48 LSP regression green.

Round-7 fix-queue item; unblocks the P0-3 daemon routing. Research/audit workflow (wyf6yx918) running for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)