### PR TITLE
fix(F4): don't cap agent confidence at 0.55 for a token-budget primary omission when the primary is corroborated

### DIFF
--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279b0f31df31b4add8aeae57d40f3b5e53aad2b531e89b982bd75ed1898851d"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -15,6 +15,17 @@ _CAPSULE_LSP_CONFIDENCE_BOOST_ENV = "TG_CAPSULE_LSP_CONFIDENCE_BOOST"
 _CAPSULE_LSP_CONFIDENCE_CAP = 0.85
 _CAPSULE_LSP_CONFIDENCE_LANGUAGES = {"javascript", "php", "python", "rust", "typescript"}
 
+# F4: the exact `_build_snippets` omission reason for a source cut by the capsule's OWN token
+# budget (agent_capsule.py `_build_snippets`) -- distinct from the generic "not present in
+# capsule snippets" fallback `_capsule_context_consistency` uses when the primary file never
+# appeared among the rendered sources at all (a genuine ranking miss, not a budget cut).
+_CAPSULE_TOKEN_BUDGET_OMISSION_REASON = "token budget exhausted"
+# Uplift ceiling for a *corroborated* token-budget-only primary omission. Deliberately below the
+# uncapped 0.9 default and matched to the >=0.75 "no ask-user" threshold (agent_capsule.py
+# `ask_user_before_editing` construction) -- this is a bounded relief from the 0.55 safety floor,
+# not a return to full confidence.
+_CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP = 0.75
+
 
 def _as_dict(value: object) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
