### PR TITLE
fix: refresh the --symbol deprecation warning (shorthand + drop stale 1.14.0 text) — dogfood 1.28.3

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7640,10 +7640,10 @@ def _resolve_path_and_symbol(
     if symbol_option is not None:
         typer.echo(
             "Warning: --symbol is deprecated for "
-            f"tg {command_name}; use a path-first positional form instead "
-            f"(for example: tg {command_name} <PATH> <SYMBOL>). "
-            "The --symbol form remains accepted during the 1.13.x deprecation cycle "
-            "and will not be removed before 1.14.0.",
+            f"tg {command_name}; pass SYMBOL as a positional instead "
+            f"(shorthand `tg {command_name} <SYMBOL>` with PATH defaulting to '.', or "
+            f"`tg {command_name} <PATH> <SYMBOL>` to scope a large repo). "
+            "The --symbol form remains accepted for backward compatibility.",
             err=True,
         )
         return path, symbol_option

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -3457,7 +3457,11 @@ def test_symbol_commands_warn_for_legacy_symbol_option(tmp_path):
             + result.output
         )
         assert f"Warning: --symbol is deprecated for tg {command}" in result.stderr
-        assert f"for example: tg {command} <PATH> <SYMBOL>" in result.stderr
+        # 1.28 dogfood: the warning documents BOTH the shorthand (PATH defaults to '.') and the
+        # path-first form, and no longer carries the stale 1.13.x/1.14.0 deprecation-cycle text.
+        assert f"`tg {command} <SYMBOL>`" in result.stderr
+        assert f"`tg {command} <PATH> <SYMBOL>`" in result.stderr
+        assert "1.14.0" not in result.stderr
         payload = json.loads(result.stdout)
         assert payload["routing_reason"] == routing_reason
         assert payload["symbol"] == "create_invoice"


### PR DESCRIPTION
**Dogfood 1.28.3 (deprecation message drift).** The runtime `--symbol` warning told users to "use a path-first positional form" and still referenced the "1.13.x deprecation cycle … not removed before 1.14.0" — both stale on 1.28.x, where single-arg shorthand (`tg <cmd> SYMBOL`, PATH defaults to '.') now works.

Now documents both forms (shorthand + path-first for large repos) and drops the stale version text. Contract assertion updated to pin the new guidance + assert 1.14.0 is gone. Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)