### PR TITLE
perf(repo_map): parse-product cache — one tree-sitter parse per (file,mtime) shared across symbol/ref/caller extractors (the #1 latency fix)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1155,6 +1155,92 @@ def _read_source_cached_bounded(path_str: str) -> bytes:
     return Path(path_str).read_bytes()
 
 
+# PERF increment 1 (parse-product cache, Fable-designed): every JS/TS/Rust symbol/ref/caller
+# extractor independently did its own `path.read_text(...)` + `parser.parse(...)` on the SAME
+# file -- caller_scan and edit-plan seeding can re-parse one file up to 3x per symbol lookup
+# (_js_ts_parser_symbols during repo-map build, _js_ts_references_and_calls during caller_scan,
+# _js_ts_import_update_target during edit-plan seeding -- the last one alone profiled at ~26% of
+# edit_plan wall time). These two functions share ONE read + ONE parse per (path, mtime, size)
+# across all of them via the same @_mtime_aware_cache seam Fix A/B7 already use.
+#
+# CRITICAL PARITY: _read_source_text_cached uses Path.read_text (universal-newline \r\n -> \n
+# translation) -- NOT a decode() of the raw-bytes cache above -- because that translated text is
+# exactly what every tree-sitter consumer .encode()'s and parses today. A raw-bytes .decode()
+# would leave \r\n intact and shift every node's byte offset on a CRLF file (silent wrong output
+# on Windows-authored sources). Do not "simplify" this into a decode of _read_source_cached.
+def _read_source_text_cached(path_str: str) -> str:
+    """Read file text (universal-newline decoded), cached by (mtime_ns, size).
+
+    Mirrors _read_source_cached's outer/inner split: oversize files bypass the cache entirely
+    (Guard 4) and are read directly, uncached, every call.
+    """
+    try:
+        size = Path(path_str).stat().st_size
+    except OSError:
+        size = -1
+    if size < 0 or size > _SYMBOL_LITERAL_SEED_MAX_BYTES:
+        return Path(path_str).read_text(encoding="utf-8")
+    return _read_source_text_cached_bounded(path_str)
+
+
+@_mtime_aware_cache(maxsize=_SOURCE_READ_CACHE_MAXSIZE)
+def _read_source_text_cached_bounded(path_str: str) -> str:
+    return Path(path_str).read_text(encoding="utf-8")
+
+
+_PARSE_PRODUCT_CACHE_MAXSIZE = 1024
+
+
+def _parser_for_source_suffix(suffix: str) -> Any | None:
+    """Select the tree-sitter parser the same way each consumer picked one inline before this
+    fix -- TS suffixes (incl. tsx) get the typescript parser, the rest of the JS/TS suffix set
+    gets the javascript parser, Rust gets the rust parser. Returns None for any other suffix (a
+    caller-side suffix pre-check, e.g. `path.suffix not in _JS_TS_SUFFIXES`, is expected to have
+    already gated the call, matching the pre-fix per-site behavior)."""
+    if suffix in _TS_SUFFIXES:
+        return _typescript_parser(tsx=suffix == ".tsx")
+    if suffix in _JS_TS_SUFFIXES:
+        return _javascript_parser()
+    if suffix in _RUST_SUFFIXES:
+        return _rust_parser()
+    return None
+
+
+def _parse_source_uncached(path_str: str) -> tuple[str, bytes, Any] | None:
+    parser = _parser_for_source_suffix(Path(path_str).suffix)
+    if parser is None:
+        return None
+    try:
+        source = _read_source_text_cached(path_str)
+    except (OSError, UnicodeDecodeError):
+        return None
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    return source, source_bytes, tree
+
+
+def _parsed_source_and_tree(path_str: str) -> tuple[str, bytes, Any] | None:
+    """One tree-sitter parse per (path, mtime, size), shared across every symbol/ref/caller/
+    import-update-target extractor that used to parse this file independently.
+
+    Guard-4 mirror (:1134-1150 note above _read_source_cached): oversize files bypass the
+    parse-product cache too -- stat-fail or size over _SYMBOL_LITERAL_SEED_MAX_BYTES reads +
+    parses UNCACHED every call, via the same outer/inner split as _read_source_cached/_bounded.
+    """
+    try:
+        size = Path(path_str).stat().st_size
+    except OSError:
+        size = -1
+    if size < 0 or size > _SYMBOL_LITERAL_SEED_MAX_BYTES:
+        return _parse_source_uncached(path_str)
+    return _parsed_source_and_tree_bounded(path_str)
+
+
+@_mtime_aware_cache(maxsize=_PARSE_PRODUCT_CACHE_MAXSIZE)
+def _parsed_source_and_tree_bounded(path_str: str) -> tuple[str, bytes, Any] | None:
+    return _parse_source_uncached(path_str)
+
+
 def _file_may_contain_literal_symbol(path: Path, symbol: str) -> bool:
     normalized_symbol = (symbol or "").strip()
     if not normalized_symbol:
@@ -1194,12 +1280,48 @@ def _file_may_import_symbol_definition(path: Path, definition_files: list[str]) 
     if not any(marker in lowered for marker in spec.import_markers):
         return False
     if spec.language_id in ("javascript", "typescript"):
-        return True
+        # PERF increment 1 / Section C (Fable-designed): a naive mirror of the branch below --
+        # matching a definition-file alias literally in this file's text -- changes results and
+        # drops a pinned caller: _module_aliases_for_path yields the DEFINITION file's own
+        # stem/parts, but a barrel re-export consumer (`import { x as y } from "./barrel"`) has
+        # neither the target symbol's name nor the definition file's alias anywhere in its text
+        # -- see test_js_ts_advanced_resolution.py::
+        # test_aliased_re_export_chain_resolves_to_original_definition. The SOUND gate instead
+        # checks for >=1 import BINDING from the exact set the expensive checks
+        # (_js_ts_file_imports_symbol_from_definition, _js_ts_import_update_target) can ever
+        # match through -- named/default/namespace imports -- which a barrel consumer always
+        # has (its own `import {...} from "./barrel"` statement), independent of what the
+        # definition file is named. This only gates out files with zero real import bindings
+        # (an "import"/"from"/"require(" marker hit only inside a comment or string, or an
+        # export-only barrel leaf with no import statement of its own).
+        return _js_ts_has_import_bindings(str(path))
     for definition_file in definition_files:
         for alias in _module_aliases_for_path(definition_file):
             if alias and alias.encode("utf-8") in lowered:
                 return True
     return False
+
+
+@_mtime_aware_cache(maxsize=_SOURCE_READ_CACHE_MAXSIZE)
+def _js_ts_has_import_bindings(path_str: str) -> bool:
+    """True iff *path_str* has >=1 real JS/TS import binding (named/default/namespace).
+
+    Backs the sound gate in _file_may_import_symbol_definition above. Fails OPEN (True) on a
+    read error, matching the fail-open stat/read-error arms just above it (:1269-70, :1275-76)
+    -- an unreadable file must never be silently excluded from the caller/import-graph scan.
+    """
+    try:
+        source = _read_source_text_cached(path_str)
+    except (OSError, UnicodeDecodeError):
+        return True
+    if any(
+        str(binding.get("statement_kind", "import")) == "import"
+        for binding in _js_ts_named_import_bindings(source)
+    ):
+        return True
+    if _js_ts_default_import_bindings(source):
+        return True
+    return bool(_js_ts_namespace_import_bindings(source))
 
 
 def _literal_symbol_seed_files(
@@ -2920,7 +3042,7 @@ def _file_imports_symbol_from_definition(
 ) -> bool:
     file_path = Path(path_str)
     try:
-        source = file_path.read_text(encoding="utf-8")
+        source = _read_source_text_cached(path_str)
     except (OSError, UnicodeDecodeError):
         return False
     spec = lang_registry.spec_for_path(file_path)
@@ -3029,17 +3151,18 @@ def _js_ts_import_update_target(
     repo_root: Path | str | None = None,
 ) -> dict[str, Any] | None:
     try:
-        source = file_path.read_text(encoding="utf-8")
+        source = _read_source_text_cached(str(file_path))
     except (OSError, UnicodeDecodeError):
         return None
 
-    parser = (
-        _typescript_parser(tsx=file_path.suffix == ".tsx")
-        if file_path.suffix in _TS_SUFFIXES
-        else _javascript_parser()
-    )
-    if parser is not None:
-        tree = parser.parse(source.encode("utf-8"))
+    # PERF increment 1 / read site 5 (Fable-designed, the "surprise 5th" site): this used to
+    # re-read + re-parse the file on every (file, symbol, definition) pair -- edit-plan seeding
+    # and _build_import_graph_consumers_from_map call it once per definition_file, profiled at
+    # ~26% of edit_plan wall time. Share the parse product with every other JS/TS extractor via
+    # the same (path, mtime, size)-keyed cache instead of parsing locally.
+    parsed = _parsed_source_and_tree(str(file_path))
+    if parsed is not None:
+        _parsed_source, _source_bytes, tree = parsed
         stack = [tree.root_node]
         while stack:
             node = stack.pop()
@@ -3502,7 +3625,7 @@ def _regex_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, An
         return [], []
 
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        lines = _read_source_text_cached(str(path)).splitlines()
     except (OSError, UnicodeDecodeError):
         return [], []
 
@@ -3669,20 +3792,10 @@ def _js_ts_parser_symbols(path: Path) -> list[dict[str, Any]]:
     if path.suffix not in _JS_TS_SUFFIXES:
         return []
 
-    if path.suffix in {".ts", ".tsx"}:
-        parser = _typescript_parser(tsx=path.suffix == ".tsx")
-    else:
-        parser = _javascript_parser()
-    if parser is None:
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
         return []
-
-    try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return []
-
-    source_bytes = source.encode("utf-8")
-    tree = parser.parse(source_bytes)
+    _source, source_bytes, tree = parsed
     symbols: list[dict[str, Any]] = []
 
     def _node_text(node: Any) -> str:
@@ -3721,17 +3834,10 @@ def _rust_parser_symbols(path: Path) -> list[dict[str, Any]]:
     if path.suffix not in _RUST_SUFFIXES:
         return []
 
-    parser = _rust_parser()
-    if parser is None:
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
         return []
-
-    try:
-        source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return []
-
-    source_bytes = source.encode("utf-8")
-    tree = parser.parse(source_bytes)
+    _source, source_bytes, tree = parsed
     symbols: list[dict[str, Any]] = []
 
     def _node_text(node: Any) -> str:
@@ -4145,23 +4251,20 @@ def _js_ts_references_and_calls(
     if path.suffix not in _JS_TS_SUFFIXES:
         return [], []
 
-    if path.suffix in {".ts", ".tsx"}:
-        parser = _typescript_parser(tsx=path.suffix == ".tsx")
-    else:
-        parser = _javascript_parser()
-    if parser is None:
-        return [], []
-
     try:
-        source = path.read_text(encoding="utf-8")
+        source = _read_source_text_cached(str(path))
     except (OSError, UnicodeDecodeError):
         return [], []
 
-    source_bytes = source.encode("utf-8")
-    tree = parser.parse(source_bytes)
-    lines = source.splitlines()
-    references: list[dict[str, Any]] = []
-    calls: list[dict[str, Any]] = []
+    # PERF increment 1 / Section B (Fable-designed): binding resolution only needs the source
+    # TEXT (not a parse tree), so it now runs BEFORE the parse -- letting a symbol-absent file
+    # skip tree-sitter parsing entirely below (the refs loop that follows has no prefilter,
+    # unlike the caller-scan literal check, so this is the biggest single payoff in this file).
+    # TRAP (do not reorder): this pass must run first so a renamed re-export
+    # (`export {x as y} from "./mod"`) still triggers a parse even though the literal target
+    # symbol name never appears in THIS file's text -- alias_names ends up non-empty and the
+    # early-exit below correctly falls through to parsing. See test_js_ts_advanced_resolution.py
+    # ::test_aliased_re_export_chain_resolves_to_original_definition.
     alias_resolution_by_name: dict[str, dict[str, Any]] = {}
     for binding in _js_ts_named_import_bindings(source):
         if str(binding.get("statement_kind", "import")) != "import":
@@ -4193,6 +4296,17 @@ def _js_ts_references_and_calls(
             continue
         alias_resolution_by_name[str(binding.get("local", ""))] = dict(resolved_import)
     alias_names = {name for name in alias_resolution_by_name if name}
+
+    if symbol not in source and not alias_names:
+        return [], []
+
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
+        return [], []
+    _parsed_source, source_bytes, tree = parsed
+    lines = source.splitlines()
+    references: list[dict[str, Any]] = []
+    calls: list[dict[str, Any]] = []
 
     def _node_text(node: Any) -> str:
         return _tree_sitter_node_text(source_bytes, node)
@@ -4310,7 +4424,7 @@ def _js_ts_provider_alias_calls(
         return []
 
     try:
-        source = path.read_text(encoding="utf-8")
+        source = _read_source_text_cached(str(path))
     except (OSError, UnicodeDecodeError):
         return []
 
@@ -4522,20 +4636,15 @@ def _rust_references_and_calls(
     if path.suffix not in _RUST_SUFFIXES:
         return [], []
 
-    parser = _rust_parser()
-    if parser is None:
-        return [], []
-
     try:
-        source = path.read_text(encoding="utf-8")
+        source = _read_source_text_cached(str(path))
     except (OSError, UnicodeDecodeError):
         return [], []
 
-    source_bytes = source.encode("utf-8")
-    tree = parser.parse(source_bytes)
-    lines = source.splitlines()
-    references: list[dict[str, Any]] = []
-    calls: list[dict[str, Any]] = []
+    # PERF increment 1 / Section B mirror (Fable-designed): same alias-aware early exit as
+    # _js_ts_references_and_calls above -- bindings only need the source TEXT, so they're
+    # resolved before the parse, and a symbol-absent file with no matching `use` binding skips
+    # tree-sitter parsing entirely.
     bindings = _rust_use_bindings(source)
     local_name_resolution_by_name: dict[str, dict[str, Any]] = {}
     for binding in bindings:
@@ -4547,6 +4656,17 @@ def _rust_references_and_calls(
         if bool(binding.get("wildcard")):
             local_name_resolution_by_name.setdefault(symbol, dict(resolved_import))
     local_names = {name for name in local_name_resolution_by_name if name}
+
+    if symbol not in source and not local_names:
+        return [], []
+
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
+        return [], []
+    _parsed_source, source_bytes, tree = parsed
+    lines = source.splitlines()
+    references: list[dict[str, Any]] = []
+    calls: list[dict[str, Any]] = []
 
     def _node_text(node: Any) -> str:
         return _tree_sitter_node_text(source_bytes, node)

--- a/tests/unit/test_parse_product_cache.py
+++ b/tests/unit/test_parse_product_cache.py
@@ -1,0 +1,346 @@
+"""PERF increment 1 (Fable-designed): parse-product cache.
+
+_js_ts_parser_symbols, _js_ts_references_and_calls, _rust_parser_symbols,
+_rust_references_and_calls, and _js_ts_import_update_target each used to independently
+`path.read_text(...)` + `parser.parse(...)` the SAME file -- caller_scan and edit-plan seeding
+could re-parse one file up to 3x per symbol lookup (_js_ts_import_update_target alone profiled
+at ~26% of edit_plan wall time). This suite exercises the golden-parity plan for the fix:
+
+  1. one-parse spy: build_repo_map -> build_symbol_callers_from_map -> build_symbol_refs_from_map
+     parses each JS/TS file at most once total; a second full pass adds zero more parses.
+  2. staleness: editing a file to a DIFFERENT byte length invalidates the parse-product cache
+     (the (mtime_ns, size) key changes) and forces a re-parse.
+  3. early-exit: a file with neither the literal symbol nor any resolved import alias skips
+     parsing entirely; a barrel consumer that only imports an ALIAS of the target symbol
+     (`import { x as y } from "./barrel"`) still parses (alias-aware) and resolves correctly.
+  4. gate: _file_may_import_symbol_definition's JS/TS branch is sound -- False for
+     comment-only/export-only files with zero real import bindings, True for each import
+     binding kind, and (the trap a naive definition-file-alias mirror would fail) True for a
+     barrel consumer whose own import statement never mentions the definition file at all.
+  5. daemon flush: _clear_all_source_caches() sweeps both the new text cache and the new
+     parse-product cache.
+  6. oversize bypass: a file over the byte cap bypasses the parse-product cache -- correct
+     output every time, but never cached (no cache growth).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli import repo_map
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _normalize(file_str: str) -> str:
+    return str(file_str).replace("\\", "/")
+
+
+def _spy_parse_calls(monkeypatch) -> dict[str, int]:
+    """Patch the single choke point every parse-product cache miss funnels through, so the
+    number of calls to it is exactly the number of REAL tree-sitter parses performed."""
+    calls = {"n": 0}
+    original = repo_map._parse_source_uncached
+
+    def counting(path_str: str):
+        calls["n"] += 1
+        return original(path_str)
+
+    monkeypatch.setattr(repo_map, "_parse_source_uncached", counting)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# (1) one-parse spy
+# ---------------------------------------------------------------------------
+
+
+def test_map_then_callers_then_refs_parses_each_file_at_most_once(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "project"
+    _write(
+        root / "src" / "core.ts",
+        "export function createInvoice(total) {\n  return total + 1;\n}\n",
+    )
+    _write(
+        root / "src" / "caller_a.ts",
+        'import { createInvoice } from "./core";\n\n'
+        "export function useA(total) {\n"
+        "  return createInvoice(total);\n"
+        "}\n",
+    )
+    _write(
+        root / "src" / "caller_b.ts",
+        'import { createInvoice } from "./core";\n\n'
+        "export function useB(total) {\n"
+        "  return createInvoice(total);\n"
+        "}\n",
+    )
+    _write(
+        root / "src" / "unrelated.ts",
+        "export function formatLabel(itemId) {\n  return `item-${itemId}`;\n}\n",
+    )
+
+    calls = _spy_parse_calls(monkeypatch)
+
+    repo_map_payload = repo_map.build_repo_map(str(root))
+    repo_map.build_symbol_callers_from_map(repo_map_payload, "createInvoice")
+    repo_map.build_symbol_refs_from_map(repo_map_payload, "createInvoice")
+
+    file_count = 4
+    assert calls["n"] == file_count, (
+        f"expected exactly {file_count} real parses (one per file), saw {calls['n']}"
+    )
+
+    # A second full pass over the SAME (unchanged) map must add zero additional parses.
+    repo_map.build_symbol_callers_from_map(repo_map_payload, "createInvoice")
+    repo_map.build_symbol_refs_from_map(repo_map_payload, "createInvoice")
+    assert calls["n"] == file_count, "warm cache: a second pass must not re-parse any file"
+
+
+# ---------------------------------------------------------------------------
+# (2) staleness
+# ---------------------------------------------------------------------------
+
+
+def test_edit_with_different_byte_length_forces_reparse(tmp_path, monkeypatch) -> None:
+    core = _write(
+        tmp_path / "core.ts",
+        "export function createInvoice(total) {\n  return total + 1;\n}\n",
+    )
+    calls = _spy_parse_calls(monkeypatch)
+
+    first = repo_map._parsed_source_and_tree(str(core))
+    assert first is not None
+    assert calls["n"] == 1
+
+    # Same content, same (mtime_ns, size) key in practice -- calling again must hit the cache.
+    second = repo_map._parsed_source_and_tree(str(core))
+    assert second is not None
+    assert calls["n"] == 1
+
+    # Rewrite with a DIFFERENT byte length -- the (mtime_ns, size) key changes, forcing a
+    # fresh parse with no explicit cache_clear() needed.
+    core.write_text(
+        "export function createInvoice(total) {\n  return total + 2;\n}\n\n// extra comment\n",
+        encoding="utf-8",
+    )
+    third = repo_map._parsed_source_and_tree(str(core))
+    assert third is not None
+    assert calls["n"] == 2
+    assert third[0] != first[0]
+
+
+# ---------------------------------------------------------------------------
+# (3) early-exit
+# ---------------------------------------------------------------------------
+
+
+def test_early_exit_symbol_absent_skips_parse_entirely(tmp_path, monkeypatch) -> None:
+    target = _write(
+        tmp_path / "leaf.ts",
+        "export function unrelatedThing() {\n  return 1;\n}\n",
+    )
+    calls = _spy_parse_calls(monkeypatch)
+
+    references, matched_calls = repo_map._js_ts_references_and_calls(target, "createInvoice")
+
+    assert references == []
+    assert matched_calls == []
+    assert calls["n"] == 0, "a file with neither the literal symbol nor an alias must not parse"
+
+
+def test_early_exit_rust_symbol_absent_skips_parse_entirely(tmp_path, monkeypatch) -> None:
+    target = _write(
+        tmp_path / "leaf.rs",
+        "fn unrelated_thing() -> i32 {\n    1\n}\n",
+    )
+    calls = _spy_parse_calls(monkeypatch)
+
+    references, matched_calls = repo_map._rust_references_and_calls(target, "create_invoice")
+
+    assert references == []
+    assert matched_calls == []
+    assert calls["n"] == 0
+
+
+def test_early_exit_aliased_re_export_still_parses_once_and_resolves(tmp_path, monkeypatch) -> None:
+    """The trap: an aliased barrel re-export (`export {x as y} from "./mod"`) means the target
+    symbol's literal name never appears in the consuming file's text at all -- the early exit
+    must still fall through to parsing because alias_names is non-empty (golden-parity anchor:
+    test_js_ts_advanced_resolution.py::test_aliased_re_export_chain_resolves_to_original_definition).
+    """
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    _write(
+        src_dir / "payments.ts",
+        "export function createInvoice(total) {\n  return total + 1;\n}\n",
+    )
+    _write(
+        src_dir / "barrel.ts",
+        'export { createInvoice as makeInvoice } from "./payments";\n',
+    )
+    service_path = _write(
+        src_dir / "service.ts",
+        'import { makeInvoice } from "./barrel";\n\n'
+        "export function buildReceipt(total) {\n"
+        "  return makeInvoice(total);\n"
+        "}\n",
+    )
+    assert "createInvoice" not in service_path.read_text(encoding="utf-8")
+
+    calls = _spy_parse_calls(monkeypatch)
+    references, _ = repo_map._js_ts_references_and_calls(service_path, "createInvoice", project)
+    assert calls["n"] > 0, "an alias-only match must still force at least one parse"
+    parses_after_first_call = calls["n"]
+    assert len(references) == 1
+    assert references[0]["line"] == 4
+    assert "re-export-chain" in references[0].get("resolution_provenance", [])
+
+    # Everything the chain resolution touched (service.ts itself, plus barrel.ts/payments.ts
+    # visited while resolving the "makeInvoice" -> "createInvoice" re-export) is now warm in the
+    # shared parse-product cache -- an identical repeat call must not re-parse ANY of them.
+    repo_map._js_ts_references_and_calls(service_path, "createInvoice", project)
+    assert calls["n"] == parses_after_first_call, "warm cache: repeat call must not re-parse"
+
+    # End-to-end: the public caller-scan surfaces the same resolved caller.
+    callers_payload = repo_map.build_symbol_callers("createInvoice", str(project))
+    service_callers = [
+        entry
+        for entry in callers_payload["callers"]
+        if _normalize(entry["file"]).endswith("src/service.ts")
+    ]
+    assert len(service_callers) == 1
+    assert service_callers[0]["line"] == 4
+    assert "re-export-chain" in service_callers[0]["resolution_provenance"]
+
+
+# ---------------------------------------------------------------------------
+# (4) gate: _file_may_import_symbol_definition's sound JS/TS branch
+# ---------------------------------------------------------------------------
+
+
+def test_gate_comment_only_import_marker_returns_false(tmp_path) -> None:
+    path = _write(
+        tmp_path / "leaf.ts",
+        "// an import used to live here\nexport function noop() {}\n",
+    )
+    definition_file = str(tmp_path / "def.ts")
+    assert repo_map._file_may_import_symbol_definition(path, [definition_file]) is False
+
+
+def test_gate_export_only_barrel_returns_false(tmp_path) -> None:
+    path = _write(
+        tmp_path / "barrel.ts",
+        'export { createInvoice } from "./payments";\n',
+    )
+    definition_file = str(tmp_path / "payments.ts")
+    assert repo_map._file_may_import_symbol_definition(path, [definition_file]) is False
+
+
+def test_gate_true_for_each_import_binding_kind(tmp_path) -> None:
+    named = _write(tmp_path / "named.ts", 'import { createInvoice } from "./payments";\n')
+    default = _write(tmp_path / "default.ts", 'import createInvoice from "./payments";\n')
+    namespace = _write(tmp_path / "namespace.ts", 'import * as payments from "./payments";\n')
+    definition_file = str(tmp_path / "payments.ts")
+    for path in (named, default, namespace):
+        assert repo_map._file_may_import_symbol_definition(path, [definition_file]) is True
+
+
+def test_gate_true_for_barrel_reexport_consumer_despite_no_definition_file_alias(
+    tmp_path,
+) -> None:
+    """The naive-mirror trap this gate design avoids: _module_aliases_for_path on the
+    DEFINITION file ("payments.ts") yields "payments"-derived aliases, none of which appear
+    anywhere in service.ts's text (it only ever mentions "./barrel"). A naive mirror of the
+    non-JS/TS branch would return False here and drop the caller; the sound gate instead checks
+    for ANY real import binding, which service.ts has (`import { makeInvoice } from "./barrel"`).
+    """
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    _write(
+        src_dir / "payments.ts",
+        "export function createInvoice(total) {\n  return total + 1;\n}\n",
+    )
+    _write(
+        src_dir / "barrel.ts",
+        'export { createInvoice as makeInvoice } from "./payments";\n',
+    )
+    service_path = _write(
+        src_dir / "service.ts",
+        'import { makeInvoice } from "./barrel";\n\n'
+        "export function buildReceipt(total) {\n"
+        "  return makeInvoice(total);\n"
+        "}\n",
+    )
+    definition_file = str(src_dir / "payments.ts")
+    assert repo_map._file_may_import_symbol_definition(service_path, [definition_file]) is True
+
+
+# ---------------------------------------------------------------------------
+# (5) daemon flush
+# ---------------------------------------------------------------------------
+
+
+def test_new_caches_registered_in_mtime_clear_registry() -> None:
+    assert repo_map._read_source_text_cached_bounded.cache_clear in (
+        repo_map._MTIME_CACHE_CLEAR_REGISTRY
+    )
+    assert repo_map._parsed_source_and_tree_bounded.cache_clear in (
+        repo_map._MTIME_CACHE_CLEAR_REGISTRY
+    )
+
+
+def test_clear_all_source_caches_sweeps_parse_product_cache(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "mod.ts"
+    target.write_text(
+        "export function createInvoice(total) {\n  return total + 1;\n}\n", encoding="utf-8"
+    )
+
+    frozen_key = (123456789, 999)
+    monkeypatch.setattr(repo_map, "_mtime_key", lambda path_str: frozen_key)
+
+    first = repo_map._parsed_source_and_tree(str(target))
+    assert first is not None
+    first_source = first[0]
+
+    # Same byte length, frozen mtime key: the pathological same-key-edit case a warm daemon
+    # can hit in practice.
+    target.write_text(
+        "export function createInvoice(total) {\n  return total + 9;\n}\n", encoding="utf-8"
+    )
+    still_stale = repo_map._parsed_source_and_tree(str(target))
+    assert still_stale is not None
+    assert still_stale[0] == first_source, "sanity: frozen key must serve the stale cached parse"
+
+    repo_map._clear_all_source_caches()
+    fresh = repo_map._parsed_source_and_tree(str(target))
+    assert fresh is not None
+    assert fresh[0] != first_source, "_clear_all_source_caches() must sweep the parse-product cache"
+
+
+# ---------------------------------------------------------------------------
+# (6) oversize bypass
+# ---------------------------------------------------------------------------
+
+
+def test_oversize_file_bypasses_parse_product_cache(tmp_path, monkeypatch) -> None:
+    big = tmp_path / "big.ts"
+    content = "export function createInvoice(total) {\n  return total + 1;\n}\n"
+    big.write_text(content, encoding="utf-8")
+    # Force the "too large to cache" branch without needing a real multi-MB fixture.
+    monkeypatch.setattr(repo_map, "_SYMBOL_LITERAL_SEED_MAX_BYTES", 10)
+
+    calls = _spy_parse_calls(monkeypatch)
+
+    first = repo_map._parsed_source_and_tree(str(big))
+    second = repo_map._parsed_source_and_tree(str(big))
+
+    assert first is not None
+    assert second is not None
+    assert first[0] == second[0] == content
+    # Bypassed the cache both times -- a giant file must never sit in the parse-product cache.
+    assert calls["n"] == 2


### PR DESCRIPTION
The #1 product latency fix (Fable-designed, golden-parity-locked). Research: the per-file tree-sitter parse is ~57% of cold-render time; today JS/TS files parse 2-3x (symbol extractor + each ref/caller scan + edit-plan seeding all re-parse independently).

**Increment 1** (repo_map.py only; Query-swap + Python-ast-cache deferred to phase 2):
- **Parse-product cache:** two `_mtime_aware_cache`d fns (`_read_source_text_cached` — uses `read_text` for CRLF-parity; `_parsed_source_and_tree` — one shared parse per (path,mtime,size), >2MB bypass). 5 read sites + `_file_imports_symbol_from_definition` consume it. Fail-closed: a cache miss maps to each consumer's exact current empty return (no new broad except).
- **Alias-aware early-exit:** `if symbol not in source and not alias_names: return [],[]` (binding-resolution runs FIRST so renamed re-exports still parse). Biggest payoff: the refs loop, which had no prefilter.
- **Sound import-binding gate** replacing the unconditional `return True` at `_file_may_import_symbol_definition` (the naive mirror would have dropped a pinned re-export caller — Fable caught this).

**Measured (tensor-grep, cold):** total 17.3s→13.0s (−25%), file_parse 4.75s→2.63s (−45%). Larger on TS-heavy repos. Unblocks raising `CALLER_SCAN_FILE_CEILING` (follow-up).

**Golden parity LOCKED:** 172 oracle tests pass UNCHANGED (byte-identical output) + 12 new parity tests (one-parse spy, staleness, barrel-rename trap, naive-mirror trap, daemon flush, oversize bypass); ruff/format/mypy clean. Verified in the real venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)