### PR TITLE
fix(mcp): confine every read-path param via a shared _confine_read_path chokepoint + bound the classify read + gate signing_key — close MCP arbitrary-file-read exfil (audit #81 #1/#2/#12, #76)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1693,6 +1693,23 @@ def _confine_write_path(candidate: str, anchor: Path, *, label: str) -> Path:
     return resolved
 
 
+def _confine_read_path(candidate: str, anchor: Path, *, label: str) -> Path:
+    """Resolve an MCP-supplied READ path and refuse anything outside ``anchor`` (round-7,
+    audit #81 #1/#2).
+
+    Read-labeled chokepoint for read-path MCP tool params. Round-6 (audit #7) already
+    generalized ``_confine_write_path`` to cover read confinement for the audit-manifest /
+    review-bundle family, because the confinement mechanism (resolve, then require the
+    result to be the anchor or a descendant) is identical for reads and writes; this wrapper
+    just gives the read side its own name so a NEW read-path param has an obvious, greppable
+    chokepoint to route through -- so this class (an unconfined read-path param forwarded raw
+    to a loader/reader = arbitrary-file-read/exfil primitive) can't recur one tool at a time.
+    See ``_confine_write_path``'s docstring for the confinement semantics (symlink-following
+    resolve, fail-closed ValueError, callers MUST forward the resolved ``Path`` this returns).
+    """
+    return _confine_write_path(candidate, anchor, label=label)
+
+
 @mcp.tool()  # type: ignore
 def tg_ruleset_scan(
     ruleset: str,
@@ -1728,11 +1745,14 @@ def tg_ruleset_scan(
         allow_broad_generated_scan: Explicit opt-in for broad temp/cache/system roots.
         baseline_path: Optional path to an existing baseline JSON file. Read-only:
             findings present in the baseline are marked as known so only new
-            findings are reported.
+            findings are reported. Confined to the scan root (``path``); a baseline that
+            legitimately lives outside the scan root must be copied in first (fail-closed,
+            not a silent drop).
         write_baseline: Optional path to write a fresh baseline JSON snapshot of the
             current findings. SIDE EFFECT: creates or overwrites this file on disk.
         suppressions_path: Optional path to an existing suppressions JSON file. Read-only:
-            matching findings are suppressed from the reported results.
+            matching findings are suppressed from the reported results. Confined to the
+            scan root (``path``) like ``baseline_path``.
         write_suppressions: Optional path to write a suppressions JSON file derived from
             the current findings. SIDE EFFECT: creates or overwrites this file on disk;
             requires ``justification``.
@@ -1776,6 +1796,17 @@ def tg_ruleset_scan(
         if write_suppressions is not None:
             write_suppressions = str(
                 _confine_write_path(write_suppressions, scan_root, label="write_suppressions")
+            )
+        # round-7 security (audit #81 #2): baseline_path/suppressions_path are READS that were
+        # forwarded to the loader unconfined -- a file-existence + JSON-schema read-oracle over
+        # any path reachable from any MCP client, even though the two WRITE siblings just above
+        # were already confined (round-4/5). Anchor to the same scan_root so a legitimate
+        # baseline/suppressions file for THIS scan (relative or in-root absolute) keeps working.
+        if baseline_path is not None:
+            baseline_path = str(_confine_read_path(baseline_path, scan_root, label="baseline_path"))
+        if suppressions_path is not None:
+            suppressions_path = str(
+                _confine_read_path(suppressions_path, scan_root, label="suppressions_path")
             )
     except ValueError as exc:
         return _ruleset_scan_error(str(exc), code="invalid_input", ruleset=ruleset, path=path)
@@ -3736,10 +3767,30 @@ def tg_classify_logs(file_path: str, structured_json: bool = True) -> str:
     CyBERT/Triton provider when TENSOR_GREP_CLASSIFY_PROVIDER=cybert is set.
 
     Args:
-        file_path: The absolute path to the log file to classify.
+        file_path: The absolute path to the log file to classify. Confined to the
+            project root (cwd); a log file that legitimately lives outside the project
+            must be copied in first (fail-closed, not a silent drop).
         structured_json: Return bounded structured JSON (default true). Set to false for
             plain-text output.
     """
+    # round-7 security (audit #81 #1): confine file_path to the project root (cwd) before any
+    # read -- unconfined it is an arbitrary-file-read/exfil primitive (FallbackReader will
+    # happily read .env/keys/anything locally readable, and up to 20 heuristic-flagged lines
+    # are echoed back verbatim in anomalies[].text below). Forward the RESOLVED path so the
+    # downstream read below sees the same anchor-validated location this check validated.
+    try:
+        file_path = str(_confine_read_path(file_path, Path.cwd(), label="file_path"))
+    except ValueError as exc:
+        if structured_json:
+            return json.dumps(
+                {
+                    "file_path": file_path,
+                    "error": {"code": "invalid_input", "message": str(exc)},
+                },
+                indent=2,
+            )
+        return f"Error: {exc}"
+
     try:
         from tensor_grep.io.reader_fallback import FallbackReader
         from tensor_grep.sidecar import (
@@ -3749,7 +3800,13 @@ def tg_classify_logs(file_path: str, structured_json: bool = True) -> str:
         )
 
         reader = FallbackReader()
-        lines = list(reader.read_lines(file_path))
+        # round-7 security (audit #81 #1): bound the read BEFORE materializing. read_lines()
+        # is a generator; previously `list(reader.read_lines(file_path))` fully materialized
+        # the entire file into memory before the DEFAULT_CLASSIFY_MAX_LINES budget was applied
+        # below -- an unbounded-memory DoS on a large (or attacker-influenceable) file. Cap the
+        # read one line past the budget via itertools.islice so `_apply_classify_line_budget`
+        # can still report `truncated=True` accurately without reading the rest of the file.
+        lines = list(itertools.islice(reader.read_lines(file_path), DEFAULT_CLASSIFY_MAX_LINES + 1))
         if not lines:
             if structured_json:
                 return json.dumps(
@@ -3994,8 +4051,10 @@ def tg_audit_manifest_verify(
         manifest_path: Path to the rewrite audit manifest JSON file. Confined to the
             project root (cwd); a manifest that legitimately lives outside the project
             must be copied in first (fail-closed, not a silent drop).
-        signing_key: Optional HMAC signing key path for signed manifests. Not confined
-            (operators legitimately keep HMAC keys outside the repo, e.g. ~/.config).
+        signing_key: Optional HMAC signing key path for signed manifests. A READ of
+            secret HMAC material; disabled on the MCP surface by default -- set
+            TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1 in the server environment to opt in
+            (mirrors tg_rewrite_apply's audit_signing_key gate, round-5).
         previous_manifest: Optional previous manifest path for validating manifest
             chaining. Confined to the project root (cwd) like manifest_path.
     """
@@ -4003,6 +4062,18 @@ def tg_audit_manifest_verify(
 
     if not manifest_path.strip():
         return _audit_manifest_error("manifest_path must not be empty.", code="invalid_input")
+
+    # round-7 security (audit #81 #12): signing_key is a READ of secret HMAC key material.
+    # Gate it default-OFF behind the same opt-in as tg_rewrite_apply's audit_signing_key
+    # (round-5) for consistency -- unrestricted, it lets any MCP client point verification at
+    # HMAC material anywhere locally readable. The key bytes themselves are never echoed back,
+    # so an env-var opt-in gate is the right control here (not path confinement -- operators
+    # legitimately keep HMAC keys outside the repo, e.g. ~/.config).
+    if signing_key is not None and os.environ.get("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ") != "1":
+        return _audit_manifest_error(
+            "signing_key read requires TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1",
+            code="unsupported_option",
+        )
 
     # round-6 security (audit #7): confine the read-path params to the project root (cwd) --
     # unconfined they are an arbitrary-file-read/exfil primitive reachable from any MCP

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1260,6 +1260,22 @@ def execute_rewrite_apply_json(
 
     loaded_policy = None
     if policy is not None:
+        # round-7 security (audit #81 Opus gate #2/#12 follow-up): policy is a caller-named
+        # JSON file path read by load_apply_policy below -- unconfined it is a file-existence +
+        # JSON-schema read-oracle over any path reachable from any MCP client
+        # (PolicyValidationError.details echoes back which required fields are missing/
+        # malformed, and a non-JSON file's json.JSONDecodeError message), same class as
+        # tg_classify_logs.file_path / tg_ruleset_scan's baseline_path/suppressions_path.
+        # Anchor to the REWRITE SCAN ROOT (path), not cwd: a policy file for THIS apply
+        # operation legitimately lives under the scanned tree (mirrors baseline_path/
+        # suppressions_path's scan_root anchor on tg_ruleset_scan, not audit_manifest's cwd
+        # anchor). Forward the RESOLVED path so load_apply_policy reads the same
+        # anchor-validated location this check validated.
+        policy_anchor = Path(path).expanduser().resolve()
+        try:
+            policy = str(_confine_read_path(policy, policy_anchor, label="policy"))
+        except ValueError as exc:
+            return _rewrite_error(str(exc), code="invalid_input"), 1
         try:
             loaded_policy = load_apply_policy(
                 policy,
@@ -2397,10 +2413,33 @@ def tg_session_file_importers(
 
     Args:
         session_id: Session ID to query.
-        file: File to find importers of.
+        file: File to find importers of. Confined to the session root (``path``); a file
+            that legitimately lives outside it must be copied in first (fail-closed, not a
+            silent drop).
         path: File or directory rooted at the session scope.
     """
     from tensor_grep.cli.session_store import SessionStaleError, session_file_importers
+
+    # round-7 security (audit #81 Opus gate #2 follow-up): confine file to the session root
+    # (path) before any read, same class/rationale as tg_file_imports/tg_file_importers above.
+    # Anchored to the session root rather than cwd because that is what session_file_importers
+    # itself resolves a relative `file` against (build_file_importers_from_map joins it onto
+    # the session's own repo_map root, not the MCP server process cwd) -- confining to cwd
+    # here would refuse a legitimate relative `file` whenever the session root differs from cwd.
+    session_root = Path(path).expanduser().resolve()
+    if not session_root.is_dir():
+        session_root = session_root.parent
+    try:
+        file = str(_confine_read_path(file, session_root, label="file"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"file": file},
+            file=file,
+        )
 
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
     try:
@@ -2962,8 +3001,27 @@ def tg_file_imports(file: str) -> str:
     repo scan. Far cheaper than a whole-repo `tg_map` for a single file's dependency edges.
 
     Args:
-        file: File to inspect for its own imports.
+        file: File to inspect for its own imports. Confined to the project root (cwd); a
+            file that legitimately lives outside the project must be copied in first
+            (fail-closed, not a silent drop).
     """
+    # round-7 security (audit #81 Opus gate #2 follow-up): confine file to the project root
+    # (cwd) before any read -- unconfined it is a file-existence + import-string read-oracle
+    # over any path reachable from any MCP client (build_file_imports below stats the file and
+    # echoes its resolved path / import list back in the JSON result), same class as
+    # tg_classify_logs.file_path above. Forward the RESOLVED path so build_file_imports sees
+    # the same anchor-validated location this check validated.
+    try:
+        file = str(_confine_read_path(file, Path.cwd(), label="file"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-imports",
+            include_schema_version=False,
+        )
+        payload["file"] = file
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
     try:
         return _inject_mcp_contract_fields(json.dumps(build_file_imports(file), indent=2))
     except FileNotFoundError:
@@ -3002,10 +3060,26 @@ def tg_file_importers(
     CONFIRMS each candidate against FILE before reporting it as an edge.
 
     Args:
-        file: File to find importers of.
+        file: File to find importers of. Confined to the project root (cwd); a file that
+            legitimately lives outside the project must be copied in first (fail-closed,
+            not a silent drop).
         path: Root to scan for importers.
         max_repo_files: Maximum repository files to scan before resolving importers.
     """
+    # round-7 security (audit #81 Opus gate #2 follow-up): confine file to the project root
+    # (cwd) before any read, same class/rationale as tg_file_imports above.
+    try:
+        file = str(_confine_read_path(file, Path.cwd(), label="file"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-importers",
+            include_schema_version=False,
+        )
+        payload["file"] = file
+        payload["path"] = str(Path(path).expanduser())
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -3997,6 +4071,9 @@ def tg_rewrite_apply(
         test_cmd: Optional command to run after apply/verify for structured test validation.
             Gated identically to lint_cmd via TG_MCP_ALLOW_VALIDATION_COMMANDS.
         policy: Optional path to an apply policy JSON file for post-apply checks and rollback.
+            Confined to the rewrite scan root (``path``); a policy file that legitimately
+            lives outside the scan root must be copied in first (fail-closed, not a silent
+            drop).
         expected_plan_digest: Optional plan_digest from a prior tg_rewrite_plan. When
             supplied, the apply is refused with code="plan_drift" if the recomputed
             digest no longer matches the current tree.

--- a/tests/unit/test_mcp_error_sanitization.py
+++ b/tests/unit/test_mcp_error_sanitization.py
@@ -154,9 +154,12 @@ def test_tg_ast_search_exception_path_sanitizes_plain_text(capsys):
     assert _SECRET_PATH in captured.err
 
 
-def test_tg_classify_logs_exception_path_does_not_leak_path_or_traceback(tmp_path, capsys):
+def test_tg_classify_logs_exception_path_does_not_leak_path_or_traceback(
+    tmp_path, capsys, monkeypatch
+):
     from tensor_grep.cli import mcp_server
 
+    monkeypatch.chdir(tmp_path)  # cwd = the read-path confinement anchor (audit #81 #1)
     log_path = tmp_path / "app.log"
     log_path.write_text("INFO startup ok\nERROR database failed\n", encoding="utf-8")
 
@@ -176,9 +179,10 @@ def test_tg_classify_logs_exception_path_does_not_leak_path_or_traceback(tmp_pat
     assert _SECRET_PATH in captured.err
 
 
-def test_tg_classify_logs_exception_path_sanitizes_plain_text(tmp_path, capsys):
+def test_tg_classify_logs_exception_path_sanitizes_plain_text(tmp_path, capsys, monkeypatch):
     from tensor_grep.cli import mcp_server
 
+    monkeypatch.chdir(tmp_path)  # cwd = the read-path confinement anchor (audit #81 #1)
     log_path = tmp_path / "app.log"
     log_path.write_text("INFO startup ok\nERROR database failed\n", encoding="utf-8")
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1011,6 +1011,7 @@ def test_tg_classify_logs_defaults_to_local_heuristics(monkeypatch, tmp_path):
         def __init__(self) -> None:
             raise AssertionError("MCP classify should not probe CyBERT by default")
 
+    monkeypatch.chdir(tmp_path)  # cwd = the read-path confinement anchor (audit #81 #1)
     log_path = tmp_path / "app.log"
     log_path.write_text("INFO startup ok\nERROR database failed\n", encoding="utf-8")
     monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
@@ -2437,6 +2438,8 @@ def test_tg_audit_manifest_verify_supports_signed_manifests(tmp_path, monkeypatc
     from tensor_grep.cli import mcp_server
 
     monkeypatch.chdir(tmp_path)  # cwd = the read-path confinement anchor (audit #7)
+    # signing_key read is gated behind an explicit opt-in (audit #81 #12).
+    monkeypatch.setenv("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ", "1")
     manifest_path = tmp_path / "rewrite-audit.json"
     signing_key_path = tmp_path / "audit.key"
     signing_key = b"top-secret"
@@ -3009,6 +3012,458 @@ def test_tg_review_bundle_verify_refuses_bundle_path_symlink_escape(tmp_path, mo
         pytest.skip("symlink creation not permitted in this environment")
 
     out = mcp_server.tg_review_bundle_verify(str(link))
+
+    _assert_audit7_refused_no_leak(out)
+
+
+# round-7 security (audit #81 #1/#2/#12): MCP read-path exfil cluster ---------------------
+#
+# tg_classify_logs (file_path) and tg_ruleset_scan (baseline_path/suppressions_path) forwarded
+# LLM-supplied read paths straight to a reader/loader with ZERO confinement -- an
+# arbitrary-file-read/exfil primitive reachable from any MCP client. tg_classify_logs also
+# fully materialized the target file into memory (`list(reader.read_lines(file_path))`)
+# BEFORE applying its DEFAULT_CLASSIFY_MAX_LINES budget -- an unbounded-memory DoS on a large
+# (or attacker-influenceable) file. tg_audit_manifest_verify's signing_key (HMAC key material)
+# was read unrestricted while its twin audit_signing_key on tg_rewrite_apply was already gated
+# behind an explicit opt-in (round-5) -- this closes that inconsistency too.
+# `_confine_read_path` is the new read-labeled chokepoint (a thin wrapper on
+# `_confine_write_path`, which round-6/audit #7 already generalized to reads) so a new
+# read-path param has an obvious place to route through instead of being forwarded raw.
+
+
+def test_confine_read_path_refuses_escape(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    anchor = tmp_path / "proj"
+    anchor.mkdir()
+    with pytest.raises(ValueError):
+        mcp_server._confine_read_path("../evil.log", anchor, label="file_path")
+    with pytest.raises(ValueError):
+        mcp_server._confine_read_path(str(tmp_path / "evil.log"), anchor, label="file_path")
+    ok = mcp_server._confine_read_path("app.log", anchor, label="file_path")
+    assert ok == (anchor.resolve() / "app.log")
+
+
+def test_confine_read_path_refuses_unc_path(tmp_path):
+    """A UNC path is absolute (outside any local anchor) and must be refused like any other
+    out-of-root absolute path. Uses \\\\localhost\\... (loopback, resolves in milliseconds,
+    no real network I/O) rather than an unreachable host, per anti-hang-test-protocol."""
+    from tensor_grep.cli import mcp_server
+
+    anchor = tmp_path / "proj"
+    anchor.mkdir()
+    unc = r"\\localhost\C$\Windows\System32\drivers\etc\hosts"
+    with pytest.raises(ValueError):
+        mcp_server._confine_read_path(unc, anchor, label="file_path")
+
+
+def test_tg_classify_logs_refuses_file_path_outside_root(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    secret = tmp_path / "secret.log"
+    secret.write_text(f"ERROR {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+
+    out = mcp_server.tg_classify_logs(str(secret))
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_tg_classify_logs_refuses_file_path_dotdot_escape(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    secret = tmp_path / "secret.log"
+    secret.write_text(f"ERROR {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+
+    out = mcp_server.tg_classify_logs("../secret.log")
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_tg_classify_logs_refuses_file_path_symlink_escape(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    secret = tmp_path / "secret.log"
+    secret.write_text(f"ERROR {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+    link = proj / "app.log"
+    try:
+        link.symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted in this environment")
+
+    out = mcp_server.tg_classify_logs(str(link))
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_tg_classify_logs_refuses_file_path_unc_escape(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+
+    out = mcp_server.tg_classify_logs(r"\\localhost\C$\Windows\System32\drivers\etc\hosts")
+
+    parsed = json.loads(out)
+    assert parsed["error"]["code"] == "invalid_input"
+
+
+def test_tg_classify_logs_accepts_relative_in_root_path(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
+    (tmp_path / "app.log").write_text("INFO ok\nERROR boom\n", encoding="utf-8")
+
+    out = mcp_server.tg_classify_logs("app.log")
+
+    parsed = json.loads(out)
+    assert parsed.get("error") is None
+    assert parsed["provider"] == "heuristic"
+
+
+def test_tg_classify_logs_bounds_read_before_materializing(tmp_path, monkeypatch):
+    """FAILS pre-fix (`list(reader.read_lines(file_path))` drains the whole generator before
+    the DEFAULT_CLASSIFY_MAX_LINES budget is applied -- unbounded-memory DoS on a large file);
+    PASSES post-fix (only DEFAULT_CLASSIFY_MAX_LINES + 1 lines are ever pulled from the
+    reader). The fake reader below yields a large-but-FINITE number of lines (not an
+    unbounded/infinite generator), so a still-broken implementation fails the assertion below
+    instead of hanging the test runner (anti-hang-test-protocol)."""
+    from tensor_grep.cli import mcp_server
+    from tensor_grep.io.reader_fallback import FallbackReader
+    from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    (proj / "huge.log").write_text("placeholder\n", encoding="utf-8")
+    monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
+
+    consumed = {"count": 0}
+    fake_total_lines = DEFAULT_CLASSIFY_MAX_LINES * 50  # large but finite
+
+    def _fake_read_lines(self, file_path):
+        for _ in range(fake_total_lines):
+            consumed["count"] += 1
+            yield "INFO line\n"
+
+    monkeypatch.setattr(FallbackReader, "read_lines", _fake_read_lines)
+
+    out = mcp_server.tg_classify_logs("huge.log")
+
+    parsed = json.loads(out)
+    assert parsed.get("error") is None
+    # the reader must be capped one line past the budget, never drained anywhere near in full.
+    assert consumed["count"] == DEFAULT_CLASSIFY_MAX_LINES + 1
+    assert consumed["count"] < fake_total_lines
+    assert parsed["sample_lines"] == DEFAULT_CLASSIFY_MAX_LINES
+    assert parsed["total_lines"] == DEFAULT_CLASSIFY_MAX_LINES + 1
+
+
+def test_ruleset_scan_refuses_baseline_path_outside_root(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    escape = tmp_path / "evil_baseline.json"
+    _write_audit7_secret(escape)
+
+    out = mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), baseline_path=str(escape)
+    )
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_ruleset_scan_refuses_baseline_path_dotdot_escape(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    escape = tmp_path / "evil_baseline.json"
+    _write_audit7_secret(escape)
+
+    out = mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), baseline_path="../evil_baseline.json"
+    )
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_ruleset_scan_refuses_baseline_path_symlink_escape(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    outside_target = tmp_path / "outside-baseline.json"
+    _write_audit7_secret(outside_target)
+    link_path = scan_root / "baseline.json"
+    try:
+        link_path.symlink_to(outside_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted in this environment")
+
+    out = mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), baseline_path="baseline.json"
+    )
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_ruleset_scan_refuses_suppressions_path_outside_root(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    escape = tmp_path / "evil_suppressions.json"
+    _write_audit7_secret(escape)
+
+    out = mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), suppressions_path=str(escape)
+    )
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_ruleset_scan_refuses_suppressions_path_dotdot_escape(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "proj"
+    scan_root.mkdir()
+    escape = tmp_path / "evil_suppressions.json"
+    _write_audit7_secret(escape)
+
+    out = mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic",
+        path=str(scan_root),
+        suppressions_path="../evil_suppressions.json",
+    )
+
+    _assert_audit7_refused_no_leak(out)
+
+
+def test_tg_audit_manifest_verify_refuses_signing_key_without_opt_in(tmp_path, monkeypatch):
+    """FAILS pre-fix (signing_key forwarded to verify_audit_manifest_json unconditionally, an
+    arbitrary-file-read-as-HMAC-key primitive); PASSES post-fix (refused with
+    code="unsupported_option" unless TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1, mirroring
+    tg_rewrite_apply's audit_signing_key gate)."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ", raising=False)
+    manifest_path = tmp_path / "rewrite-audit.json"
+    signing_key_path = tmp_path / "audit.key"
+    signing_key = b"top-secret"
+    signing_key_path.write_bytes(signing_key)
+    _write_audit_manifest(manifest_path, signing_key=signing_key)
+
+    out = mcp_server.tg_audit_manifest_verify(
+        str(manifest_path),
+        signing_key=str(signing_key_path),
+    )
+
+    parsed = json.loads(out)
+    assert parsed["error"]["code"] == "unsupported_option"
+
+
+# --- round-7 coverage: enumerate every MCP read-path tool param and assert each rejects an
+# out-of-root candidate (audit #81's "coverage test" recommendation). Covers both the
+# round-6 (audit #7) params and the round-7 (audit #81) params added above -- if a future
+# read-path param is added without confinement, add a case here too.
+
+
+def _read_path_case_classify_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    escape = tmp_path / "secret.log"
+    escape.write_text(f"ERROR {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+    return mcp_server.tg_classify_logs(str(escape))
+
+
+def _read_path_case_ruleset_scan_baseline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "scan"
+    scan_root.mkdir()
+    escape = tmp_path / "baseline.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), baseline_path=str(escape)
+    )
+
+
+def _read_path_case_ruleset_scan_suppressions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    scan_root = tmp_path / "scan"
+    scan_root.mkdir()
+    escape = tmp_path / "suppressions.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_ruleset_scan(
+        ruleset="secrets-basic", path=str(scan_root), suppressions_path=str(escape)
+    )
+
+
+def _read_path_case_audit_manifest_verify_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    escape = tmp_path / "manifest.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_audit_manifest_verify(str(escape))
+
+
+def _read_path_case_audit_manifest_verify_previous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    manifest_path = proj / "manifest.json"
+    _write_audit_manifest(manifest_path)
+    escape = tmp_path / "previous.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_audit_manifest_verify(str(manifest_path), previous_manifest=str(escape))
+
+
+def _read_path_case_audit_diff_previous(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    current_path = proj / "current.json"
+    _write_audit_manifest(current_path)
+    escape = tmp_path / "previous.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_audit_diff(str(escape), str(current_path))
+
+
+def _read_path_case_audit_diff_current(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    previous_path = proj / "previous.json"
+    _write_audit_manifest(previous_path)
+    escape = tmp_path / "current.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_audit_diff(str(previous_path), str(escape))
+
+
+def _read_path_case_review_bundle_create_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    escape = tmp_path / "manifest.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_review_bundle_create(manifest_path=str(escape))
+
+
+def _read_path_case_review_bundle_create_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    manifest_path = proj / "manifest.json"
+    _write_audit_manifest(manifest_path)
+    escape = tmp_path / "scan.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_review_bundle_create(
+        manifest_path=str(manifest_path), scan_path=str(escape)
+    )
+
+
+def _read_path_case_review_bundle_create_previous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    manifest_path = proj / "manifest.json"
+    _write_audit_manifest(manifest_path)
+    escape = tmp_path / "previous.json"
+    _write_audit7_secret(escape)
+    return mcp_server.tg_review_bundle_create(
+        manifest_path=str(manifest_path), previous_manifest=str(escape)
+    )
+
+
+def _read_path_case_review_bundle_verify_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    escape = tmp_path / "bundle.json"
+    _write_audit7_secret(escape, field="bundle_sha256")
+    return mcp_server.tg_review_bundle_verify(str(escape))
+
+
+_READ_PATH_COVERAGE_CASES = [
+    pytest.param(_read_path_case_classify_logs, id="tg_classify_logs.file_path"),
+    pytest.param(_read_path_case_ruleset_scan_baseline, id="tg_ruleset_scan.baseline_path"),
+    pytest.param(_read_path_case_ruleset_scan_suppressions, id="tg_ruleset_scan.suppressions_path"),
+    pytest.param(
+        _read_path_case_audit_manifest_verify_manifest,
+        id="tg_audit_manifest_verify.manifest_path",
+    ),
+    pytest.param(
+        _read_path_case_audit_manifest_verify_previous,
+        id="tg_audit_manifest_verify.previous_manifest",
+    ),
+    pytest.param(_read_path_case_audit_diff_previous, id="tg_audit_diff.previous_manifest"),
+    pytest.param(_read_path_case_audit_diff_current, id="tg_audit_diff.current_manifest"),
+    pytest.param(
+        _read_path_case_review_bundle_create_manifest,
+        id="tg_review_bundle_create.manifest_path",
+    ),
+    pytest.param(_read_path_case_review_bundle_create_scan, id="tg_review_bundle_create.scan_path"),
+    pytest.param(
+        _read_path_case_review_bundle_create_previous,
+        id="tg_review_bundle_create.previous_manifest",
+    ),
+    pytest.param(
+        _read_path_case_review_bundle_verify_bundle, id="tg_review_bundle_verify.bundle_path"
+    ),
+]
+
+
+@pytest.mark.parametrize("case", _READ_PATH_COVERAGE_CASES)
+def test_read_path_param_coverage_rejects_out_of_root(tmp_path, monkeypatch, case):
+    out = case(tmp_path, monkeypatch)
 
     _assert_audit7_refused_no_leak(out)
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import hmac
 import json
+import os
 import sys
 import types
 from importlib.metadata import version
@@ -3044,10 +3045,18 @@ def test_confine_read_path_refuses_escape(tmp_path):
     assert ok == (anchor.resolve() / "app.log")
 
 
+@pytest.mark.skipif(os.name != "nt", reason="UNC paths are absolute only on Windows")
 def test_confine_read_path_refuses_unc_path(tmp_path):
     """A UNC path is absolute (outside any local anchor) and must be refused like any other
     out-of-root absolute path. Uses \\\\localhost\\... (loopback, resolves in milliseconds,
-    no real network I/O) rather than an unreachable host, per anti-hang-test-protocol."""
+    no real network I/O) rather than an unreachable host, per anti-hang-test-protocol.
+
+    Windows-only (skipif-guarded): a UNC path (``Path(r"\\\\localhost\\...").is_absolute()``)
+    is absolute ONLY on Windows. On POSIX it is NOT absolute, so `_confine_write_path` joins it
+    UNDER the anchor instead of refusing it -- the confinement CODE is correct on both
+    platforms (a UNC string can't escape the anchor on POSIX either way), this test's
+    ASSERTION (raises ValueError) is just Windows-specific, so it must not run on
+    ubuntu-latest/macos-latest CI legs (audit #81 fix-council item #1)."""
     from tensor_grep.cli import mcp_server
 
     anchor = tmp_path / "proj"
@@ -3104,7 +3113,12 @@ def test_tg_classify_logs_refuses_file_path_symlink_escape(tmp_path, monkeypatch
     _assert_audit7_refused_no_leak(out)
 
 
+@pytest.mark.skipif(os.name != "nt", reason="UNC paths are absolute only on Windows")
 def test_tg_classify_logs_refuses_file_path_unc_escape(tmp_path, monkeypatch):
+    """Windows-only (skipif-guarded): passes accidentally on POSIX (a UNC string is not
+    `.is_absolute()` there, so it never hits the refusal path the assertion checks for) --
+    see test_confine_read_path_refuses_unc_path above for the full rationale. Skipped here too
+    for honesty, not just to stop a failure (audit #81 fix-council item #1)."""
     from tensor_grep.cli import mcp_server
 
     proj = tmp_path / "proj"
@@ -3432,6 +3446,61 @@ def _read_path_case_review_bundle_verify_bundle(
     return mcp_server.tg_review_bundle_verify(str(escape))
 
 
+# --- round-7 coverage gap (Opus adversarial gate on #81, fix-council item #2): the #74 file-
+# dependency primitives (tg_file_imports/tg_file_importers/tg_session_file_importers) and
+# tg_rewrite_apply's `policy` param were missed by the original round-7 sweep above -- same
+# class (a caller-named read path forwarded unconfined, echoing file existence / import
+# strings / policy-schema details back to the caller). Closed the same way: confine-then-
+# forward through `_confine_read_path`, structured invalid_input on reject.
+
+
+def _read_path_case_file_imports(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    escape = tmp_path / "secret.py"
+    escape.write_text(f"# {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+    return mcp_server.tg_file_imports(str(escape))
+
+
+def _read_path_case_file_importers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    escape = tmp_path / "secret.py"
+    escape.write_text(f"# {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+    return mcp_server.tg_file_importers(str(escape), path=str(proj))
+
+
+def _read_path_case_session_file_importers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "app.py").write_text("x = 1\n", encoding="utf-8")
+    opened = json.loads(mcp_server.tg_session_open(str(project)))
+    session_id = opened["session_id"]
+    escape = tmp_path / "secret.py"
+    escape.write_text(f"# {_AUDIT7_SECRET_MARKER}\n", encoding="utf-8")
+    return mcp_server.tg_session_file_importers(session_id, str(escape), str(project))
+
+
+def _read_path_case_rewrite_apply_policy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    escape = tmp_path / "policy.json"
+    _write_audit7_secret(escape, field="version")
+    return mcp_server.tg_rewrite_apply(
+        pattern="x", replacement="y", lang="python", path=str(proj), policy=str(escape)
+    )
+
+
 _READ_PATH_COVERAGE_CASES = [
     pytest.param(_read_path_case_classify_logs, id="tg_classify_logs.file_path"),
     pytest.param(_read_path_case_ruleset_scan_baseline, id="tg_ruleset_scan.baseline_path"),
@@ -3458,6 +3527,10 @@ _READ_PATH_COVERAGE_CASES = [
     pytest.param(
         _read_path_case_review_bundle_verify_bundle, id="tg_review_bundle_verify.bundle_path"
     ),
+    pytest.param(_read_path_case_file_imports, id="tg_file_imports.file"),
+    pytest.param(_read_path_case_file_importers, id="tg_file_importers.file"),
+    pytest.param(_read_path_case_session_file_importers, id="tg_session_file_importers.file"),
+    pytest.param(_read_path_case_rewrite_apply_policy, id="tg_rewrite_apply.policy"),
 ]
 
 
@@ -3466,6 +3539,100 @@ def test_read_path_param_coverage_rejects_out_of_root(tmp_path, monkeypatch, cas
     out = case(tmp_path, monkeypatch)
 
     _assert_audit7_refused_no_leak(out)
+
+
+# --- positive-path regression guards: confining the four params above must not break a
+# legitimate in-root call (Opus adversarial gate on #81, fix-council item #2).
+
+
+def test_tg_file_imports_accepts_in_root_path(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "util.js").write_text("export function foo() {}\n", encoding="utf-8")
+    consumer = tmp_path / "consumer.js"
+    consumer.write_text('import { foo } from "./util";\n', encoding="utf-8")
+
+    out = mcp_server.tg_file_imports("consumer.js")
+
+    parsed = json.loads(out)
+    assert parsed.get("error") is None
+    assert parsed["imports"][0]["module"] == "./util"
+    assert parsed["imports"][0]["resolved"] == str((tmp_path / "util.js").resolve())
+
+
+def test_tg_file_importers_accepts_in_root_path(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    project = tmp_path / "project"
+    project.mkdir()
+    target = project / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    consumer = project / "consumer.js"
+    consumer.write_text('import { foo } from "./util";\n', encoding="utf-8")
+    monkeypatch.chdir(project)
+
+    out = mcp_server.tg_file_importers("util.js", path=str(project))
+
+    parsed = json.loads(out)
+    assert parsed.get("error") is None
+    assert parsed["importer_files"] == [str(consumer.resolve())]
+
+
+def test_tg_session_file_importers_accepts_in_root_path(tmp_path):
+    from tensor_grep.cli import mcp_server
+
+    project = tmp_path / "project"
+    project.mkdir()
+    target = project / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    consumer = project / "consumer.js"
+    consumer.write_text('import { foo } from "./util";\n', encoding="utf-8")
+
+    opened = json.loads(mcp_server.tg_session_open(str(project)))
+    session_id = opened["session_id"]
+
+    out = mcp_server.tg_session_file_importers(session_id, "util.js", str(project))
+
+    parsed = json.loads(out)
+    assert parsed.get("error") is None
+    assert parsed["importer_files"] == [str(consumer.resolve())]
+
+
+def test_tg_rewrite_apply_accepts_policy_within_scan_root(tmp_path):
+    """VERIFY confining `policy` (round-7 fix, Opus gate item #2) does not regress a
+    legitimate in-root policy: a policy file inside the scan root must reach
+    load_apply_policy's OWN schema validation (code="invalid_policy") rather than being
+    refused by the new confinement check (which would instead surface code="invalid_input"
+    with a "must stay within" message)."""
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    policy_path = proj / "apply-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": None,
+            "ruleset_scan": None,
+            # deliberately omit on_failure: pins the failure to load_apply_policy's schema
+            # validation, proving execution got PAST the new path-confinement check below.
+        }),
+        encoding="utf-8",
+    )
+
+    out = mcp_server.tg_rewrite_apply(
+        pattern="def $F($$$ARGS): return $EXPR",
+        replacement="lambda $$$ARGS: $EXPR",
+        lang="python",
+        path=str(proj),
+        policy=str(policy_path),
+    )
+
+    parsed = json.loads(out)
+    assert parsed["error"]["code"] == "invalid_policy"
+    assert any(detail["field"] == "on_failure" for detail in parsed["error"]["details"])
 
 
 def test_tg_checkpoint_mcp_tools_wrap_checkpoint_store(tmp_path):


### PR DESCRIPTION
Closes the HIGH MCP arbitrary-file-read / content-exfil / DoS class (deep-dive #81 #1/#2/#12 + #76). Two commits: the fix, then the Opus adversarial gate's FIX-FIRST corrections.

## The fix
- **Shared `_confine_read_path(candidate, anchor, *, label)` chokepoint** — a read-labeled wrapper on `_confine_write_path` (resolve-before-containment, rejects `..`/absolute-outside/UNC/symlink-escape), so a new read-path param has one greppable place to route through and this class can't recur one tool at a time.
- **#1 `tg_classify_logs.file_path`** — confined + the read **bounded before materializing** (`itertools.islice(read_lines, MAX+1)` replaces the whole-file `list(...)`) → kills the unbounded-memory DoS + the content leak.
- **#2 `tg_ruleset_scan.baseline_path`/`.suppressions_path`** — confined to `scan_root` (mirroring the sibling write params).
- **#12 `tg_audit_manifest_verify.signing_key`** — gated behind `TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ=1` (key bytes never echoed).
- **Coverage test** over all 11 read-path params asserting each rejects out-of-root.

## Opus gate FIX-FIRST corrections (2nd commit)
1. **CI-red test bug fixed:** two UNC tests asserted a raise that only happens on Windows (`\host\...` is absolute only on `nt`) → they failed on the ubuntu/macOS CI legs. `skipif(os.name != "nt")`-guarded (the confinement *code* is correct on POSIX; the test was wrong).
2. **Completeness gap closed:** the gate found 4 more unconfined read-path params the coverage test missed — `tg_file_imports.file`, `tg_file_importers.file` (→ cwd), `tg_session_file_importers.file` (→ session root), `tg_rewrite_apply.policy` (→ scan root). All now confined + coverage + positive tests added. (TDD catch: anchoring `policy` to cwd would've broken 2 pre-existing tests → anchored to the scan root, matching the `ruleset_scan` precedent.)

## Verification
Real venv: **323 mcp tests pass** (incl. the 10 new/modified — both UNC tests, 4 coverage cases, 4 positive in-root tests); broader 9-file sweep 362 passed; ruff + format --preview + mypy clean. All 7 read-path params route through `_confine_read_path`. **Opus adversarial gate: SHIP on the confinement mechanism** (resolve-before-check, `.parents` containment, no TOCTOU, real streaming bound) after these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)