### PR TITLE
fix(repo_map): recall from-dot-import in callers/blast-radius + honest Go reverse-import gap + platform-gated module case-folding (audit #81 #3/#4/#11)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -2900,17 +2900,29 @@ def _rust_resolve_use_binding(
 
 
 def _definition_module_parts(path: str) -> list[str]:
-    raw_parts = [part.lower() for part in Path(path).with_suffix("").parts if part]
+    # audit #81 #11: case-folding every path segment made `Foo.py` match `foo.py` on a
+    # case-SENSITIVE filesystem (Linux CI/prod) -> wrong-file attribution in reverse-import
+    # edges. Gate the fold on Windows only, mirroring `_definition_file_dedupe_key` (below),
+    # which already conditions its case-handling on `os.name == "nt"` for the same reason.
+    raw_parts = [part for part in Path(path).with_suffix("").parts if part]
+    if os.name == "nt":
+        raw_parts = [part.lower() for part in raw_parts]
     parts = [part for part in raw_parts if part not in {".", ".."} and not part.endswith(":\\")]
     if not parts:
         return []
-    if parts[-1] in {"__init__", "index", "mod"} and len(parts) > 1:
+    # The __init__/index/mod magic-name check stays case-insensitive on every platform: these
+    # are real on-disk filenames that are always already lowercase by language convention
+    # (CPython only ever treats a literal `__init__.py` as a package initializer), so comparing
+    # case-insensitively here does not reintroduce the false-edge risk the fold above removed.
+    if parts[-1].lower() in {"__init__", "index", "mod"} and len(parts) > 1:
         parts = parts[:-1]
     return parts
 
 
 def _normalized_module_parts(module_name: str) -> list[str]:
-    parts = [part.lower() for part in re.split(r"[^A-Za-z0-9_]+", module_name) if part]
+    # audit #81 #11: see _definition_module_parts above -- same Windows-only case-fold gate.
+    raw_parts = [part for part in re.split(r"[^A-Za-z0-9_]+", module_name) if part]
+    parts = [part.lower() for part in raw_parts] if os.name == "nt" else raw_parts
     while parts and parts[0] in {"crate", "self", "super"}:
         parts = parts[1:]
     return parts
@@ -2986,10 +2998,29 @@ def _python_file_imports_symbol_from_definition(
             ):
                 return True
         elif isinstance(node, ast.ImportFrom):
-            if not node.module or not _module_path_matches_definition(node.module, definition_path):
-                continue
-            if any(alias.name in {"*", symbol} or alias.asname == symbol for alias in node.names):
-                return True
+            if node.module:
+                if not _module_path_matches_definition(node.module, definition_path):
+                    continue
+                if any(
+                    alias.name in {"*", symbol} or alias.asname == symbol for alias in node.names
+                ):
+                    return True
+            elif node.level:
+                # `from . import helpers` / `from .. import helpers` -- no dotted `node.module`
+                # text, only relative dots plus the imported name(s). This bare form BINDS THE
+                # SUBMODULE ITSELF (like `ast.Import`, not a `from X import symbol` name
+                # binding), so match on module path alone -- mirrors #460's fix for the forward
+                # `_python_imports_and_symbols`/`_python_imports_with_lines` extractors (the `tg
+                # imports`/`tg importers` primitive), applied here to the callers/blast-radius
+                # consumer path, which was still silently dropping this shape (audit #81 #3): the
+                # old `if not node.module: continue` guard skipped every bare relative import, so
+                # a sibling `from . import helpers` consumer was invisible to `tg callers`/`tg
+                # blast-radius` even though `tg importers` already found it.
+                if any(
+                    _module_path_matches_definition(alias.name, definition_path)
+                    for alias in node.names
+                ):
+                    return True
     return False
 
 
@@ -3166,15 +3197,30 @@ def _python_import_update_target(
                         "provenance": "parser-backed",
                     }
         elif isinstance(node, ast.ImportFrom):
-            if not node.module or not _module_path_matches_definition(node.module, definition_path):
-                continue
-            if any(alias.name in {"*", symbol} or alias.asname == symbol for alias in node.names):
-                return {
-                    "start_line": int(node.lineno),
-                    "end_line": int(getattr(node, "end_lineno", node.lineno)),
-                    "module": node.module,
-                    "provenance": "parser-backed",
-                }
+            if node.module:
+                if not _module_path_matches_definition(node.module, definition_path):
+                    continue
+                if any(
+                    alias.name in {"*", symbol} or alias.asname == symbol for alias in node.names
+                ):
+                    return {
+                        "start_line": int(node.lineno),
+                        "end_line": int(getattr(node, "end_lineno", node.lineno)),
+                        "module": node.module,
+                        "provenance": "parser-backed",
+                    }
+            elif node.level:
+                # Mirror the sibling fix in _python_file_imports_symbol_from_definition above
+                # (audit #81 #3): `from . import helpers` has no dotted `node.module`, only
+                # relative dots + the imported name(s), which bind the SUBMODULE itself.
+                for alias in node.names:
+                    if _module_path_matches_definition(alias.name, definition_path):
+                        return {
+                            "start_line": int(node.lineno),
+                            "end_line": int(getattr(node, "end_lineno", node.lineno)),
+                            "module": alias.name,
+                            "provenance": "parser-backed",
+                        }
     return None
 
 
@@ -6436,7 +6482,9 @@ def _graph_trust_summary(
     }
 
 
-def _language_coverage_gap_remediation(language: str, *, fail_closed: bool = False) -> str:
+def _language_coverage_gap_remediation(
+    language: str, *, fail_closed: bool = False, import_resolution_only: bool = False
+) -> str:
     """F12 fix: the remediation text must match what ACTUALLY happens for this gap.
 
     An unregistered-language file (``fail_closed=False``, no ``LanguageSpec`` at all) really does
@@ -6444,6 +6492,11 @@ def _language_coverage_gap_remediation(language: str, *, fail_closed: bool = Fal
     refs/callers scan loops. A registered-but-grammar-missing language with no regex fallback
     (``fail_closed=True``, e.g. Go when ``tree_sitter_go`` is not installed) produces ZERO rows
     for its files instead -- claiming a regex fallback there was simply false.
+
+    ``import_resolution_only`` (audit #81 #4): a registered language whose grammar IS installed
+    but whose ``LanguageSpec.import_update_target`` is ``None`` (Go today) -- defs/refs/callers
+    all work normally, but the reverse-import-graph edge (``import_graph_consumers``) can never
+    be computed for this language, so a zero count there must read as UNKNOWN, not proven-zero.
     """
     if fail_closed:
         return (
@@ -6452,6 +6505,16 @@ def _language_coverage_gap_remediation(language: str, *, fail_closed: bool = Fal
             f"{language} file currently produce NO rows for those files ('{language}' has no "
             "plain-text/regex fallback, unlike python/javascript/typescript/rust). Install the "
             f"missing '{language}' tree-sitter grammar package to restore coverage."
+        )
+    if import_resolution_only:
+        return (
+            f"tg has a '{language}' extractor registered and its parser/grammar is installed, "
+            f"but no reverse-import resolver is wired for '{language}' yet -- `tg callers`/`tg "
+            f"blast-radius` cannot discover a {language} file that consumes a symbol purely via "
+            "an import statement (`import_graph_consumers` is always empty for this language). "
+            "Direct-reference/call matches inside scanned files are unaffected. Treat a zero "
+            f"import-graph-consumer count for a {language} definition as UNKNOWN, not "
+            "proven-zero, until native reverse-import resolution ships."
         )
     return (
         f"tg has no parser-backed extractor registered for '{language}' files yet -- refs/"
@@ -6468,11 +6531,22 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
     Zero behavior change for python/javascript/typescript/rust today -- every file with one of
     those suffixes always resolves a spec, so this only ever fires for a language tensor-grep's
     symbol graph does not yet cover (e.g. .go, .java) that happens to sit in the scan universe.
+
+    Also covers a NARROWER partial-capability gap (audit #81 #4): a language can be fully
+    registered with a working parser (defs/refs/callers all resolve normally) yet still have
+    ``LanguageSpec.import_update_target is None`` -- Go today. Before this fix, that combination
+    fell through the two branches above straight to ``continue``, so a Go-only repo with the
+    grammar installed reported an EMPTY ``resolution_gaps`` even though
+    ``_build_import_graph_consumers_from_map`` can never produce a single reverse-import edge for
+    it -- indistinguishable from "genuinely has zero import-graph consumers". The third branch
+    below flags that combination explicitly so `tg callers`/`tg blast-radius` stay honest about
+    it instead of reading as a proven-zero.
     """
     gaps_by_language: dict[str, dict[str, Any]] = {}
     for current in bounded_files:
         spec = lang_registry.spec_for_path(current)
         fail_closed = False
+        import_resolution_only = False
         if spec is None:
             language = _provider_language_for_path(current) or (
                 current.suffix.lstrip(".").lower() or "unknown"
@@ -6492,6 +6566,13 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
                 fail_closed = True
             else:
                 continue
+        elif spec.import_update_target is None:
+            language = spec.language_id
+            reason = (
+                "registered language extractor has no reverse-import resolver -- "
+                "import_graph_consumers can never be computed for this language"
+            )
+            import_resolution_only = True
         else:
             continue
         entry = gaps_by_language.setdefault(
@@ -6501,7 +6582,9 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
                 "reason": reason,
                 "files_affected": 0,
                 "remediation": _language_coverage_gap_remediation(
-                    language, fail_closed=fail_closed
+                    language,
+                    fail_closed=fail_closed,
+                    import_resolution_only=import_resolution_only,
                 ),
             },
         )

--- a/tests/unit/test_cross_lang_resolution.py
+++ b/tests/unit/test_cross_lang_resolution.py
@@ -224,3 +224,111 @@ def test_build_symbol_impact_excludes_unrelated_tests(tmp_path: Path) -> None:
 
     assert payload["tests"][0] == str(integration_test_path.resolve())
     assert str(unrelated_test_path.resolve()) not in payload["tests"]
+
+
+# ---------------------------------------------------------------------------------------------
+# audit #81 #3: `from . import x` -- invisible in the callers/blast-radius import-graph-consumer
+# path (recall gap; #460 already fixed the sibling `tg imports`/`tg importers` primitive for the
+# exact same import shape).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_symbol_callers_recalls_python_bare_relative_import_consumer(
+    tmp_path: Path,
+) -> None:
+    """`from . import helpers` has no dotted `node.module` text -- `main.py` never references
+    "foo" anywhere in its own source, so the ONLY way it can appear here is via the
+    import-graph-consumer path (`_python_file_imports_symbol_from_definition` /
+    `_python_import_update_target`), not the direct call-site scan. Before the fix, the
+    `if not node.module: continue` guard in both functions silently dropped this shape."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    main_path = pkg / "main.py"
+    main_path.write_text("from . import helpers\n", encoding="utf-8")
+
+    payload = repo_map.build_symbol_callers("foo", project)
+
+    caller_files = {caller["file"] for caller in payload["callers"]}
+    assert str(main_path.resolve()) not in caller_files
+
+    consumer_files = set(payload["import_graph_consumer_files"])
+    assert str(main_path.resolve()) in consumer_files
+    consumer = next(
+        current
+        for current in payload["import_graph_consumers"]
+        if current["file"] == str(main_path.resolve())
+    )
+    assert consumer["module"] == "helpers"
+    assert consumer["definition_file"] == str(helpers_path.resolve())
+    assert consumer["kind"] == "import-consumer"
+    assert consumer["edge_kind"] == "reverse-import"
+
+
+def test_build_symbol_blast_radius_recalls_python_bare_relative_import_consumer(
+    tmp_path: Path,
+) -> None:
+    """Same shape as the callers test above, through the blast-radius payload (which wraps
+    `build_symbol_callers_from_map` internally, so both consume the same fix)."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    main_path = pkg / "main.py"
+    main_path.write_text("from . import helpers\n", encoding="utf-8")
+
+    payload = repo_map.build_symbol_blast_radius("foo", project)
+
+    assert str(main_path.resolve()) in set(payload["import_graph_consumer_files"])
+
+
+# ---------------------------------------------------------------------------------------------
+# audit #81 #4: Go's LanguageSpec has import_update_target=None -> import_graph_consumers can
+# never be populated for Go, and (with the grammar installed) resolution_gaps stayed silently
+# empty about it -- an honesty-floor gap, not a recall gap: the reverse-import edge is a real,
+# permanent capability hole, so it must be SURFACED, not silently read as "proven zero".
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_symbol_callers_flags_go_import_graph_gap_not_silent_empty(
+    tmp_path: Path,
+) -> None:
+    """The direct package-qualified call-site scan (independent of import_update_target) still
+    finds the real cross-package call, proving Go support otherwise works -- only the
+    reverse-import-graph edge is missing, and that absence must be an honest resolution_gaps
+    entry rather than a silent empty list."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "go.mod").write_text("module example.com/app\n\ngo 1.22\n", encoding="utf-8")
+    util_dir = project / "util"
+    util_dir.mkdir()
+    util_go = util_dir / "util.go"
+    util_go.write_text(
+        "package util\n\nfunc Foo() int {\n\treturn 1\n}\n",
+        encoding="utf-8",
+    )
+    main_go = project / "main.go"
+    main_go.write_text(
+        'package main\n\nimport "example.com/app/util"\n\nfunc main() {\n\tutil.Foo()\n}\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_callers("Foo", project)
+
+    caller_files = {caller["file"] for caller in payload["callers"]}
+    assert str(main_go.resolve()) in caller_files, "Go direct call-site resolution must still work"
+
+    assert payload["import_graph_consumer_count"] == 0
+
+    go_gaps = [gap for gap in payload["resolution_gaps"] if gap["language"] == "go"]
+    assert len(go_gaps) == 1, (
+        f"expected exactly one honest 'go' resolution_gaps entry: {payload['resolution_gaps']}"
+    )
+    assert go_gaps[0]["files_affected"] >= 1
+    assert "reverse-import" in go_gaps[0]["reason"]
+    assert "fail-closed" not in go_gaps[0]["reason"]

--- a/tests/unit/test_lang_go.py
+++ b/tests/unit/test_lang_go.py
@@ -197,7 +197,19 @@ def test_refs_cross_package_call_has_call_ref_kind_and_import_resolution(
 
     payload = repo_map.build_symbol_refs("Helper", tmp_path)
 
-    assert payload["resolution_gaps"] == []
+    # audit #81 #4 fix: Go's LanguageSpec sets import_update_target=None (no reverse-import
+    # resolver wired), so _language_coverage_gaps_for_universe now flags that as an honest
+    # partial-capability gap even though the grammar IS installed and every other Go capability
+    # exercised by this test (cross-package call resolution, below) works fine. Before the fix
+    # this silently read as resolution_gaps == [] -- indistinguishable from "Go has full
+    # capability", which was exactly the audit finding (a zero import-graph-consumer count must
+    # read as UNKNOWN, not proven-zero).
+    resolution_gaps = payload["resolution_gaps"]
+    go_gaps = [gap for gap in resolution_gaps if gap["language"] == "go"]
+    assert len(go_gaps) == 1
+    assert go_gaps[0]["files_affected"] >= 1
+    assert "reverse-import" in go_gaps[0]["reason"]
+    assert "fail-closed" not in go_gaps[0]["reason"]
     cross_package_refs = [
         ref
         for ref in payload["references"]

--- a/tests/unit/test_repo_map_graph.py
+++ b/tests/unit/test_repo_map_graph.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import time
 
 from tensor_grep.cli import repo_map
@@ -231,3 +232,81 @@ def test_edit_plan_blast_radius_uses_bounded_repo_map_for_large_cached_maps(
     assert seen_file_counts
     assert max(seen_file_counts) <= 12
     assert payload["edit_plan_seed"]["blast_radius_scope"]["scoped_file_count"] <= 12
+
+
+# ---------------------------------------------------------------------------------------------
+# audit #81 #11: _definition_module_parts / _normalized_module_parts lowercased every path
+# segment unconditionally, so on a case-SENSITIVE filesystem (Linux CI/prod) `Foo.py` matched
+# `foo.py` -> wrong-file attribution in reverse-import edges. The fold must be gated on
+# os.name == "nt" (Windows only), mirroring _definition_file_dedupe_key's existing platform gate.
+# ---------------------------------------------------------------------------------------------
+
+
+class _OSNameOverride:
+    """Delegates every attribute to the real `os` module except `.name`, which is overridden.
+
+    Lets a test simulate `os.name` on the OPPOSITE platform for repo_map's own case-fold gate
+    without also flipping `pathlib.Path`'s internal flavor selection, which reads the real,
+    global `os` module directly (a separate binding pathlib owns itself). Monkeypatching
+    `os.name` directly (e.g. `monkeypatch.setattr(repo_map.os, "name", "posix")`) mutates that
+    SAME shared `os` module object process-wide, so `Path(...)` then tries to instantiate
+    `PosixPath` on a real Windows box and raises `NotImplementedError: cannot instantiate
+    'PosixPath' on your system` before repo_map's own logic is ever reached. Rebinding just the
+    module-level name `os` inside `repo_map`'s own namespace (`monkeypatch.setattr(repo_map,
+    "os", _OSNameOverride(...))`) avoids that: `Path` construction still goes through the real,
+    untouched `os` module, while `repo_map`'s own `os.name` reads see the simulated value.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __getattr__(self, attr: str):
+        return getattr(os, attr)
+
+
+def test_definition_module_parts_case_folds_only_on_windows(monkeypatch) -> None:
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("posix"))
+    assert repo_map._definition_module_parts("pkg/Foo.py") == ["pkg", "Foo"]
+    assert repo_map._definition_module_parts("pkg/foo.py") == ["pkg", "foo"]
+
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("nt"))
+    assert repo_map._definition_module_parts("pkg/Foo.py") == ["pkg", "foo"]
+    assert repo_map._definition_module_parts("pkg/foo.py") == ["pkg", "foo"]
+
+
+def test_definition_module_parts_init_stripping_stays_case_insensitive(monkeypatch) -> None:
+    """The __init__/index/mod magic-name strip is unaffected by the platform gate on either
+    platform -- these are real on-disk filenames that are always already lowercase by language
+    convention (CPython only ever treats a literal __init__.py as a package initializer)."""
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("posix"))
+    assert repo_map._definition_module_parts("pkg/__init__.py") == ["pkg"]
+
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("nt"))
+    assert repo_map._definition_module_parts("pkg/__init__.py") == ["pkg"]
+
+
+def test_normalized_module_parts_case_folds_only_on_windows(monkeypatch) -> None:
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("posix"))
+    assert repo_map._normalized_module_parts("pkg.Foo") == ["pkg", "Foo"]
+
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("nt"))
+    assert repo_map._normalized_module_parts("pkg.Foo") == ["pkg", "foo"]
+
+
+def test_module_path_matches_definition_no_cross_case_false_edge_on_posix(monkeypatch) -> None:
+    """The end-to-end regression this finding is about: on a case-SENSITIVE filesystem, a
+    module named `foo` must NOT match a definition file `Foo.py` (that cross-case pairing would
+    be a wrong-file attribution in a reverse-import edge) -- only an exact-case match may
+    succeed."""
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("posix"))
+
+    assert repo_map._module_path_matches_definition("foo", "pkg/Foo.py") is False
+    assert repo_map._module_path_matches_definition("Foo", "pkg/Foo.py") is True
+    assert repo_map._module_path_matches_definition("foo", "pkg/foo.py") is True
+
+
+def test_module_path_matches_definition_case_insensitive_on_windows(monkeypatch) -> None:
+    """Preserves the pre-existing Windows behavior (case-insensitive match) unchanged."""
+    monkeypatch.setattr(repo_map, "os", _OSNameOverride("nt"))
+
+    assert repo_map._module_path_matches_definition("foo", "pkg/Foo.py") is True


### PR DESCRIPTION
Three confirmed correctness findings from the deep-dive audit (#81), all `repo_map.py`.

## #3 — `from . import x` was invisible to `tg callers` / `tg blast-radius`
`_python_file_imports_symbol_from_definition` + `_python_import_update_target` had `if not node.module: continue/return None`, silently skipping bare relative imports (`from . import helpers`, `ast.ImportFrom.module is None`) — the most common Python intra-package idiom — so reverse-import consumers were **missed** (a false-negative in an audit tool). Fixed by branching on `node.level` + matching the alias against the definition's in-package submodule (mirrors #460's fix for the `tg importers` path). Tests prove `pkg/main.py` doing `from . import helpers` now appears in the consumers for a symbol in `pkg/helpers.py`, and only via the import path (not a phantom direct-call edge).

## #4 — Go reverse-imports were silently empty (no honesty signal)
Go's `import_update_target=None` means no Go reverse-import edge is possible, but with the grammar present, `resolution_gaps` emitted nothing — a silent-empty that violates the module's fail-closed convention. Chose the **honesty signal** (a real Go resolver lives in `lang_go.py`, another one-writer lane): `_language_coverage_gaps_for_universe` now flags `import_update_target is None` as a partial-capability gap with an `import_resolution_only` remediation. A stale `test_lang_go.py` assertion that pinned the bug (`resolution_gaps == []`) was corrected.

## #11 — case-folded module matching → false edges on case-sensitive filesystems
`_definition_module_parts`/`_normalized_module_parts` lowercased all segments, so on Linux (CI/prod) `Foo.py` matched `foo.py` → wrong-file reverse-import attribution. Now gated on `os.name == "nt"` (mirroring `_definition_file_dedupe_key`).

## Verification
Real venv: **64 passed** (cross_lang_resolution + repo_map_graph + lang_go + file_deps; the agent's broader `-k` run was 512 passed); ruff + format --preview + mypy clean. Go tests use a real `tree_sitter_go` grammar (not mocked); the case-fold test uses an `os.name` proxy that doesn't break pathlib on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)