### PR TITLE
fix: exclude config/data files from orient centrality (round-8 audit — orient ranks non-code as central)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -19,6 +19,24 @@ _CHARS_PER_TOKEN = 3.5
 # "central CODE file", and in doc-heavy repos (many cross-linked CLAUDE.md / README) it would
 # otherwise dominate the graph and bury the real architecture.
 _CENTRAL_DOC_SUFFIXES = frozenset({".md", ".markdown", ".rst", ".adoc", ".txt"})
+# Config/data suffixes also excluded (round-8 audit): a package.json / *.yaml / *.toml / *.lock has
+# no import edges and no symbols, so in a config- or doc-heavy "harness" repo it would surface as a
+# spurious "central" file over the real code (the recurring dogfood complaint that orient ranks
+# non-code as central). build_repo_map's fallback-source set includes these, so they reach here.
+_CENTRAL_CONFIG_DATA_SUFFIXES = frozenset({
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".xml",
+    ".csv",
+    ".lock",
+    ".env",
+})
+# The full non-code exclusion applied to the centrality ranking (docs + config/data).
+_CENTRAL_NON_CODE_SUFFIXES = _CENTRAL_DOC_SUFFIXES | _CENTRAL_CONFIG_DATA_SUFFIXES
 
 # Composite-centrality tuning (see _central_files_from_map): cap in-degree so a widely-imported data
 # sink can't dominate, and bound symbol density so one giant file can't either.
@@ -57,7 +75,7 @@ def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> li
     # import via a stem collision (config.md shadowing config.py in by_stem). Exclude docs from the
     # graph entirely; fall back to all files only if the repo is pure docs so we still return context.
     code_files = [
-        f for f in all_files if Path(f).suffix.lower() not in _CENTRAL_DOC_SUFFIXES
+        f for f in all_files if Path(f).suffix.lower() not in _CENTRAL_NON_CODE_SUFFIXES
     ] or all_files
     code_file_set = set(code_files)
     imports_by_file: dict[str, list[str]] = {

--- a/tests/unit/test_orient_central_excludes_docs.py
+++ b/tests/unit/test_orient_central_excludes_docs.py
@@ -27,6 +27,38 @@ def test_docs_are_never_central_and_code_wins_stem_collision() -> None:
     assert cfg["graph_score"] == 3.0
 
 
+def test_config_and_data_files_are_never_central() -> None:
+    # round-8 audit: config/data files (package.json, *.yaml, *.toml, *.lock) have no import edges
+    # and no symbols, yet in a config-heavy "harness" repo could surface as spurious "central" files
+    # over the real code -- the recurring dogfood complaint that orient ranks non-code as central.
+    rm = {
+        "files": [
+            "package.json",
+            "config.yaml",
+            "Cargo.toml",
+            "deps.lock",
+            "src/hub.py",
+            "src/a.py",
+        ],
+        "imports": [{"file": "src/a.py", "imports": ["hub"]}],
+        "symbols": [{"name": "Hub", "kind": "class", "file": "src/hub.py"}],
+    }
+    central = _central_files_from_map(rm, max_central_files=10)
+    files = [c["file"] for c in central]
+    assert not any(
+        f.endswith((".json", ".yaml", ".yml", ".toml", ".lock", ".ini", ".cfg", ".xml", ".csv"))
+        for f in files
+    )
+    assert "src/hub.py" in files  # real code still ranks as central
+
+
+def test_pure_config_repo_falls_back_not_empty() -> None:
+    # A repo that is ONLY config/data must still return orientation context (fallback), not empty.
+    rm = {"files": ["package.json", "config.yaml"], "imports": [], "symbols": []}
+    central = _central_files_from_map(rm, max_central_files=10)
+    assert len(central) >= 1
+
+
 def test_central_files_expose_score_alias() -> None:
     # dogfood v1.20.0: agents thresholding on a generic `score` key found it null. `score` is a
     # populated alias of `graph_score` so both work.


### PR DESCRIPTION
**Round-8 fresh-eyes audit (MEDIUM-HIGH).** orient's centrality ranking excluded only doc suffixes, but `build_repo_map`'s fallback-source set also admits config/data (json/yaml/toml/lock/…). Those have no imports and no symbols, yet in a config/doc-heavy "harness" repo they surface as spurious "central" files over real code — the recurring dogfood complaint that **orient ranks non-code as central**.

Fix: exclude docs **+** config/data from the centrality candidate set; pure-config repos still fall back (never empty). 2 tests; 11 orient tests green.

Safe relocate (checkout -b, no stash — per the lesson banked this session). Independent of the P0-6 moat chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)