### PR TITLE
fix(backends H5/H6): StringZilla honors --invert-match + StringZilla/AST honor --max-count

### DIFF
--- a/src/tensor_grep/backends/ast_backend.py
+++ b/src/tensor_grep/backends/ast_backend.py
@@ -471,6 +471,22 @@ class AstBackend(ComputeBackend):
         except OSError:
             logger.debug("Failed to write AST node index cache for %s", file_path, exc_info=True)
 
+    @staticmethod
+    def _cap_to_max_count(result: SearchResult, config: SearchConfig | None) -> SearchResult:
+        """H6: cap `result` to `config.max_count`, matching cpu_backend/rust's
+        per-file cap semantics (never return every match). Must only be applied
+        to the value returned to the caller, AFTER any persistent-cache write --
+        caching a pre-capped result would silently truncate a later query that
+        requests a higher (or no) max_count for the same file/lang/pattern.
+        """
+        max_count = config.max_count if config else None
+        if not max_count or len(result.matches) <= max_count:
+            return result
+        result.matches = result.matches[:max_count]
+        result.total_matches = len(result.matches)
+        result.total_files = 1 if result.matches else 0
+        return result
+
     def _build_matches_from_line_numbers(
         self, file_path: str, lines: list[str], line_numbers: list[int], routing_reason: str
     ) -> SearchResult:
@@ -661,7 +677,7 @@ class AstBackend(ComputeBackend):
 
         persistent_cached_result = self._load_persistent_cached_result(file_path, lang, pattern)
         if persistent_cached_result is not None:
-            return persistent_cached_result
+            return self._cap_to_max_count(persistent_cached_result, config)
 
         if self._is_simple_node_type_pattern(pattern):
             node_type_index = self._load_persistent_node_type_index(file_path, lang)
@@ -677,7 +693,7 @@ class AstBackend(ComputeBackend):
                 )
                 if result.total_matches > 0:
                     self._persist_result_cache(file_path, lang, pattern, result)
-                    return result
+                    return self._cap_to_max_count(result, config)
 
         parser = self._get_parser(lang)
         _source_bytes, lines, tree = self._get_parsed_source(parser, file_path, lang)
@@ -692,7 +708,7 @@ class AstBackend(ComputeBackend):
             )
             if result.total_matches > 0:
                 self._persist_result_cache(file_path, lang, pattern, result)
-                return result
+                return self._cap_to_max_count(result, config)
 
         try:
             query = self._get_query(parser, lang, pattern)
@@ -749,4 +765,4 @@ class AstBackend(ComputeBackend):
             routing_worker_count=1,
         )
         self._persist_result_cache(file_path, lang, pattern, result)
-        return result
+        return self._cap_to_max_count(result, config)

--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -240,6 +240,26 @@ class AstGrepWrapperBackend(ComputeBackend):
             routing_worker_count=1,
         )
 
+    @staticmethod
+    def _cap_to_max_count(result: SearchResult, config: SearchConfig | None) -> SearchResult:
+        """H6: cap `result` to `config.max_count`, matching cpu_backend/rust's
+        per-file (per-call) cap semantics instead of returning every structural
+        match ast-grep found."""
+        max_count = config.max_count if config else None
+        if not max_count or len(result.matches) <= max_count:
+            return result
+        result.matches = result.matches[:max_count]
+        result.total_matches = len(result.matches)
+        matched_files_capped: list[str] = []
+        seen_files_capped: set[str] = set()
+        for match in result.matches:
+            if match.file and match.file not in seen_files_capped:
+                seen_files_capped.add(match.file)
+                matched_files_capped.append(match.file)
+        result.matched_file_paths = matched_files_capped
+        result.total_files = len(matched_files_capped)
+        return result
+
     def _parse_json_items(self, stdout: str) -> list[dict[str, Any]]:
         try:
             loaded = json.loads(stdout)
@@ -321,7 +341,7 @@ class AstGrepWrapperBackend(ComputeBackend):
                     input_text=config.ast_stdin_input if config and config.ast_stdin else None,
                 )
                 self._raise_for_nonzero(result)
-                return self._parse_result(result.stdout)
+                return self._cap_to_max_count(self._parse_result(result.stdout), config)
         except BackendExecutionError:
             raise
         except Exception as e:
@@ -343,7 +363,9 @@ class AstGrepWrapperBackend(ComputeBackend):
                     input_text=config.ast_stdin_input if config and config.ast_stdin else None,
                 )
                 self._raise_for_nonzero(result)
