### PR TITLE
fix(audit LOW): F15 rerank docstring accuracy + F23 go.work use-parsing

### DIFF
--- a/src/tensor_grep/cli/lang_go.py
+++ b/src/tensor_grep/cli/lang_go.py
@@ -407,11 +407,17 @@ def _go_work_use_dirs(go_work_path: Path) -> list[str]:
         return []
     dirs: list[str] = []
     for line_match in _GO_WORK_USE_LINE_RE.finditer(text):
-        dirs.append(line_match.group(1).strip())
+        candidate = line_match.group(1).strip()
+        # F23: the single-line `use ...$` regex also matches the `use (` block-open header,
+        # capturing "(" (or a compact `use (./m)`). Never treat the block opener as a directory.
+        if candidate and not candidate.startswith("("):
+            dirs.append(candidate)
     for block_match in _GO_WORK_USE_BLOCK_RE.finditer(text):
         for raw_line in block_match.group(1).splitlines():
-            candidate = raw_line.strip()
-            if candidate and not candidate.startswith("//"):
+            # F23: strip a trailing `// comment` (e.g. `./m // legacy`), not just full-line
+            # comments -- otherwise the comment text becomes part of the resolved directory path.
+            candidate = raw_line.split("//", 1)[0].strip()
+            if candidate:
                 dirs.append(candidate)
     return dirs
 

--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -75,8 +75,12 @@ def rerank_hybrid(
     Mirrors :func:`rerank_by_bm25`: SAME matches as the input, only the order changes. The BM25
     leg always runs; the dense leg is optional -- the caller owns dense-leg availability and the
     fail-closed BM25-only degrade (see ``core/retrieval_dense.py``), so ``dense_index=None`` here
-    simply means "fuse with the BM25 leg alone" (still routed through RRF, which is equivalent to
-    a stable BM25-only ordering when there is nothing to fuse it with).
+    simply means "fuse with the BM25 leg alone" (still routed through RRF).
+
+    NOTE (F15): a BM25-only RRF degrade is NOT byte-identical to :func:`rerank_by_bm25` on a BM25
+    SCORE TIE -- RRF breaks ties by ascending chunk index, whereas ``rerank_by_bm25``'s stable sort
+    preserves grep order. Both are valid orderings; when ``--semantic`` is requested the fused path
+    is authoritative, so this is a benign ordering divergence, not a correctness gap.
     """
     if not result.matches:
         return dataclasses.replace(result, matches=list(result.matches))

--- a/tests/unit/test_lang_go.py
+++ b/tests/unit/test_lang_go.py
@@ -610,6 +610,31 @@ def test_import_path_extraction_returns_none_for_missing_path_field() -> None:
 
 
 # ---------------------------------------------------------------------------
+# F23: go.work `use` parsing -- header not captured, trailing comments stripped.
+# ---------------------------------------------------------------------------
+
+
+def test_go_work_use_dirs_ignores_header_and_strips_comments(tmp_path: Path) -> None:
+    go_work = tmp_path / "go.work"
+    go_work.write_text(
+        "go 1.21\n\n"
+        "use ./single\n"
+        "use (\n"
+        "\t./blockmod\n"
+        "\t./commented // legacy module\n"
+        "\t// ./skipped-fullline-comment\n"
+        ")\n",
+        encoding="utf-8",
+    )
+    dirs = lang_go._go_work_use_dirs(go_work)
+    # single-line + block entries resolve; the `use (` header ("(") is NOT a dir; the trailing
+    # `// legacy module` comment is stripped; the full-line comment line is skipped.
+    assert dirs == ["./single", "./blockmod", "./commented"]
+    assert "(" not in dirs
+    assert not any("//" in d or "legacy" in d for d in dirs)
+
+
+# ---------------------------------------------------------------------------
 # F24: an intervening (nested, non-go.work) go.mod stops import resolution.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two independent LOW-tail fixes from the Fable audit (#63), in files nothing else in flight touches:

- **F15** (`core/reranker.py`): the `rerank_hybrid` docstring claimed a BM25-only RRF degrade is 'equivalent to a stable BM25-only ordering' — untrue on a BM25 SCORE TIE (RRF breaks ties by ascending chunk index; `rerank_by_bm25` preserves grep order). Both are valid; corrected the doc so it doesn't over-claim byte-identity. Docs-only, no behavior change.
- **F23** (`cli/lang_go.py` `_go_work_use_dirs`): the single-line `use` regex also matched the `use (` block-open header (captured '('), and the block loop only skipped full-line comments — a `use ./m // legacy` line kept the trailing comment in the resolved dir. Now skips the header + strips trailing `//` comments. Added a TDD test.

**Verified:** 26 tests pass in the real venv (incl. the new F23 test); ruff/format/mypy clean. F26 (Go `_walk` recursion→explicit-stack) deferred — it's a refactor needing golden parity, not a quick fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)