### PR TITLE
fix: checkpoint undo commit-phase revert must restore removed files (round-7 rank-6 data loss)

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -1113,7 +1113,10 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
         # here we attempt a best-effort revert of already-committed changes.
 
         removed_paths = 0
-        committed_removes: list[Path] = []
+        # round-7 rank-6: store (path, prior_bytes) -- NOT just the path -- so a commit-phase
+        # failure can recreate a file it already unlinked. Previously the revert had only the path
+        # and permanently lost the content.
+        committed_removes: list[tuple[Path, bytes]] = []
         committed_overwrites: list[tuple[Path, bytes]] = []
 
         try:
@@ -1121,8 +1124,13 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
             for rel_path in sorted(set(current_entries) - expected_paths, reverse=True):
                 current_path = root / Path(rel_path)
                 if current_path.exists():
+                    try:
+                        removed_bytes: bytes | None = current_path.read_bytes()
+                    except OSError:
+                        removed_bytes = None
                     current_path.unlink()
-                    committed_removes.append(current_path)
+                    if removed_bytes is not None:
+                        committed_removes.append((current_path, removed_bytes))
                     removed_paths += 1
 
             # Remove files that the snapshot records as deleted.
@@ -1130,8 +1138,13 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
                 if not exists:
                     target = resolved_targets[rel_path]
                     if target.exists():
+                        try:
+                            removed_bytes = target.read_bytes()
+                        except OSError:
+                            removed_bytes = None
                         target.unlink()
-                        committed_removes.append(target)
+                        if removed_bytes is not None:
+                            committed_removes.append((target, removed_bytes))
                         removed_paths += 1
 
             # Swap staged copies into the working tree.
@@ -1156,9 +1169,14 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
                     path_to_restore.write_bytes(prior_bytes)
                 except OSError:
                     pass
-            for _removed_path in committed_removes:
-                # We cannot recreate removed files without their snapshot; skip.
-                pass
+            for removed_path, removed_bytes in reversed(committed_removes):
+                # round-7 rank-6: recreate files unlinked earlier in THIS commit phase from the
+                # bytes snapshotted before their unlink, so a partial commit does not lose data.
+                try:
+                    removed_path.parent.mkdir(parents=True, exist_ok=True)
+                    removed_path.write_bytes(removed_bytes)
+                except OSError:
+                    pass
             raise
 
     finally:

--- a/tests/unit/test_checkpoint_atomic_undo.py
+++ b/tests/unit/test_checkpoint_atomic_undo.py
@@ -60,6 +60,39 @@ def test_undo_cleanup_does_not_remove_or_follow_a_directory_symlink(tmp_path: Pa
     )
 
 
+def test_undo_commit_failure_restores_a_removed_file(tmp_path: Path, monkeypatch) -> None:
+    """Round-7 rank-6: if the commit phase raises AFTER unlinking an extra file, the best-effort
+    revert must recreate that file from the bytes snapshotted before unlink -- not lose it.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    _make_project(root, {"src/a.py": "a-original\n"})
+    created = checkpoint_store.create_checkpoint(str(root))
+
+    (root / "src" / "a.py").write_text("a-MODIFIED\n", encoding="utf-8")  # staged + copied on undo
+    extra = root / "src" / "extra.py"
+    extra.write_text("extra-content\n", encoding="utf-8")  # not in snapshot -> removed during undo
+    assert extra.exists()
+
+    original_copy2 = checkpoint_store.shutil.copy2
+    resolved_root = root.resolve()
+
+    def _boom_copy2(src, dst, *args, **kwargs):
+        # Fail ONLY the commit-phase swap (dst under the repo root); let staging copies proceed.
+        dst_resolved = Path(dst).resolve()
+        if dst_resolved == resolved_root or resolved_root in dst_resolved.parents:
+            raise OSError("simulated commit-phase failure")
+        return original_copy2(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(checkpoint_store.shutil, "copy2", _boom_copy2)
+
+    with pytest.raises(Exception):  # noqa: B017 - the commit failure is re-raised by design
+        checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+
+    assert extra.exists(), "commit-phase revert permanently lost the removed file"
+    assert extra.read_text(encoding="utf-8") == "extra-content\n"
+
+
 # ---------------------------------------------------------------------------
 # Test: corrupt snapshot aborts BEFORE touching any working-tree file
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Round-7 fresh-eyes (MEDIUM data-loss).** In `undo_checkpoint`'s commit phase, unlinked files recorded only their **path**; if a later `copy2()` raised (Windows delete-pending/lock race), the revert restored overwrites but the removed-files loop was literally `pass` — **permanently losing** those files while calling itself a safe best-effort revert.

Fix: snapshot each file's bytes *before* unlink (`committed_removes` is now `list[tuple[Path, bytes]]`); the revert recreates them. 1 test simulates a commit-phase failure (scoped to the repo root so staging still works) and asserts the removed file is restored; 7 atomic-undo tests green.

Round-7-vetted. tg-navigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)