### PR TITLE
fix(rust): exit 2 (not 1) when rg is required-but-unavailable + fail closed on --pcre2 without PCRE2-rg (audit #81 #7/#9)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1256,6 +1256,7 @@ fn main_inner() -> anyhow::Result<()> {
     if is_top_level_pcre2_version_invocation(&raw_args)
         || is_search_pcre2_version_invocation(&raw_args)
     {
+        require_ripgrep_or_exit(ripgrep_is_available(), "--pcre2-version");
         let exit_code = execute_ripgrep_pcre2_version()?;
         if exit_code != 0 {
             std::process::exit(exit_code.max(1));
@@ -1263,6 +1264,7 @@ fn main_inner() -> anyhow::Result<()> {
         return Ok(());
     }
     if is_top_level_type_list_invocation(&raw_args) || is_search_type_list_invocation(&raw_args) {
+        require_ripgrep_or_exit(ripgrep_is_available(), "--type-list");
         let exit_code = execute_ripgrep_type_list()?;
         if exit_code != 0 {
             std::process::exit(exit_code.max(1));
@@ -1365,6 +1367,21 @@ fn env_flag_enabled(name: &str) -> bool {
             )
         })
         .unwrap_or(false)
+}
+
+/// Fail closed (exit 2, the "backend unavailable / incomplete" convention `handle_calibrate_command`
+/// already uses) instead of letting a passthrough-required rg invocation bubble an `Err` through `?`
+/// to `main()`'s default `Result` termination, which exits 1 -- indistinguishable from a genuine
+/// "no match" (audit #81 #7). Also used to refuse a `--pcre2` request when no rg is present rather
+/// than silently swapping to the native regex engine, which does not support PCRE2 syntax (#9).
+fn require_ripgrep_or_exit(rg_available: bool, context: &str) {
+    if !rg_available {
+        eprintln!(
+            "error: {context} requires the ripgrep (`rg`) backend, but rg is unavailable. \
+             Install `rg`, set TG_RG_PATH, or place a bundled ripgrep binary next to `tg`."
+        );
+        std::process::exit(2);
+    }
 }
 
 fn is_top_level_version_invocation(raw_args: &[OsString]) -> bool {
@@ -4120,6 +4137,9 @@ fn run_positional_cli(cli: PositionalCli) -> anyhow::Result<()> {
     let primary_path = paths.first().map(String::as_str).unwrap_or(".");
 
     let rg_available = ripgrep_is_available();
+    if cli.pcre2 {
+        require_ripgrep_or_exit(rg_available, "--pcre2");
+    }
     #[cfg_attr(not(feature = "cuda"), allow(unused_variables))]
     let structured_output = cli.json || cli.ndjson;
     let explicit_gpu = !cli.gpu_device_ids.is_empty();
@@ -5163,6 +5183,7 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
         return Ok(());
     }
     if args.pcre2_version {
+        require_ripgrep_or_exit(ripgrep_is_available(), "--pcre2-version");
         let exit_code = execute_ripgrep_pcre2_version()?;
         if exit_code != 0 {
             std::process::exit(exit_code.max(1));
@@ -5170,6 +5191,7 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
         return Ok(());
     }
     if args.type_list {
+        require_ripgrep_or_exit(ripgrep_is_available(), "--type-list");
         let exit_code = execute_ripgrep_type_list()?;
         if exit_code != 0 {
             std::process::exit(exit_code.max(1));
@@ -5191,6 +5213,14 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
     let structured_output = args.json || args.ndjson;
     let auto_gpu_ids: [i32; 0] = [];
 
+    // Fail closed instead of silently swapping --pcre2 to the native regex engine (which does not
+    // support PCRE2 syntax) when no rg is present. Checked before route_search, whose `config.pcre2
+    // && config.rg_available` gate otherwise falls through to NativeCpu/"rg_unavailable" with no
+    // signal that PCRE2 semantics were dropped (audit #81 #9).
+    if args.pcre2 {
+        require_ripgrep_or_exit(rg_available, "--pcre2");
+    }
+
     if search_args_need_broad_generated_guard(&args) {
         let generated_dirs = generated_scan_dir_names(&request.paths, false);
         if !generated_dirs.is_empty() {
@@ -5200,6 +5230,11 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
     }
 
     if search_prefers_ripgrep_passthrough(&args, &request, rg_available) {
+        // search_requires_ripgrep_passthrough (checked first inside the call above) can return
+        // true regardless of rg_available -- e.g. --max-depth with TG_DISABLE_RG=1. Without this
+        // guard execute_ripgrep_search's Err bubbles via `?` to main()'s default Result
+        // termination, which exits 1 -- indistinguishable from a genuine no-match (audit #81 #7).
+        require_ripgrep_or_exit(rg_available, "this search's flag combination");
         if args.verbose {
             emit_verbose_metadata(RoutingDecision::ripgrep());
         }

--- a/rust_core/tests/test_routing.rs
+++ b/rust_core/tests/test_routing.rs
@@ -1420,6 +1420,205 @@ fn test_default_frontdoor_falls_back_to_native_when_ripgrep_is_unavailable() {
     assert!(stdout.contains("hello world"), "stdout={stdout}");
 }
 
+// --- audit #81 #7/#9: rg-unavailable must fail closed with exit 2, never a masked exit 1 or a
+// silent engine swap. See rust_core/src/main.rs::require_ripgrep_or_exit and its call sites. ---
+
+#[test]
+fn test_search_required_passthrough_flag_without_ripgrep_exits_2_not_1() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    // --max-depth is in search_requires_ripgrep_passthrough's unconditional flag list, so
+    // search_prefers_ripgrep_passthrough returns true regardless of rg_available. Before the fix,
+    // execute_ripgrep_search's Err bubbled via `?` to main()'s default Result termination, which
+    // exits 1 -- indistinguishable from a genuine no-match. It must now exit 2.
+    let output = tg()
+        .arg("search")
+        .arg("--max-depth")
+        .arg("2")
+        .arg("hello")
+        .arg(dir.path())
+        .env("PATH", "")
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit 2 (backend unavailable), not 1 (no-match-shaped); status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.to_lowercase().contains("rg"), "stderr={stderr}");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_search_pcre2_without_ripgrep_fails_closed_instead_of_native_swap() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    // Before the fix: search_requires_ripgrep_passthrough does not list plain `pcre2`, so
+    // search_prefers_ripgrep_passthrough returns false and route_search's
+    // `config.pcre2 && config.rg_available` gate silently falls through to
+    // NativeCpu/"rg_unavailable" -- running the NATIVE regex engine (not PCRE2) for a `--pcre2`
+    // request with no signal that PCRE2 semantics were dropped. It must now fail closed (exit 2).
+    let output = tg()
+        .arg("search")
+        .arg("--pcre2")
+        .arg("hello")
+        .arg(dir.path())
+        .env("PATH", "")
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--pcre2"), "stderr={stderr}");
+    assert!(stderr.to_lowercase().contains("rg"), "stderr={stderr}");
+    // Must NOT have silently run a native-regex search and printed matches.
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn test_positional_pcre2_without_ripgrep_fails_closed() {
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+
+    // The root/positional shortcut (`tg PATTERN PATH`) threads --pcre2 into the same route_search
+    // call as `tg search --pcre2`; it must fail the same way.
+    let output = tg()
+        .arg("--pcre2")
+        .arg("hello")
+        .arg(dir.path())
+        .env("PATH", "")
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--pcre2"), "stderr={stderr}");
+}
+
+#[test]
+fn test_routing_pcre2_still_routes_to_ripgrep_when_available() {
+    // Regression guard: rg-PRESENT behavior for --pcre2 must be unchanged by the audit #81 #9
+    // fail-closed fix -- still routes to RipgrepBackend with reason "pcre2-required".
+    let dir = tempdir().unwrap();
+    write_text_corpus(dir.path());
+    let rg_wrapper = write_rg_wrapper(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--pcre2")
+        .arg("--verbose")
+        .arg("hello")
+        .arg(dir.path())
+        .env("TG_RG_PATH", &rg_wrapper)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_verbose_routing(&stderr, "RipgrepBackend", "pcre2-required", false);
+    assert_eq!(
+        normalize_newlines(&String::from_utf8_lossy(&output.stdout)),
+        format!("{RG_SENTINEL}\n")
+    );
+}
+
+#[test]
+fn test_pcre2_version_without_ripgrep_exits_2_not_1() {
+    let output = tg()
+        .arg("--pcre2-version")
+        .env("PATH", "")
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_search_pcre2_version_without_ripgrep_exits_2_not_1() {
+    let output = tg()
+        .arg("search")
+        .arg("--pcre2-version")
+        .env("PATH", "")
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_search_type_list_without_ripgrep_exits_2_not_1() {
+    let output = tg()
+        .arg("search")
+        .arg("--type-list")
+        .env("PATH", "")
+        .env("TG_DISABLE_RG", "1")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn test_search_json_and_ndjson_are_mutually_exclusive() {
     let dir = tempdir().unwrap();

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -272,6 +272,44 @@ def test_native_top_level_pcre2_version_matches_public_contract(parity_env) -> N
     assert result.stderr.strip() == ""
 
 
+def test_native_pcre2_without_ripgrep_fails_closed(parity_env) -> None:
+    """Audit #81 finding #9: `--pcre2` must fail closed (exit 2) when rg is unavailable rather
+    than silently swapping to the native regex engine, which does not support PCRE2 syntax."""
+    _skip_if_native_binary_missing("native")
+
+    env = dict(**os.environ, TG_DISABLE_RG="1")
+    result = _run_native_front_door(
+        ["search", "--pcre2", "apple", "target.txt"], cwd=parity_env, env=env
+    )
+
+    assert result.returncode == 2, (
+        f"expected exit 2 (backend unavailable), got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "--pcre2" in result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_native_search_required_passthrough_flag_without_ripgrep_exits_2_not_1(
+    parity_env,
+) -> None:
+    """Audit #81 finding #7: a passthrough-required flag (e.g. --max-depth) with rg unavailable
+    must exit 2 (backend unavailable), not the masked exit 1 ("no match") that bubbling the
+    `execute_ripgrep_search` error through `?` to main()'s default Result termination used to
+    produce."""
+    _skip_if_native_binary_missing("native")
+
+    env = dict(**os.environ, TG_DISABLE_RG="1")
+    result = _run_native_front_door(
+        ["search", "--max-depth", "2", "apple", "target.txt"], cwd=parity_env, env=env
+    )
+
+    assert result.returncode == 2, (
+        "expected exit 2 (backend unavailable), not 1 (no-match-shaped); got "
+        f"{result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
 def test_native_scan_ruleset_json_uses_python_full_contract_without_sgconfig(
     parity_env,
 ) -> None:


### PR DESCRIPTION
Two exit-code / fail-closed honesty findings from the deep-dive audit (#81), `rust_core/src/main.rs`.

## #7 — rg-unavailable masked as a no-match (exit 1 instead of 2)
5 call sites invoked `execute_ripgrep_search` / `--pcre2-version` / `--type-list` **without** checking `ripgrep_is_available()`. When rg is absent the `Err` bubbled via `?` to `main()`'s default termination → **exit 1** — indistinguishable from a genuine no-match, so an agent looping on `rc==1` sees a masked backend-unavailable as "no results". Fixed with a shared `require_ripgrep_or_exit(rg_available, context)` helper (`eprintln!` + `exit(2)`, matching `handle_calibrate_command`'s convention) on the 6 previously-unguarded rg-absent paths. **Exit 2 = incomplete/unavailable, distinct from exit 1 = no-match.**

## #9 — `--pcre2` silently ran native regex when rg absent
`search_requires_ripgrep_passthrough` listed `pcre2_unicode` but not plain `args.pcre2`, and `route_search`'s `pcre2 && rg_available` gate silently fell through to NativeCpu (native regex, **not** PCRE2) — a `--pcre2` request quietly ran a different engine. Now fails closed (exit 2) when no PCRE2-capable rg is present, in both `handle_ripgrep_search` and `run_positional_cli`.

## Verification (dogfooded against the real compiled binary)
- `TG_DISABLE_RG=1 tg search hello --cpu --max-depth 2` → **exit 2** (was 1)
- `TG_DISABLE_RG=1 tg search --pcre2 hello` → **exit 2, empty** (was a silent native-regex match)
- `tg search zzz_absent --cpu` → exit 1 (genuine no-match, **unchanged**)
- `tg search --pcre2 "hel+o"` with real rg → exit 0, `routing_reason=pcre2-required` (**unchanged**)
- `cargo test` full suite **0 failures** (+7 new regression tests incl. a "pcre2 still routes to rg when available" guard); `tests/e2e/test_routing_parity.py` **50 passed** (+2 native-front-door parity); `cargo check`/`cargo fmt` clean. rg-PRESENT routing untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)