### PR TITLE
fix(daemon): create the token file owner-restricted BEFORE writing the HMAC secret — close the Windows write-then-ACL disclosure window (audit #81 #13)

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -18,8 +18,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from time import monotonic
 from typing import Any, cast
+from uuid import uuid4
 
-from tensor_grep.cli._index_lock import IndexLockTimeoutError, index_lock
+from tensor_grep.cli._index_lock import IndexLockTimeoutError, index_lock, replace_with_retry
 from tensor_grep.cli.session_store import (
     _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT,
     _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT,
@@ -189,8 +190,75 @@ def _write_daemon_metadata(root: Path, payload: dict[str, Any]) -> None:
 
     # audit S3: daemon.json carries the IPC token; write it 0600 so the secret is not exposed.
     metadata_path = _daemon_metadata_path(root)
-    _write_json_atomic(metadata_path, payload, mode=_DAEMON_METADATA_MODE)
+    if sys.platform == "win32":
+        # audit #81 #13: on Windows, os.chmod/the os.open `mode=` bits grant NO real per-user
+        # access control (see _restrict_windows_file_to_current_user below), so writing the
+        # token via the shared, POSIX-oriented _write_json_atomic and only running icacls
+        # AFTERWARD (the old sequence) left the token file world-readable-under-the-parent's-
+        # default-ACL for the whole write+rename+icacls duration. Lock the ACL down before any
+        # secret byte is written instead -- see _write_daemon_metadata_windows.
+        _write_daemon_metadata_windows(metadata_path, payload)
+    else:
+        # POSIX: _write_json_atomic already creates the temp file AT mode 0600 via
+        # os.open(O_CREAT|O_EXCL, mode) -- the kernel applies the mode atomically at creation,
+        # so the file is never briefly world-readable between creation and the rename.
+        _write_json_atomic(metadata_path, payload, mode=_DAEMON_METADATA_MODE)
+    # Defense-in-depth re-assertion on the *published* path. On the Windows path above this is
+    # redundant with the temp-file lock (a same-directory rename carries the explicit DACL we
+    # just set forward, it is not recomputed from the parent), but it is cheap insurance against
+    # any future change to the publish step; on POSIX it is a no-op (sys.platform guard below).
     _restrict_windows_file_to_current_user(metadata_path)
+
+
+def _write_daemon_metadata_windows(path: Path, payload: dict[str, Any]) -> None:
+    """Windows: lock the temp file's ACL down BEFORE the HMAC token is written into it (audit #81 #13).
+
+    Mirrors ``session_store._write_json_atomic``'s create-temp/write/fsync/atomic-rename shape,
+    but inserts the ACL lockdown between temp-file *creation* (0 bytes, no secret yet) and the
+    write of the token payload, instead of applying it only after the fact on the already-
+    published path. The create-then-lock-then-write ordering keeps the same file descriptor open
+    across the ``icacls`` subprocess call -- ``os.open()`` on Windows defaults to DENY_NONE
+    sharing, so a concurrent process can set the DACL without a sharing violation (verified
+    empirically against this repo's CI Windows image) -- so there is no close/reopen gap either.
+    The rename stays within the same directory, so the explicit (non-inherited) DACL travels with
+    the file rather than being recomputed from the parent.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    data = json.dumps(payload, indent=2)
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _DAEMON_METADATA_MODE)
+    try:
+        # The lock call is INSIDE the fdopen `with` so that if it ever raised (it shouldn't --
+        # _restrict_windows_file_to_current_user swallows its own errors -- but this must stay
+        # correct even if that changes), the `with` block closes the underlying fd before the
+        # `except` below tries to unlink: Windows refuses to delete a file that is still open
+        # under this process (WinError 32).
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            # ACL-lock BEFORE any token bytes are written -- the file is still 0 bytes here, so
+            # there is nothing for another local account to read even if it wins the race to
+            # open the (randomly named) temp file before icacls completes.
+            _restrict_windows_file_to_current_user(tmp_path)
+            handle.write(data)
+            handle.flush()
+            # M6: fsync the data before the rename so a crash can never publish a truncated
+            # token file (mirrors _write_json_atomic, audit I5).
+            os.fsync(handle.fileno())
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)  # don't leave a partial/unlocked temp behind
+        raise
+    replace_with_retry(tmp_path, path)
+    # Best-effort directory-durability fsync, mirroring _write_json_atomic; a no-op/unsupported
+    # on Windows so failures here are expected and non-fatal.
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
 
 
 def _restrict_windows_file_to_current_user(path: Path) -> None:
@@ -201,6 +269,10 @@ def _restrict_windows_file_to_current_user(path: Path) -> None:
     can reach the session root could read the IPC token. Remove inherited ACLs and grant only the
     current user. The HMAC compare_digest gate remains the ENFORCED control; this is defense in
     depth and fails OPEN (a failed icacls must never break daemon startup).
+
+    Called both BEFORE the token is written (on the pre-publish temp, the real fix for audit
+    #81 #13) and again afterward on the published path (defense-in-depth) -- safe either way
+    since it only ever tightens the ACL of whatever path it is given.
     """
     if sys.platform != "win32":
         return

--- a/tests/unit/test_session_daemon_security.py
+++ b/tests/unit/test_session_daemon_security.py
@@ -194,6 +194,107 @@ def test_write_daemon_metadata_locks_down_token_file_on_windows(
     assert "/inheritance:r" in argv and "/grant:r" in argv and "testuser:F" in argv
 
 
+def test_write_daemon_metadata_locks_acl_before_token_bytes_are_written(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """audit #81 #13: icacls must run BEFORE the token reaches disk, not after.
+
+    The previous ordering wrote the full token payload via the shared ``_write_json_atomic``
+    helper and only ran ``icacls`` afterward, on the already-published ``daemon.json`` -- so the
+    file carried the sessions directory's default/inherited (broadly readable) permissions for
+    the entire write+rename+icacls duration, and any other local account able to read that
+    directory could read the HMAC token in that window.
+
+    Assert directly against on-disk state rather than call order: at the moment the FIRST icacls
+    call runs (the pre-publish lock that closes the disclosure window), the file it targets must
+    contain zero bytes -- the secret must never already be sitting on disk when that lock is
+    applied. A later defense-in-depth re-lock of the already-published, already-secret-bearing
+    ``daemon.json`` is expected and fine -- by then the file is already owner-restricted, so it
+    is not a new disclosure window; only the FIRST (pre-publish) lock is load-bearing here.
+    """
+    snapshots: list[bytes] = []
+
+    def _fake_run(argv, **_kwargs):
+        target = Path(argv[1])
+        snapshots.append(target.read_bytes() if target.exists() else b"<missing>")
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(session_daemon.subprocess, "run", _fake_run)
+    monkeypatch.setattr(session_daemon.sys, "platform", "win32")
+    monkeypatch.setenv("USERNAME", "testuser")
+
+    root = tmp_path.resolve()
+    session_daemon._write_daemon_metadata(root, {"token": "top-secret-hmac", "version": 1})
+
+    assert snapshots, "icacls was never invoked"
+    assert snapshots[0] in (b"", b"<missing>"), (
+        f"the FIRST (pre-publish) icacls lock ran while the token file already had content on "
+        f"disk: {snapshots[0]!r}"
+    )
+
+    # The write must still actually land -- the reordering must not break the daemon.json
+    # contract (shape, token value) it is required to preserve.
+    metadata_path = session_daemon._daemon_metadata_path(root)
+    assert metadata_path.exists()
+    published = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert published["token"] == "top-secret-hmac"
+
+
+def test_write_daemon_metadata_acl_targets_temp_file_before_publish(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The FIRST icacls call -- the one that closes the disclosure window -- must target the
+    # pre-publish temp file, never the already-renamed daemon.json (that would just reproduce
+    # the old write-then-restrict bug under a different name).
+    calls: list[str] = []
+
+    def _fake_run(argv, **_kwargs):
+        calls.append(str(argv[1]))
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(session_daemon.subprocess, "run", _fake_run)
+    monkeypatch.setattr(session_daemon.sys, "platform", "win32")
+    monkeypatch.setenv("USERNAME", "testuser")
+
+    root = tmp_path.resolve()
+    session_daemon._write_daemon_metadata(root, {"token": "t", "version": 1})
+
+    metadata_path = session_daemon._daemon_metadata_path(root)
+    assert calls, "icacls was never invoked"
+    assert calls[0] != str(metadata_path), "first ACL lock must target the temp, not the publish"
+    assert calls[0].endswith(".tmp"), f"expected a .tmp temp path, got {calls[0]!r}"
+
+
+def test_write_daemon_metadata_windows_cleans_up_temp_on_lock_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # _restrict_windows_file_to_current_user swallows its own errors by design (a failed icacls
+    # must never break daemon startup), but the write path must still fail closed defensively:
+    # if the lock step somehow raises, no partial/unlocked temp may be left behind and the
+    # original error must propagate rather than being swallowed.
+    def _boom(_path: Path) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(session_daemon, "_restrict_windows_file_to_current_user", _boom)
+    monkeypatch.setattr(session_daemon.sys, "platform", "win32")
+
+    root = tmp_path.resolve()
+    with pytest.raises(RuntimeError, match="boom"):
+        session_daemon._write_daemon_metadata(root, {"token": "t", "version": 1})
+
+    sessions_dir = session_daemon._sessions_dir(root)
+    leftover = list(sessions_dir.glob("*.tmp")) if sessions_dir.exists() else []
+    assert leftover == [], f"a partial/unlocked temp file was left behind: {leftover}"
+
+
 def test_restrict_windows_file_is_noop_off_windows(tmp_path: Path, monkeypatch) -> None:
     called: list[object] = []
     monkeypatch.setattr(session_daemon.subprocess, "run", lambda *a, **k: called.append(a))


### PR DESCRIPTION
The final deep-dive audit finding (#81 #13, LOW, Windows-only, narrow: local multi-user + localhost IPC).

## The bug
The per-daemon HMAC token (the *enforced* auth control) was written by `_write_json_atomic` (mode=0600) and the restrictive Windows ACL was applied via `icacls` only on the **already-published** `daemon.json` afterward. On Windows `os.chmod`/`os.open(mode=)` grant no real ACL, so the token file carried the sessions dir's inherited permissions for the whole write+rename+icacls window — another local account could read the HMAC secret in that gap, defeating "HMAC is the enforced control."

## The fix (Windows only; POSIX already correct)
New `_write_daemon_metadata_windows`: create the temp empty, **ACL-lock it via `icacls` while still holding the open fd** (verified on a real Windows box that `os.open`'s default sharing lets a concurrent `icacls` set the DACL with no violation), *then* write the token, fsync, atomic-rename (same-dir rename preserves the DACL). The token file is owner-only **before** the secret bytes are ever written. The original post-write `icacls` stays as defense-in-depth. POSIX unchanged — `_write_json_atomic` already creates via `os.open(O_CREAT|O_EXCL, 0o600)` (mode atomic-at-create).

## Verification
Real venv: **137 passed** (`session_daemon`/`daemon` tests); ruff + format --preview + mypy clean. TDD: 3 new tests, confirmed RED (on-disk evidence: `icacls ran while the token file already had content`) → GREEN — and the tests caught 2 self-introduced bugs during the fix (a too-strict ordering assert on the defense-in-depth 2nd icacls call, and a WinError-32 temp-unlink-with-open-fd, both fixed). **Real-`icacls` end-to-end (not mocked):** the published `daemon.json` ends with exactly one ACE (`…\oimir:(F)`), no inherited entries, zero leftover `.tmp`.

## Completes the deep-dive
This is finding **14 of 14** from the 2026-07-08 full-codebase audit (#81) — every finding now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)