### PR TITLE
fix(F1): tg refs/callers completeness regression — order the ceiling budget (literal-hits + interleaved tests) + structured caller_scan_limit caveat

### DIFF
--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279b0f31df31b4add8aeae57d40f3b5e53aad2b531e89b982bd75ed1898851d"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7938,19 +7938,30 @@ def _scan_truncation_warning(payload: dict[str, Any]) -> str | None:
     count) that renders identically to a real one — the single most dangerous output for a
     refactor-safety tool, since it greenlights deleting live code. The payload already knows;
     this projects it into the default output so an incomplete result can never look complete.
-    Handles all three shapes production emits: the repo-scan cap
-    (``scan_limit.possibly_truncated`` — callers/refs/impact), the repo-map output cap
-    (``output_limit.possibly_truncated`` — map/context), and the blast-radius output cap
-    (``output_limit.callers_truncated`` / ``files_truncated``). Returns None when complete.
+    Handles all four shapes production emits: the repo-scan cap
+    (``scan_limit.possibly_truncated`` — callers/refs/impact), the caller-scan ceiling
+    (``caller_scan_limit.possibly_truncated`` — F1: a COMPLETE repo-map whose own internal
+    CALLER_SCAN_FILE_CEILING still bounded how many of its files were walked for callers/refs),
+    the repo-map output cap (``output_limit.possibly_truncated`` — map/context), and the
+    blast-radius output cap (``output_limit.callers_truncated`` / ``files_truncated``). Returns
+    None when complete.
     """
-    for key in ("scan_limit", "output_limit"):
+    for key in ("scan_limit", "caller_scan_limit", "output_limit"):
         limit = payload.get(key)
-        if isinstance(limit, dict) and limit.get("possibly_truncated"):
-            scanned = limit.get("scanned_files", limit.get("emitted_files", "?"))
-            cap = limit.get("max_repo_files", limit.get("max_files", "?"))
+        if not (isinstance(limit, dict) and limit.get("possibly_truncated")):
+            continue
+        if key == "caller_scan_limit":
+            ceiling = limit.get("ceiling", "?")
+            files_total = limit.get("files_total", "?")
             return _truncation_message(
-                f"the scan stopped at a {cap}-file cap (scanned {scanned}) and dropped project files"
+                f"caller-scan bounded to the first {ceiling} of {files_total} mapped files; "
+                "narrow the PATH or raise --max-repo-files for full coverage"
             )
+        scanned = limit.get("scanned_files", limit.get("emitted_files", "?"))
+        cap = limit.get("max_repo_files", limit.get("max_files", "?"))
+        return _truncation_message(
+            f"the scan stopped at a {cap}-file cap (scanned {scanned}) and dropped project files"
+        )
     output_limit = payload.get("output_limit")
     if isinstance(output_limit, dict) and (
         output_limit.get("callers_truncated") or output_limit.get("files_truncated")

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -536,7 +536,12 @@ _CALLER_SCAN_CEILING_REMEDIATION = (
 )
 
 
-def _mark_result_incomplete(payload: dict[str, Any], *, remediation: str) -> None:
+def _mark_result_incomplete(
+    payload: dict[str, Any],
+    *,
+    remediation: str,
+    caller_scan_limit: dict[str, Any] | None = None,
+) -> None:
     """Payload-level honesty signal (round-6 council): set result_incomplete + remediation at ASSEMBLY
     time so non-CLI consumers (MCP tools, *_json) get the same truncation signal the CLI emitter adds.
     Additive; callers gate it on possibly_truncated so complete results never grow the key.
@@ -548,10 +553,20 @@ def _mark_result_incomplete(payload: dict[str, Any], *, remediation: str) -> Non
     complete (dogfood-caught: `tg callers` on a real >512-file repo set result_incomplete:true but
     scan_remediation:null). Only skip when an existing message is genuinely present (truthy), so a
     MORE SPECIFIC remediation set earlier is still preserved (test:
-    test_mark_result_incomplete_helper_does_not_clobber_existing_remediation)."""
+    test_mark_result_incomplete_helper_does_not_clobber_existing_remediation).
+
+    F1 fix: ``caller_scan_limit`` is the structured sibling of the CALLER_SCAN_CEILING
+    remediation string above -- a machine-checkable ``{"possibly_truncated": True, "ceiling":
+    ..., "files_total": ...}`` dict (mirroring the existing ``scan_limit`` shape) so a JSON
+    consumer doesn't have to regex the prose remediation to learn the ceiling/total. Only
+    callers that actually hit the caller-scan ceiling pass this; every other
+    ``_mark_result_incomplete`` call site (the generic repo-map scan truncation) omits it, so a
+    complete-map/ceiling-truncated result never grows the key."""
     payload["result_incomplete"] = True
     if not payload.get("scan_remediation"):
         payload["scan_remediation"] = remediation
+    if caller_scan_limit is not None:
+        payload["caller_scan_limit"] = caller_scan_limit
 
 
 def _copy_scan_limit(payload: dict[str, Any], source: dict[str, Any]) -> None:
