### PR TITLE
feat: tg agent --ignore <glob> to exclude vendor/skill trees (dogfood #51)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -1202,6 +1202,7 @@ def build_agent_capsule(
     semantic_provider: str = "native",
     gpu_device_ids: list[int] | None = None,
     gpu_timeout_s: float = 5.0,
+    ignore: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     resolved_path = str(Path(path).resolve())
     requested_semantic_provider = semantic_provider
@@ -1221,6 +1222,7 @@ def build_agent_capsule(
         optimize_context=True,
         render_profile="full",
         semantic_provider=effective_semantic_provider,
+        ignore=ignore,
     )
     target = _primary_target(payload)
     alternatives = _alternative_targets(payload, target)
@@ -1550,6 +1552,7 @@ def build_agent_capsule_json(
     semantic_provider: str = "native",
     gpu_device_ids: list[int] | None = None,
     gpu_timeout_s: float = 5.0,
+    ignore: tuple[str, ...] = (),
 ) -> str:
     return json.dumps(
         build_agent_capsule(
@@ -1564,6 +1567,7 @@ def build_agent_capsule_json(
             semantic_provider=semantic_provider,
             gpu_device_ids=gpu_device_ids,
             gpu_timeout_s=gpu_timeout_s,
+            ignore=ignore,
         ),
         ensure_ascii=False,
         indent=2,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7206,6 +7206,15 @@ def agent(
         min=0.1,
         help="Maximum seconds for each opt-in agent GPU evidence command.",
     ),
+    ignore: list[str] = typer.Option(
+        [],
+        "--ignore",
+        help=(
+            "Glob(s) to exclude from the capsule ranking (basename or repo-relative path), e.g. "
+            "--ignore 'seo/**' --ignore 'core/skills/**'. Excludes vendor/skill CODE trees that "
+            "otherwise rank as the primary target on a harness repo. Repeatable."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return an actionable context capsule for agents before editing."""
@@ -7232,6 +7241,7 @@ def agent(
                     semantic_provider=provider,
                     gpu_device_ids=parsed_gpu_device_ids,
                     gpu_timeout_s=gpu_timeout_s,
+                    ignore=tuple(ignore),
                 )
             )
             return
@@ -7247,6 +7257,7 @@ def agent(
             semantic_provider=provider,
             gpu_device_ids=parsed_gpu_device_ids,
             gpu_timeout_s=gpu_timeout_s,
+            ignore=tuple(ignore),
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -10007,9 +10007,17 @@ def build_context_render(
     semantic_provider: str = "native",
     profile: bool = False,
     _profiling_collector: _ProfileCollector | None = None,
+    ignore: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     collector = _resolve_profiling_collector(profile=profile, collector=_profiling_collector)
     repo_map = build_repo_map(path, max_repo_files=max_repo_files, _profiling_collector=collector)
+    if ignore:
+        # Local import avoids a module-level circular import (orient_capsule imports this module);
+        # reuses orient's tested glob filter (`tg orient --ignore`, PR #392) so `tg agent --ignore`
+        # drops the same vendor/skill CODE trees from ranking before centrality/context-pack scoring.
+        from tensor_grep.cli.orient_capsule import _apply_ignore_globs
+
+        repo_map = _apply_ignore_globs(repo_map, ignore)
     return build_context_render_from_map(
         repo_map,
         query,

--- a/tests/unit/test_agent_ignore.py
+++ b/tests/unit/test_agent_ignore.py
@@ -1,0 +1,76 @@
+"""``tg agent --ignore`` must exclude vendor/skill trees from the capsule, mirroring the
+already-shipped ``tg orient --ignore`` (PR #392).
+
+Dogfood #51 (HIGH): on a harness/doc repo, ``tg agent . "task"`` ranked vendor/SEO/skill-tree
+files as the primary target over real code. ``tg orient`` already got ``--ignore`` to exclude
+those trees; ``tg agent`` needs the identical escape hatch, applied to the same repo_map (files/
+symbols/imports) BEFORE ranking so an ignored tree can never win as primary_target or show up in
+alternatives/snippets.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.agent_capsule import build_agent_capsule
+
+
+def _write_seo_vs_src_repo(tmp_path: Path) -> None:
+    # NB: "vendor" is already excluded from the repo walk by tensor-grep's own vendor/cache dir
+    # list (repo_map._SKIP_DIR_NAMES); "seo" is not, matching the real dogfood repo (core/skills/
+    # seo) that motivated --ignore, so it's a faithful fixture for the --ignore feature itself.
+    seo = tmp_path / "seo"
+    src = tmp_path / "src"
+    seo.mkdir()
+    src.mkdir()
+    # seo/hub.py: contains the exact query match, so without --ignore it wins as primary_target.
+    (seo / "hub.py").write_text(
+        "def process_data(payload):\n    return payload\n", encoding="utf-8"
+    )
+    for i in range(8):
+        (src / f"m{i}.py").write_text(
+            "from seo.hub import process_data\n\n"
+            f"def caller_{i}():\n    return process_data({i})\n",
+            encoding="utf-8",
+        )
+    # src/app.py: real code with no direct query match, present so the ignored capsule still
+    # has non-seo source to fall back to.
+    (src / "app.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+
+
+def test_agent_ignore_excludes_seo_tree(tmp_path: Path) -> None:
+    _write_seo_vs_src_repo(tmp_path)
+
+    baseline = build_agent_capsule("process data", str(tmp_path))
+    assert "seo" in Path(baseline["primary_target"]["file"]).parts, (
+        "test fixture invalid: seo/hub.py should win as primary target without --ignore"
+    )
+
+    ignored = build_agent_capsule("process data", str(tmp_path), ignore=("seo/**",))
+
+    assert "seo" not in Path(ignored["primary_target"]["file"]).parts, "seo tree not excluded"
+
+    def _files(payload: dict) -> list[str]:
+        files = [payload["primary_target"].get("file", "")]
+        files += [alt.get("file", "") for alt in payload.get("alternative_targets", [])]
+        files += [snip.get("file", "") for snip in payload.get("snippets", [])]
+        return [f for f in files if f]
+
+    referenced = _files(ignored)
+    assert not any("seo" in Path(f).parts for f in referenced), (
+        f"seo path leaked into ignored capsule: {referenced}"
+    )
+    assert any("src" in Path(f).parts for f in referenced), (
+        f"real src code missing from ignored capsule: {referenced}"
+    )
+
+
+def test_agent_ignore_empty_is_identity(tmp_path: Path) -> None:
+    _write_seo_vs_src_repo(tmp_path)
+
+    no_ignore_kw = build_agent_capsule("process data", str(tmp_path))
+    empty_ignore = build_agent_capsule("process data", str(tmp_path), ignore=())
+
+    assert empty_ignore["primary_target"] == no_ignore_kw["primary_target"]
+    assert empty_ignore["alternative_targets"] == no_ignore_kw["alternative_targets"]
+    assert empty_ignore["snippets"] == no_ignore_kw["snippets"]


### PR DESCRIPTION
Mirrors the shipped `tg orient --ignore` (#392) for `agent`: on a harness/doc repo, root `tg agent . "task"` ranks vendor/SEO/skill scripts as the primary over real code (dogfood #51 HIGH). Adds a repeatable `--ignore <glob>` filtering the repo map before ranking, reusing `orient_capsule._apply_ignore_globs`; threaded through `build_context_render` → agent capsule (text + JSON).

**Dogfooded** on gotcontext-saddle *"audit the read gate"*: without → primary `core/skills/seo/scripts/font_audit.py` (reproduces #51); with `--ignore 'core/skills/**'` → primary `core/hooks/gotcontext_read_gate.py#read_block_enabled`, no `core/skills` paths. 31 tests (agent-capsule LSP seam kept intact); ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)