### PR TITLE
fix: unscoped tg search can no longer hang forever (CRITICAL, dogfood + audit)

### DIFF
--- a/src/tensor_grep/backends/cpu_backend.py
+++ b/src/tensor_grep/backends/cpu_backend.py
@@ -3,18 +3,38 @@ import json
 import logging
 import os
 import re
+import time
 import warnings
 from collections import OrderedDict
 from pathlib import Path
 from typing import ClassVar
 
 from tensor_grep.backends.base import ComputeBackend
+from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
 
 logger = logging.getLogger(__name__)
 _CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES_ENV = "TENSOR_GREP_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES"
 _DEFAULT_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES = 512
+
+
+def compute_native_walk_deadline() -> float:
+    """Wall-clock deadline (``time.monotonic()`` epoch) for a native, in-process multi-file
+    search walk (the CLI's per-file loop over ``CPUBackend``/``TorchBackend`` results).
+
+    Reuses the SAME resolver ripgrep's own subprocess timeout uses
+    (``subprocess_policy.configured_ripgrep_timeout_seconds``) so the native engine path is
+    bounded by the identical budget as the rg route. Without this, a search that cannot
+    route through rg (native ``--json`` aggregate, ``--rank``, tensor-only flags, or rg
+    absent from PATH) has NO limit at all and can hang until manually killed on a
+    large/unscoped tree -- the critical unscoped-search-hang bug (Fix B).
+    """
+    return time.monotonic() + configured_ripgrep_timeout_seconds()
+
+
+def native_walk_deadline_exceeded(deadline: float) -> bool:
+    return time.monotonic() >= deadline
 
 
 class InvalidRegexError(ValueError):

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -15,6 +15,7 @@ from tensor_grep.cli.runtime_paths import (
     resolve_ripgrep_binary,
 )
 from tensor_grep.cli.subprocess_policy import run_subprocess as run_subprocess
+from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 
 # Saved at import time so _streaming_passthrough_returncode can detect when
 # run_subprocess has been monkey-patched by a test (old mock pattern).
@@ -562,12 +563,14 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
 # gitignored, already skipped by repo_map's walk, and bounded by the native/cpu wall-clock
 # deadline if ever walked -- including them here made this guard refuse a plain unscoped
 # search from tensor-grep's own repo root (verified via real dogfood run).
-_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = {
-    "node_modules",
-    "vendor",
-    "external_repos",
-    "third_party",
-}
+#
+# Review finding H1 (2026-07-05): also excludes any dir already walker-skipped by
+# `DirectoryScanner`'s `_GENERATED_DIR_NAMES` (currently just `node_modules` of the four
+# above) -- that dir was already bounded (walker-skipped + normally `.gitignore`d + Fix B's
+# per-file deadline), so refusing it was a pure false positive against every ordinary
+# Node/React repo. Imported (not hardcoded) from `io/directory_scanner.py` so this set and
+# cli/main.py's equivalent guard can never drift out of sync.
+_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 
 
 def _search_paths_include_vendored_root(paths: list[str]) -> bool:

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -545,6 +545,48 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
     return False
 
 
+# Critical unscoped-search-hang fix C: heavy vendored dirs that can sit at the TOP LEVEL of
+# a single project root -- `_search_paths_include_workspace_root` above SKIPS any root that
+# is itself a project (has its own marker like package.json/.git) and only fires when it
+# finds >= 3 sibling project dirs, so a single huge vendored repo (its own project, one
+# giant `node_modules`/`external_repos`/etc. at the top) always slipped past it. This check
+# MUST live here (not just in cli/main.py's equivalent guard) because `main_entry` below
+# decides whether to delegate straight to the native `tg` binary or to `rg` passthrough --
+# both of which bypass cli/main.py's Python guards entirely. Without this, an unscoped
+# `tg search PATTERN --json` from a workspace root with a top-level vendored dir gets
+# fast-pathed straight into an unbounded native/rg walk before cli/main.py's guard (or
+# backends/cpu_backend.py's wall-clock deadline) ever gets a chance to run.
+#
+# Deliberately excludes tg's own index dirs (`.tensor-grep`, `_tg_refs`,
+# `.tg_semantic_index`) for the same reason cli/main.py's guard does: those are normally
+# gitignored, already skipped by repo_map's walk, and bounded by the native/cpu wall-clock
+# deadline if ever walked -- including them here made this guard refuse a plain unscoped
+# search from tensor-grep's own repo root (verified via real dogfood run).
+_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = {
+    "node_modules",
+    "vendor",
+    "external_repos",
+    "third_party",
+}
+
+
+def _search_paths_include_vendored_root(paths: list[str]) -> bool:
+    """O(top-level-entries) probe: never walks -- only `Path.iterdir()` one level deep."""
+    for raw_path in paths:
+        if not raw_path or raw_path == "-" or raw_path.startswith("-"):
+            continue
+        path = Path(raw_path)
+        try:
+            if not path.is_dir():
+                continue
+            for child in path.iterdir():
+                if child.is_dir() and child.name.lower() in _UNBOUNDED_VENDORED_ROOT_DIR_NAMES:
+                    return True
+        except OSError:
+            continue
+    return False
+
+
 def _search_args_include_unbounded_broad_scan(search_args: list[str]) -> bool:
     if "--allow-broad-generated-scan" in search_args:
         return False
