### PR TITLE
fix(audit): ref_kind classifier precision + Go import-resolution edge cases

### DIFF
--- a/src/tensor_grep/cli/lang_go.py
+++ b/src/tensor_grep/cli/lang_go.py
@@ -124,7 +124,15 @@ _GO_DEF_NODE_KINDS = (
 
 
 def _go_receiver_type_name(method_node: Any, source_bytes: bytes) -> str | None:
-    """Return the (possibly pointer) receiver type name for a ``method_declaration`` node."""
+    """Return the (possibly pointer, possibly generic) receiver type name for a
+    ``method_declaration`` node.
+
+    F8 fix: a GENERIC receiver (``func (r *MyType[T]) M()`` / ``func (r MyType[T]) N()``) parses
+    the receiver's type as a ``generic_type`` node whose own text is ``"MyType[T]"`` -- that never
+    matches the plain ``"MyType"`` name a ``type_spec`` declares, so method<->type association
+    silently broke for every generic Go receiver. Descending to ``generic_type``'s ``type`` field
+    (the base ``type_identifier``) restores the plain base name.
+    """
     receiver = method_node.child_by_field_name("receiver")
     if receiver is None:
         return None
@@ -144,7 +152,41 @@ def _go_receiver_type_name(method_node: Any, source_bytes: bytes) -> str | None:
         )
         if inner is not None:
             type_node = inner
+    if type_node.type == "generic_type":
+        base_type_node = type_node.child_by_field_name("type")
+        if base_type_node is not None:
+            type_node = base_type_node
     return _tree_sitter_node_text(source_bytes, type_node)
+
+
+def _go_import_spec_path_text(path_field: Any, source_bytes: bytes) -> str | None:
+    """Return an ``import_spec``'s string-literal import path (quotes stripped), or ``None``.
+
+    F11 fix: the primary route reads the ``interpreted_string_literal_content`` child that recent
+    ``tree_sitter_go`` grammar versions expose. An older/differently-built grammar package can
+    omit that child (there is no dedicated content node at all, or it is named differently) --
+    when that happens this used to silently return no path for EVERY import in the file, which
+    then silently degrades all cross-package import resolution with no error and no
+    ``resolution_gaps`` entry (the parser loaded fine, so nothing marks a gap). Falling back to
+    quote-stripping the string literal's own raw text keeps import extraction working even
+    against a grammar shape this module wasn't written against.
+    """
+    if path_field is None:
+        return None
+    content_node = next(
+        (
+            child
+            for child in path_field.children
+            if child.type == "interpreted_string_literal_content"
+        ),
+        None,
+    )
+    if content_node is not None:
+        return _tree_sitter_node_text(source_bytes, content_node)
+    raw_text = _tree_sitter_node_text(source_bytes, path_field).strip()
+    if len(raw_text) >= 2 and raw_text[0] in {'"', "`"} and raw_text[-1] == raw_text[0]:
+        return raw_text[1:-1]
+    return None
 
 
 def go_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
@@ -184,20 +226,9 @@ def go_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]
         node_type = node.type
         if node_type == "import_spec":
             path_field = node.child_by_field_name("path")
-            content_node = (
-                next(
-                    (
-                        child
-                        for child in path_field.children
-                        if child.type == "interpreted_string_literal_content"
-                    ),
-                    None,
-                )
-                if path_field is not None
-                else None
-            )
-            if content_node is not None:
-                imports.append(_node_text(content_node))
+            import_path_text = _go_import_spec_path_text(path_field, source_bytes)
+            if import_path_text is not None:
+                imports.append(import_path_text)
         elif node_type == "function_declaration":
             name_node = node.child_by_field_name("name")
             if name_node is not None:
