### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4279b0f31df31b4add8aeae57d40f3b5e53aad2b531e89b982bd75ed1898851d"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
New advisory published 2026-07-06: crossbeam-epoch 0.9.19 has an invalid pointer dereference in the `fmt::Pointer` impl (RUSTSEC-2026-0204, fix >=0.9.20). It's a transitive Rust dep in Cargo.lock, so it fails the `cargo audit` gate on EVERY open PR (#407/#408/#409/#410) — not any one PR's fault. This one-line lockfile bump patches it; the other PRs pick it up by merging main. Cargo.lock-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)