@@ -1206,12 +1221,19 @@ def _literal_symbol_seed_files(
     return seed_files
 
 
-def _repo_map_file_universe(repo_map: dict[str, Any]) -> list[Path]:
+def _repo_map_file_and_test_universe(repo_map: dict[str, Any]) -> tuple[list[Path], list[Path]]:
+    """Same normalization + cross-key dedupe as ``_repo_map_file_universe`` below, but returned
+    as SEPARATE (files, tests) lists so a caller can distinguish membership (F1 fix: the
+    caller-scan ceiling ordering needs to know which universe members are tests) without
+    re-deriving it. ``_repo_map_file_universe`` is a thin wrapper over this and its
+    source-first-then-tests concatenation order is UNCHANGED -- existing global-order
+    consumers (build_context_pack_from_map, edit-plan seeding) are untouched."""
     root = Path(str(repo_map["path"])).expanduser().resolve()
     base = root if root.is_dir() else root.parent
-    files: list[Path] = []
     seen: set[str] = set()
-    for key in ("files", "tests"):
+    files: list[Path] = []
+    tests: list[Path] = []
+    for key, bucket in (("files", files), ("tests", tests)):
         for raw_path in repo_map.get(key, []) or []:
             current = Path(str(raw_path)).expanduser()
             if not current.is_absolute():
@@ -1220,19 +1242,117 @@ def _repo_map_file_universe(repo_map: dict[str, Any]) -> list[Path]:
             if normalized in seen:
                 continue
             seen.add(normalized)
-            files.append(Path(normalized))
-    return files
+            bucket.append(Path(normalized))
+    return files, tests
 
 
-def _cap_caller_scan_files(files: list[Path]) -> tuple[list[Path], bool]:
+def _repo_map_file_universe(repo_map: dict[str, Any]) -> list[Path]:
+    files, tests = _repo_map_file_and_test_universe(repo_map)
+    return [*files, *tests]
+
+
+def _interleave_proportionally(sources: list[Path], tests: list[Path]) -> list[Path]:
+    """Merge two ordered lists so that ANY prefix of the result carries roughly its
+    proportional share of ``tests`` (a Bresenham-style proportional interleave). Used so a
+    ceiling slice taken from the FRONT of the merged list never strands 100% of the test
+    files behind a long run of source files, no matter how large ``sources`` is relative to
+    ``tests``."""
+    if not tests:
+        return list(sources)
+    if not sources:
+        return list(tests)
+    total = len(sources) + len(tests)
+    merged: list[Path] = []
+    source_idx = 0
+    test_idx = 0
+    for position in range(1, total + 1):
+        expected_tests_by_now = math.ceil(position * len(tests) / total)
+        if test_idx < expected_tests_by_now and test_idx < len(tests):
+            merged.append(tests[test_idx])
+            test_idx += 1
+        elif source_idx < len(sources):
+            merged.append(sources[source_idx])
+            source_idx += 1
+        else:
+            merged.append(tests[test_idx])
+            test_idx += 1
+    return merged
+
+
+def _order_caller_scan_candidates(
+    source_files: list[Path],
+    test_files: list[Path],
+    *,
+    symbol: str | None,
+) -> list[Path]:
+    """F1 fix (dogfood v1.42.0, 24->14 refs regression): ORDER the caller-scan candidate
+    universe before ``_cap_caller_scan_files`` applies its ``CALLER_SCAN_FILE_CEILING`` slice.
+
+    ``_repo_map_file_universe`` deliberately keeps a source-first-then-tests order (other
+    consumers depend on it -- do not change it globally); left as-is, a >CEILING-source repo
+    consumes the ENTIRE ceiling budget on source files and stone-cold strands every test file
+    past the window. This function only changes what the CEILING SLICE sees: literal
+    symbol-hit files (probed via the already-cached ``_file_may_contain_literal_symbol``, which
+    warms the same cache the per-file caller/ref scan reads right after) sort first, then any
+    remaining source and test files are interleaved proportionally to their share of what's
+    left, so the ceiling window always carries some of both instead of 0% tests.
+
+    TRAP (do not regress): literal-contains is an ORDERING signal only, never a FILTER. A
+    caller/ref can resolve with NO literal symbol byte match in the referencing file itself --
+    e.g. an aliased re-export resolved via ``_js_ts_provider_alias_calls`` -- so every file
+    stays eligible for the ceiling slice; only its position changes.
+    """
+    normalized_symbol = (symbol or "").strip()
+    if not normalized_symbol:
+        return [*source_files, *test_files]
+
+    def _is_literal_hit(path: Path) -> bool:
+        return _literal_symbol_candidate(path) and _file_may_contain_literal_symbol(
+            path, normalized_symbol
+        )
+
+    literal_hit_ids: set[str] = set()
+    literal_hits: list[Path] = []
+    for current in [*source_files, *test_files]:
+        if _is_literal_hit(current):
+            literal_hit_ids.add(str(current))
+            literal_hits.append(current)
+
+    remaining_sources = [current for current in source_files if str(current) not in literal_hit_ids]
+    remaining_tests = [current for current in test_files if str(current) not in literal_hit_ids]
+    return [*literal_hits, *_interleave_proportionally(remaining_sources, remaining_tests)]
+
+
+def _cap_caller_scan_files(
+    files: list[Path],
+    *,
+    symbol: str | None = None,
+    test_files: list[Path] | None = None,
+) -> tuple[list[Path], bool]:
     """backlog #1 chokepoint: bound the caller-scan file universe to
     CALLER_SCAN_FILE_CEILING regardless of how large the passed-in repo_map is (the map default
     was raised for routing accuracy; caller-scan latency must not scale with it). Returns
     (capped_files, ceiling_exceeded) so the caller can mark the payload result_incomplete only
-    when the ceiling actually dropped files."""
-    if len(files) > CALLER_SCAN_FILE_CEILING:
-        return files[:CALLER_SCAN_FILE_CEILING], True
-    return files, False
+    when the ceiling actually dropped files.
+
+    F1 fix: when a slice is actually needed AND the caller passes ``test_files`` (the subset of
+    ``files`` classified as tests), ORDER the candidates first via
+    ``_order_caller_scan_candidates`` so literal symbol-hit files and a proportional share of
+    tests survive the slice instead of being stranded behind a long source-file run (see that
+    function's docstring for the full rationale + trap). The ceiling itself is left at 512 on
+    purpose -- raising it reintroduces task #52's ~100s TS-regex hang, the reason
+    CALLER_SCAN_FILE_CEILING shipped (see the module note above ``CALLER_SCAN_FILE_CEILING``).
+    When no ``test_files`` are passed (or none exist), behavior is unchanged: a plain prefix
+    slice of ``files`` in whatever order the caller already supplied."""
+    if len(files) <= CALLER_SCAN_FILE_CEILING:
+        return files, False
+    if test_files:
+        test_id_set = {str(current) for current in test_files}
+        source_only = [current for current in files if str(current) not in test_id_set]
+        ordered = _order_caller_scan_candidates(source_only, test_files, symbol=symbol)
+    else:
+        ordered = files
+    return ordered[:CALLER_SCAN_FILE_CEILING], True
 
 
 def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
@@ -12576,7 +12696,12 @@ def build_symbol_refs_from_map(
         return payload
     context_payload = build_context_pack_from_map(repo_map, symbol)
     repo_root = Path(str(repo_map["path"])).resolve()
-    bounded_files, refs_ceiling_hit = _cap_caller_scan_files(_repo_map_file_universe(repo_map))
+    refs_universe_files, refs_universe_tests = _repo_map_file_and_test_universe(repo_map)
+    bounded_files, refs_ceiling_hit = _cap_caller_scan_files(
+        [*refs_universe_files, *refs_universe_tests],
+        symbol=symbol,
+        test_files=refs_universe_tests,
+    )
     bounded_file_set = {str(current) for current in bounded_files}
     references: list[dict[str, Any]] = []
     refs_scan_deadline_hit = False
@@ -12761,7 +12886,15 @@ def build_symbol_refs_from_map(
     if refs_ceiling_hit:
         # backlog #1 chokepoint: the caller-scan ceiling dropped files the map otherwise covers
         # -> the reference set is not exhaustive, so mark it honestly incomplete (exit-2 contract).
-        _mark_result_incomplete(payload, remediation=_CALLER_SCAN_CEILING_REMEDIATION)
+        _mark_result_incomplete(
+            payload,
+            remediation=_CALLER_SCAN_CEILING_REMEDIATION,
+            caller_scan_limit={
+                "possibly_truncated": True,
+                "ceiling": CALLER_SCAN_FILE_CEILING,
+                "files_total": len(refs_universe_files) + len(refs_universe_tests),
+            },
+        )
     return payload
 
 
@@ -12830,7 +12963,12 @@ def build_symbol_callers_from_map(
         payload["coverage_summary"] = _coverage_summary(payload)
         return _attach_profiling(payload, _profiling_collector)
     repo_root = Path(str(repo_map["path"])).resolve()
-    bounded_files, callers_ceiling_hit = _cap_caller_scan_files(_repo_map_file_universe(repo_map))
+    callers_universe_files, callers_universe_tests = _repo_map_file_and_test_universe(repo_map)
+    bounded_files, callers_ceiling_hit = _cap_caller_scan_files(
+        [*callers_universe_files, *callers_universe_tests],
+        symbol=symbol,
+        test_files=callers_universe_tests,
+    )
     bounded_file_set = {str(current) for current in bounded_files}
     preferred_definition_files = _preferred_definition_files(repo_map, symbol)
     preferred_definition_file_set = set(preferred_definition_files)
@@ -13166,7 +13304,15 @@ def build_symbol_callers_from_map(
     if callers_ceiling_hit:
         # backlog #1 chokepoint: the caller-scan ceiling dropped files the map otherwise covers
         # -> the caller set is not exhaustive, so mark it honestly incomplete (exit-2 contract).
-        _mark_result_incomplete(payload, remediation=_CALLER_SCAN_CEILING_REMEDIATION)
+        _mark_result_incomplete(
+            payload,
+            remediation=_CALLER_SCAN_CEILING_REMEDIATION,
+            caller_scan_limit={
+                "possibly_truncated": True,
+                "ceiling": CALLER_SCAN_FILE_CEILING,
+                "files_total": len(callers_universe_files) + len(callers_universe_tests),
+            },
+        )
     return _attach_profiling(payload, _profiling_collector)
 
 
@@ -13761,10 +13907,16 @@ def build_symbol_blast_radius_from_map(
         # can exit 2 on it WITHOUT catching a mere --max-callers/--max-files OUTPUT cap (which also sets
         # result_incomplete but is a complete analysis capped only for display -> stays exit 0).
         payload["caller_scan_truncated"] = True
+        callers_caller_scan_limit = callers_payload.get("caller_scan_limit")
         _mark_result_incomplete(
             payload,
             remediation=str(
                 callers_payload.get("scan_remediation", _CALLER_SCAN_CEILING_REMEDIATION)
+            ),
+            caller_scan_limit=(
+                dict(callers_caller_scan_limit)
+                if isinstance(callers_caller_scan_limit, dict)
+                else None
             ),
         )
     return _attach_profiling(payload, _profiling_collector)

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -164,6 +164,20 @@ DEFAULT_AGENT_REPO_MAP_LIMIT = 2000
 # file count, the payload is marked result_incomplete (see _CALLER_SCAN_CEILING_REMEDIATION)
 # so the exit-2 truncation-honesty contract still fires.
 CALLER_SCAN_FILE_CEILING = 512
+# F1-review HIGH fix (task#52 shape, 2026-07-06): _order_caller_scan_candidates probes
+# _file_may_contain_literal_symbol (a stat + cached read_bytes) across the caller-scan file
+# UNIVERSE to decide ordering, BEFORE _cap_caller_scan_files slices to CALLER_SCAN_FILE_CEILING.
+# Left unbounded, that probe pays O(map-size) I/O regardless of the 512 ceiling or --deadline --
+# exactly the pathology CALLER_SCAN_FILE_CEILING exists to prevent, just one step earlier in the
+# pipeline. This ceiling bounds the PROBE itself (belt); the deadline check threaded into the
+# same loop is the suspenders. 4x the scan ceiling so a normal (<=2000-file) map's ordering pass
+# is never truncated in practice -- it only bites when --max-repo-files is raised well past the
+# default, which is exactly the case this fix targets.
+CALLER_SCAN_ORDER_PROBE_CEILING = 4 * CALLER_SCAN_FILE_CEILING
+# How often (in probed files) the ordering pass re-checks the deadline. Checking every file would
+# add a time.monotonic() call per file; checking too rarely risks overrunning a tight --deadline
+# by a wide margin. 64 is a compromise consistent with other bounded-scan loops in this module.
+_CALLER_SCAN_ORDER_PROBE_DEADLINE_STRIDE = 64
 _DEFAULT_LSP_OPERATION_BUDGET_SECONDS = 2.0
 _LSP_OPERATION_BUDGET_ENV_VAR = "TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS"
 _SKIP_DIR_NAMES = {
@@ -1284,6 +1298,7 @@ def _order_caller_scan_candidates(
     test_files: list[Path],
     *,
     symbol: str | None,
+    deadline_monotonic: float | None = None,
 ) -> list[Path]:
     """F1 fix (dogfood v1.42.0, 24->14 refs regression): ORDER the caller-scan candidate
     universe before ``_cap_caller_scan_files`` applies its ``CALLER_SCAN_FILE_CEILING`` slice.
@@ -1293,14 +1308,25 @@ def _order_caller_scan_candidates(
     consumes the ENTIRE ceiling budget on source files and stone-cold strands every test file
     past the window. This function only changes what the CEILING SLICE sees: literal
     symbol-hit files (probed via the already-cached ``_file_may_contain_literal_symbol``, which
-    warms the same cache the per-file caller/ref scan reads right after) sort first, then any
-    remaining source and test files are interleaved proportionally to their share of what's
-    left, so the ceiling window always carries some of both instead of 0% tests.
+    warms the same cache the per-file caller/ref scan reads right after) sort first WITHIN their
+    own category (source/test), then ``_interleave_proportionally`` merges the two categories so
+    EVERY prefix of the result -- including the eventual ceiling slice -- carries a proportional
+    share of test files. Interleaving globally (rather than only after a literal-hits block) is
+    the F1-review LOW-MED fix: a source-heavy run of literal hits can no longer consume the
+    entire ceiling budget and strand 100% of the test files, hit or not, past the window.
 
     TRAP (do not regress): literal-contains is an ORDERING signal only, never a FILTER. A
     caller/ref can resolve with NO literal symbol byte match in the referencing file itself --
     e.g. an aliased re-export resolved via ``_js_ts_provider_alias_calls`` -- so every file
     stays eligible for the ceiling slice; only its position changes.
+
+    F1-review HIGH fix (task#52 shape): the literal-hit probe itself must not scale with the
+    full file universe -- bounded both by count (``CALLER_SCAN_ORDER_PROBE_CEILING``) and, when
+    a deadline is in play, by wall-clock (checked every
+    ``_CALLER_SCAN_ORDER_PROBE_DEADLINE_STRIDE`` files). Files past whichever bound is hit first
+    are simply never probed (treated as non-hits for ordering purposes) -- they are NEVER
+    dropped from the candidate list, only left unprobed, so they still land in the
+    source/test-first remainder that ``_interleave_proportionally`` merges below.
     """
     normalized_symbol = (symbol or "").strip()
     if not normalized_symbol:
@@ -1311,16 +1337,27 @@ def _order_caller_scan_candidates(
             path, normalized_symbol
         )
 
+    universe = [*source_files, *test_files]
     literal_hit_ids: set[str] = set()
-    literal_hits: list[Path] = []
-    for current in [*source_files, *test_files]:
+    for index, current in enumerate(universe):
+        if index >= CALLER_SCAN_ORDER_PROBE_CEILING:
+            break
+        if (
+            deadline_monotonic is not None
+            and index % _CALLER_SCAN_ORDER_PROBE_DEADLINE_STRIDE == 0
+            and time.monotonic() >= deadline_monotonic
+        ):
+            break
         if _is_literal_hit(current):
             literal_hit_ids.add(str(current))
-            literal_hits.append(current)
 
-    remaining_sources = [current for current in source_files if str(current) not in literal_hit_ids]
-    remaining_tests = [current for current in test_files if str(current) not in literal_hit_ids]
-    return [*literal_hits, *_interleave_proportionally(remaining_sources, remaining_tests)]
+    ordered_sources = [current for current in source_files if str(current) in literal_hit_ids] + [
+        current for current in source_files if str(current) not in literal_hit_ids
+    ]
+    ordered_tests = [current for current in test_files if str(current) in literal_hit_ids] + [
+        current for current in test_files if str(current) not in literal_hit_ids
+    ]
+    return _interleave_proportionally(ordered_sources, ordered_tests)
 
 
 def _cap_caller_scan_files(
@@ -1328,6 +1365,7 @@ def _cap_caller_scan_files(
     *,
     symbol: str | None = None,
     test_files: list[Path] | None = None,
+    deadline_monotonic: float | None = None,
 ) -> tuple[list[Path], bool]:
     """backlog #1 chokepoint: bound the caller-scan file universe to
     CALLER_SCAN_FILE_CEILING regardless of how large the passed-in repo_map is (the map default
@@ -1343,13 +1381,20 @@ def _cap_caller_scan_files(
     purpose -- raising it reintroduces task #52's ~100s TS-regex hang, the reason
     CALLER_SCAN_FILE_CEILING shipped (see the module note above ``CALLER_SCAN_FILE_CEILING``).
     When no ``test_files`` are passed (or none exist), behavior is unchanged: a plain prefix
-    slice of ``files`` in whatever order the caller already supplied."""
+    slice of ``files`` in whatever order the caller already supplied.
+
+    F1-review HIGH fix: ``deadline_monotonic`` is threaded through to
+    ``_order_caller_scan_candidates`` so the ordering PROBE (not just the later per-file scan
+    loop) honors --deadline on a repo raised via --max-repo-files -- see that function's
+    docstring."""
     if len(files) <= CALLER_SCAN_FILE_CEILING:
         return files, False
     if test_files:
         test_id_set = {str(current) for current in test_files}
         source_only = [current for current in files if str(current) not in test_id_set]
-        ordered = _order_caller_scan_candidates(source_only, test_files, symbol=symbol)
+        ordered = _order_caller_scan_candidates(
+            source_only, test_files, symbol=symbol, deadline_monotonic=deadline_monotonic
+        )
     else:
         ordered = files
     return ordered[:CALLER_SCAN_FILE_CEILING], True
@@ -12701,6 +12746,7 @@ def build_symbol_refs_from_map(
         [*refs_universe_files, *refs_universe_tests],
         symbol=symbol,
         test_files=refs_universe_tests,
+        deadline_monotonic=deadline_monotonic,
     )
     bounded_file_set = {str(current) for current in bounded_files}
     references: list[dict[str, Any]] = []
@@ -12968,6 +13014,7 @@ def build_symbol_callers_from_map(
         [*callers_universe_files, *callers_universe_tests],
         symbol=symbol,
         test_files=callers_universe_tests,
+        deadline_monotonic=deadline_monotonic,
     )
     bounded_file_set = {str(current) for current in bounded_files}
     preferred_definition_files = _preferred_definition_files(repo_map, symbol)

--- a/tests/unit/test_cap_fix_chokepoint.py
+++ b/tests/unit/test_cap_fix_chokepoint.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from tensor_grep.cli import repo_map, session_store
-from tensor_grep.cli.main import _DEFAULT_AGENT_REPO_SCAN_LIMIT, app
+from tensor_grep.cli.main import _DEFAULT_AGENT_REPO_SCAN_LIMIT, _scan_truncation_warning, app
 
 runner = CliRunner()
 
@@ -51,6 +51,39 @@ def _make_flat_repo(
         if target_index is not None and index == target_index and symbol:
             body += f"\n\ndef {symbol}():\n    return {index}\n"
         (src / f"m{index:0{width}d}.py").write_text(body, encoding="utf-8")
+    return project
+
+
+def _make_flat_repo_with_tests(
+    root: Path,
+    source_count: int,
+    *,
+    target_index: int,
+    symbol: str,
+) -> Path:
+    """F1 fixture: ``source_count`` trivial source files (one directory, so the ceiling slice
+    is genuinely source-heavy) PLUS 5 pytest-named test files (``_is_test_file`` classifies by
+    ``test_`` filename prefix regardless of directory), one of which (``test_qe.py``) actually
+    references ``symbol`` -- reproducing the dogfood regression: a >CALLER_SCAN_FILE_CEILING
+    source-only universe strands 100% of the (source-first-then-tests-ordered) test files past
+    the ceiling slice, dropping the test file's ref."""
+    project = root / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    width = max(5, len(str(source_count)))
+    for index in range(source_count):
+        body = f"def helper_{index}():\n    return {index}\n"
+        if index == target_index:
+            body += f"\n\nclass {symbol}:\n    def run(self):\n        return True\n"
+        (src / f"m{index:0{width}d}.py").write_text(body, encoding="utf-8")
+    for name in ("test_a.py", "test_b.py", "test_c.py", "test_d.py"):
+        (src / name).write_text("def test_noop():\n    assert True\n", encoding="utf-8")
+    target_module = f"m{target_index:0{width}d}"
+    (src / "test_qe.py").write_text(
+        f"from src.{target_module} import {symbol}\n\n\n"
+        f"def test_query_engine():\n    engine = {symbol}()\n    assert engine.run()\n",
+        encoding="utf-8",
+    )
     return project
 
 
@@ -272,3 +305,52 @@ def test_blast_radius_output_cap_only_stays_exit_0(tmp_path, monkeypatch) -> Non
     monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _spy)
     result = runner.invoke(app, ["blast-radius", str(tmp_path), "f", "--json"])
     assert result.exit_code == 0, result.stdout
+
+
+# --- F1 (dogfood v1.42.0, 24->14 refs regression): the ceiling slice must ORDER literal-hit ---
+# --- files + interleave tests BEFORE slicing, and stamp a structured caller_scan_limit caveat --
+
+
+def test_refs_ceiling_orders_literal_hits_and_surfaces_caller_scan_limit(tmp_path: Path) -> None:
+    project = _make_flat_repo_with_tests(tmp_path, 600, target_index=300, symbol="QueryEngine")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
+    assert len(rmap.get("tests", [])) == 5
+    universe_size = len(rmap.get("files", [])) + len(rmap.get("tests", []))
+    assert universe_size > repo_map.CALLER_SCAN_FILE_CEILING
+
+    result = repo_map.build_symbol_refs_from_map(rmap, "QueryEngine")
+
+    ref_file_names = {Path(str(ref["file"])).name for ref in result["references"]}
+    assert "test_qe.py" in ref_file_names, result["references"]
+
+    caller_scan_limit = result.get("caller_scan_limit")
+    assert isinstance(caller_scan_limit, dict)
+    assert caller_scan_limit.get("possibly_truncated") is True
+    assert caller_scan_limit.get("ceiling") == repo_map.CALLER_SCAN_FILE_CEILING
+    assert caller_scan_limit.get("files_total") == universe_size
+
+    assert result.get("result_incomplete") is True
+    assert _scan_truncation_warning(result) is not None
+
+
+def test_callers_scan_still_bounded_at_ceiling_with_ordering_enabled(tmp_path, monkeypatch) -> None:
+    """The ordering pass must not go UNBOUNDED: it probes the file universe once (for literal-hit
+    ordering) and then walks the capped 512-file window once for the real scan -- a fixed,
+    non-quadratic cost, not a blowup."""
+    project = _make_flat_repo_with_tests(tmp_path, 600, target_index=300, symbol="QueryEngine")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
+    universe_size = len(rmap.get("files", [])) + len(rmap.get("tests", []))
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = repo_map.build_symbol_callers_from_map(rmap, "QueryEngine")
+
+    assert calls["n"] <= universe_size + repo_map.CALLER_SCAN_FILE_CEILING
+    assert result.get("result_incomplete") is True

--- a/tests/unit/test_cap_fix_chokepoint.py
+++ b/tests/unit/test_cap_fix_chokepoint.py
@@ -21,6 +21,7 @@ Gate items (a)-(d) below map 1:1 onto the plan's TDD list.
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -334,12 +335,13 @@ def test_refs_ceiling_orders_literal_hits_and_surfaces_caller_scan_limit(tmp_pat
 
 
 def test_callers_scan_still_bounded_at_ceiling_with_ordering_enabled(tmp_path, monkeypatch) -> None:
-    """The ordering pass must not go UNBOUNDED: it probes the file universe once (for literal-hit
-    ordering) and then walks the capped 512-file window once for the real scan -- a fixed,
-    non-quadratic cost, not a blowup."""
+    """The ordering pass must not go UNBOUNDED: it probes at most
+    CALLER_SCAN_ORDER_PROBE_CEILING files (for literal-hit ordering) and then walks the capped
+    512-file window once for the real scan -- a fixed, non-quadratic cost, not a blowup."""
     project = _make_flat_repo_with_tests(tmp_path, 600, target_index=300, symbol="QueryEngine")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
     universe_size = len(rmap.get("files", [])) + len(rmap.get("tests", []))
+    assert universe_size < repo_map.CALLER_SCAN_ORDER_PROBE_CEILING
 
     calls = {"n": 0}
     original = repo_map._file_may_contain_literal_symbol
@@ -352,5 +354,147 @@ def test_callers_scan_still_bounded_at_ceiling_with_ordering_enabled(tmp_path, m
 
     result = repo_map.build_symbol_callers_from_map(rmap, "QueryEngine")
 
-    assert calls["n"] <= universe_size + repo_map.CALLER_SCAN_FILE_CEILING
+    assert (
+        calls["n"] <= repo_map.CALLER_SCAN_ORDER_PROBE_CEILING + repo_map.CALLER_SCAN_FILE_CEILING
+    )
     assert result.get("result_incomplete") is True
+
+
+# --- F1-review HIGH (must fix): the ordering PROBE itself is a separate hot loop from the -------
+# --- capped per-file scan loop, and must be bounded independently of the file universe size ------
+
+
+def test_ordering_probe_bounded_on_universe_larger_than_probe_ceiling(
+    tmp_path, monkeypatch
+) -> None:
+    """Regression for the F1-review HIGH finding: on a repo raised well past the default (e.g.
+    via --max-repo-files), the ordering probe inside _order_caller_scan_candidates must NOT scan
+    every file in the universe -- it must stop at CALLER_SCAN_ORDER_PROBE_CEILING regardless of
+    how large the universe is. Total _file_may_contain_literal_symbol calls therefore bound to
+    (probe ceiling) + (scan ceiling), never O(universe size)."""
+    project = _make_flat_repo_with_tests(tmp_path, 3000, target_index=1500, symbol="QueryEngine")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=3100)
+    universe_size = len(rmap.get("files", [])) + len(rmap.get("tests", []))
+    assert universe_size > repo_map.CALLER_SCAN_ORDER_PROBE_CEILING
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    result = repo_map.build_symbol_refs_from_map(rmap, "QueryEngine")
+
+    assert (
+        calls["n"] <= repo_map.CALLER_SCAN_ORDER_PROBE_CEILING + repo_map.CALLER_SCAN_FILE_CEILING
+    )
+    # sanity: the probe ceiling is actually the binding constraint here, not a fluke of the
+    # fixture -- prove it engaged by checking it's well under a naive full-universe scan.
+    assert calls["n"] < universe_size
+    assert result.get("result_incomplete") is True
+
+
+def test_ordering_probe_unprobed_files_stay_eligible_not_dropped(tmp_path) -> None:
+    """Files beyond the probe ceiling are never read for ordering, but must remain ELIGIBLE for
+    the caller-scan (ordering-only, never filtering) -- the same TRAP the F1 fix's own docstring
+    warns about, now also true of files the probe never got to."""
+    sources = [Path(f"src_{i:05d}.py") for i in range(3000)]
+    tests: list[Path] = []
+
+    ordered = repo_map._order_caller_scan_candidates(sources, tests, symbol="Anything")
+
+    assert len(ordered) == len(sources)
+    assert set(ordered) == set(sources)
+
+
+def test_ordering_probe_stops_early_when_deadline_already_elapsed(tmp_path, monkeypatch) -> None:
+    """Suspenders: even below the count ceiling, an elapsed --deadline must stop the probe (not
+    just the later per-file scan loop) -- the probe should fall back to leaving the remainder
+    unprobed rather than reading every file's bytes."""
+    sources = [tmp_path / f"src_{i:04d}.py" for i in range(600)]
+    for current in sources:
+        current.write_text("x = 1\n", encoding="utf-8")
+
+    calls = {"n": 0}
+    original = repo_map._file_may_contain_literal_symbol
+
+    def _spy(path: Path, symbol: str) -> bool:
+        calls["n"] += 1
+        return original(path, symbol)
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _spy)
+
+    # A deadline already in the past: the very first stride check (index 0) must trip it.
+    elapsed_deadline = repo_map.time.monotonic() - 1.0
+    ordered = repo_map._order_caller_scan_candidates(
+        sources, [], symbol="Anything", deadline_monotonic=elapsed_deadline
+    )
+
+    assert calls["n"] == 0
+    assert len(ordered) == len(sources)
+    assert set(ordered) == set(sources)
+
+
+# --- F1-review MEDIUM (must fix): the interleave itself, not just the literal-hits half ---------
+
+
+def test_interleave_proportionally_reserves_proportional_positions() -> None:
+    """Direct unit test of _interleave_proportionally's own documented contract: ANY prefix of
+    the merged result carries roughly its proportional share of tests. Covers 1v3, 3v1, and a
+    many-sources/few-tests shape (the ceiling-slice-relevant one)."""
+
+    def _assert_proportional(sources: list[Path], tests: list[Path]) -> None:
+        merged = repo_map._interleave_proportionally(sources, tests)
+        assert len(merged) == len(sources) + len(tests)
+        assert set(merged) == {*sources, *tests}
+        total = len(merged)
+        test_set = set(tests)
+        for cut in sorted({1, max(1, total // 4), max(1, total // 2), total}):
+            expected = math.ceil(cut * len(tests) / total)
+            actual = sum(1 for current in merged[:cut] if current in test_set)
+            assert abs(actual - expected) <= 1, (cut, expected, actual, sources, tests)
+
+    # 1 source : 3 tests -- tests dominate, must front-load quickly.
+    _assert_proportional([Path("s0.py")], [Path("t0.py"), Path("t1.py"), Path("t2.py")])
+    # 3 sources : 1 test -- a lone test must still land early, not stranded at the tail.
+    _assert_proportional([Path("s0.py"), Path("s1.py"), Path("s2.py")], [Path("t0.py")])
+    # many sources, few tests -- the shape that actually matters for the ceiling slice.
+    _assert_proportional(
+        [Path(f"s{i:04d}.py") for i in range(500)], [Path(f"t{i}.py") for i in range(5)]
+    )
+
+
+def test_order_caller_scan_candidates_reserves_proportional_test_share_in_window(
+    tmp_path, monkeypatch
+) -> None:
+    """F1-review MEDIUM fix: the existing ceiling test (test_qe.py) is a LITERAL hit, so it lands
+    in the literal-hits block unconditionally and the assertion would pass even if
+    _interleave_proportionally were entirely broken. This test forces the ONLY path into the
+    bounded window to be the interleave: most source files are literal hits (crowding the front),
+    but every test file is a literal MISS, so a test can only reach the 512-file window via
+    proportional interleaving."""
+    sources = [tmp_path / f"src_{i:04d}.py" for i in range(600)]
+    tests = [tmp_path / f"test_{i:04d}.py" for i in range(20)]
+    for current in [*sources, *tests]:
+        current.write_text("x = 1\n", encoding="utf-8")
+
+    hit_sources = set(sources[:400])  # 400 of 600 sources "match" -- a large crowding block.
+
+    def _fake(path: Path, symbol: str) -> bool:
+        return path in hit_sources
+
+    monkeypatch.setattr(repo_map, "_file_may_contain_literal_symbol", _fake)
+
+    ordered = repo_map._order_caller_scan_candidates(sources, tests, symbol="Anything")
+    window = ordered[: repo_map.CALLER_SCAN_FILE_CEILING]
+    tests_in_window = sum(1 for current in window if current in tests)
+
+    total = len(sources) + len(tests)
+    expected = math.ceil(repo_map.CALLER_SCAN_FILE_CEILING * len(tests) / total)
+    assert tests_in_window > 0
+    assert tests_in_window >= expected - 1
+    # never drop: every file (hit or not, probed or not) remains present in the full ordering.
+    assert set(ordered) == {*sources, *tests}


### PR DESCRIPTION
**Dogfood-confirmed regression (v1.42.0):** on a 1938-file repo, `tg refs QueryEngine` returned 14 refs (was 24) with a silent `possibly_truncated:false` + `result_incomplete:true` contradiction and no caveat. Root cause: the cap-fix's `CALLER_SCAN_FILE_CEILING` (512) did a blind `files[:512]` slice over a source-first universe, so on a >512-source repo the whole budget went to source and every test-file ref dropped.

**Fix (Fable-designed, Exa-validated):** (1) ORDER the ceiling budget before slicing — literal-symbol-hit files first, then source/tests interleaved proportionally — instead of enlarging the ceiling (raising it reintroduces the ~100s TS-regex hang the ceiling shipped to fix). Ordering only, never a filter (preserves alias/re-export refs). (2) A structured `caller_scan_limit` dict + a ceiling-specific `_scan_truncation_warning` message, so an agent gets an explained truncation instead of a silent contradiction.

**Verified:** 461 tests in the real venv (no governance-shape changes needed), ruff+mypy clean, real-binary dogfood shows the stranded test-file ref returns + `caller_scan_limit` surfaces + blast-radius propagates it. Ceiling stays 512; global file order untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)