### PR TITLE
fix: don't misclassify UTF-16/32 text as binary (round-8 audit)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -835,6 +835,12 @@ def _looks_like_binary_file(path: Path) -> bool:
             data = handle.read(8192)
     except OSError:
         return False
+    # A UTF-16/UTF-32 BOM means TEXT whose encoding legitimately contains NUL bytes (round-8 audit):
+    # UTF-16 interleaves a NUL after every ASCII char, so the NUL heuristic below would otherwise
+    # misclassify all UTF-16/32 text as binary and make it invisible to every tg command (a real
+    # Windows-relevant loss -- PowerShell/redirected output, some editors default to UTF-16).
+    if data[:2] in (b"\xff\xfe", b"\xfe\xff") or data.startswith(b"\x00\x00\xfe\xff"):
+        return False
     return b"\0" in data
 
 

--- a/tests/unit/test_repo_map_binary_detection.py
+++ b/tests/unit/test_repo_map_binary_detection.py
@@ -1,0 +1,37 @@
+"""Round-8 audit: _looks_like_binary_file must not misclassify UTF-16/32 text as binary.
+
+UTF-16 interleaves a NUL byte after every ASCII char, so the naive `b"\\0" in data` heuristic marked
+every UTF-16 text file binary -> invisible to every tg command (Windows-relevant: PowerShell /
+redirected output and some editors default to UTF-16). A leading UTF-16/32 BOM means text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.repo_map import _looks_like_binary_file
+
+
+def test_utf16_le_text_is_not_binary(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    path.write_text("hello world\nsecond line\n", encoding="utf-16")  # BOM + interleaved NULs
+    assert _looks_like_binary_file(path) is False
+
+
+def test_utf16_be_text_is_not_binary(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    # UTF-16-BE BOM (0xFE 0xFF) prefixed explicitly, then BE-encoded text.
+    path.write_bytes(b"\xfe\xff" + "hello world".encode("utf-16-be"))
+    assert _looks_like_binary_file(path) is False
+
+
+def test_real_binary_still_detected(tmp_path: Path) -> None:
+    path = tmp_path / "blob.bin"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")  # NUL, no text BOM
+    assert _looks_like_binary_file(path) is True
+
+
+def test_utf8_text_is_not_binary(tmp_path: Path) -> None:
+    path = tmp_path / "code.py"
+    path.write_text("def f():\n    return 1\n", encoding="utf-8")
+    assert _looks_like_binary_file(path) is False


### PR DESCRIPTION
**Round-8 fresh-eyes audit.** `_looks_like_binary_file` returned `b"\0" in data`. UTF-16 interleaves a NUL after every ASCII char, so **every UTF-16/32 text file was flagged binary and dropped from the walk** — invisible to every tg command. Windows-relevant (PowerShell/redirected output, UTF-16-default editors).

Fix: a leading UTF-16/UTF-32 BOM means text → return False before the NUL heuristic. 4 tests; ruff/mypy clean.

Round-8 audit finding; safe relocate (no stash). Sibling findings queued as a task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)