### PR TITLE
fix(mcp): anchor rewrite policy confinement to the target's parent dir for single-file targets (audit #76)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1272,6 +1272,15 @@ def execute_rewrite_apply_json(
         # anchor). Forward the RESOLVED path so load_apply_policy reads the same
         # anchor-validated location this check validated.
         policy_anchor = Path(path).expanduser().resolve()
+        # `path` may be a single FILE (a targeted rewrite), not a directory. A file has no
+        # descendants, so confining the policy under the file itself fail-closed-REJECTS a
+        # legitimately co-located policy (e.g. path=src/foo.py, policy=src/policy.json). Anchor
+        # to the target's parent directory when path is not a directory, so a co-located policy
+        # is allowed while a traversal escape (policy=../../etc/passwd) is still rejected -- the
+        # confinement scope is the apply target's own directory subtree, which the caller is
+        # already rewriting (audit #76 Opus-gate nit; the directory case is unchanged).
+        if not policy_anchor.is_dir():
+            policy_anchor = policy_anchor.parent
         try:
             policy = str(_confine_read_path(policy, policy_anchor, label="policy"))
         except ValueError as exc:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3635,6 +3635,70 @@ def test_tg_rewrite_apply_accepts_policy_within_scan_root(tmp_path):
     assert any(detail["field"] == "on_failure" for detail in parsed["error"]["details"])
 
 
+def test_tg_rewrite_apply_accepts_co_located_policy_for_single_file_target(tmp_path):
+    """audit #76 (Opus-gate nit on #464): when `path` is a single FILE (a targeted rewrite),
+    a policy co-located in the file's directory must reach load_apply_policy's schema
+    validation (code="invalid_policy"), NOT be fail-closed-refused by confinement
+    (code="invalid_input"). Pre-fix the policy anchor was the file itself, which has no
+    descendants, so any co-located policy was rejected."""
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    target = proj / "sample.py"
+    target.write_text("def add(x, y): return x + y\n", encoding="utf-8")
+    policy_path = proj / "apply-policy.json"
+    policy_path.write_text(
+        json.dumps({
+            "version": 1,
+            "lint_cmd": None,
+            "test_cmd": None,
+            "ruleset_scan": None,
+            # omit on_failure: pins the failure to load_apply_policy's schema validation,
+            # proving execution got PAST the path-confinement check with path=a single file.
+        }),
+        encoding="utf-8",
+    )
+
+    out = mcp_server.tg_rewrite_apply(
+        pattern="def $F($$$ARGS): return $EXPR",
+        replacement="lambda $$$ARGS: $EXPR",
+        lang="python",
+        path=str(target),  # a FILE, not a directory
+        policy=str(policy_path),
+    )
+
+    parsed = json.loads(out)
+    assert parsed["error"]["code"] == "invalid_policy"
+    assert any(detail["field"] == "on_failure" for detail in parsed["error"]["details"])
+
+
+def test_tg_rewrite_apply_still_rejects_policy_outside_single_file_target_dir(tmp_path):
+    """audit #76: anchoring the policy to the target FILE's parent directory (so a co-located
+    policy works) must NOT widen confinement -- a policy OUTSIDE the target's directory is still
+    fail-closed refused (code="invalid_input"), preserving the #464 exfil guard."""
+    from tensor_grep.cli import mcp_server
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    target = proj / "sample.py"
+    target.write_text("def add(x, y): return x + y\n", encoding="utf-8")
+    # sibling of proj/, i.e. OUTSIDE the target file's parent directory
+    escape = tmp_path / "outside-policy.json"
+    escape.write_text(json.dumps({"version": 1}), encoding="utf-8")
+
+    out = mcp_server.tg_rewrite_apply(
+        pattern="x",
+        replacement="y",
+        lang="python",
+        path=str(target),
+        policy=str(escape),
+    )
+
+    parsed = json.loads(out)
+    assert parsed["error"]["code"] == "invalid_input"
+
+
 def test_tg_checkpoint_mcp_tools_wrap_checkpoint_store(tmp_path):
     from tensor_grep.cli import mcp_server
 


### PR DESCRIPTION
Opus-gate nit on #464 (audit #76). `tg_rewrite_apply` confines the caller-named `policy` file under `policy_anchor = Path(path).resolve()`. When `path` is a single **file** (a targeted rewrite), the file has no descendants, so a legitimately co-located policy (`path=src/foo.py`, `policy=src/policy.json`) was fail-closed **rejected** (`invalid_input`). Default `path="."` (a directory) was unaffected.

## Fix
When `path` is not a directory, anchor confinement to its **parent directory** — a co-located policy is allowed while a traversal escape (`policy=../../etc/passwd`) is still rejected. The confinement scope becomes the apply target's own directory subtree (which the caller is already rewriting), matching the directory case's semantics. 3-line change, `+` two tests.

## Verification (real venv, 18 pass)
- New: single-file target + co-located policy now reaches `load_apply_policy` schema validation (`invalid_policy`) instead of confinement refusal.
- New: a policy **outside** the target's directory is still refused (`invalid_input`) — the #464 exfil guard is preserved.
- The full 14-case `read_path_param_coverage` exfil suite + `accepts_policy_within_scan_root` still pass. ruff + format clean.

⚠️ **Security-sensitive (mcp_server.py) — requires the mandatory adversarial security gate before merge** per the #66/#81 discipline. Note: the Opus gate that flagged this nit proposed "mirror `tg_session_file_importers`'s `is_dir()` normalization" — verified against the real merged code, that normalization does **not** exist (no `is_dir()` in mcp_server.py), so this writes the guard fresh rather than mirroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)