### PR TITLE
fix(F5): route-test stops warning on correct agreeing routes (demote low-confidence to a note)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7649,6 +7649,12 @@ def edit_plan(
 
 
 _ROUTE_TEST_CONFIDENCE_WARNING_THRESHOLD = 0.75
+# When both routes AGREE on the primary target, a sub-threshold confidence reflects ranking-score
+# calibration, not routing doubt -- it is demoted to an additive `note`, not a `warning`. But
+# agreement is not correctness (context-render + edit-plan share the upstream ranker, so they can
+# agree on the same WRONG file); if BOTH confidences fall below this floor, keep the warning as the
+# correlated-error tell.
+_ROUTE_TEST_CONFIDENCE_FLOOR = 0.4
 
 
 def _route_test_int(value: object) -> int | None:
@@ -7815,21 +7821,36 @@ def _build_route_test_payload(
     )
 
     warnings: list[str] = []
+    notes: list[str] = []
     if not agreement:
         warnings.append("primary targets disagree between context-render and edit-plan")
+    low_confidence_lines: list[str] = []
+    scored_confidences: list[float] = []
     for label, target in (
         ("context-render", context_target),
         ("edit-plan", edit_target),
     ):
         confidence_score = target.get("confidence_score")
-        if (
-            isinstance(confidence_score, int | float)
-            and confidence_score < _ROUTE_TEST_CONFIDENCE_WARNING_THRESHOLD
-        ):
-            warnings.append(
-                f"{label} primary target confidence {confidence_score:.3f} is below "
-                f"{_ROUTE_TEST_CONFIDENCE_WARNING_THRESHOLD:.2f}"
+        if isinstance(confidence_score, int | float):
+            scored_confidences.append(float(confidence_score))
+            if confidence_score < _ROUTE_TEST_CONFIDENCE_WARNING_THRESHOLD:
+                low_confidence_lines.append(
+                    f"{label} primary target confidence {confidence_score:.3f} is below "
+                    f"{_ROUTE_TEST_CONFIDENCE_WARNING_THRESHOLD:.2f}"
+                )
+    if low_confidence_lines:
+        both_very_low = len(scored_confidences) >= 2 and all(
+            c < _ROUTE_TEST_CONFIDENCE_FLOOR for c in scored_confidences
+        )
+        if agreement and not both_very_low:
+            # Routes agree -> low confidence is calibration, not routing doubt: demote to a note.
+            notes.append(
+                "context-render and edit-plan agree on the primary target; the sub-threshold "
+                "confidence reflects ranking-score calibration, not routing disagreement"
             )
+            notes.extend(low_confidence_lines)
+        else:
+            warnings.extend(low_confidence_lines)
 
     context_validation_count = _route_test_validation_command_count(context_payload)
     edit_validation_count = _route_test_validation_command_count(edit_payload)
@@ -7845,6 +7866,7 @@ def _build_route_test_payload(
             "line": line_agrees,
         },
         "warnings": warnings,
+        "notes": notes,
         "context_render": {
             "routing_reason": context_payload.get("routing_reason"),
             "primary_target": context_target,

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -4783,6 +4783,48 @@ def test_route_test_json_warns_on_disagreement_and_low_confidence(monkeypatch, t
     )
 
 
+def test_route_test_json_demotes_low_confidence_to_note_when_routes_agree(monkeypatch, tmp_path):
+    runner = CliRunner()
+    project = tmp_path / "project"
+    project.mkdir()
+    target_file = project / "target.py"
+    target_file.write_text("def create_invoice():\n    return 1\n", encoding="utf-8")
+
+    def _agreeing_target():
+        return {
+            "file": str(target_file.resolve()),
+            "symbol": "create_invoice",
+            "line": 1,
+            "confidence": {"file": 0.65, "symbol": 0.9},
+        }
+
+    def fake_context_render(*_args, **_kwargs):
+        return {
+            "routing_reason": "context-render",
+            "navigation_pack": {"primary_target": _agreeing_target(), "validation_commands": []},
+        }
+
+    def fake_edit_plan(*_args, **_kwargs):
+        return {
+            "routing_reason": "context-edit-plan",
+            "primary_target": _agreeing_target(),
+            "validation_commands": ["pytest"],
+        }
+
+    monkeypatch.setattr(repo_map, "build_context_render", fake_context_render)
+    monkeypatch.setattr(repo_map, "build_context_edit_plan", fake_edit_plan)
+
+    result = runner.invoke(app, ["route-test", str(project), "add invoice"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["agreement"] is True
+    # Routes agree -> a sub-threshold confidence is ranking calibration, NOT a routing warning.
+    assert not any("is below" in warning for warning in payload["warnings"])
+    assert any("ranking-score calibration" in note for note in payload["notes"])
+    assert any("confidence 0.650 is below" in note for note in payload["notes"])
+
+
 def test_agent_capsule_json_returns_actionable_context_capsule(tmp_path):
     runner = CliRunner()
     project = tmp_path / "project"


### PR DESCRIPTION
**Dogfood-confirmed (v1.42.0):** `tg route-test` warned "confidence 0.65 < 0.75" even when context-render + edit-plan AGREED on the target (agreement:true) — making agents second-guess correct routing.

**Fix (Fable-designed):** when the routes agree, a sub-threshold confidence reflects ranking-score *calibration*, not routing doubt — it's demoted to an additive `notes` field. `warnings` is reserved for genuine issues (disagreement, or BOTH confidences below a 0.4 floor — the correlated-error tell, since the two routes share the upstream ranker and can agree on the same wrong file). Additive `notes` key; `warnings` semantics unchanged for disagreement.

**Verified:** route-test tests pass in the real venv (new agreeing-low-confidence test + the existing disagreement/low-confidence test), ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)