### PR TITLE
fix: serialize implicit-session removal under index_lock (round-6/7 r3 cross-process RMW race)

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from time import monotonic
 from typing import Any, cast
 
+from tensor_grep.cli._index_lock import IndexLockTimeoutError, index_lock
 from tensor_grep.cli.session_store import (
     _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT,
     _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT,
@@ -26,6 +27,7 @@ from tensor_grep.cli.session_store import (
     _SESSION_VERSION,
     _configured_positive_int,
     _ensure_session_not_stale,
+    _index_path,
     _json_size_bytes,
     _load_index,
     _resolve_request_session_target,
@@ -714,12 +716,20 @@ def _implicit_session_max_repo_files(command: str, request: dict[str, Any]) -> i
 def _remove_implicit_session_payload(path: str, session_id: str) -> None:
     root = _resolve_root(Path(path))
     try:
-        _session_payload_path(root, session_id).unlink(missing_ok=True)
-        records = [record for record in _load_index(root) if record.session_id != session_id]
-        _write_index(root, records)
-    except (OSError, ValueError):
-        # ValueError: a traversal-shaped session_id is refused by _session_payload_path;
-        # treat implicit cleanup as best-effort (fails closed) rather than raising.
+        # Round-6/7 r3: serialize the index read-modify-write under the SAME cross-process lock
+        # open_session / refresh_session use (session_store.py:617/694). Without it, this unlocked
+        # load->filter->write races a concurrent locked insert: this process reads the index, the
+        # other inserts a new session record, this process writes back the filtered set WITHOUT
+        # that record -> a silently lost session entry (orphaned payload, never retention-pruned).
+        with index_lock(_index_path(root)):
+            _session_payload_path(root, session_id).unlink(missing_ok=True)
+            records = [record for record in _load_index(root) if record.session_id != session_id]
+            _write_index(root, records)
+    except (OSError, ValueError, IndexLockTimeoutError):
+        # ValueError: a traversal-shaped session_id is refused by _session_payload_path.
+        # IndexLockTimeoutError: this implicit cleanup is best-effort -- under sustained lock
+        # contention, skip it (retention prunes the record later) rather than crash the eviction
+        # path; we never WROTE, so no insert is lost by skipping.
         pass
 
 

--- a/tests/unit/test_index_lock_concurrency.py
+++ b/tests/unit/test_index_lock_concurrency.py
@@ -190,6 +190,45 @@ def test_concurrent_refresh_session_no_lost_insert(
     assert indexed == set(session_ids)
 
 
+def test_concurrent_open_and_implicit_removal_no_lost_insert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Round-6/7 r3: session_daemon._remove_implicit_session_payload did an UNLOCKED
+    load->filter->write on the SAME index.json that open_session mutates. A concurrent
+    open_session (locked) racing the implicit-session eviction cleanup could lose the open's
+    insert, or the removal could be clobbered. Both must now serialize under index_lock."""
+    from tensor_grep.cli import session_daemon
+
+    root = _make_project(tmp_path)
+    victim = session_store.open_session(str(root)).session_id  # the implicit session to evict
+
+    orig_write_index = session_store._write_index
+
+    def slow_write_index(r: Path, recs: list) -> None:
+        time.sleep(0.05)  # widen the RMW window so the opener holds the lock across the race
+        return orig_write_index(r, recs)
+
+    monkeypatch.setattr(session_store, "_write_index", slow_write_index)
+
+    opened: dict[str, str] = {}
+
+    def opener() -> None:
+        opened["new"] = session_store.open_session(str(root)).session_id
+
+    def remover() -> None:
+        session_daemon._remove_implicit_session_payload(str(root), victim)
+
+    threads = [threading.Thread(target=opener), threading.Thread(target=remover)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    indexed = {rec.session_id for rec in session_store._load_index(root)}
+    assert opened["new"] in indexed  # the concurrent open's insert survived the removal
+    assert victim not in indexed  # and the removal was not clobbered by the open
+
+
 # --------------------------------------------------------------------------------------
 # Non-contended hot path guard (tdd_test_legit A): the lock must not add material overhead
 # on the normal, uncontended path, and must not wrap build_repo_map / the snapshot copy.


### PR DESCRIPTION
**Round-6/7 audit r3 (HIGH).** `session_daemon._remove_implicit_session_payload` did an **unlocked** `_load_index → filter → _write_index` on the same `index.json` that `open_session`/`refresh_session` mutate under `index_lock`. A concurrent locked insert racing the implicit-session eviction could lose the insert (orphaned payload, never retention-pruned — the round-4 disk-growth DoS) or have its own removal clobbered.

Fix: wrap the RMW in `index_lock(_index_path(root))`, mirroring the existing locked writers; swallow `IndexLockTimeoutError` with the other best-effort exceptions (skipping loses no insert — it never writes). 1 concurrency test; 13 index-lock + 34 daemon-security green.

tg-located the fn at `session_daemon.py:714` (audit citation said session_store.py — corrected by `tg defs`). Direct main-loop fix (weekly subagent limit blocks fan-out until Jul 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)