### PR TITLE
test(ci): governance hardening — mypy-pin assert, registration-gate, full release-needs, ast-grep parity, schedule concurrency (audit #36-#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
     - cron: "17 6 * * 1"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Keying purely on `github.ref` puts the weekly `schedule` trigger (which also runs against
+  # refs/heads/main) in the SAME group as a merge-triggered push run, letting the cron run queue
+  # ahead of / behind the release-carrying push run and widen the publish push-race window. Key
+  # `schedule` into its own bucket so it never contends with the push-to-main group.
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'schedule' || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/scripts/validate_release_assets.py
+++ b/scripts/validate_release_assets.py
@@ -24,6 +24,23 @@ RELEASE_DOC_PATHS = (
     "docs/CONTINUATION_PLAN.md",
     "docs/CONTRACTS.md",
 )
+# The full set of blocking gates the `release` (Semantic Release) job must depend on. Spot-checking
+# only `benchmark-regression` let a dropped gate (e.g. `static-analysis`, `windows-agent-readiness`)
+# pass validation while still publishing without that check having run.
+RELEASE_JOB_REQUIRED_GATES = (
+    "smoke",
+    "release-readiness",
+    "agent-readiness",
+    "windows-agent-readiness",
+    "package-manager-readiness",
+    "static-analysis",
+    "test-python",
+    "test-rust-core",
+    "search-golden-parity",
+    "native-build-smoke",
+    "test-gpu-linux",
+    "benchmark-regression",
+)
 
 
 def _read(path: Path) -> str:
@@ -317,8 +334,50 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
     except yaml.YAMLError:
         parsed_ci = {}
     if isinstance(parsed_ci, dict):
+        # Push-race hardening: a concurrency group keyed only on `github.ref` puts the weekly
+        # `schedule` trigger (which also runs against refs/heads/main) in the SAME group as a
+        # merge-triggered push run. A queued schedule run can then sit ahead of (or behind) the
+        # release-carrying push run and widen the known publish push-race window. The group must
+        # key schedule runs into their own bucket.
+        concurrency_block = parsed_ci.get("concurrency")
+        if not isinstance(concurrency_block, dict):
+            errors.append("CI workflow must define a top-level `concurrency` block")
+        else:
+            concurrency_group = str(concurrency_block.get("group", ""))
+            if "github.event_name" not in concurrency_group or "schedule" not in concurrency_group:
+                errors.append(
+                    "CI workflow concurrency `group` must key the `schedule` trigger into its "
+                    "own group (e.g. via `github.event_name == 'schedule'`) so a weekly cron run "
+                    "cannot queue behind or block a merge-triggered release sharing the "
+                    "push-to-main concurrency group"
+                )
+
         jobs = parsed_ci.get("jobs")
         if isinstance(jobs, dict):
+            static_analysis_job = jobs.get("static-analysis")
+            if isinstance(static_analysis_job, dict):
+                static_analysis_steps = static_analysis_job.get("steps", [])
+                registration_step = None
+                if isinstance(static_analysis_steps, list):
+                    for step in static_analysis_steps:
+                        if (
+                            isinstance(step, dict)
+                            and step.get("name") == "Registration completeness"
+                        ):
+                            registration_step = step
+                            break
+                if registration_step is None:
+                    errors.append(
+                        "CI workflow static-analysis job must include step "
+                        "`Registration completeness`"
+                    )
+                elif registration_step.get("continue-on-error") is True:
+                    errors.append(
+                        "CI workflow static-analysis `Registration completeness` step must not "
+                        "set `continue-on-error: true` (softens the --rank-class front-door "
+                        "registration gate back to warn-only)"
+                    )
+
             release_intent_job = jobs.get("release-intent")
             if isinstance(release_intent_job, dict):
                 release_intent_if = release_intent_job.get("if")
@@ -355,8 +414,9 @@ def validate_ci_workflow_content(*, ci_workflow: str) -> list[str]:
                     needs_list = [str(item) for item in needs]
                 else:
                     needs_list = []
-                if "benchmark-regression" not in needs_list:
-                    errors.append("CI workflow release job must depend on benchmark-regression")
+                for required_gate in RELEASE_JOB_REQUIRED_GATES:
+                    if required_gate not in needs_list:
+                        errors.append(f"CI workflow release job must depend on {required_gate}")
                 release_outputs = release_job.get("outputs", {})
                 if not isinstance(release_outputs, dict):
                     release_outputs = {}
@@ -2162,6 +2222,41 @@ def validate_ci_pipeline_doc_contract(
     return errors
 
 
+_AST_GREP_VERSION_PIN_RE = re.compile(r"cargo install ast-grep --version ([0-9][0-9A-Za-z.\-]*)")
+
+
+def validate_ast_grep_version_parity(
+    *, ci_workflow_content: str, benchmark_workflow_content: str
+) -> list[str]:
+    """ci.yml's agent-readiness ast-grep probe and benchmark.yml's ast-grep comparator must run the
+    SAME ast-grep CLI version -- the two files only pin it in a comment as "matches the pinned
+    version" with no enforcement, so one file's version can drift from the other silently."""
+    errors: list[str] = []
+    ci_match = _AST_GREP_VERSION_PIN_RE.search(ci_workflow_content)
+    benchmark_match = _AST_GREP_VERSION_PIN_RE.search(benchmark_workflow_content)
+    if ci_match is None:
+        errors.append(
+            "ci.yml must pin an ast-grep CLI version via `cargo install ast-grep --version <ver>`"
+        )
+    if benchmark_match is None:
+        errors.append(
+            "benchmark.yml must pin an ast-grep CLI version via "
+            "`cargo install ast-grep --version <ver>`"
+        )
+    if (
+        ci_match is not None
+        and benchmark_match is not None
+        and ci_match.group(1) != benchmark_match.group(1)
+    ):
+        errors.append(
+            "ast-grep CLI version pin mismatch: ci.yml pins "
+            f"{ci_match.group(1)} but benchmark.yml pins {benchmark_match.group(1)} "
+            "(agent-readiness's ast-grep probe and the benchmark comparator must run the same "
+            "ast-grep build)"
+        )
+    return errors
+
+
 def validate_readme_contract(*, readme_content: str) -> list[str]:
     errors: list[str] = []
     # the canonical-docs section heading is matched case-insensitively (the README uses
@@ -3358,6 +3453,14 @@ def validate_dev_tooling_constraints(*, pyproject_content: str) -> list[str]:
             "pyproject.toml [project.optional-dependencies].dev must pin "
             f"`{expected_ruff_pin}` for CI/local formatter parity"
         )
+    # Governance for the #446 fix: an unpinned/floor mypy dependency (e.g. `mypy>=1.11`) can
+    # silently resolve a newer mypy release into CI, reproducing the #446 red-main incident.
+    expected_mypy_pin = "mypy==1.19.1"
+    if expected_mypy_pin not in {str(entry) for entry in dev_dependencies}:
+        errors.append(
+            "pyproject.toml [project.optional-dependencies].dev must pin "
+            f"`{expected_mypy_pin}` for CI/local type-check parity"
+        )
     expected_pytest_floor = "pytest>=9.0.3"
     for group_name, dependencies in (("dev", dev_dependencies), ("bench", bench_dependencies)):
         if expected_pytest_floor not in {str(entry) for entry in dependencies}:
@@ -3598,10 +3701,17 @@ def validate_all() -> list[str]:
             expected_version=py_version,
         )
     )