@@ -437,7 +468,16 @@ def _go_repo_context(repo_root: Path | str | None) -> dict[str, Any]:
 def _go_import_path_to_dir(import_path: str, context: dict[str, Any]) -> Path | None:
     """Resolve an import path (e.g. ``"example.com/mod/bar"``) to an absolute directory via the
     longest matching ``module_dirs`` prefix (longest-prefix-wins handles a workspace where one
-    module's path is itself a prefix of another's)."""
+    module's path is itself a prefix of another's).
+
+    F24 fix: stop at an intervening ``go.mod`` boundary. A nested module (its own ``go.mod`` that
+    is NOT listed as a ``go.work`` ``use`` entry -- e.g. simply forgotten) is a SEPARATE module
+    even when the enclosing module's path prefix happens to textually match its subdirectory --
+    walking past that boundary used to silently resolve a cross-package reference into the wrong
+    module's directory. Any ``go.mod`` strictly under the matched prefix's own root (which is
+    expected and ignored -- that root's ``go.mod`` is exactly what got this prefix primed) now
+    aborts resolution (returns ``None``) instead of fabricating a cross-module match.
+    """
     module_dirs = context.get("module_dirs", {})
     if not isinstance(module_dirs, dict):
         return None
@@ -448,9 +488,16 @@ def _go_import_path_to_dir(import_path: str, context: dict[str, Any]) -> Path | 
                 best_prefix = prefix
     if best_prefix is None:
         return None
-    base_dir = Path(str(module_dirs[best_prefix]))
+    base_dir = Path(str(module_dirs[best_prefix])).resolve()
     remainder = import_path[len(best_prefix) :].lstrip("/")
-    return (base_dir / remainder).resolve() if remainder else base_dir.resolve()
+    if not remainder:
+        return base_dir
+    current = base_dir
+    for part in remainder.split("/"):
+        current = current / part
+        if (current / "go.mod").is_file():
+            return None
+    return current
 
 
 def _go_import_bindings(source_bytes: bytes, tree: Any) -> list[dict[str, Any]]:
@@ -461,19 +508,8 @@ def _go_import_bindings(source_bytes: bytes, tree: Any) -> list[dict[str, Any]]:
         if node.type == "import_spec":
             path_field = node.child_by_field_name("path")
             name_field = node.child_by_field_name("name")
-            content_node = (
-                next(
-                    (
-                        child
-                        for child in path_field.children
-                        if child.type == "interpreted_string_literal_content"
-                    ),
-                    None,
-                )
-                if path_field is not None
-                else None
-            )
-            if content_node is not None:
+            import_path_text = _go_import_spec_path_text(path_field, source_bytes)
+            if import_path_text is not None:
                 alias: str | None = None
                 dot = False
                 blank = False
@@ -485,7 +521,7 @@ def _go_import_bindings(source_bytes: bytes, tree: Any) -> list[dict[str, Any]]:
                     elif name_field.type == "blank_identifier":
                         blank = True
                 bindings.append({
-                    "path": _tree_sitter_node_text(source_bytes, content_node),
+                    "path": import_path_text,
                     "alias": alias,
                     "dot": dot,
                     "blank": blank,
@@ -571,10 +607,38 @@ _GO_NAME_DEFINING_PARENT_TYPES = {
 }
 
 
+def _go_package_defines_function(target_dir: str, name: str) -> bool:
+    """F10 fallback confirmation: True iff *target_dir* (a resolved package directory) contains a
+    top-level ``function``/``method`` declaration named *name*.
+
+    Used only when ``go_references_and_calls`` is not given ``definition_dirs`` (the stronger,
+    definition-aware check used by repo_map.py's refs/callers scan -- see F25 in that function's
+    docstring). Deliberately un-cached: this module never caches anything that reads file content
+    without an mtime guard (see the module-level caches above, which are keyed on repo ROOT
+    priming, not file content), and a Go package directory is small enough that a plain per-call
+    scan is cheap.
+    """
+    directory = Path(target_dir)
+    if not directory.is_dir():
+        return False
+    try:
+        entries = sorted(directory.glob("*.go"))
+    except OSError:
+        return False
+    for entry in entries:
+        _, symbols = go_imports_and_symbols(entry)
+        for record in symbols:
+            if record.get("name") == name and record.get("kind") in {"function", "method"}:
+                return True
+    return False
+
+
 def go_references_and_calls(
     path: Path,
     symbol: str,
     repo_root: Path | str | None = None,
+    *,
+    definition_dirs: frozenset[str] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Reference/call rows for *symbol* in *path*.
 
@@ -585,15 +649,30 @@ def go_references_and_calls(
     *field*/method-selector mention is ``field_identifier``.
 
     Package-qualified access (``pkg.Symbol``) resolves through this file's import bindings +
-    the primed repo context: if the qualifying identifier is a recognized import alias whose
-    resolved directory matches *definition_path*'s directory, the row carries
-    ``resolution_provenance=["go-import-resolution"]`` at ``resolution_confidence=0.95``. A
-    selector call whose left-hand operand is NOT a recognized package alias (e.g. ``w.Write(x)``
-    where ``w`` is an arbitrary receiver variable of unknown static type) is equifinal -- ANY
-    type with a same-named method would match textually -- so it is still emitted (never
-    silently dropped) but capped at ``resolution_confidence<=0.7`` with
-    ``resolution_provenance=["receiver-heuristic"]``, per the Stage 1 no-fabricated-precision
-    trap.
+    the primed repo context. Two shapes:
+
+    - **Non-call selector** (e.g. ``config.DefaultTimeout``): F9 fix -- classified ``ref_kind``
+      "value" (a package-qualified const/var read), not "field", whenever the operand resolves as
+      a recognized import alias; an unresolved operand (e.g. a genuine struct field access) still
+      classifies "field" as before.
+    - **Call** (e.g. ``pkg.Helper(...)`` / ``w.Write(...)``): a resolved package alias only earns
+      ``resolution_provenance=["go-import-resolution"]`` at ``resolution_confidence=0.95`` if the
+      resolved package is CONFIRMED to actually own *symbol* -- F25 fix: when *definition_dirs* is
+      supplied (repo_map.py always supplies it, built from the symbol's own known definitions),
+      confirmation means the resolved directory is one of those definition dirs, which also fixes
+      a same-named-export collision (two unrelated packages each exporting a symbol with the same
+      name used to both get 0.95 turn just because the alias itself resolved); when
+      *definition_dirs* is omitted (e.g. a standalone caller), F10 fallback confirmation checks
+      whether the resolved package directory itself defines a top-level function/method named
+      *symbol* -- this is what prevents a LOCAL VARIABLE that happens to share its name with an
+      unrelated import alias (``w := SomeStruct{}`` shadowing `import w "pkg/w"`) from fabricating
+      high confidence for ``w.Method()`` when ``pkg/w`` does not actually define ``Method``.
+      Either way, an unconfirmed resolution is never dropped -- it demotes to the same
+      ``resolution_confidence<=0.7`` / ``resolution_provenance=["receiver-heuristic"]`` band as a
+      selector call whose left-hand operand is not a recognized package alias at all (e.g.
+      ``w.Write(x)`` where ``w`` is an arbitrary receiver variable of unknown static type) --
+      equifinal in both cases (ANY type with a same-named method could match textually), per the
+      Stage 1 no-fabricated-precision trap.
     """
     if path.suffix != ".go":
         return [], []
@@ -642,6 +721,21 @@ def go_references_and_calls(
         if target_dir is None:
             return None
         return {"provenance": ["go-import-resolution"], "confidence": 0.95, "dir": target_dir}
+
+    def _confident_call_resolution(package_resolution: dict[str, Any] | None) -> dict[str, Any]:
+        """F10/F25 fix: only trust ``package_resolution`` (0.95) for a CALL when the resolved
+        package is confirmed to actually own *symbol* -- see the ``go_references_and_calls``
+        docstring for the two confirmation routes. Anything unconfirmed demotes to the same
+        equifinal receiver-heuristic band a non-package selector call already gets, never drops.
+        """
+        if package_resolution is not None:
+            target_dir = str(package_resolution.get("dir", ""))
+            if definition_dirs is not None:
+                if target_dir in definition_dirs:
+                    return package_resolution
+            elif _go_package_defines_function(target_dir, symbol):
+                return package_resolution
+        return {"provenance": ["receiver-heuristic"], "confidence": 0.7}
 
     def _emit(
         bucket: list[dict[str, Any]],
@@ -715,10 +809,7 @@ def go_references_and_calls(
                         and grandparent.child_by_field_name("function") == parent
                     )
                     if is_call:
-                        resolution = package_resolution or {
-                            "provenance": ["receiver-heuristic"],
-                            "confidence": 0.7,
-                        }
+                        resolution = _confident_call_resolution(package_resolution)
                         _emit(
                             references,
                             node,
@@ -728,11 +819,14 @@ def go_references_and_calls(
                         )
                         _emit(calls, node, kind="call", ref_kind="call", resolution=resolution)
                     else:
+                        # F9 fix: a package-qualified non-call selector (`config.DefaultTimeout`)
+                        # is a VALUE read (const/var), not a struct FIELD access -- only a
+                        # genuinely unresolved operand (a real struct field access) stays "field".
                         _emit(
                             references,
                             node,
                             kind="reference",
-                            ref_kind="field",
+                            ref_kind="value" if package_resolution is not None else "field",
                             resolution=package_resolution,
                         )
         for child in node.children:

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4066,9 +4066,21 @@ _JS_TS_TYPE_ANCESTOR_TYPES: set[str] = {
     "type_annotation",
     "extends_clause",
     "implements_clause",
-    "satisfies_expression",
-    "as_expression",
     "generic_type",
+}
+
+# F7 fix: `as_expression`/`satisfies_expression` are handled by dedicated positional logic below
+# (only the TYPE-side child is "type") -- they must NOT sit in the generic ancestor-walk set above,
+# which would (and used to) mislabel the runtime VALUE operand (`Widget as unknown` -> `Widget`)
+# as "type" merely for having one of these as an ancestor.
+_JS_TS_AS_SATISFIES_TYPES: set[str] = {"as_expression", "satisfies_expression"}
+
+# F17 fix: construction/render call sites -- `new Widget()` and JSX (`<Widget/>`,
+# `<Widget>...</Widget>`) -- are call-like uses of the symbol, not bare "value" mentions.
+_JS_TS_CONSTRUCTOR_CALL_ANCESTOR_TYPES: set[str] = {
+    "jsx_self_closing_element",
+    "jsx_opening_element",
+    "jsx_closing_element",
 }
 
 
@@ -4087,6 +4099,18 @@ def _js_ts_classify_ref_kind(node: Any) -> str:
         function_node = parent.child_by_field_name("function")
         if function_node is not None and function_node == node:
             return "call"
+    if node.type == "identifier" and parent is not None and parent.type == "new_expression":
+        constructor_node = parent.child_by_field_name("constructor")
+        if constructor_node is not None and constructor_node == node:
+            return "call"
+    if (
+        node.type == "identifier"
+        and parent is not None
+        and parent.type in _JS_TS_CONSTRUCTOR_CALL_ANCESTOR_TYPES
+    ):
+        name_node = parent.child_by_field_name("name")
+        if name_node is not None and name_node == node:
+            return "call"
     if (
         node.type == "property_identifier"
         and parent is not None
@@ -4098,6 +4122,16 @@ def _js_ts_classify_ref_kind(node: Any) -> str:
             if function_node is not None and function_node == parent:
                 return "call"
         return "field"
+    if parent is not None and parent.type in _JS_TS_AS_SATISFIES_TYPES:
+        # Neither `as_expression` nor `satisfies_expression` exposes named grammar fields for its
+        # two children, so the type side is identified positionally: it is always the LAST named
+        # child (`operand as/satisfies TYPE`). Only that child is "type"; the operand falls
+        # through to keep whatever kind it would have received anyway (call/field/value).
+        type_side = (
+            parent.named_child(parent.named_child_count - 1) if parent.named_child_count else None
+        )
+        if type_side is not None and type_side == node:
+            return "type"
     if _node_has_ancestor_type(node, _JS_TS_TYPE_ANCESTOR_TYPES):
         return "type"
     return "value"
@@ -4193,10 +4227,17 @@ def _js_ts_references_and_calls(
                 alias_reference_resolution = (
                     alias_resolution_by_name.get(node_text) if node_type == "identifier" else None
                 )
+                try:
+                    ref_kind = _js_ts_classify_ref_kind(node)
+                except Exception:
+                    # F20: a classifier bug must only default THIS row to "value", never drop
+                    # every reference in the file -- classify-only, so a failure here can never
+                    # be allowed to look like a fail-closed backend error.
+                    ref_kind = "value"
                 references.append({
                     "name": symbol,
                     "kind": "reference",
-                    "ref_kind": _js_ts_classify_ref_kind(node),
+                    "ref_kind": ref_kind,
                     "file": str(path),
                     "line": node.start_point[0] + 1,
                     "text": _line_text(node),
@@ -4423,9 +4464,19 @@ def _rust_classify_ref_kind(node: Any) -> str:
     Only called for nodes the existing walker already emits a row for -- Rust's grammar splits
     type positions into ``type_identifier`` and field access into ``field_identifier`` (both
     distinct from plain ``identifier``), so those positions are never matched by the walker
-    today; widening to them is T2 (would add new rows, not just labels). ``macro_invocation``
-    is checked defensively (e.g. ``Symbol!(..)``) even though no dedicated macro-call branch
-    exists yet -- it only relabels a row the plain-identifier match already produces.
+    today; widening to them is T2 (would add new rows, not just labels).
+
+    F6 fix: only the macro NAME position (e.g. ``println`` in ``println!(...)``) is "call" --
+    ``macro_invocation``'s ``arguments`` token-tree can contain arbitrary identifiers
+    (``println!("{:?}", Symbol)``, ``vec![Symbol]``) that are plain data/argument mentions, not
+    calls, and must fall through to "value" like any other bare identifier. Checking ONLY the
+    immediate parent (rather than any ancestor) is what keeps macro *arguments* out of this branch.
+
+    F18 fix: a turbofish call (``foo::<T>()``) puts the function identifier under a
+    ``generic_function`` node (itself the ``call_expression``'s ``function`` field), one layer
+    deeper than a plain call -- both the direct-identifier and ``scoped_identifier`` (path-
+    qualified) forms are handled below so ``foo::<T>()`` and ``bar::baz::<T>()`` both classify
+    "call" instead of falling through to "value".
     """
     parent = getattr(node, "parent", None)
     # NOTE: see _js_ts_classify_ref_kind -- tree-sitter node accessors return fresh wrapper
@@ -4434,14 +4485,32 @@ def _rust_classify_ref_kind(node: Any) -> str:
         function_node = parent.child_by_field_name("function")
         if function_node is not None and function_node == node:
             return "call"
+    if parent is not None and parent.type == "generic_function":
+        grandparent = getattr(parent, "parent", None)
+        if grandparent is not None and grandparent.type == "call_expression":
+            call_function_node = grandparent.child_by_field_name("function")
+            if call_function_node is not None and call_function_node == parent:
+                generic_function_name = parent.child_by_field_name("function")
+                if generic_function_name is not None and generic_function_name == node:
+                    return "call"
     if parent is not None and parent.type == "scoped_identifier":
         grandparent = getattr(parent, "parent", None)
         if grandparent is not None and grandparent.type == "call_expression":
             function_node = grandparent.child_by_field_name("function")
             if function_node is not None and function_node == parent:
                 return "call"
-    if _node_has_ancestor_type(node, {"macro_invocation"}):
-        return "call"
+        if grandparent is not None and grandparent.type == "generic_function":
+            great_grandparent = getattr(grandparent, "parent", None)
+            if great_grandparent is not None and great_grandparent.type == "call_expression":
+                call_function_node = great_grandparent.child_by_field_name("function")
+                if call_function_node is not None and call_function_node == grandparent:
+                    generic_function_name = grandparent.child_by_field_name("function")
+                    if generic_function_name is not None and generic_function_name == parent:
+                        return "call"
+    if parent is not None and parent.type == "macro_invocation":
+        macro_name_node = parent.child_by_field_name("macro")
+        if macro_name_node is not None and macro_name_node == node:
+            return "call"
     return "value"
 
 
@@ -4502,10 +4571,16 @@ def _rust_references_and_calls(
                 and not _is_definition_identifier(node)
                 and not _node_has_ancestor_type(node, {"use_declaration"})
             ):
+                try:
+                    ref_kind = _rust_classify_ref_kind(node)
+                except Exception:
+                    # F20: a classifier bug must only default THIS row to "value", never drop
+                    # every reference in the file.
+                    ref_kind = "value"
                 references.append({
                     "name": symbol,
                     "kind": "reference",
-                    "ref_kind": _rust_classify_ref_kind(node),
+                    "ref_kind": ref_kind,
                     "file": str(path),
                     "line": node.start_point[0] + 1,
                     "text": _line_text(node),
@@ -5753,11 +5828,16 @@ def _reference_kind_counts(references: list[Any]) -> dict[str, int]:
     """Additive T1 aggregate: counts every ``references`` row by its ``ref_kind`` label.
 
     Always sums to ``len(references)`` -- ref_kind is additive-only (moat P0-T1), so this must
-    never drift from a straight tally of what is already in the list.
+    never drift from a straight tally of what is already in the list. F21 fix: a non-dict row
+    (defensive-only today -- every real producer emits dicts) used to hit a bare ``continue`` and
+    silently vanish from the tally, breaking the sum-equals-``len`` invariant the docstring
+    promises; it is now counted too (under its label-less default, "value"), same as a dict row
+    missing the ``ref_kind`` key.
     """
     counts: dict[str, int] = {"call": 0, "import": 0, "type": 0, "field": 0, "value": 0}
     for item in references:
         if not isinstance(item, dict):
+            counts["value"] += 1
             continue
         ref_kind = str(item.get("ref_kind", "value"))
         counts[ref_kind] = counts.get(ref_kind, 0) + 1
@@ -5891,7 +5971,23 @@ def _graph_trust_summary(
     }
 
 
-def _language_coverage_gap_remediation(language: str) -> str:
+def _language_coverage_gap_remediation(language: str, *, fail_closed: bool = False) -> str:
+    """F12 fix: the remediation text must match what ACTUALLY happens for this gap.
+
+    An unregistered-language file (``fail_closed=False``, no ``LanguageSpec`` at all) really does
+    fall back to plain literal-text/regex matching -- see the generic ``else`` branch in the
+    refs/callers scan loops. A registered-but-grammar-missing language with no regex fallback
+    (``fail_closed=True``, e.g. Go when ``tree_sitter_go`` is not installed) produces ZERO rows
+    for its files instead -- claiming a regex fallback there was simply false.
+    """
+    if fail_closed:
+        return (
+            f"tg has a '{language}' extractor registered but its required parser/grammar is not "
+            f"installed -- refs/callers on a symbol whose definition or usage lives in a "
+            f"{language} file currently produce NO rows for those files ('{language}' has no "
+            "plain-text/regex fallback, unlike python/javascript/typescript/rust). Install the "
+            f"missing '{language}' tree-sitter grammar package to restore coverage."
+        )
     return (
         f"tg has no parser-backed extractor registered for '{language}' files yet -- refs/"
         f"callers on a symbol whose definition or usage lives in a {language} file fall back to "
@@ -5911,6 +6007,7 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
     gaps_by_language: dict[str, dict[str, Any]] = {}
     for current in bounded_files:
         spec = lang_registry.spec_for_path(current)
+        fail_closed = False
         if spec is None:
             language = _provider_language_for_path(current) or (
                 current.suffix.lstrip(".").lower() or "unknown"
@@ -5927,6 +6024,7 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
                     "required parser/grammar is not installed for this language and it has no "
                     "regex fallback (fail-closed)"
                 )
+                fail_closed = True
             else:
                 continue
         else:
@@ -5937,7 +6035,9 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
                 "language": language,
                 "reason": reason,
                 "files_affected": 0,
-                "remediation": _language_coverage_gap_remediation(language),
+                "remediation": _language_coverage_gap_remediation(
+                    language, fail_closed=fail_closed
+                ),
             },
         )
         entry["files_affected"] += 1
@@ -12732,6 +12832,20 @@ def build_symbol_defs_from_map(
                 "narrow PATH or raise --max-repo-files."
             )
             _mark_result_incomplete(payload, remediation=_SCAN_LIMIT_TRUNCATED_REMEDIATION)
+        # F13 fix: unlike refs/callers (which compute `resolution_gaps` over the files they
+        # actually scan), defs' own no_match path used to return bare -- indistinguishable from
+        # "the symbol genuinely does not exist" even when the real cause is a grammar-missing
+        # fail-closed language (e.g. a Go-only symbol with tree_sitter_go not installed). Attach
+        # the same honesty-floor gap here so a defs-only caller gets the hint too.
+        gap_files, gap_tests = _repo_map_file_and_test_universe(repo_map)
+        resolution_gaps = _language_coverage_gaps_for_universe([*gap_files, *gap_tests])
+        payload["resolution_gaps"] = resolution_gaps
+        if resolution_gaps:
+            gap_hint = "; ".join(
+                f"{int(gap['files_affected'])} {gap['language']} file(s): {gap['remediation']}"
+                for gap in resolution_gaps
+            )
+            payload["message"] += f" Coverage gap detected: {gap_hint}"
         payload["files"] = []
         payload["symbols"] = []
         payload["imports"] = []
@@ -13200,6 +13314,15 @@ def build_symbol_refs_from_map(
         deadline_monotonic=deadline_monotonic,
     )
     bounded_file_set = {str(current) for current in bounded_files}
+    # F25 fix (Go alias-resolution confidence): the symbol's own known definition directories,
+    # so a package-qualified Go call only earns high-confidence "go-import-resolution" when it
+    # resolves to a package that actually OWNS this symbol -- not merely to a package alias that
+    # happens to resolve to SOME directory (which used to give two unrelated same-named exports
+    # identical fabricated confidence). Computed once, outside the per-file loop.
+    go_definition_dirs = frozenset(
+        str(Path(str(current_definition["file"])).resolve().parent)
+        for current_definition in payload.get("definitions", [])
+    )
     references: list[dict[str, Any]] = []
     refs_scan_deadline_hit = False
     refs_files_scanned = 0
@@ -13274,7 +13397,7 @@ def build_symbol_refs_from_map(
             # grammar-missing file yields ([], []) here and is surfaced honestly via
             # `resolution_gaps` further down, never a silently-degraded text match.
             current_refs, current_calls = lang_go.go_references_and_calls(
-                current, symbol, repo_root
+                current, symbol, repo_root, definition_dirs=go_definition_dirs
             )
             go_call_refs = [
                 {
@@ -13513,6 +13636,12 @@ def build_symbol_callers_from_map(
         if str(current["file"]) in preferred_definition_file_set
     ] or [dict(current) for current in defs_payload["definitions"]]
     definition_files = [str(current["file"]) for current in definitions]
+    # F25 fix: see the matching comment in build_symbol_refs_from_map -- only trust a Go
+    # package-alias resolution as high-confidence when it resolves to a directory that actually
+    # owns this symbol.
+    go_definition_dirs = frozenset(
+        str(Path(current_file).resolve().parent) for current_file in definition_files
+    )
     calls: list[dict[str, Any]] = []
     python_files: set[str] = set()
 
@@ -13570,7 +13699,9 @@ def build_symbol_callers_from_map(
                 # Fail-closed (Stage 1 trap): no provider-alias/regex fallback for Go -- a
                 # grammar-missing file simply contributes no calls (surfaced via
                 # `resolution_gaps` for the refs/blast-radius payloads that compute it).
-                _, current_calls = lang_go.go_references_and_calls(current, symbol, repo_root)
+                _, current_calls = lang_go.go_references_and_calls(
+                    current, symbol, repo_root, definition_dirs=go_definition_dirs
+                )
             else:
                 _, current_calls = _regex_references_and_calls(current, symbol)
             for current_call in current_calls:

--- a/tests/unit/test_lang_go.py
+++ b/tests/unit/test_lang_go.py
@@ -27,6 +27,7 @@ used to verify:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from tensor_grep.cli import agent_capsule, lang_go, lang_registry, repo_map
 
@@ -314,6 +315,14 @@ def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
     defs_payload = repo_map.build_symbol_defs("Helper", tmp_path)
     assert defs_payload.get("no_match") is True
     assert defs_payload["definitions"] == []
+    # F13: `tg defs` used to return a bare no_match here -- indistinguishable from "Helper simply
+    # does not exist anywhere". It must attach the same resolution_gaps honesty floor refs/callers
+    # already get, plus a hint in the message.
+    defs_gaps = defs_payload["resolution_gaps"]
+    assert any(gap["language"] == "go" for gap in defs_gaps)
+    defs_go_gap = next(gap for gap in defs_gaps if gap["language"] == "go")
+    assert "fail-closed" in defs_go_gap["reason"]
+    assert "Coverage gap detected" in defs_payload["message"]
 
     refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
     assert not refs_payload.get("no_match")
@@ -322,6 +331,22 @@ def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
     go_gap = next(gap for gap in gaps if gap["language"] == "go")
     assert "fail-closed" in go_gap["reason"]
     assert go_gap["files_affected"] >= 1
+    # F12: the remediation text must be HONEST for Go -- it has no regex fallback, so it must not
+    # claim "falls back to plain literal-text/regex matching" (that claim is only true for a
+    # genuinely UNREGISTERED language, e.g. .java).
+    assert "fall back to plain literal-text/regex matching" not in go_gap["remediation"]
+    assert (
+        "NO rows" in go_gap["remediation"]
+        or "no plain-text/regex fallback" in (go_gap["remediation"])
+    )
+
+
+def test_go_coverage_gap_remediation_is_honest_about_zero_rows() -> None:
+    fail_closed_text = repo_map._language_coverage_gap_remediation("go", fail_closed=True)
+    fallback_text = repo_map._language_coverage_gap_remediation("java", fail_closed=False)
+
+    assert "fall back to plain literal-text/regex matching" not in fail_closed_text
+    assert "fall back to plain literal-text/regex matching" in fallback_text
 
 
 def test_grammar_absent_cli_exit_code_is_honest_not_found(tmp_path: Path, monkeypatch) -> None:
@@ -353,3 +378,263 @@ def test_agent_capsule_reports_go_target_language_and_call_sites(tmp_path: Path)
     related_call_sites = payload.get("related_call_sites")
     assert related_call_sites
     assert any(Path(str(site.get("file", ""))).name == "bar.go" for site in related_call_sites)
+
+
+# ---------------------------------------------------------------------------
+# F8: generic receiver -> base type name (not "MyType[T]").
+# ---------------------------------------------------------------------------
+
+
+def test_generic_receiver_method_associates_with_base_type_name(tmp_path: Path) -> None:
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text("module example.com/genmod\n\ngo 1.21\n", encoding="utf-8")
+    box_go = tmp_path / "box.go"
+    box_go.write_text(
+        "package genmod\n"
+        "\n"
+        "type Box[T any] struct {\n"
+        "\tValue T\n"
+        "}\n"
+        "\n"
+        "func (b *Box[T]) Get() T {\n"
+        "\treturn b.Value\n"
+        "}\n"
+        "\n"
+        "func (b Box[T]) Peek() T {\n"
+        "\treturn b.Value\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _, symbols = lang_go.go_imports_and_symbols(box_go)
+    type_spec = next(s for s in symbols if s["name"] == "Box")
+    pointer_receiver_method = next(s for s in symbols if s["name"] == "Get")
+    value_receiver_method = next(s for s in symbols if s["name"] == "Peek")
+
+    # Before the F8 fix these were "Box[T]" -- never matching the type_spec's plain "Box" name.
+    assert pointer_receiver_method["receiver_type"] == "Box"
+    assert value_receiver_method["receiver_type"] == "Box"
+    assert pointer_receiver_method["receiver_type"] == type_spec["name"]
+
+
+# ---------------------------------------------------------------------------
+# F9: package-qualified const/var read -> "value", not "field".
+# ---------------------------------------------------------------------------
+
+
+def test_package_qualified_var_read_classified_as_value(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/cfgmod\n\ngo 1.21\n", encoding="utf-8")
+    config_dir = tmp_path / "pkg" / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.go").write_text(
+        "package config\n\nvar DefaultTimeout = 30\n",
+        encoding="utf-8",
+    )
+    app_dir = tmp_path / "cmd" / "app"
+    app_dir.mkdir(parents=True)
+    (app_dir / "main.go").write_text(
+        "package main\n"
+        "\n"
+        "import (\n"
+        '\t"example.com/cfgmod/pkg/config"\n'
+        ")\n"
+        "\n"
+        "func main() {\n"
+        "\t_ = config.DefaultTimeout\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_refs("DefaultTimeout", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["references"], "expected the package-qualified read to be found"
+    # Before the F9 fix every non-call selector classified "field", even a plain package-level
+    # const/var read.
+    assert all(row["ref_kind"] == "value" for row in payload["references"])
+    assert all(
+        row["resolution_provenance"] == ["go-import-resolution"] for row in payload["references"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# F10 / F25: an alias-selector CALL only earns high confidence when the resolved package is
+# confirmed to actually own the queried symbol.
+# ---------------------------------------------------------------------------
+
+
+def test_shadowed_alias_call_downgrades_to_receiver_heuristic_confidence(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/shadowmod\n\ngo 1.21\n", encoding="utf-8")
+
+    widget_dir = tmp_path / "pkg" / "widget"
+    widget_dir.mkdir(parents=True)
+    (widget_dir / "widget.go").write_text(
+        "package widget\n"
+        "\n"
+        "type Widget struct{}\n"
+        "\n"
+        "func (wg *Widget) Write(data []byte) (int, error) {\n"
+        "\treturn len(data), nil\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    # A second, unrelated package that does NOT define "Write" at all -- its own import alias
+    # happens to be named "w", the same name a LOCAL variable shadows it with below.
+    other_dir = tmp_path / "pkg" / "other"
+    other_dir.mkdir(parents=True)
+    (other_dir / "other.go").write_text(
+        "package other\n\ntype Other struct{}\n",
+        encoding="utf-8",
+    )
+
+    app_dir = tmp_path / "cmd" / "app"
+    app_dir.mkdir(parents=True)
+    (app_dir / "main.go").write_text(
+        "package main\n"
+        "\n"
+        "import (\n"
+        '\t"example.com/shadowmod/pkg/widget"\n'
+        '\tw "example.com/shadowmod/pkg/other"\n'
+        ")\n"
+        "\n"
+        "func main() {\n"
+        "\tvar real widget.Widget\n"
+        "\tw := &real\n"
+        '\tn, err := w.Write([]byte("hello"))\n'
+        "\t_ = n\n"
+        "\t_ = err\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_callers("Write", tmp_path)
+
+    assert payload["callers"], "expected the shadowed w.Write(...) call to still be found"
+    for caller in payload["callers"]:
+        assert caller["ref_kind"] == "call"
+        # Before the F10/F25 fix this fabricated resolution_confidence=0.95
+        # "go-import-resolution" purely because "w" lexically resolves to SOME import, even
+        # though that import (pkg/other) does not define "Write" at all.
+        assert caller["resolution_provenance"] == ["receiver-heuristic"]
+        assert caller["resolution_confidence"] <= 0.7
+
+
+def test_go_package_defines_function_fallback_confirms_or_denies(tmp_path: Path) -> None:
+    """Direct unit coverage of the F10 fallback path (``definition_dirs=None``, e.g. a standalone
+    caller of ``go_references_and_calls`` outside the repo_map.py refs/callers dispatch)."""
+    (tmp_path / "go.mod").write_text("module example.com/directmod\n\ngo 1.21\n", encoding="utf-8")
+
+    real_dir = tmp_path / "pkg" / "real"
+    real_dir.mkdir(parents=True)
+    (real_dir / "real.go").write_text(
+        "package real\n\nfunc Process() int {\n\treturn 1\n}\n",
+        encoding="utf-8",
+    )
+    empty_dir = tmp_path / "pkg" / "empty"
+    empty_dir.mkdir(parents=True)
+    (empty_dir / "empty.go").write_text("package empty\n", encoding="utf-8")
+
+    caller_dir = tmp_path / "cmd" / "confirmed"
+    caller_dir.mkdir(parents=True)
+    confirmed_go = caller_dir / "main.go"
+    confirmed_go.write_text(
+        "package main\n"
+        "\n"
+        "import (\n"
+        '\t"example.com/directmod/pkg/real"\n'
+        ")\n"
+        "\n"
+        "func main() {\n"
+        "\treal.Process()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    unconfirmed_dir = tmp_path / "cmd" / "unconfirmed"
+    unconfirmed_dir.mkdir(parents=True)
+    unconfirmed_go = unconfirmed_dir / "main.go"
+    unconfirmed_go.write_text(
+        "package main\n"
+        "\n"
+        "import (\n"
+        '\tprocess "example.com/directmod/pkg/empty"\n'
+        ")\n"
+        "\n"
+        "func main() {\n"
+        "\tprocess.Process()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    lang_go.prime_go_repo_context(tmp_path)
+
+    _, confirmed_calls = lang_go.go_references_and_calls(confirmed_go, "Process", tmp_path)
+    _, unconfirmed_calls = lang_go.go_references_and_calls(unconfirmed_go, "Process", tmp_path)
+
+    assert confirmed_calls and confirmed_calls[0]["resolution_confidence"] >= 0.9
+    assert confirmed_calls[0]["resolution_provenance"] == ["go-import-resolution"]
+
+    assert unconfirmed_calls and unconfirmed_calls[0]["resolution_confidence"] <= 0.7
+    assert unconfirmed_calls[0]["resolution_provenance"] == ["receiver-heuristic"]
+
+
+# ---------------------------------------------------------------------------
+# F11: import-path extraction falls back to quote-stripped literal text.
+# ---------------------------------------------------------------------------
+
+
+class _FakeStringLiteralNode:
+    """Minimal stand-in for a tree-sitter node shaped like an OLDER ``tree_sitter_go`` grammar's
+    import path literal -- no ``interpreted_string_literal_content`` child at all."""
+
+    def __init__(self, start_byte: int, end_byte: int) -> None:
+        self.start_byte = start_byte
+        self.end_byte = end_byte
+        self.children: list[Any] = []
+        self.type = "interpreted_string_literal"
+
+
+def test_import_path_extraction_falls_back_to_quote_stripped_text() -> None:
+    source_bytes = b'"example.com/widgetmod/pkg/foo"'
+    fake_node = _FakeStringLiteralNode(0, len(source_bytes))
+
+    assert (
+        lang_go._go_import_spec_path_text(fake_node, source_bytes)
+        == "example.com/widgetmod/pkg/foo"
+    )
+
+
+def test_import_path_extraction_returns_none_for_missing_path_field() -> None:
+    assert lang_go._go_import_spec_path_text(None, b"") is None
+
+
+# ---------------------------------------------------------------------------
+# F24: an intervening (nested, non-go.work) go.mod stops import resolution.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_go_mod_boundary_stops_import_resolution(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/nestedmod\n\ngo 1.21\n", encoding="utf-8")
+
+    # A nested module NOT listed in any go.work `use` entry (e.g. simply forgotten) -- its own
+    # go.mod makes this directory tree a SEPARATE module even though it sits under the parent
+    # module's own path prefix.
+    nested_dir = tmp_path / "toolsmod"
+    nested_dir.mkdir()
+    (nested_dir / "go.mod").write_text(
+        "module example.com/nestedmod/toolsmod\n\ngo 1.21\n", encoding="utf-8"
+    )
+    sub_dir = nested_dir / "sub"
+    sub_dir.mkdir()
+    (sub_dir / "sub.go").write_text(
+        "package sub\n\nfunc Process() int {\n\treturn 1\n}\n",
+        encoding="utf-8",
+    )
+
+    context = lang_go.prime_go_repo_context(tmp_path)
+    target_dir = lang_go._go_import_path_to_dir("example.com/nestedmod/toolsmod/sub", context)
+
+    # Before the F24 fix this greedily resolved to <root>/toolsmod/sub via the ROOT module's own
+    # prefix, silently treating a separate nested module's directory as part of the parent.
+    assert target_dir is None

--- a/tests/unit/test_typed_ref_kinds.py
+++ b/tests/unit/test_typed_ref_kinds.py
@@ -206,3 +206,227 @@ def test_mcp_agent_capsule_related_call_sites_carry_ref_kind(tmp_path: Path) -> 
     assert payload["call_site_evidence"]["status"] == "collected"
     assert payload["related_call_sites"], "fixture must produce at least one related call site"
     assert all(row.get("ref_kind") == "call" for row in payload["related_call_sites"])
+
+
+# ---------------------------------------------------------------------------
+# F6 / F18: Rust macro-argument identifiers stay "value"; turbofish calls classify "call".
+# ---------------------------------------------------------------------------
+
+
+def test_rust_macro_argument_is_not_classified_as_call(tmp_path: Path) -> None:
+    """A macro's ARGUMENTS (inside its token-tree) are data, not a call site -- only the macro
+    NAME position (``println``/``vec``, not matched here since we're querying a different symbol)
+    is "call". Before the F6 fix, ANY identifier anywhere inside a macro invocation's token tree
+    classified "call", inflating the highest-signal ref_kind count."""
+    mod_path = tmp_path / "mod.rs"
+    mod_path.write_text("pub struct Symbol;\n", encoding="utf-8")
+    use_path = tmp_path / "use_it.rs"
+    use_path.write_text(
+        "use crate::mod_a::Symbol;\n"
+        "\n"
+        "fn use_symbol() {\n"
+        '    println!("{:?}", Symbol);\n'
+        "    let v = vec![Symbol];\n"
+        "    let _ = v;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    use_refs = {
+        row["line"]: row for row in payload["references"] if row["file"] == str(use_path.resolve())
+    }
+
+    assert use_refs[4]["ref_kind"] == "value"  # println!("{:?}", Symbol);
+    assert use_refs[5]["ref_kind"] == "value"  # let v = vec![Symbol];
+    assert not any(row["ref_kind"] == "call" for row in use_refs.values())
+
+
+def test_rust_turbofish_call_classified_as_call(tmp_path: Path) -> None:
+    """``foo::<T>()`` puts the function identifier under a ``generic_function`` node one layer
+    below ``call_expression`` -- both the bare and path-qualified (``bar::Symbol::<T>()``) forms
+    must classify "call", matching a plain ``Symbol()`` call."""
+    mod_path = tmp_path / "mod.rs"
+    mod_path.write_text("pub fn Symbol() {}\n", encoding="utf-8")
+    use_path = tmp_path / "use_it.rs"
+    use_path.write_text(
+        "use crate::mod_a::Symbol;\n"
+        "\n"
+        "fn use_symbol() {\n"
+        "    Symbol::<i32>(1);\n"
+        "    bar::Symbol::<i32>(1);\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    use_refs = {
+        row["line"]: row for row in payload["references"] if row["file"] == str(use_path.resolve())
+    }
+
+    assert use_refs[4]["ref_kind"] == "call"  # Symbol::<i32>(1);
+    assert use_refs[5]["ref_kind"] == "call"  # bar::Symbol::<i32>(1);
+
+
+# ---------------------------------------------------------------------------
+# F7: JS/TS `as`/`satisfies` operand keeps its own kind, not "type".
+# ---------------------------------------------------------------------------
+
+
+def test_js_ts_as_and_satisfies_operand_keeps_own_kind(tmp_path: Path) -> None:
+    mod_path = tmp_path / "mod.ts"
+    mod_path.write_text("export class Symbol {}\n", encoding="utf-8")
+    use_path = tmp_path / "use.ts"
+    use_path.write_text(
+        'import { Symbol } from "./mod";\n'
+        "\n"
+        "function useSymbol() {\n"
+        "  const a = Symbol as unknown;\n"
+        "  const b = Symbol satisfies object;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    use_refs = {
+        row["line"]: row for row in payload["references"] if row["file"] == str(use_path.resolve())
+    }
+
+    # Before the F7 fix both of these mislabeled "type" purely because `as_expression` /
+    # `satisfies_expression` sat in the generic ancestor-walk type set -- the runtime VALUE
+    # operand must keep its own kind ("value" here, since it's a bare identifier reference).
+    assert use_refs[4]["ref_kind"] == "value"  # const a = Symbol as unknown;
+    assert use_refs[5]["ref_kind"] == "value"  # const b = Symbol satisfies object;
+
+
+# ---------------------------------------------------------------------------
+# F17: `new Widget()` / JSX construction classify "call".
+# ---------------------------------------------------------------------------
+
+
+def test_js_ts_new_expression_and_jsx_classified_as_call(tmp_path: Path) -> None:
+    mod_path = tmp_path / "mod.tsx"
+    mod_path.write_text("export class Symbol {}\n", encoding="utf-8")
+    use_path = tmp_path / "use.tsx"
+    use_path.write_text(
+        'import { Symbol } from "./mod";\n'
+        "\n"
+        "function useSymbol() {\n"
+        "  const a = new Symbol();\n"
+        "  const b = <Symbol/>;\n"
+        "  const c = <Symbol></Symbol>;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    use_refs = [row for row in payload["references"] if row["file"] == str(use_path.resolve())]
+
+    new_expr_refs = [row for row in use_refs if row["line"] == 4]
+    jsx_self_closing_refs = [row for row in use_refs if row["line"] == 5]
+    jsx_pair_refs = [row for row in use_refs if row["line"] == 6]
+
+    assert new_expr_refs and all(row["ref_kind"] == "call" for row in new_expr_refs)
+    assert jsx_self_closing_refs and all(row["ref_kind"] == "call" for row in jsx_self_closing_refs)
+    # <Symbol></Symbol> emits an opening- and closing-tag identifier at the AST level, but the
+    # pre-existing `_dedupe_symbol_references` step (identical file/line/text) collapses them to
+    # ONE row -- that dedupe is unrelated to F17 and must stay in force; what F17 fixes is the
+    # LABEL on the surviving row (was "value", now "call").
+    assert jsx_pair_refs and all(row["ref_kind"] == "call" for row in jsx_pair_refs)
+
+
+# ---------------------------------------------------------------------------
+# F20: a classifier exception must default THIS row to "value", never drop the file's rows.
+# ---------------------------------------------------------------------------
+
+
+def test_js_ts_classifier_exception_defaults_to_value_without_dropping_rows(
+    tmp_path: Path, monkeypatch
+) -> None:
+    mod_path = tmp_path / "mod.ts"
+    mod_path.write_text("export class Symbol {}\n", encoding="utf-8")
+    use_path = tmp_path / "use.ts"
+    use_path.write_text(
+        'import { Symbol } from "./mod";\n'
+        "\n"
+        "function useSymbol(x: Symbol) {\n"
+        "  return x.Symbol;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    baseline = repo_map.build_symbol_refs("Symbol", tmp_path)
+    baseline_count = len([
+        row for row in baseline["references"] if row["file"] == str(use_path.resolve())
+    ])
+    assert baseline_count > 0
+
+    def _boom(node: object) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(repo_map, "_js_ts_classify_ref_kind", _boom)
+
+    payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    use_refs = [row for row in payload["references"] if row["file"] == str(use_path.resolve())]
+
+    assert len(use_refs) == baseline_count
+    assert all(row["ref_kind"] == "value" for row in use_refs)
+
+
+def test_rust_classifier_exception_defaults_to_value_without_dropping_rows(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """``_rust_classify_ref_kind`` is only invoked for the plain-``identifier`` walker branch
+    (e.g. ``let z = Symbol;``) -- the separate ``call_expression`` branch stamps ``ref_kind="call"``
+    directly without going through the classifier at all, so it is unaffected by this monkeypatch
+    and stays "call". F20 is about THAT classifier call never dropping the row it covers."""
+    mod_path = tmp_path / "mod.rs"
+    mod_path.write_text("pub struct Symbol;\n", encoding="utf-8")
+    use_path = tmp_path / "use_it.rs"
+    use_path.write_text(
+        "use crate::mod_a::Symbol;\n"
+        "\n"
+        "fn use_symbol() -> Symbol {\n"
+        "    let z = Symbol;\n"
+        "    Symbol()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    baseline = repo_map.build_symbol_refs("Symbol", tmp_path)
+    baseline_refs = {
+        row["line"]: row for row in baseline["references"] if row["file"] == str(use_path.resolve())
+    }
+    assert baseline_refs
+
+    def _boom(node: object) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(repo_map, "_rust_classify_ref_kind", _boom)
+
+    payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    use_refs = {
+        row["line"]: row for row in payload["references"] if row["file"] == str(use_path.resolve())
+    }
+
+    assert len(use_refs) == len(baseline_refs)
+    assert use_refs[4]["ref_kind"] == "value"  # let z = Symbol; -- classifier boomed -> default
+    assert use_refs[5]["ref_kind"] == "call"  # Symbol(); -- hardcoded by a different branch
+
+
+# ---------------------------------------------------------------------------
+# F21: `_reference_kind_counts` must count non-dict rows too (sum == len invariant).
+# ---------------------------------------------------------------------------
+
+
+def test_reference_kind_counts_counts_non_dict_rows_too() -> None:
+    references = [
+        {"ref_kind": "call"},
+        {"ref_kind": "value"},
+        "not-a-dict",
+        {},
+    ]
+
+    counts = repo_map._reference_kind_counts(references)
+
+    assert sum(counts.values()) == len(references)


### PR DESCRIPTION
Fable audit MED/LOW findings F6-F13, F17, F18, F20, F21, F24, F25 (classifier/heuristic precision — none change ref/caller COUNTS, all correct the ref_kind LABEL or resolution_confidence an agent trusts).

**ref_kind classifiers (repo_map.py):**
- F6/F18 (Rust): macro args (`println!("{}", Symbol)`) fall to "value" (only the macro name is "call"); turbofish `foo::<T>()` → "call".
- F7/F17 (JS/TS): `X as unknown` operand keeps its kind (not "type"); `new Widget()` + JSX → "call".
- F20: classify() wrapped try/except → default "value", never drops a file's rows. F21: non-dict rows counted (sum==len invariant).

**Go (lang_go.py):**
- F8 generic receivers (`func (r *MyType[T])`) associate with base type `MyType`.
- F9 `pkg.Const` → "value" not "field". F10/F25 alias-selector calls only get 0.95 when the resolved package dir matches the definition (else 0.7 receiver-heuristic).
- F11 empty-import fallback (older grammar) via quote-stripping. F12 honest "produces zero rows" remediation for Go (no false regex-fallback claim). F13 `tg defs` grammar-missing → `resolution_gaps` like refs/callers. F24 nested-go.mod boundary stops greedy resolution.

**Verified:** 81 targeted + the worktree's 134 + 3440-slice; ZERO ref/caller count change (five-position tests pass unmodified); ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)