-                return self._parse_result(result.stdout, fallback_file=file_path)
+                return self._cap_to_max_count(
+                    self._parse_result(result.stdout, fallback_file=file_path), config
+                )
         except BackendExecutionError:
             raise
         except Exception as e:

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -264,6 +264,14 @@ class StringZillaBackend(ComputeBackend):
         if len(pattern) < 3:
             return None
 
+        if config and config.invert_match:
+            # H5: the trigram index only answers "which lines contain every trigram
+            # of the pattern" -- there is no cheap index-based way to enumerate the
+            # lines that DON'T contain the pattern. Fall through to the full-scan
+            # path in search(), which honors invert_match directly, rather than
+            # silently returning the (wrong, non-inverted) indexed result.
+            return None
+
         treat_binary_as_text = self._should_search_binary_as_text(config)
         cached = self._load_cached_index(file_path, ignore_case, treat_binary_as_text)
         routing_reason = "stringzilla_fixed_strings_index_cache"
@@ -315,11 +323,16 @@ class StringZillaBackend(ComputeBackend):
 
         candidate_line_indexes = self._intersect_sorted_line_indexes(postings)
         matches = []
+        max_count = config.max_count if config else None
         for line_idx in candidate_line_indexes:
             line = source_lines[line_idx]
             haystack = line.lower() if ignore_case else line
             if normalized_pattern in haystack:
                 matches.append(MatchLine(line_number=line_idx + 1, text=line, file=file_path))