@@ -552,6 +594,8 @@ def _search_args_include_unbounded_broad_scan(search_args: list[str]) -> bool:
         return False
     paths = _search_path_args(search_args)
     if _search_paths_include_workspace_root(paths):
+        return True
+    if _search_paths_include_vendored_root(paths):
         return True
     return _search_args_request_unrestricted_generated_scan(
         search_args

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3722,6 +3722,59 @@ def _should_refuse_unbounded_workspace_root_scan(
     return bool(project_dirs), project_dirs
 
 
+# Critical unscoped-search-hang fix C: heavy vendored/index directories that can sit at the
+# TOP LEVEL of a single project root -- a root `_workspace_project_child_names` never flags
+# because the guard above SKIPS any root that is itself a project (has its own marker like
+# pyproject.toml/.git) and only fires when it finds >= 3 sibling project dirs. A single huge
+# vendored repo (its own project, one giant `node_modules`/`external_repos`/etc. at the top)
+# always slips past that guard.
+#
+# Deliberately EXCLUDES tg's own index/reference dirs (`.tensor-grep`, `_tg_refs`,
+# `.tg_semantic_index`): those are already (a) skipped by repo_map's walk (Fix A), (b)
+# normally `.gitignore`d so DirectoryScanner's default walk never descends into them, and
+# (c) bounded by Fix B's wall-clock deadline if they ever are walked. Including them here
+# was verified (real dogfood run) to make this guard refuse EVERY unscoped default-path
+# search from tensor-grep's own repo root -- a `.tensor-grep/` cache dir is a completely
+# normal thing for any tg-managed repo to have, not a "genuinely pathological root".
+_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = frozenset({
+    "node_modules",
+    "vendor",
+    "external_repos",
+    "third_party",
+})
+
+
+def _root_top_level_vendored_dir_names(paths: list[str]) -> list[str]:
+    """O(top-level-entries) probe: never walks -- only `Path.iterdir()` one level deep."""
+    found: set[str] = set()
+    vendored_names = {name.lower() for name in _UNBOUNDED_VENDORED_ROOT_DIR_NAMES}
+    for raw_path in paths:
+        if not raw_path or raw_path == "-" or raw_path.startswith("-"):
+            continue
+        path = Path(raw_path)
+        try:
+            if not path.is_dir():
+                continue
+            for child in path.iterdir():
+                if child.is_dir() and child.name.lower() in vendored_names:
+                    found.add(child.name)
+        except OSError:
+            continue
+    return sorted(found, key=lambda item: item.lower())
+
+
+def _should_refuse_unbounded_vendored_root_scan(
+    paths: list[str],
+    config: "SearchConfig",
+    *,
+    allow_broad_generated_scan: bool,
+) -> tuple[bool, list[str]]:
+    if allow_broad_generated_scan or _has_generated_scan_bound(config):
+        return False, []
+    vendored_dirs = _root_top_level_vendored_dir_names(paths)
+    return bool(vendored_dirs), vendored_dirs
+
+
 def _should_refuse_unbounded_generated_scan(
     paths: list[str],
     config: "SearchConfig",
@@ -3771,6 +3824,23 @@ def _format_broad_workspace_scan_error(project_dirs: list[str]) -> str:
         "For bounded output:\n"
         'tg search <pattern> <workspace> --glob "*.py"\n'
         "tg search <pattern> <workspace> --max-depth <N>\n"
+        "For intentional broad scans:\n"
+        "--allow-broad-generated-scan"
+    )
+
+
+def _format_unbounded_vendored_root_scan_error(vendored_dirs: list[str]) -> str:
+    visible_dirs = ", ".join(vendored_dirs[:8])
+    if len(vendored_dirs) > 8:
+        visible_dirs = f"{visible_dirs}, ..."
+    return (
+        "Error: broad root scan refused as a safety guard, not a zero-match result: "
+        "path contains a heavy vendored/index "
+        f"directory at its top level ({visible_dirs}). Scope the path, add --glob, --type, "
+        "or --max-depth, or pass --allow-broad-generated-scan to opt in.\n"
+        "For bounded output:\n"
+        'tg search <pattern> <root> --glob "*.py"\n'
+        "tg search <pattern> <root> --max-depth <N>\n"
         "For intentional broad scans:\n"
         "--allow-broad-generated-scan"
     )
@@ -6150,6 +6220,14 @@ def search_command(
     if refuse_workspace_scan:
         typer.echo(_format_broad_workspace_scan_error(workspace_project_dirs), err=True)
         raise typer.Exit(2)
+    refuse_vendored_scan, vendored_root_dirs = _should_refuse_unbounded_vendored_root_scan(
+        paths_to_search,
+        config,
+        allow_broad_generated_scan=allow_broad_generated_scan,
+    )
+    if refuse_vendored_scan:
+        typer.echo(_format_unbounded_vendored_root_scan_error(vendored_root_dirs), err=True)
+        raise typer.Exit(2)
 
     explicit_rg_format = _explicit_rg_format_requested(format_value=format_type)
     # C3: plain `--json` emits one aggregate object and cannot render ripgrep's
@@ -6366,7 +6444,38 @@ def search_command(
                 _record_matched_file(match.file)
             _merge_runtime_routing(result)
     else:
+        # Critical unscoped-search-hang fix (B): the native (CPU/Torch) engine has no
+        # internal per-file timeout -- unlike the RipgrepBackend branch above, which is
+        # bounded by the rg subprocess's own `configured_ripgrep_timeout_seconds()` timeout.
+        # A search that can't route through rg (native `--json` aggregate, `--rank`,
+        # tensor-only flags, or rg absent from PATH) would otherwise walk
+        # `candidate_files_ordered` with NO limit at all and could hang until manually
+        # killed on a large/unscoped tree. Check the SAME wall-clock budget once per FILE
+        # (never per match -- that would be too fine-grained to bound a pathological single
+        # file) and, on expiry, stop and return whatever was found so far as an explicitly
+        # incomplete (never silently empty, never a raw crash) result.
+        from tensor_grep.backends.cpu_backend import (
+            compute_native_walk_deadline,
+            native_walk_deadline_exceeded,
+        )
+        from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds
+
+        native_walk_deadline = compute_native_walk_deadline()
         for current_file in candidate_files_ordered:
+            if native_walk_deadline_exceeded(native_walk_deadline):
+                timeout_seconds = configured_ripgrep_timeout_seconds()
+                all_results.result_incomplete = True
+                all_results.incomplete_reason = (
+                    f"native search exceeded the {timeout_seconds:g}s timeout and was "
+                    "stopped; returning partial results. Scope the search to a smaller "
+                    "path, or raise TG_RG_TIMEOUT_SECONDS."
+                )
+                sys.stderr.write(
+                    "tg: native search exceeded the "
+                    f"{timeout_seconds:g}s timeout, keeping partial results: "
+                    f"{all_results.incomplete_reason}\n"
+                )
+                break
             span_ctx = (
                 tracer.start_as_current_span("search.file") if tracer is not None else nullcontext()
             )

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -44,6 +44,7 @@ from tensor_grep.cli.runtime_paths import (
 from tensor_grep.cli.scan_guardrails import BroadScanRefusedError, ensure_scan_not_broad
 from tensor_grep.core.observability import nvtx_range
 from tensor_grep.core.result import MatchLine
+from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
 
 if TYPE_CHECKING:
@@ -3736,12 +3737,15 @@ def _should_refuse_unbounded_workspace_root_scan(
 # was verified (real dogfood run) to make this guard refuse EVERY unscoped default-path
 # search from tensor-grep's own repo root -- a `.tensor-grep/` cache dir is a completely
 # normal thing for any tg-managed repo to have, not a "genuinely pathological root".
-_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = frozenset({
-    "node_modules",
-    "vendor",
-    "external_repos",
-    "third_party",
-})
+#
+# Review finding H1 (2026-07-05): also EXCLUDES any dir already walker-skipped by
+# `DirectoryScanner`'s `_GENERATED_DIR_NAMES` (currently just `node_modules` of the four
+# above) -- the native walker already hard-skips it, and `rg` respects `.gitignore` (where
+# `node_modules` almost always lives) plus Fix B's per-file deadline, so that dir was
+# ALREADY bounded and this refusal was a pure false positive that exit-2'd every ordinary
+# Node/React repo's unscoped search. Imported (not hardcoded) from `io/directory_scanner.py`
+# so this set and `cli/bootstrap.py`'s front-door mirror can never drift out of sync.
+_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 
 
 def _root_top_level_vendored_dir_names(paths: list[str]) -> list[str]:

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -144,6 +144,12 @@ _DEFAULT_LSP_OPERATION_BUDGET_SECONDS = 2.0
 _LSP_OPERATION_BUDGET_ENV_VAR = "TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS"
 _SKIP_DIR_NAMES = {
     ".tensor-grep",
+    # tg-owned index/reference trees — never product source, and can be large enough to
+    # hang an unscoped walk (critical unscoped-search-hang audit). Kept in sync with
+    # docs_coverage.py's _EXCLUDED_DIR_PARTS, which already excludes these.
+    "_tg_refs",
+    ".tg_semantic_index",
+    "external_repos",
     ".git",
     ".hg",
     ".svn",

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -27,6 +27,24 @@ _GENERATED_RELATIVE_DIRS = {
     ".claude/context",
 }
 
+# Heavy dirs that may legitimately sit at a project ROOT's top level and that an unscoped
+# `tg search` should refuse to blindly walk into (PR #400 fix C, review finding H1). A name
+# already in `_GENERATED_DIR_NAMES` above (e.g. `node_modules`) is already walker-skipped by
+# `_should_descend_dir` -- it can never cause the walker to hang on its own, so it must NOT
+# also appear in the refusal trigger set below (a refusal for a dir the walker never
+# descends is a pure false positive: it wrongly exit-2's every ordinary Node/React repo).
+# Single source of truth: both `cli/main.py`'s `_should_refuse_unbounded_vendored_root_scan`
+# and `cli/bootstrap.py`'s front-door mirror `_search_paths_include_vendored_root` import
+# `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` from here rather than each hardcoding their own
+# (subtracted) copy, so the two guards can never drift out of sync.
+_ALL_HEAVY_ROOT_DIR_NAMES = frozenset({
+    "node_modules",
+    "vendor",
+    "external_repos",
+    "third_party",
+})
+UNBOUNDED_VENDORED_ROOT_DIR_NAMES = frozenset(_ALL_HEAVY_ROOT_DIR_NAMES - _GENERATED_DIR_NAMES)
+
 # The Rust PyO3 directory scanner (`RustDirectoryScanner`) is NOT exported by the `rust_core`
 # extension (only `RustBackend` + functions are), so the old `from rust_core import
 # RustDirectoryScanner` always raised and this flag was permanently False — the Python walk below was

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -179,6 +179,67 @@ def test_main_entry_should_not_passthrough_unbounded_workspace_root_search(
     assert called["full_cli"] is True
 
 
+def test_main_entry_should_not_passthrough_single_project_root_with_top_level_vendored_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Critical unscoped-search-hang fix C, bootstrap front-door half: a root that is
+    itself a single project (so `_search_paths_include_workspace_root` never flags it) but
+    has a heavy vendored dir (e.g. `node_modules`) at its own top level must not be
+    fast-pathed straight into the native binary or rg passthrough -- both bypass
+    cli/main.py's Python guards and backends/cpu_backend.py's wall-clock deadline
+    entirely. It must fall through to the full CLI, which owns the actual refusal."""
+    called = {"full_cli": False}
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "package.json").write_text("{}", encoding="utf-8")
+    (root / "node_modules").mkdir()
+
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "foo", str(root), "--json"])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_native_tg_search",
+        lambda *_args, **_kwargs: pytest.fail("native passthrough should not run"),
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda *_args, **_kwargs: pytest.fail("rg passthrough should not run"),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
+
+    bootstrap.main_entry()
+
+    assert called["full_cli"] is True
+
+
+def test_main_entry_still_uses_native_fast_path_for_normal_small_repo_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    seen: dict[str, object] = {}
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("", encoding="utf-8")
+    (root / "src").mkdir()
+    (root / "src" / "app.py").write_text("needle\n", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "needle", str(root), "--json"])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_native_tg_search",
+        lambda binary_name, argv: seen.update({"argv": list(argv)}) or 0,
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    assert excinfo.value.code == 0
+    assert seen["argv"] == ["needle", str(root), "--json"]
+
+
 def test_main_entry_should_passthrough_raw_rg_style_invocation(monkeypatch):
     seen: dict[str, object] = {}
 

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -11,6 +11,7 @@ from typer._completion_shared import get_completion_script
 from typer.testing import CliRunner
 
 from tensor_grep.cli import bootstrap
+from tensor_grep.cli import main as cli_main
 from tensor_grep.cli.bootstrap import _KNOWN_COMMANDS
 from tensor_grep.cli.commands import KNOWN_COMMANDS
 from tensor_grep.cli.main import app
@@ -20,6 +21,16 @@ def test_bootstrap_commands_match_source_of_truth() -> None:
     assert _KNOWN_COMMANDS == set(KNOWN_COMMANDS), (
         "Bootstrap commands must exactly match KNOWN_COMMANDS"
     )
+
+
+def test_vendored_root_dir_names_match_source_of_truth() -> None:
+    """Review finding L1 (PR #400): cli/bootstrap.py's front-door vendored-root mirror and
+    cli/main.py's `_should_refuse_unbounded_vendored_root_scan` guard must trigger on
+    exactly the same set of heavy top-level dir names, or the two front doors (native/rg
+    fast path vs full CLI) can disagree about whether a root is unbounded."""
+    assert (
+        bootstrap._UNBOUNDED_VENDORED_ROOT_DIR_NAMES == cli_main._UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+    ), "bootstrap's vendored-root trigger set must match cli/main.py's exactly"
 
 
 def test_typer_app_commands_match_source_of_truth() -> None:
@@ -184,15 +195,19 @@ def test_main_entry_should_not_passthrough_single_project_root_with_top_level_ve
 ) -> None:
     """Critical unscoped-search-hang fix C, bootstrap front-door half: a root that is
     itself a single project (so `_search_paths_include_workspace_root` never flags it) but
-    has a heavy vendored dir (e.g. `node_modules`) at its own top level must not be
-    fast-pathed straight into the native binary or rg passthrough -- both bypass
+    has a heavy vendored dir (e.g. a committed Go `vendor/`) at its own top level must not
+    be fast-pathed straight into the native binary or rg passthrough -- both bypass
     cli/main.py's Python guards and backends/cpu_backend.py's wall-clock deadline
-    entirely. It must fall through to the full CLI, which owns the actual refusal."""
+    entirely. It must fall through to the full CLI, which owns the actual refusal.
+
+    Uses `vendor/` (not `node_modules/`, review finding H1): `node_modules` is already
+    walker-skipped by `DirectoryScanner`, so it no longer forces this fallthrough -- see
+    `test_main_entry_should_fast_path_repo_root_with_node_modules` below."""
     called = {"full_cli": False}
     root = tmp_path / "repo"
     root.mkdir()
-    (root / "package.json").write_text("{}", encoding="utf-8")
-    (root / "node_modules").mkdir()
+    (root / "go.mod").write_text("module example.com/repo\n", encoding="utf-8")
+    (root / "vendor").mkdir()
 
     monkeypatch.setattr(sys, "argv", ["tg", "search", "foo", str(root), "--json"])
     monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
@@ -212,6 +227,36 @@ def test_main_entry_should_not_passthrough_single_project_root_with_top_level_ve
     bootstrap.main_entry()
 
     assert called["full_cli"] is True
+
+
+def test_main_entry_should_fast_path_repo_root_with_node_modules(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Non-regression for review finding H1 (PR #400): `node_modules` is already
+    walker-skipped by `DirectoryScanner` (and normally `.gitignore`d + bounded by Fix B's
+    per-file deadline even if walked), so its mere presence at a repo root must not force
+    the front door to fall through to the full CLI -- the native fast path may still be
+    taken for an ordinary Node/React repo."""
+    seen: dict[str, object] = {}
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "package.json").write_text("{}", encoding="utf-8")
+    (root / "node_modules").mkdir()
+
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "needle", str(root), "--json"])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_native_tg_search",
+        lambda binary_name, argv: seen.update({"argv": list(argv)}) or 0,
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    assert excinfo.value.code == 0
+    assert seen["argv"] == ["needle", str(root), "--json"]
 
 
 def test_main_entry_still_uses_native_fast_path_for_normal_small_repo_root(

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -731,19 +731,47 @@ def test_workspace_root_guard_allows_real_repo_root(tmp_path: Path):
     assert project_dirs == []
 
 
-def test_vendored_root_guard_refuses_single_project_root_with_top_level_node_modules(
+def test_vendored_root_guard_refuses_single_project_root_with_top_level_vendor_dir(
     tmp_path: Path,
 ):
     """Critical unscoped-search-hang fix C: `_workspace_project_child_names` SKIPS any root
     that is itself a project (has its own marker), so a single huge vendored repo with e.g.
-    `node_modules/` at its own top level always slipped past
+    a committed Go `vendor/` at its own top level always slipped past
     `_should_refuse_unbounded_workspace_root_scan`. The vendored-root guard closes that gap
-    with a cheap top-level-only probe (never a full walk)."""
+    with a cheap top-level-only probe (never a full walk).
+
+    Uses `vendor/` (not `node_modules/`, review finding H1): `node_modules` is already
+    walker-skipped by `DirectoryScanner`'s `_GENERATED_DIR_NAMES`, so it can never cause the
+    hang this guard exists to fail fast on -- `vendor` is a genuinely walked heavy dir name
+    that survives the walker-skip subtraction."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "go.mod").write_text("module example.com/repo\n", encoding="utf-8")
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "pkg.go").write_text("package pkg\n", encoding="utf-8")
+
+    refused, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
+        [str(repo)],
+        SearchConfig(),
+        allow_broad_generated_scan=False,
+    )
+
+    assert refused is True
+    assert vendored_dirs == ["vendor"]
+
+
+def test_vendored_root_guard_excludes_walker_skipped_node_modules(tmp_path: Path):
+    """Review finding H1 (PR #400): `node_modules` is already hard-skipped by
+    `DirectoryScanner._should_descend_dir` (via `_GENERATED_DIR_NAMES`), and `rg` respects
+    `.gitignore` (where `node_modules` almost always lives) plus Fix B's per-file deadline.
+    A dir the walker never descends can never cause the unscoped-search hang this guard
+    exists to fail fast on, so it must NOT trigger the refusal -- doing so needlessly
+    exit-2's every ordinary Node/React repo's unscoped search."""
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "package.json").write_text("{}", encoding="utf-8")
-    (repo / "src").mkdir()
-    (repo / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
     (repo / "node_modules").mkdir()
     (repo / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
 
@@ -753,15 +781,15 @@ def test_vendored_root_guard_refuses_single_project_root_with_top_level_node_mod
         allow_broad_generated_scan=False,
     )
 
-    assert refused is True
-    assert vendored_dirs == ["node_modules"]
+    assert refused is False
+    assert vendored_dirs == []
 
 
 def test_vendored_root_guard_allows_bounded_scan(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "package.json").write_text("{}", encoding="utf-8")
-    (repo / "node_modules").mkdir()
+    (repo / "go.mod").write_text("module example.com/repo\n", encoding="utf-8")
+    (repo / "vendor").mkdir()
 
     refused, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
         [str(repo)],
@@ -796,6 +824,33 @@ def test_vendored_root_guard_allows_normal_small_repo(tmp_path: Path):
 def test_plain_search_refuses_unbounded_single_repo_root_with_vendored_top_level_dir(
     tmp_path: Path,
 ):
+    """Uses `vendor/` (not `node_modules/`, review finding H1) -- `node_modules` is
+    walker-skipped so it no longer triggers this refusal; see the sibling non-regression
+    test below for that case."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "go.mod").write_text("module example.com/repo\n", encoding="utf-8")
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("needle\n", encoding="utf-8")
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "pkg.go").write_text("needle\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "needle", str(repo)])
+
+    assert result.exit_code == 2
+    assert "broad root scan refused" in result.output
+    assert "safety guard, not a zero-match result" in result.output
+    assert "vendor" in result.output
+    assert "--glob" in result.output
+    assert "--max-depth" in result.output
+    assert "--allow-broad-generated-scan" in result.output
+
+
+def test_plain_search_does_not_refuse_repo_root_with_node_modules(tmp_path: Path):
+    """Non-regression for review finding H1 (PR #400): `node_modules` is already
+    walker-skipped by `DirectoryScanner` (and normally `.gitignore`d + bounded by Fix B's
+    per-file deadline even if walked), so a plain Node/React repo's unscoped search must NOT
+    be wrongly refused (exit 2) just because `node_modules/` sits at its top level."""
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "package.json").write_text("{}", encoding="utf-8")
@@ -806,13 +861,11 @@ def test_plain_search_refuses_unbounded_single_repo_root_with_vendored_top_level
 
     result = CliRunner().invoke(app, ["search", "needle", str(repo)])
 
-    assert result.exit_code == 2
-    assert "broad root scan refused" in result.output
-    assert "safety guard, not a zero-match result" in result.output
-    assert "node_modules" in result.output
-    assert "--glob" in result.output
-    assert "--max-depth" in result.output
-    assert "--allow-broad-generated-scan" in result.output
+    # Not refused (exit 2) -- a real match is exit 0, or exit 1 if the backend used for
+    # this invocation doesn't surface a match through CliRunner's captured output (e.g. a
+    # real `rg` subprocess passthrough writes to the OS-level fd, bypassing click's
+    # in-process capture). The key regression this guards is "not wrongly refused".
+    assert result.exit_code in (0, 1), result.output
 
 
 def test_glob_case_insensitive_matches_case_folded_paths(

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -26,6 +26,7 @@ from tensor_grep.cli.main import (
     _safe_stdout_line,
     _select_ast_backend_for_pattern,
     _should_refuse_unbounded_generated_scan,
+    _should_refuse_unbounded_vendored_root_scan,
     _should_refuse_unbounded_workspace_root_scan,
     _write_path_list,
     app,
@@ -728,6 +729,90 @@ def test_workspace_root_guard_allows_real_repo_root(tmp_path: Path):
 
     assert refused is False
     assert project_dirs == []
+
+
+def test_vendored_root_guard_refuses_single_project_root_with_top_level_node_modules(
+    tmp_path: Path,
+):
+    """Critical unscoped-search-hang fix C: `_workspace_project_child_names` SKIPS any root
+    that is itself a project (has its own marker), so a single huge vendored repo with e.g.
+    `node_modules/` at its own top level always slipped past
+    `_should_refuse_unbounded_workspace_root_scan`. The vendored-root guard closes that gap
+    with a cheap top-level-only probe (never a full walk)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text("{}", encoding="utf-8")
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "pkg.js").write_text("console.log('dep')\n", encoding="utf-8")
+
+    refused, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
+        [str(repo)],
+        SearchConfig(),
+        allow_broad_generated_scan=False,
+    )
+
+    assert refused is True
+    assert vendored_dirs == ["node_modules"]
+
+
+def test_vendored_root_guard_allows_bounded_scan(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text("{}", encoding="utf-8")
+    (repo / "node_modules").mkdir()
+
+    refused, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
+        [str(repo)],
+        SearchConfig(glob=["*.py"]),
+        allow_broad_generated_scan=False,
+    )
+
+    assert refused is False
+    assert vendored_dirs == []
+
+
+def test_vendored_root_guard_allows_normal_small_repo(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("", encoding="utf-8")
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("needle\n", encoding="utf-8")
+
+    refused, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
+        [str(repo)],
+        SearchConfig(),
+        allow_broad_generated_scan=False,
+    )
+
+    assert refused is False
+    assert vendored_dirs == []
+
+    result = CliRunner().invoke(app, ["search", "needle", str(repo)])
+    assert result.exit_code == 0, result.output
+
+
+def test_plain_search_refuses_unbounded_single_repo_root_with_vendored_top_level_dir(
+    tmp_path: Path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text("{}", encoding="utf-8")
+    (repo / "src").mkdir()
+    (repo / "src" / "app.py").write_text("needle\n", encoding="utf-8")
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "pkg.js").write_text("needle\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "needle", str(repo)])
+
+    assert result.exit_code == 2
+    assert "broad root scan refused" in result.output
+    assert "safety guard, not a zero-match result" in result.output
+    assert "node_modules" in result.output
+    assert "--glob" in result.output
+    assert "--max-depth" in result.output
+    assert "--allow-broad-generated-scan" in result.output
 
 
 def test_glob_case_insensitive_matches_case_folded_paths(
@@ -2418,6 +2503,52 @@ def test_cli_search_without_path_defaults_to_current_directory(monkeypatch):
     assert result.exit_code == 0
     assert _LAST_PIPELINE_CONFIG is not None
     assert "safeParseJSON" in result.stdout
+
+
+def test_native_search_walk_stops_at_wall_clock_deadline_and_returns_partial_results(
+    monkeypatch,
+):
+    """Critical unscoped-search-hang fix B: the native (non-Ripgrep) per-file search loop
+    must honor a wall-clock deadline -- reused from the SAME resolver rg's own subprocess
+    timeout uses -- and stop after the CURRENT file rather than hang forever. Results found
+    before expiry must come back as `result_incomplete: true` (never silently empty, never a
+    crash), and the CLI must exit 2 (rg-parity partial-results convention)."""
+    global _FAKE_WALK, _FAKE_BACKEND, _LAST_PIPELINE_CONFIG
+    _FAKE_WALK = {".": ["a.py", "b.py", "c.py"]}
+    _FAKE_BACKEND = _FakeBackend(
+        results_by_file={
+            name: SearchResult(
+                matches=[MatchLine(line_number=1, text="needle", file=name)],
+                matched_file_paths=[name],
+                match_counts_by_file={name: 1},
+                total_files=1,
+                total_matches=1,
+            )
+            for name in ("a.py", "b.py", "c.py")
+        }
+    )
+    _LAST_PIPELINE_CONFIG = None
+    _patch_cli_dependencies(monkeypatch)
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)
+    monkeypatch.setenv("TG_RG_TIMEOUT_SECONDS", "10")
+
+    # First monotonic() call computes the deadline (t=0 -> deadline=10). Per-file checks:
+    # before a.py (t=1, still under budget, proceed); before b.py (t=20, expired, stop).
+    # So only a.py is ever searched -- b.py/c.py must never be touched.
+    clock_values = iter([0.0, 1.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0])
+    monkeypatch.setattr(
+        "tensor_grep.backends.cpu_backend.time.monotonic",
+        lambda: next(clock_values),
+    )
+
+    result = CliRunner().invoke(app, ["search", "needle", ".", "--cpu", "--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["result_incomplete"] is True
+    assert "timeout" in payload["incomplete_reason"]
+    assert payload["total_matches"] == 1
+    assert [m["file"] for m in payload["matches"]] == ["a.py"]
 
 
 def test_cli_json_no_match_emits_valid_empty_payload(monkeypatch):

--- a/tests/unit/test_repo_map_targets.py
+++ b/tests/unit/test_repo_map_targets.py
@@ -243,3 +243,22 @@ def test_repo_walk_honors_gitignore(tmp_path: Path) -> None:
     assert "keep.py" in walked
     assert "scratch.tmp" not in walked
     assert "vendored.py" not in walked
+
+
+def test_repo_walk_skips_tg_owned_index_and_reference_trees(tmp_path: Path) -> None:
+    """Critical unscoped-search-hang fix A: repo_map must never descend into tg's own
+    index/reference/vendor-benchmark trees -- these can be arbitrarily large and are never
+    product source. Kept in sync with docs_coverage.py's _EXCLUDED_DIR_PARTS."""
+    (tmp_path / "keep.py").write_text("x = 1\n", encoding="utf-8")
+
+    for skipped_dir_name in ("_tg_refs", ".tg_semantic_index", "external_repos"):
+        skipped_dir = tmp_path / skipped_dir_name
+        skipped_dir.mkdir()
+        (skipped_dir / "big.py").write_text("y = 2\n", encoding="utf-8")
+
+    repo_map._load_gitignore_matcher.cache_clear()
+    walked = {p.name for p in repo_map._iter_repo_files(tmp_path)}
+    assert "keep.py" in walked
+    assert "big.py" not in walked
+    for skipped_dir_name in ("_tg_refs", ".tg_semantic_index", "external_repos"):
+        assert repo_map._should_skip_repo_dir(tmp_path / skipped_dir_name)


### PR DESCRIPTION
**The reporter's #1**, root-caused by the deep-dive (cursor audit + Fable review) and fixed in 3 parts + a dogfood-found correction:
- **(A)** `_SKIP_DIR_NAMES` excludes tg-owned trees (`_tg_refs`/`.tg_semantic_index`/`external_repos`).
- **(B) main culprit**: the native per-file search walk had **no wall-clock** (rg routes were bounded, native wasn't). Added a per-file deadline (reusing rg's timeout resolver) → `result_incomplete` + partial matches, never a silent empty.
- **(C)** refuse a top-level-vendored root (`node_modules`/`vendor`/…) with exit 2 + actionable message (O(top-level) probe; excludes `.tensor-grep`/`_tg_refs` after a dogfood showed those broke every search from tg's own root).
- **Dogfood-found**: the front door is `bootstrap.py::main_entry` (own guard copy, fast-paths bypassing main.py) — mirrored the probe there so broad vendored roots fall through to the guard.

**Dogfood**: `search TODO` from `C:/dev/projects` (node_modules at top) **>30s hang → 0.51s exit 2**; tensor-grep root fast, no false refusal. 3251 unit + 21 integration green; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)