### PR TITLE
feat: fix the 512-cap misroute — raise routing map to 2000 + bound caller-scan via an internal ceiling (backlog #1)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -53,7 +53,16 @@ if TYPE_CHECKING:
     from tensor_grep.core.result import SearchResult
     from tensor_grep.io.directory_scanner import DirectoryScanner
 
-_DEFAULT_AGENT_REPO_SCAN_LIMIT = 512
+# backlog #1 (Fable+thinktank plan, 2026-07-06): kept numerically in sync with
+# repo_map.DEFAULT_AGENT_REPO_MAP_LIMIT (raised 512 -> 2000 for routing accuracy -- a file past
+# the old cap never entered the map, so edit-plan/agent/context-render/defs misrouted on repos
+# >512 files). This is a SEPARATE literal (not an import) because it is this module's CLI-option
+# default, shared across both ROUTING commands (edit-plan/agent/context-render/defs/source) and
+# CALLER-SCAN commands (callers/refs/blast-radius/impact/blast-radius-plan). Raising it to 2000
+# is safe for the caller-scan commands ONLY because repo_map.CALLER_SCAN_FILE_CEILING bounds
+# their actual per-file scan work at 512 regardless of how large this default is -- the
+# chokepoint, not a per-command repoint, is what keeps them fast.
+_DEFAULT_AGENT_REPO_SCAN_LIMIT = 2000
 _DEFAULT_BLAST_RADIUS_JSON_MAX_CALLERS = 25
 _DEFAULT_BLAST_RADIUS_JSON_MAX_FILES = 25
 _DOCTOR_LSP_PROBE_TIMEOUT_SECONDS = 15.0

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8680,7 +8680,12 @@ def blast_radius(
     # truncated caller-set silently trusted as exhaustive is exactly the wrong-refactor risk this gate
     # exists to prevent. An OUTPUT cap (--max-callers/--max-files) is a COMPLETE analysis, capped only for
     # display -> stays exit 0 (so gate on scan-truncation/partial, never on the output cap).
-    incomplete = bool(payload.get("partial") or scan_truncated)
+    # `caller_scan_truncated` = the backlog-#1 caller-scan ceiling (CALLER_SCAN_FILE_CEILING) dropped
+    # files the 2000-map covers -> a SCAN truncation (exit 2), distinct from an output cap. Without this
+    # the ceiling would silently exit 0 with a caller-set truncated at 512 (Fable final review of #405).
+    incomplete = bool(
+        payload.get("partial") or scan_truncated or payload.get("caller_scan_truncated")
+    )
 
     if mermaid_output:
         typer.echo(_render_blast_radius_mermaid(payload))

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -539,9 +539,19 @@ _CALLER_SCAN_CEILING_REMEDIATION = (
 def _mark_result_incomplete(payload: dict[str, Any], *, remediation: str) -> None:
     """Payload-level honesty signal (round-6 council): set result_incomplete + remediation at ASSEMBLY
     time so non-CLI consumers (MCP tools, *_json) get the same truncation signal the CLI emitter adds.
-    Additive; callers gate it on possibly_truncated so complete results never grow the key."""
+    Additive; callers gate it on possibly_truncated so complete results never grow the key.
+
+    backlog #1 fix: a plain ``setdefault`` was a no-op whenever the payload already carried a
+    ``scan_remediation`` key with value ``None`` (every repo_map/defs payload does -- build_repo_map
+    always stamps ``scan_remediation`` to either a message or ``None``, never omits the key). That
+    silently swallowed the CALLER_SCAN_FILE_CEILING remediation on a repo_map that was itself
+    complete (dogfood-caught: `tg callers` on a real >512-file repo set result_incomplete:true but
+    scan_remediation:null). Only skip when an existing message is genuinely present (truthy), so a
+    MORE SPECIFIC remediation set earlier is still preserved (test:
+    test_mark_result_incomplete_helper_does_not_clobber_existing_remediation)."""
     payload["result_incomplete"] = True
-    payload.setdefault("scan_remediation", remediation)
+    if not payload.get("scan_remediation"):
+        payload["scan_remediation"] = remediation
 
 
 def _copy_scan_limit(payload: dict[str, Any], source: dict[str, Any]) -> None:

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -139,7 +139,31 @@ def _mtime_aware_cache(
 JSON_OUTPUT_VERSION = 1
 ROUTING_BACKEND = "RepoMap"
 ROUTING_REASON = "repo-map"
-DEFAULT_AGENT_REPO_MAP_LIMIT = 512
+# backlog #1 (Fable+thinktank plan, 2026-07-06): raised 512 -> 2000 so ROUTING commands
+# (edit-plan/agent/context-render/defs/orient/session-open/MCP fallbacks) stop misrouting on
+# repos >512 files -- a file past the old cap never entered the map at all, so the right file
+# could not be found (dogfood-proven: edit-plan "API retry" -> wrong file at 512, correct at
+# 2000). Measured cold repo-map-build cost: 512=1.48s, 2000=3.51s (OK), 4000=10.35s
+# (superlinear -- do NOT raise past 2000 without re-measuring). This constant is ALSO the
+# default for `main.py`'s shared `_DEFAULT_AGENT_REPO_SCAN_LIMIT` CLI option default (kept as a
+# separate literal there deliberately -- see the comment at its definition) which feeds BOTH
+# routing commands AND the caller-scan commands (callers/refs/blast-radius/impact); raising it
+# is safe for caller-scan latency ONLY because CALLER_SCAN_FILE_CEILING below bounds their
+# actual per-file work independently of how large the map is.
+DEFAULT_AGENT_REPO_MAP_LIMIT = 2000
+# backlog #1 chokepoint (the thinktank's winning insight over "repoint every option default",
+# which leaks -- e.g. session_store.py's stored-session blast-radius calls
+# build_symbol_blast_radius_from_map directly on a full session repo_map with NO max_repo_files
+# passthrough, so a per-command option default cannot reach it). The caller-scan functions
+# (build_symbol_callers_from_map, build_symbol_blast_radius_from_map via its callers-scan,
+# build_symbol_refs_from_map) do a slow per-file prefilter + re-parse whose wall-clock scales
+# with the file universe size (task #52: ~100s on a 1941-file repo at the old 512 cap already;
+# a naive raise to 2000 would make it worse). This ceiling bounds that ONE hot loop at a single
+# internal chokepoint, so it stays fast regardless of DEFAULT_AGENT_REPO_MAP_LIMIT / an explicit
+# --max-repo-files / a stored session map's size. When the scan is capped below the map's true
+# file count, the payload is marked result_incomplete (see _CALLER_SCAN_CEILING_REMEDIATION)
+# so the exit-2 truncation-honesty contract still fires.
+CALLER_SCAN_FILE_CEILING = 512
 _DEFAULT_LSP_OPERATION_BUDGET_SECONDS = 2.0
 _LSP_OPERATION_BUDGET_ENV_VAR = "TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS"
 _SKIP_DIR_NAMES = {
@@ -498,6 +522,17 @@ _SCAN_LIMIT_TRUNCATED_REMEDIATION = (
     "A truncated scan dropped project files, so a zero or small count is NOT trustworthy. "
     "Re-run scoped to a subdirectory PATH, raise --max-repo-files, or warm the index with "
     "`tg session daemon start`."
+)
+
+# backlog #1 chokepoint: distinct from _SCAN_LIMIT_TRUNCATED_REMEDIATION above (which fires when
+# the repo-MAP itself was truncated before this symbol resolved). This fires when the map was
+# complete but the caller-scan's OWN internal ceiling (CALLER_SCAN_FILE_CEILING) bounded how many
+# of the map's files were actually walked for callers/references -- a resolved symbol may still
+# be missing callers that live past the ceiling.
+_CALLER_SCAN_CEILING_REMEDIATION = (
+    f"The caller-scan was bounded to the first {CALLER_SCAN_FILE_CEILING} repo-map files for "
+    "latency, even though the map covers more; callers/references in files past that window "
+    "may be missing. Narrow PATH to a subdirectory containing the symbol for full coverage."
 )
 
 
@@ -1177,6 +1212,17 @@ def _repo_map_file_universe(repo_map: dict[str, Any]) -> list[Path]:
             seen.add(normalized)
             files.append(Path(normalized))
     return files
+
+
+def _cap_caller_scan_files(files: list[Path]) -> tuple[list[Path], bool]:
+    """backlog #1 chokepoint: bound the caller-scan file universe to
+    CALLER_SCAN_FILE_CEILING regardless of how large the passed-in repo_map is (the map default
+    was raised for routing accuracy; caller-scan latency must not scale with it). Returns
+    (capped_files, ceiling_exceeded) so the caller can mark the payload result_incomplete only
+    when the ceiling actually dropped files."""
+    if len(files) > CALLER_SCAN_FILE_CEILING:
+        return files[:CALLER_SCAN_FILE_CEILING], True
+    return files, False
 
 
 def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
@@ -12520,7 +12566,7 @@ def build_symbol_refs_from_map(
         return payload
     context_payload = build_context_pack_from_map(repo_map, symbol)
     repo_root = Path(str(repo_map["path"])).resolve()
-    bounded_files = _repo_map_file_universe(repo_map)
+    bounded_files, refs_ceiling_hit = _cap_caller_scan_files(_repo_map_file_universe(repo_map))
     bounded_file_set = {str(current) for current in bounded_files}
     references: list[dict[str, Any]] = []
     refs_scan_deadline_hit = False
@@ -12702,6 +12748,10 @@ def build_symbol_refs_from_map(
             "reference_files_scanned": refs_files_scanned,
             "reference_files_total": len(bounded_files),
         }
+    if refs_ceiling_hit:
+        # backlog #1 chokepoint: the caller-scan ceiling dropped files the map otherwise covers
+        # -> the reference set is not exhaustive, so mark it honestly incomplete (exit-2 contract).
+        _mark_result_incomplete(payload, remediation=_CALLER_SCAN_CEILING_REMEDIATION)
     return payload
 
 
@@ -12770,7 +12820,7 @@ def build_symbol_callers_from_map(
         payload["coverage_summary"] = _coverage_summary(payload)
         return _attach_profiling(payload, _profiling_collector)
     repo_root = Path(str(repo_map["path"])).resolve()
-    bounded_files = _repo_map_file_universe(repo_map)
+    bounded_files, callers_ceiling_hit = _cap_caller_scan_files(_repo_map_file_universe(repo_map))
     bounded_file_set = {str(current) for current in bounded_files}
     preferred_definition_files = _preferred_definition_files(repo_map, symbol)
     preferred_definition_file_set = set(preferred_definition_files)
@@ -13103,6 +13153,10 @@ def build_symbol_callers_from_map(
     )
     _copy_scan_limit(payload, defs_payload)
     _copy_partial_signal(payload, defs_payload)
+    if callers_ceiling_hit:
+        # backlog #1 chokepoint: the caller-scan ceiling dropped files the map otherwise covers
+        # -> the caller set is not exhaustive, so mark it honestly incomplete (exit-2 contract).
+        _mark_result_incomplete(payload, remediation=_CALLER_SCAN_CEILING_REMEDIATION)
     return _attach_profiling(payload, _profiling_collector)
 
 
@@ -13688,6 +13742,17 @@ def build_symbol_blast_radius_from_map(
         caller_deadline_limit = callers_payload.get("deadline_limit")
         if isinstance(caller_deadline_limit, dict):
             payload["deadline_limit"] = dict(caller_deadline_limit)
+    if callers_payload.get("result_incomplete"):
+        # backlog #1 chokepoint: the direct-caller scan's internal ceiling (CALLER_SCAN_FILE_CEILING)
+        # dropped files the map covers -> the blast radius built on top of it is not exhaustive
+        # either (session_blast_radius calls this function directly on a full, unbounded session
+        # repo_map -- this is the leak fix, since a per-command option default can't reach that path).
+        _mark_result_incomplete(
+            payload,
+            remediation=str(
+                callers_payload.get("scan_remediation", _CALLER_SCAN_CEILING_REMEDIATION)
+            ),
+        )
     return _attach_profiling(payload, _profiling_collector)
 
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -13757,6 +13757,10 @@ def build_symbol_blast_radius_from_map(
         # dropped files the map covers -> the blast radius built on top of it is not exhaustive
         # either (session_blast_radius calls this function directly on a full, unbounded session
         # repo_map -- this is the leak fix, since a per-command option default can't reach that path).
+        # `caller_scan_truncated` is a DISTINCT scan-incompleteness signal so the blast-radius CLI gate
+        # can exit 2 on it WITHOUT catching a mere --max-callers/--max-files OUTPUT cap (which also sets
+        # result_incomplete but is a complete analysis capped only for display -> stays exit 0).
+        payload["caller_scan_truncated"] = True
         _mark_result_incomplete(
             payload,
             remediation=str(

--- a/tests/unit/test_cap_fix_chokepoint.py
+++ b/tests/unit/test_cap_fix_chokepoint.py
@@ -120,7 +120,8 @@ def test_build_symbol_callers_from_map_bounds_scan_to_ceiling(tmp_path, monkeypa
     assert calls["n"] <= repo_map.CALLER_SCAN_FILE_CEILING
     assert calls["n"] == repo_map.CALLER_SCAN_FILE_CEILING
     assert result.get("result_incomplete") is True
-    assert "scan_remediation" in result
+    # truthy, not just key-present: the pre-fix setdefault left scan_remediation=None (the dogfood bug)
+    assert result.get("scan_remediation")
 
 
 def test_build_symbol_callers_from_map_below_ceiling_stays_complete(tmp_path, monkeypatch) -> None:
@@ -223,3 +224,51 @@ def test_defs_on_oversized_repo_still_exits_2(tmp_path: Path) -> None:
     scan_limit = payload.get("scan_limit")
     assert isinstance(scan_limit, dict)
     assert scan_limit.get("possibly_truncated") is True
+
+
+# --- BLOCKER (Fable final review of #405): blast-radius must exit 2 on a caller-scan CEILING
+#     truncation (a SCAN truncation), while a mere --max-callers OUTPUT cap stays exit 0. ---
+
+
+def test_blast_radius_exits_2_on_caller_scan_ceiling_truncation(tmp_path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def _spy(symbol, path=".", **_kwargs):
+        # ceiling truncation: caller_scan_truncated set, but NOT partial / scan_limit (the 2000-map is
+        # itself complete) -- the blast-radius gate must STILL exit 2, not silently exit 0 at 512.
+        return {
+            "symbol": symbol,
+            "path": str(path),
+            "definitions": [{"file": "m.py", "line": 1}],
+            "callers": [{"file": "m.py", "line": 2}],
+            "files": ["m.py"],
+            "tests": [],
+            "result_incomplete": True,
+            "caller_scan_truncated": True,
+            "scan_remediation": "caller-scan bounded to 512 files",
+        }
+
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _spy)
+    result = runner.invoke(app, ["blast-radius", str(tmp_path), "f", "--json"])
+    assert result.exit_code == 2, result.stdout
+
+
+def test_blast_radius_output_cap_only_stays_exit_0(tmp_path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def _spy(symbol, path=".", **_kwargs):
+        # OUTPUT cap only (--max-callers trims a COMPLETE analysis) -> exit 0, NOT 2.
+        return {
+            "symbol": symbol,
+            "path": str(path),
+            "definitions": [{"file": "m.py", "line": 1}],
+            "callers": [{"file": "m.py", "line": 2}],
+            "files": ["m.py"],
+            "tests": [],
+            "result_incomplete": True,
+            "output_limit": {"possibly_truncated": True, "callers_truncated": True},
+        }
+
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _spy)
+    result = runner.invoke(app, ["blast-radius", str(tmp_path), "f", "--json"])
+    assert result.exit_code == 0, result.stdout

--- a/tests/unit/test_cap_fix_chokepoint.py
+++ b/tests/unit/test_cap_fix_chokepoint.py
@@ -1,0 +1,225 @@
+"""TDD for backlog #1 (Fable+thinktank plan, 2026-07-06): the cap-fix chokepoint.
+
+Two changes, tested together because they only make sense as a pair:
+
+1. ``repo_map.DEFAULT_AGENT_REPO_MAP_LIMIT`` (and the CLI's shared
+   ``main._DEFAULT_AGENT_REPO_SCAN_LIMIT``) raised 512 -> 2000 so ROUTING commands
+   (defs/edit-plan/agent/context-render) stop misrouting on repos with more than 512 files --
+   a file past the old cap never entered the map at all, so the right file could not be found.
+2. A NEW internal chokepoint, ``repo_map.CALLER_SCAN_FILE_CEILING`` (512), caps the file
+   universe that the CALLER-SCAN functions (``build_symbol_callers_from_map``,
+   ``build_symbol_blast_radius_from_map``, ``build_symbol_refs_from_map``) actually walk for
+   their slow per-file prefilter + re-parse, REGARDLESS of how large the map/session repo_map
+   is. This is what keeps callers/refs/blast-radius fast even though the map default just grew
+   4x, and it is also what fixes the session-blast-radius leak (session_store.py calls
+   ``build_symbol_blast_radius_from_map`` directly on a full stored session map with no
+   per-command cap to intercept it).
+
+Gate items (a)-(d) below map 1:1 onto the plan's TDD list.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from tensor_grep.cli import repo_map, session_store
+from tensor_grep.cli.main import _DEFAULT_AGENT_REPO_SCAN_LIMIT, app
+
+runner = CliRunner()
+
+
+def _make_flat_repo(
+    root: Path,
+    count: int,
+    *,
+    target_index: int | None = None,
+    symbol: str | None = None,
+) -> Path:
+    """Build a project with ``count`` trivial .py files in a single directory (one top-level
+    walk bucket), so the deterministic alphabetical file order is easy to reason about. When
+    ``target_index`` is given, that file ALSO defines ``symbol`` -- callers can place it past a
+    known cap boundary."""
+    project = root / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    width = max(5, len(str(count)))
+    for index in range(count):
+        body = f"def helper_{index}():\n    return {index}\n"
+        if target_index is not None and index == target_index and symbol:
+            body += f"\n\ndef {symbol}():\n    return {index}\n"
+        (src / f"m{index:0{width}d}.py").write_text(body, encoding="utf-8")
+    return project
+
+
+def test_constants_locked_to_the_plan() -> None:
+    assert repo_map.DEFAULT_AGENT_REPO_MAP_LIMIT == 2000
+    assert repo_map.CALLER_SCAN_FILE_CEILING == 512
+    # The CLI's shared routing/caller-scan default must track the map limit -- this is the
+    # "necessary correction" over the plan's literal wording: main.py's `--max-repo-files`
+    # default for defs/edit-plan/agent/context-render is a SEPARATE literal
+    # (`_DEFAULT_AGENT_REPO_SCAN_LIMIT`), not `DEFAULT_AGENT_REPO_MAP_LIMIT` -- bumping only the
+    # repo_map.py constant would silently leave those CLI commands defaulting to 512.
+    assert _DEFAULT_AGENT_REPO_SCAN_LIMIT == repo_map.DEFAULT_AGENT_REPO_MAP_LIMIT
+
+
+# --- (a) routing commands find a symbol whose definition sits past the OLD 512-file cap -------
+
+
+def test_defs_finds_symbol_past_512_at_the_new_default(tmp_path: Path) -> None:
+    project = _make_flat_repo(tmp_path, 600, target_index=550, symbol="find_me_past_512")
+
+    # Reproduce the bug at the OLD cap: the symbol's file never enters the map.
+    old_cap_result = repo_map.build_symbol_defs(
+        "find_me_past_512", str(project), max_repo_files=512
+    )
+    assert old_cap_result.get("no_match") is True
+
+    # `tg defs` with NO --max-repo-files override uses the CLI's real default.
+    result = runner.invoke(app, ["defs", str(project), "find_me_past_512", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload.get("no_match") is not True
+    assert any(str(d["file"]).endswith("m00550.py") for d in payload["definitions"])
+
+
+def test_edit_plan_routes_to_symbol_past_512_at_the_new_default(tmp_path: Path) -> None:
+    project = _make_flat_repo(tmp_path, 600, target_index=550, symbol="find_me_past_512")
+
+    result = runner.invoke(app, ["edit-plan", str(project), "find_me_past_512", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    all_paths = [
+        *payload.get("files", []),
+        *[str(s.get("file", "")) for s in payload.get("symbols", [])],
+    ]
+    assert any(path.endswith("m00550.py") for path in all_paths), payload
+
+
+# --- (b) caller-scan internally bounds its file universe + honesty flag -----------------------
+
+
+def test_build_symbol_callers_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch) -> None:
+    project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="target_symbol")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
+    assert len(rmap["files"]) + len(rmap.get("tests", [])) >= 700
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = repo_map.build_symbol_callers_from_map(rmap, "target_symbol")
+
+    assert calls["n"] <= repo_map.CALLER_SCAN_FILE_CEILING
+    assert calls["n"] == repo_map.CALLER_SCAN_FILE_CEILING
+    assert result.get("result_incomplete") is True
+    assert "scan_remediation" in result
+
+
+def test_build_symbol_callers_from_map_below_ceiling_stays_complete(tmp_path, monkeypatch) -> None:
+    project = _make_flat_repo(tmp_path, 300, target_index=0, symbol="target_symbol")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=300)
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = repo_map.build_symbol_callers_from_map(rmap, "target_symbol")
+
+    assert calls["n"] < repo_map.CALLER_SCAN_FILE_CEILING
+    assert result.get("result_incomplete") is not True
+
+
+def test_build_symbol_refs_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch) -> None:
+    project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="target_symbol")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = repo_map.build_symbol_refs_from_map(rmap, "target_symbol")
+
+    assert result.get("result_incomplete") is True
+
+
+def test_build_symbol_blast_radius_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch) -> None:
+    project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="target_symbol")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = repo_map.build_symbol_blast_radius_from_map(rmap, "target_symbol")
+
+    assert calls["n"] <= repo_map.CALLER_SCAN_FILE_CEILING
+    assert result.get("result_incomplete") is True
+
+
+# --- (c) the session-blast-radius leak: build_symbol_blast_radius_from_map is called directly --
+# --- on the full stored session repo_map, with no per-command cap to intercept it --------------
+
+
+def test_session_blast_radius_leak_fix_bounds_scan(tmp_path, monkeypatch) -> None:
+    project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="leaked_symbol")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
+
+    monkeypatch.setattr(
+        session_store,
+        "_load_session_payload",
+        lambda session_id, path, **kwargs: {"repo_map": rmap},
+    )
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = session_store.session_blast_radius("fake-session", "leaked_symbol", str(project))
+
+    assert calls["n"] <= repo_map.CALLER_SCAN_FILE_CEILING
+    assert result.get("result_incomplete") is True
+
+
+# --- (d) a genuinely oversized (>2000-file) tree still trips the exit-2 truncation contract ----
+
+
+def test_defs_on_oversized_repo_still_exits_2(tmp_path: Path) -> None:
+    project = _make_flat_repo(tmp_path, 2100, target_index=2050, symbol="beyond_new_cap")
+
+    result = runner.invoke(app, ["defs", str(project), "beyond_new_cap", "--json"])
+
+    assert result.exit_code == 2, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload.get("no_match") is True
+    assert payload.get("result_incomplete") is True
+    scan_limit = payload.get("scan_limit")
+    assert isinstance(scan_limit, dict)
+    assert scan_limit.get("possibly_truncated") is True

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -6265,7 +6265,8 @@ def test_agent_capsule_json_emits_argv_safe_recovery_commands_for_spaced_paths(t
         "--max-tokens",
         "1",
         "--max-repo-files",
-        "512",
+        # backlog #1: --max-repo-files default raised 512 -> 2000 for routing accuracy.
+        "2000",
     ]
     assert f'"{project.resolve()}"' in raw_ref["command"]
     assert "--query" not in raw_ref["argv"]
