### PR TITLE
feat: document the shared code-intelligence plane + add opt-out demand instrumentation to gate the tg-ledger decision (step-0)

### DIFF
--- a/docs/harness_cookbook.md
+++ b/docs/harness_cookbook.md
@@ -165,7 +165,7 @@ For broad repo roots, read `scan_limit` before assuming the inventory is complet
 
 ## Session Reuse Flow
 
-Use sessions when the agent will issue multiple context queries against the same repo during one edit loop.
+Use sessions when the agent will issue multiple context queries against the same repo during one edit loop. When several agents work the same repo concurrently, sessions plus the warm daemon become a shared code-intelligence plane -- see [docs/multi_agent_context_plane.md](multi_agent_context_plane.md) for what is (and is not) shared across agents.
 
 Open a cached session:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@
 - [docs/tool_comparison.md](tool_comparison.md) for the public workload-class comparison story
 - [docs/routing_policy.md](routing_policy.md) for backend routing behavior
 - [docs/harness_api.md](harness_api.md) for machine-readable CLI contracts
+- [docs/multi_agent_context_plane.md](multi_agent_context_plane.md) for how concurrent agents share machine-computed code facts through the session store and warm daemon
 - [docs/installation.md](installation.md) for install and package-manager guidance
 - [docs/CI_PIPELINE.md](CI_PIPELINE.md) for CI, release, Dependabot, and scheduled audit automation
 

--- a/docs/multi_agent_context_plane.md
+++ b/docs/multi_agent_context_plane.md
@@ -1,0 +1,186 @@
+# tensor-grep as the local shared code-intelligence plane for concurrent agents
+
+When several AI agents work the same repository at once -- a planner, an implementer, a
+reviewer, or a fan-out of subagents -- they each need the same machine-computed facts about the
+code: the repo map, the context capsule for a query, the blast radius of a symbol. Recomputing
+those per agent is wasted work and wasted tokens.
+
+`tensor-grep` is already, today, a **local shared code-intelligence plane** for those agents.
+One agent computes a repo map or a rendered edit-plan; the others reuse it. This page describes
+exactly what is shared, how, and -- just as importantly -- what is **not** shared, so a harness
+never overclaims.
+
+> This is a positioning + mechanism page. Every mechanism below is grounded in a specific
+> `file:line` in the shipped source so the claims stay honest and re-verifiable.
+
+## Thesis: share the WHAT-CODE, let a task board own the WHO-DOES-WHAT
+
+Multi-agent coordination has two distinct layers:
+
+- **Task coordination** -- who claims which task, in what order, with what status. Tools like
+  Claude Code Agent Teams or Beads own this. It is prose and workflow state.
+- **Code intelligence** -- what the code actually is: the file inventory, the symbol map, the
+  caller graph, the blast radius, a query-scoped context pack. Only `tg` computes this, and
+  computing it is the expensive part.
+
+`tg` shares the second layer. A task board and `tg` **compose**: the board tells agents what to
+do; `tg` gives every agent the same, already-computed answer to "what does this code look like."
+`tg` deliberately does not try to be a task board, a message bus, or an agent-to-agent protocol.
+
+## Mechanism 1 -- the repo-scoped cross-process session store
+
+A session is a cached repo snapshot on disk, scoped to one repository root, that any process on
+the machine can load by id.
+
+- **Where it lives.** Sessions are written under `<repo>/.tensor-grep/sessions/`
+  (`session_store.py:323-324`, index at `session_store.py:327-328`), with the root resolved by
+  `_resolve_root` (`session_store.py:318-320`).
+- **Crash-safe writes.** Every session payload and the index are written atomically with an
+  `fsync`-before-rename temp file (`_write_json_atomic`, `session_store.py:397-442`) so a crash
+  can never publish a truncated snapshot.
+- **Cross-process safety.** Session creation and refresh serialize their index read-modify-write
+  under a cross-process lock (`open_session`, `session_store.py:609`; `refresh_session`,
+  `session_store.py:674`), so two agents opening or refreshing at once never corrupt or silently
+  drop an entry.
+- **Bounded retention.** Old sessions are pruned to `TG_SESSION_MAX` (default 64,
+  `session_store.py:53`) newest-first (`_prune_session_records`, `session_store.py:449`).
+- **Load by id, across agents, confined to the root.** Another agent loads a session with
+  `get_session` (`session_store.py:806`). A traversal-shaped or absolute session id is refused
+  before any read (`_session_payload_path`, `session_store.py:331-346`), and a payload whose
+  recorded root does not match the directory it is stored under is rejected
+  (`get_session`, `session_store.py:806` onward) so an agent can never be pointed at a session
+  outside its repo.
+- **Never silently wrong.** Before serving, a session is validated against the current tree by
+  mtime + size (`_stale_changeset`, `session_store.py:526`; `_ensure_session_not_stale`,
+  `session_store.py:573`). A stale snapshot raises rather than returning outdated facts.
+
+## Mechanism 2 -- the token-authenticated loopback daemon (a warm shared cache)
+
+The session store is durable but cold: each read re-parses JSON from disk. The optional session
+daemon keeps the parsed repo map warm in memory and serves it to every agent over an
+authenticated loopback socket.
+
+- **One daemon per root.** Startup is guarded by a start-lock
+  (`_try_acquire_daemon_start_lock`, `session_daemon.py:263`) and a probe-or-reuse path
+  (`start_session_daemon`, `session_daemon.py:532`) so concurrent agents converge on a single
+  shared daemon instead of racing to spawn duplicates.
+- **Authenticated + confined.** The daemon generates a per-daemon secret and publishes it to a
+  `0600` `daemon.json` (`_write_daemon_metadata`, `session_daemon.py:187`; plus a best-effort
+  Windows ACL lockdown, `_restrict_windows_file_to_current_user`, `session_daemon.py:196`).
+  Every request is checked with a constant-time compare before dispatch (`is_authorized`,
+  `session_daemon.py:1340`), the pre-auth read is byte-bounded and time-limited
+  (`_read_bounded_request_line`, `session_daemon.py:1350`), and request paths are confined to
+  the daemon's root (`_confine_path_to_root`, `session_daemon.py:243`;
+  `_resolve_daemon_request_path`, `session_daemon.py:381`).
+- **Self-limiting.** The daemon shuts itself down after an idle stretch (default 900s) or a hard
+  max uptime (default 24h) (`session_daemon.py:82-83`; `_run_daemon_lifecycle_monitor`,
+  `session_daemon.py:1577`), so a forgotten daemon never lingers.
+- **How a second agent hits the first agent's warm cache.** Top-level `tg context-render` and
+  `tg edit-plan` reuse a *running* daemon when one exists
+  (`_maybe_context_render_via_running_daemon`, `main.py:7343`;
+  `_maybe_edit_plan_via_running_daemon`, `main.py:7393`; via
+  `request_running_session_daemon`, `session_daemon.py:703`). The `tg session ... --daemon`
+  verbs start-or-reuse a daemon (`request_session_daemon`, `session_daemon.py:688`). Implicit
+  sessions are keyed by `(root, max_repo_files)` and shared across clients
+  (`_implicit_session_id_for_request`, `session_daemon.py`), and the daemon layers a payload
+  cache plus a response cache on top so an identical render from a different agent is a cache
+  hit, not a recompute.
+
+Warm-served verbs (the shared surface): `repo_map`, `context`, `context_render`,
+`context_edit_plan`, `defs`, `impact`, `refs`, `callers`, `blast_radius`,
+`blast_radius_render`, `blast_radius_plan` (`_serve_session_request_from_payload`,
+`session_store.py:1111` onward).
+
+## Fleet quickstart
+
+The daemon must be running for agents to share the *warm* plane. Start it once at the root, then
+let every agent's context / edit-plan / session traffic reuse it.
+
+```powershell
+# 1. Start the shared plane once, at the repo root.
+tg session daemon start .
+
+# 2. Every agent now shares the warm cache automatically via the top-level verbs:
+tg context-render . "invoice payment"      # first agent computes + caches
+tg context-render . "invoice payment"      # any other agent -> cache hit
+tg edit-plan . "add a refund path"
+
+# 3. Inspect the shared plane (works even after the daemon has stopped):
+tg session daemon status . --json
+tg doctor . --json
+```
+
+## `tg` vs a task board
+
+| | Task board (Agent Teams, Beads) | tensor-grep |
+|---|---|---|
+| Owns | who does what, task status, prose | machine-computed code facts |
+| Unit | a task / claim / message | a repo map, capsule, blast radius |
+| Shared how | a task queue | the session store + warm daemon |
+
+They are complementary. Use a task board to coordinate work; use `tg` so every agent starts from
+the same, already-computed picture of the code.
+
+## Honesty: what is NOT shared (shipped behavior only)
+
+To keep harnesses from overclaiming, be precise about the current limits:
+
+- **MCP `tg_session_*` tools run in-process, not through the daemon socket.** For example,
+  `tg_session_edit_plan` calls `session_context_edit_plan` directly against the on-disk store
+  (`mcp_server.py:2147-2162`; `session_context_edit_plan`, `session_store.py:882`). They benefit
+  from the durable session store, but they do **not** route through the warm daemon's in-memory
+  response cache. To exercise the warm plane, use the CLI top-level verbs or `tg session ...
+  --daemon`.
+- **The daemon response-cache staleness check is `snapshot_mtime_only`.** It detects changes to
+  files already in the snapshot but does **not** detect newly *added* files
+  (`_DAEMON_RESPONSE_CACHE_STALE_DETECTION` / `_DAEMON_RESPONSE_CACHE_ADDED_FILE_DETECTION`,
+  `session_daemon.py`). After creating files, run `tg session refresh` (or request
+  `refresh_on_stale`) so the new files invalidate cached hits.
+- **There is no ledger, no claims/findings store, no message bus, and no agent-to-agent
+  protocol.** `tg` shares code facts through the session store and daemon cache described above,
+  and nothing more. Anything beyond that is not shipped.
+
+## Demand instrumentation (step 0 for a possible shared-context surface)
+
+Whether `tg` should grow a richer shared-context surface is a **build decision that should be
+made on real demand, not intuition.** To gather that evidence, a running daemon keeps a small,
+opt-out, PII-free demand counter and persists it to
+`<repo>/.tensor-grep/sessions/daemon_metrics.json`.
+
+It records only two things, per UTC day:
+
+1. **Concurrent distinct clients** -- how many distinct agent processes hit the same daemon, and
+   whether their request windows overlapped. The calling process pid is injected client-side in
+   `_daemon_request` (`session_daemon.py:347`) purely as a diagnostic tag; it is never used for
+   auth or routing and never fragments the response cache.
+2. **Repeated expensive artifacts** -- whether the same symbol/query was re-requested inside a
+   short window (a shared plane would de-duplicate these). The target is stored **only as a
+   truncated SHA-256 hash** -- the raw symbol/query text never touches disk.
+
+Properties, by design:
+
+- **PII-free.** No raw symbol or query text is ever persisted -- hashes only.
+- **Fail-open.** The record call at the request seam is wrapped so a metrics bug can never break
+  serving; the read-back is equally defensive.
+- **Bounded.** At most 30 day-buckets and 32 duplicate-target hashes per day on disk.
+- **Opt-out.** Set `TG_DAEMON_METRICS=0` to disable recording entirely.
+
+Read it back with no new command or flag -- it rides on the existing status and doctor surfaces:
+
+```powershell
+tg session daemon status . --json   # includes a demand_metrics block + a trailing-14-day rollup
+tg doctor .                         # one human summary line, e.g.:
+# session_daemon_demand(14d): clients=4 concurrent_days=3 dup_requests=17 pre_gate=MET
+```
+
+The `pre_gate` field distinguishes three states so the signal is never misread:
+
+- `NO-COVERAGE` -- no daemon ran in the window, so there is simply no data (not a "no demand"
+  verdict).
+- `NOT-MET` -- there is coverage, but concurrency and repeat-demand stayed below the documented
+  thresholds.
+- `MET` -- there was real cross-agent concurrency and real repeated-artifact demand over the
+  trailing 14 days.
+
+Because the metrics file is read straight from disk, the read-back works even when the daemon is
+currently stopped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
     - Hotfix Procedure: HOTFIX_PROCEDURE.md
     - Package Manager Publish: package_manager_publish.md
   - Architecture: architecture.md
