### PR TITLE
fix(M9): merge_runtime_routing surfaces mixed-backend routing instead of last-write-wins

### DIFF
--- a/src/tensor_grep/core/result.py
+++ b/src/tensor_grep/core/result.py
@@ -32,6 +32,14 @@ class SearchResult:
     routing_gpu_chunk_plan_mb: list[tuple[int, int]] = field(default_factory=list)
     routing_distributed: bool = False
     routing_worker_count: int = 0
+    # M9: the DISTINCT backends actually used across a heterogeneous per-file scan. `routing_backend`
+    # above is last-write-wins (a per-file merge overwrites it each call), so on a scan where some
+    # files ran on Torch and others fell back to CPU, `routing_backend` alone reports only whichever
+    # file was processed last — silently hiding that matches came from more than one engine. These
+    # two additive fields carry the truth: `routing_backends_seen` is the accumulated set (insertion
+    # order), `is_mixed_routing` is True once >1 distinct backend contributed.
+    routing_backends_seen: list[str] = field(default_factory=list)
+    is_mixed_routing: bool = False
     # GPU execution telemetry — optional; None when not measured or not applicable.
     # Populated by GPU backends that instrument their kernel and transfer timing.
     kernel_time_ms: float | None = None
@@ -64,6 +72,13 @@ def merge_runtime_routing(aggregate: SearchResult, result: SearchResult) -> None
     backend must adopt the runtime values rather than keep reporting the planned route.
     Shared by the CLI, MCP, and GPU-sidecar paths so the merge semantics cannot drift.
     """
+    # M9: accumulate the distinct backends BEFORE the last-write-wins overwrite below, so a
+    # heterogeneous per-file scan (e.g. Torch for some files, CPU-fallback for others) surfaces
+    # every engine that contributed rather than only the last-merged one.
+    for _seen_backend in (aggregate.routing_backend, result.routing_backend):
+        if _seen_backend and _seen_backend not in aggregate.routing_backends_seen:
+            aggregate.routing_backends_seen.append(_seen_backend)
+    aggregate.is_mixed_routing = len(aggregate.routing_backends_seen) > 1
     if result.routing_backend:
         aggregate.routing_backend = result.routing_backend
         aggregate.routing_gpu_device_ids = list(result.routing_gpu_device_ids)

--- a/tests/unit/test_result_merge_routing.py
+++ b/tests/unit/test_result_merge_routing.py
@@ -1,0 +1,52 @@
+"""M9: merge_runtime_routing must not misreport a heterogeneous per-file scan.
+
+`merge_runtime_routing` is called once per (file, pattern) by the sidecar/CLI/MCP paths, and
+`routing_backend` is last-write-wins -- so on a scan where some files ran on one engine and others
+fell back to another (e.g. Torch -> CPU for an unsupported regex path), the aggregate used to report
+only whichever file was processed last, silently hiding the mixed routing. The additive
+`routing_backends_seen` / `is_mixed_routing` fields carry the truth.
+"""
+
+from __future__ import annotations
+
+from tensor_grep.core.result import SearchResult, merge_runtime_routing
+
+
+def _result(backend: str | None) -> SearchResult:
+    return SearchResult(routing_backend=backend)
+
+
+def test_merge_tracks_mixed_backends() -> None:
+    aggregate = _result("TorchBackend")
+    merge_runtime_routing(aggregate, _result("CPUBackend"))
+
+    assert aggregate.is_mixed_routing is True
+    assert aggregate.routing_backends_seen == ["TorchBackend", "CPUBackend"]
+    # routing_backend stays last-write-wins for back-compat; the mix is surfaced additively.
+    assert aggregate.routing_backend == "CPUBackend"
+
+
+def test_merge_single_backend_is_not_mixed() -> None:
+    aggregate = _result("CPUBackend")
+    merge_runtime_routing(aggregate, _result("CPUBackend"))
+
+    assert aggregate.is_mixed_routing is False
+    assert aggregate.routing_backends_seen == ["CPUBackend"]
+
+
+def test_merge_three_way_mix_dedups_and_preserves_order() -> None:
+    aggregate = _result("CPUBackend")
+    merge_runtime_routing(aggregate, _result("TorchBackend"))
+    merge_runtime_routing(aggregate, _result("CPUBackend"))  # a repeat must not double-count
+    merge_runtime_routing(aggregate, _result("StringZillaBackend"))
+
+    assert aggregate.is_mixed_routing is True
+    assert aggregate.routing_backends_seen == ["CPUBackend", "TorchBackend", "StringZillaBackend"]
+
+
+def test_merge_ignores_empty_backend() -> None:
+    aggregate = _result("CPUBackend")
+    merge_runtime_routing(aggregate, _result(None))  # a sub-result with no routing metadata
+
+    assert aggregate.is_mixed_routing is False
+    assert aggregate.routing_backends_seen == ["CPUBackend"]


### PR DESCRIPTION
Fable correctness audit M9. `merge_runtime_routing` (the shared CLI/MCP/sidecar merge, called once per (file,pattern)) sets `routing_backend` last-write-wins — so a heterogeneous scan (e.g. some files on Torch, others fell back to CPU) reported only whichever file was processed LAST, silently hiding that matches came from more than one engine (a trust/observability bug an agent would misread).

**Fix (data layer, additive):** the merge now accumulates the distinct backends into `routing_backends_seen` (insertion order, deduped) and sets `is_mixed_routing=True` once >1 engine contributed. `routing_backend` stays last-write-wins for back-compat. The aggregate now carries the truth regardless of which consumer reads it.

**Verified:** 52 tests (4 new — mix, single, three-way-dedup, empty-backend + the existing merge suite + pipeline); ruff/format/mypy clean. Self-contained in `core/result.py` (no gated files). Surfacing the flag in the search `--json` envelope is a small additive follow-up (that emit lives in `main.py`, currently owned by the draining #433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)