### PR TITLE
fix: single-file inventory names the file, not "." (round-8 audit)

### DIFF
--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -146,6 +146,11 @@ def _category_for(path: Path, root: Path) -> str:
 
 
 def _relative_posix(path: Path, root: Path) -> str:
+    # Round-8 audit: `tg inventory <FILE>` walks a single file whose path IS the root, so
+    # relative_to(root) yields a useless "." -- report the basename instead so largest_files names
+    # the file. (For a directory root, files are always deeper, so path == root never fires there.)
+    if path == root:
+        return path.name
     try:
         return path.relative_to(root).as_posix()
     except ValueError:

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -34,6 +34,11 @@ class TestFailClosedAndBasics:
         assert inv["totals"]["files"] == 1
         assert inv["top_level_dirs"] == []
         assert any(rec["language"] == "python" for rec in inv["languages"])
+        # Round-8 audit: a single-file target must NAME the file in largest_files, not report "."
+        # (the file IS the root, so relative_to(root) would collapse to ".").
+        largest = inv["largest_files"]
+        assert largest and largest[0]["path"] == "solo.py"
+        assert all(rec["path"] != "." for rec in largest)
 
 
 class TestWalkExclusions:


### PR DESCRIPTION
**Round-8 fresh-eyes audit (LOW-MED).** `tg inventory <FILE>` walks a single file whose path IS the resolved root, so `_relative_posix` collapsed to a useless `.` in `largest_files` — an agent couldn't tell which file. Return the basename when `path == root` (a directory root never hits this — its files are deeper — so no regression). Dogfooded: single-file → `solo.py`, directory unchanged. 1 test.

Round-8 audit remainder (#50); #1 (truncation_cause) verified a **non-bug** (the walk pre-excludes vendor). Safe relocate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)