+  - Multi-Agent Context Plane: multi_agent_context_plane.md
   - Benchmarks: benchmarks.md
   - Tool Comparison: tool_comparison.md
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3259,6 +3259,23 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
         state = "stale-metadata" if session_payload.get("stale_metadata") else "stopped"
         lines.append(f"session_daemon: {state}")
 
+    # tg-ledger step-0 (demand instrumentation, see docs/multi_agent_context_plane.md): a single
+    # human summary line for the trailing-14-day demand receipt that the daemon persists to
+    # daemon_metrics.json (read-back works even when the daemon is currently stopped).
+    demand_metrics = cast(dict[str, Any], session_payload.get("demand_metrics") or {})
+    demand_days_covered = int(demand_metrics.get("days_covered", 0) or 0)
+    if "error" in demand_metrics or demand_days_covered == 0:
+        demand_pre_gate = "NO-COVERAGE"
+    else:
+        demand_pre_gate = "MET" if demand_metrics.get("pre_gate_met") else "NOT-MET"
+    lines.append(
+        "session_daemon_demand(14d): "
+        f"clients={int(demand_metrics.get('max_distinct_client_pids_14d', 0) or 0)} "
+        f"concurrent_days={int(demand_metrics.get('days_with_2plus_concurrent', 0) or 0)} "
+        f"dup_requests={int(demand_metrics.get('dup_requests_14d', 0) or 0)} "
+        f"pre_gate={demand_pre_gate}"
+    )
+
     lsp_payload = cast(dict[str, Any], payload.get("lsp", {}))
     if lsp_payload.get("enabled"):
         lines.append("lsp_providers:")

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
 import hmac
 import json
 import os
@@ -13,7 +14,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from time import monotonic
 from typing import Any, cast
