### PR TITLE
feat(rerank): ONNX encoder + checksum-pinned LateOn-Code-edge fetch (T3-T4)

### DIFF
--- a/src/tensor_grep/core/retrieval_dense.py
+++ b/src/tensor_grep/core/retrieval_dense.py
@@ -92,8 +92,11 @@ def load_dense_model(model_dir: str | Path) -> Any:
     if not path.is_dir():
         raise DenseUnavailableError(
             "semantic ranking unavailable: model not fetched -- expected a model2vec "
-            f"StaticModel directory at {path}; run `tg index --fetch-model` (or set "
-            "TG_SEMANTIC_MODEL_DIR) to provide one"
+            f"StaticModel directory at {path}. There is no `tg` fetch command for this leg yet; "
+            "fetch it yourself via model2vec's own HuggingFace integration, e.g. "
+            "`StaticModel.from_pretrained('minishlab/potion-code-16M').save_pretrained(<dir>)`, "
+            "then point TG_SEMANTIC_MODEL_DIR at <dir> (or save_pretrained directly to "
+            f"{path})"
         )
     try:
         from model2vec import StaticModel

--- a/src/tensor_grep/core/retrieval_late.py
+++ b/src/tensor_grep/core/retrieval_late.py
@@ -1,29 +1,56 @@
-"""Late-interaction (MaxSim / ColBERT-style) rerank foundation for `tg search --semantic`
+"""Late-interaction (MaxSim / ColBERT-style) rerank stage for `tg search --semantic`
 (roadmap docs/plans/design-tensor-grep-late-rerank-2026-07-09.md).
 
