### PR TITLE
fix: checkpoint undo cleanup must not follow/remove a directory symlink (round-7, symlink-follow deletion)

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -1166,6 +1166,12 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
 
     if scope_kind != "file" and mode != "git-worktree-snapshot":
         for directory in sorted(root.rglob("*"), reverse=True):
+            # Never follow or remove a symlink during the empty-dir cleanup sweep: is_dir() follows
+            # the link (True for a symlink -> dir), so an rmdir here could delete a user-placed
+            # directory symlink (or, on some platforms, act through it) -- the symlink-follow
+            # deletion class from the AGENTS.md hardening lens. Only real dirs we created are pruned.
+            if directory.is_symlink():
+                continue
             if not directory.is_dir():
                 continue
             if directory == _checkpoint_storage_dir(root).parent:

--- a/tests/unit/test_checkpoint_atomic_undo.py
+++ b/tests/unit/test_checkpoint_atomic_undo.py
@@ -30,6 +30,36 @@ def _make_project(root: Path, files: dict[str, str]) -> None:
         target.write_text(content, encoding="utf-8")
 
 
+def test_undo_cleanup_does_not_remove_or_follow_a_directory_symlink(tmp_path: Path) -> None:
+    """Round-7 fresh-eyes: the post-undo empty-dir cleanup sweep must skip symlinks.
+
+    ``root.rglob('*')`` yields a directory symlink, ``is_dir()`` follows it, and ``rmdir()`` would
+    delete the user's symlink (or act through it on some platforms) -- the symlink-follow deletion
+    class. The symlink is created BEFORE the checkpoint so undo's extra-file removal does not touch
+    it and it reaches the cleanup sweep.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    _make_project(root, {"src/alpha.py": "alpha\n"})
+
+    external = tmp_path / "external"
+    (external / "keep").mkdir(parents=True)
+    link = root / "linkdir"
+    try:
+        link.symlink_to(external, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported / not privileged on this platform")
+
+    created = checkpoint_store.create_checkpoint(str(root))
+    (root / "src" / "alpha.py").write_text("alpha-MUTATED\n", encoding="utf-8")  # something to undo
+    checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+
+    assert link.is_symlink(), "the cleanup sweep removed the directory symlink"
+    assert (external / "keep").is_dir(), (
+        "the cleanup sweep acted THROUGH the symlink into its target"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test: corrupt snapshot aborts BEFORE touching any working-tree file
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Round-7 fresh-eyes audit (HIGH, NEW security).** `undo_checkpoint`'s post-undo empty-dir cleanup sweep `rmdir()`s empty dirs found via `root.rglob("*")`. `is_dir()` **follows** a symlink, so a user's directory symlink pointing at an empty target was `rmdir`'d — deleting the symlink (or acting through it) — the AGENTS.md symlink-follow-deletion class (sibling of #30).

Fix: skip symlinks in the sweep before `is_dir()`. Test: symlink created *before* the checkpoint (so it reaches the sweep, not undo's extra-file removal) survives + its target is untouched (guarded for symlink privilege). 19 checkpoint regression green.

Found by the round-7 audit workflow (which then hit the weekly subagent limit — switched to direct main-loop fixes). Verified with `tg` navigation (undo_checkpoint at checkpoint_store.py:1028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)