### PR TITLE
feat(rerank): wire the late-interaction stage into --semantic behind TG_LATE_RERANK (T5-T6 seam + fail-closed)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3548,8 +3548,23 @@ def _set_semantic_rank_fallback_reason(all_results: "SearchResult") -> None:
         sys.stderr.write(f"tg: {unavailable_reason}\n")
 
 
+def _note_late_rerank_degraded(all_results: "SearchResult", reason: str) -> None:
+    """Append (or set) ``rank_fallback_reason`` for a RECOVERABLE late-rerank degrade (the
+    ``rerank`` extra absent, or the model not fetched) and echo the same ``tg:``-prefixed stderr
+    line the dense leg uses (T6, design doc "Fail-closed contract"). Appends rather than
+    overwrites so a simultaneous dense-leg degrade is never clobbered -- both signals must survive
+    on the returned envelope.
+    """
+    if all_results.rank_fallback_reason:
+        all_results.rank_fallback_reason = f"{all_results.rank_fallback_reason}; {reason}"
+    else:
+        all_results.rank_fallback_reason = reason
+    sys.stderr.write(f"tg: {reason}\n")
+
+
 def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "SearchResult":
-    """Apply the `--semantic` hybrid (BM25 + dense RRF) rerank, fail-closed to BM25-only.
+    """Apply the `--semantic` hybrid (BM25 + dense RRF [+ late MaxSim]) rerank, fail-closed to
+    BM25-only.
 
     The dense leg is best-effort: when the `semantic` extra is absent, the model has not been
     fetched, the model produces a malformed/mismatched embedding, or a query-time dense fault
@@ -3560,6 +3575,16 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
     raises ``BackendExecutionError`` instead of degrading, per the Backend Fail-Closed Contract --
     that is NOT caught here; the caller (the `search` command) must catch it and exit cleanly
     (F4).
