### PR TITLE
fix: exit 2 only for an EMPTY truncated result (dogfood 1.40.1 caught #398 over-extension)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7594,14 +7594,16 @@ def _emit_symbol_command_result(
         emit_text(payload)
         if caveat is not None:
             typer.echo(f"{'warning' if is_truncation else 'note'}: {caveat}")
-    # Exit-code contract (dogfood 1.40.0): a deadline/scan-truncated result is INCOMPLETE -- it must
-    # NOT read as complete (0) nor as a genuine not-found (1). Exit 2 mirrors `tg search`'s
-    # result_incomplete convention so an agent can distinguish "ran out of budget/cap, retry with more"
-    # from "genuinely absent", and never trusts a truncated (possibly empty) result as the full answer.
-    # `--deadline` sets `partial`; a max-repo-files cap sets `result_incomplete`; either -> exit 2.
-    if payload.get("partial") or payload.get("result_incomplete"):
-        raise typer.Exit(2)
+    # Exit-code contract (dogfood 1.40.1 -- narrowed from 1.40.0): the exit-2 "incomplete" signal
+    # applies ONLY to an EMPTY result. A result WITH findings is valid and exits 0 even when the scan
+    # was truncated (`result_incomplete`/`partial` in the JSON flags "the set may be incomplete, raise
+    # the budget for more") -- otherwise EVERY symbol query on a repo larger than the default
+    # --max-repo-files cap would exit 2 and an agent looping `if rc==0` could never proceed. An EMPTY
+    # result from a truncated scan is UNTRUSTWORTHY ("nothing found" may be a false negative because the
+    # scan did not finish) -> exit 2 (retry), NOT 1. A complete empty scan is a real not-found -> exit 1.
     if not_found:
+        if payload.get("partial") or payload.get("result_incomplete"):
+            raise typer.Exit(2)
         raise typer.Exit(1)
 
 
@@ -8226,7 +8228,12 @@ def blast_radius(
     # more. So gate on partial/scan_limit, NOT result_incomplete (which _annotate also sets on output cap).
     scan_limit = payload.get("scan_limit")
     scan_truncated = isinstance(scan_limit, dict) and bool(scan_limit.get("possibly_truncated"))
-    incomplete = bool(payload.get("partial") or scan_truncated)
+    # Only an EMPTY blast radius from a truncated scan is untrustworthy -> exit 2 (dogfood 1.40.1). A
+    # radius that RESOLVED callers is valid even if the scan was capped (matches the symbol-command
+    # rule); an OUTPUT cap (--max-callers/--max-files) is a complete analysis and stays exit 0.
+    incomplete = _symbol_payload_has_no_results(payload, "callers") and bool(
+        payload.get("partial") or scan_truncated
+    )
 
     if mermaid_output:
         typer.echo(_render_blast_radius_mermaid(payload))

--- a/tests/unit/test_cli_deadline_flag.py
+++ b/tests/unit/test_cli_deadline_flag.py
@@ -140,10 +140,12 @@ def test_impact_propagates_caller_scan_partial_exits_2(tmp_path: Path, monkeypat
     (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
 
     def _impact(symbol, path=".", **_kwargs):
+        # EMPTY impact (files=[]) + a deadline-truncated caller pass -> the empty is untrustworthy ->
+        # exit 2. (A non-empty impact is a valid found result and exits 0, dogfood 1.40.1.)
         return {
             "symbol": symbol,
             "path": str(path),
-            "files": ["m.py"],
+            "files": [],
             "tests": [],
             "callers": [],
             "no_match": False,
@@ -156,3 +158,44 @@ def test_impact_propagates_caller_scan_partial_exits_2(tmp_path: Path, monkeypat
     monkeypatch.setattr(repo_map, "build_symbol_callers", _callers)
     result = CliRunner().invoke(app, ["impact", "foo", str(tmp_path), "--json"])
     assert result.exit_code == 2, result.output
+
+
+def test_found_with_partial_exits_0(tmp_path: Path, monkeypatch) -> None:
+    # dogfood 1.40.1: a result WITH findings is valid even if the scan was --deadline/cap truncated ->
+    # exit 0 (result_incomplete/partial in JSON flags "maybe more"). Only an EMPTY truncated result -> 2.
+    assert (
+        _exit_code_for_payload(
+            tmp_path, monkeypatch, {"callers": [{"file": "m.py", "line": 1}], "partial": True}
+        )
+        == 0
+    )
+
+
+def test_found_with_result_incomplete_exits_0(tmp_path: Path, monkeypatch) -> None:
+    assert (
+        _exit_code_for_payload(
+            tmp_path,
+            monkeypatch,
+            {"callers": [{"file": "m.py", "line": 1}], "result_incomplete": True},
+        )
+        == 0
+    )
+
+
+def test_blast_radius_found_partial_exits_0(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def _spy(symbol, path=".", **_kwargs):
+        return {
+            "symbol": symbol,
+            "path": str(path),
+            "definitions": [{"file": "m.py", "line": 1}],
+            "callers": [{"file": "m.py", "line": 1}],
+            "files": ["m.py"],
+            "tests": [],
+            "partial": True,
+        }
+
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _spy)
+    result = CliRunner().invoke(app, ["blast-radius", "foo", str(tmp_path), "--json"])
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
Re-dogfooding #398 on the real 1,884-file TS repo caught an over-extension I shipped: `tg callers QueryEngine` (no --deadline) returned `callers=1` (**found**) but **exit 2**, because the default `--max-repo-files` cap truncated the scan. So *every* symbol query on a repo larger than the default cap exited 2 even when it found the answer — an agent looping `if rc==0` could never proceed.

**Narrow** the exit-2 signal to EMPTY results only: found → exit 0 (valid, `result_incomplete`/`partial` in JSON flags 'maybe more'); empty+truncated → exit 2 (untrustworthy); empty+complete → exit 1. Applied to symbol commands + blast-radius. Verified on the real binary: found+scan-capped → rc 0, empty+deadline → rc 2. 13 + 84 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)