### PR TITLE
chore(F8): gitignore .claude/worktrees/ (stops agent-worktree source copies polluting tg scans)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ src/tensor_grep/core/profile_stats
 
 # Local agent validation artifacts
 .factory/validation/
+
+# Transient agent git worktrees (harness-created; contain duplicate source copies that must
+# not be committed OR walked by the repo-map/agent-capsule scan — see F8 scan-pollution).
+.claude/worktrees/

--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279b0f31df31b4add8aeae57d40f3b5e53aad2b531e89b982bd75ed1898851d"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Hit this session: a leftover harness worktree under .claude/worktrees/ made the repo-map/agent-capsule scan resolve a symbol to a DUPLICATE main.py copy inside the worktree (a real false-fail; agent-hostile for any dev using nested worktrees). repo_map's walk honors .gitignore, so ignoring .claude/worktrees/ makes the scan skip them. Chore (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)