+
+    T5/T6 (design doc "The seam" + "Fail-closed contract"): when ``TG_LATE_RERANK=1`` is set, a
+    late-interaction (MaxSim) reranker is built here (``late_available()`` probe, then
+    ``load_late_reranker()``) and passed into the PRIMARY ``rerank_hybrid`` call only -- never
+    into any of the BM25-only degrade retries below, since those already mean the whole hybrid
+    stage bypassed the late stage too (each appends "; late rerank skipped" to its
+    ``rank_fallback_reason`` when late rerank was requested). A RECOVERABLE late-leg failure
+    (extra absent, model not fetched) degrades here exactly like the dense leg; an UNRECOVERABLE
+    ``BackendExecutionError`` (e.g. a corrupt model directory) deliberately propagates, same as
+    the dense leg's.
     """
     from tensor_grep.core.reranker import rerank_hybrid
     from tensor_grep.core.retrieval_bm25 import Bm25Index
@@ -3571,6 +3596,15 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
         dense_available,
         load_dense_model,
     )
+
+    late_rerank_requested = os.environ.get("TG_LATE_RERANK") == "1"
+
+    def _maybe_append_late_skip(reason: str) -> str:
+        """The 3 upstream degrade paths below all BYPASS the late stage entirely (it is only ever
+        wired into the PRIMARY rerank_hybrid call further down) -- when late rerank was
+        requested, say so explicitly rather than leaving the envelope silently ambiguous about
+        why no late reorder happened (T6)."""
+        return f"{reason}; late rerank skipped" if late_rerank_requested else reason
 
     dense_index = None
     available, unavailable_reason = dense_available()
@@ -3592,7 +3626,7 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
             # can still trip it on its own even before the corpus-wide cap below is reached. Either
             # way, degrade to BM25-only (using whatever we already have -- discard the corpus, let
             # rerank_hybrid rebuild its own BM25-only chunks) rather than crash the whole search.
-            all_results.rank_fallback_reason = str(exc)
+            all_results.rank_fallback_reason = _maybe_append_late_skip(str(exc))
             sys.stderr.write(f"tg: {exc}\n")
             return rerank_hybrid(
                 all_results, pattern, all_results.matched_file_paths, dense_index=None
@@ -3604,7 +3638,7 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
                 f"({_SEMANTIC_CORPUS_CHUNK_CAP}) exceeded across the matched file set -- narrow "
                 "the search to fewer files for a semantic rerank"
             )
-            all_results.rank_fallback_reason = reason
+            all_results.rank_fallback_reason = _maybe_append_late_skip(reason)
             sys.stderr.write(f"tg: {reason}\n")
             return rerank_hybrid(
                 all_results, pattern, all_results.matched_file_paths, dense_index=None
@@ -3622,6 +3656,26 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
         # BackendExecutionError (e.g. a corrupt model directory) deliberately propagates: that is
         # an unrecoverable fault the CLI boundary must catch and exit on (F4), not degrade here.
 
+    late_reranker = None
+    if late_rerank_requested:
+        from tensor_grep.core.retrieval_late import (
+            LateRerankUnavailableError,
+            late_available,
+            load_late_reranker,
+        )
+
+        late_ok, late_reason = late_available()
+        if not late_ok:
+            _note_late_rerank_degraded(all_results, late_reason or "late rerank unavailable")
+        else:
+            try:
+                late_reranker = load_late_reranker()
+            except LateRerankUnavailableError as exc:
+                _note_late_rerank_degraded(all_results, str(exc))
+            # BackendExecutionError (e.g. a corrupt model directory) deliberately propagates: an
+            # unrecoverable fault the CLI boundary must catch and exit on, not degrade here --
+            # mirrors the dense leg immediately above.
+
     try:
         return rerank_hybrid(
             all_results,
@@ -3629,13 +3683,15 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
             all_results.matched_file_paths,
             bm25_index=bm25_index,
             dense_index=dense_index,
+            late_reranker=late_reranker,
         )
     except DenseUnavailableError as exc:
         # F1: a query-time dense fault (e.g. a dim mismatch) is raised from INSIDE rerank_hybrid's
         # call to `DenseIndex.query`, outside the try/except above (which only guards index
         # construction). Degrade to BM25-only here too -- reuse the SAME bm25_index (no second
-        # chunk pass) rather than let it traceback.
-        all_results.rank_fallback_reason = str(exc)
+        # chunk pass) rather than let it traceback. This also BYPASSES the late stage (it is only
+        # ever wired into the primary call above, never into this retry).
+        all_results.rank_fallback_reason = _maybe_append_late_skip(str(exc))
         sys.stderr.write(f"tg: {exc}\n")
         return rerank_hybrid(
             all_results,

--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import sys
+import time
 from collections import defaultdict
 
 from tensor_grep.core.result import SearchResult
@@ -19,6 +21,7 @@ from tensor_grep.core.retrieval_bm25 import Bm25Index
 from tensor_grep.core.retrieval_chunker import Chunk, chunk_file
 from tensor_grep.core.retrieval_dense import DenseIndex
 from tensor_grep.core.retrieval_fusion import DEFAULT_K, reciprocal_rank_fusion
+from tensor_grep.core.retrieval_late import LateReranker, LateRerankUnavailableError
 from tensor_grep.core.retrieval_lexical import split_terms
 
 # PR-S2 (channelized RRF, sverklo steal-list #2): a third, opt-in fusion leg that ranks chunks by
@@ -33,6 +36,34 @@ PATH_CHANNEL_WEIGHT: float = 1.5
 
 def _rrf_channels_enabled() -> bool:
     return os.environ.get(_RRF_CHANNELS_ENV) == "1"
+
+
+# T5/T6 (design doc "The seam" + "Fail-closed contract",
+# docs/plans/design-tensor-grep-late-rerank-2026-07-09.md): a 4th, opt-in, ORDER-ONLY stage that
+# MaxSim-reranks the head of the RRF-fused pool via an injected `LateReranker`
+# (core/retrieval_late.py, T0-T4, not modified here). The caller (`_apply_semantic_rerank` in
+# cli/main.py) owns the `TG_LATE_RERANK=1` gate, late-leg availability, and model load; this
+# module only needs the pool size and the latency budget, both read directly from the
+# environment right where they are used (mirrors `_RRF_CHANNELS_ENV` above) so `rerank_hybrid`'s
+# signature gains a single new `late_reranker` kwarg and nothing else has to be threaded through.
+_RERANK_POOL_K_ENV: str = "TG_RERANK_POOL_K"
+_RERANK_BUDGET_MS_ENV: str = "TG_RERANK_BUDGET_MS"
+_DEFAULT_RERANK_POOL_K: int = 50
+_MAX_RERANK_POOL_K: int = 100
+_DEFAULT_RERANK_BUDGET_MS: int = 2000
+
+
+def _int_env(name: str, default: int) -> int:
+    """Parse a numeric ``TG_*`` env var, falling back to ``default`` on any missing or
+    non-numeric value -- a malformed override must degrade gracefully, never crash the whole
+    search (the same fail-closed spirit as the rest of the late-rerank contract)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
 
 
 def _path_channel_ranking(chunks: list[Chunk], query: str) -> list[int]:
