### PR TITLE
fix: daemon lifecycle monitor must not shut down mid-request (round-7 r8 in-flight drain)

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -72,6 +72,9 @@ _DAEMON_MAX_UPTIME_SECONDS_ENV = "TG_SESSION_DAEMON_MAX_UPTIME_SECONDS"
 _DEFAULT_DAEMON_IDLE_SHUTDOWN_SECONDS = 900.0
 _DEFAULT_DAEMON_MAX_UPTIME_SECONDS = 86400.0
 _DAEMON_LIFECYCLE_POLL_SECONDS = 5.0
+# audit r8: cap the wait for in-flight requests to drain at the hard max-uptime shutdown, so a
+# wedged request cannot postpone the daemon's self-shutdown forever.
+_DAEMON_SHUTDOWN_DRAIN_GRACE_SECONDS = 30.0
 
 
 def _daemon_metadata_path(root: Path) -> Path:
@@ -891,6 +894,9 @@ class _ThreadedSessionDaemon(socketserver.ThreadingMixIn, socketserver.TCPServer
         self.request_count = 0
         # audit I7: track last client activity so an idle daemon can shut itself down.
         self.last_activity_at = monotonic()
+        # audit r8: count in-flight (dispatched, not-yet-completed) requests so the lifecycle
+        # monitor never tears the daemon down mid-request. Guarded by _request_lock.
+        self.inflight_requests = 0
         self._request_lock = threading.Lock()
         self._response_cache_lock = threading.Lock()
         self._implicit_session_lock = threading.Lock()
@@ -947,6 +953,7 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
             server.request_count += 1
         request_session_id = ""
         request_path = str(server.root)
+        inflight_incremented = False
 
         try:
             request = cast(dict[str, Any], json.loads(line))
@@ -961,6 +968,11 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                 self.wfile.flush()
                 return
             server.note_activity()
+            # audit r8: mark this request in-flight (after auth, so unauthorized clients don't
+            # count) so the lifecycle monitor won't shut the daemon down mid-dispatch.
+            with server._request_lock:
+                server.inflight_requests += 1
+            inflight_incremented = True
             session_id = str(request.get("session_id", "")).strip()
             request_path = _resolve_daemon_request_path(
                 server.root,
@@ -1021,6 +1033,7 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                     ),
                     "uptime_seconds": max(0.0, monotonic() - server.started_at),
                     "request_count": server.request_count,
+                    "inflight_requests": server.inflight_requests,
                 }
             elif command == "health":
                 payload, cache_status = _load_payload_with_status_retry(
@@ -1113,6 +1126,10 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                 "session_id": request_session_id,
                 "error": {"code": "invalid_request", "message": str(exc)},
             }
+        finally:
+            if inflight_incremented:
+                with server._request_lock:
+                    server.inflight_requests -= 1
 
         self.wfile.write((json.dumps(response) + "\n").encode("utf-8"))
         self.wfile.flush()
@@ -1134,10 +1151,24 @@ def _run_daemon_lifecycle_monitor(
         now = monotonic()
         with server._request_lock:
             idle_for = now - server.last_activity_at
+            inflight = server.inflight_requests
         uptime = now - server.started_at
-        if (idle_limit > 0 and idle_for >= idle_limit) or (max_uptime > 0 and uptime >= max_uptime):
-            threading.Thread(target=server.shutdown, daemon=True).start()
-            return
+        idle_reached = idle_limit > 0 and idle_for >= idle_limit
+        uptime_reached = max_uptime > 0 and uptime >= max_uptime
+        if not (idle_reached or uptime_reached):
+            continue
+        # audit r8: never tear the daemon down while a request is in flight -- that resets the
+        # client mid-dispatch. Wait for in-flight work to drain. Bound the wait ONLY for the hard
+        # max-uptime cap (a wedged request must not postpone shutdown forever); the idle path has
+        # no such hard deadline, so it simply waits until inflight == 0.
+        if inflight > 0:
+            past_hard_drain = (
+                max_uptime > 0 and uptime >= max_uptime + _DAEMON_SHUTDOWN_DRAIN_GRACE_SECONDS
+            )
+            if not past_hard_drain:
+                continue
+        threading.Thread(target=server.shutdown, daemon=True).start()
+        return
 
 
 def run_session_daemon_server(path: str = ".") -> None:

--- a/tests/unit/test_session_daemon_security.py
+++ b/tests/unit/test_session_daemon_security.py
@@ -429,6 +429,50 @@ def test_lifecycle_monitor_shuts_down_on_max_uptime(tmp_path: Path, monkeypatch)
         server.server_close()
 
 
+def test_lifecycle_monitor_defers_shutdown_while_request_in_flight(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # audit r8: a request in flight must block the idle/uptime self-shutdown (no mid-request reset)
+    # until it drains. max-uptime is already exceeded here, so only inflight gates the shutdown.
+    monkeypatch.setattr(session_daemon, "_DAEMON_LIFECYCLE_POLL_SECONDS", 0.01)
+    monkeypatch.setenv(session_daemon._DAEMON_MAX_UPTIME_SECONDS_ENV, "0.05")
+    monkeypatch.setenv(session_daemon._DAEMON_IDLE_SHUTDOWN_SECONDS_ENV, "0")
+
+    server = session_daemon._ThreadedSessionDaemon(
+        tmp_path.resolve(), ("127.0.0.1", 0), token="tok"
+    )
+    serve_thread = _serve(server)
+    stop_event = threading.Event()
+    monitor = threading.Thread(
+        target=session_daemon._run_daemon_lifecycle_monitor,
+        args=(server, stop_event),
+        daemon=True,
+    )
+    try:
+        with server._request_lock:
+            server.inflight_requests = 1  # a request is mid-dispatch
+        server.started_at -= (
+            10.0  # max-uptime already exceeded (but well under the 30s drain grace)
+        )
+        monitor.start()
+        # Uptime is past the cap, but a request is in flight and we are inside the drain grace:
+        # the daemon must NOT tear itself down.
+        serve_thread.join(timeout=0.3)
+        assert serve_thread.is_alive(), "daemon shut down mid-request despite inflight_requests > 0"
+        # Drain the in-flight request -> the monitor may now self-shutdown.
+        with server._request_lock:
+            server.inflight_requests = 0
+        serve_thread.join(timeout=3)
+        assert not serve_thread.is_alive(), (
+            "daemon should self-shutdown once in-flight work drained"
+        )
+    finally:
+        stop_event.set()
+        server.shutdown()
+        serve_thread.join(timeout=2)
+        server.server_close()
+
+
 def test_lifecycle_monitor_returns_when_both_limits_disabled(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv(session_daemon._DAEMON_MAX_UPTIME_SECONDS_ENV, "0")
     monkeypatch.setenv(session_daemon._DAEMON_IDLE_SHUTDOWN_SECONDS_ENV, "0")


### PR DESCRIPTION
**Round-7 audit r8 (HIGH).** The session daemon called `server.shutdown()` (which doesn't join dispatched threads) the moment it went idle or hit max-uptime, with **no in-flight check** — a request whose handling exceeds the idle window, or any request straddling the hard max-uptime, got torn down and the client saw a reset.

Fix: an `inflight_requests` counter (incr after auth+note_activity, decr in `finally`). The monitor won't shut down while `inflight>0`; the hard uptime cap waits up to a 30s drain grace so a wedged request can't postpone shutdown forever. Also fills the `inflight_requests` stats key the contract already reserved. 1 lifecycle test; 27 daemon-security green.

Round-7 workflow-vetted fix (22/22 agents, adversarially verified). tg-navigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)