### PR TITLE
fix(FFI R1): pass Rust bridge args by keyword + real-extension bidirectional test (retires the mock-green-but-dead bridge class)

### DIFF
--- a/src/tensor_grep/backends/rust_backend.py
+++ b/src/tensor_grep/backends/rust_backend.py
@@ -196,53 +196,57 @@ class RustCoreBackend(ComputeBackend):
         bridge_fallback_reason: str | None = None
         if pcre2 or max_filesize or no_ignore_vcs:
             try:
+                # Every argument is passed by KEYWORD (matching the exact parameter names of
+                # `execute_ripgrep` in rust_core/src/lib.rs) so that any future Rust-side signature
+                # drift (an inserted/reordered/renamed parameter) raises a loud TypeError instead of
+                # silently shifting every trailing bool into the wrong flag (R1a).
                 exit_code = self.inner.execute_ripgrep(
-                    [pattern],
-                    str(file_path),
-                    ignore_case,
-                    fixed_strings,
-                    invert_match,
-                    count_only,
-                    False,  # count_matches
-                    config.line_number if config else True,
-                    config.column if config else False,
-                    config.only_matching if config else False,
-                    config.context if config else None,
-                    config.before_context if config else None,
-                    config.after_context if config else None,
-                    config.max_count if config else None,
-                    config.word_regexp if config else False,
-                    config.smart_case if config else False,
-                    (config.glob or []) if config else [],
-                    config.no_ignore if config else False,
-                    config.no_ignore_dot if config else False,
-                    config.no_ignore_exclude if config else False,
-                    config.no_ignore_files if config else False,
-                    config.no_ignore_global if config else False,
-                    config.no_ignore_parent if config else False,
-                    no_ignore_vcs,
-                    config.hidden if config else False,
-                    config.follow if config else False,
-                    config.text if config else False,
-                    False,  # files_with_matches
-                    False,  # files_without_match
-                    (config.file_type or []) if config else [],
-                    config.color if config else None,
-                    config.replace_str if config else None,
-                    config.passthru if config else False,
-                    config.no_config if config else False,
-                    pcre2,
-                    max_filesize,
+                    patterns=[pattern],
+                    path=str(file_path),
+                    ignore_case=ignore_case,
+                    fixed_strings=fixed_strings,
+                    invert_match=invert_match,
+                    count=count_only,
+                    count_matches=False,
+                    line_number=config.line_number if config else True,
+                    column=config.column if config else False,
+                    only_matching=config.only_matching if config else False,
+                    context=config.context if config else None,
+                    before_context=config.before_context if config else None,
+                    after_context=config.after_context if config else None,
+                    max_count=config.max_count if config else None,
+                    word_regexp=config.word_regexp if config else False,
+                    smart_case=config.smart_case if config else False,
+                    globs=(config.glob or []) if config else [],
+                    no_ignore=config.no_ignore if config else False,
+                    no_ignore_dot=config.no_ignore_dot if config else False,
+                    no_ignore_exclude=config.no_ignore_exclude if config else False,
+                    no_ignore_files=config.no_ignore_files if config else False,
+                    no_ignore_global=config.no_ignore_global if config else False,
+                    no_ignore_parent=config.no_ignore_parent if config else False,
+                    no_ignore_vcs=no_ignore_vcs,
+                    hidden=config.hidden if config else False,
+                    follow=config.follow if config else False,
+                    text=config.text if config else False,
+                    files_with_matches=False,
+                    files_without_match=False,
+                    file_types=(config.file_type or []) if config else [],
+                    color=config.color if config else None,
+                    replace=config.replace_str if config else None,
+                    passthru=config.passthru if config else False,
+                    no_config=config.no_config if config else False,
+                    pcre2=pcre2,
+                    max_filesize=max_filesize,
                     # Previously hardcoded in the PyO3 bridge (audit #3) — forward them so a
                     # passthrough search honors these flags. no_line_number carries the resolved
                     # "hide" decision (rg_passthrough checks no_line_number before line_number).
-                    not (config.line_number if config else True),
-                    config.path_separator if config else None,
-                    config.vimgrep if config else False,
-                    config.sort_files if config else False,
-                    config.max_depth if config else None,
-                    config.null if config else False,
-                    config.null_data if config else False,
+                    no_line_number=not (config.line_number if config else True),
+                    path_separator=config.path_separator if config else None,
+                    vimgrep=config.vimgrep if config else False,
+                    sort_files=config.sort_files if config else False,
+                    max_depth=config.max_depth if config else None,
+                    null=config.null if config else False,
+                    null_data=config.null_data if config else False,
                 )
                 # Results are emitted directly to stdout by the ripgrep binary, so the exact match
                 # count is unknowable here. Reflect FOUND-vs-NOT-FOUND via rg's exit code (0 = at
