### PR TITLE
fix(audit): wire the semantic fail-closed contract at the CLI boundary + gate blast-radius-plan for exit-2

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -44,6 +44,7 @@ from tensor_grep.cli.runtime_paths import (
 from tensor_grep.cli.scan_guardrails import BroadScanRefusedError, ensure_scan_not_broad
 from tensor_grep.core.observability import nvtx_range
 from tensor_grep.core.result import MatchLine
+from tensor_grep.core.retrieval_chunker import MAX_CHUNKS
 from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
 
@@ -3503,18 +3504,47 @@ def _search_with_cpu_fallback(
     return CPUBackend().search(current_file, pattern, config=config)
 
 
+# F5 (Fable audit MED): retrieval_chunker.MAX_CHUNKS bounds a single chunk_file() call (per FILE).
+# A matched-file set of many small files can still blow past a sane CORPUS-wide total even though
+# no single file trips the per-file guard, so DenseIndex.__init__'s single-batch encode would face
+# unbounded memory. Cap the CORPUS total here too, sharing the same threshold as the per-file guard
+# (no separate magic number to keep in sync).
+_SEMANTIC_CORPUS_CHUNK_CAP = MAX_CHUNKS
+
+
+def _set_semantic_rank_fallback_reason(all_results: "SearchResult") -> None:
+    """Probe dense-leg availability and set ``rank_fallback_reason`` (F16, Fable audit LOW).
+
+    Used for the 0-match `--semantic` case: with no matches there is nothing to rerank, so the
+    full :func:`_apply_semantic_rerank` path (chunking, model load) is skipped entirely -- but the
+    availability probe must still run so the JSON envelope stays honest (a dense-unavailable
+    search must report that even when it happens to find zero matches, not silently omit
+    ``rank_fallback_reason``).
+    """
+    from tensor_grep.core.retrieval_dense import dense_available
+
+    available, unavailable_reason = dense_available()
+    if not available:
+        all_results.rank_fallback_reason = unavailable_reason
+        sys.stderr.write(f"tg: {unavailable_reason}\n")
+
+
 def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "SearchResult":
     """Apply the `--semantic` hybrid (BM25 + dense RRF) rerank, fail-closed to BM25-only.
 
     The dense leg is best-effort: when the `semantic` extra is absent, the model has not been
-    fetched, or the model produces a malformed/mismatched embedding, this degrades VISIBLY to a
-    BM25-only rerank (stderr warning + ``rank_fallback_reason`` set) -- it never silently returns
-    unranked output and never mislabels BM25-only output as "semantic". A genuine backend fault
-    (e.g. a corrupt model directory) raises ``BackendExecutionError`` instead of degrading, per
-    the Backend Fail-Closed Contract -- that is NOT caught here.
+    fetched, the model produces a malformed/mismatched embedding, or a query-time dense fault
+    occurs (F1: e.g. a dim mismatch raised from inside `rerank_hybrid`'s call to
+    `DenseIndex.query`), this degrades VISIBLY to a BM25-only rerank (stderr warning +
+    ``rank_fallback_reason`` set) -- it never silently returns unranked output and never mislabels
+    BM25-only output as "semantic". A genuine backend fault (e.g. a corrupt model directory)
+    raises ``BackendExecutionError`` instead of degrading, per the Backend Fail-Closed Contract --
+    that is NOT caught here; the caller (the `search` command) must catch it and exit cleanly
+    (F4).
     """
     from tensor_grep.core.reranker import rerank_hybrid
-    from tensor_grep.core.retrieval_chunker import chunk_file
+    from tensor_grep.core.retrieval_bm25 import Bm25Index
+    from tensor_grep.core.retrieval_chunker import Chunk, chunk_file
     from tensor_grep.core.retrieval_dense import (
         DenseIndex,
         DenseUnavailableError,
@@ -3528,23 +3558,73 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
     if not available:
         all_results.rank_fallback_reason = unavailable_reason
         sys.stderr.write(f"tg: {unavailable_reason}\n")
-    else:
+
+    # F3 (Fable audit MED): build the chunk corpus ONCE and share it between the BM25 and dense
+    # legs. Previously the dense leg's corpus was built here while the BM25 leg rebuilt its own
+    # corpus from scratch inside `rerank_hybrid` (bm25_index=None) -- a second full file-I/O pass,
+    # and a silent RRF-misalignment risk if the two passes' chunk_size/overlap defaults ever
+    # diverge.
+    chunks: list[Chunk] = []
+    for path in all_results.matched_file_paths:
+        try:
+            file_chunks = chunk_file(path)
+        except RuntimeError as exc:
+            # F5: retrieval_chunker's own MAX_CHUNKS guard is PER FILE; a single pathological file
+            # can still trip it on its own even before the corpus-wide cap below is reached. Either
+            # way, degrade to BM25-only (using whatever we already have -- discard the corpus, let
+            # rerank_hybrid rebuild its own BM25-only chunks) rather than crash the whole search.
+            all_results.rank_fallback_reason = str(exc)
+            sys.stderr.write(f"tg: {exc}\n")
+            return rerank_hybrid(
+                all_results, pattern, all_results.matched_file_paths, dense_index=None
+            )
+        chunks.extend(file_chunks)
+        if len(chunks) > _SEMANTIC_CORPUS_CHUNK_CAP:
+            reason = (
+                "semantic ranking unavailable: corpus chunk cap "
+                f"({_SEMANTIC_CORPUS_CHUNK_CAP}) exceeded across the matched file set -- narrow "
+                "the search to fewer files for a semantic rerank"
+            )
+            all_results.rank_fallback_reason = reason
+            sys.stderr.write(f"tg: {reason}\n")
+            return rerank_hybrid(
+                all_results, pattern, all_results.matched_file_paths, dense_index=None
+            )
+
+    bm25_index = Bm25Index(chunks)
+
+    if available:
         try:
             model = load_dense_model(default_model_dir())
-            chunks = []
-            for path in all_results.matched_file_paths:
-                chunks.extend(chunk_file(path))
             dense_index = DenseIndex(chunks, model)
         except DenseUnavailableError as exc:
             all_results.rank_fallback_reason = str(exc)
             sys.stderr.write(f"tg: {exc}\n")
+        # BackendExecutionError (e.g. a corrupt model directory) deliberately propagates: that is
+        # an unrecoverable fault the CLI boundary must catch and exit on (F4), not degrade here.
 
-    return rerank_hybrid(
-        all_results,
-        pattern,
-        all_results.matched_file_paths,
-        dense_index=dense_index,
-    )
+    try:
+        return rerank_hybrid(
+            all_results,
+            pattern,
+            all_results.matched_file_paths,
+            bm25_index=bm25_index,
+            dense_index=dense_index,
+        )
+    except DenseUnavailableError as exc:
+        # F1: a query-time dense fault (e.g. a dim mismatch) is raised from INSIDE rerank_hybrid's
+        # call to `DenseIndex.query`, outside the try/except above (which only guards index
+        # construction). Degrade to BM25-only here too -- reuse the SAME bm25_index (no second
+        # chunk pass) rather than let it traceback.
+        all_results.rank_fallback_reason = str(exc)
+        sys.stderr.write(f"tg: {exc}\n")
+        return rerank_hybrid(
+            all_results,
+            pattern,
+            all_results.matched_file_paths,
+            bm25_index=bm25_index,
+            dense_index=None,
+        )
 
 
 def _search_error_payload(error: str, detail: str) -> dict[str, object]:
@@ -6661,8 +6741,25 @@ def search_command(
             all_results.match_counts_by_file[match.file] = (
                 all_results.match_counts_by_file.get(match.file, 0) + 1
             )
-    if config.semantic_rank and all_results.matches:
-        all_results = _apply_semantic_rerank(all_results, pattern)
+    if config.semantic_rank:
+        if all_results.matches:
+            try:
+                all_results = _apply_semantic_rerank(all_results, pattern)
+            except BackendExecutionError as exc:
+                # F4 (Fable audit MED): a genuine dense-backend fault (e.g. a corrupt model
+                # directory) must exit cleanly with a `tg:` message, never a raw traceback --
+                # `_apply_semantic_rerank` deliberately does NOT catch this (see its docstring);
+                # this is the CLI boundary the Backend Fail-Closed Contract requires.
+                if json:
+                    _emit_search_error_json("semantic_backend_error", str(exc))
+                else:
+                    typer.echo(f"tg: {exc}", err=True)
+                sys.exit(2)
+        else:
+            # F16 (Fable audit LOW): probe dense-leg availability even on a 0-match search so
+            # `rank_fallback_reason` is set whenever the leg is unavailable, regardless of match
+            # count -- skipping the probe here silently made the JSON envelope dishonest.
+            _set_semantic_rank_fallback_reason(all_results)
     elif config.rank_bm25 and all_results.matches:
         from tensor_grep.core.reranker import rerank_by_bm25
 
@@ -9013,10 +9110,7 @@ def blast_radius_plan(
 
     Like `blast-radius --json` but shaped as an edit/action plan (no source snippets).
     """
-    from tensor_grep.cli.repo_map import (
-        build_symbol_blast_radius_plan,
-        build_symbol_blast_radius_plan_json,
-    )
+    from tensor_grep.cli.repo_map import build_symbol_blast_radius_plan
 
     try:
         resolved_path, resolved_symbol = _resolve_path_and_symbol(
@@ -9025,20 +9119,6 @@ def blast_radius_plan(
             symbol_option=symbol,
             command_name="blast-radius-plan",
         )
-        if json_output:
-            typer.echo(
-                build_symbol_blast_radius_plan_json(
-                    resolved_symbol,
-                    resolved_path,
-                    max_depth=max_depth,
-                    max_files=max_files,
-                    max_symbols=max_symbols,
-                    semantic_provider=provider,
-                    max_repo_files=max_repo_files,
-                )
-            )
-            return
-
         payload = build_symbol_blast_radius_plan(
             resolved_symbol,
             resolved_path,
@@ -9052,10 +9132,21 @@ def blast_radius_plan(
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
 
-    typer.echo(f"Blast radius plan for {payload['symbol']} in {payload['path']}")
-    typer.echo(
-        f"files={len(payload['files'])} tests={len(payload['tests'])} symbols={len(payload['symbols'])}"
-    )
+    # F14 (Fable audit MED): output the payload FIRST, then gate on the shared _scan_incomplete
+    # contract -- mirrors blast-radius/map/context-render/edit-plan/blast-radius-render (Cluster B,
+    # 2026-07-06). This payload is built from build_symbol_blast_radius_from_map and carries the
+    # exact scan_limit/caller_scan_truncated markers the gate checks; without this, a scan-truncated
+    # plan exited 0 while the sibling `blast-radius` command exits 2 on identical truncation.
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+    else:
+        typer.echo(f"Blast radius plan for {payload['symbol']} in {payload['path']}")
+        typer.echo(
+            f"files={len(payload['files'])} tests={len(payload['tests'])} symbols={len(payload['symbols'])}"
+        )
+
+    if _scan_incomplete(payload):
+        raise typer.Exit(2)
 
 
 @session_app.command("open")

--- a/src/tensor_grep/core/retrieval_dense.py
+++ b/src/tensor_grep/core/retrieval_dense.py
@@ -107,11 +107,24 @@ def load_dense_model(model_dir: str | Path) -> Any:
 
 def _encode_matrix(model: Any, texts: list[str]) -> np.ndarray:
     """Encode ``texts`` raw (no BM25 tokenization -- static embeddings tokenize internally) and
-    shape-validate the result into a 2-D ``float32`` matrix."""
+    shape-validate the result into a 2-D ``float32`` matrix.
+
+    ``model.encode`` and ``np.asarray`` are third-party/numpy calls outside this module's control:
+    a broken or incompatible model can raise anything (a bare ``RuntimeError`` from model2vec, a
+    ``ValueError`` from numpy refusing to build an array out of a ragged nested sequence, etc). Per
+    the Backend Fail-Closed Contract (module docstring), that is a genuine unrecoverable backend
+    fault, not the deliberately-recoverable shape mismatch below -- so it is re-raised as
+    :class:`~tensor_grep.backends.base.BackendExecutionError`, never left to propagate raw.
+    """
     import numpy as np
 
-    raw = model.encode(texts)
-    matrix = np.asarray(raw, dtype=np.float32)
+    try:
+        raw = model.encode(texts)
+        matrix = np.asarray(raw, dtype=np.float32)
+    except Exception as exc:
+        raise BackendExecutionError(
+            f"dense model encode failed for {len(texts)} input(s): {exc}"
+        ) from exc
     if matrix.ndim == 1:
         # Some encoders collapse a single-text batch to a 1-D vector; treat it as one row.
         matrix = matrix.reshape(1, -1)

--- a/tests/integration/test_semantic_search_flag.py
+++ b/tests/integration/test_semantic_search_flag.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import numpy as np
 from typer.testing import CliRunner
 
+from tensor_grep.backends.base import BackendExecutionError
 from tensor_grep.cli.main import app
 from tensor_grep.core.config import SearchConfig
-from tensor_grep.core.retrieval_dense import default_model_dir
+from tensor_grep.core.retrieval_dense import DenseIndex, DenseUnavailableError, default_model_dir
 
 
 def test_search_config_has_semantic_rank_field() -> None:
@@ -55,6 +57,237 @@ def test_search_semantic_falls_back_to_bm25_when_dense_unavailable(
     rank_files = [m["file"] for m in rank_payload["matches"]]
     assert semantic_files == rank_files
     assert "rank_fallback_reason" not in rank_payload  # never set for plain --rank
+
+
+def test_search_semantic_zero_matches_still_probes_availability(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """F16 (Fable audit LOW): a 0-match `--semantic` search must still set
+    `rank_fallback_reason` when the dense leg is unavailable -- skipping the probe on an empty
+    result silently omitted the fallback reason from the JSON envelope, even though the leg is
+    genuinely unavailable (a dishonest envelope)."""
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.dense_available",
+        lambda: (False, "semantic ranking unavailable: model2vec not installed -- test stub"),
+    )
+
+    sample = tmp_path / "sample.py"
+    sample.write_text("x = 1\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["search", "--semantic", "--json", "zzz_no_such_pattern", str(tmp_path)]
+    )
+    payload = json.loads(result.stdout)
+    assert payload["total_matches"] == 0
+    assert payload.get("rank_fallback_reason") is not None
+    assert "model2vec not installed" in payload["rank_fallback_reason"]
+    assert "semantic ranking unavailable" in result.stderr
+
+
+def test_search_semantic_query_time_dim_mismatch_degrades_to_bm25(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """F1 (Fable audit MED): a query-time `DenseUnavailableError` (e.g. a dim mismatch) raised
+    from INSIDE `rerank_hybrid`'s call to `DenseIndex.query` -- outside the try/except that only
+    guards index CONSTRUCTION -- must still degrade to BM25-only + set `rank_fallback_reason`,
+    never a traceback."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    class _FakeModel:
+        def encode(self, texts: list[str]) -> np.ndarray:
+            return np.ones((len(texts), 4), dtype=np.float32)
+
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.load_dense_model", lambda _dir: _FakeModel()
+    )
+
+    def _raising_query(self, text: str, *, top_k: int = 10):
+        raise DenseUnavailableError(
+            "semantic ranking unavailable: query embedding dim mismatch (test stub)"
+        )
+
+    monkeypatch.setattr(DenseIndex, "query", _raising_query)
+
+    dense = tmp_path / "dense.py"
+    dense.write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+    sparse = tmp_path / "sparse.py"
+    sparse.write_text("# one passing invoice mention\nx = 1\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "dim mismatch" in result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is not None
+    assert "dim mismatch" in payload["rank_fallback_reason"]
+
+    # Fail-closed to BM25-only: same order as plain `--rank` over the same corpus.
+    rank_result = CliRunner().invoke(app, ["search", "--rank", "--json", "invoice", str(tmp_path)])
+    rank_payload = json.loads(rank_result.stdout)
+    semantic_files = [m["file"] for m in payload["matches"]]
+    rank_files = [m["file"] for m in rank_payload["matches"]]
+    assert semantic_files == rank_files
+
+
+def test_search_semantic_corrupt_model_dir_exits_cleanly_json(tmp_path: Path, monkeypatch) -> None:
+    """F4 (Fable audit MED): a genuine BackendExecutionError (e.g. a corrupt model directory)
+    must exit cleanly with a `tg:` message and exit code 2, never a raw traceback."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    def _raise_corrupt(_dir: object) -> None:
+        raise BackendExecutionError(
+            "dense model at <dir> failed to load (corrupt or incompatible): boom"
+        )
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.load_dense_model", _raise_corrupt)
+
+    sample = tmp_path / "sample.py"
+    sample.write_text("def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 2, result.output
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean sys.exit(2), got a raw traceback: {result.exception!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "boom" in payload["detail"]
+
+
+def test_search_semantic_corrupt_model_dir_exits_cleanly_text(tmp_path: Path, monkeypatch) -> None:
+    """F4, text-mode variant: same clean `tg:`-prefixed message + exit 2, no traceback."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    def _raise_corrupt(_dir: object) -> None:
+        raise BackendExecutionError(
+            "dense model at <dir> failed to load (corrupt or incompatible): boom"
+        )
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.load_dense_model", _raise_corrupt)
+
+    sample = tmp_path / "sample.py"
+    sample.write_text("def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "invoice", str(tmp_path)])
+    assert result.exit_code == 2, result.output
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean sys.exit(2), got a raw traceback: {result.exception!r}"
+    )
+    assert "tg: dense model at <dir> failed to load" in result.stderr
+
+
+def test_search_semantic_corpus_chunk_cap_exceeded_degrades_to_bm25(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """F5 (Fable audit MED): retrieval_chunker.MAX_CHUNKS bounds a single chunk_file() call (per
+    FILE); a matched-file set with many small files can still blow past a sane CORPUS-wide total.
+    `_apply_semantic_rerank`'s corpus-level cap must catch that and degrade to BM25-only with
+    `rank_fallback_reason` set, instead of handing DenseIndex.__init__ an unbounded encode batch."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+    monkeypatch.setattr("tensor_grep.cli.main._SEMANTIC_CORPUS_CHUNK_CAP", 1)
+
+    dense = tmp_path / "dense.py"
+    dense.write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+    sparse = tmp_path / "sparse.py"
+    sparse.write_text("# one passing invoice mention\nx = 1\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "corpus chunk cap" in result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is not None
+    assert "corpus chunk cap" in payload["rank_fallback_reason"]
+
+    rank_result = CliRunner().invoke(app, ["search", "--rank", "--json", "invoice", str(tmp_path)])
+    rank_payload = json.loads(rank_result.stdout)
+    semantic_files = [m["file"] for m in payload["matches"]]
+    rank_files = [m["file"] for m in rank_payload["matches"]]
+    assert semantic_files == rank_files
+
+
+def test_search_semantic_chunker_runtime_error_degrades_to_bm25(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """F5, the chunker's OWN per-file MAX_CHUNKS guard: `chunk_file` raising RuntimeError (e.g. a
+    single pathological file that trips the per-file cap on its own) must also degrade to BM25,
+    not crash the whole search."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    def _raising_chunk_file(path: str, **kwargs: object) -> list[object]:
+        raise RuntimeError(f"MAX_CHUNKS exceeded while chunking {path!r}")
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_chunker.chunk_file", _raising_chunk_file)
+
+    sample = tmp_path / "sample.py"
+    sample.write_text("def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is not None
+    assert "MAX_CHUNKS exceeded" in payload["rank_fallback_reason"]
+
+
+def test_search_semantic_builds_chunk_corpus_once_shared_by_both_legs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """F3 (Fable audit MED): the dense leg's chunk corpus and the BM25 leg's chunk corpus must
+    come from the SAME `chunk_file()` pass -- previously the dense leg built its own corpus in
+    `_apply_semantic_rerank` while the BM25 leg rebuilt an independent one inside `rerank_hybrid`
+    (a second full file-I/O pass, and a silent RRF-misalignment risk if the two passes'
+    chunk_size/overlap defaults ever diverge)."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    class _FakeModel:
+        def encode(self, texts: list[str]) -> np.ndarray:
+            return np.ones((len(texts), 4), dtype=np.float32)
+
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.load_dense_model", lambda _dir: _FakeModel()
+    )
+
+    from tensor_grep.core import retrieval_chunker
+
+    real_chunk_file = retrieval_chunker.chunk_file
+    calls: list[str] = []
+
+    def _counting_chunk_file(path: str, **kwargs: object):
+        calls.append(path)
+        return real_chunk_file(path, **kwargs)
+
+    # Patch BOTH bind sites: main.py's function-local import re-resolves the source module
+    # attribute on every call, but reranker.py bound its own module-level name at import time --
+    # a regression that reintroduces the second (BM25-leg) chunk_file pass would call THAT name.
+    monkeypatch.setattr("tensor_grep.core.retrieval_chunker.chunk_file", _counting_chunk_file)
+    monkeypatch.setattr("tensor_grep.core.reranker.chunk_file", _counting_chunk_file)
+
+    dense = tmp_path / "dense.py"
+    dense.write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+    sparse = tmp_path / "sparse.py"
+    sparse.write_text("# one passing invoice mention\nx = 1\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is None
+
+    # Exactly ONE chunk_file() call per matched file -- not two.
+    assert len(calls) == len(set(calls)) == 2, (
+        f"expected exactly one chunk_file() call per file, got {calls!r}"
+    )
 
 
 def test_search_semantic_off_is_byte_identical_to_plain_json(tmp_path: Path) -> None:

--- a/tests/unit/test_render_daemon_exit_codes.py
+++ b/tests/unit/test_render_daemon_exit_codes.py
@@ -178,6 +178,20 @@ def test_context_render_text_complete_stays_exit_0(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
 
 
+def test_context_render_json_output_cap_only_stays_exit_0(tmp_path: Path) -> None:
+    # F27 (Fable audit LOW): the cold output-cap-only case was pinned only for `map`, not
+    # `context-render` -- `--max-files` truncates the render bundle to fewer files than the scan
+    # actually found (a COMPLETE analysis capped only for display) and must stay exit 0.
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(
+        app, ["context-render", str(project), "helper", "--json", "--max-files", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert len(payload["files"]) == 1
+    assert payload["scan_limit"]["possibly_truncated"] is False
+
+
 # --------------------------------------------------------------------------------------------
 # context-render -- daemon fast-path (json + text)
 # --------------------------------------------------------------------------------------------
@@ -331,6 +345,16 @@ def test_edit_plan_text_complete_stays_exit_0(tmp_path: Path) -> None:
     project = _flat_repo(tmp_path, 8)
     result = runner.invoke(app, ["edit-plan", str(project), "helper"])
     assert result.exit_code == 0, result.output
+
+
+def test_edit_plan_json_output_cap_only_stays_exit_0(tmp_path: Path) -> None:
+    # F27: the cold output-cap-only case was pinned only for `map`, not `edit-plan`.
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(app, ["edit-plan", str(project), "helper", "--json", "--max-files", "1"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert len(payload["files"]) == 1
+    assert payload["scan_limit"]["possibly_truncated"] is False
 
 
 # --------------------------------------------------------------------------------------------
@@ -506,4 +530,76 @@ def test_blast_radius_render_text_scan_truncated_exits_2_with_full_output(
 def test_blast_radius_render_text_complete_stays_exit_0(tmp_path: Path) -> None:
     project = _flat_repo(tmp_path, 8)
     result = runner.invoke(app, ["blast-radius-render", str(project), "helper_0"])
+    assert result.exit_code == 0, result.output
+
+
+def test_blast_radius_render_json_output_cap_only_stays_exit_0(tmp_path: Path) -> None:
+    # F27: the cold output-cap-only case was pinned only for `map`, not `blast-radius-render`.
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(
+        app, ["blast-radius-render", str(project), "helper_0", "--json", "--max-files", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["scan_limit"]["possibly_truncated"] is False
+
+
+# --------------------------------------------------------------------------------------------
+# blast-radius-plan -- cold path only (json + text); no daemon fast-path exists for this command.
+# --------------------------------------------------------------------------------------------
+
+
+def test_blast_radius_plan_json_scan_truncated_exits_2_with_full_payload(tmp_path: Path) -> None:
+    # F14 (Fable audit MED): blast-radius-plan's payload is built from
+    # build_symbol_blast_radius_from_map and carries the exact scan_limit/caller_scan_truncated
+    # markers `_scan_incomplete` gates on, but the command was UNGATED -- a scan-truncated plan
+    # exited 0 while the sibling `blast-radius` command exits 2 on identical truncation.
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(
+        app,
+        [
+            "blast-radius-plan",
+            str(project),
+            "helper_0",
+            "--json",
+            "--max-repo-files",
+            "1",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["scan_limit"]["possibly_truncated"] is True
+    # full payload still printed, not swallowed by the exit
+    assert "files" in payload and "symbols" in payload
+
+
+def test_blast_radius_plan_json_complete_stays_exit_0(tmp_path: Path) -> None:
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(app, ["blast-radius-plan", str(project), "helper_0", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["scan_limit"]["possibly_truncated"] is False
+
+
+def test_blast_radius_plan_json_output_cap_only_stays_exit_0(tmp_path: Path) -> None:
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(
+        app, ["blast-radius-plan", str(project), "helper_0", "--json", "--max-files", "1"]
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_blast_radius_plan_text_scan_truncated_exits_2_with_full_output(tmp_path: Path) -> None:
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(
+        app,
+        ["blast-radius-plan", str(project), "helper_0", "--max-repo-files", "1"],
+    )
+    assert result.exit_code == 2, result.output
+    assert "Blast radius plan for" in result.output
+
+
+def test_blast_radius_plan_text_complete_stays_exit_0(tmp_path: Path) -> None:
+    project = _flat_repo(tmp_path, 8)
+    result = runner.invoke(app, ["blast-radius-plan", str(project), "helper_0"])
     assert result.exit_code == 0, result.output

--- a/tests/unit/test_retrieval_dense.py
+++ b/tests/unit/test_retrieval_dense.py
@@ -135,6 +135,37 @@ class TestDenseIndexShapeValidation:
         with pytest.raises(DenseUnavailableError):
             DenseIndex(chunks, _FixedDimModel(dim=4, row_count_delta=1))
 
+    def test_encode_raw_runtime_error_becomes_backend_execution_error(self) -> None:
+        # F2 (Fable audit MED): a bare RuntimeError from model.encode (e.g. a broken/incompatible
+        # model2vec runtime) must never propagate raw -- it violates the module's fail-closed
+        # contract. It is unrecoverable (not the deliberate shape-mismatch degrade), so it must
+        # become BackendExecutionError, not crash the caller with an unhandled RuntimeError.
+        class _RaisingModel:
+            dim = 4
+
+            def encode(self, texts: list[str]) -> np.ndarray:
+                raise RuntimeError("model2vec runtime exploded")
+
+        chunks = [Chunk(file_path="a.py", start_line=1, end_line=1, text="hello")]
+        with pytest.raises(BackendExecutionError, match="model2vec runtime exploded"):
+            DenseIndex(chunks, _RaisingModel())
+
+    def test_encode_ragged_array_becomes_backend_execution_error(self) -> None:
+        # F2: model.encode returning a ragged nested sequence makes np.asarray(..., dtype=float32)
+        # raise a raw ValueError -- must also degrade to BackendExecutionError, not propagate raw.
+        class _RaggedModel:
+            dim = 4
+
+            def encode(self, texts: list[str]) -> list[list[float]]:
+                return [[1.0, 2.0], [1.0, 2.0, 3.0]]
+
+        chunks = [
+            Chunk(file_path="a.py", start_line=1, end_line=1, text="hello"),
+            Chunk(file_path="b.py", start_line=1, end_line=1, text="world"),
+        ]
+        with pytest.raises(BackendExecutionError):
+            DenseIndex(chunks, _RaggedModel())
+
     def test_query_dim_mismatch_degrades_not_indexerror(self) -> None:
         chunks = [Chunk(file_path="a.py", start_line=1, end_line=1, text="hello world")]
         index = DenseIndex(chunks, _FixedDimModel(dim=4))


### PR DESCRIPTION
Fable audit MED findings F1-F5, F14, F16, F27 (correctness/robustness hardening; the audit found 0 HIGH — this wires fail-closed contracts that were designed right but under-wired at the CLI boundary).

- **F1** semantic dense-leg `DenseUnavailableError` (dim-mismatch) now degrades to BM25 with `rank_fallback_reason` instead of a traceback (the `rerank_hybrid` call was outside the guarded block).
- **F2** `retrieval_dense._encode_matrix` re-raises any `model.encode`/`asarray` failure as `BackendExecutionError` (fail-closed contract).
- **F3** chunk corpus built ONCE — `Bm25Index`/`DenseIndex` share the same chunk space (was 2x I/O + a silent RRF-misalignment risk).
- **F4** `BackendExecutionError` (corrupt model dir) → clean `tg: <reason>` + exit 2, no traceback.
- **F5** corpus-level chunk cap (`_SEMANTIC_CORPUS_CHUNK_CAP`) bounds total chunks across matched files + catches the chunker RuntimeError.
- **F14** `blast-radius-plan` now honors the exit-2-on-scan-truncation contract (its sibling `blast-radius` already did) — output-caps stay exit 0.
- **F16** 0-match `--semantic` still sets `rank_fallback_reason`. **F27** cold-path output-cap→exit-0 tests for context-render/edit-plan/blast-radius-render.

**Verified:** 81 (semantic+render) + the worktree's 521+298 full gate; ruff/format/mypy clean; `--semantic`-off byte-identity intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)