### PR TITLE
feat: build_repo_map deadline -> partial results (moat P0-6 step 1)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4452,6 +4452,7 @@ def build_repo_map(
     *,
     max_repo_files: int | None = None,
     extra_files: list[Path] | None = None,
+    deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     root = Path(path).expanduser().resolve()
@@ -4491,7 +4492,17 @@ def build_repo_map(
 
         imports: list[dict[str, Any]] = []
         symbols: list[dict[str, Any]] = []
+        # moat P0-6: a supplied ABSOLUTE monotonic deadline stops the CPU-bound per-file parse loop
+        # early and returns partial results (partial:true + deadline_limit) instead of running
+        # unbounded, so a huge repo degrades gracefully instead of the caller's hard timeout
+        # discarding all work. The file LIST above is already walked cheaply; only symbol/import
+        # PARSING is bounded here. Break + keep what we have -- never raise, never zero the results.
+        deadline_hit = False
+        files_scanned = 0
         for current in context_files:
+            if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+                deadline_hit = True
+                break
             if _profiling_collector is None:
                 current_imports, current_symbols = _imports_and_symbols_for_path(current)
             else:
@@ -4506,6 +4517,7 @@ def build_repo_map(
                     "provenance": _symbol_navigation_provenance_for_path(str(current)),
                 })
             symbols.extend(current_symbols)
+            files_scanned += 1
 
         payload["files"] = source_files
         payload["symbols"] = symbols
@@ -4532,6 +4544,18 @@ def build_repo_map(
                 "truncation_cause": _cause if _capped else None,
             }
             payload["scan_remediation"] = _SCAN_LIMIT_TRUNCATED_REMEDIATION if _truncated else None
+        # moat P0-6: signal a deadline-truncated parse as a top-level `partial` flag (the one field
+        # an agent's parser checks) plus a `deadline_limit` sibling. Kept SEPARATE from scan_limit
+        # on purpose: scan_limit means "the FILE LIST was capped by max_repo_files" (remedy: raise
+        # --max-repo-files), a deadline means "PARSING ran out of time" (remedy: raise --deadline /
+        # scope the query) -- conflating the two causes gives wrong-knob advice.
+        if deadline_hit:
+            payload["partial"] = True
+            payload["deadline_limit"] = {
+                "deadline_exceeded": True,
+                "files_scanned": files_scanned,
+                "files_total": len(context_files),
+            }
     return _attach_profiling(payload, _profiling_collector)
 
 

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -18,7 +18,9 @@ def _make_repo(root: Path, count: int) -> None:
     src = root / "src"
     src.mkdir(parents=True)
     for index in range(count):
-        (src / f"m{index}.py").write_text(f"def f{index}():\n    return {index}\n", encoding="utf-8")
+        (src / f"m{index}.py").write_text(
+            f"def f{index}():\n    return {index}\n", encoding="utf-8"
+        )
 
 
 def test_deadline_already_expired_returns_partial_immediately(tmp_path: Path) -> None:

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -1,0 +1,63 @@
+"""Moat P0-6 STEP 1: build_repo_map deadline -> partial results on a time budget.
+
+A supplied ABSOLUTE monotonic deadline stops the CPU-bound per-file parse loop early and returns
+partial:true + a deadline_limit sibling, instead of the caller's hard timeout discarding all work
+(the recurring dogfood complaint: '60s cap errors with bare timed-out, exit 1, zero JSON'). The
+signal is kept SEPARATE from scan_limit (file-cap cause) so the remediation advice is the right knob.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import tensor_grep.cli.repo_map as repo_map
+
+
+def _make_repo(root: Path, count: int) -> None:
+    src = root / "src"
+    src.mkdir(parents=True)
+    for index in range(count):
+        (src / f"m{index}.py").write_text(f"def f{index}():\n    return {index}\n", encoding="utf-8")
+
+
+def test_deadline_already_expired_returns_partial_immediately(tmp_path: Path) -> None:
+    _make_repo(tmp_path, 6)
+    # An already-expired deadline must return a valid partial dict (no exception, no hang).
+    result = repo_map.build_repo_map(str(tmp_path), deadline_monotonic=time.monotonic() - 1.0)
+    assert isinstance(result, dict)
+    assert result.get("partial") is True
+    assert result["deadline_limit"]["deadline_exceeded"] is True
+    assert result["deadline_limit"]["files_scanned"] == 0  # broke before any parse
+
+
+def test_deadline_mid_scan_keeps_partial_results(tmp_path: Path, monkeypatch) -> None:
+    _make_repo(tmp_path, 10)
+    # Deterministic fake clock: monotonic only advances when a file is parsed, so the deadline
+    # crosses after exactly 5 parses regardless of any other monotonic() callers.
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_parse = repo_map._imports_and_symbols_for_path
+
+    def _clock_advancing_parse(path, **kwargs):
+        clock["t"] += 1.0
+        return original_parse(path, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_imports_and_symbols_for_path", _clock_advancing_parse)
+
+    result = repo_map.build_repo_map(str(tmp_path), deadline_monotonic=base + 5.0)
+
+    assert result.get("partial") is True
+    deadline_limit = result["deadline_limit"]
+    assert deadline_limit["deadline_exceeded"] is True
+    assert 0 < deadline_limit["files_scanned"] < deadline_limit["files_total"]  # some but not all
+    assert result["symbols"], "partial work must be RETAINED, not zeroed"
+
+
+def test_deadline_none_is_no_op(tmp_path: Path) -> None:
+    _make_repo(tmp_path, 6)
+    result = repo_map.build_repo_map(str(tmp_path))  # no deadline -> unchanged behavior
+    assert "partial" not in result
+    assert "deadline_limit" not in result
+    assert result["symbols"]  # full parse, nothing bounded


### PR DESCRIPTION
**Moat P0-6 step 1** (round-8-designed, both dogfooders' #1 ask). Today a huge-repo graph query hits the caller's hard 60s timeout and returns a bare error with **zero JSON — all work discarded**. Step 1 adds the core mechanism: `build_repo_map` takes an absolute `deadline_monotonic` and breaks the per-file parse loop early when it passes, **keeping** the symbols/imports gathered so far and returning normally (never raises).

Signal shape (chairman-decided): top-level `partial:true` + a `deadline_limit` sibling `{deadline_exceeded, files_scanned, files_total}`, kept **separate** from `scan_limit` (deadline cause vs file-cap cause → right remediation knob). `None` = pure no-op (parity).

3 TDD tests; ruff/mypy clean. First of the P0-6 chain: step 2 (propagate to symbol builders) · 3 (`deadline_seconds` threading) · 4 (CLI `--deadline`) · **5 (daemon client-timeout = the actual 60s-error fix)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)