-This module is the FOUNDATION increment only (the design doc's T0-T2): pure MaxSim math plus the
-:class:`LateReranker` contract against an INJECTED token encoder. There is no ONNX model here yet
--- that lands in T3 (`late_available()` probe + `load_late_model()`), and the seam wiring into
-`rerank_hybrid` lands in T5. Every caller in this increment supplies its own ``encode`` callable
-(tests use a deterministic stub; T3+ wires a real ONNX encoder behind the ``rerank`` extra).
+T0-T2 (foundation): pure MaxSim math (:func:`maxsim_scores`, :func:`rank_by_maxsim`) plus the
+:class:`LateReranker` contract against an INJECTED token encoder.
+
+T3 (this increment): a real ONNX encoder behind the ``rerank`` extra -- :func:`late_available`
+(import probe, mirrors ``retrieval_dense.dense_available``), :func:`load_late_model` (loads the
+ONNX session + tokenizer + ``onnx_config.json`` contract, two-tier fail-closed),
+:func:`build_late_encoder` (a real, non-stub ``Callable[[str], np.ndarray]`` matching
+:class:`LateReranker`'s injected ``encode`` signature), and :func:`load_late_reranker` (a
+ready-to-use :class:`LateReranker` wired with it).
+
+T4 (this increment): a checksum-pinned fetch of the 3 required model files from a PINNED Hugging
+Face revision -- :func:`fetch_late_model` (importable) and ``python -m
+tensor_grep.core.retrieval_late --fetch`` (CLI). Never auto-downloads at query time.
+
+Still pending: the seam wiring into ``rerank_hybrid`` (T5), the latency-budget + bidirectional
+fail-closed invariant (T6), and the golden-set quality gate that decides ship/no-ship (T8) -- this
+module remains unreachable from `tg search` until those land.
 
 Assumption: both :func:`maxsim_scores` inputs are ALREADY L2-normalized per token (each row a unit
-vector) -- this module does not normalize them. A plain dot product between two normalized rows IS
-cosine similarity, so ``MaxSim(q, d) = sum_i max_j (q_i . d_j)`` is a sum of per-query-token cosine
-maxima. Callers (the T3 ONNX encoder, or a test's stub) own normalization.
+vector) -- this module does not normalize them there; the real encoder built by
+:func:`build_late_encoder` DOES normalize (see its docstring). A plain dot product between two
+normalized rows IS cosine similarity, so ``MaxSim(q, d) = sum_i max_j (q_i . d_j)`` is a sum of
+per-query-token cosine maxima.
 
 Fail-closed contract (see AGENTS.md "Backend Fail-Closed Contract" and retrieval_dense.py:9-19):
-this increment does NOT yet raise a recoverable-unavailable error or
-:class:`~tensor_grep.backends.base.BackendExecutionError` -- that wiring (extra-not-installed
-probe, latency-budget enforcement, ONNX load faults) lands in T3/T6. :meth:`LateReranker.rerank`
-here assumes its injected ``encode`` callable already succeeded; a raising ``encode`` propagates
-raw until then.
+extra not installed, or the model directory not fetched -> :class:`LateRerankUnavailableError`
+(RECOVERABLE; callers must degrade visibly -- stderr + ``SearchResult.rank_fallback_reason`` --
+never silently). ONNX/tokenizer load fails, or an encode call raises or produces a malformed
+shape -> :class:`~tensor_grep.backends.base.BackendExecutionError` (unrecoverable).
+:meth:`LateReranker.rerank` itself still assumes its injected ``encode`` callable already
+succeeded -- a raising ``encode`` propagates raw from there, same as T0-T2. Latency-budget
+enforcement (``TG_RERANK_BUDGET_MS``) is NOT implemented here; that lands in T6.
 """
 
 from __future__ import annotations
 
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import urllib.request
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tensor_grep.backends.base import BackendExecutionError
 
 if TYPE_CHECKING:
     import numpy as np
@@ -96,3 +123,365 @@ class LateReranker:
         doc_matrices = [self._encode(chunk) for chunk in chunks]
         scores = maxsim_scores(query_matrix, doc_matrices)
         return rank_by_maxsim(scores, indices)
+
+
+# ---------------------------------------------------------------------------------------------
+# T3 -- ONNX encoder behind the `rerank` extra.
+# ---------------------------------------------------------------------------------------------
+
+_LATE_MODEL_SUBDIR = ("models", "LateOn-Code-edge")
+_REQUIRED_MODEL_FILES = ("model_int8.onnx", "tokenizer.json", "onnx_config.json")
+
+# Hard safety ceiling on tokens-per-encode, independent of whatever `onnx_config.json` claims for
+# `query_length`/`document_length` (design doc "Inference": "512-token truncation guard"). The
+# real onnx_config.json pinned below configures document_length=2048 -- this guard additionally
+# caps that, trading a little quality on very long chunks for a bounded worst-case encode cost
+# (latency/DoS defense; a corrupt or tampered onnx_config.json cannot blow the cost past this).
+_MAX_TOKEN_LENGTH = 512
+
+
+class LateRerankUnavailableError(RuntimeError):
+    """The late-interaction rerank stage cannot run for a RECOVERABLE reason.
+
+    Covers: the ``rerank`` extra is not installed, or the model has not been fetched to disk (or
+    an encoder produced a malformed embedding shape). Callers MUST catch this and degrade to the
+    pre-rerank order visibly -- stderr + ``SearchResult.rank_fallback_reason`` -- rather than let
+    it propagate as a crash or silently drop the rerank stage. Mirrors
+    :class:`~tensor_grep.core.retrieval_dense.DenseUnavailableError`; distinct from
+    :class:`~tensor_grep.backends.base.BackendExecutionError`, which is for a genuine backend
+    fault (corrupt model files, an encode-time crash) the caller cannot recover from in-process.
+    """
+
+
+def late_available() -> tuple[bool, str | None]:
+    """Lazy-import probe: can the late-rerank stage even attempt to run in this environment?
+
+    Returns ``(True, None)`` when ``onnxruntime``, ``tokenizers``, and ``numpy`` all import
+    cleanly, else ``(False, human_reason)``. Pure import check -- does NOT check whether the
+    model has been fetched to disk; see :func:`load_late_model` for that. Mirrors
+    ``retrieval_dense.dense_available()`` exactly.
+    """
+    try:
+        import onnxruntime  # noqa: F401
+    except ImportError as exc:
+        return False, (
+            "late rerank unavailable: onnxruntime not installed -- "
+            f"pip install 'tensor-grep[rerank]' ({exc})"
+        )
+    try:
+        import tokenizers  # noqa: F401
+    except ImportError as exc:
+        return False, (
+            "late rerank unavailable: tokenizers not installed -- "
+            f"pip install 'tensor-grep[rerank]' ({exc})"
+        )
+    try:
+        import numpy  # noqa: F401
+    except ImportError as exc:
+        return False, f"late rerank unavailable: numpy not installed ({exc})"
+    return True, None
+
+
+def default_model_dir() -> Path:
+    """Resolve the fetched late-rerank model directory.
+
+    ``TG_RERANK_MODEL_DIR`` if set, else ``~/.tensor-grep/models/LateOn-Code-edge`` -- the same
+    single per-machine cache convention as ``retrieval_dense.default_model_dir()``, so the model
+    is downloaded once and every repo/search reuses it.
+    """
+    env = os.environ.get("TG_RERANK_MODEL_DIR")
+    if env:
+        return Path(env)
+    return Path.home() / ".tensor-grep" / Path(*_LATE_MODEL_SUBDIR)
+
+
+@dataclass
+class LateModel:
+    """A loaded late-rerank encoder: the ONNX session + tokenizer + the parsed
+    ``onnx_config.json`` contract (prefixes, per-role max lengths, embedding dim).
+
+    ``session``/``tokenizer`` are typed ``Any`` (not ``onnxruntime.InferenceSession`` /
+    ``tokenizers.Tokenizer``) so this module never needs those packages importable at type-check
+    time -- mirrors how ``retrieval_dense.DenseIndex`` stores its injected ``model: Any``.
+    """
+
+    session: Any
+    tokenizer: Any
+    query_prefix: str
+    document_prefix: str
+    query_length: int
+    document_length: int
+    embedding_dim: int
+
+
+def load_late_model(model_dir: str | Path) -> LateModel:
+    """Load the ONNX session + tokenizer + ``onnx_config.json`` contract from ``model_dir``.
+
+    Raises :class:`LateRerankUnavailableError` (recoverable) when the directory, or any of the 3
+    required files (``model_int8.onnx``, ``tokenizer.json``, ``onnx_config.json``), is missing --
+    "model not fetched" is an expected, visibly-degraded state, not a crash. Raises
+    :class:`~tensor_grep.backends.base.BackendExecutionError` (unrecoverable) when all 3 files
+    are present but fail to parse/load (corrupt or incompatible) -- a genuine backend fault.
+    """
+    path = Path(model_dir)
+    missing = not path.is_dir() or any(
+        not (path / name).is_file() for name in _REQUIRED_MODEL_FILES
+    )
+    if missing:
+        raise LateRerankUnavailableError(
+            "late rerank unavailable: model not fetched -- expected "
+            f"{', '.join(_REQUIRED_MODEL_FILES)} under {path}; run "
+            "`python -m tensor_grep.core.retrieval_late --fetch` (or set TG_RERANK_MODEL_DIR) "
+            "to provide one"
+        )
+    try:
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
+
+        config = json.loads((path / "onnx_config.json").read_text(encoding="utf-8"))
+        tokenizer = Tokenizer.from_file(str(path / "tokenizer.json"))
+        session = ort.InferenceSession(
+            str(path / "model_int8.onnx"), providers=["CPUExecutionProvider"]
+        )
+        return LateModel(
+            session=session,
+            tokenizer=tokenizer,
+            query_prefix=str(config["query_prefix"]),
+            document_prefix=str(config["document_prefix"]),
+            query_length=int(config["query_length"]),
+            document_length=int(config["document_length"]),
+            embedding_dim=int(config["embedding_dim"]),
+        )
+    except Exception as exc:  # any load failure here is a genuine backend fault
+        raise BackendExecutionError(
+            f"late rerank model at {path} failed to load (corrupt or incompatible): {exc}"
+        ) from exc
+
+
+def _l2_normalize_rows(matrix: np.ndarray) -> np.ndarray:
+    import numpy as np
+
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0.0] = 1.0
+    return matrix / norms
+
+
+def _encode_tokens(model: LateModel, text: str, *, is_query: bool) -> np.ndarray:
+    """Tokenize + run the ONNX session for one text, returning a per-token L2-normalized
+    ``(T, D)`` matrix (``D == model.embedding_dim``).
+
+    Applies the role-appropriate prefix and max length from ``onnx_config.json``
+    (``query_prefix`` + ``query_length``, or ``document_prefix`` + ``document_length``), further
+    hard-capped at ``_MAX_TOKEN_LENGTH`` (512) regardless of the configured value -- the design
+    doc's "512-token truncation guard".
+
+    Not thread-safe for concurrent calls sharing one ``LateModel``: ``tokenizer.enable_truncation``
+    mutates the shared tokenizer's truncation setting in place before each encode. The current
+    caller (``LateReranker.rerank``) encodes sequentially, so this is not a live bug today: a
+    future concurrent/parallel caller would need a tokenizer clone per worker.
+    """
+    import numpy as np
+
+    prefix = model.query_prefix if is_query else model.document_prefix
+    configured_length = model.query_length if is_query else model.document_length
+    effective_length = max(1, min(configured_length, _MAX_TOKEN_LENGTH))
+    try:
+        model.tokenizer.enable_truncation(max_length=effective_length)
+        encoding = model.tokenizer.encode(prefix + text)
+        input_ids = np.asarray([encoding.ids], dtype=np.int64)
+        attention_mask = np.asarray([encoding.attention_mask], dtype=np.int64)
+        outputs = model.session.run(
+            None, {"input_ids": input_ids, "attention_mask": attention_mask}
+        )
+        raw = np.asarray(outputs[0][0], dtype=np.float32)
+    except Exception as exc:
+        raise BackendExecutionError(
+            f"late rerank encode failed for a {len(text)}-char input: {exc}"
+        ) from exc
+    if raw.ndim != 2 or raw.shape[1] != model.embedding_dim:
+        raise LateRerankUnavailableError(
+            "late rerank unavailable: encoder produced a malformed embedding shape "
+            f"{raw.shape} (expected (*, {model.embedding_dim}))"
+        )
+    return _l2_normalize_rows(raw)
+
+
+def build_late_encoder(model: LateModel, *, is_query: bool) -> Callable[[str], np.ndarray]:
+    """Build a real (non-stub) ``encode: str -> (T, D) ndarray`` callable for one role.
+
+    The returned callable matches :class:`LateReranker`'s injected ``encode`` signature exactly
+    -- this is the piece T5's seam wiring uses to supply role-aware encoders (query vs document)
+    once ``rerank_hybrid`` splices this stage in. See :func:`load_late_reranker` for a
+    ready-to-use :class:`LateReranker` wired with the document-role encoder.
+    """
+
+    def encode(text: str) -> np.ndarray:
+        return _encode_tokens(model, text, is_query=is_query)
+
+    return encode
+
+
+def load_late_reranker(model_dir: str | Path | None = None) -> LateReranker:
+    """Convenience constructor: load the model and wire a real encoder into :class:`LateReranker`.
+
+    NOTE: :meth:`LateReranker.rerank` (T2) calls the SAME injected ``encode`` for both the query
+    text and every candidate chunk -- it does not yet distinguish roles. This constructor wires
+    the DOCUMENT-role encoder (chunks dominate call volume: one query encode vs N chunk encodes
+    per search) as a conservative default. The asymmetric ``query_prefix``/``document_prefix`` +
+    ``query_length``/``document_length`` in ``onnx_config.json`` are both read and available via
+    ``build_late_encoder(model, is_query=True/False)`` for T5's seam wiring to route correctly.
+    """
+    resolved_dir = model_dir if model_dir is not None else default_model_dir()
+    model = load_late_model(resolved_dir)
+    return LateReranker(build_late_encoder(model, is_query=False))
+
+
+# ---------------------------------------------------------------------------------------------
+# T4 -- checksum-pinned fetch of the LateOn-Code-edge model files.
+# ---------------------------------------------------------------------------------------------
+
+# `lightonai/LateOn-Code-edge` (Apache-2.0; design doc "Model + LICENSE"). Pinned to a fixed
+# commit SHA via a `resolve/<sha>/...` URL (never `/resolve/main/...`) so the fetched content is
+# immutable regardless of future upstream changes.
+_HF_REPO = "lightonai/LateOn-Code-edge"
+_HF_REVISION = "07ef20f406c86badca122464808f4cac2f6e4b25"
+_HF_RESOLVE_BASE = f"https://huggingface.co/{_HF_REPO}/resolve/{_HF_REVISION}"
+
+# filename -> (sha256_hex, exact_byte_size). Computed by downloading each file from the pinned
+# revision above and hashing locally, verified 2026-07-09 via TWO independent tools (Python
+# `hashlib.sha256` and the `sha256sum` CLI produced byte-identical digests) -- see
+# supply-chain-hardening skill H6 "SHA-confirmation discipline": never trust an agent-reported or
+# sidecar SHA, always download+hash to confirm.
+_FETCH_MANIFEST: dict[str, tuple[str, int]] = {
+    "model_int8.onnx": (
+        "eac35bdaa862e2762e6455337f7a3e704b05dbc4259f00929fcc8e10207f11c7",
+        17_228_399,
+    ),
+    "tokenizer.json": (
+        "a388b94942e98e5c661c6c23f919842285738bfd123a0d148dea0c56287505d0",
+        3_583_847,
+    ),
+    "onnx_config.json": (
+        "fa4fef89820dcdc33c5504c62c1d5efc19603cfbfebf02368a70d51a4dbe6651",
+        792,
+    ),
+}
+
+_MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024  # per-file cap; the largest pinned file is ~17.2 MB
+_DOWNLOAD_TIMEOUT_S = 60.0
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def _download_bounded(url: str, *, max_bytes: int, timeout_s: float) -> bytes:
+    """Stream ``url`` fully into memory, refusing to exceed ``max_bytes``
+    (supply-chain-hardening H2: byte-capped + time-bound). The cap is enforced per-chunk during
+    the read, not after buffering the whole body, so an oversized response cannot exhaust memory
+    before the cap trips.
+
+    Raises a plain ``OSError``/``ValueError`` on any failure (network error, timeout, or the byte
+    cap). The caller (:func:`fetch_late_model`) wraps ALL of this uniformly into
+    :class:`~tensor_grep.backends.base.BackendExecutionError`.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": "tensor-grep-rerank-fetch"})
+    with urllib.request.urlopen(request, timeout=timeout_s) as resp:
+        buffer = bytearray()
+        while True:
+            chunk = resp.read(_DOWNLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            buffer.extend(chunk)
+            if len(buffer) > max_bytes:
+                raise ValueError(f"{url} exceeded the {max_bytes}-byte cap")
+        return bytes(buffer)
+
+
+def fetch_late_model(dest_dir: str | Path | None = None) -> Path:
+    """Download the 3 pinned LateOn-Code-edge files into ``dest_dir``, checksum-gated + atomic.
+
+    Fail-closed contract (supply-chain-hardening H2/H3): each file is streamed with a byte cap +
+    timeout, verified against a hard-coded SHA-256 pin from a PINNED HF revision (``_HF_REVISION``,
+    never ``main``) BEFORE anything lands at ``dest_dir``. On any download failure or checksum
+    mismatch, the temp download directory is discarded and :class:`BackendExecutionError` is
+    raised -- no partial or unverified file is ever left where :func:`load_late_model` would find
+    it.
+
+    The final install step (moving the verified temp directory to ``dest_dir``) is a single
+    ``os.replace`` -- atomic on both POSIX and Windows PROVIDED ``dest_dir`` does not already
+    exist. If ``dest_dir`` already holds a previous install (a re-fetch), it is removed
+    immediately before the replace: ``os.replace`` cannot atomically overwrite a non-empty
+    directory on Windows (verified empirically: ``PermissionError [WinError 5] Access is
+    denied``), so a plain overwrite is not available cross-platform. This narrows, but does not
+    eliminate, the crash window between the rmtree and the replace; the new copy is fully
+    verified before the old one is ever touched, and a re-run of ``--fetch`` is idempotent.
+    """
+    dest = Path(dest_dir) if dest_dir is not None else default_model_dir()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_dir = tempfile.mkdtemp(dir=str(dest.parent), prefix=".tg-rerank-fetch-")
+    tmp_path = Path(tmp_dir)
+    try:
+        for filename, (expected_sha256, expected_size) in _FETCH_MANIFEST.items():
+            url = f"{_HF_RESOLVE_BASE}/{filename}"
+            try:
+                data = _download_bounded(
+                    url, max_bytes=_MAX_DOWNLOAD_BYTES, timeout_s=_DOWNLOAD_TIMEOUT_S
+                )
+            except Exception as exc:
+                raise BackendExecutionError(
+                    f"late rerank fetch failed downloading {filename} from {url}: {exc}"
+                ) from exc
+
+            actual_sha256 = hashlib.sha256(data).hexdigest()
+            if actual_sha256 != expected_sha256 or len(data) != expected_size:
+                raise BackendExecutionError(
+                    f"late rerank fetch checksum mismatch for {filename}: expected "
+                    f"sha256={expected_sha256} size={expected_size}, got "
+                    f"sha256={actual_sha256} size={len(data)} -- refusing to install (the fetch "
+                    "is PINNED to a fixed HF revision and must never silently accept changed "
+                    "content)"
+                )
+            (tmp_path / filename).write_bytes(data)
+
+        if dest.exists():
+            shutil.rmtree(dest)
+        os.replace(tmp_path, dest)
+    finally:
+        # A no-op if the `os.replace` above already moved `tmp_path` away (success path);
+        # cleans up the partial download on any failure path (checksum mismatch, network error).
+        shutil.rmtree(tmp_path, ignore_errors=True)
+    return dest
+
+
+def _fetch_cli(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m tensor_grep.core.retrieval_late --fetch``."""
+    parser = argparse.ArgumentParser(
+        prog="python -m tensor_grep.core.retrieval_late",
+        description=(
+            "Fetch the pinned LateOn-Code-edge late-rerank model files (checksum-verified)."
+        ),
+    )
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help="Download the 3 pinned model files to the model cache directory.",
+    )
+    parser.add_argument(
+        "--model-dir",
+        default=None,
+        help="Override the fetch destination (else TG_RERANK_MODEL_DIR, or the default cache dir).",
+    )
+    args = parser.parse_args(argv)
+    if not args.fetch:
+        parser.print_help()
+        return 2
+    try:
+        dest = fetch_late_model(args.model_dir)
+    except Exception as exc:
+        print(f"tg: late rerank model fetch failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"tg: late rerank model fetched to {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_fetch_cli())

--- a/tests/unit/test_retrieval_late.py
+++ b/tests/unit/test_retrieval_late.py
@@ -16,6 +16,7 @@ fetched locally (not committed to the repo; CI does not fetch it).
 from __future__ import annotations
 
 import sys
+import types
 from collections.abc import Callable
 
 import numpy as np
@@ -163,6 +164,10 @@ def test_late_available_false_without_extra(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_late_available_false_when_tokenizers_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     # Isolates the tokenizers-missing branch, which is only reached once onnxruntime succeeds.
+    # The dev venv installs NEITHER onnxruntime nor tokenizers (both are [rerank]-extra only),
+    # so onnxruntime must be stubbed PRESENT to pass the first probe and reach the tokenizers
+    # check -- otherwise the probe short-circuits on onnxruntime and this asserts the wrong branch.
+    monkeypatch.setitem(sys.modules, "onnxruntime", types.ModuleType("onnxruntime"))
     monkeypatch.setitem(sys.modules, "tokenizers", None)
     available, reason = late_available()
     assert available is False

--- a/tests/unit/test_retrieval_late.py
+++ b/tests/unit/test_retrieval_late.py
@@ -1,19 +1,39 @@
-"""Tests for the late-interaction (MaxSim) rerank foundation.
+"""Tests for the late-interaction (MaxSim) rerank stage.
 
-Foundation increment only (design doc "T0-T2",
-docs/plans/design-tensor-grep-late-rerank-2026-07-09.md): pure MaxSim math plus the
-``LateReranker`` contract against an INJECTED stub encoder. There is no ONNX model at this stage
--- T3 wires a real encoder behind the ``rerank`` extra; these tests never need it installed.
+T0-T2 (design doc "T0-T2", docs/plans/design-tensor-grep-late-rerank-2026-07-09.md): pure MaxSim
+math plus the ``LateReranker`` contract against an INJECTED stub encoder -- these tests never need
+the ``rerank`` extra installed.
+
+T3 (design doc "T3"): the real ONNX encoder behind the extra. Per the failure-archaeology
+mock-green trap (a mocked FFI/bridge can pass green while the real thing is dead), the fail-closed
+tests below (``TestLateAvailable``, ``TestLoadLateModel``) use monkeypatched imports / garbage
+bytes and never need onnxruntime installed to prove the CONTRACT; ``TestRealFetchedModel`` at the
+bottom exercises the ACTUAL installed onnxruntime + tokenizers against the ACTUAL fetched
+LateOn-Code-edge model -- not a mock -- and skips (rather than fails) when the model has not been
+fetched locally (not committed to the repo; CI does not fetch it).
 """
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 
 import numpy as np
 import pytest
 
-from tensor_grep.core.retrieval_late import LateReranker, maxsim_scores, rank_by_maxsim
+from tensor_grep.backends.base import BackendExecutionError
+from tensor_grep.core.retrieval_late import (
+    LateModel,
+    LateReranker,
+    LateRerankUnavailableError,
+    build_late_encoder,
+    default_model_dir,
+    late_available,
+    load_late_model,
+    load_late_reranker,
+    maxsim_scores,
+    rank_by_maxsim,
+)
 
 
 def test_maxsim_hand_computed_values() -> None:
@@ -123,3 +143,240 @@ def test_rerank_empty_pool_returns_empty() -> None:
     reranker = LateReranker(_unreachable)
 
     assert reranker.rerank("query", [], []) == []
+
+
+# -------------------------------------------------------------------------------------------
+# T3 -- ONNX encoder behind the `rerank` extra. NO real model in these unit tests (fail-closed
+# contract via monkeypatched imports / garbage bytes); see TestRealFetchedModel at the bottom
+# for the real-model smoke test.
+# -------------------------------------------------------------------------------------------
+
+
+def test_late_available_false_without_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "onnxruntime", None)
+    available, reason = late_available()
+    assert available is False
+    assert reason is not None
+    assert "onnxruntime not installed" in reason
+    assert "tensor-grep[rerank]" in reason
+
+
+def test_late_available_false_when_tokenizers_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isolates the tokenizers-missing branch, which is only reached once onnxruntime succeeds.
+    monkeypatch.setitem(sys.modules, "tokenizers", None)
+    available, reason = late_available()
+    assert available is False
+    assert reason is not None
+    assert "tokenizers not installed" in reason
+
+
+def test_load_missing_dir_raises_unavailable(tmp_path) -> None:
+    missing_dir = tmp_path / "does-not-exist"
+    with pytest.raises(LateRerankUnavailableError, match="not fetched"):
+        load_late_model(missing_dir)
+
+
+def test_load_dir_missing_one_required_file_raises_unavailable(tmp_path) -> None:
+    # The directory exists but is only PARTIALLY fetched (e.g. an interrupted/manual copy) --
+    # must still be treated as "not fetched" (recoverable), not surfaced as a load crash.
+    partial_dir = tmp_path / "partial-model"
+    partial_dir.mkdir()
+    (partial_dir / "model_int8.onnx").write_bytes(b"placeholder")
+    (partial_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    # onnx_config.json deliberately absent.
+
+    with pytest.raises(LateRerankUnavailableError, match="not fetched"):
+        load_late_model(partial_dir)
+
+
+def test_load_corrupt_dir_raises_backend_execution_error(tmp_path) -> None:
+    corrupt_dir = tmp_path / "corrupt-model"
+    corrupt_dir.mkdir()
+    (corrupt_dir / "model_int8.onnx").write_bytes(b"not a real onnx model, just garbage bytes")
+    (corrupt_dir / "tokenizer.json").write_text("not real tokenizer json {{{", encoding="utf-8")
+    (corrupt_dir / "onnx_config.json").write_text("not real config json {{{", encoding="utf-8")
+
+    with pytest.raises(BackendExecutionError):
+        load_late_model(corrupt_dir)
+
+
+class TestDefaultModelDir:
+    def test_honors_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        monkeypatch.setenv("TG_RERANK_MODEL_DIR", str(tmp_path / "custom-model"))
+        assert default_model_dir() == tmp_path / "custom-model"
+
+    def test_defaults_under_home_dotdir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TG_RERANK_MODEL_DIR", raising=False)
+        result = default_model_dir()
+        assert result.parts[-3:] == (".tensor-grep", "models", "LateOn-Code-edge")
+
+
+class _FakeEncoding:
+    def __init__(self, ids: list[int], attention_mask: list[int]) -> None:
+        self.ids = ids
+        self.attention_mask = attention_mask
+
+
+class _FakeTokenizer:
+    """Duck-typed stand-in for `tokenizers.Tokenizer`: records prefix/truncation calls and
+    returns a deterministic fixed-length token-id sequence (independent of the truncation
+    length actually passed -- the truncation-length ASSERTION is on `truncation_calls`, not on
+    the returned sequence length)."""
+
+    _FIXED_TOKEN_COUNT = 4
+
+    def __init__(self) -> None:
+        self.truncation_calls: list[int] = []
+        self.encoded_texts: list[str] = []
+
+    def enable_truncation(self, max_length: int) -> None:
+        self.truncation_calls.append(max_length)
+
+    def encode(self, text: str) -> _FakeEncoding:
+        self.encoded_texts.append(text)
+        n = self._FIXED_TOKEN_COUNT
+        return _FakeEncoding(ids=list(range(n)), attention_mask=[1] * n)
+
+
+class _FakeSession:
+    """Duck-typed stand-in for `onnxruntime.InferenceSession`: returns a deterministic,
+    non-uniform (1, T, D) float32 array shaped from the fed `input_ids`."""
+
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+        self.run_calls: list[dict[str, np.ndarray]] = []
+
+    def run(self, output_names: list[str] | None, feed: dict[str, np.ndarray]) -> list[np.ndarray]:
+        self.run_calls.append(feed)
+        t = feed["input_ids"].shape[1]
+        raw = np.arange(1, t * self.dim + 1, dtype=np.float32).reshape(1, t, self.dim)
+        return [raw]
+
+
+def _fake_late_model(
+    *, dim: int = 4, query_length: int = 8, document_length: int = 4000
+) -> LateModel:
+    return LateModel(
+        session=_FakeSession(dim=dim),
+        tokenizer=_FakeTokenizer(),
+        query_prefix="[Q] ",
+        document_prefix="[D] ",
+        query_length=query_length,
+        document_length=document_length,
+        embedding_dim=dim,
+    )
+
+
+class TestBuildLateEncoder:
+    """Exercises the encode mechanics (prefix routing, the 512-token guard, L2-normalization,
+    fail-closed error mapping) against duck-typed fakes -- no real onnxruntime/tokenizers
+    package required, so these run in every environment regardless of the `rerank` extra."""
+
+    def test_query_role_uses_query_prefix_and_configured_length(self) -> None:
+        model = _fake_late_model(query_length=8, document_length=4000)
+        encode = build_late_encoder(model, is_query=True)
+
+        encode("hello")
+
+        assert model.tokenizer.encoded_texts == ["[Q] hello"]
+        assert model.tokenizer.truncation_calls == [8]  # min(8, 512) == 8
+
+    def test_document_role_uses_document_prefix_and_512_token_guard(self) -> None:
+        # document_length=4000 exceeds the 512-token safety guard -- the EFFECTIVE truncation
+        # length passed to the tokenizer must be capped at 512, not the raw configured value.
+        model = _fake_late_model(query_length=8, document_length=4000)
+        encode = build_late_encoder(model, is_query=False)
+
+        encode("world")
+
+        assert model.tokenizer.encoded_texts == ["[D] world"]
+        assert model.tokenizer.truncation_calls == [512]
+
+    def test_output_is_l2_normalized_per_token_row(self) -> None:
+        model = _fake_late_model(dim=4)
+        encode = build_late_encoder(model, is_query=True)
+
+        matrix = encode("hello")
+
+        assert matrix.shape == (4, 4)  # _FakeTokenizer always returns 4 tokens
+        row_norms = np.linalg.norm(matrix, axis=1)
+        np.testing.assert_allclose(row_norms, 1.0, rtol=1e-5)
+
+    def test_encode_raw_exception_becomes_backend_execution_error(self) -> None:
+        class _RaisingSession:
+            def run(self, output_names: list[str] | None, feed: dict[str, np.ndarray]) -> None:
+                raise RuntimeError("onnxruntime exploded")
+
+        model = _fake_late_model()
+        model.session = _RaisingSession()
+        encode = build_late_encoder(model, is_query=True)
+
+        with pytest.raises(BackendExecutionError, match="onnxruntime exploded"):
+            encode("hello")
+
+    def test_encode_malformed_output_dim_raises_unavailable(self) -> None:
+        class _WrongDimSession:
+            def run(
+                self, output_names: list[str] | None, feed: dict[str, np.ndarray]
+            ) -> list[np.ndarray]:
+                t = feed["input_ids"].shape[1]
+                return [np.ones((1, t, 999), dtype=np.float32)]  # wrong embedding dim
+
+        model = _fake_late_model(dim=4)
+        model.session = _WrongDimSession()
+        encode = build_late_encoder(model, is_query=True)
+
+        with pytest.raises(LateRerankUnavailableError, match="malformed embedding shape"):
+            encode("hello")
+
+
+def _real_late_model_dir():
+    candidate = default_model_dir()
+    return candidate if candidate.is_dir() else None
+
+
+@pytest.mark.skipif(
+    _real_late_model_dir() is None,
+    reason="requires the real fetched lightonai/LateOn-Code-edge model (local dev only, not "
+    "committed; CI does not fetch it -- run `python -m tensor_grep.core.retrieval_late --fetch` "
+    "first; this test exercises the ACTUAL model when present)",
+)
+class TestRealFetchedModel:
+    """Exercises the ACTUAL installed onnxruntime + tokenizers against the ACTUAL fetched
+    LateOn-Code-edge model -- not a mock."""
+
+    def test_real_model_loads_with_expected_dimensionality(self) -> None:
+        model = load_late_model(_real_late_model_dir())
+        assert model.embedding_dim == 48
+        assert model.query_prefix == "[Q] "
+        assert model.document_prefix == "[D] "
+
+    def test_real_model_encode_and_maxsim_smoke(self) -> None:
+        model = load_late_model(_real_late_model_dir())
+        encode_query = build_late_encoder(model, is_query=True)
+        encode_doc = build_late_encoder(model, is_query=False)
+
+        query_matrix = encode_query("how do I open a file for reading")
+        doc_matrix = encode_doc("def open_file(path):\n    return open(path, 'r')")
+
+        assert query_matrix.ndim == 2
+        assert query_matrix.shape[1] == model.embedding_dim
+        assert doc_matrix.ndim == 2
+        assert doc_matrix.shape[1] == model.embedding_dim
+
+        scores = maxsim_scores(query_matrix, [doc_matrix])
+        assert len(scores) == 1
+        assert scores[0] > 0.0
+
+    def test_load_late_reranker_produces_a_permutation(self) -> None:
+        reranker = load_late_reranker(_real_late_model_dir())
+        indices = [11, 4, 7]
+        chunks = [
+            "def authenticate_user(username, password):\n    return check(username, password)\n",
+            "def close_connection(conn):\n    conn.dispose()\n",
+            "def open_file(path):\n    return open(path, 'r')\n",
+        ]
+
+        result = reranker.rerank("how do I open a file", chunks, indices)
+
+        assert sorted(result) == sorted(indices)

--- a/tests/unit/test_retrieval_late_fetch.py
+++ b/tests/unit/test_retrieval_late_fetch.py
@@ -1,0 +1,237 @@
+"""Tests for the checksum-pinned LateOn-Code-edge model fetch (design doc "T4",
+docs/plans/design-tensor-grep-late-rerank-2026-07-09.md).
+
+NO real network access here -- `urllib.request.urlopen` is monkeypatched to a deterministic fake
+response for every test (supply-chain-hardening H2/H3: byte-capped + time-bound downloads,
+checksum-gated fail-closed installs). `retrieval_late._FETCH_MANIFEST` (the real pinned
+17.2MB/3.5MB/792B manifest) is also monkeypatched to a small synthetic manifest in the tests that
+need a file to actually pass verification -- SHA-256 is preimage-resistant, so there is no way to
+construct a small fake payload that matches the REAL pinned hashes; the checksum-mismatch/atomicity
+tests instead intentionally serve WRONG bytes against the real manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import urllib.request
+from typing import Any
+
+import pytest
+
+from tensor_grep.backends.base import BackendExecutionError
+from tensor_grep.core import retrieval_late
+
+
+class _FakeHTTPResponse:
+    """Duck-typed stand-in for the context-managed object `urllib.request.urlopen` returns."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            chunk = self._data[self._pos :]
+            self._pos = len(self._data)
+            return chunk
+        chunk = self._data[self._pos : self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+def _make_fake_urlopen(payloads: dict[str, bytes]) -> Any:
+    """Build a fake `urlopen(request, timeout=...)` keyed by the request URL's final path
+    segment (the filename) -- looks up `payloads[filename]` and returns it wrapped as a fake
+    HTTP response; raises `KeyError` (a test bug, not a production path) for an unexpected URL.
+    """
+
+    def fake_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        filename = request.full_url.rsplit("/", 1)[-1]
+        return _FakeHTTPResponse(payloads[filename])
+
+    return fake_urlopen
+
+
+def test_fetch_rejects_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # Every file downloads "successfully" (200 OK, bytes returned) but the content does not
+    # match ANY of the real pinned SHA-256 hashes -- must be rejected, not silently accepted.
+    wrong_payloads = {
+        name: b"wrong bytes, not the pinned content for " + name.encode()
+        for name in retrieval_late._FETCH_MANIFEST
+    }
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(wrong_payloads))
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="checksum mismatch"):
+        retrieval_late.fetch_late_model(dest)
+
+    # Fail-closed: no files land, no partial state left behind anywhere under tmp_path.
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_is_atomic_on_partial_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # file_a downloads AND verifies successfully; file_b's declared checksum does not match what
+    # the fake server actually returns. The whole multi-file fetch must be all-or-nothing: even
+    # though file_a is fully valid on its own, its verified bytes must NOT be left behind
+    # anywhere once file_b's failure aborts the overall fetch.
+    good_bytes = b"real verified content for file A"
+    fake_manifest = {
+        "file_a.bin": (hashlib.sha256(good_bytes).hexdigest(), len(good_bytes)),
+        "file_b.bin": (hashlib.sha256(b"the CORRECT content for file B").hexdigest(), 30),
+    }
+    monkeypatch.setattr(retrieval_late, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _make_fake_urlopen({
+            "file_a.bin": good_bytes,
+            "file_b.bin": b"WRONG bytes served for file B!",
+        }),
+    )
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="checksum mismatch"):
+        retrieval_late.fetch_late_model(dest)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_download_error_becomes_backend_execution_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A raw network failure (not a checksum mismatch) must ALSO be wrapped, never propagate as a
+    # bare OSError, and must ALSO leave no partial state behind.
+    def _raising_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        raise OSError("simulated connection reset")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raising_urlopen)
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="simulated connection reset"):
+        retrieval_late.fetch_late_model(dest)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_download_exceeding_byte_cap_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # H2 byte-cap enforcement: shrink the cap to 10 bytes and serve 11 -- must be refused, not
+    # silently truncated or accepted.
+    monkeypatch.setattr(retrieval_late, "_MAX_DOWNLOAD_BYTES", 10)
+    oversized = b"x" * 11
+    first_filename = next(iter(retrieval_late._FETCH_MANIFEST))
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen({first_filename: oversized}))
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="byte cap"):
+        retrieval_late.fetch_late_model(dest)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_respects_TG_RERANK_MODEL_DIR(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    target_dir = tmp_path / "env-configured-model-dir"
+    monkeypatch.setenv("TG_RERANK_MODEL_DIR", str(target_dir))
+
+    fake_payloads = {
+        name: f"synthetic content for {name}".encode() for name in retrieval_late._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_late, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    # No explicit dest_dir -- must fall back to default_model_dir(), which itself must honor
+    # TG_RERANK_MODEL_DIR.
+    result = retrieval_late.fetch_late_model()
+
+    assert result == target_dir
+    for name, data in fake_payloads.items():
+        assert (target_dir / name).read_bytes() == data
+
+
+def test_fetch_succeeds_end_to_end_and_is_idempotent_on_refetch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A full successful fetch, followed by a SECOND successful fetch to the same destination
+    # (e.g. a user re-running `--fetch` to refresh) -- the second run must also succeed and
+    # correctly replace the first install (exercises the "dest already exists" removal path,
+    # which is required on Windows: os.replace cannot overwrite a non-empty directory there).
+    dest = tmp_path / "model-dest"
+    fake_payloads = {
+        name: f"content v1 for {name}".encode() for name in retrieval_late._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_late, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    result1 = retrieval_late.fetch_late_model(dest)
+    assert result1 == dest
+    for name, data in fake_payloads.items():
+        assert (dest / name).read_bytes() == data
+
+    # Re-fetch with DIFFERENT content under the same filenames -- must fully replace, not merge.
+    fake_payloads_v2 = {
+        name: f"content v2 for {name}".encode() for name in retrieval_late._FETCH_MANIFEST
+    }
+    fake_manifest_v2 = {
+        name: (hashlib.sha256(data).hexdigest(), len(data))
+        for name, data in fake_payloads_v2.items()
+    }
+    monkeypatch.setattr(retrieval_late, "_FETCH_MANIFEST", fake_manifest_v2)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads_v2))
+
+    result2 = retrieval_late.fetch_late_model(dest)
+    assert result2 == dest
+    for name, data in fake_payloads_v2.items():
+        assert (dest / name).read_bytes() == data
+
+
+def test_fetch_cli_returns_zero_on_success(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    fake_payloads = {
+        name: f"cli content for {name}".encode() for name in retrieval_late._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_late, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    dest = tmp_path / "cli-model-dest"
+    exit_code = retrieval_late._fetch_cli(["--fetch", "--model-dir", str(dest)])
+
+    assert exit_code == 0
+    for name, data in fake_payloads.items():
+        assert (dest / name).read_bytes() == data
+
+
+def test_fetch_cli_without_fetch_flag_prints_help_and_exits_nonzero() -> None:
+    exit_code = retrieval_late._fetch_cli([])
+    assert exit_code == 2
+
+
+def test_fetch_cli_returns_nonzero_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    def _raising_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        raise OSError("simulated connection reset")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raising_urlopen)
+
+    dest = tmp_path / "cli-model-dest"
+    exit_code = retrieval_late._fetch_cli(["--fetch", "--model-dir", str(dest)])
+
+    assert exit_code == 1
+    assert not dest.exists()


### PR DESCRIPTION
Increment 2 of the late-interaction rerank feature (design: `docs/plans/design-tensor-grep-late-rerank-2026-07-09.md`; builds on the T0-T2 foundation #471). Still **inert/default-OFF** — no seam wiring (T5), no `--rerank` flag (T9); this adds the encoder + the model-fetch behind the `rerank` extra.

- **T3** — ONNX encoder: `late_available()` import probe (onnxruntime+tokenizers), `load_late_model()` (two-tier fail-closed: missing dir → recoverable `LateRerankUnavailableError`; corrupt → `BackendExecutionError`), `build_late_encoder()` (int8 ONNX + `tokenizers`, per-token L2-normalized, 512-token truncation), `load_late_reranker()` wiring the real encoder into `LateReranker`.
- **T4** — checksum-pinned fetch: `python -m tensor_grep.core.retrieval_late --fetch` downloads exactly 3 files from a **pinned HF revision** (`07ef20f4…`, immutable), **SHA-256-verifies each** (fail-closed on mismatch, delete-partial), **bounded** (max bytes + socket timeout), **atomic** (temp → verify-all → rename). Also fixes the ghost `tg index --fetch-model` message in `retrieval_dense.py:95`.

## Verification (real venv)
28 passed, 3 skipped (the 3 real-model tests skip w/o a fetched model); ruff check + `ruff format --preview` + mypy clean. The **harvest caught a real env-dependent bug** the build agent's ad-hoc Python 3.14 hid (a probe test that assumed onnxruntime was installed) — fixed. The build agent independently verified the 3 SHA-256 pins two ways (`hashlib` + `sha256sum`) and ran the real int8 ONNX + MaxSim end-to-end after fetching the actual model.

⚠️ **Network-fetch supply-chain surface — a focused adversarial Opus gate on the checksum path runs before merge.**

## Not in this PR (later): T5-T6 (the `rerank_hybrid` seam + fail-closed CLI wiring), T7 (latency receipt), **T8 (golden-set quality gate = ship/no-ship)**, T9-T10 (`--rerank` registration + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)