### PR TITLE
fix: restrict daemon.json token file with a Windows ACL (round-7 r7)

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -117,7 +117,39 @@ def _write_daemon_metadata(root: Path, payload: dict[str, Any]) -> None:
     from tensor_grep.cli.session_store import _write_json_atomic
 
     # audit S3: daemon.json carries the IPC token; write it 0600 so the secret is not exposed.
-    _write_json_atomic(_daemon_metadata_path(root), payload, mode=_DAEMON_METADATA_MODE)
+    metadata_path = _daemon_metadata_path(root)
+    _write_json_atomic(metadata_path, payload, mode=_DAEMON_METADATA_MODE)
+    _restrict_windows_file_to_current_user(metadata_path)
+
+
+def _restrict_windows_file_to_current_user(path: Path) -> None:
+    """Best-effort Windows ACL lockdown of the daemon token file (round-7 r7).
+
+    On POSIX the 0600 mode from _write_json_atomic isolates the token. On Windows os.chmod only
+    toggles the read-only DOS bit -- it grants NO per-user access control, so any local account that
+    can reach the session root could read the IPC token. Remove inherited ACLs and grant only the
+    current user. The HMAC compare_digest gate remains the ENFORCED control; this is defense in
+    depth and fails OPEN (a failed icacls must never break daemon startup).
+    """
+    if sys.platform != "win32":
+        return
+    import getpass
+
+    try:
+        user = os.environ.get("USERNAME") or getpass.getuser()
+    except Exception:
+        return
+    if not user:
+        return
+    try:
+        subprocess.run(
+            ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:F"],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
 
 
 def _daemon_token(metadata: dict[str, Any] | None) -> str:

--- a/tests/unit/test_session_daemon_security.py
+++ b/tests/unit/test_session_daemon_security.py
@@ -150,6 +150,40 @@ def test_daemon_handler_sets_socket_timeout() -> None:
     assert timeout is not None and timeout > 0
 
 
+def test_write_daemon_metadata_locks_down_token_file_on_windows(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # round-7 r7: on Windows, 0600 is a no-op ACL, so the token file must be restricted via icacls.
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(list(argv))
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(session_daemon.subprocess, "run", _fake_run)
+    monkeypatch.setattr(session_daemon.sys, "platform", "win32")
+    monkeypatch.setenv("USERNAME", "testuser")
+
+    session_daemon._write_daemon_metadata(tmp_path.resolve(), {"token": "sekret", "version": 1})
+
+    icacls_calls = [argv for argv in calls if argv and argv[0] == "icacls"]
+    assert icacls_calls, "daemon.json write did not lock down ACLs on Windows"
+    argv = icacls_calls[0]
+    assert "/inheritance:r" in argv and "/grant:r" in argv and "testuser:F" in argv
+
+
+def test_restrict_windows_file_is_noop_off_windows(tmp_path: Path, monkeypatch) -> None:
+    called: list[object] = []
+    monkeypatch.setattr(session_daemon.subprocess, "run", lambda *a, **k: called.append(a))
+    monkeypatch.setattr(session_daemon.sys, "platform", "linux")
+    session_daemon._restrict_windows_file_to_current_user(tmp_path / "daemon.json")
+    assert called == []  # no subprocess spawned on non-Windows
+
+
 # ---------------------------------------------------------------- S3: path confinement
 
 


### PR DESCRIPTION
**Round-7 r7 (HIGH, HMAC-mitigated).** `daemon.json` carries the IPC HMAC token and is written 0600, but on Windows `os.chmod` only toggles the read-only DOS bit — no per-user isolation — so any local account reaching the session root could read the token.

Fix: after the atomic write, best-effort `icacls /inheritance:r /grant:r <user>:F` on win32. Fails **open** (never breaks daemon startup); HMAC remains the enforced control — defense in depth. 2 tests + **dogfooded on a real Windows box** (daemon.json ACL reduced to `<user>:(F)` only); 28 daemon-security green.

Round-7 fix-queue item. Meanwhile the round-8 workflow (w5uobzwvk) is designing P0-6 (--deadline + partial results — the top dogfood ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)