### PR TITLE
build(ruff): exclude .claude/skills from lint+format (fixes recurring skill-markdown format-gate false-alarms)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ extend-exclude = [
     "benchmarks/bench_ast_data",
     "benchmarks/gpu_bench_data",
     "benchmarks/external_repos",
+    # Skill docs are prose, not code. `ruff format --preview` reformats python fenced code blocks
+    # inside their markdown, which false-alarms the CI format gate on skill examples (and the
+    # harness re-touches these files with CRLF). Exclude them from lint+format entirely.
+    ".claude/skills",
 ]
 
 [tool.ruff.format]

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -39,6 +39,7 @@ def test_ruff_should_extend_default_excludes_for_repo_specific_bench_dirs() -> N
         "benchmarks/bench_ast_data",
         "benchmarks/gpu_bench_data",
         "benchmarks/external_repos",
+        ".claude/skills",
     ]
 
 


### PR DESCRIPTION
The CI 'Formatting & Linting' gate runs `ruff format --check --preview .`, which reformats python fenced code blocks *inside* skill markdown. Combined with the harness re-touching `.claude/skills/*.md` (CRLF churn), this keeps false-failing the gate on skill-doc PRs (#402) despite `line-ending = lf` already being set. Skills are prose docs, not code — excluding `.claude/skills` from lint+format is the root-cause fix + prevents recurrence for all future skill PRs. Unblocks #402 (rebase onto this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)