@@ -281,7 +285,10 @@ class RustCoreBackend(ComputeBackend):
             if count_only and not invert_match:
                 # Use highly-optimized Rayon parallel count fast-path
                 total_count = self.inner.count_matches(
-                    pattern, str(file_path), ignore_case, fixed_strings
+                    pattern=pattern,
+                    path=str(file_path),
+                    ignore_case=ignore_case,
+                    fixed_strings=fixed_strings,
                 )
                 return SearchResult(
                     matches=[],  # No lines needed for count
@@ -295,13 +302,18 @@ class RustCoreBackend(ComputeBackend):
                     fallback_reason=bridge_fallback_reason,
                 )
 
-            # Support older signature and new signature smoothly
-            try:
-                results = self.inner.search(
-                    pattern, str(file_path), ignore_case, fixed_strings, invert_match
-                )
-            except TypeError:
-                results = self.inner.search(pattern, str(file_path), ignore_case, fixed_strings)
+            # Single signature, keyword args: the extension has supported `invert_match` since
+            # before this bridge shipped, so the old 4-arg fallback (R7a) targeted a checkpoint
+            # that no longer exists and — worse — swallowed a real TypeError raised *inside* the
+            # Rust function under the same exception type, which would silently drop
+            # invert_match and return wrong results instead of surfacing the failure.
+            results = self.inner.search(
+                pattern=pattern,
+                path=str(file_path),
+                ignore_case=ignore_case,
+                fixed_strings=fixed_strings,
+                invert_match=invert_match,
+            )
         except Exception as exc:
             if _is_invalid_regex_error(exc):
                 raise InvalidRegexError(f"invalid regex pattern: {exc}") from exc

--- a/tests/unit/test_rust_core.py
+++ b/tests/unit/test_rust_core.py
@@ -28,6 +28,37 @@ def test_rust_backend_search(tmp_path: Path):
     assert result.routing_reason == "rust_regex"
 
 
+def test_rust_backend_real_extension_bidirectional_oracle(tmp_path: Path):
+    """R1: exercise the REAL pyo3 extension end-to-end through the keyword-argument bridge.
+
+    A bidirectional oracle -- a correct query MATCHES and a wrong query returns EMPTY, and an
+    invert_match query returns the complement -- so a dead or mis-forwarded bridge is caught here
+    (a ``*args, **kwargs`` mock would swallow a transposed/dropped flag silently). Passing every
+    argument by keyword also means a future Rust-side signature change fails loudly with a
+    ``TypeError`` instead of silently shifting flag meanings.
+    """
+    import importlib.util
+
+    if not importlib.util.find_spec("tensor_grep.rust_core"):
+        pytest.skip("native tensor_grep.rust_core extension not compiled")
+
+    from tensor_grep.backends.rust_backend import RustCoreBackend
+    from tensor_grep.core.config import SearchConfig
+
+    log_file = tmp_path / "bidir.txt"
+    log_file.write_text("alpha\nbeta\nalpha\n")
+    backend = RustCoreBackend()
+    assert backend.is_available()
+
+    # match direction: 'alpha' appears on two lines
+    assert backend.search(str(log_file), "alpha", SearchConfig()).total_matches == 2
+    # non-match direction (the half a one-sided test misses): a wrong query returns EMPTY
+    assert backend.search(str(log_file), "zzz", SearchConfig()).total_matches == 0
+    # invert_match kwarg forwards correctly: the complement is the single 'beta' line
+    inverted = backend.search(str(log_file), "alpha", SearchConfig(invert_match=True))
+    assert inverted.total_matches == 1
+
+
 def test_rust_backend_respects_invert_and_skips_count_fast_path(monkeypatch, tmp_path: Path):
     from tensor_grep.backends import rust_backend as rb
     from tensor_grep.core.config import SearchConfig

