### PR TITLE
feat: propagate the deadline partial signal through symbol builders (moat P0-6 step 2)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -456,6 +456,20 @@ def _copy_scan_limit(payload: dict[str, Any], source: dict[str, Any]) -> None:
             payload["scan_remediation"] = source["scan_remediation"]
 
 
+def _copy_partial_signal(payload: dict[str, Any], source: dict[str, Any]) -> None:
+    """Moat P0-6 step 2: carry the deadline PARTIAL signal forward when a symbol builder repackages a
+    build_repo_map / build_symbol_defs result into its own payload. Without this, a deadline-truncated
+    map silently loses partial:true + deadline_limit the moment it is wrapped, so the agent sees a
+    small result with no signal it was cut short. Only propagates when the source was actually
+    partial (a complete result carries neither key -- parity). Kept separate from _copy_scan_limit:
+    scan_limit is the file-cap fact, partial is the time-budget outcome."""
+    if source.get("partial"):
+        payload["partial"] = True
+        deadline_limit = source.get("deadline_limit")
+        if isinstance(deadline_limit, dict):
+            payload["deadline_limit"] = dict(deadline_limit)
+
+
 def _is_test_file(path: Path) -> bool:
     name = path.name
     return (
@@ -11531,6 +11545,7 @@ def build_symbol_source_from_map(
     payload["provider_status"] = dict(defs_payload.get("provider_status", default_status))
     _copy_lsp_evidence_status(payload, defs_payload)
     _copy_scan_limit(payload, defs_payload)
+    _copy_partial_signal(payload, defs_payload)
     return _attach_profiling(payload, _profiling_collector)
 
 
@@ -11733,6 +11748,7 @@ def build_symbol_impact_from_map(
     payload["provider_status"] = dict(defs_payload.get("provider_status", default_status))
     _copy_lsp_evidence_status(payload, defs_payload)
     _copy_scan_limit(payload, defs_payload)
+    _copy_partial_signal(payload, defs_payload)
     return _attach_profiling(payload, _profiling_collector)
 
 
@@ -12382,6 +12398,7 @@ def build_symbol_callers_from_map(
         fallback_used=fallback_used,
     )
     _copy_scan_limit(payload, defs_payload)
+    _copy_partial_signal(payload, defs_payload)
     return _attach_profiling(payload, _profiling_collector)
 
 

--- a/tests/unit/test_repo_map_partial_propagation.py
+++ b/tests/unit/test_repo_map_partial_propagation.py
@@ -1,0 +1,56 @@
+"""Moat P0-6 step 2: the deadline PARTIAL signal must survive when a symbol builder repackages a
+build_symbol_defs result into its own payload. Without _copy_partial_signal, a deadline-truncated
+map silently loses partial:true/deadline_limit the moment it is wrapped by callers/impact/source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tensor_grep.cli.repo_map as repo_map
+
+
+def test_copy_partial_signal_copies_when_present() -> None:
+    source = {
+        "partial": True,
+        "deadline_limit": {"deadline_exceeded": True, "files_scanned": 3, "files_total": 10},
+    }
+    payload: dict = {}
+    repo_map._copy_partial_signal(payload, source)
+    assert payload["partial"] is True
+    assert payload["deadline_limit"]["files_scanned"] == 3
+    # a defensive copy, not an alias
+    source["deadline_limit"]["files_scanned"] = 99
+    assert payload["deadline_limit"]["files_scanned"] == 3
+
+
+def test_copy_partial_signal_is_noop_when_complete() -> None:
+    payload: dict = {}
+    repo_map._copy_partial_signal(payload, {"files": []})  # no partial key = complete scan
+    assert "partial" not in payload
+    assert "deadline_limit" not in payload
+
+
+def test_symbol_builder_propagates_partial_from_defs(tmp_path: Path, monkeypatch) -> None:
+    # A builder that wraps build_symbol_defs_from_map must forward the partial signal.
+    partial_defs = {
+        "path": str(tmp_path),
+        "definitions": [],
+        "files": [],
+        "symbols": [],
+        "imports": [],
+        "tests": [],
+        "no_match": True,
+        "message": "No exact definition found.",
+        "provider_agreement": {},
+        "provider_status": {},
+        "partial": True,
+        "deadline_limit": {"deadline_exceeded": True, "files_scanned": 2, "files_total": 20},
+    }
+    monkeypatch.setattr(repo_map, "build_symbol_defs_from_map", lambda *a, **k: dict(partial_defs))
+
+    repo = {"path": str(tmp_path), "files": [], "symbols": [], "imports": [], "tests": []}
+    result = repo_map.build_symbol_source_from_map(repo, "foo")
+
+    assert result.get("partial") is True, "builder dropped the deadline partial signal"
+    assert result["deadline_limit"]["files_scanned"] == 2


### PR DESCRIPTION
**Moat P0-6 step 2** (round-8-designed). Step 1 added `partial:true` + `deadline_limit` to `build_repo_map`, but a symbol builder repackages a `build_symbol_defs` result into its **own** payload — dropping the signal the moment it wraps, so `callers`/`impact`/`source` would show a deadline-truncated result with no indication it was cut short.

Fix: a `_copy_partial_signal` helper (sibling of `_copy_scan_limit`) forwarding `partial`+`deadline_limit` only when the source was partial (complete → neither, parity). Wired at all 3 `_copy_scan_limit` sites. 3 TDD tests (incl. a real builder propagating a partial payload); 13 parity green.

Chain: step 1 (merged) → **step 2 (this)** → step 3 (thread `deadline_seconds`) → step 4 (CLI `--deadline`) → step 5 (daemon 60s-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)