### PR TITLE
feat: make the daemon client response timeout env-configurable (moat P0-6 step 5)

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -48,6 +48,12 @@ _DAEMON_START_LOCK_FILE = ".daemon-start.lock"
 _DAEMON_HOST = "127.0.0.1"
 _DAEMON_CONNECT_TIMEOUT_SECONDS = 0.5
 _DAEMON_RESPONSE_TIMEOUT_SECONDS = 60.0
+# moat P0-6 step 5: the client-side socket read timeout for a daemon response is env-configurable so
+# a large repo whose warm-daemon graph query legitimately needs >60s is NOT killed by a hard cap that
+# returns a bare "timed out" / exit 1 / zero JSON (the recurring dogfood "60s cap errors" complaint).
+# Full partial-at-deadline for the DAEMON path needs a separate traversal-deadline (the served graph
+# commands run on the cached map, so the scan-deadline of steps 1-4 does not bound them) -- tracked.
+_DAEMON_RESPONSE_TIMEOUT_ENV = "TG_SESSION_DAEMON_RESPONSE_TIMEOUT_SECONDS"
 _DAEMON_START_TIMEOUT_SECONDS = 5.0
 _DAEMON_SESSION_LOOKUP_RETRY_SECONDS = 0.25
 _DAEMON_RESPONSE_CACHE_MAX_ENTRIES = 32
@@ -585,6 +591,19 @@ def stop_session_daemon(path: str = ".") -> dict[str, Any]:
     return response
 
 
+def _daemon_response_timeout() -> float:
+    """Resolve the client read timeout, honoring TG_SESSION_DAEMON_RESPONSE_TIMEOUT_SECONDS. A
+    non-positive / unparseable value falls back to the 60s default (never an instant/zero timeout)."""
+    raw = os.environ.get(_DAEMON_RESPONSE_TIMEOUT_ENV)
+    if raw is None:
+        return _DAEMON_RESPONSE_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DAEMON_RESPONSE_TIMEOUT_SECONDS
+    return value if value > 0 else _DAEMON_RESPONSE_TIMEOUT_SECONDS
+
+
 def request_session_daemon(path: str, request: dict[str, Any]) -> dict[str, Any]:
     status = start_session_daemon(path)
     # audit S3: read the token from the (0600) daemon.json the daemon just published so the
@@ -595,6 +614,7 @@ def request_session_daemon(path: str, request: dict[str, Any]) -> dict[str, Any]
         str(status.get("host", _DAEMON_HOST)),
         int(status["port"]),
         request,
+        response_timeout=_daemon_response_timeout(),
         token=token,
     )
 
@@ -608,6 +628,7 @@ def request_running_session_daemon(path: str, request: dict[str, Any]) -> dict[s
         str(metadata.get("host", _DAEMON_HOST)),
         int(metadata["port"]),
         request,
+        response_timeout=_daemon_response_timeout(),
         token=_daemon_token(metadata),
     )
 

--- a/tests/unit/test_session_daemon_security.py
+++ b/tests/unit/test_session_daemon_security.py
@@ -150,6 +150,24 @@ def test_daemon_handler_sets_socket_timeout() -> None:
     assert timeout is not None and timeout > 0
 
 
+def test_daemon_response_timeout_defaults_and_env_override(monkeypatch) -> None:
+    # moat P0-6 step 5: the client read timeout is env-configurable so a >60s warm-daemon query is
+    # not killed with zero JSON (the "60s cap errors" dogfood complaint).
+    monkeypatch.delenv(session_daemon._DAEMON_RESPONSE_TIMEOUT_ENV, raising=False)
+    assert session_daemon._daemon_response_timeout() == 60.0
+
+    monkeypatch.setenv(session_daemon._DAEMON_RESPONSE_TIMEOUT_ENV, "180")
+    assert session_daemon._daemon_response_timeout() == 180.0
+
+
+def test_daemon_response_timeout_rejects_nonpositive_and_garbage(monkeypatch) -> None:
+    # A non-positive / unparseable value must fall back to the 60s default -- never an instant
+    # (zero) timeout that would make every daemon request fail immediately.
+    for bad_value in ("0", "-5", "abc", ""):
+        monkeypatch.setenv(session_daemon._DAEMON_RESPONSE_TIMEOUT_ENV, bad_value)
+        assert session_daemon._daemon_response_timeout() == 60.0
+
+
 def test_write_daemon_metadata_locks_down_token_file_on_windows(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
**Moat P0-6 step 5 (partial).** The warm-daemon client read timeout was a hard 60s, so a large repo whose daemon-routed graph query legitimately needs >60s got a bare timeout / exit 1 / **zero JSON** — the recurring dogfood '60s cap errors, work discarded' complaint. Now configurable via `TG_SESSION_DAEMON_RESPONSE_TIMEOUT_SECONDS` (both client entry points); non-positive/garbage → 60s fallback.

**Scope note (verified while wiring):** daemon-served graph commands run on the **cached** map (`_from_map`, no re-scan), so the scan-deadline from steps 1-4 doesn't bound them — full partial-at-deadline on the daemon path needs a separate **traversal**-deadline + a profile of the real bottleneck (tracked). This step removes the hard-60s wall so a slow-but-completing query succeeds. 2 tests; 31 daemon-security green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)