+    benchmark_workflow_content = _read(ROOT / ".github" / "workflows" / "benchmark.yml")
     errors.extend(
         validate_ci_pipeline_doc_contract(
             ci_pipeline_content=_read(ROOT / "docs" / "CI_PIPELINE.md"),
-            benchmark_workflow_content=_read(ROOT / ".github" / "workflows" / "benchmark.yml"),
+            benchmark_workflow_content=benchmark_workflow_content,
+        )
+    )
+    errors.extend(
+        validate_ast_grep_version_parity(
+            ci_workflow_content=ci_workflow,
+            benchmark_workflow_content=benchmark_workflow_content,
         )
     )
     support_matrix = _read(ROOT / "docs" / "SUPPORT_MATRIX.md")

--- a/tests/unit/test_release_assets_validation.py
+++ b/tests/unit/test_release_assets_validation.py
@@ -1063,6 +1063,7 @@ def test_should_require_dev_tooling_security_floors_for_ci_format_parity():
     errors = module.validate_dev_tooling_constraints(pyproject_content=textwrap.dedent(pyproject))
     joined_errors = "\n".join(errors)
     assert "ruff==0.15.20" in joined_errors
+    assert "mypy==1.19.1" in joined_errors
     assert "pytest>=9.0.3" in joined_errors
 
 
