### PR TITLE
feat(PathA Stage1): Go symbol graph — first language expansion beyond the original 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -432,7 +432,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "torch_geometric>=2.5.0"]
 gpu-win = ["torch>=2.0", "torch_geometric>=2.5.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "pygls>=1.3.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "pygls>=1.3.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline
@@ -452,6 +452,7 @@ dev = [
   "tree-sitter-javascript",
   "tree-sitter-typescript",
   "tree-sitter-rust",
+  "tree-sitter-go",
   "types-PyYAML",
 ]
 bench = [
@@ -462,6 +463,7 @@ bench = [
   "tree-sitter-javascript",
   "tree-sitter-typescript",
   "tree-sitter-rust",
+  "tree-sitter-go",
   "torch>=2.0",
   "nvtx>=0.2",
 ]

--- a/src/tensor_grep/cli/lang_go.py
+++ b/src/tensor_grep/cli/lang_go.py
@@ -1,0 +1,754 @@
+"""Go language extractor for tensor-grep's multi-language symbol graph (PATH A Stage 1).
+
+First language expansion beyond the original four (python/javascript/typescript/rust). Plugs
+into the ``lang_registry`` seam Stage 0 built (see ``lang_registry.py`` + the
+``lang_registry.register_language(...)`` calls near the bottom of ``repo_map.py``) -- Go gets
+its OWN ``LanguageSpec`` entry, registered from ``repo_map.py``, with zero special-casing beyond
+the couple of dispatch sites documented in the module docstring there.
+
+Like ``lang_registry.py``, this module imports NOTHING from ``repo_map.py`` (``repo_map`` ->
+``lang_go``, never the reverse -- ``repo_map.py`` needs to import this module to register Go's
+``LanguageSpec`` and to call its ``references_and_calls``/``file_imports_symbol_from_definition``
+directly at a couple of per-language dispatch sites that mirror how it calls the Rust
+equivalents; a reverse import would cycle). The handful of tiny helpers this module needs from
+``repo_map.py`` are duplicated here instead of imported, matching ``lang_registry.py``'s own
+precedent.
+
+FAIL-CLOSED CONTRACT (Stage 0 honesty floor, extended to Go): Go has NO regex-heuristic
+fallback. When the ``tree_sitter_go`` grammar package is not installed, every extractor in this
+module returns empty ([]/([], [])) rather than degrading to a regex/text heuristic (unlike
+JS/TS/Rust, which all fall back to regex extraction when their own tree-sitter grammar is
+missing). ``LanguageSpec.provenance_when_missing="grammar-missing"`` (NOT ``"regex-heuristic"``)
+is what makes ``_language_coverage_gaps_for_universe`` in repo_map.py treat a grammar-absent Go
+file as a genuine ``resolution_gaps`` entry instead of silently reporting zero matches as if the
+symbol just did not exist.
+
+Go's import/package model is much simpler than Rust's (no ``mod`` tree to walk): a Go
+"package" IS a directory, and cross-package access is resolved by mapping an imported path
+(e.g. ``"example.com/mod/bar"``) through the enclosing module's ``go.mod`` ``module`` line (plus
+any ``go.work`` ``use`` entries for a multi-module workspace) to an absolute directory, then
+checking whether the definition file lives in that directory. Exported-ness
+(``symbol[0].isupper()``) gates cross-package visibility exactly as the Go compiler does;
+same-package access needs no import at all (and reaches even unexported symbols).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Duplicated tiny helpers -- see the module docstring: no import from repo_map.py, to avoid an
+# import cycle (repo_map.py imports THIS module). Keep byte-identical to repo_map.py's twins
+# (``_tree_sitter_node_text`` / ``_is_clean_symbol_name`` / ``_node_has_ancestor_type`` /
+# ``_symbol_record``) if any of them ever change there.
+# ---------------------------------------------------------------------------
+
+_CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _is_clean_symbol_name(name: str) -> bool:
+    return bool(_CLEAN_SYMBOL_NAME_RE.match(name))
+
+
+def _tree_sitter_node_text(source_bytes: bytes, node: Any) -> str:
+    return source_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _node_has_ancestor_type(node: Any, ancestor_types: set[str]) -> bool:
+    current = getattr(node, "parent", None)
+    while current is not None:
+        if current.type in ancestor_types:
+            return True
+        current = getattr(current, "parent", None)
+    return False
+
+
+def _symbol_record(
+    *,
+    name: str,
+    kind: str,
+    file: Path,
+    start_line: int,
+    end_line: int | None = None,
+) -> dict[str, Any]:
+    normalized_end_line = start_line if end_line is None else end_line
+    return {
+        "name": name,
+        "kind": kind,
+        "file": str(file),
+        "line": start_line,
+        "start_line": start_line,
+        "end_line": normalized_end_line,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parser factory (clone of repo_map.py's ``_rust_parser`` shape).
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _go_parser() -> Any | None:
+    try:
+        import tree_sitter
+        import tree_sitter_go
+    except ImportError:
+        return None
+
+    language = tree_sitter.Language(tree_sitter_go.language())
+    return tree_sitter.Parser(language)
+
+
+# ---------------------------------------------------------------------------
+# Defs + imports: one tree-sitter pass per file.
+# ---------------------------------------------------------------------------
+
+_GO_TYPE_SPEC_KIND_BY_TYPE_FIELD = {
+    "struct_type": "struct",
+    "interface_type": "interface",
+}
+# node types a Go value/type can be nested under on its way to a name-bearing declaration --
+# used only for documentation/introspection parity with the other LanguageSpec entries; the
+# actual walk below matches concrete node kinds directly rather than deriving them from this set.
+_GO_DEF_NODE_KINDS = (
+    "function_declaration",
+    "method_declaration",
+    "type_spec",
+    "const_spec",
+    "var_spec",
+)
+
+
+def _go_receiver_type_name(method_node: Any, source_bytes: bytes) -> str | None:
+    """Return the (possibly pointer) receiver type name for a ``method_declaration`` node."""
+    receiver = method_node.child_by_field_name("receiver")
+    if receiver is None:
+        return None
+    param_decl = next(
+        (child for child in receiver.children if child.type == "parameter_declaration"),
+        None,
+    )
+    if param_decl is None:
+        return None
+    type_node = param_decl.child_by_field_name("type")
+    if type_node is None:
+        return None
+    if type_node.type == "pointer_type":
+        inner = next(
+            (child for child in type_node.children if child.type != "*"),
+            None,
+        )
+        if inner is not None:
+            type_node = inner
+    return _tree_sitter_node_text(source_bytes, type_node)
+
+
+def go_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    """Extract import paths + top-level definitions from a Go source file, one AST pass.
+
+    Defs covered: ``function_declaration`` (kind "function"), ``method_declaration`` (kind
+    "method", with an additive ``receiver_type`` field), ``type_spec`` (kind "struct"/
+    "interface"/"type" depending on the underlying type), and top-level ``const_spec``/
+    ``var_spec`` (kind "const"/"var" -- local var/const statements INSIDE a function body are
+    deliberately excluded via the ``"block"`` ancestor check, matching "top-level" in the
+    design). Imports come from every ``import_spec``'s string-literal path, regardless of
+    whether it carries an alias/dot/blank qualifier (the qualifier only matters for reference
+    resolution, not for the flat import-path list this function returns).
+    """
+    if path.suffix != ".go":
+        return [], []
+
+    parser = _go_parser()
+    if parser is None:
+        return [], []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    imports: list[str] = []
+    symbols: list[dict[str, Any]] = []
+
+    def _walk(node: Any) -> None:
+        node_type = node.type
+        if node_type == "import_spec":
+            path_field = node.child_by_field_name("path")
+            content_node = (
+                next(
+                    (
+                        child
+                        for child in path_field.children
+                        if child.type == "interpreted_string_literal_content"
+                    ),
+                    None,
+                )
+                if path_field is not None
+                else None
+            )
+            if content_node is not None:
+                imports.append(_node_text(content_node))
+        elif node_type == "function_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                name = _node_text(name_node)
+                if _is_clean_symbol_name(name):
+                    symbols.append(
+                        _symbol_record(
+                            name=name,
+                            kind="function",
+                            file=path,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                        )
+                    )
+        elif node_type == "method_declaration":
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                name = _node_text(name_node)
+                if _is_clean_symbol_name(name):
+                    record = _symbol_record(
+                        name=name,
+                        kind="method",
+                        file=path,
+                        start_line=node.start_point[0] + 1,
+                        end_line=node.end_point[0] + 1,
+                    )
+                    receiver_type = _go_receiver_type_name(node, source_bytes)
+                    if receiver_type:
+                        record["receiver_type"] = receiver_type
+                    symbols.append(record)
+        elif node_type == "type_spec":
+            name_node = node.child_by_field_name("name")
+            type_node = node.child_by_field_name("type")
+            if name_node is not None:
+                name = _node_text(name_node)
+                if _is_clean_symbol_name(name):
+                    kind = _GO_TYPE_SPEC_KIND_BY_TYPE_FIELD.get(
+                        type_node.type if type_node is not None else "", "type"
+                    )
+                    symbols.append(
+                        _symbol_record(
+                            name=name,
+                            kind=kind,
+                            file=path,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                        )
+                    )
+        elif node_type in {"const_spec", "var_spec"} and not _node_has_ancestor_type(
+            node, {"block"}
+        ):
+            kind = "const" if node_type == "const_spec" else "var"
+            for name_node in node.children_by_field_name("name"):
+                if name_node.type != "identifier":
+                    continue
+                name = _node_text(name_node)
+                if _is_clean_symbol_name(name):
+                    symbols.append(
+                        _symbol_record(
+                            name=name,
+                            kind=kind,
+                            file=path,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                        )
+                    )
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    imports = sorted(dict.fromkeys(imports))
+    symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
+    return imports, symbols
+
+
+def go_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
+    """Full source text of every top-level def matching *symbol* (mirrors the Rust/JS-TS
+    ``_parser_symbol_sources`` shape for the ``tg source`` command)."""
+    if path.suffix != ".go":
+        return []
+
+    parser = _go_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    sources: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _walk(node: Any) -> None:
+        node_type = node.type
+        name_node: Any | None = None
+        kind: str | None = None
+        if node_type == "function_declaration":
+            name_node = node.child_by_field_name("name")
+            kind = "function"
+        elif node_type == "method_declaration":
+            name_node = node.child_by_field_name("name")
+            kind = "method"
+        elif node_type == "type_spec":
+            name_node = node.child_by_field_name("name")
+            type_node = node.child_by_field_name("type")
+            kind = _GO_TYPE_SPEC_KIND_BY_TYPE_FIELD.get(
+                type_node.type if type_node is not None else "", "type"
+            )
+        if name_node is not None and kind is not None and _node_text(name_node) == symbol:
+            block = _node_text(node)
+            if block and not block.endswith("\n"):
+                block = f"{block}\n"
+            sources.append({
+                "name": symbol,
+                "kind": kind,
+                "file": str(path),
+                "start_line": node.start_point[0] + 1,
+                "end_line": node.end_point[0] + 1,
+                "source": block,
+            })
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
+    return sources
+
+
+# ---------------------------------------------------------------------------
+# Per-repo-root context: go.mod ``module`` line + go.work ``use`` entries -> {import path
+# prefix: absolute dir}. Cached with the same move-to-end-on-hit / evict-oldest-beyond-max
+# shape as repo_map.py's ``_remember_repo_context`` (duplicated locally rather than imported,
+# same no-cycle rationale as the tiny helpers above).
+# ---------------------------------------------------------------------------
+
+_GO_REPO_CONTEXT_CACHE_MAX_ROOTS = 32
+_GO_REPO_CONTEXTS: OrderedDict[str, dict[str, Any]] = OrderedDict()
+
+_GO_MODULE_LINE_RE = re.compile(r"^\s*module\s+(\S+)\s*$", re.MULTILINE)
+_GO_WORK_USE_LINE_RE = re.compile(r"^\s*use\s+(\S+)\s*$", re.MULTILINE)
+_GO_WORK_USE_BLOCK_RE = re.compile(r"use\s*\(([^)]*)\)", re.DOTALL)
+
+
+def _remember_go_repo_context(key: str, context: dict[str, Any]) -> dict[str, Any]:
+    _GO_REPO_CONTEXTS.pop(key, None)
+    _GO_REPO_CONTEXTS[key] = context
+    while len(_GO_REPO_CONTEXTS) > _GO_REPO_CONTEXT_CACHE_MAX_ROOTS:
+        _GO_REPO_CONTEXTS.popitem(last=False)
+    return context
+
+
+def clear_go_repo_context_cache() -> None:
+    """Exposed so repo_map.py's daemon-refresh sweep (``_clear_all_source_caches``) can flush
+    this module's per-repo-root cache too, matching the existing JS/TS + Rust context clears."""
+    _GO_REPO_CONTEXTS.clear()
+
+
+def _parse_go_mod_module(go_mod_path: Path) -> str | None:
+    try:
+        text = go_mod_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    match = _GO_MODULE_LINE_RE.search(text)
+    return match.group(1).strip() if match else None
+
+
+def _go_work_use_dirs(go_work_path: Path) -> list[str]:
+    try:
+        text = go_work_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    dirs: list[str] = []
+    for line_match in _GO_WORK_USE_LINE_RE.finditer(text):
+        dirs.append(line_match.group(1).strip())
+    for block_match in _GO_WORK_USE_BLOCK_RE.finditer(text):
+        for raw_line in block_match.group(1).splitlines():
+            candidate = raw_line.strip()
+            if candidate and not candidate.startswith("//"):
+                dirs.append(candidate)
+    return dirs
+
+
+def _prime_go_repo_context(root: Path) -> dict[str, Any]:
+    """Prime the ``{module-path-prefix: absolute-dir}`` map for *root* from its own ``go.mod``
+    plus any ``go.work`` workspace ``use`` entries (each pointing at ANOTHER directory with its
+    own ``go.mod``, e.g. a multi-module monorepo)."""
+    normalized_root = root.expanduser().resolve()
+    key = str(normalized_root)
+    module_dirs: dict[str, str] = {}
+
+    go_mod = normalized_root / "go.mod"
+    if go_mod.is_file():
+        module_path = _parse_go_mod_module(go_mod)
+        if module_path:
+            module_dirs[module_path] = str(normalized_root)
+
+    go_work = normalized_root / "go.work"
+    if go_work.is_file():
+        for use_dir in _go_work_use_dirs(go_work):
+            candidate_dir = (normalized_root / use_dir).resolve()
+            candidate_mod = candidate_dir / "go.mod"
+            if candidate_mod.is_file():
+                candidate_module_path = _parse_go_mod_module(candidate_mod)
+                if candidate_module_path:
+                    module_dirs[candidate_module_path] = str(candidate_dir)
+
+    context = {"root": key, "module_dirs": module_dirs}
+    return _remember_go_repo_context(key, context)
+
+
+def prime_go_repo_context(root: Path) -> dict[str, Any]:
+    """Public entry point for repo_map.py's registry-driven ``_prime_all_language_repo_contexts``
+    (the ``LanguageSpec.prime_repo_context`` callable field)."""
+    return _prime_go_repo_context(root)
+
+
+def _go_repo_context(repo_root: Path | str | None) -> dict[str, Any]:
+    if repo_root is None:
+        return {"root": None, "module_dirs": {}}
+    try:
+        normalized_root = Path(repo_root).expanduser().resolve()
+    except OSError:
+        return {"root": None, "module_dirs": {}}
+    key = str(normalized_root)
+    cached = _GO_REPO_CONTEXTS.get(key)
+    if cached is not None:
+        _GO_REPO_CONTEXTS.move_to_end(key)
+        return cached
+    return _prime_go_repo_context(normalized_root)
+
+
+def _go_import_path_to_dir(import_path: str, context: dict[str, Any]) -> Path | None:
+    """Resolve an import path (e.g. ``"example.com/mod/bar"``) to an absolute directory via the
+    longest matching ``module_dirs`` prefix (longest-prefix-wins handles a workspace where one
+    module's path is itself a prefix of another's)."""
+    module_dirs = context.get("module_dirs", {})
+    if not isinstance(module_dirs, dict):
+        return None
+    best_prefix: str | None = None
+    for prefix in module_dirs:
+        if import_path == prefix or import_path.startswith(f"{prefix}/"):
+            if best_prefix is None or len(prefix) > len(best_prefix):
+                best_prefix = prefix
+    if best_prefix is None:
+        return None
+    base_dir = Path(str(module_dirs[best_prefix]))
+    remainder = import_path[len(best_prefix) :].lstrip("/")
+    return (base_dir / remainder).resolve() if remainder else base_dir.resolve()
+
+
+def _go_import_bindings(source_bytes: bytes, tree: Any) -> list[dict[str, Any]]:
+    """Every ``import_spec`` in *tree*: ``{"path", "alias", "dot", "blank"}``."""
+    bindings: list[dict[str, Any]] = []
+
+    def _walk(node: Any) -> None:
+        if node.type == "import_spec":
+            path_field = node.child_by_field_name("path")
+            name_field = node.child_by_field_name("name")
+            content_node = (
+                next(
+                    (
+                        child
+                        for child in path_field.children
+                        if child.type == "interpreted_string_literal_content"
+                    ),
+                    None,
+                )
+                if path_field is not None
+                else None
+            )
+            if content_node is not None:
+                alias: str | None = None
+                dot = False
+                blank = False
+                if name_field is not None:
+                    if name_field.type == "package_identifier":
+                        alias = _tree_sitter_node_text(source_bytes, name_field)
+                    elif name_field.type == "dot":
+                        dot = True
+                    elif name_field.type == "blank_identifier":
+                        blank = True
+                bindings.append({
+                    "path": _tree_sitter_node_text(source_bytes, content_node),
+                    "alias": alias,
+                    "dot": dot,
+                    "blank": blank,
+                })
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    return bindings
+
+
+def _go_alias_to_import_path(bindings: list[dict[str, Any]]) -> dict[str, str]:
+    alias_to_path: dict[str, str] = {}
+    for binding in bindings:
+        if binding.get("blank") or binding.get("dot"):
+            continue
+        import_path = str(binding["path"])
+        local_name = str(binding.get("alias") or import_path.rsplit("/", 1)[-1])
+        alias_to_path[local_name] = import_path
+    return alias_to_path
+
+
+# ---------------------------------------------------------------------------
+# Import-based caller-scan pre-filter (registered as ``file_imports_symbol_from_definition``).
+# ---------------------------------------------------------------------------
+
+
+def go_file_imports_symbol_from_definition(
+    file_path: Path,
+    source: str,
+    symbol: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+) -> bool:
+    """True iff *file_path* can see *symbol*'s definition: same package (any visibility) OR a
+    resolved import of the definition's package AND *symbol* is exported (``symbol[0].isupper()``
+    -- Go's own visibility rule, not a tensor-grep heuristic)."""
+    try:
+        definition_dir = Path(definition_path).expanduser().resolve().parent
+        importer_dir = file_path.expanduser().resolve().parent
+    except OSError:
+        return False
+    if importer_dir == definition_dir:
+        return True
+    if not symbol or not symbol[:1].isupper():
+        return False
+
+    parser = _go_parser()
+    if parser is None:
+        return False
+    try:
+        source_bytes = source.encode("utf-8")
+        tree = parser.parse(source_bytes)
+    except (UnicodeDecodeError, ValueError):
+        return False
+
+    context = _go_repo_context(repo_root)
+    for binding in _go_import_bindings(source_bytes, tree):
+        if binding.get("blank"):
+            continue
+        target_dir = _go_import_path_to_dir(str(binding["path"]), context)
+        if target_dir is not None and target_dir == definition_dir:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# References + calls: identifier / type_identifier / field_identifier (selector) walk.
+# ---------------------------------------------------------------------------
+
+# Node types whose "name" field (or, for const/var specs, "name"-field-tagged children) defines
+# *this* declaration rather than referencing an existing one elsewhere -- excluded from the
+# reference/call walk below exactly like every other language's ``_is_definition_identifier``.
+_GO_NAME_DEFINING_PARENT_TYPES = {
+    "function_declaration",
+    "method_declaration",
+    "type_spec",
+    "const_spec",
+    "var_spec",
+    "field_declaration",
+    "method_elem",
+    "parameter_declaration",
+}
+
+
+def go_references_and_calls(
+    path: Path,
+    symbol: str,
+    repo_root: Path | str | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Reference/call rows for *symbol* in *path*.
+
+    Go's grammar gives ``ref_kind`` classification almost for free at the node-type level
+    (unlike JS/Python/Rust, where a single ``identifier`` node type is reused across value/type/
+    field roles and ref_kind must be inferred from ancestor context): a *value*-position mention
+    is node type ``identifier``, a *type*-position mention is ``type_identifier``, and a
+    *field*/method-selector mention is ``field_identifier``.
+
+    Package-qualified access (``pkg.Symbol``) resolves through this file's import bindings +
+    the primed repo context: if the qualifying identifier is a recognized import alias whose
+    resolved directory matches *definition_path*'s directory, the row carries
+    ``resolution_provenance=["go-import-resolution"]`` at ``resolution_confidence=0.95``. A
+    selector call whose left-hand operand is NOT a recognized package alias (e.g. ``w.Write(x)``
+    where ``w`` is an arbitrary receiver variable of unknown static type) is equifinal -- ANY
+    type with a same-named method would match textually -- so it is still emitted (never
+    silently dropped) but capped at ``resolution_confidence<=0.7`` with
+    ``resolution_provenance=["receiver-heuristic"]``, per the Stage 1 no-fabricated-precision
+    trap.
+    """
+    if path.suffix != ".go":
+        return [], []
+
+    parser = _go_parser()
+    if parser is None:
+        return [], []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    lines = source.splitlines()
+    references: list[dict[str, Any]] = []
+    calls: list[dict[str, Any]] = []
+
+    context = _go_repo_context(repo_root)
+    alias_to_path = _go_alias_to_import_path(_go_import_bindings(source_bytes, tree))
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _line_text(node: Any) -> str:
+        line_index = node.start_point[0]
+        return lines[line_index] if 0 <= line_index < len(lines) else ""
+
+    def _is_definition_identifier(node: Any) -> bool:
+        parent = node.parent
+        if parent is None or parent.type not in _GO_NAME_DEFINING_PARENT_TYPES:
+            return False
+        name_field = parent.child_by_field_name("name")
+        if name_field is not None and name_field == node:
+            return True
+        return any(candidate == node for candidate in parent.children_by_field_name("name"))
+
+    def _resolution_for_package(pkg_name: str | None) -> dict[str, Any] | None:
+        if not pkg_name:
+            return None
+        import_path = alias_to_path.get(pkg_name)
+        if import_path is None:
+            return None
+        target_dir = _go_import_path_to_dir(import_path, context)
+        if target_dir is None:
+            return None
+        return {"provenance": ["go-import-resolution"], "confidence": 0.95, "dir": target_dir}
+
+    def _emit(
+        bucket: list[dict[str, Any]],
+        node: Any,
+        *,
+        kind: str,
+        ref_kind: str,
+        resolution: dict[str, Any] | None,
+    ) -> None:
+        entry: dict[str, Any] = {
+            "name": symbol,
+            "kind": kind,
+            "ref_kind": ref_kind,
+            "file": str(path),
+            "line": node.start_point[0] + 1,
+            "text": _line_text(node),
+        }
+        if resolution is not None:
+            entry["resolution_provenance"] = list(resolution.get("provenance", []))
+            entry["resolution_confidence"] = float(resolution.get("confidence", 0.95))
+        bucket.append(entry)
+
+    def _walk(node: Any) -> None:
+        node_type = node.type
+        node_text = (
+            _node_text(node)
+            if node_type in {"identifier", "type_identifier", "field_identifier"}
+            else ""
+        )
+        if (
+            node_type == "identifier"
+            and node_text == symbol
+            and not _is_definition_identifier(node)
+        ):
+            parent = node.parent
+            if (
+                parent is not None
+                and parent.type == "call_expression"
+                and parent.child_by_field_name("function") == node
+            ):
+                _emit(references, node, kind="reference", ref_kind="call", resolution=None)
+                _emit(calls, node, kind="call", ref_kind="call", resolution=None)
+            else:
+                _emit(references, node, kind="reference", ref_kind="value", resolution=None)
+        elif (
+            node_type == "type_identifier"
+            and node_text == symbol
+            and not _is_definition_identifier(node)
+        ):
+            _emit(references, node, kind="reference", ref_kind="type", resolution=None)
+        elif (
+            node_type == "field_identifier"
+            and node_text == symbol
+            and not _is_definition_identifier(node)
+        ):
+            parent = node.parent
+            if parent is not None and parent.type == "selector_expression":
+                field_node = parent.child_by_field_name("field")
+                if field_node is not None and field_node == node:
+                    operand_node = parent.child_by_field_name("operand")
+                    operand_name = (
+                        _node_text(operand_node)
+                        if operand_node is not None and operand_node.type == "identifier"
+                        else None
+                    )
+                    package_resolution = _resolution_for_package(operand_name)
+                    grandparent = getattr(parent, "parent", None)
+                    is_call = (
+                        grandparent is not None
+                        and grandparent.type == "call_expression"
+                        and grandparent.child_by_field_name("function") == parent
+                    )
+                    if is_call:
+                        resolution = package_resolution or {
+                            "provenance": ["receiver-heuristic"],
+                            "confidence": 0.7,
+                        }
+                        _emit(
+                            references,
+                            node,
+                            kind="reference",
+                            ref_kind="call",
+                            resolution=resolution,
+                        )
+                        _emit(calls, node, kind="call", ref_kind="call", resolution=resolution)
+                    else:
+                        _emit(
+                            references,
+                            node,
+                            kind="reference",
+                            ref_kind="field",
+                            resolution=package_resolution,
+                        )
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    references.sort(key=lambda item: (item["file"], item["line"], item["text"]))
+    calls.sort(key=lambda item: (item["file"], item["line"], item["text"]))
+    return references, calls
+
+
+__all__ = [
+    "clear_go_repo_context_cache",
+    "go_file_imports_symbol_from_definition",
+    "go_imports_and_symbols",
+    "go_parser_symbol_sources",
+    "go_references_and_calls",
+    "prime_go_repo_context",
+]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
-from tensor_grep.cli import lang_registry
+from tensor_grep.cli import lang_go, lang_registry
 from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LSPTransportError
 from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 
@@ -68,6 +68,7 @@ def _clear_all_source_caches() -> None:
     # after an edit. Clear them too so the sweep is actually complete (they rebuild on demand).
     _JS_TS_REPO_CONTEXTS.clear()
     _RUST_REPO_CONTEXTS.clear()
+    lang_go.clear_go_repo_context_cache()
 
 
 # Fix B: the JS/TS import-resolution path (_js_ts_module_candidates / _js_ts_candidate_files /
@@ -5065,6 +5066,38 @@ lang_registry.register_language(
     )
 )
 
+# PATH A Stage 1: first language expansion beyond the original four. Go's grammar/import model
+# is simpler than Rust's (package == directory, no mod-tree to walk), so its extractor lives in
+# its own module (lang_go.py) rather than inline here -- see that module's docstring for the
+# no-import-cycle rationale. provenance_when_missing="grammar-missing" (NOT "regex-heuristic")
+# is what makes a grammar-absent Go file a genuine `resolution_gaps` entry instead of a silent
+# empty result (Go has no regex fallback, unlike JS/TS/Rust).
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="go",
+        suffixes=frozenset({".go"}),
+        grammar_modules=("tree_sitter", "tree_sitter_go"),
+        parser_for_path=lambda path: lang_go._go_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="grammar-missing",
+        import_markers=(b"import ",),
+        def_node_kinds=(
+            "function_declaration",
+            "method_declaration",
+            "type_spec",
+            "const_spec",
+            "var_spec",
+        ),
+        extract_imports_and_symbols=None,
+        references_and_calls=lang_go.go_references_and_calls,
+        provider_alias_calls=None,
+        file_imports_symbol_from_definition=lang_go.go_file_imports_symbol_from_definition,
+        import_update_target=None,
+        prime_repo_context=lang_go.prime_go_repo_context,
+        classify_ref_kind=None,
+    )
+)
+
 
 def _prime_all_language_repo_contexts(context_root: Path) -> None:
     """Prime every registered language's per-repo-root context exactly once.
@@ -5114,6 +5147,11 @@ def _imports_and_symbols_for_path(
             current_symbols = _rust_parser_symbols(path)
             if not current_symbols:
                 _, current_symbols = _regex_imports_and_symbols(path)
+        elif spec is not None and spec.language_id == "go":
+            # Fail-closed (Stage 1 trap): NO regex fallback for Go. A grammar-missing Go file
+            # returns ([], []) here -- surfaced honestly via `resolution_gaps`, never silently
+            # degraded to a text heuristic the way JS/TS/Rust are.
+            current_imports, current_symbols = lang_go.go_imports_and_symbols(path)
         elif not current_imports and not current_symbols:
             current_imports, current_symbols = _regex_imports_and_symbols(path)
         return current_imports, current_symbols
@@ -5501,6 +5539,13 @@ def _target_language_for_path(path: str | Path | None) -> str | None:
         return "javascript"
     if suffix in _RUST_SUFFIXES:
         return "rust"
+    if suffix == ".go":
+        # MOST-FORGOTTEN seam (PATH A Stage 1 design note): without this, the capsule's
+        # query-language-vs-target-language 0.55 confidence cap (agent_capsule.py) never even
+        # sees "go" as a candidate target language, so it can silently misfire on Go targets --
+        # e.g. treating a Go primary file as having "no target language" instead of correctly
+        # reporting primary_target_language == "go".
+        return "go"
     return None
 
 
@@ -12763,6 +12808,8 @@ def build_symbol_source_from_map(
                 current_sources = _js_ts_parser_symbol_sources(current_path, symbol)
             if not current_sources and current_path.suffix in _RUST_SUFFIXES:
                 current_sources = _rust_parser_symbol_sources(current_path, symbol)
+            if not current_sources and current_path.suffix == ".go":
+                current_sources = lang_go.go_parser_symbol_sources(current_path, symbol)
             if not current_sources:
                 current_sources = _regex_symbol_sources(current_path, symbol)
             sources.extend(current_sources)
@@ -13222,6 +13269,34 @@ def build_symbol_refs_from_map(
                 for call in current_calls
             ]
             current_refs.extend(rust_call_refs)
+        elif current_spec is not None and current_spec.language_id == "go":
+            # Fail-closed (Stage 1 trap): no regex/provider-alias fallback for Go -- a
+            # grammar-missing file yields ([], []) here and is surfaced honestly via
+            # `resolution_gaps` further down, never a silently-degraded text match.
+            current_refs, current_calls = lang_go.go_references_and_calls(
+                current, symbol, repo_root
+            )
+            go_call_refs = [
+                {
+                    "name": str(call["name"]),
+                    "kind": "reference",
+                    "ref_kind": str(call.get("ref_kind", "call")),
+                    "file": str(call["file"]),
+                    "line": int(call["line"]),
+                    "text": str(call["text"]),
+                    "provenance": current_provenance,
+                    **(
+                        {
+                            "resolution_provenance": list(call.get("resolution_provenance", [])),
+                            "resolution_confidence": float(call.get("resolution_confidence", 0.95)),
+                        }
+                        if "resolution_provenance" in call
+                        else {}
+                    ),
+                }
+                for call in current_calls
+            ]
+            current_refs.extend(go_call_refs)
         else:
             current_refs, _ = _regex_references_and_calls(current, symbol)
         references.extend(
@@ -13491,6 +13566,11 @@ def build_symbol_callers_from_map(
                     current_calls = _rust_provider_alias_calls(current, symbol, repo_root)
                 if not current_calls:
                     _, current_calls = _regex_references_and_calls(current, symbol)
+            elif current_spec is not None and current_spec.language_id == "go":
+                # Fail-closed (Stage 1 trap): no provider-alias/regex fallback for Go -- a
+                # grammar-missing file simply contributes no calls (surfaced via
+                # `resolution_gaps` for the refs/blast-radius payloads that compute it).
+                _, current_calls = lang_go.go_references_and_calls(current, symbol, repo_root)
             else:
                 _, current_calls = _regex_references_and_calls(current, symbol)
             for current_call in current_calls:

--- a/tests/unit/test_agent_capsule_lsp_confidence.py
+++ b/tests/unit/test_agent_capsule_lsp_confidence.py
@@ -300,10 +300,13 @@ def test_capsule_lsp_boost_keeps_confirmation_when_tied_alternative_is_lsp_backe
 def test_capsule_lsp_boost_requires_supported_target_language(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    primary_file = tmp_path / "payments.go"
-    alternative_file = tmp_path / "billing.go"
-    primary_file.write_text("func create_invoice() {}\n", encoding="utf-8")
-    alternative_file.write_text("func create_invoice() {}\n", encoding="utf-8")
+    # PATH A Stage 1: .go moved from "unsupported target language" to "supported" (it now has
+    # its own LanguageSpec + _target_language_for_path("go") mapping), so .rb (still genuinely
+    # unsupported) stands in here instead -- this test is about the None-target-language case.
+    primary_file = tmp_path / "payments.rb"
+    alternative_file = tmp_path / "billing.rb"
+    primary_file.write_text("def create_invoice\nend\n", encoding="utf-8")
+    alternative_file.write_text("def create_invoice\nend\n", encoding="utf-8")
     monkeypatch.setenv(agent_capsule._CAPSULE_LSP_CONFIDENCE_BOOST_ENV, "1")
     monkeypatch.setattr(
         repo_map,

--- a/tests/unit/test_lang_go.py
+++ b/tests/unit/test_lang_go.py
@@ -1,0 +1,355 @@
+"""PATH A STAGE 1 -- Go symbol graph (lang_go.py) tests.
+
+First language expansion beyond the original four (python/javascript/typescript/rust). The
+fixture below is a tiny multi-package Go module (``go.mod`` + two packages + a ``_test.go``)
+used to verify:
+
+- ``defs``: an exported function is found with provenance "tree-sitter".
+- ``refs``/``callers``: a cross-package call (``foo.Helper(...)``) resolves through the
+  ``go.mod`` import context with ``ref_kind == "call"`` and
+  ``resolution_provenance == ["go-import-resolution"]``; a same-package call (from the
+  internal ``_test.go``) is also found.
+- Type-position usage (``var w foo.Widget`` / ``foo.Widget{...}``) is classified
+  ``ref_kind == "type"``.
+- An UNEXPORTED symbol (``helper``) is only ever a caller from WITHIN its own package -- a
+  cross-package file that happens to import the package can never legally call it, matching Go's
+  own visibility rule, and tensor-grep's caller-scan must not fabricate a cross-package hit.
+- A method call through an arbitrary (non-package-alias) receiver variable (``w.Write(...)``) is
+  equifinal -- emitted, never dropped, but capped at ``resolution_confidence<=0.7`` with
+  ``resolution_provenance == ["receiver-heuristic"]`` (never fabricated precision).
+- Grammar-absent (monkeypatched ``lang_go._go_parser`` -> ``None``): fail-closed, zero
+  fabricated rows, an honest ``resolution_gaps`` entry, and an honest (non-zero, non-silent)
+  CLI exit code for a target that lives entirely in the grammar-missing language.
+- The agent capsule reports ``primary_target_language == "go"`` and populates
+  ``related_call_sites`` from the cross-package caller.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli import agent_capsule, lang_go, lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# Fixture: go.mod + pkg/foo (exported Helper + unexported helper + Widget/Write) + pkg/bar
+# (cross-package caller) + cmd/app (receiver-heuristic caller) + pkg/foo/foo_test.go
+# (same-package caller).
+# ---------------------------------------------------------------------------
+
+
+def _write_go_fixture(root: Path) -> dict[str, Path]:
+    (root / "go.mod").write_text("module example.com/widgetmod\n\ngo 1.21\n", encoding="utf-8")
+
+    foo_dir = root / "pkg" / "foo"
+    foo_dir.mkdir(parents=True)
+    foo_go = foo_dir / "foo.go"
+    foo_go.write_text(
+        "package foo\n"
+        "\n"
+        "// Helper is exported: other packages may call it.\n"
+        "func Helper(x int) int {\n"
+        "\treturn x + helper()\n"
+        "}\n"
+        "\n"
+        "// helper is unexported: only this package may call it.\n"
+        "func helper() int {\n"
+        "\treturn 1\n"
+        "}\n"
+        "\n"
+        "// Widget is an exported struct with an exported method.\n"
+        "type Widget struct {\n"
+        "\tName string\n"
+        "}\n"
+        "\n"
+        "// Write has an ambiguous (equifinal) receiver-call surface from a caller that only\n"
+        "// knows the receiver variable's name, not its static type.\n"
+        "func (w *Widget) Write(data []byte) (int, error) {\n"
+        "\treturn len(data), nil\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    foo_test_go = foo_dir / "foo_test.go"
+    foo_test_go.write_text(
+        "package foo\n"
+        "\n"
+        'import "testing"\n'
+        "\n"
+        # Deliberately NOT named TestHelper: a name containing the target symbol as a
+        # substring skews the agent-capsule's file/symbol ranking (a query for "Helper" then
+        # ties against this test function itself), which is a ranking-heuristic artifact
+        # unrelated to what this fixture is testing (the actual call site inside the body).
+        "func TestFooPackageBehavior(t *testing.T) {\n"
+        "\tif Helper(1) != 2 {\n"
+        '\t\tt.Fatal("unexpected")\n'
+        "\t}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    bar_dir = root / "pkg" / "bar"
+    bar_dir.mkdir(parents=True)
+    bar_go = bar_dir / "bar.go"
+    bar_go.write_text(
+        "package bar\n"
+        "\n"
+        "import (\n"
+        '\t"example.com/widgetmod/pkg/foo"\n'
+        ")\n"
+        "\n"
+        "// UseFoo cross-package-calls the exported Helper and references the exported Widget\n"
+        "// type.\n"
+        "func UseFoo() int {\n"
+        "\tvar w foo.Widget\n"
+        '\tw.Name = "test"\n'
+        "\treturn foo.Helper(3)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    app_dir = root / "cmd" / "app"
+    app_dir.mkdir(parents=True)
+    main_go = app_dir / "main.go"
+    main_go.write_text(
+        "package main\n"
+        "\n"
+        "import (\n"
+        '\t"fmt"\n'
+        "\n"
+        '\t"example.com/widgetmod/pkg/foo"\n'
+        ")\n"
+        "\n"
+        "func main() {\n"
+        '\tw := &foo.Widget{Name: "app"}\n'
+        '\tn, err := w.Write([]byte("hello"))\n'
+        "\tfmt.Println(n, err)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "foo.go": foo_go,
+        "foo_test.go": foo_test_go,
+        "bar.go": bar_go,
+        "main.go": main_go,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_go_is_registered_with_tree_sitter_provenance() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["go"]
+    assert spec.suffixes == frozenset({".go"})
+    assert spec.provenance_when_parsed == "tree-sitter"
+    # Fail-closed (Stage 1 trap): never "regex-heuristic"/"heuristic" -- Go has no fallback.
+    assert spec.provenance_when_missing == "grammar-missing"
+    assert spec.parser_for_path is not None
+
+
+def test_target_language_for_path_reports_go() -> None:
+    assert repo_map._target_language_for_path("pkg/foo/foo.go") == "go"
+    assert repo_map._language_for_path("pkg/foo/foo.go") == "go"
+    assert repo_map._provider_language_for_path("pkg/foo/foo.go") == "go"
+
+
+# ---------------------------------------------------------------------------
+# defs
+# ---------------------------------------------------------------------------
+
+
+def test_defs_finds_exported_function_with_tree_sitter_provenance(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Helper", tmp_path)
+
+    assert not payload.get("no_match")
+    assert len(payload["definitions"]) == 1
+    definition = payload["definitions"][0]
+    assert definition["kind"] == "function"
+    assert definition["provenance"] == "tree-sitter"
+    assert definition["file"].replace("\\", "/").endswith("pkg/foo/foo.go")
+
+
+def test_defs_finds_method_and_struct(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    write_payload = repo_map.build_symbol_defs("Write", tmp_path)
+    widget_payload = repo_map.build_symbol_defs("Widget", tmp_path)
+
+    assert not write_payload.get("no_match")
+    assert write_payload["definitions"][0]["kind"] == "method"
+    assert not widget_payload.get("no_match")
+    assert widget_payload["definitions"][0]["kind"] == "struct"
+
+
+# ---------------------------------------------------------------------------
+# refs / callers: cross-package call resolution + type-position classification
+# ---------------------------------------------------------------------------
+
+
+def test_refs_cross_package_call_has_call_ref_kind_and_import_resolution(
+    tmp_path: Path,
+) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_refs("Helper", tmp_path)
+
+    assert payload["resolution_gaps"] == []
+    cross_package_refs = [
+        ref
+        for ref in payload["references"]
+        if ref["file"].replace("\\", "/").endswith("pkg/bar/bar.go")
+    ]
+    assert cross_package_refs, "expected a cross-package reference to Helper in bar.go"
+    for ref in cross_package_refs:
+        assert ref["ref_kind"] == "call"
+        assert ref["resolution_provenance"] == ["go-import-resolution"]
+        assert ref["resolution_confidence"] >= 0.9
+
+    same_package_refs = [
+        ref
+        for ref in payload["references"]
+        if ref["file"].replace("\\", "/").endswith("pkg/foo/foo_test.go")
+    ]
+    assert same_package_refs, "expected the internal _test.go call to Helper to be found"
+    assert all(ref["ref_kind"] == "call" for ref in same_package_refs)
+
+
+def test_callers_cross_package_ref_kind_call(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_callers("Helper", tmp_path)
+
+    caller_files = {str(Path(c["file"])) for c in payload["callers"]}
+    assert any(f.replace("\\", "/").endswith("pkg/bar/bar.go") for f in caller_files)
+    assert any(f.replace("\\", "/").endswith("pkg/foo/foo_test.go") for f in caller_files)
+    assert all(c["ref_kind"] == "call" for c in payload["callers"])
+
+
+def test_type_position_reference_classified_as_type(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_refs("Widget", tmp_path)
+
+    type_refs = [ref for ref in payload["references"] if ref["ref_kind"] == "type"]
+    assert type_refs, "expected at least one type-position reference to Widget"
+    referencing_files = {Path(ref["file"]).name for ref in type_refs}
+    assert "bar.go" in referencing_files or "main.go" in referencing_files
+
+
+# ---------------------------------------------------------------------------
+# Unexported symbol: cross-package is NOT a caller
+# ---------------------------------------------------------------------------
+
+
+def test_unexported_symbol_has_no_cross_package_caller(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_callers("helper", tmp_path)
+
+    caller_files = {Path(c["file"]).name for c in payload["callers"]}
+    # helper() is unexported -- only foo.go (same package, Helper calling helper()) may call
+    # it. bar.go and main.go import the "foo" package but can never legally reference the
+    # unexported symbol, and must NOT appear as callers.
+    assert "bar.go" not in caller_files
+    assert "main.go" not in caller_files
+    assert caller_files, "expected the intra-package caller (Helper -> helper()) to be found"
+    assert caller_files == {"foo.go"}
+
+
+def test_go_file_imports_symbol_from_definition_exported_gate(tmp_path: Path) -> None:
+    fixture = _write_go_fixture(tmp_path)
+    foo_source = fixture["foo.go"].read_text(encoding="utf-8")
+    bar_source = fixture["bar.go"].read_text(encoding="utf-8")
+
+    # Cross-package + exported -> True (bar.go imports the package Helper's definition lives in).
+    assert lang_go.go_file_imports_symbol_from_definition(
+        fixture["bar.go"], bar_source, "Helper", str(fixture["foo.go"]), repo_root=tmp_path
+    )
+    # Cross-package + UNexported -> False, even though bar.go imports the same package.
+    assert not lang_go.go_file_imports_symbol_from_definition(
+        fixture["bar.go"], bar_source, "helper", str(fixture["foo.go"]), repo_root=tmp_path
+    )
+    # Same package (no import needed) -> True even for an unexported symbol.
+    assert lang_go.go_file_imports_symbol_from_definition(
+        fixture["foo.go"], foo_source, "helper", str(fixture["foo.go"]), repo_root=tmp_path
+    )
+
+
+# ---------------------------------------------------------------------------
+# Equifinal receiver-method call: never dropped, never over-confident.
+# ---------------------------------------------------------------------------
+
+
+def test_receiver_method_call_is_equifinal_low_confidence(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_callers("Write", tmp_path)
+
+    assert payload["callers"], "expected the w.Write(...) call in main.go to be found"
+    for caller in payload["callers"]:
+        assert caller["ref_kind"] == "call"
+        assert caller["resolution_provenance"] == ["receiver-heuristic"]
+        assert caller["resolution_confidence"] <= 0.7
+
+
+# ---------------------------------------------------------------------------
+# Grammar-absent: fail-closed, resolution_gaps, honest exit code.
+# ---------------------------------------------------------------------------
+
+
+def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_go_fixture(tmp_path)
+    # A python symbol elsewhere in the same repo so refs/callers has something REAL to find --
+    # the resolution_gaps floor is about a Go file being an honestly-labeled BYSTANDER in the
+    # scan universe, not about the query's own target living in the grammar-missing language
+    # (that case short-circuits to no_match, exercised separately below).
+    (tmp_path / "target.py").write_text("def Target():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(lang_go, "_go_parser", lambda: None)
+
+    defs_payload = repo_map.build_symbol_defs("Helper", tmp_path)
+    assert defs_payload.get("no_match") is True
+    assert defs_payload["definitions"] == []
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    assert not refs_payload.get("no_match")
+    gaps = refs_payload["resolution_gaps"]
+    assert any(gap["language"] == "go" for gap in gaps)
+    go_gap = next(gap for gap in gaps if gap["language"] == "go")
+    assert "fail-closed" in go_gap["reason"]
+    assert go_gap["files_affected"] >= 1
+
+
+def test_grammar_absent_cli_exit_code_is_honest_not_found(tmp_path: Path, monkeypatch) -> None:
+    """A Go-only target with the grammar missing must exit 1 (honest not-found) -- never a
+    silent 0 (which would imply a fabricated/incorrect match) and never a crash."""
+    from typer.testing import CliRunner
+
+    from tensor_grep.cli.main import app
+
+    _write_go_fixture(tmp_path)
+    monkeypatch.setattr(lang_go, "_go_parser", lambda: None)
+
+    result = CliRunner().invoke(app, ["defs", str(tmp_path), "Helper"])
+
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Agent capsule
+# ---------------------------------------------------------------------------
+
+
+def test_agent_capsule_reports_go_target_language_and_call_sites(tmp_path: Path) -> None:
+    _write_go_fixture(tmp_path)
+
+    payload = agent_capsule.build_agent_capsule("Helper", tmp_path, include_blast_radius=True)
+
+    assert payload["context_consistency"]["primary_target_language"] == "go"
+    related_call_sites = payload.get("related_call_sites")
+    assert related_call_sites
+    assert any(Path(str(site.get("file", ""))).name == "bar.go" for site in related_call_sites)

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tensor_grep.cli import lang_registry, repo_map
+from tensor_grep.cli import lang_go, lang_registry, repo_map
 
 # ---------------------------------------------------------------------------
 # spec_for_path / graph_suffixes
@@ -43,6 +43,7 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
         "foo.ts": "typescript",
         "foo.tsx": "typescript",
         "foo.rs": "rust",
+        "foo.go": "go",
     }
     for name, expected_language in expectations.items():
         spec = lang_registry.spec_for_path(Path(name))
@@ -51,7 +52,11 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
 
 
 def test_spec_for_path_unknown_suffix_returns_none() -> None:
-    for name in ("foo.go", "foo.java", "foo.rb", "foo.txt", "foo", "foo.md"):
+    # PATH A Stage 1: .go is now a REGISTERED language (see
+    # test_spec_for_path_resolves_every_registered_suffix), so it moved out of this "still
+    # unsupported" list -- .rb stands in as the still-unsupported example for the resolution_gaps
+    # tests below instead.
+    for name in ("foo.java", "foo.rb", "foo.txt", "foo", "foo.md"):
         assert lang_registry.spec_for_path(Path(name)) is None
 
 
@@ -65,15 +70,17 @@ def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
         ".ts",
         ".tsx",
         ".rs",
+        ".go",
     })
 
 
-def test_language_registry_has_exactly_the_four_stage0_languages() -> None:
+def test_language_registry_has_exactly_the_stage1_languages() -> None:
     assert set(lang_registry.LANGUAGE_REGISTRY.keys()) == {
         "python",
         "javascript",
         "typescript",
         "rust",
+        "go",
     }
 
 
@@ -94,6 +101,10 @@ def test_js_ts_and_rust_provenance_is_tree_sitter_when_grammar_present() -> None
     assert repo_map._symbol_navigation_provenance_for_path("foo.js") == "tree-sitter"
     assert repo_map._symbol_navigation_provenance_for_path("foo.ts") == "tree-sitter"
     assert repo_map._symbol_navigation_provenance_for_path("foo.rs") == "tree-sitter"
+
+
+def test_go_provenance_is_tree_sitter_when_grammar_present() -> None:
+    assert repo_map._symbol_navigation_provenance_for_path("foo.go") == "tree-sitter"
 
 
 def test_grammar_absent_monkeypatch_js_ts_provenance_flips_to_regex_heuristic(monkeypatch) -> None:
@@ -121,52 +132,70 @@ def test_grammar_absent_monkeypatch_rust_provenance_flips_to_regex_heuristic(mon
     assert provenance != ""
 
 
+def test_grammar_absent_monkeypatch_go_provenance_flips_to_grammar_missing(monkeypatch) -> None:
+    """Go has NO regex fallback (Stage 1 fail-closed trap): a grammar-absent .go file's
+    provenance label must flip to "grammar-missing" (not "regex-heuristic" -- Go never
+    silently degrades to a text heuristic the way JS/TS/Rust do)."""
+    monkeypatch.setattr(lang_go, "_go_parser", lambda: None)
+
+    provenance = repo_map._symbol_navigation_provenance_for_path("foo.go")
+
+    assert provenance == "grammar-missing"
+    assert provenance != ""
+
+
 # ---------------------------------------------------------------------------
 # resolution_gaps honesty floor
 # ---------------------------------------------------------------------------
 
 
-def _write_python_symbol_plus_go_file(tmp_path: Path) -> tuple[Path, Path]:
+def _write_python_symbol_plus_unsupported_language_file(tmp_path: Path) -> tuple[Path, Path]:
+    # PATH A Stage 1: .go moved from "unsupported" to "registered" (it has its own LanguageSpec
+    # now), so .java stands in here instead -- still genuinely unregistered, AND (like .go
+    # before it) already a member of _SOURCE_FIRST_SUFFIXES, so it actually enters the
+    # refs/callers scan universe (a suffix outside that set, e.g. .rb, would be invisible to
+    # the scan and never produce a gap at all). This fixture is about the resolution_gaps floor
+    # for a language tensor-grep does NOT yet cover.
     py_path = tmp_path / "target.py"
     py_path.write_text(
         "def Target():\n    return 1\n\n\ndef caller():\n    return Target()\n",
         encoding="utf-8",
     )
-    go_path = tmp_path / "helper.go"
-    go_path.write_text(
-        "package main\n\nfunc Helper() int {\n\treturn Target()\n}\n",
+    java_path = tmp_path / "Helper.java"
+    java_path.write_text(
+        "class Helper {\n  void helper() { Target(); }\n}\n",
         encoding="utf-8",
     )
-    return py_path, go_path
+    return py_path, java_path
 
 
 def test_refs_emits_resolution_gaps_for_unsupported_language_file(tmp_path: Path) -> None:
-    _write_python_symbol_plus_go_file(tmp_path)
+    _write_python_symbol_plus_unsupported_language_file(tmp_path)
 
     payload = repo_map.build_symbol_refs("Target", tmp_path)
 
     assert not payload.get("no_match")
     assert "resolution_gaps" in payload
     gaps = payload["resolution_gaps"]
-    assert any(gap["language"] == "go" for gap in gaps)
-    go_gap = next(gap for gap in gaps if gap["language"] == "go")
-    assert go_gap["files_affected"] >= 1
-    assert go_gap["reason"]
-    assert go_gap["remediation"]
+    assert any(gap["language"] == "java" for gap in gaps)
+    java_gap = next(gap for gap in gaps if gap["language"] == "java")
+    assert java_gap["files_affected"] >= 1
+    assert java_gap["reason"]
+    assert java_gap["remediation"]
     # Additive-only: existing fields must still be present and shaped as before.
     assert "coverage_summary" in payload
     assert "references" in payload
 
 
 def test_callers_emits_resolution_gaps_for_unsupported_language_file(tmp_path: Path) -> None:
-    _write_python_symbol_plus_go_file(tmp_path)
+    _write_python_symbol_plus_unsupported_language_file(tmp_path)
 
     payload = repo_map.build_symbol_callers("Target", tmp_path)
 
     assert not payload.get("no_match")
     assert "resolution_gaps" in payload
     gaps = payload["resolution_gaps"]
-    assert any(gap["language"] == "go" for gap in gaps)
+    assert any(gap["language"] == "java" for gap in gaps)
     assert "coverage_summary" in payload
     assert "callers" in payload
 
@@ -186,7 +215,7 @@ def test_resolution_gaps_empty_for_pure_python_repo(tmp_path: Path) -> None:
 
 
 def test_blast_radius_downgrades_graph_trust_summary_when_gaps_present(tmp_path: Path) -> None:
-    _write_python_symbol_plus_go_file(tmp_path)
+    _write_python_symbol_plus_unsupported_language_file(tmp_path)
 
     payload = repo_map.build_symbol_blast_radius("Target", tmp_path)
 

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -27,6 +27,15 @@ def test_bench_extra_should_include_stringzilla_for_hot_query_benchmarks() -> No
     assert "stringzilla>=4.0" in deps
 
 
+def test_ast_dev_bench_extras_include_tree_sitter_go_for_path_a_stage1() -> None:
+    # PATH A Stage 1 (Go symbol graph, first language expansion beyond the original four):
+    # tree-sitter-go must ship in every extra that already carries the other tree-sitter
+    # grammar packages, or an --all-extras --locked export silently drops Go support.
+    deps = _optional_dependencies()
+    for extra_name in ("ast", "dev", "bench"):
+        assert "tree-sitter-go" in deps[extra_name], f"tree-sitter-go missing from [{extra_name}]"
+
+
 def test_semantic_extra_should_pin_model2vec_and_numpy_no_torch() -> None:
     deps = _optional_dependencies()["semantic"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -623,8 +623,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pywin32", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/75/0814c3ca505d5fb1986e381b4967cc1d0d62c6d5f52d271546f51cd4991c/cuda_bindings-12.9.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b65cbe73aa657daf8cc0137da2223e1858e4057056aad727aae5f839f35a724c", size = 12515235, upload-time = "2025-08-18T15:47:27.748Z" },
@@ -649,8 +649,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -678,7 +678,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/a5/e9d37c10f6c27c9c65d53c6cd6d9763e1df99c004780585fc2ad9041fbe3/cuda_bindings-12.9.6-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2662f59db67d9aeaf8959c593c91f600792c2970cf02cae2814387fc687b115a", size = 7090971, upload-time = "2026-03-11T14:47:29.526Z" },
@@ -697,7 +697,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/62/ed3039d866879872099fc855f8ad8b5e2ae9010b5e30d702fde3d66f23df/cuda_core-0.6.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07df8dd46494bd53943759232051facd4372104f2997732e0d39c5bc12a616d5", size = 21790662, upload-time = "2026-02-23T18:59:27.064Z" },
@@ -726,8 +726,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/83/03139c7d9c0425ec4824d6269cfd9e1ac8ae1cc88f12540578a405113083/cuda_core-0.7.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69946d1d5e2d96fc65b7bb36164d26c328cca75d9482b74ee7d61b2c1e1d33a7", size = 30374690, upload-time = "2026-04-08T17:03:08.962Z" },
@@ -790,7 +790,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/3c/4475aebeaab9651f2e61000fbe76f91a476d371dbfbf0a1cf46e689af253/cuda_python-12.9.0-py3-none-any.whl", hash = "sha256:926acba49b2c0a0374c61b7c98f337c085199cf51cdfe4d6423c4129c20547a7", size = 7532, upload-time = "2025-05-06T19:14:07.771Z" },
@@ -807,7 +807,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
@@ -824,7 +824,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/69/4a79126959ad6f1653504122ee1eb22d089dd6272d3fa37694dcdeb78ba5/cuda_python-12.9.6-py3-none-any.whl", hash = "sha256:ed5cf30e1129729eecf4605dff6e8bce84f2d30c17b17c7e5ac4b76448de35d2", size = 7596, upload-time = "2026-03-11T15:35:17.282Z" },
@@ -846,19 +846,19 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -877,16 +877,16 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -900,24 +900,24 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"] },
-    { name = "numpy" },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pynvjitlink-cu12" },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cachetools", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pandas", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pynvjitlink-cu12", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rich", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/d3/1686e1a2d6187bf8cc248b7d0a8efbea6eb20784a707176dfdd881529149/cudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:888641383ee908b820a7acafec028e8bd9851b8884009c61281d19b312c15ca9", size = 2630152, upload-time = "2025-08-07T12:23:36.002Z" },
@@ -943,25 +943,25 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
     { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "numba-cuda", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
-    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version < '3.14' or platform_machine != 'x86_64'" },
-    { name = "numpy" },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pandas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pyarrow", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rich", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/36/5caed16456ce318abb32ce66717231d5ce7b9713047ac4ae315d3f9b179e/cudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:43cbc0175e5016fa94ae96de83355c578dc149b644961301b47c6e28d5f61f49", size = 2715406, upload-time = "2026-04-09T09:42:26.382Z" },
@@ -993,7 +993,7 @@ name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
@@ -1524,7 +1524,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5", size = 54320, upload-time = "2024-08-20T17:11:42.348Z" }
 wheels = [
@@ -1547,7 +1547,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1622,12 +1622,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "zarr" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "zarr", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/b7/fbc1968592c92396efd3dc68f330d0e3da98a1150bfae414029bea9f9fe1/kvikio_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51094df8e0793485ae5021174b65bcd2bc584853cd832c142e6b463380bf4109", size = 672337, upload-time = "2025-08-07T13:50:13.422Z" },
@@ -1653,10 +1653,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/24/95abc4335e8db5b8e140dbe7bdaa9bd7c8620cc087b33ccf748f474c43b0/kvikio_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72cf92d7786b9cb34c60d616a25ef1c802ee465ebc20dd4b5ca2a365b409be16", size = 587150, upload-time = "2026-04-09T11:38:07.743Z" },
@@ -1734,9 +1734,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/69/529bd3a5b6d8edac3e530a0b71c3a8f620a544248c9e22d509852be269a7/libcudf_cu12-25.8.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2ae790b881a67511b414451821ec894f014e4c49d3c62e8f230c45b56cfce0cb", size = 521220643, upload-time = "2025-08-07T11:49:07.039Z" },
@@ -1758,10 +1758,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-libnvcomp-cu12" },
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-libnvcomp-cu12", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/26/f0ae0915b0efac09de00229a205912e25691163e3a6cb51d5327b75d2119/libcudf_cu12-26.4.0-py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2448f34ec63ef9bca6ec47b2089fb331826a834e5e256ae9e0f21a5a7e56df", size = 674674052, upload-time = "2026-04-20T17:52:44.693Z" },
@@ -1813,7 +1813,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fe/35789d6aed0df9336ca07fcb57e756f0f91df4136c5c3087ffa97f912f4e/librmm_cu12-25.8.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18381166e7d855d1ee9ab4684d2ab8af67a115e2015753f1ce91b8ef1ad06013", size = 3539813, upload-time = "2025-08-07T11:22:46.099Z" },
@@ -1835,7 +1835,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/dc/04009da12d0ebccee9c7319929194839d1b3c0f306877c32e85ae1778fb3/librmm_cu12-26.4.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7fa86af3cf2fdd956c5906f8bd9c2a139ddcbb1a5e4c9c4aa33f391623be6c3", size = 3969220, upload-time = "2026-04-09T12:45:21.77Z" },
@@ -2355,7 +2355,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "numba" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/94/63e54c690f093869c5ed3e811ff440554e87085e4301ba9fe37953a6dd80/numba_cuda-0.14.1.tar.gz", hash = "sha256:2e23bc9f5946e850f21f42cb2dcd24a2cb8ea84b60ad020b6e3b357830a9a697", size = 491974, upload-time = "2025-08-22T16:40:43.58Z" }
 wheels = [
@@ -2364,11 +2364,11 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 
 [[package]]
@@ -2379,10 +2379,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "numba", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/51/8935ff9ae5150e1ffed945bf1b95002a6a5e1f9256aeb1143e1c159b68c5/numba_cuda-0.24.0.tar.gz", hash = "sha256:f15a11a8d224e160e9cb2345049c5fa0bbd49eb255b2e8f661086746a7feb378", size = 1347749, upload-time = "2026-01-12T22:38:08.289Z" }
 wheels = [
@@ -2396,9 +2396,9 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"] },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2415,11 +2415,11 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numba", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/aa/78ba931a3ddce12d0948302ae46b6fd7a5fe9009cf0e0add84d8f7ad9197/numba_cuda-0.28.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:733ca2823c208baab10d5d67107c267c248bca11ad94eee14c5a90cb57041b33", size = 1838625, upload-time = "2026-03-03T18:17:37.461Z" },
@@ -2438,12 +2438,12 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 
 [[package]]
@@ -2451,8 +2451,8 @@ name = "numcodecs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
 wheels = [
@@ -2683,7 +2683,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2694,7 +2694,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2721,9 +2721,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2734,7 +2734,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3396,12 +3396,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/12/023332074131122d839be397fe78195eb51eae131a82004438933e9ffbbc/pylibcudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18d7032242d2b8a136f226b7ae4fd8e631e526cbc886186cb7571eb1c25fbcef", size = 28162734, upload-time = "2025-08-07T11:45:56.918Z" },
@@ -3428,10 +3428,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ad/d2a1961ae8b194ce33a9d8269dd046629fb556147aca74223cabc632a07b/pylibcudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0b191096b574cff4d709bb0880d2f0a346120493090cc8103098de9abead71", size = 8009026, upload-time = "2026-04-09T13:28:51.019Z" },
@@ -3913,9 +3913,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/2c/3363bbf6f5ee3699e28f5a3c525a165bedfa496b5a2a426777648a0297d6/rmm_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:856c38c22e8e1ea8a7216ff9c55d902a9a59b0a18a7affd426338743781f6725", size = 1139163, upload-time = "2025-08-07T11:18:37.215Z" },
@@ -3942,9 +3942,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c1/6c3a3c0e14ccd1f92e43dd90d1137bd3d0592794c02e871bbcc6cdbf2888/rmm_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be5e54e32bfac027803a658e1ee41d0c0c4fd89849a77c5ed148c3edcdc0269d", size = 1197307, upload-time = "2026-04-09T14:23:55.527Z" },
@@ -4328,6 +4328,7 @@ dependencies = [
 ast = [
     { name = "pygls" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-go" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -4339,6 +4340,7 @@ bench = [
     { name = "stringzilla" },
     { name = "torch" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-go" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -4358,6 +4360,7 @@ dev = [
     { name = "ruff" },
     { name = "stringzilla" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-go" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -4425,6 +4428,9 @@ requires-dist = [
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'bench'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'dev'", specifier = ">=0.22" },
+    { name = "tree-sitter-go", marker = "extra == 'ast'" },
+    { name = "tree-sitter-go", marker = "extra == 'bench'" },
+    { name = "tree-sitter-go", marker = "extra == 'dev'" },
     { name = "tree-sitter-javascript", marker = "extra == 'ast'" },
     { name = "tree-sitter-javascript", marker = "extra == 'bench'" },
     { name = "tree-sitter-javascript", marker = "extra == 'dev'" },
@@ -4692,6 +4698,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/727308adbbc79bcb1c92fc0ea10556a735f9d0f0a5435a18f59d40f7fd77/tree_sitter_go-0.25.0.tar.gz", hash = "sha256:a7466e9b8d94dda94cae8d91629f26edb2d26166fd454d4831c3bf6dfa2e8d68", size = 93890, upload-time = "2025-08-29T06:20:25.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/aa/0984707acc2b9bb461fe4a41e7e0fc5b2b1e245c32820f0c83b3c602957c/tree_sitter_go-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b852993063a3429a443e7bd0aa376dd7dd329d595819fabf56ac4cf9d7257b54", size = 47117, upload-time = "2025-08-29T06:20:14.286Z" },
+    { url = "https://files.pythonhosted.org/packages/32/16/dd4cb124b35e99239ab3624225da07d4cb8da4d8564ed81d03fcb3a6ba9f/tree_sitter_go-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:503b81a2b4c31e302869a1de3a352ad0912ccab3df9ac9950197b0a9ceeabd8f", size = 48674, upload-time = "2025-08-29T06:20:17.557Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fb/b30d63a08044115d8b8bd196c6c2ab4325fb8db5757249a4ef0563966e2e/tree_sitter_go-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04b3b3cb4aff18e74e28d49b716c6f24cb71ddfdd66768987e26e4d0fa812f74", size = 66418, upload-time = "2025-08-29T06:20:18.345Z" },
+    { url = "https://files.pythonhosted.org/packages/26/21/d3d88a30ad007419b2c97b3baeeef7431407faf9f686195b6f1cad0aedf9/tree_sitter_go-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:148255aca2f54b90d48c48a9dbb4c7faad6cad310a980b2c5a5a9822057ed145", size = 72006, upload-time = "2025-08-29T06:20:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/0dd6442353ced8a88bbda9e546f4ea29e381b59b5a40b122e5abb586bb6c/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4d338116cdf8a6c6ff990d2441929b41323ef17c710407abe0993c13417d6aad", size = 70603, upload-time = "2025-08-29T06:20:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
 ]
 
 [[package]]
@@ -5096,12 +5118,12 @@ name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "google-crc32c", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [


### PR DESCRIPTION
Path A Stage 1 (Fable-designed) — the first language on the Stage 0 registry, proving the abstraction turns a language into a plug-in.

- **New `lang_go.py`** (754 lines): Go defs/refs/callers/blast-radius in one tree-sitter pass — functions/methods/structs/interfaces/consts/vars; `go.mod`+`go.work` import resolution (import-prefix→dir); typed `ref_kind` (call/type/field/value); package-qualified `pkg.Symbol` resolved at confidence 0.95; equifinal receiver-methods (`w.Write`) emitted at ≤0.7 provenance `receiver-heuristic` — never dropped, never fabricated.
- **Fail-closed:** grammar absent → `resolution_gaps` (Stage 0 floor), no regex fallback.
- **The capsule seam:** `.go`→"go" in `_target_language_for_path` so the query-vs-target-language confidence cap works on Go targets.
- `tree-sitter-go` added to the ast/dev/bench extras + `uv lock`ed.

**Verified:** 114 targeted + **3393 full-suite / 0 regressions** to the 4 existing languages; ruff/mypy clean. Live fixture confirms cross-package call resolution, type-position refs, unexported-symbol scoping, grammar-absent honesty, and capsule `primary_target_language:"go"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)