### PR TITLE
feat: tg orient --ignore <glob> to exclude vendor/skill trees (1.35 dogfood)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6802,6 +6802,15 @@ def orient(
     max_central_files: int = typer.Option(
         10, "--max-central-files", help="Number of top central files to surface", min=1
     ),
+    ignore: list[str] = typer.Option(
+        [],
+        "--ignore",
+        help=(
+            "Glob(s) to exclude from the centrality ranking (basename or repo-relative path), e.g. "
+            "--ignore 'seo/**' --ignore 'core/skills/**'. Excludes vendor/skill CODE trees that "
+            "otherwise rank as 'central' on a harness repo. Repeatable."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit the capsule as JSON"),
 ) -> None:
     """Emit a one-call codebase orientation capsule (central files, entry points, AST snippets)."""
@@ -6810,11 +6819,16 @@ def orient(
     if json_output:
         typer.echo(
             build_orient_capsule_json(
-                path, max_tokens=max_tokens, max_central_files=max_central_files
+                path,
+                max_tokens=max_tokens,
+                max_central_files=max_central_files,
+                ignore=tuple(ignore),
             )
         )
         return
-    payload = build_orient_capsule(path, max_tokens=max_tokens, max_central_files=max_central_files)
+    payload = build_orient_capsule(
+        path, max_tokens=max_tokens, max_central_files=max_central_files, ignore=tuple(ignore)
+    )
     typer.echo(f"# Codebase orientation: {payload['path']}")
     typer.echo(f"central files ({len(payload['central_files'])}):")
     for cf in payload["central_files"]:

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -7,6 +7,7 @@ map, and AST-boundary snippets within a token budget. Pure-CPU, no API key, no G
 
 from __future__ import annotations
 
+import fnmatch
 import json
 from pathlib import Path
 from typing import Any
@@ -165,6 +166,36 @@ def _ast_chunked_snippet(path_str: str, symbols: list[dict[str, Any]]) -> str | 
     return None
 
 
+def _apply_ignore_globs(rm: dict[str, Any], ignore: tuple[str, ...]) -> dict[str, Any]:
+    """Drop files matching any --ignore glob (basename OR repo-relative posix path) from the map
+    before ranking (1.35 dogfood): `tg orient . --ignore 'seo/**' 'core/skills/**'` excludes vendor /
+    skill trees that would otherwise rank as 'central' on a doc- or harness-heavy repo, even though
+    they are .py CODE (so the doc/config suffix exclusions don't catch them)."""
+    if not ignore:
+        return rm
+    root = Path(str(rm.get("path", ".")))
+
+    def _excluded(file_str: str) -> bool:
+        candidate = Path(file_str)
+        try:
+            rel = candidate.relative_to(root).as_posix()
+        except ValueError:
+            rel = candidate.as_posix()
+        return any(
+            fnmatch.fnmatch(rel, glob) or fnmatch.fnmatch(candidate.name, glob) for glob in ignore
+        )
+
+    filtered = dict(rm)
+    filtered["files"] = [f for f in rm.get("files", []) if not _excluded(str(f))]
+    filtered["symbols"] = [
+        s for s in rm.get("symbols", []) if not _excluded(str(s.get("file", "")))
+    ]
+    filtered["imports"] = [
+        i for i in rm.get("imports", []) if not _excluded(str(i.get("file", "")))
+    ]
+    return filtered
+
+
 def build_orient_capsule(
     path: str | Path = ".",
     *,
@@ -173,6 +204,7 @@ def build_orient_capsule(
     max_tokens: int = 3000,
     max_repo_files: int | None = None,
     render_profile: str = "compact",
+    ignore: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     """Build a bounded codebase orientation capsule (no API key, no GPU)."""
     from tensor_grep.cli.repo_map import DEFAULT_AGENT_REPO_MAP_LIMIT
@@ -181,6 +213,7 @@ def build_orient_capsule(
         max_repo_files if max_repo_files is not None else DEFAULT_AGENT_REPO_MAP_LIMIT
     )
     rm = _repo_map.build_repo_map(path, max_repo_files=effective_max_repo_files)
+    rm = _apply_ignore_globs(rm, ignore)
 
     central_files = _central_files_from_map(rm, max_central_files=max_central_files)
     entry_points = _detect_entry_points(rm)

--- a/tests/unit/test_orient_central_excludes_docs.py
+++ b/tests/unit/test_orient_central_excludes_docs.py
@@ -101,3 +101,43 @@ def test_pure_docs_repo_falls_back_not_empty() -> None:
     rm = {"files": ["a.md", "b.md"], "imports": [], "symbols": []}
     central = _central_files_from_map(rm, max_central_files=10)
     assert len(central) >= 1
+
+
+def test_orient_ignore_globs_exclude_matching_tree(tmp_path):
+    # 1.35 dogfood: `tg orient . --ignore 'vendor/**'` must drop a vendor/skill CODE tree from the
+    # capsule (central files, symbol map) so it can't rank as "central" on a harness repo, while
+    # non-ignored code is preserved.
+    from tensor_grep.cli.orient_capsule import build_orient_capsule
+
+    (tmp_path / "vendor").mkdir()
+    (tmp_path / "src").mkdir()
+    (tmp_path / "vendor" / "hub.py").write_text(
+        "\n".join(f"class C{i}:\n    pass\n" for i in range(6)), encoding="utf-8"
+    )
+    (tmp_path / "src" / "app.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+    for i in range(8):
+        (tmp_path / "src" / f"m{i}.py").write_text("from vendor.hub import C0\n", encoding="utf-8")
+
+    ignored = build_orient_capsule(str(tmp_path), ignore=("vendor/**",))
+    assert not any("vendor" in c["file"] for c in ignored["central_files"]), (
+        "vendor tree not excluded"
+    )
+    assert not any("vendor" in path for path in ignored["symbol_map"])
+    assert any("app.py" in c["file"] or "m0.py" in c["file"] for c in ignored["central_files"])
+
+
+def test_orient_apply_ignore_globs_matches_basename_and_relpath(tmp_path):
+    from tensor_grep.cli.orient_capsule import _apply_ignore_globs
+
+    rm = {
+        "path": str(tmp_path),
+        "files": [str(tmp_path / "seo" / "x.py"), str(tmp_path / "src" / "keep.py")],
+        "symbols": [{"file": str(tmp_path / "seo" / "x.py"), "name": "A", "kind": "class"}],
+        "imports": [{"file": str(tmp_path / "seo" / "x.py"), "imports": []}],
+    }
+    filtered = _apply_ignore_globs(rm, ("seo/**",))
+    assert filtered["files"] == [str(tmp_path / "src" / "keep.py")]
+    assert filtered["symbols"] == []
+    assert filtered["imports"] == []
+    # empty ignore -> unchanged (identity)
+    assert _apply_ignore_globs(rm, ()) is rm


### PR DESCRIPTION
**Dogfood 1.35.0 (recurring HIGH/Medium).** On a doc/harness repo, `tg orient .` ranks vendor/SEO/skill-tree scripts as 'central' over real code. Those are `.py` CODE, so the doc/config suffix exclusions (#385) don't catch them.

Add a repeatable `--ignore <glob>` (mirrors docs-coverage's `--ignore`) that drops matching files (basename or repo-relative path) from the map before ranking — so `tg orient . --ignore 'seo/**' --ignore 'core/skills/**'` surfaces the real architecture. Central files, entry points, symbol map, and snippets all honor it; empty = no-op. 2 tests + real-binary dogfood; 13 orient green.

Next (same dogfood): `--ignore` on `agent` + populate `validation_commands`. Safe relocate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)