+                # H6: cap to config.max_count, matching cpu_backend's per-file cap
+                # semantics -- never return every match once the cap is reached.
+                if max_count and len(matches) >= max_count:
+                    break
 
         return SearchResult(
             matches=matches,
@@ -364,13 +377,23 @@ class StringZillaBackend(ComputeBackend):
         # Since StringZilla 4.x, we can split by lines extremely fast
         lines = sz_str.splitlines()
         matches = []
+        invert_match = bool(config and config.invert_match)
+        max_count = config.max_count if config else None
 
         # Evaluate using stringzilla's native find
         for i, line in enumerate(lines):
             haystack = str(line).lower() if ignore_case else line
             needle = pattern.lower() if ignore_case else pattern
-            if haystack.find(needle) != -1:
+            found = haystack.find(needle) != -1
+            # H5: honor invert_match -- a matching line under invert_match is one
+            # where the pattern is ABSENT, the complement of the normal result.
+            matched = (not found) if invert_match else found
+            if matched:
                 matches.append(MatchLine(line_number=i + 1, text=str(line), file=file_path))
+                # H6: cap to config.max_count, matching cpu_backend's per-file cap
+                # semantics -- never return every match once the cap is reached.
+                if max_count and len(matches) >= max_count:
+                    break
 
         return SearchResult(
             matches=matches,

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -376,6 +376,14 @@ class StringZillaBackend(ComputeBackend):
 
         # Since StringZilla 4.x, we can split by lines extremely fast
         lines = sz_str.splitlines()
+        # Unlike Python's str.splitlines(), StringZilla's Str.splitlines() emits an
+        # extra trailing empty entry when the source text ends with a line
+        # terminator (e.g. "a\n" -> ["a", ""] instead of ["a"]). Uncorrected, that
+        # phantom empty "line" spuriously matches under invert_match (it never
+        # contains the pattern) and shifts every subsequent line number. Trim it so
+        # line numbering and invert_match semantics match cpu_backend/rg.
+        if lines and str(lines[-1]) == "" and content.endswith(("\n", "\r")):
+            lines = lines[:-1]
         matches = []
         invert_match = bool(config and config.invert_match)
         max_count = config.max_count if config else None

--- a/tests/unit/test_ast_backend.py
+++ b/tests/unit/test_ast_backend.py
@@ -207,6 +207,116 @@ class TestAstBackend:
         assert result.routing_backend == "AstBackend"
         assert result.routing_reason == "ast_structural_match"
 
+    def test_should_cap_matches_to_max_count_for_query_capture_path(self, tmp_path, mocker):
+        """H6: --ast ... --max-count N must cap the returned matches to N, matching
+        the per-file cap semantics of cpu_backend/rust, instead of returning every
+        structural match."""
+        from tensor_grep.backends.ast_backend import AstBackend
+
+        backend = AstBackend()
+        mocker.patch.object(backend, "is_available", return_value=True)
+
+        class FakeNode:
+            def __init__(self, line_number):
+                self.start_point = (line_number, 0)
+
+        class FakeQuery:
+            def captures(self, _root):
+                return [(FakeNode(line), "match") for line in range(4)]
+
+        class FakeLanguage:
+            def query(self, _pattern):
+                return FakeQuery()
+
+        class FakeTree:
+            class RootNode:
+                type = "module"
+                start_point = (0, 0)
+                children = ()
+
+            root_node = RootNode()
+
+        class FakeParser:
+            language = FakeLanguage()
+
+            def parse(self, _source):
+                return FakeTree()
+
+        mocker.patch.object(backend, "_get_parser", return_value=FakeParser())
+
+        file_path = tmp_path / "test.py"
+        file_path.write_text("a\nb\nc\nd\n", encoding="utf-8")
+
+        result = backend.search(
+            str(file_path),
+            "function_definition",
+            SearchConfig(ast=True, lang="python", max_count=2),
+        )
+
+        assert result.total_matches == 2
+        assert [m.line_number for m in result.matches] == [1, 2]
+
+    def test_max_count_cap_does_not_poison_the_persisted_cache(self, tmp_path, mocker, monkeypatch):
+        """The capped result must never be what's persisted -- otherwise a later
+        query with a higher/no max_count would silently replay the truncated
+        result from a previous capped query."""
+        from tensor_grep.backends.ast_backend import AstBackend
+
+        cache_dir = tmp_path / "ast-cache"
+        monkeypatch.setenv("TENSOR_GREP_AST_CACHE_DIR", str(cache_dir))
+        AstBackend._clear_shared_caches()
+
+        backend = AstBackend()
+        mocker.patch.object(backend, "is_available", return_value=True)
+
+        class FakeNode:
+            def __init__(self, line_number):
+                self.start_point = (line_number, 0)
+
+        class FakeQuery:
+            def captures(self, _root):
+                return [(FakeNode(line), "match") for line in range(4)]
+
+        class FakeLanguage:
+            def query(self, _pattern):
+                return FakeQuery()
+
+        class FakeTree:
+            class RootNode:
+                type = "module"
+                start_point = (0, 0)
+                children = ()
+
+            root_node = RootNode()
+
+        class FakeParser:
+            language = FakeLanguage()
+
+            def parse(self, _source):
+                return FakeTree()
+
+        mocker.patch.object(backend, "_get_parser", return_value=FakeParser())
+
+        file_path = tmp_path / "test.py"
+        file_path.write_text("a\nb\nc\nd\n", encoding="utf-8")
+
+        capped = backend.search(
+            str(file_path),
+            "function_definition",
+            SearchConfig(ast=True, lang="python", max_count=1),
+        )
+        assert capped.total_matches == 1
+
+        # A second, uncapped query for the same file/lang/pattern hits the
+        # persistent result cache -- it must return the FULL match set, proving
+        # the cache stored the uncapped result rather than the capped one.
+        uncapped = backend.search(
+            str(file_path),
+            "function_definition",
+            SearchConfig(ast=True, lang="python"),
+        )
+        assert uncapped.total_matches == 4
+
     def test_should_reuse_compiled_query_and_parsed_source_for_repeated_searches(
         self, tmp_path, mocker
     ):
@@ -565,6 +675,63 @@ class TestAstBackend:
         assert second.matches[0].line_number == 3
         assert parser_two.parse_calls == 0
         assert parser_two.language.query_calls == 0
+
+    def test_should_cap_matches_for_node_type_index_path(self, tmp_path, mocker, monkeypatch):
+        """H6: the simple-node-type-index fast path (a different code path from the
+        tree-sitter query-capture path) must also honor max_count."""
+        from tensor_grep.backends.ast_backend import AstBackend
+
+        cache_dir = tmp_path / "ast-cache"
+        monkeypatch.setenv("TENSOR_GREP_AST_CACHE_DIR", str(cache_dir))
+        AstBackend._clear_shared_caches()
+
+        class FakeNode:
+            def __init__(self, node_type, line_number, children=()):
+                self.type = node_type
+                self.start_point = (line_number, 0)
+                self.children = children
+
+        class FakeQuery:
+            def captures(self, _root):
+                return []
+
+        class FakeLanguage:
+            def query(self, _pattern):
+                return FakeQuery()
+
+        class FakeTree:
+            def __init__(self):
+                self.root_node = FakeNode(
+                    "module",
+                    0,
+                    children=(
+                        FakeNode("function_definition", 0),
+                        FakeNode("function_definition", 1),
+                        FakeNode("function_definition", 2),
+                    ),
+                )
+
+        class FakeParser:
+            language = FakeLanguage()
+
+            def parse(self, _source):
+                return FakeTree()
+
+        backend = AstBackend()
+        mocker.patch.object(backend, "is_available", return_value=True)
+        mocker.patch.object(backend, "_get_parser", return_value=FakeParser())
+
+        file_path = tmp_path / "test.py"
+        file_path.write_text("a\nb\nc\n", encoding="utf-8")
+
+        result = backend.search(
+            str(file_path),
+            "function_definition",
+            SearchConfig(ast=True, lang="python", max_count=2),
+        )
+
+        assert result.total_matches == 2
+        assert [m.line_number for m in result.matches] == [1, 2]
 
     def test_should_reuse_shared_in_memory_caches_across_backend_instances(
         self, tmp_path, mocker, monkeypatch

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -120,6 +120,58 @@ def test_ast_wrapper_backend_should_emit_runtime_routing_metadata():
     assert result.routing_worker_count == 1
 
 
+def test_ast_wrapper_backend_should_honor_max_count_on_search():
+    """H6: --ast ... --max-count N must cap the returned matches, matching the
+    per-file cap semantics cpu_backend/rust already apply, instead of returning
+    every structural match ast-grep found."""
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps([
+        {"text": "def a():", "range": {"start": {"line": 0}}},
+        {"text": "def b():", "range": {"start": {"line": 1}}},
+        {"text": "def c():", "range": {"start": {"line": 2}}},
+    ])
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+    ):
+        result = backend.search(
+            "example.py",
+            "function_definition",
+            config=SearchConfig(ast=True, lang="python", max_count=2),
+        )
+
+    assert result.total_matches == 2
+    assert [m.line_number for m in result.matches] == [1, 2]
+
+
+def test_ast_wrapper_backend_should_honor_max_count_on_search_many():
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.stdout = json.dumps([
+        {"text": "def hello():", "file": "a.py", "range": {"start": {"line": 0}}},
+        {"text": "class World:", "file": "b.py", "range": {"start": {"line": 4}}},
+        {"text": "def again():", "file": "a.py", "range": {"start": {"line": 8}}},
+    ])
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+    ):
+        result = backend.search_many(
+            ["a.py", "b.py"],
+            "function_definition",
+            config=SearchConfig(ast=True, lang="python", max_count=1),
+        )
+
+    assert result.total_matches == 1
+
+
 def test_ast_wrapper_backend_should_batch_many_files():
     backend = AstGrepWrapperBackend()
 

--- a/tests/unit/test_stringzilla_backend.py
+++ b/tests/unit/test_stringzilla_backend.py
@@ -184,6 +184,96 @@ def test_stringzilla_cache_hit_search_uses_sorted_posting_intersection(tmp_path,
     assert calls["count"] == 1
 
 
+def test_stringzilla_honors_invert_match_indexed_path(backend, tmp_path):
+    """H5: -F --invert-match must return the COMPLEMENT (lines NOT containing the
+    pattern), not the matching lines. Pattern length >=3 hits the trigram-index
+    fast path by default; invert_match must fall through to a full scan there since
+    the index can only answer "which lines DO contain every trigram", not the
+    inverse."""
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("INFO ok\nERROR failure\nDEBUG trace\nERROR timeout\n", encoding="utf-8")
+
+    config = SearchConfig(fixed_strings=True, invert_match=True)
+    result = backend.search(str(log_file), "ERROR", config=config)
+
+    assert result.total_matches == 2
+    assert [m.line_number for m in result.matches] == [1, 3]
+    assert all("ERROR" not in m.text for m in result.matches)
+
+
+def test_stringzilla_honors_invert_match_matches_cpu_backend(tmp_path):
+    """H5 parity: stringzilla's inverted result must match CPUBackend's (the
+    already-correct reference implementation) for the same query."""
+    from tensor_grep.backends.cpu_backend import CPUBackend
+
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("INFO ok\nERROR failure\nDEBUG trace\nERROR timeout\n", encoding="utf-8")
+
+    config = SearchConfig(fixed_strings=True, invert_match=True)
+    sz_result = StringZillaBackend().search(str(log_file), "ERROR", config=config)
+    cpu_result = CPUBackend().search(str(log_file), "ERROR", config)
+
+    assert sz_result.total_matches == cpu_result.total_matches
+    assert [m.line_number for m in sz_result.matches] == [
+        m.line_number for m in cpu_result.matches
+    ]
+
+
+def test_stringzilla_honors_invert_match_non_indexed_path(backend, tmp_path, monkeypatch):
+    """H5 also applies on the short-pattern (<3 chars) path that bypasses the
+    trigram index entirely."""
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("hi\nno\nhi\n", encoding="utf-8")
+
+    config = SearchConfig(fixed_strings=True, invert_match=True)
+    result = backend.search(str(log_file), "hi", config=config)
+
+    assert result.total_matches == 1
+    assert result.matches[0].line_number == 2
+
+
+def test_stringzilla_honors_max_count_indexed_path(backend, tmp_path):
+    """H6: -F --max-count 2 must cap to exactly 2 matches, matching rg/cpu_backend's
+    per-file cap semantics, not return every match."""
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("ERROR one\nERROR two\nERROR three\nERROR four\n", encoding="utf-8")
+
+    config = SearchConfig(fixed_strings=True, max_count=2)
+    result = backend.search(str(log_file), "ERROR", config=config)
+
+    assert result.total_matches == 2
+    assert [m.line_number for m in result.matches] == [1, 2]
+
+
+def test_stringzilla_max_count_matches_cpu_backend(tmp_path):
+    from tensor_grep.backends.cpu_backend import CPUBackend
+
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("ERROR one\nERROR two\nERROR three\nERROR four\n", encoding="utf-8")
+
+    config = SearchConfig(fixed_strings=True, max_count=3)
+    sz_result = StringZillaBackend().search(str(log_file), "ERROR", config=config)
+    cpu_result = CPUBackend().search(str(log_file), "ERROR", config)
+
+    assert sz_result.total_matches == cpu_result.total_matches == 3
+    assert [m.line_number for m in sz_result.matches] == [
+        m.line_number for m in cpu_result.matches
+    ]
+
+
+def test_stringzilla_honors_max_count_non_indexed_path(backend, tmp_path, monkeypatch):
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("hi\nhi\nhi\n", encoding="utf-8")
+
+    config = SearchConfig(fixed_strings=True, max_count=2)
+    result = backend.search(str(log_file), "hi", config=config)
+
+    assert result.total_matches == 2
+    assert [m.line_number for m in result.matches] == [1, 2]
+
+
 def test_stringzilla_in_memory_index_cache_obeys_entry_cap(tmp_path, monkeypatch):
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX_CACHE_MAX_ENTRIES", "2")

--- a/tests/unit/test_stringzilla_backend.py
+++ b/tests/unit/test_stringzilla_backend.py
@@ -214,9 +214,7 @@ def test_stringzilla_honors_invert_match_matches_cpu_backend(tmp_path):
     cpu_result = CPUBackend().search(str(log_file), "ERROR", config)
 
     assert sz_result.total_matches == cpu_result.total_matches
-    assert [m.line_number for m in sz_result.matches] == [
-        m.line_number for m in cpu_result.matches
-    ]
+    assert [m.line_number for m in sz_result.matches] == [m.line_number for m in cpu_result.matches]
 
 
 def test_stringzilla_honors_invert_match_non_indexed_path(backend, tmp_path, monkeypatch):
@@ -257,9 +255,7 @@ def test_stringzilla_max_count_matches_cpu_backend(tmp_path):
     cpu_result = CPUBackend().search(str(log_file), "ERROR", config)
 
     assert sz_result.total_matches == cpu_result.total_matches == 3
-    assert [m.line_number for m in sz_result.matches] == [
-        m.line_number for m in cpu_result.matches
-    ]
+    assert [m.line_number for m in sz_result.matches] == [m.line_number for m in cpu_result.matches]
 
 
 def test_stringzilla_honors_max_count_non_indexed_path(backend, tmp_path, monkeypatch):


### PR DESCRIPTION
Fable correctness audit — two HIGH wrong-output bugs (the `--pcre2` silent-flag-drop class):

- **H5**: StringZillaBackend had ZERO references to `invert_match` — `tg search -F --invert-match` returned MATCHING lines instead of the complement. Now honors it (complement of the normal result), with the line-model matched to the CPU backend so counts agree exactly.
- **H6**: StringZilla + AST backends had ZERO references to `max_count` — `--max-count N` returned every match. Now capped per-file, matching the primary backends' semantics.

**Verified:** full backend suite 68 passed in the real venv (incl. new tests asserting StringZilla/AST now match the CPU backend for these flags); ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)