### PR TITLE
fix: confine ruleset_scan.baseline to the policy dir (round-7 arbitrary JSON-file disclosure)

### DIFF
--- a/src/tensor_grep/cli/apply_policy.py
+++ b/src/tensor_grep/cli/apply_policy.py
@@ -146,6 +146,22 @@ def _validate_ruleset_scan(
         baseline_path = Path(baseline)
         if not baseline_path.is_absolute():
             baseline_path = (policy_dir / baseline_path).resolve()
+        else:
+            baseline_path = baseline_path.resolve()
+        # Confine the baseline to the policy directory (round-7 fresh-eyes). Without this, an
+        # absolute path, or a `..`-escaping relative path, bypasses the policy_dir anchor and
+        # _load_json_object below reads an arbitrary JSON file -- a disclosure primitive when the
+        # policy file itself is untrusted (e.g. committed in a cloned repo an agent applies).
+        try:
+            baseline_path.relative_to(policy_dir.resolve())
+        except ValueError:
+            raise _policy_validation_error({
+                "field": "ruleset_scan.baseline",
+                "message": (
+                    "baseline path must be within the policy directory "
+                    f"({policy_dir}): {baseline_path}"
+                ),
+            }) from None
         if not baseline_path.exists():
             raise _policy_validation_error({
                 "field": "ruleset_scan.baseline",

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -430,6 +430,41 @@ def test_load_apply_policy_resolves_relative_baseline_against_policy_file(tmp_pa
     assert policy.ruleset_scan.baseline == str(baseline_path.resolve())
 
 
+def test_load_apply_policy_rejects_baseline_outside_policy_dir(tmp_path: Path) -> None:
+    # Round-7 fresh-eyes: an absolute (or ..-escaping) baseline that leaves the policy directory
+    # must be refused -- otherwise _load_json_object reads an arbitrary JSON file, a disclosure
+    # primitive when the policy file itself is untrusted.
+    from tensor_grep.cli.apply_policy import PolicyValidationError, load_apply_policy
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.json"
+    secret.write_text(json.dumps({"token": "s3cr3t"}), encoding="utf-8")
+
+    policy_root = tmp_path / "repo"
+    policy_root.mkdir()
+    policy_path = _write_policy(
+        policy_root,
+        {
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": None,
+            "ruleset_scan": {
+                "enabled": True,
+                "pack": "auth-safe",
+                "language": "python",
+                "baseline": str(secret),  # absolute path OUTSIDE the policy directory
+            },
+            "on_failure": "warn",
+        },
+    )
+
+    with pytest.raises(PolicyValidationError) as excinfo:
+        load_apply_policy(str(policy_path))
+    messages = " ".join(detail.get("message", "") for detail in excinfo.value.details)
+    assert "within the policy directory" in messages
+
+
 def test_evaluate_apply_policy_reports_success_for_all_null_checks(tmp_path: Path) -> None:
     from tensor_grep.cli.apply_policy import evaluate_apply_policy, load_apply_policy
 


### PR DESCRIPTION
**Round-7 fresh-eyes audit (MED-HIGH).** `apply_policy._validate_ruleset_scan` resolved `ruleset_scan.baseline` under `policy_dir` **only for relative paths** — an absolute (or `..`-escaping) baseline bypassed the anchor, and `_load_json_object` then read it. With an untrusted policy file (committed in a repo an agent applies), that's an arbitrary-JSON-file disclosure primitive.

Fix: resolve + require the baseline to be within `policy_dir` (same shape as the round-3 traversal chokepoints). 1 rejection test; 71 apply-policy tests green.

Direct main-loop fix (round-7 workflow `wymhco4q9` re-verifying the rest concurrently). r5/r6 (MCP stdio DoS + multibyte) deferred: they need one binary-transport refactor of the load-bearing primary MCP reader — real regression risk, not a $0 inline edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)