### PR TITLE
feat: tg inventory --deadline wall-clock bound (#53)

### DIFF
--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -22,6 +22,7 @@ Design (round-4 [e], 3-lens design council 2026-07-03):
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -169,12 +170,21 @@ def _sorted_records(
 
 
 def build_inventory(
-    path: str = ".", *, max_files: int = DEFAULT_MAX_INVENTORY_FILES
+    path: str = ".",
+    *,
+    max_files: int = DEFAULT_MAX_INVENTORY_FILES,
+    deadline_seconds: float | None = None,
 ) -> dict[str, Any]:
     """Build a walk-only inventory manifest for ``path``.
 
     Raises ``FileNotFoundError`` when ``path`` does not exist (fail closed — a missing
     path must never read as a valid empty repository).
+
+    ``deadline_seconds``, when supplied, bounds the WALL-CLOCK time of the per-file
+    stat()+``_looks_like_binary_file`` loop (the real cost on a huge workspace — the
+    walk itself is cheap; see module docstring). A deadline that fires returns a
+    partial, honestly-labeled inventory (``scan_limit.truncation_cause == "deadline"``)
+    rather than hanging for minutes. It never lowers ``max_files`` itself.
     """
     root = Path(path)
     if not root.exists():
@@ -208,7 +218,13 @@ def build_inventory(
     dir_files: dict[str, int] = {}
     largest: list[tuple[int, str]] = []
 
+    deadline = time.monotonic() + deadline_seconds if deadline_seconds is not None else None
+    deadline_hit = False
+
     for file_path in walked:
+        if deadline is not None and time.monotonic() >= deadline:
+            deadline_hit = True
+            break
         try:
             size = file_path.stat().st_size
         except OSError:
@@ -241,6 +257,17 @@ def build_inventory(
         cat_bytes[category] = cat_bytes.get(category, 0) + size
 
     largest.sort(key=lambda item: (-item[0], item[1]))
+
+    if deadline_hit:
+        # The deadline BROKE the per-file loop before it processed the full walked set, so the time
+        # budget -- not the file cap -- is the BINDING constraint on the count (strictly fewer than
+        # max_files were processed). Label it "deadline" even when the walk was ALSO cap-truncated:
+        # raising --max-repo-files would not help here, extending --deadline would. If the loop had
+        # instead COMPLETED within budget (deadline_hit=False), the pre-loop "project-files" cap label
+        # stands. (Dogfood 2026-07-05: the earlier "keep project-files" guard mislabeled a real 20s
+        # deadline hit on C:/dev/projects as a file-cap truncation.)
+        possibly_truncated = True
+        truncation_cause = "deadline"
 
     return {
         "version": INVENTORY_SCHEMA_VERSION,
@@ -284,10 +311,16 @@ def render_inventory_text(inventory: dict[str, Any]) -> str:
         lines.append(f"  categories: {cats}")
     scan = inventory["scan_limit"]
     if scan["possibly_truncated"]:
-        lines.append(
-            f"  [!] truncated at max_files={scan['max_files']} "
-            f"(cause={scan['truncation_cause']}); counts are a floor, not complete."
-        )
+        if scan["truncation_cause"] == "deadline":
+            lines.append(
+                "  [!] stopped after the time budget (cause=deadline); "
+                "counts are a floor, not complete."
+            )
+        else:
+            lines.append(
+                f"  [!] truncated at max_files={scan['max_files']} "
+                f"(cause={scan['truncation_cause']}); counts are a floor, not complete."
+            )
     return "\n".join(lines)
 
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6701,6 +6701,15 @@ def inventory(
         min=1,
         help="Maximum repo files to scan before truncating (walk-only; defaults to 50000).",
     ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
+            "whatever was found so far, instead of running unbounded."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Emit a single-pass repository inventory (files, bytes, languages, categories)."""
@@ -6709,7 +6718,7 @@ def inventory(
     from tensor_grep.cli.inventory import build_inventory, render_inventory_text
 
     try:
-        payload = build_inventory(path, max_files=max_repo_files)
+        payload = build_inventory(path, max_files=max_repo_files, deadline_seconds=deadline)
     except FileNotFoundError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6706,8 +6706,9 @@ def inventory(
         "--deadline",
         min=0.1,
         help=(
-            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
-            "whatever was found so far, instead of running unbounded."
+            "Stop the inventory scan after N seconds and return a partial manifest labeled "
+            "scan_limit.truncation_cause='deadline' (counts are a floor), instead of running unbounded "
+            "on a huge tree."
         ),
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -241,3 +241,48 @@ class TestRegistration:
         from tensor_grep.cli.commands import KNOWN_COMMANDS
 
         assert "inventory" in KNOWN_COMMANDS
+
+
+class TestDeadlineCliWiring:
+    # codex review (round-6): the CLI --deadline flag needs acceptance + min-rejection + thread-through
+    # coverage, not just build_inventory() behavior.
+    def test_inventory_deadline_flag_accepted_and_threaded(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+
+        from tensor_grep.cli import main as tg_main
+
+        (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+        recorded: dict = {}
+
+        def _spy(path, *, max_files=None, deadline_seconds=None):
+            recorded["deadline_seconds"] = deadline_seconds
+            return {
+                "totals": {"files": 0, "bytes": 0},
+                "binary": {"files": 0, "bytes": 0},
+                "languages": [],
+                "categories": [],
+                "top_level_dirs": [],
+                "largest_files": [],
+                "path": str(path),
+                "scan_limit": {"possibly_truncated": False, "truncation_cause": None},
+            }
+
+        # The inventory command imports build_inventory from tensor_grep.cli.inventory at call time,
+        # so patch it at the source module (not on main, where it isn't a module-level attr).
+        monkeypatch.setattr("tensor_grep.cli.inventory.build_inventory", _spy)
+        result = CliRunner().invoke(
+            tg_main.app, ["inventory", str(tmp_path), "--deadline", "5", "--json"]
+        )
+        assert result.exit_code == 0, result.output
+        assert recorded.get("deadline_seconds") == 5.0
+
+    def test_inventory_deadline_rejects_sub_floor_value(self, tmp_path):
+        from typer.testing import CliRunner
+
+        from tensor_grep.cli import main as tg_main
+
+        # min=0.1 -> a sub-floor deadline is a usage error, not a silent 0-budget run.
+        result = CliRunner().invoke(
+            tg_main.app, ["inventory", str(tmp_path), "--deadline", "0.001"]
+        )
+        assert result.exit_code == 2

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import tensor_grep.cli.inventory as inventory_module
 from tensor_grep.cli.inventory import build_inventory
 
 
@@ -153,6 +154,76 @@ class TestDeterminism:
         first = json.dumps(build_inventory(str(tmp_path)), sort_keys=False)
         second = json.dumps(build_inventory(str(tmp_path)), sort_keys=False)
         assert first == second
+
+
+class TestDeadline:
+    # Fix C (2026-07-05): the per-file stat()+_looks_like_binary_file cost (~29s/10k files)
+    # dominates over the walk itself (~0.9s/10k). A huge workspace with a large max_files
+    # cap could still take minutes even though the cap was never hit. A wall-clock deadline
+    # lets the caller bound total time and get an honestly-labeled partial inventory instead.
+
+    @staticmethod
+    def _install_advancing_clock(monkeypatch, base=1000.0):
+        # Same fake-clock idiom as tests/unit/test_repo_map_deadline.py: monotonic only
+        # advances when a file is actually processed, so the deadline crosses deterministically.
+        clock = {"t": base}
+        monkeypatch.setattr(inventory_module.time, "monotonic", lambda: clock["t"])
+        original = inventory_module._looks_like_binary_file
+
+        def _advancing(path):
+            clock["t"] += 1.0
+            return original(path)
+
+        monkeypatch.setattr(inventory_module, "_looks_like_binary_file", _advancing)
+        return clock
+
+    def test_deadline_fires_marks_truncation_cause_and_returns_partial_floor(
+        self, tmp_path, monkeypatch
+    ):
+        for i in range(10):
+            _write(tmp_path, f"f{i}.py", "x=1\n")
+        self._install_advancing_clock(monkeypatch)
+
+        inv = build_inventory(str(tmp_path), deadline_seconds=2.0)
+
+        assert inv["scan_limit"]["possibly_truncated"] is True
+        assert inv["scan_limit"]["truncation_cause"] == "deadline"
+        assert inv["totals"]["files"] < 10  # broke early -- a floor, not the real count
+        assert inv["scan_limit"]["scanned_files"] == inv["totals"]["files"]
+
+    def test_deadline_binds_over_file_cap_when_it_fires_early(self, tmp_path, monkeypatch):
+        # Corrected precedence (dogfood 2026-07-05): when the deadline BREAKS the loop before it
+        # processes max_files, STRICTLY FEWER than the cap were scanned, so the time budget is the
+        # BINDING constraint -> cause="deadline" even though the walk was also cap-truncated. (Raising
+        # --max-repo-files would not help; extending --deadline would.) The earlier "keep
+        # project-files" guard mislabeled a real 20s deadline hit on C:/dev/projects as a file-cap.
+        for i in range(10):
+            _write(tmp_path, f"f{i}.py", "x=1\n")
+        self._install_advancing_clock(monkeypatch)
+
+        inv = build_inventory(str(tmp_path), max_files=3, deadline_seconds=2.0)
+
+        assert inv["scan_limit"]["possibly_truncated"] is True
+        assert inv["scan_limit"]["truncation_cause"] == "deadline"
+        assert inv["totals"]["files"] < 3  # deadline broke it before the 3-file cap
+
+    def test_file_cap_without_firing_deadline_stays_project_files(self, tmp_path):
+        # No deadline supplied: a walk larger than max_files stays labeled "project-files".
+        for i in range(10):
+            _write(tmp_path, f"f{i}.py", "x=1\n")
+
+        inv = build_inventory(str(tmp_path), max_files=3)
+
+        assert inv["scan_limit"]["truncation_cause"] == "project-files"
+        assert inv["totals"]["files"] == 3  # processed all cap-limited files, no early break
+
+    def test_no_deadline_supplied_is_unchanged_parity(self, tmp_path):
+        for i in range(3):
+            _write(tmp_path, f"f{i}.py", "x=1\n")
+        inv = build_inventory(str(tmp_path))
+        assert inv["scan_limit"]["possibly_truncated"] is False
+        assert inv["scan_limit"]["truncation_cause"] is None
+        assert inv["totals"]["files"] == 3
 
 
 class TestRegistration:


### PR DESCRIPTION
**Fix C of the scale/honesty campaign** (council-plan-vetted). `tg inventory C:/dev/projects` (50k default cap) hung **>2min** on a 50k+ workspace — the cost is the per-file `stat()`+`_looks_like_binary_file` (~29s/10k), not the walk. Don't lower the default cap (rejected by design). Add a wall-clock `--deadline` that returns a partial, honestly-labeled inventory instead of hanging.

**Dogfooded** on `C:/dev/projects`: `--deadline 15` → ~15s, *"stopped after the time budget (cause=deadline)"* (was >2min). The dogfood **caught a labeling bug the council missed**: when the deadline breaks the loop early (fewer than max_files processed) the deadline is the *binding* constraint → label `deadline`, not `project-files` (raising --max-repo-files wouldn't help). Fixed precedence + cause-aware renderer. 24 tests.

Fix B (#394) is draining ahead of this (one-merge-per-tick). Next: codex + Fable review, then queue behind #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)