### PR TITLE
refactor(PathA Stage0): language-extractor registry + resolution_gaps floor (zero behavior change; enables language expansion)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -498,6 +498,9 @@ def _collect_capsule_call_site_evidence(
         "omitted_call_sites": int(output_limit.get("omitted_callers", 0) or 0),
         "provenance": provenance,
         "graph_trust_summary": _as_dict(radius_payload.get("graph_trust_summary")),
+        # PATH A Stage 0 (additive): surface the same resolution_gaps floor blast-radius now
+        # carries so an agent sees WHY graph_trust_summary was downgraded, not just that it was.
+        "resolution_gaps": _as_list_of_dicts(radius_payload.get("resolution_gaps")),
     }
     return related_call_sites, evidence
 

--- a/src/tensor_grep/cli/lang_registry.py
+++ b/src/tensor_grep/cli/lang_registry.py
@@ -1,0 +1,148 @@
+"""Language-extractor registry for tensor-grep's multi-language symbol graph (PATH A Stage 0).
+
+This module is the single source of truth for "which languages does the repo-map symbol graph
+(defs/refs/callers/blast-radius) support, and which callables implement each stage of
+extraction for that language". ``repo_map.py`` registers the CURRENT four languages (python,
+javascript, typescript, rust) by wrapping its own existing, UNCHANGED functions -- see the
+``lang_registry.register_language(...)`` calls near the language-specific helper functions in
+``repo_map.py``.
+
+This module intentionally imports NOTHING from ``repo_map`` (a one-directional dependency:
+``repo_map`` -> ``lang_registry``, never the reverse) to avoid an import cycle; the two tiny
+helpers it would otherwise need are duplicated below instead of imported.
+
+Stage 0 is a PURE PARITY REFACTOR: the registry replaces scattered
+``path.suffix in _JS_TS_SUFFIXES`` / ``_RUST_SUFFIXES`` dispatch in ``repo_map.py`` with
+``spec_for_path(path)`` lookups, with ZERO behavior change for the 4 currently-supported
+languages. It also underpins the ``resolution_gaps`` honesty floor (see repo_map.py's
+``_resolution_gaps_for_universe``): a file in the refs/callers scan universe with no
+registered ``LanguageSpec`` becomes a labeled gap instead of a silent, unexplained absence.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Duplicated tiny helpers (see module docstring: this module imports nothing from repo_map.py
+# to avoid a cycle, so the couple of one-line helpers a LanguageSpec's callables might want are
+# copied here rather than imported). Keep these BYTE-IDENTICAL to their repo_map.py twins
+# (``_tree_sitter_node_text`` / ``_is_clean_symbol_name`` there) if either ever changes.
+# ---------------------------------------------------------------------------
+
+_CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _is_clean_symbol_name(name: str) -> bool:
+    return bool(_CLEAN_SYMBOL_NAME_RE.match(name))
+
+
+def _tree_sitter_node_text(source_bytes: bytes, node: Any) -> str:
+    return source_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Callable shapes. Every LanguageSpec callable field uses a UNIFORM signature across languages
+# (even where one language's underlying repo_map.py function does not need every argument --
+# e.g. python's import_update_target ignores repo_root) so a generic call site never needs a
+# per-language special case just to invoke the callable.
+# ---------------------------------------------------------------------------
+
+ReferencesAndCalls = Callable[
+    [Path, str, "Path | str | None"], tuple[list[dict[str, Any]], list[dict[str, Any]]]
+]
+ProviderAliasCalls = Callable[[Path, str, "Path | str | None"], list[dict[str, Any]]]
+FileImportsSymbolFromDefinition = Callable[[Path, str, str, str, "Path | str | None"], bool]
+ImportUpdateTarget = Callable[[Path, str, str, "Path | str | None"], "dict[str, Any] | None"]
+ExtractImportsAndSymbols = Callable[[Path], tuple[list[str], list[dict[str, Any]]]]
+PrimeRepoContext = Callable[[Path], dict[str, Any]]
+ParserForPath = Callable[[Path], "Any | None"]
+ClassifyRefKind = Callable[..., str]
+
+
+@dataclass(frozen=True)
+class LanguageSpec:
+    """One entry in the multi-language symbol-graph registry.
+
+    Every callable field is a THIN WRAPPER over an existing repo_map.py function (Stage 0:
+    zero new parsing logic -- just a registry-shaped seam other dispatch sites can look up
+    instead of re-deriving suffix membership by hand). Fields a language genuinely has no
+    behavior for (e.g. python has no separate repo-context priming step, since it needs no
+    tsconfig/Cargo.toml-style workspace context) are ``None``; callers must check for that
+    before invoking.
+    """
+
+    language_id: str
+    suffixes: frozenset[str]
+    # Third-party grammar package names this language's tree-sitter parser depends on (empty
+    # for python, which uses the stdlib ``ast`` module and has no external grammar to miss).
+    grammar_modules: tuple[str, ...] = ()
+    # Returns the parser object for *path* (already bound to the right grammar variant, e.g.
+    # tsx vs plain typescript), or None if the grammar package is not installed. None for
+    # python (no gating: `ast.parse` is always attempted directly).
+    parser_for_path: ParserForPath | None = None
+    provenance_when_parsed: str = "heuristic"
+    provenance_when_missing: str = "regex-heuristic"
+    # Byte markers checked (case-insensitively) against a file's raw bytes to cheaply decide
+    # whether it is even worth running the more expensive import-resolution machinery on it.
+    import_markers: tuple[bytes, ...] = ()
+    # Tree-sitter node type names (or, for python, ast node class names) this language's
+    # definition-symbol walker matches on. Informational/documentation only in Stage 0 -- no
+    # dispatch seam reads this field yet; it exists so a Stage 1+ language and any tooling that
+    # introspects the registry has a place to look without re-deriving it from source.
+    def_node_kinds: tuple[str, ...] = ()
+    extract_imports_and_symbols: ExtractImportsAndSymbols | None = None
+    references_and_calls: ReferencesAndCalls | None = None
+    provider_alias_calls: ProviderAliasCalls | None = None
+    file_imports_symbol_from_definition: FileImportsSymbolFromDefinition | None = None
+    import_update_target: ImportUpdateTarget | None = None
+    # Primes any per-repo-root context this language's import resolution needs (e.g. JS/TS
+    # tsconfig paths/baseUrl). None for languages with no such per-repo state (python, and
+    # rust's own priming is registered separately since it caches Cargo-workspace layout).
+    prime_repo_context: PrimeRepoContext | None = None
+    # Classifies an already-matched reference node into the T1 ref_kind taxonomy
+    # (call/import/type/field/value). Preserved here for discoverability; the T1 emission
+    # sites call the underlying per-language classify function directly and are NOT rewired
+    # through the registry in Stage 0 (do not regress the T1 work).
+    classify_ref_kind: ClassifyRefKind | None = None
+
+
+LANGUAGE_REGISTRY: dict[str, LanguageSpec] = {}
+_SPEC_BY_SUFFIX: dict[str, LanguageSpec] = {}
+
+
+def register_language(spec: LanguageSpec) -> LanguageSpec:
+    """Register (or replace) a LanguageSpec.
+
+    Idempotent: re-registering the same ``language_id`` (e.g. a module reload during tests)
+    simply replaces the prior entry and re-derives every suffix pointer it owns, so a stale
+    suffix -> spec mapping never survives a re-registration.
+    """
+    LANGUAGE_REGISTRY[spec.language_id] = spec
+    for suffix in spec.suffixes:
+        _SPEC_BY_SUFFIX[suffix.lower()] = spec
+    return spec
+
+
+def spec_for_path(path: str | Path) -> LanguageSpec | None:
+    """Return the registered LanguageSpec for *path*'s suffix, or None if unregistered."""
+    suffix = Path(path).suffix.lower()
+    return _SPEC_BY_SUFFIX.get(suffix)
+
+
+def graph_suffixes() -> frozenset[str]:
+    """Return every suffix with a registered LanguageSpec (the symbol-graph suffix gate)."""
+    return frozenset(_SPEC_BY_SUFFIX.keys())
+
+
+__all__ = [
+    "LANGUAGE_REGISTRY",
+    "LanguageSpec",
+    "graph_suffixes",
+    "register_language",
+    "spec_for_path",
+]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
+from tensor_grep.cli import lang_registry
 from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LSPTransportError
 from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 