@@ -1081,11 +1082,37 @@ def test_should_accept_dev_tooling_security_floors_for_ci_format_parity():
     version = "1.3.2"
 
     [project.optional-dependencies]
-    dev = ["ruff==0.15.20", "pytest>=9.0.3"]
+    dev = ["ruff==0.15.20", "mypy==1.19.1", "pytest>=9.0.3"]
     bench = ["pytest>=9.0.3"]
     """
     errors = module.validate_dev_tooling_constraints(pyproject_content=textwrap.dedent(pyproject))
     assert errors == []
+
+
+def test_should_require_exact_mypy_pin_not_a_floor_constraint():
+    # Regression guard for #446 (a loosened mypy dependency merged green, then the next mypy
+    # release turned main red). A floor like `mypy>=1.11` must NOT satisfy the pin -- only the
+    # exact `mypy==1.19.1` pin does.
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    pyproject = """
+    [project]
+    name = "tensor-grep"
+    version = "1.3.2"
+
+    [project.optional-dependencies]
+    dev = ["ruff==0.15.20", "mypy>=1.11", "pytest>=9.0.3"]
+    bench = ["pytest>=9.0.3"]
+    """
+    errors = module.validate_dev_tooling_constraints(pyproject_content=textwrap.dedent(pyproject))
+    joined_errors = "\n".join(errors)
+    assert "mypy==1.19.1" in joined_errors
 
 
 def test_should_require_ci_package_manager_bundle_build_and_checksum_verification():
@@ -1218,6 +1245,195 @@ def test_should_require_release_job_to_depend_on_benchmark_regression_gate():
     """
     errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
     assert any("release job must depend on benchmark-regression" in err for err in errors)
