### PR TITLE
fix(lock): make the index lock ownership-aware (uuid4 token + mtime heartbeat) so a stale-reclaimed holder can't delete the new owner's live lock (audit #14)

### DIFF
--- a/src/tensor_grep/cli/_index_lock.py
+++ b/src/tensor_grep/cli/_index_lock.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from uuid import uuid4
 
 _POLL_S = 0.02
 _STALE_AFTER_S = 10.0  # RMW-scaled, NOT daemon-launch-scaled
@@ -48,6 +50,70 @@ def _lock_path_for(index_path: Path) -> Path:
     return index_path.with_name(f".{index_path.name}.lock")
 
 
+def _token_for_lock(lock_path: Path) -> str | None:
+    """Read back the ownership token written by ``index_lock`` on acquire (the second line
+    of ``{pid}\\n{token}\\n``). Returns ``None`` if the file is gone, unreadable, or lacks a
+    token line (e.g. a legacy/malformed lock content in an existing test fixture) -- callers
+    treat ``None`` as "not mine", never as a match."""
+    try:
+        content = lock_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    lines = content.splitlines()
+    if len(lines) < 2:
+        return None
+    token = lines[1].strip()
+    return token or None
+
+
+def _release_lock(lock_path: Path, token: str) -> None:
+    """audit #14 ownership-token backstop: unlink ``lock_path`` ONLY if it still carries
+    ``token`` (i.e. this instance still owns it). If a waiter reclaimed the lock as stale
+    while this holder was still slow-but-alive, the token on disk no longer matches --
+    leave that live lock alone instead of deleting it out from under the new owner
+    (the lost-update / two-holders race). Tolerates the lock already being gone
+    (``FileNotFoundError``) and the Windows delete-pending ``PermissionError``.
+
+    Known residual (theoretical, accepted): there is a sub-millisecond read-then-unlink
+    window -- if a waiter stale-reclaims between the token read below and the ``unlink``,
+    this ``unlink`` could delete the new owner's file. It is not portably closable (no
+    filesystem compare-and-delete primitive) and is rendered practically unreachable by
+    the mtime heartbeat, which keeps this holder's lock fresh (age << the 10s stale
+    threshold) right up until release -- so a waiter cannot observe staleness during the
+    release window unless this process is actually dead. This is strictly smaller than the
+    pre-fix unconditional ``unlink`` it replaces."""
+    if _token_for_lock(lock_path) != token:
+        return
+    try:
+        lock_path.unlink()
+    except OSError:
+        pass
+
+
+def _default_heartbeat_interval_s(stale_after_s: float, poll_interval_s: float) -> float:
+    # Well under stale_after_s so a live-but-slow holder's mtime never crosses the
+    # staleness threshold between beats; floored at poll_interval_s so a tiny custom
+    # stale_after_s (tests) can't drive this to ~0 and busy-loop the heartbeat thread.
+    return max(poll_interval_s, stale_after_s / 3.0)
+
+
+def _heartbeat_loop(lock_path: Path, token: str, stop: threading.Event, interval_s: float) -> None:
+    """audit #14 primary defense: while a section is long-held, periodically touch the
+    lockfile's mtime so a concurrent waiter's staleness check never sees a live holder as
+    dead (preventing the false-stale reclaim race before it starts -- the token guard in
+    ``_release_lock`` is only the backstop for if it still happens). Re-checks ownership
+    every beat before touching mtime so a heartbeat thread that outlives its own lock (e.g.
+    release already ran, or -- defensively -- someone else reclaimed) never props up a
+    DIFFERENT holder's lock."""
+    while not stop.wait(interval_s):
+        if _token_for_lock(lock_path) != token:
+            return  # no longer ours -- stop, do not touch whatever/whoever is there now
+        try:
+            os.utime(lock_path, None)
+        except OSError:
+            pass  # transient (e.g. Windows delete-pending); next beat retries
+
+
 @contextmanager
 def index_lock(
     index_path: Path,
@@ -55,6 +121,7 @@ def index_lock(
     poll_interval_s: float = _POLL_S,
     timeout_s: float = _TIMEOUT_S,
     stale_after_s: float = _STALE_AFTER_S,
+    heartbeat_interval_s: float | None = None,
 ) -> Iterator[None]:
     lock_path = _lock_path_for(index_path)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -87,14 +154,31 @@ def index_lock(
                 f"could not acquire {lock_path} within {timeout_s}s"
             ) from None
         time.sleep(poll_interval_s)
+    # audit #14: a uuid4 ownership token (not just the pid, which can collide across a
+    # crash+relaunch) identifies THIS acquisition. Written alongside the pid so a stale
+    # legacy/pid-only lock (no second line) is still tolerated by `_token_for_lock`.
+    token = uuid4().hex
+    hb_interval = (
+        heartbeat_interval_s
+        if heartbeat_interval_s is not None
+        else _default_heartbeat_interval_s(stale_after_s, poll_interval_s)
+    )
     try:
         try:
-            os.write(fd, f"{os.getpid()}\n".encode())
+            os.write(fd, f"{os.getpid()}\n{token}\n".encode())
         finally:
             os.close(fd)
-        yield
-    finally:
+        stop_heartbeat = threading.Event()
+        heartbeat = threading.Thread(
+            target=_heartbeat_loop,
+            args=(lock_path, token, stop_heartbeat, hb_interval),
+            daemon=True,
+        )
+        heartbeat.start()
         try:
-            lock_path.unlink()
-        except OSError:
-            pass
+            yield
+        finally:
+            stop_heartbeat.set()
+            heartbeat.join(timeout=1.0)  # bounded: never hang release on a wedged thread
+    finally:
+        _release_lock(lock_path, token)

--- a/tests/unit/test_index_lock.py
+++ b/tests/unit/test_index_lock.py
@@ -168,8 +168,14 @@ def test_heartbeat_keeps_mtime_fresh_during_long_hold(tmp_path: Path) -> None:
     hold."""
     index_path = tmp_path / "index.json"
     lock_path = _index_lock._lock_path_for(index_path)
-    stale_after_s = 0.15
-    hold_s = 0.6  # several multiples of stale_after_s
+    # Absolute values are deliberately generous: the property under test is that the
+    # heartbeat keeps mtime younger than stale_after_s, which only requires the heartbeat
+    # interval to be a small fraction of stale_after_s. Tight sub-100ms bounds flake on
+    # loaded 2-core CI runners where the heartbeat thread can be GIL-starved for >150ms
+    # (observed: 0.152s > 0.15s on macos-latest). stale_after_s here is 12x the heartbeat
+    # interval, so realistic scheduling jitter stays well clear of the bound.
+    stale_after_s = 0.6
+    hold_s = 1.5  # several multiples of stale_after_s
 
     max_observed_age = 0.0
     stop_observer = threading.Event()

--- a/tests/unit/test_index_lock.py
+++ b/tests/unit/test_index_lock.py
@@ -11,6 +11,7 @@ fresh-but-dead lock would NEVER be reclaimed within the wait window -- every wai
 from __future__ import annotations
 
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -50,3 +51,190 @@ def test_fresh_stale_lock_is_reclaimed_before_the_waiter_gives_up(tmp_path: Path
 
     assert elapsed < 1.2
     assert not lock_path.exists()
+
+
+# --------------------------------------------------------------------------------------
+# audit #14: index-lock not ownership-aware. The lock wrote `{pid}` on acquire but never
+# read it back, and `finally` unconditionally unlinked the lockfile. Failure sequence: A
+# acquires; A goes slow past the staleness threshold; a waiter B sees A's lock as stale and
+# reclaims it (deletes A's file, writes its own); A's `finally` finally runs and
+# unconditionally deletes B's LIVE lock -- the index now has no lock while B still thinks
+# it holds one -> lost-update / two concurrent writers. Fix is two mechanisms: a uuid4
+# ownership token verified on release (the correctness backstop), plus an mtime heartbeat
+# while a section is long-held (the primary defense -- prevents a live-but-slow holder from
+# ever LOOKING stale to a waiter in the first place).
+# --------------------------------------------------------------------------------------
+
+
+def test_acquire_writes_pid_and_token(tmp_path: Path) -> None:
+    """Acquire must write `{pid}\\n{token}\\n`, and the token must round-trip through the
+    same reader `_release_lock` uses to decide ownership."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    with _index_lock.index_lock(index_path):
+        content = lock_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        assert len(lines) == 2
+        assert lines[0] == str(os.getpid())
+        assert lines[1]  # a non-empty uuid4 hex token
+        assert _index_lock._token_for_lock(lock_path) == lines[1]
+
+
+def test_release_with_matching_token_unlinks(tmp_path: Path) -> None:
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    token = "matching-token"
+    lock_path.write_text(f"{os.getpid()}\n{token}\n", encoding="utf-8")
+
+    _index_lock._release_lock(lock_path, token)
+
+    assert not lock_path.exists()
+
+
+def test_release_with_mismatched_token_does_not_unlink(tmp_path: Path) -> None:
+    """The correctness backstop: if the token on disk isn't ours (another holder reclaimed
+    it), release must leave that live lock alone."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    lock_path.write_text(f"{os.getpid()}\nsomeone-elses-token\n", encoding="utf-8")
+
+    _index_lock._release_lock(lock_path, "my-token")
+
+    assert lock_path.exists()
+
+
+def test_release_tolerates_lock_already_gone(tmp_path: Path) -> None:
+    """`_release_lock` must not raise if the lockfile is already gone (e.g. reclaimed and
+    then that reclaimer also already released)."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    assert not lock_path.exists()
+
+    _index_lock._release_lock(lock_path, "any-token")  # must not raise
+
+    assert not lock_path.exists()
+
+
+def test_core_race_A_release_does_not_delete_B_live_lock(tmp_path: Path) -> None:
+    """The audit #14 core race, exercised through the real acquire/release code paths (not
+    a hand simulation): A acquires; A's lock is pushed past the staleness threshold
+    (simulating "A went slow"); B runs the real acquire loop, sees A's lock as stale, and
+    reclaims it (unlink + own O_CREAT|O_EXCL + own token); A's `finally` then runs and MUST
+    NOT delete B's live lock because A's token no longer matches what's on disk. The
+    heartbeat is disabled here (a huge interval) to force the exact race the token backstop
+    exists for -- the heartbeat's own defense is proven separately."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+
+    cm_a = _index_lock.index_lock(
+        index_path, stale_after_s=0.05, timeout_s=5.0, heartbeat_interval_s=999.0
+    )
+    cm_a.__enter__()  # A acquires
+    try:
+        token_a = _index_lock._token_for_lock(lock_path)
+        assert token_a is not None
+
+        # A "goes slow": push the lock well past the stale threshold.
+        stale_mtime = time.time() - 10.0
+        os.utime(lock_path, (stale_mtime, stale_mtime))
+
+        # B runs the REAL acquire loop: sees A's lock as stale, reclaims it, writes its own.
+        cm_b = _index_lock.index_lock(index_path, stale_after_s=0.05, timeout_s=5.0)
+        cm_b.__enter__()
+        try:
+            token_b = _index_lock._token_for_lock(lock_path)
+            assert token_b is not None
+            assert token_b != token_a
+
+            # A finally finishes its slow work and releases.
+            cm_a.__exit__(None, None, None)
+            cm_a = None  # already exited -- don't double-exit in the outer finally
+
+            # B's live lock must survive A's release.
+            assert lock_path.exists()
+            assert _index_lock._token_for_lock(lock_path) == token_b
+        finally:
+            cm_b.__exit__(None, None, None)
+        assert not lock_path.exists()  # B released cleanly too
+    finally:
+        if cm_a is not None:
+            cm_a.__exit__(None, None, None)
+
+
+def test_heartbeat_keeps_mtime_fresh_during_long_hold(tmp_path: Path) -> None:
+    """The primary defense: while a section is long-held, the heartbeat thread must keep
+    the lockfile's mtime fresh so a concurrent waiter's staleness check never sees it as
+    dead -- the observed age of the lockfile must never approach `stale_after_s` during the
+    hold."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    stale_after_s = 0.15
+    hold_s = 0.6  # several multiples of stale_after_s
+
+    max_observed_age = 0.0
+    stop_observer = threading.Event()
+
+    def observe() -> None:
+        nonlocal max_observed_age
+        while not stop_observer.wait(0.02):
+            try:
+                age = time.time() - lock_path.stat().st_mtime
+            except OSError:
+                continue
+            max_observed_age = max(max_observed_age, age)
+
+    observer = threading.Thread(target=observe)
+    with _index_lock.index_lock(index_path, stale_after_s=stale_after_s, heartbeat_interval_s=0.03):
+        observer.start()
+        time.sleep(hold_s)
+        stop_observer.set()
+        observer.join(timeout=2.0)
+
+    assert max_observed_age < stale_after_s
+
+
+def test_heartbeat_stops_propping_up_a_lock_it_no_longer_owns(tmp_path: Path) -> None:
+    """Defensive property of `_heartbeat_loop`: once the token on disk no longer matches
+    the heartbeat's own token, it must stop touching mtime rather than propping up whatever
+    (or whoever) is there now."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    my_token = "my-token"
+    lock_path.write_text(f"{os.getpid()}\n{my_token}\n", encoding="utf-8")
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=_index_lock._heartbeat_loop, args=(lock_path, my_token, stop, 0.02)
+    )
+    thread.start()
+    time.sleep(0.05)  # let at least one beat land while it's still "ours"
+
+    # Someone else takes over the same path (as a real stale-reclaim would).
+    lock_path.write_text("999999\nsomeone-elses-token\n", encoding="utf-8")
+    other_mtime = time.time() - 5.0
+    os.utime(lock_path, (other_mtime, other_mtime))
+
+    # Give the heartbeat thread time to notice the mismatch and self-stop, then a further
+    # window during which it must NOT have touched the file again.
+    time.sleep(0.2)
+    age_after_takeover = time.time() - lock_path.stat().st_mtime
+    stop.set()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+
+    assert age_after_takeover >= 5.0 - 0.25  # untouched since the "someone else" write
+
+
+def test_repeated_acquire_release_hammer_windows(tmp_path: Path) -> None:
+    """#355 repeated-spawn class: 15-20x acquire/release of the SAME index lock in one
+    process must never crash, leak a PermissionError, or leave an orphaned lockfile --
+    now also exercising the added heartbeat-thread spawn/join and token round-trip on every
+    single cycle."""
+    index_path = tmp_path / "index.json"
+    lock_path = _index_lock._lock_path_for(index_path)
+    for i in range(20):
+        with _index_lock.index_lock(index_path, timeout_s=5.0):
+            assert lock_path.exists()
+            assert _index_lock._token_for_lock(lock_path) is not None
+        assert not lock_path.exists(), f"orphaned lockfile after cycle {i}"

--- a/tests/unit/test_index_lock.py
+++ b/tests/unit/test_index_lock.py
@@ -190,7 +190,7 @@ def test_heartbeat_keeps_mtime_fresh_during_long_hold(tmp_path: Path) -> None:
             max_observed_age = max(max_observed_age, age)
 
     observer = threading.Thread(target=observe)
-    with _index_lock.index_lock(index_path, stale_after_s=stale_after_s, heartbeat_interval_s=0.03):
+    with _index_lock.index_lock(index_path, stale_after_s=stale_after_s, heartbeat_interval_s=0.05):
         observer.start()
         time.sleep(hold_s)
         stop_observer.set()


### PR DESCRIPTION
## The bug (HIGH — cross-process lost-update / two-holders)
`_index_lock` wrote `{pid}` to the lockfile on acquire but **never read it back**, and the `finally` **unconditionally unlinked** the lockfile. Failure sequence: holder A acquires → A goes slow (exceeds the 10s stale threshold) → waiter B reclaims the "stale" lock (deletes A's file, writes B's) → A finishes and its `finally` **deletes B's live lock** → the index now has two effective holders → lost-update / orphaned-record (the round-4 disk-growth class). This is the #355 file (3 Windows lock bugs previously caught).

## The fix (both mechanisms)
1. **Ownership token (backstop):** acquire writes `{pid}\n{token}\n` (uuid4). Release reads the file back and unlinks **only if the token still matches** — a mismatch means a waiter reclaimed it, so B's live lock is left intact. Tolerates `FileNotFoundError` + Windows delete-pending `PermissionError`; a torn/partial read can never equal the full token, so it fails safe (mismatch → don't delete).
2. **Mtime heartbeat (primary defense):** a `daemon=True` thread touches the lockfile's mtime while held, so a live-but-slow holder never *looks* stale to a waiter — preventing the false-stale reclaim entirely. It self-stops on token mismatch (never props up a different holder) and dies with the process (a crashed holder's lock still stale-reclaims after 10s — no deadlock-forever).

**Preserved (verified intact):** the double-reclaim unlink guard, Windows delete-pending handling, `O_CREAT|O_EXCL` acquire, 10s stale-reclaim, 12s fail-closed `IndexLockTimeoutError`. Callers use `with index_lock(...)` (no `as`) → fully backward-compatible.

## Verification
- Real venv: **109 passed** (`test_index_lock` + `test_index_lock_concurrency` + downstream `session_cli` + `checkpoint_containment`); ruff + `ruff format --check --preview` + mypy clean. New tests incl. the core race (A's release does not delete B's live lock), heartbeat freshness/self-stop, and a **20x Windows repeated-acquire hammer**.
- **Opus adversarial security gate: SHIP** — all hunt targets pass (heartbeat correctness, dead-holder-still-reclaimable, Windows read-back, preserved defenses, write atomicity). It flagged one theoretical sub-ms read→unlink TOCTOU that the heartbeat renders practically unreachable and that is strictly smaller than the unconditional-unlink bug it replaces — documented as a known residual in the `_release_lock` docstring (no portable fix exists).

## Note
New tests went in `tests/unit/test_index_lock.py` (not `test_index_lock_concurrency.py`, whose docstring flags it as owned by another change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)