@@ -108,6 +139,7 @@ def rerank_hybrid(
     k: int = DEFAULT_K,
     bm25_index: Bm25Index | None = None,
     dense_index: DenseIndex | None = None,
+    late_reranker: LateReranker | None = None,
 ) -> SearchResult:
     """Return a copy of ``result`` re-sorted by best RRF-fused (BM25 + dense) chunk score (desc).
 
@@ -123,6 +155,20 @@ def rerank_hybrid(
     ``weights=None`` exactly as before -- a byte-identical no-op (see
     :func:`~tensor_grep.core.retrieval_fusion.reciprocal_rank_fusion`) -- so this is a zero-risk
     additive change pending a golden-set default-flip in a separate PR.
+
+    ``late_reranker`` (optional, T5, design doc "The seam"): a 4th, ORDER-ONLY stage layered on
+    top of the fused ranking above -- it MaxSim-reranks the head of ``fused_order`` (size
+    ``TG_RERANK_POOL_K``, default 50, hard-capped at 100) and leaves the tail untouched in its RRF
+    order. Same matches, same membership, same JSON shape -- only a permutation of the head.
+    ``late_reranker=None`` (the default) skips this stage entirely: a byte-identical no-op,
+    mirroring ``dense_index=None`` and the ``TG_RRF_CHANNELS`` pattern above. The caller
+    (``_apply_semantic_rerank`` in ``cli/main.py``) owns late-leg availability and model load; a
+    RECOVERABLE failure at rerank time (a malformed embedding shape, or the
+    ``TG_RERANK_BUDGET_MS`` latency budget -- default 2000ms -- exceeded) degrades in-place here
+    to the plain RRF order for that pool and is reported via the returned result's
+    ``rank_fallback_reason`` (appended, never clobbering an existing reason); an UNRECOVERABLE
+    ``BackendExecutionError`` from the injected encoder is NOT caught here and propagates to the
+    CLI boundary, per the Backend Fail-Closed Contract.
 
     NOTE (F15): a BM25-only RRF degrade is NOT byte-identical to :func:`rerank_by_bm25` on a BM25
     SCORE TIE -- RRF breaks ties by ascending chunk index, whereas ``rerank_by_bm25``'s stable sort
@@ -155,6 +201,38 @@ def rerank_hybrid(
             weights.append(PATH_CHANNEL_WEIGHT)
 
     fused_order = reciprocal_rank_fusion(rankings, k=k, weights=weights)
+
+    # T5/T6: the late-interaction splice. Order-only over `fused_order`'s chunk indices -- same
+    # matches, same membership, same JSON shape (design doc "The seam"). `late_reranker=None`
+    # (the default) skips this block entirely: byte-identical to the pre-T5 fused order.
+    late_rank_fallback_reason: str | None = None
+    if late_reranker is not None:
+        pool_k = max(
+            0, min(_int_env(_RERANK_POOL_K_ENV, _DEFAULT_RERANK_POOL_K), _MAX_RERANK_POOL_K)
+        )
+        budget_ms = _int_env(_RERANK_BUDGET_MS_ENV, _DEFAULT_RERANK_BUDGET_MS)
+        head = fused_order[:pool_k]
+        late_rerank_start = time.perf_counter()
+        try:
+            reranked_head = late_reranker.rerank(query, [chunks[i].text for i in head], head)
+        except LateRerankUnavailableError as exc:
+            # RECOVERABLE (e.g. a malformed embedding shape from the injected encoder): degrade
+            # to the plain RRF order for this pool, never crash. A genuine BackendExecutionError
+            # (a real encode-time fault) is deliberately NOT caught here -- it propagates to the
+            # CLI boundary (cli/main.py ~:6804-6813) per the Backend Fail-Closed Contract.
+            late_rank_fallback_reason = str(exc)
+            sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
+        else:
+            elapsed_ms = (time.perf_counter() - late_rerank_start) * 1000.0
+            if elapsed_ms > budget_ms:
+                late_rank_fallback_reason = (
+                    "late rerank unavailable: budget exceeded "
+                    f"({elapsed_ms:.0f}ms > {budget_ms}ms at pool_k={pool_k})"
+                )
+                sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
+            else:
+                fused_order = reranked_head + fused_order[pool_k:]
+
     # Position in the fused order is a monotonic proxy for the underlying RRF score: RRF ties are
     # already broken by ascending chunk index before this list is built, so using position
     # preserves the exact fused ordering while giving `match_score` below a single comparable
@@ -177,4 +255,15 @@ def rerank_hybrid(
 
     # Stable sort by descending fused score (Python's sort is stable -> ties keep grep order).
     reranked = sorted(result.matches, key=match_score, reverse=True)
+    if late_rank_fallback_reason is not None:
+        # Append rather than overwrite: an earlier (e.g. dense-leg) fallback reason must survive
+        # alongside the late-stage one -- see T6's bidirectional invariant (exactly one of "order
+        # provably changed, reason untouched" / "reason non-None" holds; this is the "reason
+        # non-None" side for the late stage specifically).
+        combined_reason = (
+            f"{result.rank_fallback_reason}; {late_rank_fallback_reason}"
+            if result.rank_fallback_reason
+            else late_rank_fallback_reason
+        )
+        return dataclasses.replace(result, matches=reranked, rank_fallback_reason=combined_reason)
     return dataclasses.replace(result, matches=reranked)

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -1,9 +1,14 @@
 """Tests for BM25 re-ranking of an existing SearchResult."""
 
+import time
 from pathlib import Path
 
-from tensor_grep.core.reranker import rerank_by_bm25
+import numpy as np
+
+from tensor_grep.core.reranker import rerank_by_bm25, rerank_hybrid
 from tensor_grep.core.result import MatchLine, SearchResult
+from tensor_grep.core.retrieval_chunker import Chunk
+from tensor_grep.core.retrieval_late import LateReranker, LateRerankUnavailableError
 
 
 def test_rerank_orders_by_bm25_score(tmp_path: Path) -> None:
@@ -62,3 +67,176 @@ def test_rerank_preserves_other_fields(tmp_path: Path) -> None:
 
     assert out.routing_backend == "cpu"
     assert out.total_matches == 1
+
+
+# --- T5/T6: the late-interaction (MaxSim) rerank seam in `rerank_hybrid` --------------------
+# (design doc docs/plans/design-tensor-grep-late-rerank-2026-07-09.md, "The seam" + "Fail-closed
+# contract"). These tests inject a real `LateReranker` (core/retrieval_late.py, T0-T2) wired with
+# a deterministic stub `encode` callable -- no ONNX model, no `rerank` extra required.
+
+
+class _FixedBm25Index:
+    """A minimal ``Bm25Index`` stand-in: a hardcoded query ranking + a chunk list, so a
+    scenario's BM25/RRF order is fully predictable regardless of the real scorer's internals
+    (mirrors ``_FixedVectorModel`` in test_reranker_hybrid.py, which stubs the dense leg the same
+    way)."""
+
+    def __init__(self, chunks: list[Chunk], ranking: list[tuple[int, float]]) -> None:
+        self.chunks = chunks
+        self._ranking = ranking
+
+    def query(self, query: str, *, top_k: int = 10) -> list[tuple[int, float]]:
+        del query  # the stub ignores the query text -- the ranking is hardcoded per scenario
+        return self._ranking[:top_k]
+
+
+def _four_chunk_scenario() -> tuple[SearchResult, _FixedBm25Index]:
+    """4 chunks, a descending BM25 ranking [0, 1, 2, 3] (single leg -> RRF preserves it exactly),
+    and matches supplied in a SCRAMBLED order so a passing test proves the sort actually ran."""
+    chunks = [
+        Chunk(file_path="c0.py", start_line=1, end_line=1, text="chunk zero"),
+        Chunk(file_path="c1.py", start_line=1, end_line=1, text="chunk one"),
+        Chunk(file_path="c2.py", start_line=1, end_line=1, text="chunk two"),
+        Chunk(file_path="c3.py", start_line=1, end_line=1, text="chunk three"),
+    ]
+    bm25_index = _FixedBm25Index(chunks, [(0, 4.0), (1, 3.0), (2, 2.0), (3, 1.0)])
+    result = SearchResult(
+        matches=[
+            MatchLine(line_number=1, text="chunk three", file="c3.py"),
+            MatchLine(line_number=1, text="chunk one", file="c1.py"),
+            MatchLine(line_number=1, text="chunk zero", file="c0.py"),
+            MatchLine(line_number=1, text="chunk two", file="c2.py"),
+        ],
+        total_matches=4,
+    )
+    return result, bm25_index
+
+
+def test_late_reranker_none_is_byte_identical() -> None:
+    """The zero-risk-additive proof (T5): `late_reranker=None` (the default) must be
+    byte-identical to calling `rerank_hybrid` without the kwarg at all -- adding the parameter
+    changes nothing about today's behavior."""
+    result, bm25_index = _four_chunk_scenario()
+
+    without_kwarg = rerank_hybrid(result, "q", [], bm25_index=bm25_index)
+    with_explicit_none = rerank_hybrid(result, "q", [], bm25_index=bm25_index, late_reranker=None)
+
+    assert with_explicit_none == without_kwarg
+    assert with_explicit_none.rank_fallback_reason is None
+
+
+def test_late_reranker_reorders_head_only_tail_stable(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T5 "The seam": the late reranker reorders ONLY the head (size TG_RERANK_POOL_K) of the
+    RRF-fused pool; the tail keeps its RRF order untouched."""
+    monkeypatch.setenv("TG_RERANK_POOL_K", "2")
+    result, bm25_index = _four_chunk_scenario()
+
+    baseline = rerank_hybrid(result, "q", [], bm25_index=bm25_index)
+    assert [m.file for m in baseline.matches] == ["c0.py", "c1.py", "c2.py", "c3.py"]
+
+    # Deterministic stub: "chunk one" scores higher against the query than "chunk zero" ->
+    # MaxSim reverses the [0, 1] head to [1, 0]. Only chunks 0/1 are ever encoded (the head at
+    # pool_k=2), so the stub does not need entries for chunks 2/3.
+    vectors = {"q": [1.0, 0.0], "chunk zero": [0.0, 1.0], "chunk one": [0.7, 0.7]}
+
+    def _encode(text: str) -> np.ndarray:
+        return np.array([vectors[text]], dtype=np.float32)
+
+    out = rerank_hybrid(
+        result, "q", [], bm25_index=bm25_index, late_reranker=LateReranker(encode=_encode)
+    )
+
+    assert [m.file for m in out.matches[:2]] == ["c1.py", "c0.py"]  # head: reordered
+    assert [m.file for m in out.matches[2:]] == ["c2.py", "c3.py"]  # tail: untouched RRF order
+    assert out.rank_fallback_reason is None  # order changed -> reason stays untouched (T6 XOR)
+
+
+def test_late_rerank_same_match_membership() -> None:
+    """T5: the late stage never adds or drops a match -- only reorders (design doc "The seam":
+    "same matches, same membership, same JSON shape")."""
+    chunks = [
+        Chunk(file_path="c0.py", start_line=1, end_line=1, text="chunk zero"),
+        Chunk(file_path="c1.py", start_line=1, end_line=1, text="chunk one"),
+        Chunk(file_path="c2.py", start_line=1, end_line=1, text="chunk two"),
+    ]
+    bm25_index = _FixedBm25Index(chunks, [(0, 3.0), (1, 2.0), (2, 1.0)])
+    result = SearchResult(
+        matches=[
+            MatchLine(line_number=1, text="chunk zero", file="c0.py"),
+            MatchLine(line_number=1, text="chunk one", file="c1.py"),
+            MatchLine(line_number=1, text="chunk two", file="c2.py"),
+        ],
+        total_matches=3,
+    )
+
+    def _encode(text: str) -> np.ndarray:
+        # Arbitrary but deterministic -- this test only cares about membership, not order.
+        return np.array([[float(len(text)), 1.0]], dtype=np.float32)
+
+    baseline = rerank_hybrid(result, "q", [], bm25_index=bm25_index)
+    out = rerank_hybrid(
+        result, "q", [], bm25_index=bm25_index, late_reranker=LateReranker(encode=_encode)
+    )
+
+    assert {m.file for m in out.matches} == {m.file for m in baseline.matches}
+    assert len(out.matches) == len(baseline.matches) == 3
+    assert out.total_matches == baseline.total_matches == 3
+
+
+def test_late_reranker_shape_mismatch_degrades_to_rrf_order_with_reason() -> None:
+    """T6 fail-closed contract: a RECOVERABLE `LateRerankUnavailableError` raised from the
+    injected encoder (e.g. a malformed embedding shape) must degrade to the plain RRF order,
+    never crash, and set `rank_fallback_reason` (the other side of the bidirectional XOR)."""
+    result, bm25_index = _four_chunk_scenario()
+    baseline = rerank_hybrid(result, "q", [], bm25_index=bm25_index)
+
+    def _raising_encode(text: str) -> np.ndarray:
+        raise LateRerankUnavailableError(
+            "late rerank unavailable: malformed embedding shape (test stub)"
+        )
+
+    out = rerank_hybrid(
+        result, "q", [], bm25_index=bm25_index, late_reranker=LateReranker(encode=_raising_encode)
+    )
+
+    assert [m.file for m in out.matches] == [m.file for m in baseline.matches]
+    assert out.rank_fallback_reason is not None
+    assert "malformed embedding shape" in out.rank_fallback_reason
+
+
+def test_late_reranker_budget_exceeded_degrades_to_rrf_order_with_reason(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6 fail-closed contract: exceeding TG_RERANK_BUDGET_MS degrades to the plain RRF order
+    (the reorder is computed but DISCARDED, never applied) and sets `rank_fallback_reason`."""
+    monkeypatch.setenv("TG_RERANK_BUDGET_MS", "1")
+    result, bm25_index = _four_chunk_scenario()
+    baseline = rerank_hybrid(result, "q", [], bm25_index=bm25_index)
+
+    def _slow_encode(text: str) -> np.ndarray:
+        time.sleep(0.05)  # 50ms, comfortably over the 1ms budget
+        return np.array([[1.0, 0.0]], dtype=np.float32)
+
+    out = rerank_hybrid(
+        result, "q", [], bm25_index=bm25_index, late_reranker=LateReranker(encode=_slow_encode)
+    )
+
+    assert [m.file for m in out.matches] == [m.file for m in baseline.matches]
+    assert out.rank_fallback_reason is not None
+    assert "budget exceeded" in out.rank_fallback_reason
+
+
+def test_late_rerank_appends_to_existing_fallback_reason() -> None:
+    """T6: a late-stage degrade must APPEND to (never clobber) a fallback reason the caller
+    already set (e.g. the dense leg's) -- both signals must survive on the returned envelope."""
+    result, bm25_index = _four_chunk_scenario()
+    result.rank_fallback_reason = "semantic ranking unavailable: model2vec not installed"
+
+    def _raising_encode(text: str) -> np.ndarray:
+        raise LateRerankUnavailableError("late rerank unavailable: model not fetched")
+
+    out = rerank_hybrid(
+        result, "q", [], bm25_index=bm25_index, late_reranker=LateReranker(encode=_raising_encode)
+    )
+
+    assert out.rank_fallback_reason is not None
+    assert "model2vec not installed" in out.rank_fallback_reason
+    assert "model not fetched" in out.rank_fallback_reason

--- a/tests/unit/test_search_semantic_rerank.py
+++ b/tests/unit/test_search_semantic_rerank.py
@@ -1,0 +1,222 @@
+"""T5/T6: the late-interaction (MaxSim) rerank stage wired into `tg search --semantic` behind
+`TG_LATE_RERANK=1` (design doc docs/plans/design-tensor-grep-late-rerank-2026-07-09.md, "The
+seam" + "Fail-closed contract").
+
+Mirrors the CliRunner-based patterns in tests/integration/test_semantic_search_flag.py: every
+test here also monkeypatches the DENSE leg to a known-clean, always-succeeding state, so every
+assertion is isolated to the LATE stage specifically rather than confounded by whatever the real
+environment's dense-leg availability happens to be. No `rerank` extra (onnxruntime/tokenizers) or
+fetched model is required -- `load_late_reranker` is monkeypatched to return a `LateReranker`
+wired with a deterministic stub encoder (or to raise, for the fail-closed paths).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+from typer.testing import CliRunner
+
+from tensor_grep.backends.base import BackendExecutionError
+from tensor_grep.cli.main import app
+from tensor_grep.core.retrieval_late import LateReranker
+
+
+class _FakeDenseModel:
+    """A working dense-leg stand-in so the dense leg always contributes cleanly (no fallback
+    reason of its own) -- isolates every assertion below to the LATE stage."""
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
+def _write_corpus(tmp_path: Path) -> None:
+    # dense.py mentions "invoice" 3x (a strong BM25/dense signal); sparse.py mentions it once, in
+    # a comment (a weak signal). Both legs naturally favor dense.py -- tests that need an
+    # OBSERVABLE reorder deliberately invert this via the injected late encoder.
+    dense = tmp_path / "dense.py"
+    dense.write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+    sparse = tmp_path / "sparse.py"
+    sparse.write_text("# one passing invoice mention\nx = 1\n", encoding="utf-8")
+
+
+def _stub_dense_clean(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.load_dense_model", lambda _dir: _FakeDenseModel()
+    )
+
+
+def _prefer_sparse_encode(text: str) -> np.ndarray:
+    """Deliberately inverts the natural BM25/dense preference (see `_write_corpus`) so a
+    reorder's effect is observable regardless of the exact natural fused order: the query text
+    and sparse.py's chunk both align (dot=1.0); dense.py's chunk is orthogonal (dot=0.0)."""
+    if text == "invoice" or "passing invoice mention" in text:
+        return np.array([[1.0, 0.0]], dtype=np.float32)
+    return np.array([[0.0, 1.0]], dtype=np.float32)
+
+
+def test_rerank_env_off_is_noop(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T5: with `TG_LATE_RERANK` unset (the default), the late stage must be a TRUE no-op -- not
+    merely "happens to produce the same order", but never even PROBED. Spy on `late_available`
+    (raising if called) to prove the gate short-circuits before any late-rerank code runs at
+    all."""
+    monkeypatch.delenv("TG_LATE_RERANK", raising=False)
+    _stub_dense_clean(monkeypatch)
+    _write_corpus(tmp_path)
+
+    def _must_not_be_called() -> tuple[bool, str | None]:
+        raise AssertionError("late_available() must not be called when TG_LATE_RERANK is unset")
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", _must_not_be_called)
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+
+    assert result.exception is None, f"late_available() was called: {result.exception!r}"
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is None
+
+
+def test_rerank_budget_exceeded_degrades_with_reason(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6: a stub late reranker that sleeps past `TG_RERANK_BUDGET_MS` must degrade to the plain
+    RRF order (identical to the TG_LATE_RERANK-off baseline) and set `rank_fallback_reason`,
+    never silently apply a slow reorder and never crash."""
+    monkeypatch.setenv("TG_LATE_RERANK", "1")
+    monkeypatch.setenv("TG_RERANK_BUDGET_MS", "1")
+    _stub_dense_clean(monkeypatch)
+    _write_corpus(tmp_path)
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", lambda: (True, None))
+
+    def _slow_encode(text: str) -> np.ndarray:
+        time.sleep(0.05)  # 50ms, comfortably over the 1ms budget
+        return np.array([[1.0, 0.0]], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_late.load_late_reranker",
+        lambda *a, **kw: LateReranker(encode=_slow_encode),
+    )
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "budget exceeded" in result.stderr
+    assert "tg:" in result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is not None
+    assert "budget exceeded" in payload["rank_fallback_reason"]
+
+    # Fail-closed to the plain RRF order: same file order as a TG_LATE_RERANK-off baseline over
+    # the same corpus/query.
+    monkeypatch.delenv("TG_LATE_RERANK", raising=False)
+    baseline = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    baseline_payload = json.loads(baseline.stdout)
+    assert [m["file"] for m in payload["matches"]] == [
+        m["file"] for m in baseline_payload["matches"]
+    ]
+
+
+def test_corrupt_late_model_exits_2(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6: an UNRECOVERABLE BackendExecutionError from `load_late_reranker` (e.g. a corrupt
+    model directory) must exit cleanly with a `tg:` message and exit code 2, never a raw
+    traceback -- mirrors the dense leg's identical contract
+    (test_search_semantic_corrupt_model_dir_exits_cleanly_json)."""
+    monkeypatch.setenv("TG_LATE_RERANK", "1")
+    _stub_dense_clean(monkeypatch)
+    _write_corpus(tmp_path)
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", lambda: (True, None))
+
+    def _raise_corrupt(*_args: object, **_kwargs: object) -> LateReranker:
+        raise BackendExecutionError(
+            "late rerank model at <dir> failed to load (corrupt or incompatible): boom"
+        )
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.load_late_reranker", _raise_corrupt)
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 2, result.output
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean sys.exit(2), got a raw traceback: {result.exception!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "boom" in payload["detail"]
+
+
+def test_corrupt_late_model_exits_2_text_mode(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6, text-mode variant: same clean `tg:`-prefixed message + exit 2, no traceback."""
+    monkeypatch.setenv("TG_LATE_RERANK", "1")
+    _stub_dense_clean(monkeypatch)
+    _write_corpus(tmp_path)
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", lambda: (True, None))
+
+    def _raise_corrupt(*_args: object, **_kwargs: object) -> LateReranker:
+        raise BackendExecutionError(
+            "late rerank model at <dir> failed to load (corrupt or incompatible): boom"
+        )
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.load_late_reranker", _raise_corrupt)
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "invoice", str(tmp_path)])
+    assert result.exit_code == 2, result.output
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean sys.exit(2), got a raw traceback: {result.exception!r}"
+    )
+    assert "tg: late rerank model at <dir> failed to load" in result.stderr
+
+
+def test_rerank_ran_xor_fallback_reason_set(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6 bidirectional invariant: when TG_LATE_RERANK=1 was active, EITHER the order provably
+    changed (reason untouched, i.e. None) XOR `rank_fallback_reason` is non-None. No third
+    state. Exercises both branches against the SAME env-off baseline."""
+    _stub_dense_clean(monkeypatch)
+    _write_corpus(tmp_path)
+
+    monkeypatch.delenv("TG_LATE_RERANK", raising=False)
+    baseline = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert baseline.exit_code == 0, baseline.output
+    baseline_files = [m["file"] for m in json.loads(baseline.stdout)["matches"]]
+
+    # Branch A: the late stage runs successfully and (deliberately) reorders.
+    monkeypatch.setenv("TG_LATE_RERANK", "1")
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", lambda: (True, None))
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_late.load_late_reranker",
+        lambda *a, **kw: LateReranker(encode=_prefer_sparse_encode),
+    )
+    reordered = CliRunner().invoke(
+        app, ["search", "--semantic", "--json", "invoice", str(tmp_path)]
+    )
+    assert reordered.exit_code == 0, reordered.output
+    reordered_payload = json.loads(reordered.stdout)
+    reordered_files = [m["file"] for m in reordered_payload["matches"]]
+    assert reordered_files != baseline_files, "expected the late stage to observably reorder"
+
+    # Branch B: the late stage is unavailable -> degrades to the baseline (RRF) order.
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_late.late_available",
+        lambda: (False, "late rerank unavailable: onnxruntime not installed -- test stub"),
+    )
+    degraded = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert degraded.exit_code == 0, degraded.output
+    degraded_payload = json.loads(degraded.stdout)
+    degraded_files = [m["file"] for m in degraded_payload["matches"]]
+    assert degraded_files == baseline_files, "expected a degrade to fall back to the RRF order"
+
+    # The invariant itself, stated as a literal XOR for both branches.
+    for files, payload in (
+        (reordered_files, reordered_payload),
+        (degraded_files, degraded_payload),
+    ):
+        order_provably_changed = files != baseline_files
+        reason_set = payload.get("rank_fallback_reason") is not None
+        assert order_provably_changed != reason_set, (
+            "bidirectional invariant violated: "
+            f"order_changed={order_provably_changed}, reason_set={reason_set}"
+        )


### PR DESCRIPTION
Increment 3 of the late-interaction rerank feature (design: `docs/plans/design-tensor-grep-late-rerank-2026-07-09.md`; builds on #471 T0-T2 + #472 T3-T4). This is **the seam** — where the rerank finally wires into `--semantic`. Still **default-OFF**: gated behind `TG_LATE_RERANK=1` env, NO `--rerank` flag yet (that's T9), inert until explicitly enabled *and* the model is fetched.

- **T5** — `rerank_hybrid()` gains an optional `late_reranker` kwarg (mirrors `dense_index`); after RRF produces `fused_order` it splices head/tail (`pool_k` top candidates re-ordered by MaxSim, tail keeps RRF order) — **order-only over chunk indices: same matches, same membership, same JSON shape.** Wired in `_apply_semantic_rerank` behind the env gate (mirrors the shipped `TG_RRF_CHANNELS` pattern).
- **T6** — the fail-closed contract: recoverable failures (extra missing / model not fetched / `TG_RERANK_BUDGET_MS` exceeded / shape mismatch) degrade to RRF order + set `rank_fallback_reason` + a `tg:` stderr line; unrecoverable (ONNX load/encode) raises `BackendExecutionError` → exit 2. Bidirectional invariant tested: the stage ran (order changed) XOR `rank_fallback_reason` is set.

## Verification (real venv)
24 tests pass; ruff check + `ruff format --preview` + mypy clean. **Flag-off is provably byte-identical** (`test_late_reranker_none_is_byte_identical` + `test_rerank_env_off_is_noop` spies that `late_available()` is never even called when the env is unset) — zero-risk additive. The build's verify-against-code caught two real bugs (a `Chunk`-vs-`str` type mismatch → `.text`, and a fail-closed path missing its `tg:` stderr line) — both fixed.

## Not in this PR (later): T7 (real-model latency receipt), **T8 (golden-set quality gate = ship/no-ship)**, T9-T10 (`--rerank` registration + docs). The feature stays env-gated-experimental until T8 proves a retrieval-quality lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)