### PR TITLE
feat: thread semantic_provider through all 7 daemon-served symbol commands (moat P0-4)

### DIFF
--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -1157,11 +1157,16 @@ def _serve_session_request_from_payload(
         response["routing_reason"] = "session-context-edit-plan"
         return response
 
+    # moat P0-4: thread the requested engine through EVERY daemon-served symbol command. Without
+    # this, all 7 branches dropped semantic_provider and silently pinned refs/callers/impact/
+    # blast-radius to native even when the client asked for lsp/hybrid. repo_map normalizes +
+    # fails closed to native for an unknown value, so no re-validation here.
+    provider = str(request.get("provider", "native"))
     if command == "defs":
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("defs requests require a non-empty symbol")
-        response = build_symbol_defs_from_map(repo_map, symbol)
+        response = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=provider)
         response["session_id"] = session_id
         response["routing_reason"] = "session-defs"
         return response
@@ -1170,7 +1175,7 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("impact requests require a non-empty symbol")
-        response = build_symbol_impact_from_map(repo_map, symbol)
+        response = build_symbol_impact_from_map(repo_map, symbol, semantic_provider=provider)
         response["session_id"] = session_id
         response["routing_reason"] = "session-impact"
         return response
@@ -1179,7 +1184,7 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("refs requests require a non-empty symbol")
-        response = build_symbol_refs_from_map(repo_map, symbol)
+        response = build_symbol_refs_from_map(repo_map, symbol, semantic_provider=provider)
         response["session_id"] = session_id
         response["routing_reason"] = "session-refs"
         return response
@@ -1188,7 +1193,7 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("callers requests require a non-empty symbol")
-        response = build_symbol_callers_from_map(repo_map, symbol)
+        response = build_symbol_callers_from_map(repo_map, symbol, semantic_provider=provider)
         response["session_id"] = session_id
         response["routing_reason"] = "session-callers"
         return response
@@ -1201,6 +1206,7 @@ def _serve_session_request_from_payload(
             repo_map,
             symbol,
             max_depth=int(request.get("max_depth", 3)),
+            semantic_provider=provider,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-blast-radius"
@@ -1225,6 +1231,7 @@ def _serve_session_request_from_payload(
             optimize_context=bool(request.get("optimize_context", False)),
             render_profile=str(request.get("render_profile", "full")),
             profile=bool(request.get("profile", False)),
+            semantic_provider=provider,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-blast-radius-render"
@@ -1240,6 +1247,7 @@ def _serve_session_request_from_payload(
             max_depth=int(request.get("max_depth", 3)),
             max_files=int(request.get("max_files", 3)),
             max_symbols=int(request.get("max_symbols", 5)),
+            semantic_provider=provider,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-blast-radius-plan"

--- a/tests/unit/test_session_serve.py
+++ b/tests/unit/test_session_serve.py
@@ -526,3 +526,40 @@ def test_daemon_request_separates_connect_and_response_timeouts(monkeypatch) -> 
     assert seen_timeouts[0] == session_daemon_module._DAEMON_CONNECT_TIMEOUT_SECONDS
     assert seen_timeouts[1] == session_daemon_module._DAEMON_RESPONSE_TIMEOUT_SECONDS
     assert seen_timeouts[1] > seen_timeouts[0]
+
+
+def test_daemon_served_symbol_commands_thread_requested_provider(monkeypatch) -> None:
+    """Moat P0-4: every daemon-served symbol command must forward the requested engine.
+
+    Before the fix, all 7 branches called build_symbol_*_from_map with NO semantic_provider kwarg,
+    silently pinning daemon-routed refs/callers/impact/blast-radius to native even when the client
+    asked for lsp/hybrid. The builders are monkeypatched via the name AS IMPORTED INTO session_store.
+    """
+    monkeypatch.setattr(session_store, "_ensure_session_not_stale", lambda *a, **k: None)
+
+    recorded: dict[str, str] = {}
+
+    def _spy(_repo_map, _symbol, *, semantic_provider="native", **_kwargs):
+        recorded["provider"] = semantic_provider
+        return {"symbol": _symbol}
+
+    cases = [
+        ("defs", "build_symbol_defs_from_map"),
+        ("impact", "build_symbol_impact_from_map"),
+        ("refs", "build_symbol_refs_from_map"),
+        ("callers", "build_symbol_callers_from_map"),
+        ("blast_radius", "build_symbol_blast_radius_from_map"),
+        ("blast_radius_render", "build_symbol_blast_radius_render_from_map"),
+        ("blast_radius_plan", "build_symbol_blast_radius_plan_from_map"),
+    ]
+    for command, builder_name in cases:
+        recorded.clear()
+        monkeypatch.setattr(session_store, builder_name, _spy)
+        session_store._serve_session_request_from_payload(
+            "sid",
+            {"command": command, "symbol": "foo", "provider": "lsp"},
+            {"repo_map": {}},
+        )
+        assert recorded.get("provider") == "lsp", (
+            f"{command} dropped semantic_provider (forced native)"
+        )


### PR DESCRIPTION
**Moat P0-4 (the #1 graph-latency ask, round-7-vetted).** All 7 symbol branches in `_serve_session_request_from_payload` called `build_symbol_*_from_map` with **no** `semantic_provider=` kwarg — so every daemon-routed graph command was silently pinned to native even when the client asked for lsp/hybrid. That's a correctness bug *and* the blocker for routing the slow graph family through the warm daemon.

Fix: compute `provider` once, thread it into all 7 builders (repo_map already fails closed to native for unknowns). Verified all 7 builders accept the kwarg before threading. 1 parametrized test (each command forwards `provider='lsp'`); 16 session-serve tests green.

**Next: P0-3** — invert the main.py daemon-route guard so the graph commands actually reach the warm daemon, with `routing_reason` payload-parity normalization. Then the persisted graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)