### PR TITLE
fix: restore exit-2-on-truncation even when found (revert #399, council-verified B)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7707,16 +7707,19 @@ def _emit_symbol_command_result(
         emit_text(payload)
         if caveat is not None:
             typer.echo(f"{'warning' if is_truncation else 'note'}: {caveat}")
-    # Exit-code contract (dogfood 1.40.1 -- narrowed from 1.40.0): the exit-2 "incomplete" signal
-    # applies ONLY to an EMPTY result. A result WITH findings is valid and exits 0 even when the scan
-    # was truncated (`result_incomplete`/`partial` in the JSON flags "the set may be incomplete, raise
-    # the budget for more") -- otherwise EVERY symbol query on a repo larger than the default
-    # --max-repo-files cap would exit 2 and an agent looping `if rc==0` could never proceed. An EMPTY
-    # result from a truncated scan is UNTRUSTWORTHY ("nothing found" may be a false negative because the
-    # scan did not finish) -> exit 2 (retry), NOT 1. A complete empty scan is a real not-found -> exit 1.
+    # Exit-code contract (council-verified B, 2026-07-05): a deadline/scan-truncated result is INCOMPLETE
+    # and must NOT read as complete (0) nor as a genuine not-found (1). Exit 2 -- REGARDLESS of whether
+    # results were found -- mirrors `tg search`'s result_incomplete convention (see the search command) so
+    # an agent sees ONE contract across every command, never trusts a truncated caller-set as exhaustive
+    # (a wrong blast-radius/refactor decision), and can distinguish "ran out of budget/cap, retry with
+    # more" from "genuinely absent". A found-but-truncated result exiting 0 was tried (#399) and overturned
+    # by a UNANIMOUS design council: truncation trumps found. The "every big-repo query exits 2" friction
+    # is a DEFAULT-CAP miscalibration (512, entangled with the slow TS caller re-parse), to fix separately
+    # -- NOT a reason to fork the contract in two. `--deadline` sets `partial`; a --max-repo-files cap sets
+    # `result_incomplete`; either -> exit 2.
+    if payload.get("partial") or payload.get("result_incomplete"):
+        raise typer.Exit(2)
     if not_found:
-        if payload.get("partial") or payload.get("result_incomplete"):
-            raise typer.Exit(2)
         raise typer.Exit(1)
 
 
@@ -8341,12 +8344,12 @@ def blast_radius(
     # more. So gate on partial/scan_limit, NOT result_incomplete (which _annotate also sets on output cap).
     scan_limit = payload.get("scan_limit")
     scan_truncated = isinstance(scan_limit, dict) and bool(scan_limit.get("possibly_truncated"))
-    # Only an EMPTY blast radius from a truncated scan is untrustworthy -> exit 2 (dogfood 1.40.1). A
-    # radius that RESOLVED callers is valid even if the scan was capped (matches the symbol-command
-    # rule); an OUTPUT cap (--max-callers/--max-files) is a complete analysis and stays exit 0.
-    incomplete = _symbol_payload_has_no_results(payload, "callers") and bool(
-        payload.get("partial") or scan_truncated
-    )
+    # A SCAN-truncated blast radius is INCOMPLETE regardless of whether callers were found -> exit 2
+    # (council-verified B, 2026-07-05; found-but-truncated->0 was tried in #399 and overturned). A
+    # truncated caller-set silently trusted as exhaustive is exactly the wrong-refactor risk this gate
+    # exists to prevent. An OUTPUT cap (--max-callers/--max-files) is a COMPLETE analysis, capped only for
+    # display -> stays exit 0 (so gate on scan-truncation/partial, never on the output cap).
+    incomplete = bool(payload.get("partial") or scan_truncated)
 
     if mermaid_output:
         typer.echo(_render_blast_radius_mermaid(payload))

--- a/tests/unit/test_cli_deadline_flag.py
+++ b/tests/unit/test_cli_deadline_flag.py
@@ -140,12 +140,13 @@ def test_impact_propagates_caller_scan_partial_exits_2(tmp_path: Path, monkeypat
     (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
 
     def _impact(symbol, path=".", **_kwargs):
-        # EMPTY impact (files=[]) + a deadline-truncated caller pass -> the empty is untrustworthy ->
-        # exit 2. (A non-empty impact is a valid found result and exits 0, dogfood 1.40.1.)
+        # impact FOUND files, but its second caller-scan pass is deadline-truncated -> impact must carry
+        # that partial signal and exit 2 EVEN THOUGH it found files (council-verified B: truncation trumps
+        # found), so an agent never trusts a truncated impact set as exhaustive.
         return {
             "symbol": symbol,
             "path": str(path),
-            "files": [],
+            "files": ["m.py"],
             "tests": [],
             "callers": [],
             "no_match": False,
@@ -160,29 +161,31 @@ def test_impact_propagates_caller_scan_partial_exits_2(tmp_path: Path, monkeypat
     assert result.exit_code == 2, result.output
 
 
-def test_found_with_partial_exits_0(tmp_path: Path, monkeypatch) -> None:
-    # dogfood 1.40.1: a result WITH findings is valid even if the scan was --deadline/cap truncated ->
-    # exit 0 (result_incomplete/partial in JSON flags "maybe more"). Only an EMPTY truncated result -> 2.
+def test_found_with_partial_exits_2(tmp_path: Path, monkeypatch) -> None:
+    # Council-verified B (2026-07-05): truncation trumps found -- a --deadline/cap-truncated result
+    # exits 2 EVEN WITH findings, so an agent never trusts a truncated caller-set as exhaustive. (The
+    # found->exit-0 narrowing was tried in #399 and overturned by a unanimous design council.)
     assert (
         _exit_code_for_payload(
             tmp_path, monkeypatch, {"callers": [{"file": "m.py", "line": 1}], "partial": True}
         )
-        == 0
+        == 2
     )
 
 
-def test_found_with_result_incomplete_exits_0(tmp_path: Path, monkeypatch) -> None:
+def test_found_with_result_incomplete_exits_2(tmp_path: Path, monkeypatch) -> None:
     assert (
         _exit_code_for_payload(
             tmp_path,
             monkeypatch,
             {"callers": [{"file": "m.py", "line": 1}], "result_incomplete": True},
         )
-        == 0
+        == 2
     )
 
 
-def test_blast_radius_found_partial_exits_0(tmp_path: Path, monkeypatch) -> None:
+def test_blast_radius_found_partial_exits_2(tmp_path: Path, monkeypatch) -> None:
+    # Council-verified B: a scan-truncated blast radius exits 2 even when callers were resolved.
     (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
 
     def _spy(symbol, path=".", **_kwargs):
@@ -198,4 +201,4 @@ def test_blast_radius_found_partial_exits_0(tmp_path: Path, monkeypatch) -> None
 
     monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _spy)
     result = CliRunner().invoke(app, ["blast-radius", "foo", str(tmp_path), "--json"])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 2, result.output


### PR DESCRIPTION
A unanimous design council overturned #399's found-but-truncated->exit-0 narrowing. Both lenses concluded **truncation must trump found**: `tg search` already exits 2 on `result_incomplete` regardless of matches (#399 forked the contract in two); the exit code is one control-flow bit and getting 'is this the COMPLETE set' wrong (a blast-radius that misses call-sites beyond the cap) is worse than a wasted retry; and the 'every big-repo query exits 2' friction is a **default-cap miscalibration** (512, entangled with the slow TS caller re-parse) to fix separately.

Restores `_emit_symbol_command_result` + the blast-radius block to exit 2 on `partial or result_incomplete` regardless of found/empty (blast-radius keeps output-cap-stays-0). Tests assert found+truncated -> 2. Dogfooded: `callers QueryEngine` on a big repo -> exit 2 (found but scan-capped = incomplete). Default-cap auto-scaling tracked in #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)