--- a/tests/unit/test_rust_core.py
+++ b/tests/unit/test_rust_core.py
@@ -143,15 +143,22 @@ def test_rust_backend_limit_passthrough_reports_found_via_exit_code(monkeypatch,
 def test_rust_limit_passthrough_forwards_previously_dropped_rg_flags(monkeypatch, tmp_path: Path):
     """The PyO3 execute_ripgrep bridge must FORWARD path_separator/vimgrep/sort_files/max_depth/null/
     null_data and the resolved no_line_number, not hardcode them — rg_passthrough.rs already supports
-    them. Audit #3 (the bug was the Python<->Rust bridge, not the rg command builder)."""
+    them. Audit #3 (the bug was the Python<->Rust bridge, not the rg command builder).
+
+    R1a: the bridge call now passes every argument by KEYWORD (matching the exact parameter names of
+    `execute_ripgrep` in rust_core/src/lib.rs), so this fake captures **kwargs and asserts by name
+    instead of by position — a stale/renamed key here would raise KeyError immediately rather than
+    silently reading the wrong positional slot.
+    """
     from tensor_grep.backends import rust_backend as rb
     from tensor_grep.core.config import SearchConfig
 
-    captured: dict[str, tuple] = {}
+    captured: dict[str, dict] = {}
 
     class FakeNativeRustBackend:
         def execute_ripgrep(self, *args, **kwargs):
-            captured["args"] = args
+            assert args == (), "execute_ripgrep must be called with keyword args only (R1a)"
+            captured["kwargs"] = kwargs
             return 0
 
     monkeypatch.setattr(rb, "HAVE_RUST", True)
@@ -172,16 +179,20 @@ def test_rust_limit_passthrough_forwards_previously_dropped_rg_flags(monkeypatch
     )
 
     backend.search(str(log_file), "ERROR", config=config)
-    args = captured["args"]
-    # The 7 previously-dropped fields are appended after the existing 36 positional bridge args, in
-    # order: no_line_number (= not line_number), path_separator, vimgrep, sort_files, max_depth, null,
-    # null_data. rg_passthrough.rs checks no_line_number before line_number, so a resolved "hide" must
-    # arrive as no_line_number=True.
-    assert args[-7:] == (True, "/", True, True, 5, True, True)
-    # globs (idx 16) and file_types (idx 29) must be [] not None: rg's PyO3 Vec<String> rejects None,
-    # which silently fell the whole passthrough back to a flag-dropping path (config.glob and
-    # config.file_type both default to None). This guard is what makes #2/#3 actually take effect.
-    assert args[16] == [] and args[29] == []
+    kwargs = captured["kwargs"]
+    # rg_passthrough.rs checks no_line_number before line_number, so a resolved "hide" must arrive as
+    # no_line_number=True.
+    assert kwargs["no_line_number"] is True
+    assert kwargs["path_separator"] == "/"
+    assert kwargs["vimgrep"] is True
+    assert kwargs["sort_files"] is True
+    assert kwargs["max_depth"] == 5
+    assert kwargs["null"] is True
+    assert kwargs["null_data"] is True
+    # globs/file_types must be [] not None: rg's PyO3 Vec<String> rejects None, which silently fell
+    # the whole passthrough back to a flag-dropping path (config.glob and config.file_type both
+    # default to None). This guard is what makes #2/#3 actually take effect.
+    assert kwargs["globs"] == [] and kwargs["file_types"] == []
 
 
 def test_rust_pcre2_bridge_failure_fails_closed(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
Fable architecture audit R1 — the repo's worst bug class at its most exposed seam.

`rust_backend.py` forwarded ~44 POSITIONAL args to the pyo3 `execute_ripgrep` (33 bools). A Rust-side signature reorder would silently transpose flags — nothing crashes, results go wrong — and every test used a `*args/**kwargs` mock, so the contract was pinned nowhere.

**Fix:** every argument now passed BY KEYWORD (names matched to `rust_core/src/lib.rs`), so future signature drift fails loudly with `TypeError: unexpected keyword argument` instead of shifting flag meanings. Plus a new **real-extension bidirectional oracle** test (`importorskip`-guarded): exercises the live pyo3 bridge with a match (2), a non-match (0), and an `invert_match` complement (1) — the check a mock cannot make.

**Verified against the REAL .pyd** (not a mock, per the 'verify FFI against the real extension' rule): live `RustCoreBackend` search returns 2/0/1 correctly. 53 tests pass (rust_core + pipeline); ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)