@@ -1225,6 +1236,140 @@ def _confidence(
     return {"overall": round(overall, 3), "downgrade_reasons": deduped_reasons}
 
 
+def _primary_target_matches_query(query: str, target: dict[str, Any]) -> bool:
+    """True when the primary target's symbol or file stem is actually named by the query.
+
+    Corroboration signal for `_apply_capsule_token_budget_confidence_uplift`: a token-budget
+    omission is only safe to uplift when the primary target itself is independently confirmed
+    by the query, not merely by ranking.
+    """
+    query_terms = set(repo_map._query_terms(query))
+    if not query_terms:
+        return False
+    symbol = str(target.get("symbol") or "")
+    if symbol and set(split_terms(symbol)) & query_terms:
+        return True
+    file_path = str(target.get("file") or "")
+    if file_path and set(split_terms(Path(file_path).stem)) & query_terms:
+        return True
+    return False
+
+
+def _capsule_primary_omission_is_token_budget_only(consistency: dict[str, Any]) -> bool:
+    """True when the ONLY primary-file downgrade signal is a corroborable token-budget cut.
+
+    This is the split at the heart of F4: `primary_file_included is False` /
+    `rendered_context_includes_primary is False` mean ranking never selected or rendered the
+    primary at all -- a genuine misroute, and this function must return False so the 0.55
+    degrade-to-ask safety floor (v1.17.13) keeps holding. `capsule_primary_file_omitted` with
+    the SPECIFIC `_CAPSULE_TOKEN_BUDGET_OMISSION_REASON` means the primary WAS selected/rendered
+    upstream and only the capsule's own snippet token budget cut it -- a much weaker signal.
+    The generic "primary file not present in capsule snippets" fallback text (used when the
+    primary never appeared among `_build_snippets`' omitted sources either) intentionally does
+    NOT match here, so it still falls through to the safety floor.
+    """
+    if consistency.get("primary_file_included") is False:
+        return False
+    if consistency.get("rendered_context_includes_primary") is False:
+        return False
+    if not consistency.get("capsule_primary_file_omitted"):
+        return False
+    return (
+        consistency.get("capsule_primary_file_omission_reason")
+        == _CAPSULE_TOKEN_BUDGET_OMISSION_REASON
+    )
+
+
+def _capsule_token_budget_uplift_eligible(
+    *,
+    query: str,
+    target: dict[str, Any],
+    snippets: list[dict[str, Any]],
+    consistency: dict[str, Any],
+    call_site_evidence: dict[str, Any],
+) -> bool:
+    if not snippets:
+        return False
+    if not _capsule_primary_omission_is_token_budget_only(consistency):
+        return False
+    # Require the token-budget cut to be the ONLY confidence-downgrading signal in play -- if a
+    # trust-level conflict (language mismatch, validation misalignment), an alternative-target
+    # tie, or a marker-helper demotion is ALSO present, leave the existing (conservative)
+    # behavior untouched rather than trying to partially unwind a multi-cause downgrade.
+    other_reasons = {
+        str(reason) for reason in (consistency.get("downgrade_reasons") or []) if reason
+    } - {"primary file omitted from capsule snippets by token budget"}
+    if other_reasons:
+        return False
+    if not _primary_target_matches_query(query, target):
+        return False
+    return call_site_evidence.get("status") == "collected"
+
+
+def _apply_capsule_token_budget_confidence_uplift(
+    *,
+    query: str,
+    target: dict[str, Any],
+    alternatives: list[dict[str, Any]],
+    snippets: list[dict[str, Any]],
+    consistency: dict[str, Any],
+    confidence: dict[str, Any],
+    confidence_cap: float,
+    call_site_evidence: dict[str, Any],
+    ask_reasons: list[str],
+) -> None:
+    """Uplift the 0.55 primary-omission clamp to <=0.75 for a CORROBORATED token-budget-only
+    omission -- never for a genuine misroute (see `_capsule_primary_omission_is_token_budget_only`).
+
+    STRUCTURAL note: this must run AFTER `_collect_capsule_call_site_evidence` (agent_capsule.py
+    call order), since verified caller evidence -- the corroboration this uplift depends on --
+    isn't available until that call returns. It mutates `confidence`, `target`, `alternatives`,
+    and `ask_reasons` in place so `build_agent_capsule`'s already-assembled payload reflects the
+    uplift without re-deriving `ask_user_before_editing` from scratch.
+    """
+    current_overall = float(confidence.get("overall", 0.0))
+    if current_overall > 0.55:
+        return
+    if not _capsule_token_budget_uplift_eligible(
+        query=query,
+        target=target,
+        snippets=snippets,
+        consistency=consistency,
+        call_site_evidence=call_site_evidence,
+    ):
+        return
+    uplifted = round(min(_CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP, confidence_cap), 3)
+    if uplifted <= current_overall:
+        return
+    confidence["overall"] = uplifted
+    remaining_reasons = [
+        reason
+        for reason in confidence.get("downgrade_reasons", [])
+        if reason != "primary file omitted from capsule snippets by token budget"
+    ]
+    remaining_reasons.append(
+        "primary file omitted by token budget only; uplifted to "
+        f"{uplifted} on corroborated call-site evidence"
+    )
+    confidence["downgrade_reasons"] = remaining_reasons
+    consistency["capsule_token_budget_confidence_uplifted"] = True
+    _cap_primary_target_confidence(target, uplifted)
+    _cap_alternative_target_confidences(alternatives, target)
+    # These three ask-reasons were added solely because of the primary-file-omission clamp we
+    # just uplifted (asserted by the "no other downgrade reason" eligibility check above) -- clear
+    # them so `ask_user_before_editing.required` deliberately flips to False for this case.
+    ask_reasons[:] = [
+        reason
+        for reason in ask_reasons
+        if reason
+        not in {
+            "confidence below 0.75",
+            "primary file omitted from capsule snippets",
+            "context consistency requires confirmation",
+        }
+    ]
+
+
 def build_agent_capsule(
     query: str,
     path: str | Path = ".",
@@ -1506,6 +1651,20 @@ def build_agent_capsule(
         include_blast_radius=include_blast_radius,
         max_files=max_files,
         max_repo_files=max_repo_files,
+    )
+    # F4: verified call-site evidence is only available NOW (after the collection above), so the
+    # token-budget-omission confidence uplift must happen here, post-hoc, rather than inside
+    # `_confidence` -- see `_apply_capsule_token_budget_confidence_uplift`'s docstring.
+    _apply_capsule_token_budget_confidence_uplift(
+        query=query,
+        target=target,
+        alternatives=alternatives,
+        snippets=snippets,
+        consistency=consistency,
+        confidence=confidence,
+        confidence_cap=confidence_cap,
+        call_site_evidence=call_site_evidence,
+        ask_reasons=ask_reasons,
     )
     rollback_ref = _command_ref(["tg", "checkpoint", "create", resolved_path])
     route_rationale: list[dict[str, Any]] = [

--- a/tests/unit/test_agent_capsule_token_budget_confidence.py
+++ b/tests/unit/test_agent_capsule_token_budget_confidence.py
@@ -1,0 +1,218 @@
+"""F4: a token-budget primary-file omission must not be treated the same as a genuine misroute.
+
+`_confidence` clamps `overall` to 0.55 whenever the primary file is missing from the capsule's
+rendered snippets -- this is the v1.17.13 degrade-to-ask safety floor and it correctly catches a
+primary target that ranking never selected/rendered at all. But it ALSO fires when the primary
+WAS correctly identified and its source simply didn't fit the capsule's own (default 1200,
+here 200) token budget -- a much weaker signal that should not, by itself, force a human
+confirmation when the primary is independently corroborated (query names it explicitly AND
+blast-radius finds real callers).
+
+These tests build a real two-file project so blast-radius call-site collection
+(`_collect_capsule_call_site_evidence`) runs for real, while `repo_map.build_context_render` is
+monkeypatched to deterministically control which source lands in vs. out of the capsule's token
+budget (mirrors the pattern in test_agent_capsule_lsp_confidence.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tensor_grep.cli import agent_capsule, repo_map
+
+_PRIMARY_SYMBOL = "handle_widget_request"
+_CALLER_SYMBOL = "process_incoming_request"
+_OVERSIZED_SOURCE = "def handle_widget_request(payload):\n" + ("    pass  # padding\n" * 100)
+_SMALL_CALLER_SOURCE = (
+    "def process_incoming_request(payload):\n    return handle_widget_request(payload)\n"
+)
+
+
+def _write_project(tmp_path: Path) -> dict[str, Path]:
+    project = tmp_path / "workspace"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    handler_file = project / "handler.py"
+    handler_file.write_text(
+        "def handle_widget_request(payload):\n    return payload\n",
+        encoding="utf-8",
+    )
+    caller_file = project / "caller.py"
+    caller_file.write_text(_SMALL_CALLER_SOURCE, encoding="utf-8")
+    return {"project": project, "handler": handler_file, "caller": caller_file}
+
+
+def _context_payload(
+    *,
+    primary_file: Path,
+    caller_file: Path,
+    primary_symbol: str,
+) -> dict[str, Any]:
+    return {
+        "routing_backend": "RepoMap",
+        "routing_reason": "context-render",
+        "semantic_provider": "native",
+        "files": [str(primary_file), str(caller_file)],
+        "sources": [
+            {
+                "file": str(primary_file),
+                "symbol": primary_symbol,
+                "name": primary_symbol,
+                "start_line": 1,
+                "end_line": 1,
+                "source": _OVERSIZED_SOURCE,
+            },
+            {
+                "file": str(caller_file),
+                "symbol": _CALLER_SYMBOL,
+                "name": _CALLER_SYMBOL,
+                "start_line": 1,
+                "end_line": 2,
+                "source": _SMALL_CALLER_SOURCE,
+            },
+        ],
+        "validation_commands": ["uv run pytest -q"],
+        "edit_plan_seed": {
+            "primary_file": str(primary_file),
+            "primary_symbol": {"name": primary_symbol, "kind": "function"},
+            "primary_span": {"start_line": 1, "end_line": 1},
+            "confidence": {"overall": 0.9},
+            "validation_plan": [
+                {
+                    "runner": "pytest",
+                    "scope": "repo",
+                    "target": "",
+                    "command": "uv run pytest -q",
+                    "confidence": 0.55,
+                    "detection": "detected",
+                }
+            ],
+            "validation_commands": ["uv run pytest -q"],
+            "validation_alignment": {"status": "aligned", "kept_count": 1, "filtered_count": 0},
+            "edit_ordering": [str(primary_file)],
+        },
+        "navigation_pack": {
+            "primary_target": {
+                "file": str(primary_file),
+                "symbol": primary_symbol,
+                "kind": "function",
+                "start_line": 1,
+                "end_line": 1,
+                "confidence": {"overall": 0.9},
+            },
+            "follow_up_reads": [],
+        },
+        "candidate_edit_targets": {"files": [str(primary_file)], "symbols": [], "tests": []},
+        "context_consistency": {
+            "primary_file_included": True,
+            "rendered_context_includes_primary": True,
+        },
+    }
+
+
+def test_capsule_uplifts_confidence_for_corroborated_token_budget_omission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _write_project(tmp_path)
+    monkeypatch.setattr(
+        repo_map,
+        "build_context_render",
+        lambda *args, **kwargs: _context_payload(
+            primary_file=paths["handler"].resolve(),
+            caller_file=paths["caller"].resolve(),
+            primary_symbol=_PRIMARY_SYMBOL,
+        ),
+    )
+
+    payload = agent_capsule.build_agent_capsule(
+        _PRIMARY_SYMBOL,
+        paths["project"],
+        max_tokens=200,
+    )
+
+    # The primary file's snippet really was cut by the tight token budget (not a genuine
+    # ranking miss) -- this is the mechanism F4 targets.
+    consistency = payload["context_consistency"]
+    assert consistency["capsule_primary_file_omitted"] is True
+    assert consistency["capsule_primary_file_omission_reason"] == "token budget exhausted"
+    assert consistency["primary_file_included"] is True
+    assert consistency["rendered_context_includes_primary"] is True
+
+    # Corroboration held (query names the symbol explicitly + blast-radius found a real caller),
+    # so the capsule uplifts past the 0.55 safety floor and stops demanding confirmation for it.
+    assert payload["call_site_evidence"]["status"] == "collected"
+    assert payload["confidence"]["overall"] >= 0.75
+    assert payload["primary_target"]["confidence"] >= 0.75
+    assert payload["ask_user_before_editing"]["required"] is False
+
+
+def test_capsule_keeps_safety_floor_when_symbol_not_named_and_no_call_sites(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same token-budget-omission mechanism, but the query never names the primary symbol, so
+    blast-radius call-site collection is skipped (no corroboration). The 0.55 degrade-to-ask
+    floor MUST still hold -- this is the TRAP the fix guards against (uplifting on the bare
+    string "token budget" without corroboration would reopen a confident-wrong-target hole).
+    """
+    paths = _write_project(tmp_path)
+    monkeypatch.setattr(
+        repo_map,
+        "build_context_render",
+        lambda *args, **kwargs: _context_payload(
+            primary_file=paths["handler"].resolve(),
+            caller_file=paths["caller"].resolve(),
+            primary_symbol=_PRIMARY_SYMBOL,
+        ),
+    )
+
+    payload = agent_capsule.build_agent_capsule(
+        "update the request handler",  # does not name handle_widget_request explicitly
+        paths["project"],
+        max_tokens=200,
+    )
+
+    assert payload["context_consistency"]["capsule_primary_file_omitted"] is True
+    assert payload["call_site_evidence"]["status"] != "collected"
+    assert payload["confidence"]["overall"] <= 0.55
+    assert payload["ask_user_before_editing"]["required"] is True
+
+
+def test_capsule_keeps_safety_floor_for_genuine_misroute_even_with_corroboration_signals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuine misroute (primary never ranked/selected at all -- `primary_file_included` is
+    False) must stay at the 0.55 floor even when the query names the symbol and a caller exists
+    -- corroboration must never override the "never ranked" signal, only the "cut by budget"
+    signal.
+    """
+    paths = _write_project(tmp_path)
+
+    def fake_context_render(*args: object, **kwargs: object) -> dict[str, Any]:
+        payload = _context_payload(
+            primary_file=paths["handler"].resolve(),
+            caller_file=paths["caller"].resolve(),
+            primary_symbol=_PRIMARY_SYMBOL,
+        )
+        payload["context_consistency"] = {
+            "primary_file_included": False,
+            "rendered_context_includes_primary": False,
+        }
+        return payload
+
+    monkeypatch.setattr(repo_map, "build_context_render", fake_context_render)
+
+    payload = agent_capsule.build_agent_capsule(
+        _PRIMARY_SYMBOL,
+        paths["project"],
+        max_tokens=200,
+    )
+
+    assert payload["context_consistency"]["primary_file_included"] is False
+    assert payload["confidence"]["overall"] <= 0.55
+    assert payload["ask_user_before_editing"]["required"] is True


### PR DESCRIPTION
**Dogfood-confirmed (v1.42.0):** `tg agent` returned the CORRECT primary but clamped `confidence.overall` to 0.55 + forced `ask_user_before_editing:true` solely because the 1200-token default budget dropped the primary's snippet from the capsule.

**Fix (Fable-designed):** a bounded post-hoc uplift (0.55→min(0.75, confidence_cap)) that fires ONLY when the omission is specifically the token-budget reason (not a genuine ranking miss), the query names the primary symbol/file, AND blast-radius actually collected caller evidence. Never exceeds the trust confidence_cap; re-runs the primary/alt cap logic.

**Safety floor preserved** (Fable's trap): a genuine misroute (`primary_file_included:False`) or a query that doesn't name the symbol STAYS ≤0.55 with ask-required — proven by 3 new tests. 708 tests green in-worktree, ruff+mypy clean. (The one local failure on my box is a leftover-worktree repo-scan pollution — fails on origin/main too, green on CI's clean checkout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)