### PR TITLE
feat: bound the caller-scan traversal with --deadline (moat P0-6 step 6 — central-symbol hangs)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -12499,6 +12499,7 @@ def build_symbol_blast_radius(
         symbol,
         max_depth=max_depth,
         semantic_provider=semantic_provider,
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
     )
     scan_limit = payload.get("scan_limit")
@@ -12525,6 +12526,7 @@ def build_symbol_blast_radius(
                 symbol,
                 max_depth=max_depth,
                 semantic_provider=semantic_provider,
+                deadline_monotonic=deadline_monotonic,
                 _profiling_collector=_profiling_collector,
             )
             payload_scan_limit = payload.get("scan_limit")
@@ -12649,6 +12651,7 @@ def build_symbol_blast_radius_from_map(
     *,
     max_depth: int = 3,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
@@ -12690,6 +12693,7 @@ def build_symbol_blast_radius_from_map(
         repo_map,
         symbol,
         semantic_provider=semantic_provider,
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
     )
     impact_payload = build_symbol_impact_from_map(
@@ -12986,6 +12990,15 @@ def build_symbol_blast_radius_from_map(
     _copy_lsp_evidence_status(payload, callers_payload)
     if "scan_limit" in repo_map:
         payload["scan_limit"] = dict(repo_map["scan_limit"])
+    # moat P0-6 step 6: the direct-caller scan may have been cut by --deadline for a CENTRAL symbol
+    # -> carry its partial + deadline_limit onto the blast radius so a caller does not trust a
+    # truncated caller_tree / blast_radius_score as complete.
+    if callers_payload.get("partial"):
+        payload["partial"] = True
+        payload["graph_completeness"] = "partial"
+        caller_deadline_limit = callers_payload.get("deadline_limit")
+        if isinstance(caller_deadline_limit, dict):
+            payload["deadline_limit"] = dict(caller_deadline_limit)
     return _attach_profiling(payload, _profiling_collector)
 
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -12112,6 +12112,7 @@ def build_symbol_callers(
         repo_map,
         symbol,
         semantic_provider=semantic_provider,
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
     )
     _copy_partial_signal(result, repo_map)
@@ -12123,6 +12124,7 @@ def build_symbol_callers_from_map(
     symbol: str,
     *,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
@@ -12164,8 +12166,18 @@ def build_symbol_callers_from_map(
             for definition_file in definition_files
         )
 
+    caller_scan_deadline_hit = False
+    caller_files_scanned = 0
     with _profiling_phase(_profiling_collector, "caller_scan"):
         for current in bounded_files:
+            # moat P0-6 step 6: bound the CALLER-SCAN traversal, not just the repo-map parse. A
+            # CENTRAL symbol's cost is scanning many files for references here (leaf symbols were
+            # bounded by the parse-loop deadline; central ones hung past it because this loop was
+            # unbounded -- dogfood 1.35.0). Break + return partial callers instead of overrunning.
+            if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+                caller_scan_deadline_hit = True
+                break
+            caller_files_scanned += 1
             if not _should_scan_for_symbol_callers(current):
                 continue
             if current.suffix == ".py":
@@ -12398,6 +12410,17 @@ def build_symbol_callers_from_map(
     payload["symbols"] = context_payload["symbols"]
     payload["related_paths"] = related_paths
     payload["graph_completeness"] = "moderate"
+    if caller_scan_deadline_hit:
+        # moat P0-6 step 6: the caller-scan was cut short by --deadline -> partial (the callers list
+        # holds what was found before the budget). graph_completeness downgrades so an agent does not
+        # trust a small/zero caller count on a deadline-truncated central-symbol scan.
+        payload["partial"] = True
+        payload["graph_completeness"] = "partial"
+        payload["deadline_limit"] = {
+            "deadline_exceeded": True,
+            "caller_files_scanned": caller_files_scanned,
+            "caller_files_total": len(bounded_files),
+        }
     payload["ranking_quality"] = _ranking_quality(
         context_payload["file_matches"],
         context_payload["test_matches"],

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -11884,7 +11884,9 @@ def build_symbol_refs(
     repo_map = build_repo_map(
         path, max_repo_files=max_repo_files, deadline_monotonic=deadline_monotonic
     )
-    result = build_symbol_refs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
+    result = build_symbol_refs_from_map(
+        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+    )
     _copy_partial_signal(result, repo_map)
     return result
 
@@ -11894,6 +11896,7 @@ def build_symbol_refs_from_map(
     symbol: str,
     *,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
     payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
     if payload.get("no_match"):
@@ -11908,7 +11911,16 @@ def build_symbol_refs_from_map(
     bounded_files = _repo_map_file_universe(repo_map)
     bounded_file_set = {str(current) for current in bounded_files}
     references: list[dict[str, Any]] = []
+    refs_scan_deadline_hit = False
+    refs_files_scanned = 0
     for current in bounded_files:
+        # moat P0-6 step 6: bound the reference-scan traversal so a CENTRAL symbol honors --deadline
+        # instead of hanging past it (1.35.0 dogfood: `refs QueryEngine --deadline 15` -> 45s timeout,
+        # no partial). Same per-file-scan hot loop as callers.
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            refs_scan_deadline_hit = True
+            break
+        refs_files_scanned += 1
         current_provenance = _symbol_navigation_provenance_for_path(str(current))
         if current.suffix == ".py":
             current_refs, _ = _python_references_and_calls(current, symbol)
@@ -12071,6 +12083,13 @@ def build_symbol_refs_from_map(
         lsp_count=lsp_proof_count,
         fallback_used=fallback_used,
     )
+    if refs_scan_deadline_hit:
+        payload["partial"] = True
+        payload["deadline_limit"] = {
+            "deadline_exceeded": True,
+            "reference_files_scanned": refs_files_scanned,
+            "reference_files_total": len(bounded_files),
+        }
     return payload
 
 

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -151,3 +151,22 @@ def test_step6_blast_radius_no_deadline_is_complete(tmp_path: Path) -> None:
     rm = repo_map.build_repo_map(str(tmp_path))
     result = repo_map.build_symbol_blast_radius_from_map(rm, "widget")  # no deadline
     assert "partial" not in result
+
+
+def test_step6_refs_honors_scan_deadline(tmp_path: Path) -> None:
+    # moat P0-6 step 6: refs runs the same per-file reference scan -> must honor --deadline for
+    # central symbols (1.35.0 dogfood: `refs QueryEngine --deadline 15` -> 45s timeout, no partial).
+    _make_caller_repo(tmp_path, 6)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    result = repo_map.build_symbol_refs_from_map(
+        rm, "widget", deadline_monotonic=time.monotonic() - 1.0
+    )
+    assert result.get("partial") is True
+    assert result["deadline_limit"]["deadline_exceeded"] is True
+
+
+def test_step6_refs_no_deadline_is_complete(tmp_path: Path) -> None:
+    _make_caller_repo(tmp_path, 4)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    result = repo_map.build_symbol_refs_from_map(rm, "widget")  # no deadline
+    assert "partial" not in result

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -100,3 +100,35 @@ def test_step3_deadline_none_leaves_builders_unbounded(tmp_path: Path) -> None:
     result = repo_map.build_symbol_callers("f1", str(tmp_path))  # no deadline
     assert "partial" not in result
     assert "deadline_limit" not in result
+
+
+def _make_caller_repo(root: Path, callers: int) -> None:
+    src = root / "src"
+    src.mkdir(parents=True)
+    (src / "target.py").write_text("def widget():\n    return 1\n", encoding="utf-8")
+    for index in range(callers):
+        (src / f"caller{index}.py").write_text(
+            "from src.target import widget\n\n\ndef use():\n    return widget()\n", encoding="utf-8"
+        )
+
+
+def test_step6_caller_scan_honors_already_expired_deadline(tmp_path: Path) -> None:
+    # moat P0-6 step 6: the CALLER-SCAN traversal (not just the repo-map parse) must honor the
+    # deadline -- this is why central symbols hung past --deadline while leaf symbols didn't.
+    _make_caller_repo(tmp_path, 6)
+    rm = repo_map.build_repo_map(str(tmp_path))  # full map, no deadline
+    result = repo_map.build_symbol_callers_from_map(
+        rm, "widget", deadline_monotonic=time.monotonic() - 1.0
+    )
+    assert result.get("partial") is True
+    assert result["graph_completeness"] == "partial"
+    assert result["deadline_limit"]["deadline_exceeded"] is True
+
+
+def test_step6_caller_scan_no_deadline_is_complete(tmp_path: Path) -> None:
+    _make_caller_repo(tmp_path, 4)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    result = repo_map.build_symbol_callers_from_map(rm, "widget")  # no deadline
+    assert "partial" not in result
+    assert result["graph_completeness"] == "moderate"
+    assert len(result["callers"]) >= 1  # found the real callers when unbounded

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -132,3 +132,22 @@ def test_step6_caller_scan_no_deadline_is_complete(tmp_path: Path) -> None:
     assert "partial" not in result
     assert result["graph_completeness"] == "moderate"
     assert len(result["callers"]) >= 1  # found the real callers when unbounded
+
+
+def test_step6_blast_radius_honors_caller_scan_deadline(tmp_path: Path) -> None:
+    # moat P0-6 step 6: blast-radius runs the same direct-caller scan, so it must honor --deadline
+    # for central symbols too (the 1.35.0 dogfood: `blast-radius QueryEngine --deadline 10` hung 90s+).
+    _make_caller_repo(tmp_path, 6)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    result = repo_map.build_symbol_blast_radius_from_map(
+        rm, "widget", deadline_monotonic=time.monotonic() - 1.0
+    )
+    assert result.get("partial") is True
+    assert result["graph_completeness"] == "partial"
+
+
+def test_step6_blast_radius_no_deadline_is_complete(tmp_path: Path) -> None:
+    _make_caller_repo(tmp_path, 4)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    result = repo_map.build_symbol_blast_radius_from_map(rm, "widget")  # no deadline
+    assert "partial" not in result


### PR DESCRIPTION
**Moat P0-6 step 6.** Dogfood 1.35.0 **profiled the exact gap**: `--deadline` bounded leaf symbols (~23s, partial) but **central symbols ran 90s+ ignoring it**. Root cause: steps 1-4 bounded `build_repo_map`'s **parse** loop, but a central symbol's cost is the **caller-scan traversal** in `build_symbol_callers_from_map` (scanning many files for references) — which was unbounded.

Fix: thread `deadline_monotonic` into `build_symbol_callers_from_map`; check it at the top of the caller-scan loop → break + `partial:true` with callers-so-far, `graph_completeness: partial` (so an agent doesn't trust a small/zero count on a truncated scan), + `deadline_limit`. Threaded from the top-level builder (impact routes through callers). 2 TDD tests; 7 P0-6 green.

Also reframes the caller-under-detection complaint: `graph_completeness=partial` signals the count isn't trustworthy. **Next**: same check in `blast_radius`'s reverse-import traversal + the daemon path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)