+
+
+def test_should_require_release_job_to_depend_on_full_required_gate_set():
+    # Guard for the "spot-check only benchmark-regression" gap: dropping ANY blocking gate from
+    # the release job's `needs` list (not just benchmark-regression) must fail validation, or a
+    # future refactor could silently drop e.g. static-analysis/windows-agent-readiness and still
+    # publish without that check having run.
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      release:
+        needs: [smoke, release-readiness, package-manager-readiness, static-analysis, test-python, test-rust-core, search-golden-parity, native-build-smoke, test-gpu-linux, benchmark-regression]
+    """
+    # Missing: agent-readiness, windows-agent-readiness
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert any("release job must depend on agent-readiness" in err for err in errors)
+    assert any("release job must depend on windows-agent-readiness" in err for err in errors)
+
+
+def test_should_accept_release_job_with_full_required_gate_set():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      release:
+        needs: [smoke, release-readiness, agent-readiness, windows-agent-readiness, package-manager-readiness, static-analysis, test-python, test-rust-core, search-golden-parity, native-build-smoke, test-gpu-linux, benchmark-regression]
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert not any("release job must depend on" in err for err in errors)
+
+
+def test_should_require_registration_completeness_step_in_static_analysis_job():
+    # Audit #36: a future "just make CI green" pass could re-add `continue-on-error: true` to the
+    # Registration completeness step, silently softening the --rank-class front-door gate back to
+    # warn-only with no test failing. Guard both "step missing" and "step present but softened".
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow_missing_step = """
+    jobs:
+      static-analysis:
+        steps:
+          - name: Some other step
+            run: echo hi
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow_missing_step)
+    assert any(
+        "static-analysis job must include step `Registration completeness`" in err for err in errors
+    )
+
+    ci_workflow_softened = """
+    jobs:
+      static-analysis:
+        steps:
+          - name: Registration completeness
+            continue-on-error: true
+            run: python -m tensor_grep.core.registration_check .tg-registration.toml
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow_softened)
+    assert any(
+        "Registration completeness` step must not set `continue-on-error: true`" in err
+        for err in errors
+    )
+
+
+def test_should_accept_registration_completeness_step_without_continue_on_error():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    jobs:
+      static-analysis:
+        steps:
+          - name: Registration completeness
+            run: python -m tensor_grep.core.registration_check .tg-registration.toml
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert not any("Registration completeness" in err for err in errors)
+
+
+def test_should_require_concurrency_group_to_isolate_scheduled_runs():
+    # Audit #39: a concurrency group keyed only on `github.ref` puts the weekly `schedule`
+    # trigger in the SAME group as a merge-triggered push run, letting a queued weekly run widen
+    # the known release push-race window. The group must key `schedule` into its own bucket.
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    jobs:
+      release:
+        needs: []
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert any(
+        "concurrency `group` must key the `schedule` trigger into its own group" in err
+        for err in errors
+    )
+
+
+def test_should_accept_concurrency_group_that_isolates_scheduled_runs():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow = """
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'schedule' || github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    jobs:
+      release:
+        needs: []
+    """
+    errors = module.validate_ci_workflow_content(ci_workflow=ci_workflow)
+    assert not any("concurrency" in err for err in errors)
+
+
+def test_should_require_ast_grep_version_parity_between_ci_and_benchmark_workflows():
+    # Audit #40: ci.yml's agent-readiness ast-grep probe and benchmark.yml's ast-grep comparator
+    # are pinned independently (a comment says "matches the pinned version" with no enforcement),
+    # so one file's version can drift from the other silently.
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow_content = "run: cargo install ast-grep --version 0.41.1 --locked"
+    benchmark_workflow_content = "run: cargo install ast-grep --version 0.40.0 --locked"
+    errors = module.validate_ast_grep_version_parity(
+        ci_workflow_content=ci_workflow_content,
+        benchmark_workflow_content=benchmark_workflow_content,
+    )
+    assert any("ast-grep CLI version pin mismatch" in err for err in errors)
+    assert any("0.41.1" in err and "0.40.0" in err for err in errors)
+
+
+def test_should_accept_ast_grep_version_parity_when_pins_match():
+    root = Path(__file__).resolve().parents[2]
+    script_path = root / "scripts" / "validate_release_assets.py"
+    spec = importlib.util.spec_from_file_location("validate_release_assets", script_path)
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ci_workflow_content = "run: cargo install ast-grep --version 0.41.1 --locked"
+    benchmark_workflow_content = "run: cargo install ast-grep --version 0.41.1 --locked"
+    errors = module.validate_ast_grep_version_parity(
+        ci_workflow_content=ci_workflow_content,
+        benchmark_workflow_content=benchmark_workflow_content,
+    )
+    assert errors == []
 
 
 def test_should_require_release_intent_job_and_semantic_pr_title_validator():


### PR DESCRIPTION
Audit deep-dive cluster #36-#40 — governance tests + one conservative ci.yml edit that prevent the exact regression classes that bit this campaign.
- **#38** `validate_dev_tooling_constraints` asserts `mypy==1.19.1` (mirrors the ruff pin) — closes the C6/#446 gap (an unpinned mypy red every PR). **Proved it guards**: flipping the pin to `mypy>=1.11` fails the validator.
- **#36** requires the `Registration completeness` step in static-analysis with no `continue-on-error` (can't silently soften the --rank front-door gate).
- **#37** replaces the single `benchmark-regression` spot-check with the full 12-gate `RELEASE_JOB_REQUIRED_GATES` set (dropping any gate fails validation).
- **#40** asserts the ast-grep `--version` pin is equal between ci.yml and benchmark.yml.
- **#39** (only behavior change) isolates the weekly cron into its own concurrency group (ternary idiom already used in audit.yml) so it can't queue behind a merge-triggered release (widens the push-race).

**Verified real venv:** 151 governance tests pass; ruff/format/mypy clean; ci.yml parses. No release/build job logic altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)