### PR TITLE
fix(backends): comply with the Backend Fail-Closed Contract — raise BackendExecutionError not bare RuntimeError / empty-return / unwrapped native fault (audit #79/#10/#14)

### DIFF
--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from tensor_grep.backends.base import ComputeBackend
+from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds, run_subprocess
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
@@ -119,11 +119,11 @@ class RipgrepBackend(ComputeBackend):
             # one unreadable/missing path among many); if it still emitted matches for the readable
             # files, KEEP them + flag incomplete so we exit 2 like rg AND surface a "suppression !=
             # absence" marker. Only a genuine total failure (exit >2, or exit 2 with nothing parsed)
-            # stays fail-closed with the byte-identical RuntimeError message.
+            # stays fail-closed with the byte-identical BackendExecutionError message.
             partial = result.returncode == 2 and total_matches > 0
             if result.returncode > 1 and not partial:
                 stderr = result.stderr.strip()
-                raise RuntimeError(
+                raise BackendExecutionError(
                     f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
                 )
             search_result = SearchResult(
@@ -194,7 +194,7 @@ class RipgrepBackend(ComputeBackend):
                 incomplete_reason=reason,
             )
         except Exception as e:
-            raise RuntimeError(f"Ripgrep backend failed: {e}") from e
+            raise BackendExecutionError(f"Ripgrep backend failed: {e}") from e
 
     @staticmethod
     def _parse_ndjson_matches(
@@ -294,7 +294,7 @@ class RipgrepBackend(ComputeBackend):
             partial = result.returncode == 2 and bool(matched_file_paths)
             if result.returncode > 1 and not partial:
                 stderr = result.stderr.strip()
-                raise RuntimeError(
+                raise BackendExecutionError(
                     f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
                 )
             search_result = SearchResult(
@@ -341,7 +341,7 @@ class RipgrepBackend(ComputeBackend):
                 incomplete_reason=reason,
             )
         except Exception as e:
-            raise RuntimeError(f"Ripgrep backend failed: {e}") from e
+            raise BackendExecutionError(f"Ripgrep backend failed: {e}") from e
 
     def _parse_count_stdout(
         self, stdout: str, config: SearchConfig, file_path: str | list[str]
@@ -410,7 +410,7 @@ class RipgrepBackend(ComputeBackend):
             partial = result.returncode == 2 and total_matches > 0
             if result.returncode > 1 and not partial:
                 stderr = result.stderr.strip()
-                raise RuntimeError(
+                raise BackendExecutionError(
                     f"rg failed with exit code {result.returncode}: {stderr or 'no stderr output'}"
                 )
             routing_reason = "rg_count_matches" if config.count_matches else "rg_count"
@@ -458,7 +458,7 @@ class RipgrepBackend(ComputeBackend):
                 incomplete_reason=reason,
             )
         except Exception as e:
-            raise RuntimeError(f"Ripgrep backend failed: {e}") from e
+            raise BackendExecutionError(f"Ripgrep backend failed: {e}") from e
 
     def search_passthrough(
         self, file_path: str | list[str], pattern: str, config: SearchConfig | None = None
@@ -502,7 +502,7 @@ class RipgrepBackend(ComputeBackend):
     ) -> list[str]:
         binary_name = self._get_binary_name()
         if binary_name is None:
-            raise RuntimeError("RipgrepBackend requires the 'rg' binary to be installed.")
+            raise BackendExecutionError("RipgrepBackend requires the 'rg' binary to be installed.")
 
         cmd: list[str] = [binary_name]
         if json_mode:

--- a/src/tensor_grep/backends/rust_backend.py
+++ b/src/tensor_grep/backends/rust_backend.py
@@ -126,14 +126,15 @@ class RustCoreBackend(ComputeBackend):
         self, file_path: str, pattern: str, config: SearchConfig | None = None
     ) -> SearchResult:
         if not self.inner:
-            return SearchResult(
-                matches=[],
-                total_files=0,
-                total_matches=0,
-                routing_backend="RustCoreBackend",
-                routing_reason="rust_unavailable",
-                routing_distributed=False,
-                routing_worker_count=1,
+            # audit #14: is_available() (HAVE_RUST) gates pipeline selection of this backend,
+            # so this is normally unreachable -- but a direct caller that skips the
+            # is_available() gate must not get a silent empty-but-success SearchResult for
+            # what is actually a missing native extension. Per the Backend Fail-Closed
+            # Contract (base.py), a backend must raise BackendExecutionError instead of
+            # returning an empty result that is indistinguishable from a genuine no-match.
+            raise BackendExecutionError(
+                "RustCoreBackend requires the native tensor_grep.rust_core extension, "
+                "which is not available (HAVE_RUST is False)."
             )
 
         ignore_case = False

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import ClassVar
 
-from tensor_grep.backends.base import ComputeBackend
+from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
 
@@ -349,66 +349,77 @@ class StringZillaBackend(ComputeBackend):
     ) -> SearchResult:
         # audit D3: removed the outer `try/except Exception: raise e` wrapper — it only
         # obscured the original traceback without providing any fallback behaviour.
-        import stringzilla as sz
+        # audit #10: replaced with a wrap that converts a native StringZilla fault (or any
+        # other failure in this method) into BackendExecutionError per the Backend
+        # Fail-Closed Contract (base.py), instead of letting it escape raw -- main.py's
+        # per-file loop only retries on the CPU fallback for BackendExecutionError (`except
+        # BackendExecutionError`); an unwrapped native error falls into its broad `except
+        # Exception` and re-raises uncaught instead of degrading to CPU.
+        try:
+            import stringzilla as sz
 
-        ignore_case = bool(config and config.ignore_case)
-        if config and config.fixed_strings:
-            indexed = self._search_with_index(file_path, pattern, config, ignore_case)
-            if indexed is not None:
-                return indexed
+            ignore_case = bool(config and config.ignore_case)
+            if config and config.fixed_strings:
+                indexed = self._search_with_index(file_path, pattern, config, ignore_case)
+                if indexed is not None:
+                    return indexed
 
-        content = self._load_searchable_text(
-            file_path,
-            treat_binary_as_text=self._should_search_binary_as_text(config),
-        )
-        if content is None:
+            content = self._load_searchable_text(
+                file_path,
+                treat_binary_as_text=self._should_search_binary_as_text(config),
+            )
+            if content is None:
+                return SearchResult(
+                    matches=[],
+                    total_files=0,
+                    total_matches=0,
+                    routing_backend="StringZillaBackend",
+                    routing_reason="stringzilla_fixed_strings_skipped_binary",
+                    routing_distributed=False,
+                    routing_worker_count=1,
+                )
+
+            sz_str = sz.Str(content)
+
+            # Since StringZilla 4.x, we can split by lines extremely fast
+            lines = sz_str.splitlines()
+            # Unlike Python's str.splitlines(), StringZilla's Str.splitlines() emits an
+            # extra trailing empty entry when the source text ends with a line
+            # terminator (e.g. "a\n" -> ["a", ""] instead of ["a"]). Uncorrected, that
+            # phantom empty "line" spuriously matches under invert_match (it never
+            # contains the pattern) and shifts every subsequent line number. Trim it so
+            # line numbering and invert_match semantics match cpu_backend/rg.
+            if lines and str(lines[-1]) == "" and content.endswith(("\n", "\r")):
+                lines = lines[:-1]
+            matches = []
+            invert_match = bool(config and config.invert_match)
+            max_count = config.max_count if config else None
+
+            # Evaluate using stringzilla's native find
+            for i, line in enumerate(lines):
+                haystack = str(line).lower() if ignore_case else line
+                needle = pattern.lower() if ignore_case else pattern
+                found = haystack.find(needle) != -1
+                # H5: honor invert_match -- a matching line under invert_match is one
+                # where the pattern is ABSENT, the complement of the normal result.
+                matched = (not found) if invert_match else found
+                if matched:
+                    matches.append(MatchLine(line_number=i + 1, text=str(line), file=file_path))
+                    # H6: cap to config.max_count, matching cpu_backend's per-file cap
+                    # semantics -- never return every match once the cap is reached.
+                    if max_count and len(matches) >= max_count:
+                        break
+
             return SearchResult(
-                matches=[],
-                total_files=0,
-                total_matches=0,
+                matches=matches,
+                total_files=1 if matches else 0,
+                total_matches=len(matches),
                 routing_backend="StringZillaBackend",
-                routing_reason="stringzilla_fixed_strings_skipped_binary",
+                routing_reason="stringzilla_fixed_strings",
                 routing_distributed=False,
                 routing_worker_count=1,
             )
-
-        sz_str = sz.Str(content)
-
-        # Since StringZilla 4.x, we can split by lines extremely fast
-        lines = sz_str.splitlines()
-        # Unlike Python's str.splitlines(), StringZilla's Str.splitlines() emits an
-        # extra trailing empty entry when the source text ends with a line
-        # terminator (e.g. "a\n" -> ["a", ""] instead of ["a"]). Uncorrected, that
-        # phantom empty "line" spuriously matches under invert_match (it never
-        # contains the pattern) and shifts every subsequent line number. Trim it so
-        # line numbering and invert_match semantics match cpu_backend/rg.
-        if lines and str(lines[-1]) == "" and content.endswith(("\n", "\r")):
-            lines = lines[:-1]
-        matches = []
-        invert_match = bool(config and config.invert_match)
-        max_count = config.max_count if config else None
-
-        # Evaluate using stringzilla's native find
-        for i, line in enumerate(lines):
-            haystack = str(line).lower() if ignore_case else line
-            needle = pattern.lower() if ignore_case else pattern
-            found = haystack.find(needle) != -1
-            # H5: honor invert_match -- a matching line under invert_match is one
-            # where the pattern is ABSENT, the complement of the normal result.
-            matched = (not found) if invert_match else found
-            if matched:
-                matches.append(MatchLine(line_number=i + 1, text=str(line), file=file_path))
-                # H6: cap to config.max_count, matching cpu_backend's per-file cap
-                # semantics -- never return every match once the cap is reached.
-                if max_count and len(matches) >= max_count:
-                    break
-
-        return SearchResult(
-            matches=matches,
-            total_files=1 if matches else 0,
-            total_matches=len(matches),
-            routing_backend="StringZillaBackend",
-            routing_reason="stringzilla_fixed_strings",
-            routing_distributed=False,
-            routing_worker_count=1,
-        )
+        except Exception as e:
+            raise BackendExecutionError(
+                f"StringZillaBackend failed to search {file_path}: {e}"
+            ) from e

--- a/src/tensor_grep/backends/torch_backend.py
+++ b/src/tensor_grep/backends/torch_backend.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-from tensor_grep.backends.base import ComputeBackend
+from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.hardware.device_detect import DeviceDetector
 from tensor_grep.core.result import MatchLine, SearchResult
@@ -169,7 +169,7 @@ class TorchBackend(ComputeBackend):
         self, file_path: str, pattern: str, config: SearchConfig | None = None
     ) -> SearchResult:
         if not self.is_available():
-            raise RuntimeError("TorchBackend requires CUDA-enabled PyTorch.")
+            raise BackendExecutionError("TorchBackend requires CUDA-enabled PyTorch.")
 
         cfg = config or SearchConfig()
 
@@ -205,7 +205,7 @@ class TorchBackend(ComputeBackend):
                 else:
                     resolved_device_ids = []
         if not resolved_device_ids:
-            raise RuntimeError(
+            raise BackendExecutionError(
                 "TorchBackend requires concrete CUDA device IDs for routing; "
                 "detector returned no routable devices."
             )
@@ -213,92 +213,104 @@ class TorchBackend(ComputeBackend):
             list(resolved_device_ids),
             self.chunk_sizes_mb,
         )
-        devices = [torch.device(f"cuda:{device_id}") for device_id in resolved_device_ids]
+        # audit #10: the CUDA/tensor compute region below (device tensor allocation, file
+        # read, unfold/compare kernels, and the multi-GPU thread-pool fan-out) is wrapped so a
+        # native CUDA fault (OOM, device fault, driver error) or an IO/encoding fault never
+        # escapes raw -- it must surface as BackendExecutionError per the Backend Fail-Closed
+        # Contract (base.py) so main.py's per-file loop retries on the CPU fallback (`except
+        # BackendExecutionError`) instead of an unwrapped error falling into the broad `except
+        # Exception` there and re-raising uncaught.
+        try:
+            devices = [torch.device(f"cuda:{device_id}") for device_id in resolved_device_ids]
 
-        with open(file_path, encoding="utf-8", errors="replace") as handle:
-            lines = handle.read().splitlines()
+            with open(file_path, encoding="utf-8", errors="replace") as handle:
+                lines = handle.read().splitlines()
 
-        matches: list[MatchLine] = []
-        query = (
-            pattern.lower()
-            if cfg.ignore_case or (cfg.smart_case and pattern.islower())
-            else pattern
-        )
-
-        pattern_bytes = query.encode("utf-8", errors="replace")
-        routing_chunk_plan_mb: list[tuple[int, int]] = []
-        if normalized_chunk_sizes and len(normalized_chunk_sizes) == len(resolved_device_ids):
-            routing_chunk_plan_mb = list(
-                zip(resolved_device_ids, normalized_chunk_sizes, strict=False)
+            matches: list[MatchLine] = []
+            query = (
+                pattern.lower()
+                if cfg.ignore_case or (cfg.smart_case and pattern.islower())
+                else pattern
             )
-        if not pattern_bytes:
-            return SearchResult(
-                matches=[],
-                total_files=0,
-                total_matches=0,
-                routing_backend="TorchBackend",
-                routing_reason=(
-                    "torch_multi_gpu_fanout" if len(devices) > 1 else "torch_single_gpu"
-                ),
-                routing_gpu_device_ids=list(resolved_device_ids),
-                routing_gpu_chunk_plan_mb=routing_chunk_plan_mb,
-                routing_distributed=len(devices) > 1,
-                routing_worker_count=len(devices),
-            )
-        pattern_len = len(pattern_bytes)
-        pattern_tensors = [
-            torch.tensor(list(pattern_bytes), dtype=torch.uint8, device=device)
-            for device in devices
-        ]
 
-        numbered_lines = list(enumerate(lines, 1))
-        if len(devices) > 1:
-            if normalized_chunk_sizes and len(normalized_chunk_sizes) == len(devices):
-                shards = self._build_weighted_shards(numbered_lines, normalized_chunk_sizes)
-            else:
-                shards = self._build_round_robin_shards(numbered_lines, len(devices))
-
-            with ThreadPoolExecutor(max_workers=len(devices)) as executor:
-                futures = []
-                for slot, device in enumerate(devices):
-                    futures.append(
-                        executor.submit(
-                            self._search_lines_on_device,
-                            torch=torch,
-                            numbered_lines=shards[slot],
-                            query=query,
-                            cfg=cfg,
-                            file_path=file_path,
-                            pattern_tensor=pattern_tensors[slot],
-                            pattern_len=pattern_len,
-                            device=device,
-                        )
-                    )
-                for future in futures:
-                    matches.extend(future.result())
-            matches.sort(key=lambda item: item.line_number)
-            if cfg.max_count:
-                matches = matches[: cfg.max_count]
-        else:
-            for line_number, line in numbered_lines:
-                is_match = self._contains_literal_torch(
-                    torch=torch,
-                    line=(
-                        line.lower()
-                        if cfg.ignore_case or (cfg.smart_case and query.islower())
-                        else line
-                    ),
-                    pattern_tensor=pattern_tensors[0],
-                    pattern_len=pattern_len,
-                    device=devices[0],
+            pattern_bytes = query.encode("utf-8", errors="replace")
+            routing_chunk_plan_mb: list[tuple[int, int]] = []
+            if normalized_chunk_sizes and len(normalized_chunk_sizes) == len(resolved_device_ids):
+                routing_chunk_plan_mb = list(
+                    zip(resolved_device_ids, normalized_chunk_sizes, strict=False)
                 )
-                if cfg.invert_match:
-                    is_match = not is_match
+            if not pattern_bytes:
+                return SearchResult(
+                    matches=[],
+                    total_files=0,
+                    total_matches=0,
+                    routing_backend="TorchBackend",
+                    routing_reason=(
+                        "torch_multi_gpu_fanout" if len(devices) > 1 else "torch_single_gpu"
+                    ),
+                    routing_gpu_device_ids=list(resolved_device_ids),
+                    routing_gpu_chunk_plan_mb=routing_chunk_plan_mb,
+                    routing_distributed=len(devices) > 1,
+                    routing_worker_count=len(devices),
+                )
+            pattern_len = len(pattern_bytes)
+            pattern_tensors = [
+                torch.tensor(list(pattern_bytes), dtype=torch.uint8, device=device)
+                for device in devices
+            ]
 
-                if is_match:
-                    matches.append(MatchLine(line_number=line_number, text=line, file=file_path))
-                if cfg.max_count and len(matches) >= cfg.max_count:
-                    break
+            numbered_lines = list(enumerate(lines, 1))
+            if len(devices) > 1:
+                if normalized_chunk_sizes and len(normalized_chunk_sizes) == len(devices):
+                    shards = self._build_weighted_shards(numbered_lines, normalized_chunk_sizes)
+                else:
+                    shards = self._build_round_robin_shards(numbered_lines, len(devices))
+
+                with ThreadPoolExecutor(max_workers=len(devices)) as executor:
+                    futures = []
+                    for slot, device in enumerate(devices):
+                        futures.append(
+                            executor.submit(
+                                self._search_lines_on_device,
+                                torch=torch,
+                                numbered_lines=shards[slot],
+                                query=query,
+                                cfg=cfg,
+                                file_path=file_path,
+                                pattern_tensor=pattern_tensors[slot],
+                                pattern_len=pattern_len,
+                                device=device,
+                            )
+                        )
+                    for future in futures:
+                        matches.extend(future.result())
+                matches.sort(key=lambda item: item.line_number)
+                if cfg.max_count:
+                    matches = matches[: cfg.max_count]
+            else:
+                for line_number, line in numbered_lines:
+                    is_match = self._contains_literal_torch(
+                        torch=torch,
+                        line=(
+                            line.lower()
+                            if cfg.ignore_case or (cfg.smart_case and query.islower())
+                            else line
+                        ),
+                        pattern_tensor=pattern_tensors[0],
+                        pattern_len=pattern_len,
+                        device=devices[0],
+                    )
+                    if cfg.invert_match:
+                        is_match = not is_match
+
+                    if is_match:
+                        matches.append(
+                            MatchLine(line_number=line_number, text=line, file=file_path)
+                        )
+                    if cfg.max_count and len(matches) >= cfg.max_count:
+                        break
+        except Exception as e:
+            raise BackendExecutionError(f"TorchBackend compute failed: {e}") from e
 
         return SearchResult(
             matches=matches,

--- a/tests/unit/test_backend_bug_fixes.py
+++ b/tests/unit/test_backend_bug_fixes.py
@@ -102,11 +102,22 @@ def test_ast_to_graph_deep_tree_does_not_raise_recursion_error() -> None:
 
 # ---------------------------------------------------------------------------
 # D3 — StringZillaBackend: traceback is not swallowed by bare re-raise
+# audit #10 (supersedes D3's "propagate the raw type" stance): base.py's Backend
+# Fail-Closed Contract explicitly names "encoding/IO errors" as faults backends MUST
+# raise as BackendExecutionError instead of letting escape raw -- D3 predates that
+# contract clause and left search() with no try/except at all, so an IO fault (like a
+# TOCTOU-deleted file) fell into main.py's per-file loop's broad `except Exception`
+# and crashed the whole search instead of being retried on the CPU fallback (`except
+# BackendExecutionError`). The original exception is NOT swallowed: it is chained via
+# `raise ... from e`, so its type and traceback stay inspectable as __cause__.
 # ---------------------------------------------------------------------------
 
 
 def test_stringzilla_search_propagates_real_exception(tmp_path: Any) -> None:
-    """Errors from underlying I/O must propagate with their original type, not wrapped."""
+    """An IO fault (missing file) must raise BackendExecutionError, per the Backend
+    Fail-Closed Contract (base.py) -- not escape raw as D3 originally required, and not
+    be swallowed either: the original FileNotFoundError is preserved as __cause__."""
+    from tensor_grep.backends.base import BackendExecutionError
     from tensor_grep.backends.stringzilla_backend import StringZillaBackend
     from tensor_grep.core.config import SearchConfig
 
@@ -115,12 +126,15 @@ def test_stringzilla_search_propagates_real_exception(tmp_path: Any) -> None:
 
     try:
         backend.search(missing, "anything", config=SearchConfig(fixed_strings=True))
-    except FileNotFoundError:
-        pass  # correct — original exception type preserved
+    except BackendExecutionError as exc:
+        assert isinstance(exc.__cause__, FileNotFoundError)  # original type preserved as cause
     except Exception as exc:
         raise AssertionError(
-            f"Expected FileNotFoundError but got {type(exc).__name__}: {exc}"
+            f"Expected BackendExecutionError (caused by FileNotFoundError) but got "
+            f"{type(exc).__name__}: {exc}"
         ) from exc
+    else:
+        raise AssertionError("Expected BackendExecutionError, but search() returned normally")
 
 
 def test_stringzilla_search_returns_result_without_wrapper(tmp_path: Any) -> None:

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -371,6 +371,64 @@ def test_should_raise_on_rg_fatal_error():
             backend.search("test.log", "(")
 
 
+def test_should_raise_backend_execution_error_on_rg_fatal_exit_code():
+    """audit #79: a fatal rg exit code previously raised a bare RuntimeError, which is
+    invisible to a caller's `except BackendExecutionError` handler (e.g. main.py's
+    per-file CPU-fallback retry, cli/main.py:6756-6761) -- it fell into the broad
+    `except Exception` there instead and crashed the whole search. It must raise
+    BackendExecutionError (still a RuntimeError, so broader `except RuntimeError`/
+    `except Exception` handlers keep working)."""
+    from tensor_grep.backends.base import BackendExecutionError
+
+    backend = RipgrepBackend()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 2
+    mock_result.stdout = ""
+    mock_result.stderr = "regex parse error"
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch("tensor_grep.backends.ripgrep_backend.run_subprocess", return_value=mock_result),
+    ):
+        with pytest.raises(BackendExecutionError):
+            backend.search("test.log", "(")
+
+
+def test_should_raise_backend_execution_error_on_unexpected_subprocess_failure():
+    """audit #79: an unexpected exception from run_subprocess (e.g. an OSError launching
+    rg) fell into search()'s broad `except Exception` and was re-raised as a bare
+    RuntimeError. It must now be BackendExecutionError so the CLI's per-file loop retries
+    on the CPU backend instead of crashing with an uncaught traceback (audit B2/I1)."""
+    from tensor_grep.backends.base import BackendExecutionError
+
+    backend = RipgrepBackend()
+
+    with (
+        patch.object(backend, "_get_binary_name", return_value="rg"),
+        patch(
+            "tensor_grep.backends.ripgrep_backend.run_subprocess",
+            side_effect=OSError("boom"),
+        ),
+    ):
+        with pytest.raises(BackendExecutionError):
+            backend.search("test.log", "ERROR")
+
+
+def test_should_raise_backend_execution_error_when_rg_binary_missing():
+    """audit #79: _build_cmd's missing-binary guard raised a bare RuntimeError. Any
+    direct caller of search()/search_passthrough() that skips the is_available() gate
+    must see BackendExecutionError, per the Backend Fail-Closed Contract (base.py)."""
+    from tensor_grep.backends.base import BackendExecutionError
+
+    backend = RipgrepBackend()
+    with patch.object(backend, "_get_binary_name", return_value=None):
+        with pytest.raises(BackendExecutionError):
+            backend._build_cmd(
+                file_path="test.log", pattern="ERROR", config=SearchConfig(), json_mode=True
+            )
+
+
 def test_count_with_filename_single_file_parses_path_prefixed_output():
     """Audit HIGH: a single-file ``--count -H`` makes rg emit ``path:count``, but the
     count parser only path-split on the list/dir heuristic (ignoring ``with_filename``),

--- a/tests/unit/test_rust_core.py
+++ b/tests/unit/test_rust_core.py
@@ -352,21 +352,28 @@ def test_rust_backend_count_fast_path_reports_routing_metadata(monkeypatch, tmp_
     assert result.routing_reason == "rust_count"
 
 
-def test_rust_backend_unavailable_should_report_routing_metadata(monkeypatch, tmp_path: Path):
+def test_rust_backend_unavailable_should_raise_backend_execution_error(monkeypatch, tmp_path: Path):
+    """audit #14: a direct caller that bypasses the ``is_available()`` gate and calls
+    ``search()`` while ``self.inner is None`` must not get a silent empty-but-success
+    ``SearchResult`` -- that is indistinguishable from a genuine no-match. Per the Backend
+    Fail-Closed Contract (base.py), it must raise ``BackendExecutionError`` instead, exactly
+    like a genuine native-search failure (see
+    ``test_rust_backend_exception_should_raise_backend_execution_error`` below), which a
+    caller catching ``BackendExecutionError`` (e.g. main.py's per-file CPU-fallback retry)
+    can react to instead of silently trusting a false no-match.
+    """
     from tensor_grep.backends import rust_backend as rb
+    from tensor_grep.backends.base import BackendExecutionError
 
     monkeypatch.setattr(rb, "HAVE_RUST", False)
 
     backend = rb.RustCoreBackend()
+    assert backend.inner is None
     log_file = tmp_path / "missing_rust.log"
     log_file.write_text("ERROR\n")
-    result = backend.search(str(log_file), "ERROR")
 
-    assert result.total_matches == 0
-    assert result.routing_backend == "RustCoreBackend"
-    assert result.routing_reason == "rust_unavailable"
-    assert result.routing_distributed is False
-    assert result.routing_worker_count == 1
+    with pytest.raises(BackendExecutionError):
+        backend.search(str(log_file), "ERROR")
 
 
 def test_rust_backend_exception_should_raise_backend_execution_error(monkeypatch, tmp_path: Path):

--- a/tests/unit/test_stringzilla_backend.py
+++ b/tests/unit/test_stringzilla_backend.py
@@ -270,6 +270,33 @@ def test_stringzilla_honors_max_count_non_indexed_path(backend, tmp_path, monkey
     assert [m.line_number for m in result.matches] == [1, 2]
 
 
+def test_stringzilla_native_fault_raises_backend_execution_error(tmp_path, monkeypatch):
+    """audit #10: search() previously had no try/except, so a native StringZilla panic
+    (e.g. from ``sz.Str()`` construction) escaped raw instead of surfacing as
+    BackendExecutionError per the Backend Fail-Closed Contract (base.py). A caller's
+    `except BackendExecutionError` handler (main.py's per-file CPU-fallback retry,
+    cli/main.py:6756-6761) must catch it instead of the search crashing outright."""
+    import stringzilla
+
+    from tensor_grep.backends.base import BackendExecutionError
+
+    log_file = tmp_path / "sys.log"
+    log_file.write_text("ERROR failure\n", encoding="utf-8")
+
+    def _raise_native_panic(*_args, **_kwargs):
+        raise RuntimeError("native stringzilla panic: kaboom")
+
+    monkeypatch.setattr(stringzilla, "Str", _raise_native_panic)
+
+    backend = StringZillaBackend()
+    # fixed_strings=False bypasses the pure-Python trigram-index fast path
+    # (_search_with_index) so the native sz.Str() construction is actually exercised.
+    with pytest.raises(BackendExecutionError) as exc_info:
+        backend.search(str(log_file), "ERROR", config=SearchConfig(fixed_strings=False))
+    assert isinstance(exc_info.value, RuntimeError)  # broader `except RuntimeError` still works
+    assert "kaboom" in str(exc_info.value)
+
+
 def test_stringzilla_in_memory_index_cache_obeys_entry_cap(tmp_path, monkeypatch):
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX_CACHE_MAX_ENTRIES", "2")

--- a/tests/unit/test_torch_backend.py
+++ b/tests/unit/test_torch_backend.py
@@ -2,6 +2,8 @@ import types
 from typing import ClassVar
 from unittest.mock import patch
 
+import pytest
+
 from tensor_grep.core.config import SearchConfig
 
 
@@ -438,6 +440,91 @@ def test_torch_backend_search_should_fallback_to_get_device_ids_when_enumeration
     assert result.routing_gpu_device_ids == [5, 2]
     assert "cuda:5" in fake_torch.device_calls
     assert "cuda:2" in fake_torch.device_calls
+
+
+def test_torch_backend_unavailable_raises_backend_execution_error(tmp_path):
+    """audit #79: search() previously raised a bare RuntimeError when CUDA/PyTorch is
+    unavailable. It must raise BackendExecutionError so a caller's `except
+    BackendExecutionError` handler (main.py's per-file CPU-fallback retry) catches it
+    instead of the search crashing with an uncaught traceback."""
+    from tensor_grep.backends.base import BackendExecutionError
+    from tensor_grep.backends.torch_backend import TorchBackend
+
+    path = tmp_path / "torch_unavailable.log"
+    path.write_text("ERROR A\n", encoding="utf-8")
+
+    backend = TorchBackend()
+    with patch.object(TorchBackend, "is_available", return_value=False):
+        with pytest.raises(BackendExecutionError):
+            backend.search(str(path), "ERROR", SearchConfig(fixed_strings=True))
+
+
+def test_torch_backend_no_concrete_device_ids_raises_backend_execution_error(tmp_path):
+    """audit #79: the 'no routable devices' guard also raised a bare RuntimeError."""
+    from tensor_grep.backends.base import BackendExecutionError
+    from tensor_grep.backends.torch_backend import TorchBackend
+
+    path = tmp_path / "torch_no_ids.log"
+    path.write_text("ERROR A\n", encoding="utf-8")
+
+    class _CountOnlyDetector:
+        def get_device_count(self):
+            return 2
+
+    fake_torch = _FakeTorch()
+    backend = TorchBackend(device_ids=None)
+    backend.device_detector = _CountOnlyDetector()
+
+    with (
+        patch.object(TorchBackend, "is_available", return_value=True),
+        patch.dict("sys.modules", {"torch": fake_torch}),
+    ):
+        with pytest.raises(BackendExecutionError, match="concrete CUDA device IDs"):
+            backend.search(str(path), "ERROR", SearchConfig(fixed_strings=True))
+
+
+class _FailingTensorTorch(types.ModuleType):
+    """A fake ``torch`` module whose tensor allocation raises, simulating a native
+    CUDA/tensor compute fault (e.g. a CUDA-OOM or device fault) inside the compute
+    region."""
+
+    uint8 = "uint8"
+
+    def __init__(self):
+        super().__init__("torch")
+
+    def device(self, value: str):
+        return value
+
+    def tensor(self, values, dtype=None, device=None):
+        raise RuntimeError("CUDA error: out of memory")
+
+
+def test_torch_backend_compute_fault_raises_backend_execution_error(tmp_path):
+    """audit #10: the CUDA compute region (device tensor allocation, unfold/compare
+    kernels, multi-GPU fan-out) previously had no try/except, so a native CUDA/tensor
+    fault escaped raw. It must surface as BackendExecutionError per the Backend
+    Fail-Closed Contract (base.py), caught by `except BackendExecutionError` (not just a
+    bare `except RuntimeError` that happens to also match), so main.py's per-file loop
+    retries on the CPU fallback instead of the search crashing outright."""
+    from tensor_grep.backends.base import BackendExecutionError
+    from tensor_grep.backends.torch_backend import TorchBackend
+
+    path = tmp_path / "torch_fault.log"
+    path.write_text("ERROR A\n", encoding="utf-8")
+
+    backend = TorchBackend(device_ids=[0])
+    with (
+        patch.object(TorchBackend, "is_available", return_value=True),
+        patch.dict("sys.modules", {"torch": _FailingTensorTorch()}),
+    ):
+        try:
+            backend.search(str(path), "ERROR", SearchConfig(fixed_strings=True))
+        except BackendExecutionError as exc:
+            assert isinstance(exc, RuntimeError)  # broader `except RuntimeError` still works
+            assert "CUDA error" in str(exc)
+        else:
+            pytest.fail("expected BackendExecutionError")
 
 
 def test_torch_backend_empty_pattern_should_preserve_routing_metadata(tmp_path):


### PR DESCRIPTION
## Why
`base.py:7-10` — `BackendExecutionError` "Covers native panics, encoding/IO errors, version skew, and GPU/CUDA/OOM faults." Backends MUST raise it on failure so callers' `except BackendExecutionError` handlers catch it. Three backends violated this (found by the deep-dive audit #81):

- **#79** — `ripgrep_backend.py` (7 sites) + `torch_backend.py` (2 sites) raised **bare `RuntimeError`** → `except BackendExecutionError` (a *subclass*) MISSES it → a real backend failure escapes the fail-closed handler.
- **#10** — `stringzilla_backend.py` `search()` (no try/except) + `torch_backend.py` CUDA compute region (unwrapped) let a native SZ / CUDA-OOM fault escape RAW instead of `BackendExecutionError` — defeats the CPU-fallback retry.
- **#14** — `rust_backend.py` returned a fail-OPEN empty `SearchResult` when `inner is None` instead of raising (latent, currently gated by `is_available()`).

## Fix
`raise RuntimeError` → `raise BackendExecutionError` (chained `from e`); wrapped the SZ + CUDA compute regions; `rust_backend` now raises. Safe: `BackendExecutionError` subclasses `RuntimeError`, so any broader `except RuntimeError`/`except Exception` still catches it. No matching-logic change (the torch wrap is a pure re-indent).

## A stale contract-test corrected
`test_backend_bug_fixes.py::test_stringzilla_search_propagates_real_exception` (an older "audit D3") pinned the **opposite** contract (IO errors keep their original type). That predates base.py's current docstring which explicitly names IO/encoding errors as `BackendExecutionError` faults. Updated it to the current contract while still asserting the original exception is preserved via `exc.__cause__`.

## Verification
Real venv: **133 passed** (all 4 backend test files + pipeline + the corrected contract tests; the agent's broader `-k backend or ripgrep or pipeline or fail_closed` gate was **367 passed**); ruff + format --preview + mypy clean. New tests assert each backend's failure surfaces as `BackendExecutionError` (caught by the contract handler), incl. a mocked native-compute fault for torch (no GPU needed). `cpu_backend.py` + `base.py` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)