### PR TITLE
feat: --deadline CLI flag on the 4 graph commands (moat P0-6 step 4)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7826,6 +7826,15 @@ def impact(
         min=1,
         help="Maximum repo files to scan before returning a bounded result.",
     ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
+            "whatever was found so far, instead of running unbounded."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return likely impacted files and tests for a symbol change."""
@@ -7843,6 +7852,7 @@ def impact(
             resolved_path,
             semantic_provider=provider,
             max_repo_files=max_repo_files,
+            deadline_seconds=deadline,
         )
         # H5: impact previously surfaced only definition/import-derived `files` and so
         # under-reported call sites relative to `tg callers` (which finds the CLI
@@ -7854,6 +7864,7 @@ def impact(
                 resolved_path,
                 semantic_provider=provider,
                 max_repo_files=max_repo_files,
+                deadline_seconds=deadline,
             )
             payload["callers"] = list(callers_payload.get("callers", []))
             for caller in payload["callers"]:
@@ -7901,6 +7912,15 @@ def refs(
         min=1,
         help="Maximum repo files to scan before returning a bounded result.",
     ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
+            "whatever was found so far, instead of running unbounded."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return Python-first symbol references across the inventory root."""
@@ -7918,6 +7938,7 @@ def refs(
             resolved_path,
             semantic_provider=provider,
             max_repo_files=max_repo_files,
+            deadline_seconds=deadline,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
@@ -7955,6 +7976,15 @@ def callers(
         min=1,
         help="Maximum repo files to scan before returning a bounded result.",
     ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
+            "whatever was found so far, instead of running unbounded."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return Python-first call sites and likely impacted tests for a symbol."""
@@ -7972,6 +8002,7 @@ def callers(
             resolved_path,
             semantic_provider=provider,
             max_repo_files=max_repo_files,
+            deadline_seconds=deadline,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
@@ -8084,6 +8115,15 @@ def blast_radius(
         min=1,
         help="Maximum impacted files to include in output; raise for fuller broad impact analysis.",
     ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
+            "whatever was found so far, instead of running unbounded."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
     mermaid_output: bool = typer.Option(
         False,
@@ -8115,6 +8155,7 @@ def blast_radius(
             max_repo_files=max_repo_files,
             max_callers=max_callers,
             max_files=max_files,
+            deadline_seconds=deadline,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)

--- a/tests/unit/test_cli_deadline_flag.py
+++ b/tests/unit/test_cli_deadline_flag.py
@@ -57,11 +57,15 @@ def test_callers_without_deadline_passes_none(tmp_path: Path, monkeypatch) -> No
     assert recorded.get("deadline_seconds") is None
 
 
-def test_deadline_flag_present_on_all_four_graph_commands() -> None:
+def test_deadline_flag_accepted_on_all_four_graph_commands() -> None:
+    # Robust to --help text wrapping (which is terminal-WIDTH dependent -> CI vs local diverge, the
+    # same fragility as the earlier --daemon help test): assert the flag is REGISTERED by passing it
+    # with --help. An UNKNOWN option exits 2 before eager --help fires; a KNOWN option is consumed,
+    # then --help exits 0. So exit_code == 0 proves --deadline exists without parsing help text.
     runner = CliRunner()
     for command in ("callers", "refs", "impact", "blast-radius"):
-        out = runner.invoke(app, [command, "--help"]).output
-        assert "--deadline" in out, f"{command} is missing the --deadline flag"
+        result = runner.invoke(app, [command, "--deadline", "5", "--help"])
+        assert result.exit_code == 0, f"{command} rejected --deadline: {result.output}"
 
 
 def test_deadline_rejects_sub_floor_value(tmp_path: Path) -> None:

--- a/tests/unit/test_cli_deadline_flag.py
+++ b/tests/unit/test_cli_deadline_flag.py
@@ -1,0 +1,70 @@
+"""Moat P0-6 step 4: the --deadline CLI flag threads deadline_seconds into the symbol builders.
+
+End-to-end (partial:true JSON) is dogfooded against the real binary; this is a fast regression guard
+that the flag exists on all 4 commands and forwards the value (or None when absent).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import tensor_grep.cli.repo_map as repo_map
+from tensor_grep.cli.main import app
+
+
+def _stub_payload(symbol: str, path: str) -> dict:
+    return {
+        "symbol": symbol,
+        "path": str(path),
+        "callers": [],
+        "files": [],
+        "tests": [],
+        "related_paths": [],
+        "definitions": [],
+        "symbols": [],
+        "imports": [],
+        "routing_reason": "symbol-callers",
+    }
+
+
+def test_callers_deadline_flag_threads_seconds(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    recorded: dict = {}
+
+    def _spy(symbol, path=".", *, deadline_seconds=None, **_kwargs):
+        recorded["deadline_seconds"] = deadline_seconds
+        return _stub_payload(symbol, path)
+
+    monkeypatch.setattr(repo_map, "build_symbol_callers", _spy)
+    result = CliRunner().invoke(app, ["callers", "foo", str(tmp_path), "--deadline", "5", "--json"])
+    assert result.exit_code in (0, 1), result.output
+    assert recorded.get("deadline_seconds") == 5.0
+
+
+def test_callers_without_deadline_passes_none(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    recorded: dict = {"deadline_seconds": "sentinel"}
+
+    def _spy(symbol, path=".", *, deadline_seconds=None, **_kwargs):
+        recorded["deadline_seconds"] = deadline_seconds
+        return _stub_payload(symbol, path)
+
+    monkeypatch.setattr(repo_map, "build_symbol_callers", _spy)
+    result = CliRunner().invoke(app, ["callers", "foo", str(tmp_path), "--json"])
+    assert result.exit_code in (0, 1), result.output
+    assert recorded.get("deadline_seconds") is None
+
+
+def test_deadline_flag_present_on_all_four_graph_commands() -> None:
+    runner = CliRunner()
+    for command in ("callers", "refs", "impact", "blast-radius"):
+        out = runner.invoke(app, [command, "--help"]).output
+        assert "--deadline" in out, f"{command} is missing the --deadline flag"
+
+
+def test_deadline_rejects_sub_floor_value(tmp_path: Path) -> None:
+    # min=0.1: a sub-floor deadline is a usage error (exit 2), not a silent 0-budget run.
+    result = CliRunner().invoke(app, ["callers", "foo", str(tmp_path), "--deadline", "0.001"])
+    assert result.exit_code == 2


### PR DESCRIPTION
**Moat P0-6 step 4.** Steps 1-3 built the deadline mechanism end-to-end; step 4 exposes it as `--deadline <seconds>` on `callers`/`refs`/`impact`/`blast-radius`, threaded into every `build_symbol_*` call. `min=0.1`; default `None` = unbounded (today).

**Verified on the real binary**: `tg callers X . --deadline 0.1 --json` → `partial:true` + `deadline_limit {files_scanned:1, files_total:463}`; no flag → exit 0, 9 callers, no partial. Exit code composes with the existing contract (a deadline no-match exits 1 + `result_incomplete`, same as `--max-repo-files` truncation — the JSON `partial` flag is the primary agent signal). 4 TDD tests.

**Next: step 5** — the daemon default-budget change, the actual fix for the '60s error, zero JSON' pain. Then step 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)