@@ -38,6 +39,7 @@ from tensor_grep.cli.session_store import (
     _SessionServeCache,
     _SessionServeResponseCacheEntry,
     _write_index,
+    _write_json_atomic,
     open_session,
     refresh_session,
     serve_session_request,
@@ -83,6 +85,64 @@ _DAEMON_LIFECYCLE_POLL_SECONDS = 5.0
 # audit r8: cap the wait for in-flight requests to drain at the hard max-uptime shutdown, so a
 # wedged request cannot postpone the daemon's self-shutdown forever.
 _DAEMON_SHUTDOWN_DRAIN_GRACE_SECONDS = 30.0
+
+# tg-ledger step-0 (demand instrumentation, NOT a ledger): a lightweight, fail-open, PII-free
+# demand receipt used only to decide whether a shared local code-intelligence plane ("tg
+# ledger") is worth building. Never stores raw symbol/query text -- only a truncated SHA-256
+# hash -- and never changes response behavior. See docs/multi_agent_context_plane.md.
+_DAEMON_METRICS_ENABLED_ENV = "TG_DAEMON_METRICS"
+_DAEMON_METRICS_FILE = "daemon_metrics.json"
+_DAEMON_METRICS_SCHEMA_VERSION = 1
+# Commands that are auto-issued by daemon-lifecycle plumbing itself (health probes, the CLI's
+# start-or-reuse probe, stats polling, and stop) and would fabricate demand if counted.
+_DAEMON_METRICS_EXCLUDED_COMMANDS = frozenset({"ping", "stats", "stop", "health"})
+# The commands that build/return an expensive artifact (a rendered repo map, a symbol graph
+# query, a context/edit-plan render) -- the surface where a shared plane would de-duplicate
+# repeated work across concurrent agents.
+_DAEMON_METRICS_EXPENSIVE_COMMANDS = frozenset({
+    "repo_map",
+    "context",
+    "context_render",
+    "context_edit_plan",
+    "defs",
+    "impact",
+    "refs",
+    "callers",
+    "blast_radius",
+    "blast_radius_render",
+    "blast_radius_plan",
+})
+_DAEMON_METRICS_SYMBOL_COMMANDS = frozenset({
+    "defs",
+    "impact",
+    "refs",
+    "callers",
+    "blast_radius",
+    "blast_radius_render",
+    "blast_radius_plan",
+})
+_DAEMON_METRICS_QUERY_COMMANDS = frozenset({"context", "context_render", "context_edit_plan"})
+_DAEMON_METRICS_CLIENT_WINDOW_SECONDS = 300.0
+_DAEMON_METRICS_DUP_WINDOW_SECONDS = 900.0
+_DAEMON_METRICS_DUP_LRU_MAX_ENTRIES = 256
+_DAEMON_METRICS_DAY_PID_SET_CAP = 128
+_DAEMON_METRICS_MAX_DAY_BUCKETS = 30
+_DAEMON_METRICS_MAX_DUP_TARGETS_PER_DAY = 32
+_DAEMON_METRICS_FLUSH_POLL_INTERVALS = 12  # ~60s at the default 5s lifecycle poll
+_DAEMON_METRICS_ROLLUP_WINDOW_DAYS = 14
+_DAEMON_METRICS_ROLLUP_SHORT_WINDOW_DAYS = 7
+# Heuristic build-decision gate for the tg-ledger step-0 demand receipt -- deliberately not a
+# hard business commitment, just a documented, adjustable bar for "there is real cross-agent
+# concurrency AND real repeated-artifact demand" over the trailing 14 days.
+_DAEMON_METRICS_PRE_GATE_MIN_CONCURRENT_DAYS = 3
+_DAEMON_METRICS_PRE_GATE_MIN_DUP_REQUESTS_14D = 10
+
+
+def _daemon_metrics_enabled() -> bool:
+    raw = os.environ.get(_DAEMON_METRICS_ENABLED_ENV)
+    if raw is None:
+        return True
+    return raw.strip() != "0"
 
 
 def _daemon_metadata_path(root: Path) -> Path:
@@ -296,6 +356,15 @@ def _daemon_request(
     # client (which read the token from the 0600 daemon.json) authenticates transparently.
     if token:
         request = {**request, _DAEMON_TOKEN_FIELD: token}
+    # tg-ledger step-0 (demand instrumentation): tag every request with the CALLING process's
+    # pid so the daemon can distinguish concurrent distinct clients. A fresh TCP connection per
+    # request means client_address is ephemeral and the token is shared per-daemon (not
+    # per-client), so pid is the only signal available. Every client path (request_session_daemon,
+    # request_running_session_daemon, the ping/stats probes) funnels through this function. The
+    # pid is diagnostic-only -- never used for auth/routing -- and no response-cache key reads it
+    # (see _context_render_response_cache_key / _context_edit_plan_response_cache_key), so it
+    # cannot fragment cache hits between otherwise-identical requests.
+    request = {**request, "client_pid": os.getpid()}
     with socket.create_connection(
         (host, int(port)),
         timeout=_DAEMON_CONNECT_TIMEOUT_SECONDS,
@@ -404,47 +473,59 @@ def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
             live = _probe_daemon(discovered_root)
             if live is None:
                 continue
-            return _merge_live_daemon_stats(
-                {
-                    "version": _SESSION_VERSION,
-                    "root": str(discovered_root),
-                    "requested_root": str(root),
-                    "discovered": True,
-                    "running": True,
-                    "host": str(live.get("host", _DAEMON_HOST)),
-                    "port": int(live["port"]),
-                    "pid": int(live["pid"]),
-                    "started_at": str(live["started_at"]),
-                },
-                token=_daemon_token(live),
+            return _attach_demand_metrics(
+                _merge_live_daemon_stats(
+                    {
+                        "version": _SESSION_VERSION,
+                        "root": str(discovered_root),
+                        "requested_root": str(root),
+                        "discovered": True,
+                        "running": True,
+                        "host": str(live.get("host", _DAEMON_HOST)),
+                        "port": int(live["port"]),
+                        "pid": int(live["pid"]),
+                        "started_at": str(live["started_at"]),
+                    },
+                    token=_daemon_token(live),
+                ),
+                discovered_root,
             )
-        return {
-            "version": _SESSION_VERSION,
-            "root": str(root),
-            "discovered": False,
-            "running": False,
-        }
+        return _attach_demand_metrics(
+            {
+                "version": _SESSION_VERSION,
+                "root": str(root),
+                "discovered": False,
+                "running": False,
+            },
+            root,
+        )
     live = _probe_daemon(root)
     if live is None:
-        return {
-            "version": _SESSION_VERSION,
-            "root": str(root),
-            "discovered": False,
-            "running": False,
-            "stale_metadata": True,
-        }
-    return _merge_live_daemon_stats(
-        {
-            "version": _SESSION_VERSION,
-            "root": str(root),
-            "discovered": False,
-            "running": True,
-            "host": str(live.get("host", _DAEMON_HOST)),
-            "port": int(live["port"]),
-            "pid": int(live["pid"]),
-            "started_at": str(live["started_at"]),
-        },
-        token=_daemon_token(live),
+        return _attach_demand_metrics(
+            {
+                "version": _SESSION_VERSION,
+                "root": str(root),
+                "discovered": False,
+                "running": False,
+                "stale_metadata": True,
+            },
+            root,
+        )
+    return _attach_demand_metrics(
+        _merge_live_daemon_stats(
+            {
+                "version": _SESSION_VERSION,
+                "root": str(root),
+                "discovered": False,
+                "running": True,
+                "host": str(live.get("host", _DAEMON_HOST)),
+                "port": int(live["port"]),
+                "pid": int(live["pid"]),
+                "started_at": str(live["started_at"]),
+            },
+            token=_daemon_token(live),
+        ),
+        root,
     )
 
 
@@ -853,6 +934,291 @@ def _serve_daemon_response_with_cache(
     return response, "miss"
 
 
+# --------------------------------------------------------------------------------------------
+# tg-ledger step-0: demand instrumentation (docs/multi_agent_context_plane.md)
+#
+# Answers two questions with real traffic, not intuition, before any ledger/claims/A2A surface
+# is built: (1) do multiple distinct agent processes actually hit the same daemon concurrently,
+# and (2) do they actually re-request the same expensive artifact (symbol/query) within a short
+# window that a shared plane would de-duplicate. This is diagnostic-only: it never changes a
+# response, never stores raw symbol/query text (hash only), and a failure in `record()` must
+# never break serving (callers wrap it in `except Exception: pass`).
+# --------------------------------------------------------------------------------------------
+
+
+def _metrics_file_path(root: Path) -> Path:
+    return _sessions_dir(root) / _DAEMON_METRICS_FILE
+
+
+def _metrics_target_hash(command: str, target: str) -> str:
+    digest = hashlib.sha256(f"{command}\x00{target}".encode()).hexdigest()
+    return digest[:16]
+
+
+def _metrics_target_for_request(command: str, request: dict[str, Any]) -> str:
+    if command in _DAEMON_METRICS_SYMBOL_COMMANDS:
+        return str(request.get("symbol", "")).strip().lower()
+    if command in _DAEMON_METRICS_QUERY_COMMANDS:
+        return str(request.get("query", "")).strip().lower()
+    return ""
+
+
+def _utc_day_bucket(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=UTC).strftime("%Y-%m-%d")
+
+
+def _normalize_client_pid(client_pid: object) -> int | None:
+    try:
+        pid = int(cast(Any, client_pid))
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _empty_metrics_day_bucket() -> dict[str, Any]:
+    return {
+        "requests": 0,
+        "expensive_requests": 0,
+        "distinct_client_pids": 0,
+        "max_concurrent_distinct_clients": 0,
+        "overlap_events": 0,
+        "dup_requests": 0,
+        "dup_targets": {},
+        "by_command": {},
+    }
+
+
+def _sanitize_metrics_days(raw: object) -> dict[str, dict[str, Any]]:
+    """Defensively normalize a loaded (possibly hand-edited or stale-schema) days dict."""
+    sanitized: dict[str, dict[str, Any]] = {}
+    if not isinstance(raw, dict):
+        return sanitized
+    for day, bucket in raw.items():
+        if not isinstance(day, str) or not isinstance(bucket, dict):
+            continue
+        dup_targets_raw = bucket.get("dup_targets")
+        dup_targets = (
+            {str(key): int(cast(Any, value)) for key, value in dup_targets_raw.items()}
+            if isinstance(dup_targets_raw, dict)
+            else {}
+        )
+        by_command_raw = bucket.get("by_command")
+        by_command = (
+            {str(key): int(cast(Any, value)) for key, value in by_command_raw.items()}
+            if isinstance(by_command_raw, dict)
+            else {}
+        )
+        clean = _empty_metrics_day_bucket()
+        for field in (
+            "requests",
+            "expensive_requests",
+            "distinct_client_pids",
+            "max_concurrent_distinct_clients",
+            "overlap_events",
+            "dup_requests",
+        ):
+            try:
+                clean[field] = int(cast(Any, bucket.get(field, 0)) or 0)
+            except (TypeError, ValueError):
+                clean[field] = 0
+        clean["dup_targets"] = dup_targets
+        clean["by_command"] = by_command
+        sanitized[day] = clean
+    return sanitized
+
+
+class _DemandMetrics:
+    """In-memory, fail-open, PII-free demand counters for the tg-ledger step-0 gate.
+
+    Guarded by its own lock (independent of ``server._request_lock`` /
+    ``_response_cache_lock``) so metrics bookkeeping never contends with request dispatch or
+    the response cache. Every public method is defensive: bad input degrades to a no-op rather
+    than raising, because a metrics bug must never take the daemon down.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._clients: dict[int, float] = {}  # client_pid -> last_seen (monotonic)
+        self._day_pid_sets: dict[str, set[int]] = {}  # day -> distinct client pids seen this run
+        self._dup_lru: OrderedDict[str, float] = OrderedDict()  # target_hash -> last_seen (wall)
+        self._days: dict[str, dict[str, Any]] = {}
+        self._dirty = False
+
+    def load(self, days: object) -> None:
+        """Seed from a previously-persisted ``daemon_metrics.json`` (startup load-merge)."""
+        with self._lock:
+            self._days = _sanitize_metrics_days(days)
+
+    def record(self, *, command: str, client_pid: object, request: dict[str, Any]) -> None:
+        if command in _DAEMON_METRICS_EXCLUDED_COMMANDS or not _daemon_metrics_enabled():
+            return
+        now_monotonic = monotonic()
+        now_wall = time.time()
+        day = _utc_day_bucket(now_wall)
+        pid = _normalize_client_pid(client_pid)
+        with self._lock:
+            bucket = self._days.setdefault(day, _empty_metrics_day_bucket())
+            bucket["requests"] += 1
+            by_command = cast(dict[str, int], bucket["by_command"])
+            by_command[command] = by_command.get(command, 0) + 1
+
+            if pid is not None:
+                stale = [
+                    seen_pid
+                    for seen_pid, last_seen in self._clients.items()
+                    if now_monotonic - last_seen > _DAEMON_METRICS_CLIENT_WINDOW_SECONDS
+                ]
+                for seen_pid in stale:
+                    del self._clients[seen_pid]
+                self._clients[pid] = now_monotonic
+                concurrent = len(self._clients)
+                bucket["max_concurrent_distinct_clients"] = max(
+                    cast(int, bucket["max_concurrent_distinct_clients"]), concurrent
+                )
+                day_pids = self._day_pid_sets.setdefault(day, set())
+                if len(day_pids) < _DAEMON_METRICS_DAY_PID_SET_CAP:
+                    day_pids.add(pid)
+                bucket["distinct_client_pids"] = max(
+                    cast(int, bucket["distinct_client_pids"]), len(day_pids)
+                )
+                if concurrent >= 2:
+                    bucket["overlap_events"] += 1
+
+            if command in _DAEMON_METRICS_EXPENSIVE_COMMANDS:
+                bucket["expensive_requests"] += 1
+                target = _metrics_target_for_request(command, request)
+                target_hash = _metrics_target_hash(command, target)
+                last_seen_wall = self._dup_lru.get(target_hash)
+                if (
+                    last_seen_wall is not None
+                    and (now_wall - last_seen_wall) <= _DAEMON_METRICS_DUP_WINDOW_SECONDS
+                ):
+                    bucket["dup_requests"] += 1
+                    dup_targets = cast(dict[str, int], bucket["dup_targets"])
+                    if target_hash in dup_targets:
+                        dup_targets[target_hash] += 1
+                    elif len(dup_targets) < _DAEMON_METRICS_MAX_DUP_TARGETS_PER_DAY:
+                        dup_targets[target_hash] = 1
+                self._dup_lru[target_hash] = now_wall
+                self._dup_lru.move_to_end(target_hash)
+                while len(self._dup_lru) > _DAEMON_METRICS_DUP_LRU_MAX_ENTRIES:
+                    self._dup_lru.popitem(last=False)
+
+            self._dirty = True
+
+    def consume_dirty(self) -> bool:
+        with self._lock:
+            was_dirty = self._dirty
+            self._dirty = False
+            return was_dirty
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            if len(self._days) > _DAEMON_METRICS_MAX_DAY_BUCKETS:
+                newest_days = sorted(self._days)[-_DAEMON_METRICS_MAX_DAY_BUCKETS:]
+                self._days = {day: self._days[day] for day in newest_days}
+            return copy.deepcopy(self._days)
+
+
+def _write_demand_metrics(root: Path, metrics: _DemandMetrics) -> None:
+    payload = {
+        "version": _DAEMON_METRICS_SCHEMA_VERSION,
+        "root": str(root),
+        "days": metrics.snapshot(),
+    }
+    _write_json_atomic(_metrics_file_path(root), payload)
+
+
+def _flush_demand_metrics_if_dirty(server: _ThreadedSessionDaemon, *, force: bool = False) -> None:
+    dirty = server.demand_metrics.consume_dirty()
+    if not (force or dirty):
+        return
+    try:
+        _write_demand_metrics(server.root, server.demand_metrics)
+    except Exception:
+        pass  # metrics persistence must never crash the daemon
+
+
+def _read_demand_metrics_days(root: Path) -> dict[str, Any]:
+    path = _metrics_file_path(root)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    days = data.get("days") if isinstance(data, dict) else None
+    return days if isinstance(days, dict) else {}
+
+
+def _demand_metrics_status_payload(
+    root: Path, *, reference: datetime | None = None
+) -> dict[str, Any]:
+    """Read ``daemon_metrics.json`` from disk (works even with the daemon STOPPED) and roll the
+    trailing 14 days up into a build-decision-ready summary for the tg-ledger step-0 gate.
+    """
+    days = _sanitize_metrics_days(_read_demand_metrics_days(root))
+    now = reference or datetime.now(UTC)
+    cutoff_14 = (now - timedelta(days=_DAEMON_METRICS_ROLLUP_WINDOW_DAYS)).date()
+    cutoff_7 = (now - timedelta(days=_DAEMON_METRICS_ROLLUP_SHORT_WINDOW_DAYS)).date()
+
+    days_covered = 0
+    days_with_2plus_concurrent = 0
+    overlap_events_14d = 0
+    dup_requests_7d = 0
+    dup_requests_14d = 0
+    max_distinct_client_pids_14d = 0
+
+    for day_str, bucket in days.items():
+        try:
+            day_date = datetime.strptime(day_str, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+        if day_date > now.date() or day_date < cutoff_14:
+            continue
+        days_covered += 1
+        if cast(int, bucket["max_concurrent_distinct_clients"]) >= 2:
+            days_with_2plus_concurrent += 1
+        overlap_events_14d += cast(int, bucket["overlap_events"])
+        dup_requests_14d += cast(int, bucket["dup_requests"])
+        if day_date >= cutoff_7:
+            dup_requests_7d += cast(int, bucket["dup_requests"])
+        max_distinct_client_pids_14d = max(
+            max_distinct_client_pids_14d, cast(int, bucket["distinct_client_pids"])
+        )
+
+    pre_gate_met = (
+        days_covered > 0
+        and days_with_2plus_concurrent >= _DAEMON_METRICS_PRE_GATE_MIN_CONCURRENT_DAYS
+        and dup_requests_14d >= _DAEMON_METRICS_PRE_GATE_MIN_DUP_REQUESTS_14D
+    )
+
+    return {
+        "window_days": _DAEMON_METRICS_ROLLUP_WINDOW_DAYS,
+        "days_covered": days_covered,
+        "days_with_2plus_concurrent": days_with_2plus_concurrent,
+        "overlap_events_14d": overlap_events_14d,
+        "dup_requests_7d": dup_requests_7d,
+        "dup_requests_14d": dup_requests_14d,
+        "max_distinct_client_pids_14d": max_distinct_client_pids_14d,
+        "pre_gate_met": pre_gate_met,
+        "pre_gate_thresholds": {
+            "min_concurrent_days": _DAEMON_METRICS_PRE_GATE_MIN_CONCURRENT_DAYS,
+            "min_dup_requests_14d": _DAEMON_METRICS_PRE_GATE_MIN_DUP_REQUESTS_14D,
+        },
+    }
+
+
+def _attach_demand_metrics(status: dict[str, Any], metrics_root: Path) -> dict[str, Any]:
+    try:
+        status["demand_metrics"] = _demand_metrics_status_payload(metrics_root)
+    except Exception:
+        # Read-back must never break `tg doctor` / `tg session daemon status` (fail-open,
+        # mirrors the record()-side contract).
+        status["demand_metrics"] = {"error": "unavailable"}
+    return status
+
+
 class _SessionResponseCache:
     def __init__(
         self,
@@ -952,6 +1318,8 @@ class _ThreadedSessionDaemon(socketserver.ThreadingMixIn, socketserver.TCPServer
         self.token = token
         self.payload_cache = _SessionServeCache()
         self.response_cache = _SessionResponseCache()
+        # tg-ledger step-0: demand instrumentation, see docs/multi_agent_context_plane.md.
+        self.demand_metrics = _DemandMetrics()
         self.implicit_session_ids: OrderedDict[tuple[str, str], str] = OrderedDict()
         self.started_at = monotonic()
         self.request_count = 0
@@ -1047,6 +1415,14 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                 request, session_id, request_path
             )
             command = str(request.get("command", "")).strip().lower()
+            try:
+                server.demand_metrics.record(
+                    command=command,
+                    client_pid=request.get("client_pid"),
+                    request=request,
+                )
+            except Exception:
+                pass  # tg-ledger step-0 metrics must never break serving
             request_session_id = _implicit_session_id_for_request(
                 server,
                 command=command,
@@ -1210,7 +1586,14 @@ def _run_daemon_lifecycle_monitor(
     )
     if idle_limit <= 0 and max_uptime <= 0:
         return
+    # tg-ledger step-0: piggyback a low-frequency demand-metrics flush on this same poll loop
+    # (~once per _DAEMON_METRICS_FLUSH_POLL_INTERVALS ticks) rather than a dedicated thread.
+    flush_countdown = _DAEMON_METRICS_FLUSH_POLL_INTERVALS
     while not stop_event.wait(_DAEMON_LIFECYCLE_POLL_SECONDS):
+        flush_countdown -= 1
+        if flush_countdown <= 0:
+            flush_countdown = _DAEMON_METRICS_FLUSH_POLL_INTERVALS
+            _flush_demand_metrics_if_dirty(server)
         now = monotonic()
         with server._request_lock:
             idle_for = now - server.last_activity_at
@@ -1240,6 +1623,9 @@ def run_session_daemon_server(path: str = ".") -> None:
     # read daemon.json may issue commands.
     token = secrets.token_urlsafe(32)
     with _ThreadedSessionDaemon(root, (_DAEMON_HOST, 0), token=token) as server:
+        # tg-ledger step-0: load any prior demand-metrics history for this root before serving,
+        # so a daemon restart never clobbers the day-bucket counts a prior run already persisted.
+        server.demand_metrics.load(_read_demand_metrics_days(root))
         host, port = cast(tuple[str, int], server.server_address)
         _write_daemon_metadata(
             root,
@@ -1264,6 +1650,7 @@ def run_session_daemon_server(path: str = ".") -> None:
             server.serve_forever(poll_interval=0.1)
         finally:
             stop_event.set()
+            _flush_demand_metrics_if_dirty(server, force=True)
             _remove_daemon_metadata(root)
 
 

--- a/tests/unit/test_session_daemon_metrics.py
+++ b/tests/unit/test_session_daemon_metrics.py
@@ -1,0 +1,543 @@
+"""Tests for the tg-ledger step-0 demand instrumentation on the session daemon.
+
+This is DOCS + INSTRUMENTATION only (see ``docs/multi_agent_context_plane.md``) -- there is no
+ledger, no claims/findings surface, and no new command/flag. The counters exist purely to answer
+two build-decision questions with real traffic: (1) do multiple distinct agent processes hit the
+same daemon concurrently, and (2) do they re-request the same expensive artifact within a short
+window that a shared plane would de-duplicate.
+
+Mirrors the ``_ThreadedSessionDaemon`` harness in ``test_session_daemon_security.py``: a real
+loopback server, driven with real sockets via ``session_daemon._daemon_request``, with the
+session-store/repo-map layer stubbed out so these tests never need the compiled rust_core
+extension or a real repo.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import tensor_grep.cli.session_daemon as session_daemon
+from tensor_grep.cli.main import _render_doctor_payload
+
+
+def _serve(server: session_daemon._ThreadedSessionDaemon) -> threading.Thread:
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+def _stub_dispatch(monkeypatch: Any, root: Path) -> None:
+    """Route every non-lifecycle command through a cheap fake (mirrors the routing-only stub
+    in test_session_daemon_security.py::test_daemon_request_path_field_cannot_escape_root) so
+    these tests never touch the real session store / repo-map builder."""
+
+    def _fake_serve(
+        session_id: str,
+        request: dict[str, Any],
+        path: str,
+        *,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {"ok": True, "session_id": session_id, "command": request.get("command")}
+
+    monkeypatch.setattr(session_daemon, "serve_session_request", _fake_serve)
+    monkeypatch.setattr(
+        session_daemon,
+        "_implicit_session_id_for_request",
+        lambda server, *, command, session_id, path, request: session_id or "session-x",
+    )
+    monkeypatch.setattr(
+        session_daemon,
+        "_load_payload_with_status_retry",
+        lambda cache, session_id, path: ({"root": str(root), "repo_map": {}}, "miss"),
+    )
+
+
+def _minimal_doctor_payload(session_daemon_status: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "platform": "test",
+        "python_executable": "/usr/bin/python",
+        "invoked_as": "tg",
+        "root": "/repo",
+        "session_daemon": session_daemon_status,
+    }
+
+
+def _empty_day_bucket(**overrides: Any) -> dict[str, Any]:
+    bucket = {
+        "requests": 0,
+        "expensive_requests": 0,
+        "distinct_client_pids": 0,
+        "max_concurrent_distinct_clients": 0,
+        "overlap_events": 0,
+        "dup_requests": 0,
+        "dup_targets": {},
+        "by_command": {},
+    }
+    bucket.update(overrides)
+    return bucket
+
+
+# ------------------------------------------------------------------ 1: concurrent distinct clients
+
+
+def test_concurrent_distinct_clients_tracked(tmp_path: Path, monkeypatch: Any) -> None:
+    root = (tmp_path / "project-distinct").resolve()
+    root.mkdir()
+    _stub_dispatch(monkeypatch, root)
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        monkeypatch.setattr(session_daemon.os, "getpid", lambda: 111)
+        session_daemon._daemon_request(
+            host, port, {"command": "defs", "symbol": "foo"}, token="tok"
+        )
+        monkeypatch.setattr(session_daemon.os, "getpid", lambda: 222)
+        session_daemon._daemon_request(
+            host, port, {"command": "defs", "symbol": "bar"}, token="tok"
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    days = server.demand_metrics.snapshot()
+    assert len(days) == 1
+    bucket = next(iter(days.values()))
+    assert bucket["max_concurrent_distinct_clients"] == 2
+    assert bucket["overlap_events"] >= 1
+
+
+def test_repeated_same_client_pid_stays_at_one_concurrent_with_no_overlap(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    root = (tmp_path / "project-same-pid").resolve()
+    root.mkdir()
+    _stub_dispatch(monkeypatch, root)
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        monkeypatch.setattr(session_daemon.os, "getpid", lambda: 333)
+        session_daemon._daemon_request(
+            host, port, {"command": "defs", "symbol": "foo"}, token="tok"
+        )
+        session_daemon._daemon_request(
+            host, port, {"command": "defs", "symbol": "foo2"}, token="tok"
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    days = server.demand_metrics.snapshot()
+    bucket = next(iter(days.values()))
+    assert bucket["max_concurrent_distinct_clients"] == 1
+    assert bucket["overlap_events"] == 0
+
+
+# ------------------------------------------------------------------------- 2: repeat-artifact dup
+
+
+def test_repeat_expensive_artifact_detected_as_dup(tmp_path: Path, monkeypatch: Any) -> None:
+    root = (tmp_path / "project-dup").resolve()
+    root.mkdir()
+    _stub_dispatch(monkeypatch, root)
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        # same blast_radius symbol twice -> 1 dup
+        session_daemon._daemon_request(
+            host, port, {"command": "blast_radius", "symbol": "Foo"}, token="tok"
+        )
+        session_daemon._daemon_request(
+            host, port, {"command": "blast_radius", "symbol": "Foo"}, token="tok"
+        )
+        # a different symbol -> 0 additional dups
+        session_daemon._daemon_request(
+            host, port, {"command": "blast_radius", "symbol": "Bar"}, token="tok"
+        )
+        # same context_render query twice -> 1 dup
+        session_daemon._daemon_request(
+            host,
+            port,
+            {"command": "context_render", "query": "invoice payment"},
+            token="tok",
+        )
+        session_daemon._daemon_request(
+            host,
+            port,
+            {"command": "context_render", "query": "invoice payment"},
+            token="tok",
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    days = server.demand_metrics.snapshot()
+    bucket = next(iter(days.values()))
+    assert bucket["dup_requests"] == 2
+    assert bucket["expensive_requests"] == 5
+
+
+# ------------------------------------------------------------------ 3: lifecycle commands excluded
+
+
+def test_lifecycle_commands_never_counted(tmp_path: Path, monkeypatch: Any) -> None:
+    root = (tmp_path / "project-lifecycle").resolve()
+    root.mkdir()
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        monkeypatch.setattr(session_daemon.os, "getpid", lambda: 555)
+        session_daemon._daemon_request(host, port, {"command": "ping"}, token="tok")
+        session_daemon._daemon_request(host, port, {"command": "stats"}, token="tok")
+        session_daemon._daemon_request(
+            host, port, {"command": "health", "session_id": "nope"}, token="tok"
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    assert server.demand_metrics.snapshot() == {}
+
+    # "stop" is excluded too, but a live "stop" round trip would shut the server down mid-test
+    # (it self-terminates cooperatively), so verify the exclusion directly against record().
+    server.demand_metrics.record(command="stop", client_pid=555, request={"command": "stop"})
+    assert server.demand_metrics.snapshot() == {}
+
+
+# --------------------------------------------------------------- 4: unauthorized records nothing
+
+
+def test_unauthorized_request_records_nothing(tmp_path: Path, monkeypatch: Any) -> None:
+    root = (tmp_path / "project-unauth").resolve()
+    root.mkdir()
+    _stub_dispatch(monkeypatch, root)
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        # No token at all.
+        session_daemon._daemon_request(host, port, {"command": "defs", "symbol": "foo"})
+        # Wrong token.
+        session_daemon._daemon_request(
+            host, port, {"command": "defs", "symbol": "foo", "token": "nope"}
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    assert server.demand_metrics.snapshot() == {}
+
+
+# ----------------------------------------------------------------------------- 5: flush integrity
+
+
+def test_flush_writes_valid_pii_free_json_and_prunes_bounds(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    root = (tmp_path / "project-flush").resolve()
+    root.mkdir()
+    metrics = session_daemon._DemandMetrics()
+
+    secret_symbol = "TopSecretInternalApiKeyRotationHandler"
+    secret_query = "rotate the internal api key handler right now"
+
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+
+    # 35 distinct days -> must prune to the newest 30 on flush.
+    for day_index in range(35):
+        moment = base + timedelta(days=day_index)
+        monkeypatch.setattr(session_daemon.time, "time", lambda m=moment: m.timestamp())
+        metrics.record(
+            command="defs",
+            client_pid=1000 + day_index,
+            request={"command": "defs", "symbol": secret_symbol},
+        )
+
+    # On the newest day: 40 distinct symbols, each requested twice (a dup pair) -> dup_targets
+    # must cap at 32 entries even though every symbol is a genuine, distinct dup target.
+    last_moment = base + timedelta(days=34)
+    monkeypatch.setattr(session_daemon.time, "time", lambda m=last_moment: m.timestamp())
+    for n in range(40):
+        symbol = f"sym-{n}"
+        metrics.record(command="refs", client_pid=1, request={"command": "refs", "symbol": symbol})
+        metrics.record(command="refs", client_pid=1, request={"command": "refs", "symbol": symbol})
+    # A query-shaped secret must also never reach disk in the clear.
+    metrics.record(
+        command="context_render",
+        client_pid=1,
+        request={"command": "context_render", "query": secret_query},
+    )
+
+    metrics_path = session_daemon._metrics_file_path(root)
+    session_daemon._write_demand_metrics(root, metrics)
+
+    assert metrics_path.exists()
+    leftover_tmp = list(metrics_path.parent.glob(f".{metrics_path.name}.*.tmp"))
+    assert leftover_tmp == [], "atomic write must not leave a .tmp behind"
+
+    raw_bytes = metrics_path.read_bytes()
+    data = json.loads(raw_bytes)  # must be valid JSON
+    assert isinstance(data["days"], dict)
+    assert len(data["days"]) == 30, "35 day-buckets must prune down to the newest 30"
+
+    newest_day = max(data["days"])
+    dup_targets = data["days"][newest_day]["dup_targets"]
+    assert len(dup_targets) <= 32
+
+    # PII-free: the persisted bytes must never contain the literal symbol/query text.
+    assert secret_symbol.encode("utf-8") not in raw_bytes
+    assert secret_query.encode("utf-8") not in raw_bytes
+    assert b"sym-0" not in raw_bytes
+
+
+def test_metrics_target_hash_never_embeds_the_raw_target() -> None:
+    target_hash = session_daemon._metrics_target_hash("defs", "super_secret_symbol")
+    assert "super_secret_symbol" not in target_hash
+    assert len(target_hash) == 16
+    # deterministic for the same (command, target) pair
+    assert target_hash == session_daemon._metrics_target_hash("defs", "super_secret_symbol")
+    # different target -> different hash
+    assert target_hash != session_daemon._metrics_target_hash("defs", "other_symbol")
+
+
+# -------------------------------------------------------------- 6: load-merge survives a restart
+
+
+def test_preseeded_metrics_survive_load_and_flush_no_clobber(tmp_path: Path) -> None:
+    root = (tmp_path / "project-preseed").resolve()
+    session_daemon._sessions_dir(root).mkdir(parents=True)
+
+    preseeded = {
+        "version": 1,
+        "root": str(root),
+        "days": {
+            "2026-06-01": {
+                "requests": 50,
+                "expensive_requests": 40,
+                "distinct_client_pids": 5,
+                "max_concurrent_distinct_clients": 3,
+                "overlap_events": 7,
+                "dup_requests": 12,
+                "dup_targets": {"abc123": 4},
+                "by_command": {"defs": 30, "refs": 10},
+            }
+        },
+    }
+    metrics_path = session_daemon._metrics_file_path(root)
+    metrics_path.write_text(json.dumps(preseeded), encoding="utf-8")
+
+    # Simulate a fresh daemon process (new server, new in-memory metrics object) loading the
+    # prior run's history before serving anything.
+    metrics = session_daemon._DemandMetrics()
+    metrics.load(session_daemon._read_demand_metrics_days(root))
+    session_daemon._write_demand_metrics(root, metrics)
+
+    data = json.loads(metrics_path.read_text(encoding="utf-8"))
+    bucket = data["days"]["2026-06-01"]
+    assert bucket["requests"] == 50
+    assert bucket["distinct_client_pids"] == 5
+    assert bucket["max_concurrent_distinct_clients"] == 3
+    assert bucket["dup_targets"] == {"abc123": 4}
+    assert bucket["by_command"] == {"defs": 30, "refs": 10}
+
+
+# --------------------------------------------------------- 7: status read-back + doctor rendering
+
+
+def test_status_readback_includes_demand_metrics_and_pre_gate_met(tmp_path: Path) -> None:
+    root = (tmp_path / "project-status-met").resolve()
+    session_daemon._sessions_dir(root).mkdir(parents=True)
+
+    today = datetime.now(UTC).date()
+    days = {
+        (today - timedelta(days=i)).strftime("%Y-%m-%d"): _empty_day_bucket(
+            requests=20,
+            expensive_requests=15,
+            distinct_client_pids=3,
+            max_concurrent_distinct_clients=2,
+            overlap_events=5,
+            dup_requests=4,
+        )
+        for i in range(4)
+    }
+    session_daemon._metrics_file_path(root).write_text(
+        json.dumps({"version": 1, "root": str(root), "days": days}), encoding="utf-8"
+    )
+
+    # No daemon.json here -> the status read-back must work with the daemon STOPPED.
+    status = session_daemon.get_session_daemon_status(str(root))
+    assert status["running"] is False
+    assert "demand_metrics" in status
+    demand = status["demand_metrics"]
+    assert demand["days_covered"] == 4
+    assert demand["days_with_2plus_concurrent"] == 4
+    assert demand["dup_requests_14d"] == 16
+    assert demand["pre_gate_met"] is True
+
+    rendered = _render_doctor_payload(_minimal_doctor_payload(status))
+    assert "session_daemon_demand(14d):" in rendered
+    assert "pre_gate=MET" in rendered
+
+
+def test_doctor_line_distinguishes_no_coverage_from_not_met(tmp_path: Path) -> None:
+    # NO-COVERAGE: no daemon_metrics.json exists at all for this root.
+    empty_root = (tmp_path / "project-empty").resolve()
+    empty_root.mkdir()
+    empty_status = session_daemon.get_session_daemon_status(str(empty_root))
+    rendered_empty = _render_doctor_payload(_minimal_doctor_payload(empty_status))
+    assert "pre_gate=NO-COVERAGE" in rendered_empty
+
+    # NOT-MET: a covered day exists, but it does not clear the gate thresholds.
+    sparse_root = (tmp_path / "project-sparse").resolve()
+    session_daemon._sessions_dir(sparse_root).mkdir(parents=True)
+    sparse_day = (datetime.now(UTC).date() - timedelta(days=1)).strftime("%Y-%m-%d")
+    sparse_days = {
+        sparse_day: _empty_day_bucket(
+            requests=5,
+            expensive_requests=3,
+            distinct_client_pids=1,
+            max_concurrent_distinct_clients=1,
+            dup_requests=1,
+        )
+    }
+    session_daemon._metrics_file_path(sparse_root).write_text(
+        json.dumps({"version": 1, "root": str(sparse_root), "days": sparse_days}),
+        encoding="utf-8",
+    )
+    sparse_status = session_daemon.get_session_daemon_status(str(sparse_root))
+    rendered_sparse = _render_doctor_payload(_minimal_doctor_payload(sparse_status))
+    assert "pre_gate=NOT-MET" in rendered_sparse
+    assert sparse_status["demand_metrics"]["days_covered"] == 1
+    assert sparse_status["demand_metrics"]["pre_gate_met"] is False
+
+
+# --------------------------------------------------------------------------- 8: fail-open record
+
+
+def test_record_exception_never_breaks_serving(tmp_path: Path, monkeypatch: Any) -> None:
+    root = (tmp_path / "project-failopen").resolve()
+    root.mkdir()
+    _stub_dispatch(monkeypatch, root)
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("demand_metrics exploded")
+
+    monkeypatch.setattr(server.demand_metrics, "record", _boom)
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        response = session_daemon._daemon_request(
+            host, port, {"command": "defs", "symbol": "foo"}, token="tok"
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    assert response.get("ok") is True
+
+
+# ----------------------------------------------------------- 9: client_pid does not split caching
+
+
+def test_client_pid_does_not_fragment_response_cache(tmp_path: Path, monkeypatch: Any) -> None:
+    root = (tmp_path / "project-cache").resolve()
+    root.mkdir()
+
+    call_count = {"n": 0}
+
+    def _fake_serve(
+        session_id: str,
+        request: dict[str, Any],
+        path: str,
+        *,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        call_count["n"] += 1
+        return {
+            "ok": True,
+            "session_id": session_id,
+            "routing_reason": "session-context-render",
+        }
+
+    monkeypatch.setattr(session_daemon, "serve_session_request", _fake_serve)
+    monkeypatch.setattr(
+        session_daemon,
+        "_implicit_session_id_for_request",
+        lambda server, *, command, session_id, path, request: session_id or "session-x",
+    )
+    monkeypatch.setattr(
+        session_daemon,
+        "_load_payload_with_status_retry",
+        lambda cache, session_id, path: ({"root": str(root), "repo_map": {}}, "miss"),
+    )
+
+    server = session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token="tok")
+    thread = _serve(server)
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        request = {
+            "command": "context_render",
+            "session_id": "session-x",
+            "query": "invoice payment",
+        }
+        monkeypatch.setattr(session_daemon.os, "getpid", lambda: 111)
+        first = session_daemon._daemon_request(host, port, dict(request), token="tok")
+        monkeypatch.setattr(session_daemon.os, "getpid", lambda: 222)
+        second = session_daemon._daemon_request(host, port, dict(request), token="tok")
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+    assert call_count["n"] == 1, "serve_session_request must only actually run once"
+    assert first["daemon_response_cache"]["status"] == "miss"
+    assert second["daemon_response_cache"]["status"] == "hit"
+    assert server.response_cache.hits >= 1
+
+
+# -------------------------------------------------------------------------- bonus: kill switch
+
+
+def test_kill_switch_disables_recording(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setenv(session_daemon._DAEMON_METRICS_ENABLED_ENV, "0")
+    metrics = session_daemon._DemandMetrics()
+    metrics.record(command="defs", client_pid=1, request={"command": "defs", "symbol": "foo"})
+    assert metrics.snapshot() == {}
+
+
+def test_metrics_enabled_by_default(monkeypatch: Any) -> None:
+    monkeypatch.delenv(session_daemon._DAEMON_METRICS_ENABLED_ENV, raising=False)
+    assert session_daemon._daemon_metrics_enabled() is True
+    monkeypatch.setenv(session_daemon._DAEMON_METRICS_ENABLED_ENV, "0")
+    assert session_daemon._daemon_metrics_enabled() is False
+    monkeypatch.setenv(session_daemon._DAEMON_METRICS_ENABLED_ENV, "1")
+    assert session_daemon._daemon_metrics_enabled() is True


### PR DESCRIPTION
## What this is
CEO-approved **step-0** of the `tg ledger` exploration (A2A / local agent context-sharing). Per the 3-seat thinktank verdict (**DOCUMENT-NOW-BUILD-LATER-ON-GATE**): document what tg already ships for concurrent agents, and instrument the daemon to **measure real demand** — so the eventual ledger build is earned by data, not built on a hunch. **No ledger, no claims/findings, no new command/flag/protocol.**

## What's built
- **Docs** — new `docs/multi_agent_context_plane.md`: tg is the local shared *code-intelligence* plane (repo-scoped session store + token-authed daemon serve the warm repo-map/capsule to any agent on the same repo); task boards (Agent Teams/Beads) own the *prose* coordination layer — complementary. Every mechanism claim grounded in a `file:line`; includes an honesty section (MCP `tg_session_*` are in-process not daemon-routed; response-cache is `snapshot_mtime_only`; no ledger/A2A). Wired into `index.md`, `mkdocs.yml`, and one cross-link in `harness_cookbook.md`.
- **Demand instrumentation** (`session_daemon.py`) — a `_DemandMetrics` counter recording (a) concurrent-distinct-clients and (b) repeat expensive-artifact requests. **Auth-gated** (record sits after `is_authorized`, unauthorized clients count nothing), **fail-open** (`try/except: pass` — a metrics error can never break serving), **PII-free** (SHA-256 hashes of symbols/queries, never raw text), **bounded** (30 day-buckets, 32 dup-targets/day, LRU-256), single-writer atomic file. **Default-ON with `TG_DAEMON_METRICS=0` kill switch.**
- **Read-back, no new command/flag** — `get_session_daemon_status` attaches a 14-day rollup (surfaces in `tg session daemon status --json` + `tg doctor --json`) with `days_covered` + `pre_gate_met`, so "no daemon ran" reads as `NO-COVERAGE`, never a false "no demand".

## The 2-week pre-gate it feeds
Build the ledger only if: ≥3 days with ≥2 concurrent agents on one repo AND (≥5 duplicate computations/week OR ≥1 real overlapping-edit rework). Otherwise document-only was correct — learned for $0.

## Verification
Real venv: **53 passed, 1 skipped** (`test_session_daemon_metrics.py` = 14 tests incl. PII-free-raw-bytes, fail-open, NO-COVERAGE-vs-NOT-MET); ruff + `ruff format --check --preview` + mypy clean; docs governance green. Record seam manually confirmed auth-gated + fail-open (session_daemon.py:1392/1418-1425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)