### PR TITLE
feat: scoped file-dependency primitives (tg imports / tg importers) — the benchmark-proven P4 moat gap (#74)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1004,6 +1004,18 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Show what a file imports, resolved to target files
+    #[command(name = "imports", disable_help_flag = true)]
+    Imports {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Find the files that import a given file
+    #[command(name = "importers", disable_help_flag = true)]
+    Importers {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Build a transitive blast-radius graph for a symbol
     #[command(name = "blast-radius", disable_help_flag = true)]
     BlastRadius {
@@ -3924,6 +3936,8 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         Commands::Source { args } => handle_python_passthrough("source", args),
         Commands::Impact { args } => handle_python_passthrough("impact", args),
         Commands::Callers { args } => handle_python_passthrough("callers", args),
+        Commands::Imports { args } => handle_python_passthrough("imports", args),
+        Commands::Importers { args } => handle_python_passthrough("importers", args),
         Commands::BlastRadius { args } => handle_python_passthrough("blast-radius", args),
         Commands::BlastRadiusRender { args } => {
             handle_python_passthrough("blast-radius-render", args)

--- a/src/tensor_grep/cli/commands.py
+++ b/src/tensor_grep/cli/commands.py
@@ -28,6 +28,8 @@ KNOWN_COMMANDS = {
     "source",
     "impact",
     "callers",
+    "imports",
+    "importers",
     "blast-radius",
     "blast-radius-render",
     "blast-radius-plan",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8860,6 +8860,101 @@ def callers(
     )
 
 
+@app.command()
+def imports(
+    file: str = typer.Argument(..., help="File to inspect for its own imports."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+) -> None:
+    """Return what a single FILE imports, resolved to target files where possible.
+
+    The scoped forward file-dependency primitive (#74): O(1) -- parses exactly one file, no
+    repo scan, no --deadline. Use `tg importers FILE` for the reverse question (who imports
+    this file). Both are far cheaper than `tg map` for a single file's dependency edges.
+    """
+    from tensor_grep.cli.repo_map import build_file_imports
+
+    try:
+        payload = build_file_imports(file)
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    def _emit_text(current: dict[str, Any]) -> None:
+        typer.echo(f"Imports for {current['file']}")
+        typer.echo(
+            f"imports={len(current['imports'])} resolved={len(current['resolved_files'])} "
+            f"external={len(current['external_modules'])} unresolved={len(current['unresolved'])}"
+        )
+        for entry in current["imports"]:
+            if entry.get("resolved"):
+                target = str(entry["resolved"])
+            elif entry.get("external"):
+                target = "external"
+            else:
+                target = "unresolved"
+            typer.echo(f"  {entry['line']}: {entry['module']} -> {target}")
+
+    _emit_symbol_command_result(
+        payload,
+        result_key="imports",
+        json_output=json_output,
+        emit_text=_emit_text,
+    )
+
+
+@app.command()
+def importers(
+    file: str = typer.Argument(..., help="File to find importers of."),
+    root: str = typer.Argument(".", help="Root to scan for importers."),
+    max_repo_files: int = typer.Option(
+        _DEFAULT_AGENT_REPO_SCAN_LIMIT,
+        "--max-repo-files",
+        min=1,
+        help="Maximum repo files to scan before returning a bounded result.",
+    ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the underlying repo scan after N seconds and return partial:true JSON with "
+            "whatever was found so far, instead of running unbounded."
+        ),
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+) -> None:
+    """Return the files that import a single FILE (the reverse #74 file-dependency primitive).
+
+    Bounded reverse lookup: prefilters candidate importers via the repo's import-alias graph,
+    then re-parses and CONFIRMS each candidate against FILE before reporting it as an edge (the
+    alias prefilter alone over-counts -- see `tg callers`' import-consumer precision notes).
+    """
+    from tensor_grep.cli.repo_map import build_file_importers
+
+    try:
+        payload = build_file_importers(
+            file,
+            root,
+            max_repo_files=max_repo_files,
+            deadline_seconds=deadline,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    def _emit_text(current: dict[str, Any]) -> None:
+        typer.echo(f"Importers of {current['file']}")
+        typer.echo(f"importers={current['importer_count']} files={len(current['importer_files'])}")
+        _echo_symbol_location_rows(current["importers"])
+
+    _emit_symbol_command_result(
+        payload,
+        result_key="importers",
+        json_output=json_output,
+        emit_text=_emit_text,
+    )
+
+
 def _mermaid_label(text: str) -> str:
     """Neutralize characters that would break a quoted Mermaid node/edge label."""
     return text.replace("\\", "/").replace('"', "'")
@@ -9845,6 +9940,57 @@ def session_blast_radius_cmd(
         return
 
     typer.echo(payload["rendered_caller_tree"])
+
+
+@session_app.command("importers")
+def session_importers_cmd(
+    session_id: str = typer.Argument(..., help="Session ID to query."),
+    file: str = typer.Argument(..., help="File to find importers of."),
+    refresh_on_stale: bool = typer.Option(
+        False,
+        "--refresh-on-stale",
+        help="Refresh the cached session once when file changes are detected, then retry the request.",
+    ),
+    daemon: bool = typer.Option(
+        False,
+        "--daemon",
+        help="Route this request through the warm localhost session daemon.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+) -> None:
+    """Return a cached-session (zero-reparse) list of the files that import FILE."""
+    from tensor_grep.cli.session_daemon import request_session_daemon
+    from tensor_grep.cli.session_store import session_file_importers
+
+    try:
+        if daemon:
+            payload = request_session_daemon(
+                ".",
+                {
+                    "command": "file_importers",
+                    "session_id": session_id,
+                    "path": ".",
+                    "file": file,
+                    "refresh_on_stale": refresh_on_stale,
+                },
+            )
+        else:
+            payload = session_file_importers(
+                session_id,
+                file,
+                refresh_on_stale=refresh_on_stale,
+            )
+    except Exception as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    if json_output:
+        typer.echo(json.dumps(_with_schema_version(payload, version=1), indent=2))
+        return
+
+    typer.echo(f"Importers of {payload['file']}")
+    typer.echo(f"importers={payload['importer_count']} files={len(payload['importer_files'])}")
+    _echo_symbol_location_rows(payload["importers"])
 
 
 @session_app.command("blast-radius-render")

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -40,6 +40,8 @@ from tensor_grep.cli.repo_map import (
     _apply_context_token_budget,
     build_context_pack,
     build_context_render,
+    build_file_importers,
+    build_file_imports,
     build_repo_map,
     build_symbol_blast_radius,
     build_symbol_blast_radius_render,
@@ -121,6 +123,9 @@ _PYTHON_LOCAL_MCP_TOOLS = (
     "tg_symbol_impact",
     "tg_symbol_refs",
     "tg_symbol_callers",
+    "tg_file_imports",
+    "tg_file_importers",
+    "tg_session_file_importers",
     "tg_symbol_blast_radius",
     "tg_symbol_blast_radius_render",
     "tg_search",
@@ -2349,6 +2354,64 @@ def tg_session_blast_radius(
 
 
 @mcp.tool()  # type: ignore
+def tg_session_file_importers(
+    session_id: str,
+    file: str,
+    path: str = ".",
+    refresh_on_stale: bool = False,
+    auto_refresh: bool | None = None,
+) -> str:
+    """
+    Return a cached-session (zero-reparse) list of the files that import FILE.
+
+    Args:
+        session_id: Session ID to query.
+        file: File to find importers of.
+        path: File or directory rooted at the session scope.
+    """
+    from tensor_grep.cli.session_store import SessionStaleError, session_file_importers
+
+    effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
+    try:
+        return json.dumps(
+            session_file_importers(
+                session_id,
+                file,
+                path,
+                refresh_on_stale=effective_refresh,
+            ),
+            indent=2,
+        )
+    except SessionStaleError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"file": file},
+            file=file,
+        )
+    except FileNotFoundError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"file": file},
+            file=file,
+        )
+    except Exception as exc:  # propagate as structured error, never a raw exception
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="internal_error",
+            message=str(exc),
+            detail={"file": file},
+            file=file,
+        )
+
+
+@mcp.tool()  # type: ignore
 def tg_symbol_blast_radius_plan(
     symbol: str,
     path: str = ".",
@@ -2856,6 +2919,91 @@ def tg_symbol_callers(
             "message": str(exc),
             "retryable": False,
         }
+        return json.dumps(payload, indent=2)
+
+
+@mcp.tool()  # type: ignore
+def tg_file_imports(file: str) -> str:
+    """
+    Return what a single FILE imports, resolved to target files where possible.
+
+    The scoped forward file-dependency primitive (#74): O(1) -- parses exactly one file, no
+    repo scan. Far cheaper than a whole-repo `tg_map` for a single file's dependency edges.
+
+    Args:
+        file: File to inspect for its own imports.
+    """
+    try:
+        return _inject_mcp_contract_fields(json.dumps(build_file_imports(file), indent=2))
+    except FileNotFoundError:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-imports",
+            include_schema_version=False,
+        )
+        payload["file"] = str(Path(file).expanduser())
+        payload["error"] = {
+            "code": "invalid_input",
+            "message": f"File not found: {Path(file).expanduser().resolve()}",
+        }
+        return json.dumps(payload, indent=2)
+    except Exception as exc:  # propagate as structured error, never a raw exception
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-imports",
+            include_schema_version=False,
+        )
+        payload["file"] = str(Path(file).expanduser())
+        payload["error"] = _sanitized_tool_error("tg_file_imports", exc)
+        return json.dumps(payload, indent=2)
+
+
+@mcp.tool()  # type: ignore
+def tg_file_importers(
+    file: str,
+    path: str = ".",
+    max_repo_files: int = _DEFAULT_MCP_REPO_SCAN_LIMIT,
+) -> str:
+    """
+    Return the files that import a single FILE (the reverse #74 file-dependency primitive).
+
+    Prefilters candidate importers via the repo's import-alias graph, then re-parses and
+    CONFIRMS each candidate against FILE before reporting it as an edge.
+
+    Args:
+        file: File to find importers of.
+        path: Root to scan for importers.
+        max_repo_files: Maximum repository files to scan before resolving importers.
+    """
+    try:
+        return _inject_mcp_contract_fields(
+            json.dumps(
+                build_file_importers(file, path, max_repo_files=max_repo_files),
+                indent=2,
+            )
+        )
+    except FileNotFoundError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-importers",
+            include_schema_version=False,
+        )
+        payload["file"] = str(Path(file).expanduser())
+        payload["path"] = str(Path(path).expanduser())
+        payload["error"] = {
+            "code": "invalid_input",
+            "message": str(exc),
+        }
+        return json.dumps(payload, indent=2)
+    except Exception as exc:  # propagate as structured error, never a raw exception
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-importers",
+            include_schema_version=False,
+        )
+        payload["file"] = str(Path(file).expanduser())
+        payload["path"] = str(Path(path).expanduser())
+        payload["error"] = _sanitized_tool_error("tg_file_importers", exc)
         return json.dumps(payload, indent=2)
 
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1559,6 +1559,20 @@ def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, A
                 imports.append(node.module)
                 for alias in node.names:
                     imports.append(f"{node.module}.{alias.name}")
+            elif node.level:
+                # `from . import x` / `from .. import x` -- no dotted module text, only
+                # relative dots plus the imported names (which may themselves be sibling
+                # submodules, e.g. `from . import helpers` importing `helpers.py`). Recording
+                # the bare alias name keeps this import in the reverse-import alias graph
+                # (`_reverse_importers`/`_module_aliases_for_path`) so `tg importers` can even
+                # PREFILTER a sibling `from . import X` importer -- omitting it here (unlike
+                # `_python_imports_with_lines`, which already records it for the forward
+                # `tg imports` primitive) was a genuine recall gap, not an intentional
+                # exclusion (#74 review fix). The precise per-candidate CONFIRM step
+                # (`_python_module_matches_definition`) still disambiguates which file it
+                # actually resolves to -- this only widens the prefilter's candidate set.
+                for alias in node.names:
+                    imports.append(alias.name)
 
     for symbol_node in ast.walk(tree):
         if isinstance(symbol_node, ast.ClassDef):
@@ -5633,6 +5647,54 @@ def _python_module_candidates(
             seen.add(key)
             deduped.append(Path(key))
     return {"paths": deduped, "provenance": provenance, "confidence": confidence}
+
+
+def _python_module_match_details(
+    importer_path: Path,
+    module_name: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+    *,
+    level: int = 0,
+) -> dict[str, Any]:
+    """Resolve-then-compare Python reverse-import confirm.
+
+    Mirrors `_js_ts_module_match_details` / `_rust_module_match_details`: reuses the SAME
+    precise resolver the forward `tg imports` uses (`_python_module_candidates`) instead of a
+    bare path-SUFFIX match, so two files sharing a basename (`app/config.py` vs
+    `tools/config.py`) no longer produce a phantom reverse edge just because an importer's
+    `import config` textually ends with "config" (#74 review fix -- see
+    `_module_path_matches_definition`, which is exactly that suffix match and is what this
+    function replaces for the Python confirm step).
+
+    Deliberately has NO suffix-match fallback (unlike JS/TS's bare-specifier partial-resolution
+    or Rust's non-workspace-crate partial-resolution) -- that fallback IS the bug this closes,
+    so it must not be reintroduced here.
+    """
+    candidate_info = _python_module_candidates(importer_path, module_name, repo_root, level=level)
+    resolved_definition = _resolved_path_str(definition_path)
+    if any(str(candidate) == resolved_definition for candidate in candidate_info["paths"]):
+        return {
+            "matched": True,
+            "provenance": list(candidate_info["provenance"]),
+            "confidence": float(candidate_info["confidence"] or 1.0),
+        }
+    return {"matched": False, "provenance": [], "confidence": 0.0}
+
+
+def _python_module_matches_definition(
+    importer_path: Path,
+    module_name: str,
+    definition_path: str,
+    repo_root: Path | str | None = None,
+    *,
+    level: int = 0,
+) -> bool:
+    return bool(
+        _python_module_match_details(
+            importer_path, module_name, definition_path, repo_root, level=level
+        )["matched"]
+    )
 
 
 def _group_symbols_by_file(symbols: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -14170,7 +14232,16 @@ def _confirm_import_edges(
                 candidate_importer, module, target_file, repo_root
             )
         else:
-            matched = _module_path_matches_definition(module, target_file)
+            # Python: resolve-then-compare via the SAME precise resolver the forward
+            # `tg imports` uses, symmetric with the JS/TS/Rust branches above (#74 review
+            # fix). `level` (0 for absolute, >=1 for `from .`/`from ..`) is carried on the raw
+            # entry by `_python_imports_with_lines` -- threading it through here is what lets
+            # `_python_module_candidates` resolve a relative import correctly instead of
+            # falling back to a bare path-suffix match that ignores directory context.
+            level = int(raw_entry.get("level", 0) or 0)
+            matched = _python_module_matches_definition(
+                candidate_importer, module, target_file, repo_root, level=level
+            )
         if not matched or line in seen_lines:
             continue
         seen_lines.add(line)

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -5407,6 +5407,234 @@ def _imports_and_symbols_for_path(
         return current_imports, current_symbols
 
 
+# #74 moat: `tg imports`/`tg importers` -- the scoped file-dependency primitive. Companion to
+# `_imports_and_symbols_for_path` above, which collapses imports to a deduped, line-less
+# `list[str]` (fine for the reverse-import alias graph, useless for a command that must report
+# *where* each import statement lives). Mirrors that function's per-language extraction sources
+# exactly (same AST node types / same regexes as `_python_imports_and_symbols` and
+# `_regex_imports_and_symbols`) so raw recall stays identical -- this only adds the line number
+# `tg imports` needs and keeps one row per import STATEMENT (not one row per imported symbol),
+# which is the right unit for a file-dependency primitive.
+def _python_imports_with_lines(path: Path) -> list[dict[str, Any]]:
+    if path.suffix != ".py":
+        return []
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        file_size = 0
+    if file_size > _max_parse_bytes():
+        return []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                entries.append({"module": alias.name, "line": int(node.lineno), "level": 0})
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                entries.append({
+                    "module": node.module,
+                    "line": int(node.lineno),
+                    "level": int(node.level or 0),
+                })
+            elif node.level:
+                # `from . import x` / `from .. import x` -- no dotted module text, only
+                # relative dots plus the imported names, which may themselves be
+                # submodules (e.g. `from . import utils` importing sibling `utils.py`).
+                for alias in node.names:
+                    entries.append({
+                        "module": alias.name,
+                        "line": int(node.lineno),
+                        "level": int(node.level),
+                    })
+    return entries
+
+
+def _js_ts_imports_with_lines(path: Path) -> list[dict[str, Any]]:
+    if path.suffix not in _JS_TS_SUFFIXES:
+        return []
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        file_size = 0
+    if file_size > _max_parse_bytes():
+        return []
+    try:
+        lines = _read_source_text_cached(str(path)).splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for line_number, line in enumerate(lines, start=1):
+        import_match = re.match(r'^\s*import\s+.*?from\s+["\']([^"\']+)["\']', line)
+        export_from_match = re.match(r'^\s*export\s+.*?from\s+["\']([^"\']+)["\']', line)
+        require_match = re.match(
+            r"^\s*(?:const|let|var)\s+(?:\{[^}]+\}|[A-Za-z_][A-Za-z0-9_]*)"
+            r'\s*=\s*require\(["\']([^"\']+)["\']\)',
+            line,
+        )
+        if import_match:
+            entries.append({"module": import_match.group(1), "line": line_number})
+        if export_from_match:
+            entries.append({"module": export_from_match.group(1), "line": line_number})
+        if require_match:
+            entries.append({"module": require_match.group(1), "line": line_number})
+    return entries
+
+
+def _rust_imports_with_lines(path: Path) -> list[dict[str, Any]]:
+    if path.suffix not in _RUST_SUFFIXES:
+        return []
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        file_size = 0
+    if file_size > _max_parse_bytes():
+        return []
+    try:
+        lines = _read_source_text_cached(str(path)).splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for line_number, line in enumerate(lines, start=1):
+        # Same single-line `use ... ;` regex as `_regex_imports_and_symbols` -- a brace-group
+        # `use` spanning multiple lines is a pre-existing extraction gap there too, not a new
+        # one introduced here (recall gaps must stay honest, not silently "fixed" here only).
+        use_match = re.match(r"^\s*use\s+([^;]+);", line)
+        if use_match:
+            entries.append({"module": use_match.group(1).strip(), "line": line_number})
+    return entries
+
+
+def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
+    """Raw per-statement imports with 1-based line numbers for the 4 supported languages.
+
+    Returns ``[]`` for an unsupported language (e.g. Go) or an over-cap file -- callers that
+    need to distinguish "genuinely no imports" from "not scanned" must check those conditions
+    themselves (see ``build_file_imports``'s ``result_incomplete`` handling).
+    """
+    spec = lang_registry.spec_for_path(path)
+    if spec is None:
+        return []
+    if spec.language_id == "python":
+        return _python_imports_with_lines(path)
+    if spec.language_id in ("javascript", "typescript"):
+        return _js_ts_imports_with_lines(path)
+    if spec.language_id == "rust":
+        return _rust_imports_with_lines(path)
+    return []
+
+
+def _python_module_parts(module_name: str) -> list[str]:
+    return [part for part in module_name.split(".") if part]
+
+
+def _python_relative_base_dir(importer_path: Path, level: int) -> Path:
+    # PEP 328: level=1 ("from . import x") resolves relative to the importer's OWN package
+    # dir (its parent); level=2 ("from .. import x") goes one dir further up, etc.
+    current = importer_path.parent
+    for _ in range(max(0, level - 1)):
+        current = current.parent
+    return current
+
+
+def _python_candidate_roots(importer_path: Path, repo_root: Path | str | None) -> list[Path]:
+    """Plausible absolute-import search roots for a Python file with no `sys.path` to consult.
+
+    Unlike JS/TS (tsconfig baseUrl/paths) or Rust (Cargo.toml workspace members), tensor-grep
+    has no primed "project context" for Python module resolution -- this is the net-new
+    resolution seam the #74 design flagged as the highest-risk part of `tg imports`. Tries, in
+    order: the repo root, a `src/` layout root, the importer's own directory, and each ancestor
+    directory up to the repo root (covers same-package absolute imports without a full
+    `sys.path` simulation). A bare specifier that is a local workspace package NOT reachable via
+    one of these roots is honestly misclassified as external -- see the module docstring risk
+    note; recall gaps here are disclosed via ``external``/``unresolved``, never silently hidden.
+    """
+    roots: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(candidate: Path | None) -> None:
+        if candidate is None:
+            return
+        key = str(candidate)
+        if key not in seen:
+            seen.add(key)
+            roots.append(candidate)
+
+    normalized_root = _normalized_repo_root(repo_root)
+    _add(normalized_root)
+    if normalized_root is not None:
+        _add(normalized_root / "src")
+    current = importer_path.parent
+    _add(current)
+    if normalized_root is not None:
+        try:
+            current.relative_to(normalized_root)
+            within_root = True
+        except ValueError:
+            within_root = False
+        if within_root:
+            while current != normalized_root:
+                current = current.parent
+                _add(current)
+    # Walk up past every `__init__.py`-marked package directory: the first ancestor WITHOUT
+    # one is the natural Python "import root" for an absolute dotted import (e.g. `pkg.helpers`
+    # written inside `pkg/main.py` resolves relative to pkg's PARENT, not pkg itself). This
+    # covers the common case where no project-root marker file exists at all.
+    package_top = importer_path.parent
+    while (package_top / "__init__.py").exists():
+        parent = package_top.parent
+        if parent == package_top:
+            break
+        package_top = parent
+    _add(package_top)
+    return roots
+
+
+def _python_module_candidates(
+    importer_path: Path,
+    module_name: str,
+    repo_root: Path | str | None = None,
+    *,
+    level: int = 0,
+) -> dict[str, Any]:
+    parts = _python_module_parts(module_name)
+    if not parts:
+        return {"paths": [], "provenance": [], "confidence": 0.0}
+
+    candidates: list[Path] = []
+    if level > 0:
+        base_dir = _python_relative_base_dir(importer_path, level)
+        target = base_dir.joinpath(*parts)
+        candidates.append(target.with_suffix(".py"))
+        candidates.append(target / "__init__.py")
+        provenance = ["relative"]
+        confidence = 1.0
+    else:
+        for root in _python_candidate_roots(importer_path, repo_root):
+            candidates.append(root.joinpath(*parts).with_suffix(".py"))
+            candidates.append(root.joinpath(*parts, "__init__.py"))
+        provenance = ["python-path-heuristic"]
+        confidence = 0.7
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            key = _resolved_path_str(str(candidate))
+        except OSError:
+            continue
+        if key not in seen:
+            seen.add(key)
+            deduped.append(Path(key))
+    return {"paths": deduped, "provenance": provenance, "confidence": confidence}
+
+
 def _group_symbols_by_file(symbols: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
     grouped: dict[str, list[dict[str, Any]]] = {}
     for symbol in symbols:
@@ -13745,6 +13973,316 @@ def build_symbol_refs_json(
         ),
         indent=2,
     )
+
+
+# #74 moat: `tg imports FILE` / `tg importers FILE [ROOT]` -- the scoped file-dependency
+# primitive. The benchmark that motivated this (docs/benchmarks.md P4) showed `tg` losing to
+# plain grep ~10x on file-dependency lookups because the only existing primitive was the
+# whole-repo `tg map` (~53K tokens on a mid-size repo); these two commands answer "what does
+# this ONE file import" (O(1) parse, no scan) and "who imports this ONE file" (bounded reverse
+# lookup) directly, at ~1-2K tokens.
+_PROJECT_ROOT_MARKERS = (".git", "pyproject.toml", "package.json", "Cargo.toml", "tsconfig.json")
+
+
+def _infer_project_root(file_path: Path) -> Path:
+    """Walk upward from a file looking for a project-root marker; falls back to its own dir.
+
+    `tg imports FILE` takes no ROOT argument (by design -- it is meant to be a true O(1)
+    single-file operation), so bare-specifier / tsconfig-alias / Rust-workspace resolution needs
+    a plausible root inferred from the file's own location rather than passed explicitly.
+    """
+    current = file_path.parent
+    for candidate in [current, *current.parents]:
+        try:
+            if any((candidate / marker).exists() for marker in _PROJECT_ROOT_MARKERS):
+                return candidate
+        except OSError:
+            continue
+    return current
+
+
+_SUPPORTED_FILE_DEPENDENCY_LANGUAGES = frozenset({"python", "javascript", "typescript", "rust"})
+
+
+def _resolve_raw_import_entry(
+    importer_path: Path,
+    entry: dict[str, Any],
+    repo_root: Path | str | None,
+    language_id: str,
+) -> dict[str, Any]:
+    module = str(entry.get("module", ""))
+    line = int(entry.get("line", 0) or 0)
+
+    if language_id in ("javascript", "typescript"):
+        candidate_info = _js_ts_module_candidates(importer_path, module, repo_root)
+        is_relative = module.startswith(".")
+        has_candidates = bool(candidate_info["paths"])
+        resolved = next(
+            (str(current) for current in candidate_info["paths"] if Path(current).is_file()),
+            None,
+        )
+        external = (not is_relative) and not has_candidates
+        provenance = list(candidate_info["provenance"]) or (["relative"] if is_relative else [])
+        confidence = float(candidate_info["confidence"]) if resolved is not None else 0.0
+    elif language_id == "rust":
+        candidates = _rust_module_candidates(importer_path, module, repo_root)
+        resolved_candidate = next(
+            (current for current in candidates if Path(str(current["path"])).is_file()),
+            None,
+        )
+        parts = [part.strip() for part in module.split("::") if part.strip()]
+        first = parts[0] if parts else ""
+        is_workspace_crate = first not in {"crate", "self", "super"} and (
+            _rust_workspace_entry_for_crate(first, repo_root) is not None
+        )
+        is_local_syntax = first in {"crate", "self", "super"} or is_workspace_crate
+        resolved = str(resolved_candidate["path"]) if resolved_candidate else None
+        external = resolved is None and not is_local_syntax
+        provenance = list(resolved_candidate["provenance"]) if resolved_candidate else []
+        confidence = float(resolved_candidate["confidence"]) if resolved_candidate else 0.0
+    elif language_id == "python":
+        level = int(entry.get("level", 0) or 0)
+        candidate_info = _python_module_candidates(importer_path, module, repo_root, level=level)
+        resolved = next(
+            (str(current) for current in candidate_info["paths"] if Path(current).is_file()),
+            None,
+        )
+        external = resolved is None
+        provenance = list(candidate_info["provenance"])
+        confidence = float(candidate_info["confidence"]) if resolved is not None else 0.0
+    else:
+        resolved, external, provenance, confidence = None, True, [], 0.0
+
+    return {
+        "module": module,
+        "line": line,
+        "resolved": resolved,
+        "provenance": provenance,
+        "resolution_confidence": confidence,
+        "external": external,
+    }
+
+
+def build_file_imports(file_path: str | Path) -> dict[str, Any]:
+    """Return what a single FILE imports, resolved to target files where possible.
+
+    O(1): parses exactly one file (plus lazily-primed, cached repo context for tsconfig/Cargo
+    workspace lookups) -- no repo scan, no scan cap, no ``--deadline``. See ``build_file_importers``
+    for the reverse (who imports this file) primitive, which does need a bounded repo scan.
+    """
+    resolved_file = Path(file_path).expanduser().resolve()
+    if not resolved_file.exists():
+        raise FileNotFoundError(f"File not found: {resolved_file}")
+    if resolved_file.is_dir():
+        raise ValueError(f"tg imports expects a FILE, not a directory: {resolved_file}")
+
+    payload = _envelope(resolved_file)
+    payload["routing_reason"] = "file-imports"
+    payload["file"] = str(resolved_file)
+
+    spec = lang_registry.spec_for_path(resolved_file)
+    language_id = spec.language_id if spec is not None else None
+    supported = language_id in _SUPPORTED_FILE_DEPENDENCY_LANGUAGES
+
+    try:
+        file_size = resolved_file.stat().st_size
+    except OSError:
+        file_size = 0
+    max_parse_bytes = _max_parse_bytes()
+    over_cap = file_size > max_parse_bytes
+
+    imports: list[dict[str, Any]] = []
+    result_incomplete = False
+    incomplete_reason: str | None = None
+
+    if over_cap:
+        # Fix-A-lineage honesty rule (#74 design): the underlying per-file byte cap
+        # (`_imports_and_symbols_for_path`, `_imports_with_lines_for_path`) returns an empty
+        # result for an over-cap file -- that must NEVER read as "this file genuinely has zero
+        # imports". Surface it as an incomplete scan instead of a clean empty list.
+        result_incomplete = True
+        incomplete_reason = (
+            f"file exceeds the {max_parse_bytes}-byte parse cap (size={file_size}); "
+            "imports were not scanned"
+        )
+    elif not supported:
+        result_incomplete = True
+        incomplete_reason = (
+            "no import extractor registered for this file suffix"
+            if spec is None
+            else f"'{language_id}' has no import-resolution support in `tg imports` yet"
+        )
+    else:
+        repo_root = _infer_project_root(resolved_file)
+        for raw_entry in _imports_with_lines_for_path(resolved_file):
+            imports.append(
+                _resolve_raw_import_entry(resolved_file, raw_entry, repo_root, str(language_id))
+            )
+
+    payload["imports"] = imports
+    payload["resolved_files"] = sorted(
+        dict.fromkeys(str(current["resolved"]) for current in imports if current.get("resolved"))
+    )
+    payload["external_modules"] = sorted(
+        dict.fromkeys(str(current["module"]) for current in imports if current.get("external"))
+    )
+    payload["unresolved"] = sorted(
+        dict.fromkeys(
+            str(current["module"])
+            for current in imports
+            if not current.get("external") and not current.get("resolved")
+        )
+    )
+    payload["result_incomplete"] = result_incomplete
+    if incomplete_reason is not None:
+        payload["incomplete_reason"] = incomplete_reason
+    return payload
+
+
+def _confirm_import_edges(
+    candidate_importer: Path,
+    target_file: str,
+    repo_root: Path | str | None,
+) -> list[dict[str, Any]]:
+    """Re-parse ONE prefiltered candidate file and confirm which (if any) of its raw imports
+    actually resolve to ``target_file``.
+
+    Precision step for `tg importers`: the alias-substring prefilter (`_reverse_importers`)
+    deliberately over-counts (it is the same mechanism behind the Case-4 false-edge bug) --
+    this is what turns "maybe imports it" into "confirmed imports it, on this exact line".
+    """
+    spec = lang_registry.spec_for_path(candidate_importer)
+    language_id = spec.language_id if spec is not None else None
+    if language_id not in ("javascript", "typescript", "rust", "python"):
+        return []
+
+    edges: list[dict[str, Any]] = []
+    seen_lines: set[int] = set()
+    for raw_entry in _imports_with_lines_for_path(candidate_importer):
+        module = str(raw_entry.get("module", ""))
+        line = int(raw_entry.get("line", 0) or 0)
+        if language_id in ("javascript", "typescript"):
+            matched = _js_ts_module_matches_definition(
+                candidate_importer, module, target_file, repo_root
+            )
+        elif language_id == "rust":
+            matched = _rust_module_matches_definition(
+                candidate_importer, module, target_file, repo_root
+            )
+        else:
+            matched = _module_path_matches_definition(module, target_file)
+        if not matched or line in seen_lines:
+            continue
+        seen_lines.add(line)
+        provenance = "parser-backed" if language_id == "python" else "heuristic"
+        edges.append({
+            "file": str(candidate_importer),
+            "line": line,
+            "text": _source_line_text(candidate_importer, line),
+            "kind": "import-consumer",
+            "edge_kind": "reverse-import",
+            "module": module,
+            "provenance": provenance,
+            "resolution_confidence": _import_graph_resolution_confidence(provenance),
+        })
+    return edges
+
+
+def build_file_importers_from_map(
+    repo_map: dict[str, Any],
+    file_path: str | Path,
+    *,
+    deadline_monotonic: float | None = None,
+) -> dict[str, Any]:
+    repo_root = Path(str(repo_map["path"])).resolve()
+    resolved_file = Path(file_path).expanduser()
+    if not resolved_file.is_absolute():
+        resolved_file = repo_root / resolved_file
+    resolved_file = resolved_file.resolve()
+    if not resolved_file.exists():
+        raise FileNotFoundError(f"File not found: {resolved_file}")
+    target_file = str(resolved_file)
+
+    payload = _envelope(repo_root)
+    payload["routing_reason"] = "file-importers"
+    payload["file"] = target_file
+
+    all_files = [str(current) for current in repo_map.get("files", [])]
+    imports_by_file = {
+        str(current["file"]): list(
+            dict.fromkeys(str(name) for name in current.get("imports", []) if name)
+        )
+        for current in repo_map.get("imports", [])
+    }
+    reverse_map = _reverse_importers(all_files, imports_by_file)
+    prefiltered = sorted(reverse_map.get(target_file, set()))
+
+    ceiling_hit = len(prefiltered) > CALLER_SCAN_FILE_CEILING
+    bounded_candidates = prefiltered[:CALLER_SCAN_FILE_CEILING]
+
+    edges: list[dict[str, Any]] = []
+    deadline_hit = False
+    scanned_count = 0
+    for candidate in bounded_candidates:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            deadline_hit = True
+            break
+        scanned_count += 1
+        edges.extend(_confirm_import_edges(Path(candidate), target_file, repo_root))
+    edges.sort(key=lambda item: (str(item["file"]), int(item.get("line", 0) or 0)))
+
+    payload["importers"] = edges
+    payload["importer_files"] = sorted(dict.fromkeys(str(item["file"]) for item in edges))
+    payload["importer_count"] = len(edges)
+    if ceiling_hit:
+        # task #61 lesson: bound this sibling loop with the SAME ceiling the caller-scan main
+        # loop uses, and mark it via the shared `caller_scan_limit` shape so the CLI's existing
+        # `_scan_truncation_warning`/exit-2 contract picks it up with no bespoke wiring.
+        payload["caller_scan_limit"] = {
+            "possibly_truncated": True,
+            "ceiling": CALLER_SCAN_FILE_CEILING,
+            "files_total": len(prefiltered),
+        }
+    if deadline_hit:
+        payload["partial"] = True
+        payload["deadline_limit"] = {
+            "deadline_exceeded": True,
+            "importer_candidates_scanned": scanned_count,
+            "importer_candidates_total": len(bounded_candidates),
+        }
+    _copy_scan_limit(payload, repo_map)
+    payload["resolution_gaps"] = list(repo_map.get("resolution_gaps", []))
+    return payload
+
+
+def build_file_importers(
+    file_path: str | Path,
+    root: str | Path = ".",
+    *,
+    max_repo_files: int | None = None,
+    deadline_seconds: float | None = None,
+    _profiling_collector: _ProfileCollector | None = None,
+) -> dict[str, Any]:
+    """Return which files import a single FILE (the reverse #74 file-dependency primitive).
+
+    Cold tier: builds (or reuses a cached) repo map over ROOT, then confirms candidate importer
+    edges precisely. See ``session_file_importers`` in session_store.py for the zero-reparse
+    session tier, which calls ``build_file_importers_from_map`` directly on a cached map.
+    """
+    deadline_monotonic = _deadline_monotonic_from_seconds(deadline_seconds)
+    repo_map = build_repo_map(
+        root,
+        max_repo_files=max_repo_files,
+        deadline_monotonic=deadline_monotonic,
+        _profiling_collector=_profiling_collector,
+    )
+    result = build_file_importers_from_map(
+        repo_map,
+        file_path,
+        deadline_monotonic=deadline_monotonic,
+    )
+    _copy_partial_signal(result, repo_map)
+    return result
 
 
 def build_symbol_callers(

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -24,6 +24,7 @@ from tensor_grep.cli.repo_map import (
     build_context_edit_plan_from_map,
     build_context_pack_from_map,
     build_context_render_from_map,
+    build_file_importers_from_map,
     build_repo_map,
     build_repo_map_incremental,
     build_symbol_blast_radius_from_map,
@@ -1049,6 +1050,22 @@ def session_blast_radius(
     return response
 
 
+def session_file_importers(
+    session_id: str,
+    file_path: str,
+    path: str = ".",
+    *,
+    refresh_on_stale: bool = False,
+) -> dict[str, Any]:
+    """Zero-reparse reverse #74 lookup: who imports ``file_path``, served from the session's
+    cached repo map (no fresh repo scan, unlike the cold ``build_file_importers``)."""
+    payload = _load_session_payload(session_id, path, refresh_on_stale=refresh_on_stale)
+    response = build_file_importers_from_map(payload["repo_map"], file_path)
+    response["session_id"] = session_id
+    response["routing_reason"] = "session-file-importers"
+    return response
+
+
 def session_blast_radius_plan(
     session_id: str,
     symbol: str,
@@ -1246,6 +1263,15 @@ def _serve_session_request_from_payload(
         response = build_symbol_callers_from_map(repo_map, symbol, semantic_provider=provider)
         response["session_id"] = session_id
         response["routing_reason"] = "session-callers"
+        return response
+
+    if command == "file_importers":
+        target_file = str(request.get("file", "")).strip()
+        if not target_file:
+            raise ValueError("file_importers requests require a non-empty file")
+        response = build_file_importers_from_map(repo_map, target_file)
+        response["session_id"] = session_id
+        response["routing_reason"] = "session-file-importers"
         return response
 
     if command == "blast_radius":

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -35,6 +35,8 @@ PUBLIC_TOP_LEVEL_COMMANDS = {
     "source",
     "impact",
     "callers",
+    "imports",
+    "importers",
     "blast-radius",
     "blast-radius-render",
     "blast-radius-plan",
@@ -331,6 +333,8 @@ COMMAND_CASES = [
     (["defs", "--help"], 0, assert_text_lines, no_check),
     (["refs", "--help"], 0, assert_text_lines, no_check),
     (["context", "--help"], 0, assert_text_lines, no_check),
+    (["imports", "--help"], 0, assert_text_lines, no_check),
+    (["importers", "--help"], 0, assert_text_lines, no_check),
     # --- blast-radius, rulesets, audit ---
     (["blast-radius", "--help"], 0, assert_text_lines, no_check),
     (["rulesets", "--help"], 0, assert_text_lines, no_check),

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -1,0 +1,357 @@
+"""TDD for the #74 moat: `tg imports FILE` / `tg importers FILE [ROOT]`.
+
+The scoped file-dependency primitive that closes the P4 benchmark gap (docs/benchmarks.md):
+`tg map` alone made tg ~10x WORSE than grep on file-dependency lookups because it had no
+primitive scoped to a single file. These commands answer "what does this file import"
+(forward, O(1) parse) and "who imports this file" (reverse, bounded repo scan) directly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from tensor_grep.cli import bootstrap, repo_map, session_store
+from tensor_grep.cli.commands import KNOWN_COMMANDS
+from tensor_grep.cli.main import app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------------------------
+# Registration: both names wired at all 4 sites (miss one -> `tg imports x.py` greps the
+# literal string "imports" via ripgrep instead of routing to the handler).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_imports_and_importers_registered_in_known_commands() -> None:
+    assert "imports" in KNOWN_COMMANDS
+    assert "importers" in KNOWN_COMMANDS
+
+
+def test_bootstrap_routes_imports_to_full_cli_not_rg(monkeypatch, tmp_path: Path) -> None:
+    """CliRunner bypasses the bootstrap front door (bootstrap.py:285) -- this tests the ACTUAL
+    router: `first_arg in _KNOWN_COMMANDS` must send `tg imports <file>` to the full Typer CLI,
+    never to rg passthrough (which would search for the literal string "imports")."""
+    target = tmp_path / "a.py"
+    target.write_text("import os\n", encoding="utf-8")
+    called = {"full_cli": False}
+
+    monkeypatch.setattr(sys, "argv", ["tg", "imports", str(target)])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda *_a, **_k: pytest.fail("rg passthrough must not run for `tg imports`"),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
+
+    bootstrap.main_entry()
+
+    assert called["full_cli"] is True
+
+
+def test_bootstrap_routes_importers_to_full_cli_not_rg(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("import os\n", encoding="utf-8")
+    called = {"full_cli": False}
+
+    monkeypatch.setattr(sys, "argv", ["tg", "importers", str(target)])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda *_a, **_k: pytest.fail("rg passthrough must not run for `tg importers`"),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
+
+    bootstrap.main_entry()
+
+    assert called["full_cli"] is True
+
+
+# ---------------------------------------------------------------------------------------------
+# Forward resolution: relative, require+index-probe, external, Python dotted.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_imports_resolves_relative_js_import(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    util_path = src / "util.js"
+    util_path.write_text("export function foo() {}\n", encoding="utf-8")
+    consumer = src / "consumer.js"
+    consumer.write_text('import { foo } from "./util";\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    assert payload["result_incomplete"] is False
+    assert len(payload["imports"]) == 1
+    entry = payload["imports"][0]
+    assert entry["module"] == "./util"
+    assert entry["line"] == 1
+    assert entry["resolved"] == str(util_path.resolve())
+    assert entry["external"] is False
+    assert entry["resolution_confidence"] == pytest.approx(1.0)
+    assert payload["resolved_files"] == [str(util_path.resolve())]
+    assert payload["external_modules"] == []
+    assert payload["unresolved"] == []
+
+
+def test_build_file_imports_resolves_require_via_index_probe(tmp_path: Path) -> None:
+    """`require('./router')` resolving to `router/index.js` -- the express-style index probe."""
+    project = tmp_path / "project"
+    router_dir = project / "lib" / "router"
+    router_dir.mkdir(parents=True)
+    index_path = router_dir / "index.js"
+    index_path.write_text("module.exports = {};\n", encoding="utf-8")
+    consumer = project / "lib" / "app.js"
+    consumer.write_text('const router = require("./router");\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = payload["imports"][0]
+    assert entry["module"] == "./router"
+    assert entry["resolved"] == str(index_path.resolve())
+
+
+def test_build_file_imports_classifies_bare_specifier_as_external(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    consumer = project / "app.js"
+    consumer.write_text('import express from "express";\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = payload["imports"][0]
+    assert entry["module"] == "express"
+    assert entry["resolved"] is None
+    assert entry["external"] is True
+    assert payload["external_modules"] == ["express"]
+    assert payload["unresolved"] == []
+
+
+def test_build_file_imports_resolves_python_dotted_import(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "main.py"
+    consumer.write_text("import pkg.helpers\n", encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "pkg.helpers")
+    assert entry["resolved"] == str(helpers_path.resolve())
+    assert entry["external"] is False
+
+
+def test_build_file_imports_resolves_python_relative_import(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "main.py"
+    consumer.write_text("from . import helpers\n", encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = payload["imports"][0]
+    assert entry["module"] == "helpers"
+    assert entry["resolved"] == str(helpers_path.resolve())
+    assert entry["provenance"] == ["relative"]
+
+
+# ---------------------------------------------------------------------------------------------
+# Reverse EXACTNESS: 1 real importer + 2 precision traps, both excluded.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_importers_confirms_real_importer_and_excludes_precision_traps(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+
+    real_importer = src / "consumer.js"
+    real_importer.write_text('import { foo } from "./util";\n', encoding="utf-8")
+
+    # Trap A: a file that merely MENTIONS the target's stem in a comment/string -- it has no
+    # actual import statement, so it must never appear as an importer.
+    comment_trap = src / "mentions_stem_only.js"
+    comment_trap.write_text(
+        '// unrelated to util.js, just says the word here\nexport const label = "util";\n',
+        encoding="utf-8",
+    )
+
+    # Trap B (the Case-4 false-edge / prefilter over-match bug): imports a DIFFERENT module
+    # whose name merely CONTAINS the target's "util" stem as a word fragment. The alias-
+    # substring prefilter (`_reverse_importers`) will flag this file as a CANDIDATE, but the
+    # precise per-candidate matcher (`_js_ts_module_matches_definition`) must reject it because
+    # "./util-helpers" resolves to a different file than "./util".
+    (src / "util-helpers.js").write_text("export function helper() {}\n", encoding="utf-8")
+    fragment_trap = src / "fragment_trap.js"
+    fragment_trap.write_text('import { helper } from "./util-helpers";\n', encoding="utf-8")
+
+    # Trap C: a same-named module ("util.js") from a DIFFERENT directory.
+    other_dir = project / "other"
+    other_dir.mkdir()
+    (other_dir / "util.js").write_text("export function bar() {}\n", encoding="utf-8")
+    same_name_trap = other_dir / "consumer.js"
+    same_name_trap.write_text('import { bar } from "./util";\n', encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    importer_files = set(payload["importer_files"])
+    assert importer_files == {str(real_importer.resolve())}
+    assert payload["importer_count"] == 1
+    assert str(comment_trap.resolve()) not in importer_files
+    assert str(fragment_trap.resolve()) not in importer_files
+    assert str(same_name_trap.resolve()) not in importer_files
+
+    edge = payload["importers"][0]
+    assert edge["file"] == str(real_importer.resolve())
+    assert edge["line"] == 1
+    assert edge["module"] == "./util"
+    assert edge["edge_kind"] == "reverse-import"
+    assert edge["kind"] == "import-consumer"
+
+
+def test_build_file_importers_finds_tsconfig_alias_importer(tmp_path: Path) -> None:
+    """Prefilter recall: a tsconfig path-alias importer must still be found (not just plain
+    relative imports)."""
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    (project / "tsconfig.json").write_text(
+        json.dumps({
+            "compilerOptions": {"baseUrl": ".", "paths": {"@app/*": ["src/*"]}},
+        }),
+        encoding="utf-8",
+    )
+    target = src / "util.ts"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    importer = src / "consumer.ts"
+    importer.write_text('import { foo } from "@app/util";\n', encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(importer.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(importer.resolve())
+    )
+    assert edge["module"] == "@app/util"
+
+
+# ---------------------------------------------------------------------------------------------
+# Token economy: the reverse payload must be far smaller than a whole-repo `tg map`.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_importers_payload_is_far_smaller_than_map(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    (src / "consumer0.js").write_text('import { foo } from "./util";\n', encoding="utf-8")
+    for index in range(1, 25):
+        (src / f"other{index}.js").write_text(
+            f"export function fn{index}() {{ return {index}; }}\n", encoding="utf-8"
+        )
+
+    importers_payload = repo_map.build_file_importers(target, project)
+    map_payload = repo_map.build_repo_map(project)
+
+    importers_size = len(json.dumps(importers_payload))
+    map_size = len(json.dumps(map_payload))
+
+    assert importers_size < 0.1 * map_size, (
+        f"importers payload ({importers_size}B) is not <0.1x the map payload ({map_size}B)"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# Honesty: over-cap -> exit2 (never a clean empty), missing -> exit1, --max-repo-files 1 ->
+# truncated exit2, session == cold edges.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_imports_missing_file_exits_1() -> None:
+    result = runner.invoke(app, ["imports", "does/not/exist.py"])
+    assert result.exit_code == 1
+
+
+def test_importers_missing_file_exits_1(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["importers", str(tmp_path / "nope.py"), str(tmp_path)])
+    assert result.exit_code == 1
+
+
+def test_imports_over_parse_cap_exits_2_never_clean_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "big.py"
+    target.write_text("import os\n", encoding="utf-8")
+    monkeypatch.setenv("TENSOR_GREP_MAX_PARSE_BYTES", "1")
+
+    result = runner.invoke(app, ["imports", str(target), "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["result_incomplete"] is True
+    assert payload["imports"] == []
+    assert "incomplete_reason" in payload
+
+
+def test_importers_max_repo_files_truncation_exits_2(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    (src / "consumer.js").write_text('import { foo } from "./util";\n', encoding="utf-8")
+    (src / "other1.js").write_text("export const a = 1;\n", encoding="utf-8")
+    (src / "other2.js").write_text("export const b = 2;\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["importers", str(target), str(project), "--max-repo-files", "1", "--json"],
+    )
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    scan_limit = payload.get("scan_limit")
+    assert isinstance(scan_limit, dict) and scan_limit.get("possibly_truncated")
+    assert payload.get("result_incomplete") is True
+
+
+def test_session_importers_matches_cold_importers(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    (src / "consumer.js").write_text('import { foo } from "./util";\n', encoding="utf-8")
+
+    session_id = session_store.open_session(str(project)).session_id
+
+    cold = repo_map.build_file_importers(target, project)
+    warm = session_store.session_file_importers(session_id, str(target), str(project))
+
+    assert set(warm["importer_files"]) == set(cold["importer_files"])
+    assert warm["importer_count"] == cold["importer_count"]
+    assert warm["importer_count"] > 0

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -258,6 +258,102 @@ def test_build_file_importers_finds_tsconfig_alias_importer(tmp_path: Path) -> N
 
 
 # ---------------------------------------------------------------------------------------------
+# Python reverse precision + recall (#74 review fix): the reverse confirm step used to suffix-
+# match Python imports (`_module_path_matches_definition`) with NO directory/resolution
+# context, unlike the already-precise JS/TS/Rust branches -- two files sharing a basename
+# (e.g. `app/config.py` and `tools/config.py`) produced a phantom importer edge on the wrong
+# one. The fix makes the Python confirm step resolve-then-compare via the SAME precise
+# resolver the forward `tg imports` uses (`_python_module_candidates`). A companion recall gap
+# (`from . import X` was silently dropped from the reverse alias graph because it has no
+# dotted `node.module` text) is fixed alongside it.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_importers_python_excludes_duplicate_basename_false_edge(
+    tmp_path: Path,
+) -> None:
+    """The Case-4-style false edge, but for Python: `import config` in tools/run.py resolves
+    (per Python's own import semantics -- the importer's own directory is searched) to
+    tools/config.py, NOT app/config.py, even though both end with the same basename."""
+    project = tmp_path / "project"
+    app_dir = project / "app"
+    tools_dir = project / "tools"
+    app_dir.mkdir(parents=True)
+    tools_dir.mkdir(parents=True)
+
+    app_config = app_dir / "config.py"
+    app_config.write_text("APP_SETTING = 1\n", encoding="utf-8")
+    tools_config = tools_dir / "config.py"
+    tools_config.write_text("TOOLS_SETTING = 2\n", encoding="utf-8")
+
+    run_py = tools_dir / "run.py"
+    run_py.write_text("import config\n", encoding="utf-8")
+
+    app_payload = repo_map.build_file_importers(app_config, project)
+    tools_payload = repo_map.build_file_importers(tools_config, project)
+
+    assert str(run_py.resolve()) not in set(app_payload["importer_files"])
+    assert app_payload["importer_count"] == 0
+
+    assert str(run_py.resolve()) in set(tools_payload["importer_files"])
+    edge = next(
+        current
+        for current in tools_payload["importers"]
+        if current["file"] == str(run_py.resolve())
+    )
+    assert edge["module"] == "config"
+
+
+def test_build_file_importers_python_recalls_from_dot_import(tmp_path: Path) -> None:
+    """`from . import helpers` has no dotted `node.module` text -- the reverse-import alias
+    graph used to silently DROP it, so a sibling `from . import X` importer was invisible to
+    `tg importers` entirely (never even reached the confirm step), not merely over-counted."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    main_path = pkg / "main.py"
+    main_path.write_text("from . import helpers\n", encoding="utf-8")
+
+    payload = repo_map.build_file_importers(helpers_path, project)
+
+    assert str(main_path.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(main_path.resolve())
+    )
+    assert edge["module"] == "helpers"
+    assert edge["line"] == 1
+
+
+def test_build_file_importers_python_dotted_import_precision(tmp_path: Path) -> None:
+    """A dotted absolute import (`from app.config import X`) must confirm against the file it
+    actually names, not a same-basename sibling under a different top-level package."""
+    project = tmp_path / "project"
+    app_dir = project / "app"
+    tools_dir = project / "tools"
+    app_dir.mkdir(parents=True)
+    tools_dir.mkdir(parents=True)
+    (app_dir / "__init__.py").write_text("", encoding="utf-8")
+    (tools_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    app_config = app_dir / "config.py"
+    app_config.write_text("APP_SETTING = 1\n", encoding="utf-8")
+    tools_config = tools_dir / "config.py"
+    tools_config.write_text("TOOLS_SETTING = 2\n", encoding="utf-8")
+
+    consumer = project / "consumer.py"
+    consumer.write_text("from app.config import APP_SETTING\n", encoding="utf-8")
+
+    app_payload = repo_map.build_file_importers(app_config, project)
+    tools_payload = repo_map.build_file_importers(tools_config, project)
+
+    assert str(consumer.resolve()) in set(app_payload["importer_files"])
+    assert str(consumer.resolve()) not in set(tools_payload["importer_files"])
+
+
+# ---------------------------------------------------------------------------------------------
 # Token economy: the reverse payload must be far smaller than a whole-repo `tg map`.
 # ---------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why (benchmark-proven)
The token-economy benchmark showed tg is **~10x WORSE than grep on file-dependency questions** (P4: 53,631 vs 5,367 tok/correct) because it had **no scoped file-dep primitive** — the only way to answer "what does file X import / who imports X" was `tg map` (whole-repo, ~53K tokens). This adds the scoped commands at ~1-2K tokens.

## What
- **`tg imports FILE [--json]`** — forward: what FILE imports, resolved to target files (O(1) single-file parse, no scan). Added a Python candidate-resolver (`_python_module_candidates`); reuses the JS/TS + Rust resolvers.
- **`tg importers FILE [ROOT] [--max-repo-files] [--deadline]`** — reverse: which files import FILE. Prefilter (alias graph) then **confirm each edge with the precise per-language resolver** — closes the Case-4 alias-substring false-edge for JS/TS/Rust **and Python**.
- **`tg session importers`** + daemon arm; **MCP**: `tg_file_imports` / `tg_file_importers` / `tg_session_file_importers`.
- Registered at all **5 sites** (commands.py, rust main.rs clap + dispatch, test_routing_parity, main.py @app.command, mcp capabilities registry — the 5th caught by a governance test).
- Honesty: over-2MB/unsupported → `result_incomplete` + exit 2 (never clean-empty); reverse scan-cap → `partial` + exit 2 (the #401 contract). Reverse confirm bounded by `CALLER_SCAN_FILE_CEILING` before the per-candidate loop (no O(files×candidates) blowup).

## Precision fix (from the Opus review)
The review caught a real defect: the Python reverse path used **suffix-only matching** → phantom importers on duplicate basenames (`config.py`, `models.py` — ubiquitous), invisible because all reverse tests were JS/TS. Fixed: **resolve-then-compare** (mirrors JS/TS/Rust), plus `from . import X` recall as a real fix (it was silently dropped from the reverse graph). 3 new Python reverse tests added.

## Verification
Real venv: **85 passed** (test_file_deps 19 incl. the new Python precision/recall tests + bootstrap routing) + 417-test regression sweep clean; ruff + format --preview + mypy clean; `cargo check` clean; the rebuilt native binary was dogfooded directly (routes correctly, resolves Python/JS imports). **Opus review: SHIP after the precision fix.**

## Follow-up
The `from . import X` invisibility also affects `tg callers`/blast-radius via `_python_file_imports_symbol_from_definition` (repo_map.py:2975) — filed as deep-dive finding #3 (#81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)