@@ -1173,7 +1174,8 @@ def _file_may_contain_literal_symbol(path: Path, symbol: str) -> bool:
 
 
 def _file_may_import_symbol_definition(path: Path, definition_files: list[str]) -> bool:
-    if path.suffix not in ({".py"} | _JS_TS_SUFFIXES | _RUST_SUFFIXES):
+    spec = lang_registry.spec_for_path(path)
+    if spec is None:
         return False
     try:
         stat = path.stat()
@@ -1188,16 +1190,9 @@ def _file_may_import_symbol_definition(path: Path, definition_files: list[str]) 
     if b"\0" in data[:8192]:
         return False
     lowered = data.lower()
-    markers: tuple[bytes, ...]
-    if path.suffix == ".py":
-        markers = (b"import ", b"from ")
-    elif path.suffix in _JS_TS_SUFFIXES:
-        markers = (b"import ", b"from ", b"require(")
-    else:
-        markers = (b"use ",)
-    if not any(marker in lowered for marker in markers):
+    if not any(marker in lowered for marker in spec.import_markers):
         return False
-    if path.suffix in _JS_TS_SUFFIXES:
+    if spec.language_id in ("javascript", "typescript"):
         return True
     for definition_file in definition_files:
         for alias in _module_aliases_for_path(definition_file):
@@ -1491,22 +1486,16 @@ def _rust_parser() -> Any | None:
 
 
 def _symbol_navigation_provenance_for_path(path: str) -> str:
-    suffix = Path(path).suffix.lower()
-    if suffix == ".py":
-        return "python-ast"
-    if suffix in _JS_TS_SUFFIXES:
-        return (
-            "tree-sitter"
-            if (
-                _typescript_parser(tsx=suffix == ".tsx") is not None
-                if suffix in _TS_SUFFIXES
-                else _javascript_parser() is not None
-            )
-            else "regex-heuristic"
-        )
-    if suffix in _RUST_SUFFIXES:
-        return "tree-sitter" if _rust_parser() is not None else "regex-heuristic"
-    return "heuristic"
+    spec = lang_registry.spec_for_path(path)
+    if spec is None:
+        return "heuristic"
+    if spec.parser_for_path is None:
+        return spec.provenance_when_parsed
+    return (
+        spec.provenance_when_parsed
+        if spec.parser_for_path(Path(path)) is not None
+        else spec.provenance_when_missing
+    )
 
 
 _CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