@@ -7166,7 +7167,8 @@ def test_edit_plan_json_returns_machine_readable_plan_bundle(tmp_path):
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["routing_reason"] == "context-edit-plan"
-    assert payload["scan_limit"]["max_repo_files"] == 512
+    # backlog #1: --max-repo-files default raised 512 -> 2000 for routing accuracy.
+    assert payload["scan_limit"]["max_repo_files"] == 2000
     assert "rendered_context" not in payload
     assert "sources" not in payload
     assert payload["candidate_edit_targets"]["files"][0] == str(module_path.resolve())

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -1805,7 +1805,8 @@ def test_top_level_context_render_uses_running_daemon_response_cache(
             "optimize_context": False,
             "render_profile": "llm",
             "profile": False,
-            "max_repo_files": 512,
+            # backlog #1: --max-repo-files default raised 512 -> 2000 for routing accuracy.
+            "max_repo_files": 2000,
         }
     ]
 
@@ -1866,7 +1867,8 @@ def test_top_level_edit_plan_uses_running_daemon_response_cache(
             "max_tokens": None,
             "max_symbols": 5,
             "profile": False,
-            "max_repo_files": 512,
+            # backlog #1: --max-repo-files default raised 512 -> 2000 for routing accuracy.
+            "max_repo_files": 2000,
         }
     ]
 


### PR DESCRIPTION
**The #1 product issue** (triple-confirmed: exit-code council + 2 dogfoods). Fable-designed, thinktank-adversarially-reviewed (the thinktank's chokepoint insight replaced a leaky 8-site plan).

**Two changes:**
1. `DEFAULT_AGENT_REPO_MAP_LIMIT` 512→**2000** — routing commands (edit-plan/agent/context-render/defs/orient) now see the whole repo (cold cost measured 3.5s; 4000 was superlinear).
2. **The chokepoint** — a `CALLER_SCAN_FILE_CEILING=512` inside the `_from_map` caller-scan functions bounds the slow re-parse REGARDLESS of map size, so callers/refs/blast-radius (and the direct-`_from_map` **session blast-radius**, which the thinktank caught leaks) stay fast; still exits 2 when the ceiling truncates.
+ a dogfood-caught fix: `_mark_result_incomplete` no longer swallows the ceiling remediation when `scan_remediation` is None.

**Verified (real venv):** 548 tests pass; ruff/mypy clean. **Dogfood (1938-file TS repo):** `defs QueryEngine` now `result_incomplete=false` (was truncated at 512); `callers` bounded (~20s, exit 2, not the ~100s unbounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)