### PR TITLE
fix(ast): -- sentinel before user paths in ast-grep argv — close CWE-88 flag injection (a path like --update-all could turn a read scan into a file rewrite) (audit #5)

### DIFF
--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -129,6 +129,12 @@ class AstGrepWrapperBackend(ComputeBackend):
             if stdin_enabled:
                 cmd.append("--stdin")
             else:
+                # CWE-88 / native-argv flag injection: a user-supplied path that
+                # looks like a flag (e.g. "-U" / "--update-all") would otherwise
+                # be parsed by ast-grep's clap CLI as its auto-fix flag, turning
+                # a read-only scan into a file rewrite. The "--" sentinel forces
+                # everything after it to be treated as a positional path.
+                cmd.append("--")
                 cmd.extend(paths)
             return cmd, nullcontext()
 
@@ -147,7 +153,9 @@ class AstGrepWrapperBackend(ComputeBackend):
             ]),
             encoding="utf-8",
         )
-        cmd = [self._get_binary_name(), "scan", "--json", "--rule", str(rule_file), *paths]
+        # CWE-88: "--" sentinel prevents a user path like "-U" / "--update-all"
+        # from being interpreted as ast-grep's auto-fix flag (see comment above).
+        cmd = [self._get_binary_name(), "scan", "--json", "--rule", str(rule_file), "--", *paths]
         return cmd, context
 
     def _raise_for_nonzero(self, result: subprocess.CompletedProcess[str]) -> None:
@@ -305,6 +313,10 @@ class AstGrepWrapperBackend(ComputeBackend):
                 "--json",
                 "--config",
                 config_path,
+                # CWE-88: "--" sentinel prevents a user-supplied root_path like
+                # "-U" / "--update-all" from being interpreted as ast-grep's
+                # auto-fix flag (see comment on the run-command path above).
+                "--",
                 root_path,
             ])
         except BackendExecutionError:

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -247,6 +247,7 @@ def test_ast_wrapper_backend_should_forward_ast_grep_run_semantic_options():
         "*.py",
         "--globs",
         "!generated/**",
+        "--",
         "src",
     ]
 
@@ -462,6 +463,132 @@ def test_ast_wrapper_backend_should_tolerate_non_mapping_range_payload():
     assert result.matches[0].range is None
 
 
+def test_ast_wrapper_backend_should_sentinel_guard_flag_like_paths_on_run(monkeypatch):
+    """CWE-88 / audit #5: a user-supplied path that looks like an ast-grep flag
+    (e.g. "-U" / "--update-all") must not be parsed by ast-grep's clap CLI as
+    its auto-fix flag -- a "--" sentinel must precede every user path on the
+    ``sg run`` argv (site: _build_command, non-multiline branch)."""
+    backend = AstGrepWrapperBackend()
+    monkeypatch.delenv("TG_AST_GREP_TIMEOUT_SECONDS", raising=False)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        backend.search_many(
+            ["-U", "--update-all", "src"],
+            "print($A)",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+    cmd = run.call_args.args[0]
+    assert cmd.count("--") == 1
+    sentinel_index = cmd.index("--")
+    assert cmd[sentinel_index + 1 :] == ["-U", "--update-all", "src"]
+
+
+def test_ast_wrapper_backend_should_sentinel_guard_flag_like_path_on_single_search(monkeypatch):
+    """Same site as above (_build_command, non-multiline branch), exercised via
+    the single-file ``search`` entry point rather than ``search_many``."""
+    backend = AstGrepWrapperBackend()
+    monkeypatch.delenv("TG_AST_GREP_TIMEOUT_SECONDS", raising=False)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        backend.search(
+            "--rewrite",
+            "print($A)",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+    cmd = run.call_args.args[0]
+    assert cmd.count("--") == 1
+    sentinel_index = cmd.index("--")
+    assert cmd[sentinel_index + 1 :] == ["--rewrite"]
+
+
+def test_ast_wrapper_backend_should_sentinel_guard_flag_like_path_on_multiline_rule_scan(
+    monkeypatch,
+):
+    """Multiline patterns route through the ``sg scan --rule`` argv (site:
+    _build_command, rule-file branch) -- must also sentinel-guard the path."""
+    backend = AstGrepWrapperBackend()
+    monkeypatch.delenv("TG_AST_GREP_TIMEOUT_SECONDS", raising=False)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        backend.search(
+            "-U",
+            "def $FUNC():\n    $$$BODY",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+    cmd = run.call_args.args[0]
+    assert cmd[:4] == ["sg", "scan", "--json", "--rule"]
+    assert cmd.count("--") == 1
+    sentinel_index = cmd.index("--")
+    assert cmd[sentinel_index + 1 :] == ["-U"]
+
+
+def test_ast_wrapper_backend_should_sentinel_guard_flag_like_root_path_on_project_scan():
+    """search_project (site: search_project's sg scan --config argv) must also
+    sentinel-guard its root_path."""
+    backend = AstGrepWrapperBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "[]"
+    mock_result.stderr = ""
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result
+        ) as run,
+    ):
+        backend.search_project("--update-all", "sgconfig.yml")
+
+    cmd = run.call_args.args[0]
+    assert cmd == [
+        "sg",
+        "scan",
+        "--json",
+        "--config",
+        "sgconfig.yml",
+        "--",
+        "--update-all",
+    ]
+
+
 def test_ast_wrapper_backend_should_group_project_scan_results_by_rule_id():
     backend = AstGrepWrapperBackend()
 
@@ -481,7 +608,15 @@ def test_ast_wrapper_backend_should_group_project_scan_results_by_rule_id():
     ):
         results = backend.search_project("project", "sgconfig.yml")
 
-    assert run.call_args.args[0] == ["sg", "scan", "--json", "--config", "sgconfig.yml", "project"]
+    assert run.call_args.args[0] == [
+        "sg",
+        "scan",
+        "--json",
+        "--config",
+        "sgconfig.yml",
+        "--",
+        "project",
+    ]
     assert results["rule-a"].total_matches == 2
     assert results["rule-a"].matched_file_paths == ["a.py"]
     assert results["rule-b"].total_matches == 1


### PR DESCRIPTION
## The bug (deep-dive audit #81 finding #5, CONFIRMED + live-verified)
User-supplied paths were appended to `sg run` / `sg scan` (ast-grep) argv at 3 sites in `ast_wrapper_backend.py` with **no `--` sentinel**. A path that looks like an ast-grep flag — `-U` / `--update-all` / `--rewrite` — was parsed by ast-grep's clap as a **flag**, so a read-only scan could silently become a **file rewrite** (CWE-88 / native-argv injection, the class AGENTS.md lists as a standing sweep target).

## The fix
Inserted a literal `"--"` argument immediately before the user path(s) at all 3 sites (`_build_command` run branch, `_build_command` rule-scan branch, `search_project` config-scan). After `--`, ast-grep treats every remaining arg as a positional path. Purely defensive — no other behavior change.

## Live-verified against the real ast-grep 0.42.1 binary (not just mocks)
- **Without `--`:** `-U` → clap parses it as `--update-all` (the rewrite flag; `sg scan` absorbs it silently, exit 0 — a rule with a `fix:` field would rewrite files).
- **With `--`:** `-U` → treated as a literal path → "file not found" (os error 2). Correct.

## Verification
Real venv: **64 passed** (`test_ast_wrapper_backend` incl. 4 new per-site injection tests asserting the sentinel appears exactly once + precedes the user paths + `test_pipeline`); ruff + format --preview + mypy clean. Sentinel placement confirmed at lines 137-138, 158, 316-319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)