### PR TITLE
fix(repo_map): reference line content uses parsed-source read, not a stale separate read (audit C3 TOCTOU)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4348,8 +4348,13 @@ def _js_ts_references_and_calls(
     parsed = _parsed_source_and_tree(str(path))
     if parsed is None:
         return [], []
-    _parsed_source, source_bytes, tree = parsed
-    lines = source.splitlines()
+    parsed_source, source_bytes, tree = parsed
+    # `lines` MUST come from the SAME read as `source_bytes`/`tree` (all three from the single
+    # `_parsed_source_and_tree` product), NOT from the earlier `source` text read above: the two are
+    # independent (path, mtime, size)-keyed cache lookups, so a file edited between them would leave
+    # tree node line-indices (from the parse) indexing into stale `lines` -> wrong reported line
+    # content / IndexError. The pre-parse text read keeps using `source` (a cheap heuristic gate).
+    lines = parsed_source.splitlines()
     references: list[dict[str, Any]] = []
     calls: list[dict[str, Any]] = []
 
@@ -4708,8 +4713,13 @@ def _rust_references_and_calls(
     parsed = _parsed_source_and_tree(str(path))
     if parsed is None:
         return [], []
-    _parsed_source, source_bytes, tree = parsed
-    lines = source.splitlines()
+    parsed_source, source_bytes, tree = parsed
+    # `lines` MUST come from the SAME read as `source_bytes`/`tree` (all three from the single
+    # `_parsed_source_and_tree` product), NOT from the earlier `source` text read above: the two are
+    # independent (path, mtime, size)-keyed cache lookups, so a file edited between them would leave
+    # tree node line-indices (from the parse) indexing into stale `lines` -> wrong reported line
+    # content / IndexError. The pre-parse text read keeps using `source` (a cheap heuristic gate).
+    lines = parsed_source.splitlines()
     references: list[dict[str, Any]] = []
     calls: list[dict[str, Any]] = []
 

--- a/tests/unit/test_parse_product_cache.py
+++ b/tests/unit/test_parse_product_cache.py
@@ -344,3 +344,33 @@ def test_oversize_file_bypasses_parse_product_cache(tmp_path, monkeypatch) -> No
     assert first[0] == second[0] == content
     # Bypassed the cache both times -- a giant file must never sit in the parse-product cache.
     assert calls["n"] == 2
+
+
+def test_references_use_parsed_source_lines_not_a_separate_stale_text_read(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # C3 (audit): `_js_ts_references_and_calls` reads the source TEXT once (cheap pre-parse gate)
+    # and the parse PRODUCT (source+bytes+tree) via a SECOND independent (path, mtime, size) cache
+    # lookup. `lines` (used for a reference's "text" line content) must come from the SAME read as
+    # the tree, or a file edited between the two lookups makes tree line-indices index into stale
+    # `lines` -> wrong reported line content. Simulate the skew: freeze the parse product on the
+    # real file while the text read returns a line-shifted stale copy; the reference text must match
+    # the PARSED source (correct), not the stale text read (blank-shifted).
+    source_file = tmp_path / "widget.ts"
+    real_source = "const total = computeWidgetTotal();\ncomputeWidgetTotal();\n"
+    source_file.write_text(real_source, encoding="utf-8")
+
+    # Stale text read: same symbol present (so the symbol-absent early-exit still falls through),
+    # but two blank lines prepended -> every line index is shifted by 2 vs the real parsed source.
+    stale_source = "\n\n" + real_source
+    monkeypatch.setattr(repo_map, "_read_source_text_cached", lambda _p: stale_source)
+
+    references, _calls = repo_map._js_ts_references_and_calls(source_file, "computeWidgetTotal")
+
+    assert references, "expected at least one reference to computeWidgetTotal"
+    # With the fix, line content comes from the parsed source (real file) -> the actual code line.
+    # With the bug (lines from the stale text read), index 0 would be the prepended blank line "".
+    for ref in references:
+        assert "computeWidgetTotal" in ref["text"], (
+            f"reference text {ref['text']!r} came from the stale text read, not the parsed source"
+        )


### PR DESCRIPTION
**Audit C3 (MED).** `_js_ts_references_and_calls` (+ the `_rust_references_and_calls` mirror) reads the source TEXT once (a cheap pre-parse symbol-absent gate) and the parse PRODUCT (source+bytes+tree) via a SECOND, independent `(path, mtime, size)`-keyed cache lookup. `lines` — used for a reference's `text` line content — was built from the FIRST read (`source`) while `source_bytes`/`tree` came from the SECOND (`_parsed_source`). A file edited between the two lookups leaves tree node line-indices (from the parse) indexing into stale `lines` -> wrong reported line content / IndexError, during a long caller-scan while the user edits.

Fix: `lines = parsed_source.splitlines()` — `lines`/`source_bytes`/`tree` now all derive from the single `_parsed_source_and_tree` product. The pre-parse text read keeps using `source` (a cheap heuristic gate; its staleness only affects whether we bother parsing, not offset correctness).

**Verified real venv:** new skew regression test (stale line-shifted text read + fresh parse product -> reference text must match the PARSED source) + parse-cache suite + golden-parity oracles (cross_lang_resolution, repo_map_targets, js_ts_advanced_resolution) = 60 passed; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)