@@ -2821,6 +2810,106 @@ def _rust_module_matches_definition(
 #
 # Guard 4: bound the cache's entry count -- this key includes symbol+definition_path+repo_root,
 # so it can grow faster than a plain per-file cache; keep it generous but finite.
+def _python_file_imports_symbol_from_definition(
+    file_path: Path,
+    source: str,
+    symbol: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+) -> bool:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(
+                _module_path_matches_definition(alias.name, definition_path) for alias in node.names
+            ):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            if not node.module or not _module_path_matches_definition(node.module, definition_path):
+                continue
+            if any(alias.name in {"*", symbol} or alias.asname == symbol for alias in node.names):
+                return True
+    return False
+
+
+def _js_ts_file_imports_symbol_from_definition(
+    file_path: Path,
+    source: str,
+    symbol: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+) -> bool:
+    bindings = _js_ts_named_import_bindings(source)
+    default_bindings = _js_ts_default_import_bindings(source)
+    namespace_bindings = _js_ts_namespace_import_bindings(source)
+    return (
+        any(
+            _js_ts_import_match_details(
+                file_path,
+                module_name=str(binding["module"]),
+                imported_name=str(binding["imported"]),
+                symbol=symbol,
+                definition_path=definition_path,
+                repo_root=repo_root,
+            )
+            is not None
+            for binding in bindings
+            if str(binding.get("statement_kind", "import")) == "import"
+        )
+        or any(
+            _js_ts_import_match_details(
+                file_path,
+                module_name=str(binding["module"]),
+                imported_name="default",
+                symbol=symbol,
+                definition_path=definition_path,
+                repo_root=repo_root,
+                is_default=True,
+            )
+            is not None
+            for binding in default_bindings
+        )
+        or any(
+            _js_ts_module_matches_definition(
+                file_path,
+                binding["module"],
+                definition_path,
+                repo_root,
+            )
+            for binding in namespace_bindings
+        )
+    )
+
+
+def _rust_file_imports_symbol_from_definition(
+    file_path: Path,
+    source: str,
+    symbol: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+) -> bool:
+    bindings = _rust_use_bindings(source)
+    if any(
+        _rust_use_binding_match_details(
+            file_path,
+            binding,
+            symbol,
+            definition_path,
+            repo_root,
+        )
+        is not None
+        for binding in bindings
+    ):
+        return True
+    if _is_test_file(file_path):
+        return _rust_file_references_symbol_from_definition(file_path, symbol, definition_path)
+    return False
+
+
 @_mtime_aware_cache(maxsize=2048)  # Fix A: mtime+size in key; replaces per-call read+parse
 def _file_imports_symbol_from_definition(
     path_str: str,
@@ -2833,92 +2922,12 @@ def _file_imports_symbol_from_definition(
         source = file_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return False
-
-    if file_path.suffix == ".py":
-        try:
-            tree = ast.parse(source)
-        except SyntaxError:
-            return False
-
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Import):
-                if any(
-                    _module_path_matches_definition(alias.name, definition_path)
-                    for alias in node.names
-                ):
-                    return True
-            elif isinstance(node, ast.ImportFrom):
-                if not node.module or not _module_path_matches_definition(
-                    node.module, definition_path
-                ):
-                    continue
-                if any(
-                    alias.name in {"*", symbol} or alias.asname == symbol for alias in node.names
-                ):
-                    return True
+    spec = lang_registry.spec_for_path(file_path)
+    if spec is None or spec.file_imports_symbol_from_definition is None:
         return False
-
-    if file_path.suffix in _JS_TS_SUFFIXES:
-        bindings = _js_ts_named_import_bindings(source)
-        default_bindings = _js_ts_default_import_bindings(source)
-        namespace_bindings = _js_ts_namespace_import_bindings(source)
-        return (
-            any(
-                _js_ts_import_match_details(
-                    file_path,
-                    module_name=str(binding["module"]),
-                    imported_name=str(binding["imported"]),
-                    symbol=symbol,
-                    definition_path=definition_path,
-                    repo_root=repo_root,
-                )
-                is not None
-                for binding in bindings
-                if str(binding.get("statement_kind", "import")) == "import"
-            )
-            or any(
-                _js_ts_import_match_details(
-                    file_path,
-                    module_name=str(binding["module"]),
-                    imported_name="default",
-                    symbol=symbol,
-                    definition_path=definition_path,
-                    repo_root=repo_root,
-                    is_default=True,
-                )
-                is not None
-                for binding in default_bindings
-            )
-            or any(
-                _js_ts_module_matches_definition(
-                    file_path,
-                    binding["module"],
-                    definition_path,
-                    repo_root,
-                )
-                for binding in namespace_bindings
-            )
-        )
-
-    if file_path.suffix in _RUST_SUFFIXES:
-        bindings = _rust_use_bindings(source)
-        if any(
-            _rust_use_binding_match_details(
-                file_path,
-                binding,
-                symbol,
-                definition_path,
-                repo_root,
-            )
-            is not None
-            for binding in bindings
-        ):
-            return True
-        if _is_test_file(file_path):
-            return _rust_file_references_symbol_from_definition(file_path, symbol, definition_path)
-        return False
-
-    return False
+    return spec.file_imports_symbol_from_definition(
+        file_path, source, symbol, definition_path, repo_root
+    )
 
 
 def _import_names_reference_symbol_definition(
@@ -3157,13 +3166,10 @@ def _import_update_target(
 ) -> dict[str, Any] | None:
     if str(file_path.resolve()) == str(Path(definition_path).resolve()):
         return None
-    if file_path.suffix == ".py":
-        return _python_import_update_target(file_path, symbol, definition_path)
-    if file_path.suffix in _JS_TS_SUFFIXES:
-        return _js_ts_import_update_target(file_path, symbol, definition_path, repo_root)
-    if file_path.suffix in _RUST_SUFFIXES:
-        return _rust_import_update_target(file_path, symbol, definition_path, repo_root)
-    return None
+    spec = lang_registry.spec_for_path(file_path)
+    if spec is None or spec.import_update_target is None:
+        return None
+    return spec.import_update_target(file_path, symbol, definition_path, repo_root)
 
 
 def _source_line_text(path: Path, line_number: int) -> str:
@@ -3204,7 +3210,7 @@ def _build_import_graph_consumers_from_map(
             current_file = str(current)
             if current_file in definition_file_set:
                 continue
-            if current.suffix not in ({".py"} | _JS_TS_SUFFIXES | _RUST_SUFFIXES):
+            if lang_registry.spec_for_path(current) is None:
                 continue
             if not _file_may_import_symbol_definition(current, definition_files):
                 continue
@@ -4947,6 +4953,139 @@ def _regex_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
     return sources
 
 
+# ---------------------------------------------------------------------------
+# PATH A Stage 0: language-extractor registry registration.
+#
+# Registers the CURRENT four languages (python, javascript, typescript, rust) with
+# lang_registry by WRAPPING the functions defined above UNCHANGED. This is a pure-parity
+# refactor: every dispatch seam that used to test `path.suffix in _JS_TS_SUFFIXES` /
+# `_RUST_SUFFIXES` / `== ".py"` directly now asks `lang_registry.spec_for_path(path)` instead,
+# but the underlying per-language logic those specs point to is untouched.
+#
+# javascript and typescript are two separate LanguageSpec entries (distinct language_id,
+# distinct suffixes) but both wrap the SAME `_js_ts_*` functions -- those functions already
+# branch on the .ts/.tsx suffix internally (parser/tsx selection), so registering the pair
+# twice changes nothing observable; only which suffix routes to which spec entry differs,
+# mirroring how `_target_language_for_path`/`_provider_language_for_path` already distinguish
+# "javascript" from "typescript" today.
+# ---------------------------------------------------------------------------
+
+
+def _python_references_and_calls_for_registry(
+    path: Path, symbol: str, repo_root: Path | str | None = None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    return _python_references_and_calls(path, symbol)
+
+
+def _python_provider_alias_calls_for_registry(
+    path: Path, symbol: str, repo_root: Path | str | None = None
+) -> list[dict[str, Any]]:
+    return _python_provider_alias_calls(path, symbol)
+
+
+def _python_import_update_target_for_registry(
+    file_path: Path,
+    symbol: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+) -> dict[str, Any] | None:
+    return _python_import_update_target(file_path, symbol, definition_path)
+
+
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="python",
+        suffixes=frozenset({".py"}),
+        grammar_modules=(),
+        parser_for_path=None,
+        provenance_when_parsed="python-ast",
+        provenance_when_missing="python-ast",
+        import_markers=(b"import ", b"from "),
+        def_node_kinds=("ClassDef", "FunctionDef", "AsyncFunctionDef"),
+        extract_imports_and_symbols=_python_imports_and_symbols,
+        references_and_calls=_python_references_and_calls_for_registry,
+        provider_alias_calls=_python_provider_alias_calls_for_registry,
+        file_imports_symbol_from_definition=_python_file_imports_symbol_from_definition,
+        import_update_target=_python_import_update_target_for_registry,
+        prime_repo_context=None,
+        classify_ref_kind=_python_classify_ref_kind,
+    )
+)
+
+_JS_TS_REGISTRY_SHARED_KWARGS: dict[str, Any] = {
+    "grammar_modules": ("tree_sitter", "tree_sitter_javascript", "tree_sitter_typescript"),
+    "provenance_when_parsed": "tree-sitter",
+    "provenance_when_missing": "regex-heuristic",
+    "import_markers": (b"import ", b"from ", b"require("),
+    "def_node_kinds": ("function_declaration", "class_declaration", "method_definition"),
+    "extract_imports_and_symbols": None,
+    "references_and_calls": _js_ts_references_and_calls,
+    "provider_alias_calls": _js_ts_provider_alias_calls,
+    "file_imports_symbol_from_definition": _js_ts_file_imports_symbol_from_definition,
+    "import_update_target": _js_ts_import_update_target,
+    "prime_repo_context": _prime_js_ts_repo_context,
+    "classify_ref_kind": _js_ts_classify_ref_kind,
+}
+
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="javascript",
+        suffixes=frozenset({".js", ".jsx", ".mjs", ".cjs"}),
+        parser_for_path=lambda path: _javascript_parser(),
+        **_JS_TS_REGISTRY_SHARED_KWARGS,
+    )
+)
+
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="typescript",
+        suffixes=frozenset({".ts", ".tsx"}),
+        parser_for_path=lambda path: _typescript_parser(tsx=path.suffix == ".tsx"),
+        **_JS_TS_REGISTRY_SHARED_KWARGS,
+    )
+)
+
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="rust",
+        suffixes=frozenset({".rs"}),
+        grammar_modules=("tree_sitter", "tree_sitter_rust"),
+        parser_for_path=lambda path: _rust_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="regex-heuristic",
+        import_markers=(b"use ",),
+        def_node_kinds=("function_item", "struct_item", "enum_item", "trait_item"),
+        extract_imports_and_symbols=None,
+        references_and_calls=_rust_references_and_calls,
+        provider_alias_calls=_rust_provider_alias_calls,
+        file_imports_symbol_from_definition=_rust_file_imports_symbol_from_definition,
+        import_update_target=_rust_import_update_target,
+        prime_repo_context=_prime_rust_repo_context,
+        classify_ref_kind=_rust_classify_ref_kind,
+    )
+)
+
+
+def _prime_all_language_repo_contexts(context_root: Path) -> None:
+    """Prime every registered language's per-repo-root context exactly once.
+
+    Registry-driven replacement for the previous hardcoded
+    ``_prime_js_ts_repo_context(...); _prime_rust_repo_context(...)`` pair. javascript and
+    typescript are separate LanguageSpec entries that both point at the SAME
+    ``_prime_js_ts_repo_context`` callable -- dedupe by callable identity so a repo with both
+    suffixes present still primes the shared JS/TS context exactly once, matching prior
+    behavior (which called it a single time regardless of how many JS/TS suffixes appeared).
+    """
+    primed: set[int] = set()
+    for spec in lang_registry.LANGUAGE_REGISTRY.values():
+        if spec.prime_repo_context is None:
+            continue
+        if id(spec.prime_repo_context) in primed:
+            continue
+        primed.add(id(spec.prime_repo_context))
+        spec.prime_repo_context(context_root)
+
+
 def _imports_and_symbols_for_path(
     path: Path,
     *,
@@ -4963,13 +5102,14 @@ def _imports_and_symbols_for_path(
         return [], []
     with _profiling_phase(_profiling_collector, "file_parse"):
         current_imports, current_symbols = _python_imports_and_symbols(path)
-        if path.suffix in _JS_TS_SUFFIXES:
+        spec = lang_registry.spec_for_path(path)
+        if spec is not None and spec.language_id in ("javascript", "typescript"):
             current_imports, regex_symbols = _regex_imports_and_symbols(path)
             current_symbols = _dedupe_symbol_records([
                 *_js_ts_parser_symbols(path),
                 *regex_symbols,
             ])
-        elif path.suffix in _RUST_SUFFIXES:
+        elif spec is not None and spec.language_id == "rust":
             current_imports, _ = _regex_imports_and_symbols(path)
             current_symbols = _rust_parser_symbols(path)
             if not current_symbols:
@@ -5023,8 +5163,7 @@ def build_repo_map(
 
     with _profiling_phase(_profiling_collector, "repo_map_build"):
         context_root = root if root.is_dir() else root.parent
-        _prime_js_ts_repo_context(context_root)
-        _prime_rust_repo_context(context_root)
+        _prime_all_language_repo_contexts(context_root)
         payload = _envelope(root)
         if _profiling_collector is None:
             all_files = _iter_repo_files(root, max_files=normalized_max_repo_files)
@@ -5131,8 +5270,7 @@ def build_repo_map_incremental(
         raise FileNotFoundError(f"Path not found: {root}")
 
     context_root = root if root.is_dir() else root.parent
-    _prime_js_ts_repo_context(context_root)
-    _prime_rust_repo_context(context_root)
+    _prime_all_language_repo_contexts(context_root)
     normalized_changeset = _normalized_changeset_paths(root, changeset)
     changed_files = set(normalized_changeset["added"]) | set(normalized_changeset["modified"])
     # D2: normalized_changeset["removed"] is computed by _normalized_changeset_paths
@@ -5706,6 +5844,82 @@ def _graph_trust_summary(
             "by_ref_kind": by_ref_kind,
         },
     }
+
+
+def _language_coverage_gap_remediation(language: str) -> str:
+    return (
+        f"tg has no parser-backed extractor registered for '{language}' files yet -- refs/"
+        f"callers on a symbol whose definition or usage lives in a {language} file fall back to "
+        "plain literal-text/regex matching (no import-graph resolution, no AST-verified call "
+        "sites). Treat matches in these files as lower-confidence until native support ships."
+    )
+
+
+def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict[str, Any]]:
+    """PATH A Stage 0 honesty floor (additive): label files in the refs/callers scan universe
+    that have no registered ``LanguageSpec`` (or, for a registered language whose grammar is
+    fail-closed with no regex fallback, no usable parser) instead of silently degrading them.
+    Zero behavior change for python/javascript/typescript/rust today -- every file with one of
+    those suffixes always resolves a spec, so this only ever fires for a language tensor-grep's
+    symbol graph does not yet cover (e.g. .go, .java) that happens to sit in the scan universe.
+    """
+    gaps_by_language: dict[str, dict[str, Any]] = {}
+    for current in bounded_files:
+        spec = lang_registry.spec_for_path(current)
+        if spec is None:
+            language = _provider_language_for_path(current) or (
+                current.suffix.lstrip(".").lower() or "unknown"
+            )
+            reason = "no registered language extractor for this file suffix"
+        elif spec.parser_for_path is not None and spec.parser_for_path(current) is None:
+            # Only a genuine gap for a language that FAILS CLOSED with no fallback when its
+            # grammar is missing (Stage 1+ languages like Go). None of the 4 current languages
+            # set this: JS/TS/Rust always fall back to regex-heuristic extraction, so this
+            # branch is unreachable for them today and only matters for future registrations.
+            if spec.provenance_when_missing not in {"regex-heuristic", "heuristic"}:
+                language = spec.language_id
+                reason = (
+                    "required parser/grammar is not installed for this language and it has no "
+                    "regex fallback (fail-closed)"
+                )
+            else:
+                continue
+        else:
+            continue
+        entry = gaps_by_language.setdefault(
+            language,
+            {
+                "language": language,
+                "reason": reason,
+                "files_affected": 0,
+                "remediation": _language_coverage_gap_remediation(language),
+            },
+        )
+        entry["files_affected"] += 1
+    return sorted(
+        gaps_by_language.values(),
+        key=lambda item: (-int(item["files_affected"]), str(item["language"])),
+    )
+
+
+def _downgrade_graph_trust_summary_for_coverage_gaps(
+    summary: dict[str, Any],
+    resolution_gaps: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Additive downgrade: a non-empty ``resolution_gaps`` means part of the caller/reference
+    universe was scanned with no parser-backed extractor, so the blast-radius trust summary
+    should not read as more confident than that. Downgrades ``confidence`` by exactly one rung
+    and stamps ``resolution_gaps_present`` -- never touches anything when gaps are empty, so
+    the 4 currently-supported languages see byte-identical output."""
+    if not resolution_gaps:
+        return summary
+    confidence_order = {"weak": 1, "moderate": 2, "strong": 3}
+    rank_to_confidence = {value: key for key, value in confidence_order.items()}
+    current_rank = confidence_order.get(str(summary.get("confidence", "weak")), 1)
+    downgraded = dict(summary)
+    downgraded["confidence"] = rank_to_confidence[max(1, current_rank - 1)]
+    downgraded["resolution_gaps_present"] = True
+    return downgraded
 
 
 def _is_parser_backed_provenance(label: str) -> bool:
@@ -11536,12 +11750,20 @@ def _normalize_semantic_provider(provider: str) -> str:
 
 
 def _language_for_path(path: str | Path) -> str:
-    suffix = Path(path).suffix.lower()
-    if suffix in _JS_TS_SUFFIXES:
+    # PATH A Stage 0 honesty fix: this used to default unconditionally to "python" for ANY
+    # suffix it didn't recognize (e.g. an lsp-provenance fallback label for a .go/.rb/.txt
+    # file would be silently stamped "lsp-python") -- dishonest, and only reachable today via
+    # the `_provider_language_for_path(...) or _language_for_path(...)` fallback chain for
+    # suffixes _provider_language_for_path *also* doesn't recognize. Route through the
+    # registry and fall back to "unknown" instead. javascript/typescript are intentionally
+    # collapsed to the single "javascript" label here (unchanged from before) since callers of
+    # this function have never distinguished the two.
+    spec = lang_registry.spec_for_path(path)
+    if spec is None:
+        return "unknown"
+    if spec.language_id in ("javascript", "typescript"):
         return "javascript"
-    if suffix in _RUST_SUFFIXES:
-        return "rust"
-    return "python"
+    return spec.language_id
 
 
 def _provider_language_for_path(path: str | Path) -> str | None:
@@ -12919,6 +13141,7 @@ def build_symbol_refs_from_map(
         payload["string_refs"] = []
         payload["ranking_quality"] = "empty"
         payload["coverage_summary"] = _coverage_summary(payload)
+        payload["resolution_gaps"] = []
         return payload
     context_payload = build_context_pack_from_map(repo_map, symbol)
     repo_root = Path(str(repo_map["path"])).resolve()
@@ -12942,9 +13165,10 @@ def build_symbol_refs_from_map(
             break
         refs_files_scanned += 1
         current_provenance = _symbol_navigation_provenance_for_path(str(current))
-        if current.suffix == ".py":
+        current_spec = lang_registry.spec_for_path(current)
+        if current_spec is not None and current_spec.language_id == "python":
             current_refs, _ = _python_references_and_calls(current, symbol)
-        elif current.suffix in _JS_TS_SUFFIXES:
+        elif current_spec is not None and current_spec.language_id in ("javascript", "typescript"):
             current_refs, current_calls = _js_ts_references_and_calls(current, symbol, repo_root)
             if not current_refs and not current_calls:
                 current_calls = _js_ts_provider_alias_calls(current, symbol, repo_root)
@@ -12971,7 +13195,7 @@ def build_symbol_refs_from_map(
                 for call in current_calls
             ]
             current_refs.extend(js_ts_call_refs)
-        elif current.suffix in _RUST_SUFFIXES:
+        elif current_spec is not None and current_spec.language_id == "rust":
             current_refs, current_calls = _rust_references_and_calls(current, symbol, repo_root)
             if not current_refs and not current_calls:
                 current_calls = _rust_provider_alias_calls(current, symbol, repo_root)
@@ -13086,6 +13310,7 @@ def build_symbol_refs_from_map(
         context_payload["test_matches"],
     )
     payload["coverage_summary"] = _coverage_summary(payload)
+    payload["resolution_gaps"] = _language_coverage_gaps_for_universe(bounded_files)
     payload["semantic_provider"] = normalized_provider
     lsp_proof_count = _lsp_proof_row_count(references)
     if normalized_provider != "native" and lsp_proof_count == 0 and references:
@@ -13194,6 +13419,7 @@ def build_symbol_callers_from_map(
         payload["import_graph_consumer_count"] = 0
         payload["ranking_quality"] = "empty"
         payload["coverage_summary"] = _coverage_summary(payload)
+        payload["resolution_gaps"] = []
         return _attach_profiling(payload, _profiling_collector)
     repo_root = Path(str(repo_map["path"])).resolve()
     callers_universe_files, callers_universe_tests = _repo_map_file_and_test_universe(repo_map)
@@ -13218,7 +13444,7 @@ def build_symbol_callers_from_map(
     def _should_scan_for_symbol_callers(current: Path) -> bool:
         if _file_may_contain_literal_symbol(current, symbol):
             return True
-        if current.suffix not in ({".py"} | _JS_TS_SUFFIXES | _RUST_SUFFIXES):
+        if lang_registry.spec_for_path(current) is None:
             return False
         if not _file_may_import_symbol_definition(current, definition_files):
             return False
@@ -13246,16 +13472,20 @@ def build_symbol_callers_from_map(
             caller_files_scanned += 1
             if not _should_scan_for_symbol_callers(current):
                 continue
-            if current.suffix == ".py":
+            current_spec = lang_registry.spec_for_path(current)
+            if current_spec is not None and current_spec.language_id == "python":
                 python_files.add(str(current))
                 _, current_calls = _python_references_and_calls(current, symbol)
-            elif current.suffix in _JS_TS_SUFFIXES:
+            elif current_spec is not None and current_spec.language_id in (
+                "javascript",
+                "typescript",
+            ):
                 _, current_calls = _js_ts_references_and_calls(current, symbol, repo_root)
                 if not current_calls:
                     current_calls = _js_ts_provider_alias_calls(current, symbol, repo_root)
                 if not current_calls:
                     _, current_calls = _regex_references_and_calls(current, symbol)
-            elif current.suffix in _RUST_SUFFIXES:
+            elif current_spec is not None and current_spec.language_id == "rust":
                 _, current_calls = _rust_references_and_calls(current, symbol, repo_root)
                 if not current_calls:
                     current_calls = _rust_provider_alias_calls(current, symbol, repo_root)
@@ -13515,6 +13745,7 @@ def build_symbol_callers_from_map(
         context_payload["test_matches"],
     )
     payload["coverage_summary"] = _coverage_summary(payload)
+    payload["resolution_gaps"] = _language_coverage_gaps_for_universe(bounded_files)
     payload["semantic_provider"] = normalized_provider
     lsp_proof_count = _lsp_proof_row_count(calls)
     if normalized_provider != "native" and lsp_proof_count == 0 and calls:
@@ -13807,6 +14038,7 @@ def build_symbol_blast_radius_from_map(
             "edge_confidence": "none",
             "evidence_counts": {"parser_backed": 0, "heuristic": 0},
         }
+        payload["resolution_gaps"] = []
         payload["ranking_quality"] = "empty"
         payload["coverage_summary"] = _coverage_summary(payload)
         payload["provider_agreement"] = dict(default_agreement)
@@ -14114,7 +14346,11 @@ def build_symbol_blast_radius_from_map(
     payload["test_matches"] = [test_match_lookup[str(current)] for current in related_tests]
     payload["caller_tree"] = caller_tree
     payload["rendered_caller_tree"] = "\n".join(rendered_lines)
-    payload["graph_trust_summary"] = _graph_trust_summary(caller_tree, calls=direct_callers)
+    payload["resolution_gaps"] = list(callers_payload.get("resolution_gaps", []))
+    payload["graph_trust_summary"] = _downgrade_graph_trust_summary_for_coverage_gaps(
+        _graph_trust_summary(caller_tree, calls=direct_callers),
+        payload["resolution_gaps"],
+    )
     payload["imports"] = impact_payload["imports"]
     payload["symbols"] = impact_payload["symbols"]
     payload["related_paths"] = related_paths

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -1,0 +1,195 @@
+"""PATH A STAGE 0 -- language-extractor registry (lang_registry.py) tests.
+
+Stage 0 is a PURE PARITY REFACTOR: `lang_registry.py` replaces the scattered
+`path.suffix in _JS_TS_SUFFIXES` / `_RUST_SUFFIXES` / `== ".py"` dispatch across repo_map.py
+with `spec_for_path(path)` lookups, with ZERO behavior change for the 4 currently-supported
+languages (python, javascript, typescript, rust). It also adds one additive honesty field:
+`resolution_gaps` on `build_symbol_refs_from_map` / `build_symbol_callers_from_map`, which
+labels a file in the refs/callers scan universe that has no registered `LanguageSpec` instead
+of silently degrading it to a plain regex scan with no explanation.
+
+Covered here:
+- `spec_for_path` resolves every registered suffix to the right LanguageSpec, and returns
+  `None` for an unregistered suffix (e.g. `.go`).
+- `graph_suffixes()` matches the historical hardcoded suffix union exactly.
+- The provenance labeler (`_symbol_navigation_provenance_for_path`) honors each LanguageSpec's
+  `provenance_when_parsed` / `provenance_when_missing`, including the grammar-absent case
+  (tree-sitter uninstalled) for JS/TS and rust -- it must flip to "regex-heuristic", never
+  return an empty string.
+- The `resolution_gaps` floor: a repo containing a `.go` file alongside a resolvable python
+  symbol surfaces an additive `resolution_gaps` entry tagged `language: "go"` on both
+  `build_symbol_refs` and `build_symbol_callers`, without changing the exit-code contract or
+  the existing `coverage_summary` shape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli import lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# spec_for_path / graph_suffixes
+# ---------------------------------------------------------------------------
+
+
+def test_spec_for_path_resolves_every_registered_suffix() -> None:
+    expectations = {
+        "foo.py": "python",
+        "foo.js": "javascript",
+        "foo.jsx": "javascript",
+        "foo.mjs": "javascript",
+        "foo.cjs": "javascript",
+        "foo.ts": "typescript",
+        "foo.tsx": "typescript",
+        "foo.rs": "rust",
+    }
+    for name, expected_language in expectations.items():
+        spec = lang_registry.spec_for_path(Path(name))
+        assert spec is not None, f"expected a LanguageSpec for {name}"
+        assert spec.language_id == expected_language
+
+
+def test_spec_for_path_unknown_suffix_returns_none() -> None:
+    for name in ("foo.go", "foo.java", "foo.rb", "foo.txt", "foo", "foo.md"):
+        assert lang_registry.spec_for_path(Path(name)) is None
+
+
+def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
+    assert lang_registry.graph_suffixes() == frozenset({
+        ".py",
+        ".js",
+        ".jsx",
+        ".mjs",
+        ".cjs",
+        ".ts",
+        ".tsx",
+        ".rs",
+    })
+
+
+def test_language_registry_has_exactly_the_four_stage0_languages() -> None:
+    assert set(lang_registry.LANGUAGE_REGISTRY.keys()) == {
+        "python",
+        "javascript",
+        "typescript",
+        "rust",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provenance labeling (parsed vs missing-grammar)
+# ---------------------------------------------------------------------------
+
+
+def test_python_provenance_is_always_python_ast_no_parser_gate() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["python"]
+    assert spec.parser_for_path is None
+    assert repo_map._symbol_navigation_provenance_for_path("foo.py") == "python-ast"
+
+
+def test_js_ts_and_rust_provenance_is_tree_sitter_when_grammar_present() -> None:
+    # In this dev/test environment the tree-sitter grammar packages ARE installed (ast extra),
+    # so the happy path should report "tree-sitter", not fall back.
+    assert repo_map._symbol_navigation_provenance_for_path("foo.js") == "tree-sitter"
+    assert repo_map._symbol_navigation_provenance_for_path("foo.ts") == "tree-sitter"
+    assert repo_map._symbol_navigation_provenance_for_path("foo.rs") == "tree-sitter"
+
+
+def test_grammar_absent_monkeypatch_js_ts_provenance_flips_to_regex_heuristic(monkeypatch) -> None:
+    """Simulate tree-sitter-javascript/typescript being uninstalled (ImportError inside the
+    parser factory returns None, per repo_map._javascript_parser/_typescript_parser). The
+    provenance label must fail OPEN to "regex-heuristic" -- never empty, never a crash."""
+    monkeypatch.setattr(repo_map, "_javascript_parser", lambda: None)
+    monkeypatch.setattr(repo_map, "_typescript_parser", lambda *, tsx: None)
+
+    js_provenance = repo_map._symbol_navigation_provenance_for_path("foo.js")
+    ts_provenance = repo_map._symbol_navigation_provenance_for_path("foo.tsx")
+
+    assert js_provenance == "regex-heuristic"
+    assert ts_provenance == "regex-heuristic"
+    assert js_provenance != ""
+    assert ts_provenance != ""
+
+
+def test_grammar_absent_monkeypatch_rust_provenance_flips_to_regex_heuristic(monkeypatch) -> None:
+    monkeypatch.setattr(repo_map, "_rust_parser", lambda: None)
+
+    provenance = repo_map._symbol_navigation_provenance_for_path("foo.rs")
+
+    assert provenance == "regex-heuristic"
+    assert provenance != ""
+
+
+# ---------------------------------------------------------------------------
+# resolution_gaps honesty floor
+# ---------------------------------------------------------------------------
+
+
+def _write_python_symbol_plus_go_file(tmp_path: Path) -> tuple[Path, Path]:
+    py_path = tmp_path / "target.py"
+    py_path.write_text(
+        "def Target():\n    return 1\n\n\ndef caller():\n    return Target()\n",
+        encoding="utf-8",
+    )
+    go_path = tmp_path / "helper.go"
+    go_path.write_text(
+        "package main\n\nfunc Helper() int {\n\treturn Target()\n}\n",
+        encoding="utf-8",
+    )
+    return py_path, go_path
+
+
+def test_refs_emits_resolution_gaps_for_unsupported_language_file(tmp_path: Path) -> None:
+    _write_python_symbol_plus_go_file(tmp_path)
+
+    payload = repo_map.build_symbol_refs("Target", tmp_path)
+
+    assert not payload.get("no_match")
+    assert "resolution_gaps" in payload
+    gaps = payload["resolution_gaps"]
+    assert any(gap["language"] == "go" for gap in gaps)
+    go_gap = next(gap for gap in gaps if gap["language"] == "go")
+    assert go_gap["files_affected"] >= 1
+    assert go_gap["reason"]
+    assert go_gap["remediation"]
+    # Additive-only: existing fields must still be present and shaped as before.
+    assert "coverage_summary" in payload
+    assert "references" in payload
+
+
+def test_callers_emits_resolution_gaps_for_unsupported_language_file(tmp_path: Path) -> None:
+    _write_python_symbol_plus_go_file(tmp_path)
+
+    payload = repo_map.build_symbol_callers("Target", tmp_path)
+
+    assert not payload.get("no_match")
+    assert "resolution_gaps" in payload
+    gaps = payload["resolution_gaps"]
+    assert any(gap["language"] == "go" for gap in gaps)
+    assert "coverage_summary" in payload
+    assert "callers" in payload
+
+
+def test_resolution_gaps_empty_for_pure_python_repo(tmp_path: Path) -> None:
+    py_path = tmp_path / "target.py"
+    py_path.write_text(
+        "def Target():\n    return 1\n\n\ndef caller():\n    return Target()\n",
+        encoding="utf-8",
+    )
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    callers_payload = repo_map.build_symbol_callers("Target", tmp_path)
+
+    assert refs_payload["resolution_gaps"] == []
+    assert callers_payload["resolution_gaps"] == []
+
+
+def test_blast_radius_downgrades_graph_trust_summary_when_gaps_present(tmp_path: Path) -> None:
+    _write_python_symbol_plus_go_file(tmp_path)
+
+    payload = repo_map.build_symbol_blast_radius("Target", tmp_path)
+
+    assert "resolution_gaps" in payload
+    if payload["resolution_gaps"]:
+        assert payload["graph_trust_summary"].get("resolution_gaps_present") is True


### PR DESCRIPTION
Path A Stage 0 of the strategic roadmap (Fable-designed). The foundation that turns each new language into a plug-in.

- **New `lang_registry.py`** — a `LanguageSpec` registry replaces the scattered 4-language suffix dispatch (`{.py} | JS/TS | .rs`) across ~10 seams in repo_map.py (import-marker prefilter, provenance, S7 import-resolver, S8 import-update, refs/callers dispatch, caller-scan gate, repo-context priming, `_language_for_path`). The 4 current languages are registered by **wrapping the existing functions unchanged** — bit-identical behavior.
- **Additive `resolution_gaps` floor** — a symbol whose files are in the map but belong to an unsupported language (Go/Java/…) now gets a labeled `resolution_gaps` entry (+ a graph_trust downgrade) instead of the exit-1 "not found on a complete scan" *lie*. No exit-code change.

**Verified:** the FULL parity oracle — **3348 passed / 0 regressions** (baseline 3336 + 12 new lang_registry tests); 206-test repo_map/symbol/capsule cluster re-run in the real venv; ruff/mypy clean. Zero new languages (bisectable). The build agent also caught + fixed a subtle self-ranking artifact (helper names containing "resolution" → renamed to "coverage").

Enables Stage 1 (Go) as a clean per-language build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)