### PR TITLE
fix(agent): scoped-agent + edit-plan validation-plan parity + budget-corroborated confidence (dogfood #84)

### DIFF
--- a/docs/plans/design-tensor-grep-84-validation-plan-parity-2026-07-09.md
+++ b/docs/plans/design-tensor-grep-84-validation-plan-parity-2026-07-09.md
@@ -1,0 +1,42 @@
+# Design — Dogfood #84: scoped-agent / edit-plan empty validation_plan + budget-only confidence drag
+
+**Verdict: GO-WITH-CHANGES.** Fable design 2026-07-09 (agent a88b45b45), live-reproduced on the real gotcontext-saddle repo, every seam file:line-verified. Type: features/quality (NOT security). Load-bearing (repo_map + agent_capsule core); the confidence change is IDF/ranking-fragility-adjacent — gate carefully.
+
+## Convergence (fix lands once in the shared seed builder)
+All 3 surfaces (`tg agent <scope>`, `tg edit-plan`, session/daemon/MCP edit-plan) flow through `_build_edit_plan_seed` (repo_map.py:11143) via `_attach_edit_plan_metadata` (repo_map.py:12315 / 11457) / `build_context_edit_plan_from_map` (session_store.py:902). Capsule reads the plan at agent_capsule.py:1836, re-aligns via `_capsule_validation_alignment` (:248-279), emits at :2186-2188 (plan) / :2204 (confidence) / :2205-2208 (ask_user_before_editing).
+
+## The two bugs (both live-reproduced)
+**Bug A (root cause of the empty plan) — boundary-README trap in `_validation_repo_root` (repo_map.py:8257-8296).** The walk-up breaks at the first dir with a BOUNDARY marker (README.md/.gitignore/LICENSE/AGENTS.md, :8274-8279) BEFORE examining that dir's parent (:8293-8294). `gotcontext-saddle/core/hooks/README.md` traps the walk at `core/hooks` → never reaches root `pyproject.toml`. Cascade: discovery early-returns `[]` (validation_root==scoped_path, :3653-3656); python fallback dies (no markers/tests at the trapped root, :8952-8966); raw detection gets python_detection="heuristic" → no fallback.
+Live receipt: `_validation_repo_root(saddle/core/hooks)` → `core\hooks` (trapped); from `core` → true root. `_validation_plan_and_alignment_for_tests([], repo_root=scope, primary=hook.py)` → `[] / "no-validation"`; same with `repo_root=root` → `['uv run pytest -q'] / "aligned"`.
+
+**Bug B (blocks root-parity) — discovery is JS/TS-only.** `_discover_validation_tests_for_primary_file` skips non-JS/TS: `if current.suffix.lower() not in _JS_TS_SUFFIXES: continue` (repo_map.py:3689-3690). Python discovery never existed (git log: born JS-only, commit fa9cbb0). So even post-Fix-A a scoped python run gets only the repo-scope `uv run pytest -q`, never the per-file `uv run pytest tests/hooks/... -q` root emits.
+
+NOT a --max-files cap, NOT a scope filter: discovery walks the real FS via `_iter_repo_files(validation_root, max_files=512)` (:3674-3678) and already finds out-of-scope tests for JS/TS.
+
+## The fix (smallest change, shared builder)
+**Fix A — strong-boundary qualification (repo_map.py:8288-8289):** a dir becomes `boundary_candidate` only if STRONG — has `.git` (dir/file) OR >=2 distinct boundary markers. `core/hooks` (README only) no longer arms the :8293 break → walk reaches root. Project markers (:8286-8287) still win first. Keep the tempdir guard (:8283-8285) + `boundary_candidate or root` return (:8296). This one function anchors discovery (:3653), python fallback (:8899), suggested-cmd probe (:9031), raw detection (:9174), seed (:10862) — heals all.
+
+**Fix B — Python branch in `_discover_validation_tests_for_primary_file` (repo_map.py:3679-3701):** replace the blanket non-JS/TS `continue` (:3689-3690) — `.py` test files (already `_is_test_file`-gated at :3680) proceed to scoring (:3691-3701, language-neutral); JS/TS keep the node:test gate (:3685-3688). Downstream safe: `.py` tests flow to validation_tests (:10870-10880), `_raw_validation_plan_for_tests` emits pytest unconditionally for `.py` (:9261-9286), root-relative paths (root=`_validation_repo_root`, now correct). No dup fallback (`_ensure_primary_language_validation_fallback` returns once a python step exists, :9087-9090).
+
+**Do NOT change:** the explicit_root detection branch (:9195-9199, protects python-subdir-in-JS-monorepo), the lightweight path (:11268-11283), the JS/TS node:test gate. Scope/ignore: validation walk honors gitignore only, not `--ignore` globs (validation evidence = repo-truth, intended). Session no-walk contract preserved (`_precomputed_validation_files_for_root` short-circuits every walk, :1071-1096; pin test_session_cli.py:493-538).
+
+## The confidence fix (finding 3) — capped corroboration channel
+Mechanism: default max_tokens=1200 → primary snippet cut → `capsule_primary_file_omitted` → `_confidence` floors overall=0.55 (agent_capsule.py:1554-1557). The existing uplift (`_apply_capsule_token_budget_confidence_uplift`, :1669/:2092) requires call_site_evidence.status=="collected" (:1666), which a non-symbol query ("audit gotcontext read gate") can't earn (:475-479). So a populated plan buys nothing.
+**Change:** in `_capsule_token_budget_uplift_eligible` (:1606-1666), accept an alternative: `targeted_validation_evidence` non-empty (`_targeted_validation_evidence` :351-364 — steps scope in {symbol,file} + non-empty target + confidence>=0.7) AND alignment "aligned" or ("mismatch-filtered" & kept>0). Thread `targeted_validation_evidence` (:1938) + `validation_alignment_status` (:1936) into the :2092 call.
+**Threshold (ranking-fragility lens):** uplift to `_CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP=0.75` (:32, below the graph-corroborated 0.8 at :38). 0.75 meets the no-ask threshold (:2055-2056). Append a channel-distinct reason for telemetry. NON-relaxations kept verbatim: scan-truncation (:1639), no-snippets (:1641), genuine-misroute (:1643-1650), tie (:1651), non-budget reasons (:1659-1663), query-overlap (:1664). A repo-scope `uv run pytest -q` @0.55 step is NOT targeted evidence → plans with only the fallback never uplift. Fix A+B alone also clears the scoped `ask_user_before_editing: required`-for-no-evidence (:2043-2052).
+
+## Contract safety
+Envelope additive-value-only (no schema change). Pins that stay green (verified): fail-closed no-evidence test_validation_commands.py:687-707 (still []); scoped fixtures :1066-1130 (no subdir README → unaffected; python one gets stronger); test_trust_planning.py:370-387; the 3 uplift/floor pins test_agent_capsule_token_budget_confidence.py:119-218 (test-2 fixture is repo-scope/0.55 → new channel doesn't flip it; test-3 misroute untouched); session no-walk :493-538. NO existing test pins the README-trap empty behavior → only NEW tests. Update any drifted pin in the same PR.
+
+## TDD tasks (each red->green; gate uv run --no-sync)
+1. Unit: `_validation_repo_root(core/hooks with README + root pyproject)` returns root (red today) + companions (git-top-stop, lone-subdir-README, tempdir guard).
+2. Implement Fix A (:8288-8289) -> 1 green.
+3. Unit: python discovery — `scoped/` (WITH README) + root pyproject + sibling `tests/test_<stem>.py`; discovery returns the test (red today); JS/TS gate unchanged.
+4. Implement Fix B (:3685-3690) -> 3 green.
+5. E2E headline: `build_agent_capsule("do thing", scoped_dir)` -> validation_plan has a pytest step scope=="file", root-relative target, detection=="detected"; validation_commands non-empty; ask_user_before_editing lacks "no validation command evidence". Mirror through build_context_edit_plan (finding-2 parity).
+6. Confidence: (a) targeted step (scope:file, target:tests/test_handler.py, 0.82, aligned) + budget-cut + non-symbol query -> overall==0.75, required False, channel reason; (b) repo-scope step -> <=0.55, required True; (c) targeted + misroute -> floored; (d) existing 3 untouched-green.
+7. Implement the confidence change (:1606/1666/1669/2092 threading) -> 6 green.
+8. Regression sweep (test_validation_commands, test_agent_capsule_token_budget_confidence, test_trust_planning, test_session_cli, test_harness_api_docs) + full suite + REAL-BINARY dogfood `tg agent core/hooks "audit gotcontext read gate" --json` on gotcontext-saddle (CliRunner insufficient).
+
+## Biggest risk + guard
+The confidence change masking a genuine low-confidence case (a wrong-but-plausible primary whose stem matches a real test file gains "targeted evidence"). Guards: every genuine-ambiguity disqualifier retained verbatim (:1639-1663); channel only relieves the BUDGET-only clamp; 0.75 < graph-corroborated 0.8; repo-scope fallbacks never qualify; TDD 6b/6c pin the floor for the masking scenarios. Residual (accepted/documented): a vendored subtree with README+LICENSE (>=2 markers) still arms the old trap — but such subtrees usually carry their own project marker anyway.

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -1603,6 +1603,26 @@ def _capsule_primary_omission_is_token_budget_only(consistency: dict[str, Any]) 
     )
 
 
+def _targeted_validation_corroboration_qualifies(
+    targeted_validation_evidence: list[str],
+    validation_alignment_status: str,
+    validation_kept_count: int,
+) -> bool:
+    """Dogfood #84: the SECOND corroboration channel for the token-budget uplift, alongside
+    verified call-site evidence. `targeted_validation_evidence` (`_targeted_validation_evidence`)
+    is non-empty only for steps SCOPED to the primary (symbol/file, non-empty target,
+    confidence>=0.7) -- a repo-scope fallback step (e.g. `uv run pytest -q` @ 0.55) can never
+    populate it, so it can never qualify here either. The alignment check mirrors the tie-break
+    use of the same evidence elsewhere in this module: "aligned", or "mismatch-filtered" with at
+    least one step actually kept for the primary's language.
+    """
+    if not targeted_validation_evidence:
+        return False
+    if validation_alignment_status == "aligned":
+        return True
+    return validation_alignment_status == "mismatch-filtered" and validation_kept_count > 0
+
+
 def _capsule_token_budget_uplift_eligible(
     *,
     query: str,
@@ -1611,6 +1631,9 @@ def _capsule_token_budget_uplift_eligible(
     consistency: dict[str, Any],
     call_site_evidence: dict[str, Any],
     scan_truncated: bool,
+    targeted_validation_evidence: list[str],
+    validation_alignment_status: str,
+    validation_kept_count: int,
 ) -> bool:
     """T2: eligibility for the corroborated-resolution uplift, covering BOTH the original
     capsule-own-budget primary omission (F4) and a render-truncated-only cut where the primary's
@@ -1620,7 +1643,7 @@ def _capsule_token_budget_uplift_eligible(
     selected/rendered at all, an unresolved alternative-target tie, an unrequested marker-helper
     demotion, or any downgrade reason outside the render/token-budget family (language mismatch,
     validation misalignment, ...). Only a target independently corroborated by the query AND by
-    verified call-site evidence is eligible.
+    EITHER verified call-site evidence OR targeted validation evidence (dogfood #84) is eligible.
 
     PR-1 (1D): a TRUNCATED repo scan (`scan_truncated`, from `_capsule_scan_incomplete` on the
     inner context-render payload) is ALSO a first-class disqualifier, checked first -- the ranking
@@ -1635,6 +1658,13 @@ def _capsule_token_budget_uplift_eligible(
     make the check disqualify itself. Every genuine (non-budget) cause of that flag already leaves
     its own specific, non-generic text in `consistency["downgrade_reasons"]` (trust mismatches) or
     is checked explicitly above (ties, marker-helper demotion, never-ranked primary).
+
+    Dogfood #84: EVERY disqualifier above this point gates BOTH corroboration channels
+    identically -- the targeted-validation channel added below is only an alternative to the
+    FINAL `call_site_evidence` check, never a bypass of scan-truncation, no-snippets, genuine
+    misroute, alternative-target tie, marker-helper demotion, any non-budget downgrade reason, or
+    the query-overlap check. This is deliberate: a validation step matching a WRONG primary's stem
+    by coincidence must not corroborate anything the query itself never named.
     """
     if scan_truncated:
         return False
@@ -1663,7 +1693,13 @@ def _capsule_token_budget_uplift_eligible(
         return False
     if not _primary_target_matches_query(query, target):
         return False
-    return call_site_evidence.get("status") == "collected"
+    if call_site_evidence.get("status") == "collected":
+        return True
+    return _targeted_validation_corroboration_qualifies(
+        targeted_validation_evidence,
+        validation_alignment_status,
+        validation_kept_count,
+    )
 
 
 def _apply_capsule_token_budget_confidence_uplift(
@@ -1678,6 +1714,9 @@ def _apply_capsule_token_budget_confidence_uplift(
     call_site_evidence: dict[str, Any],
     ask_reasons: list[str],
     scan_truncated: bool,
+    targeted_validation_evidence: list[str],
+    validation_alignment_status: str,
+    validation_kept_count: int,
 ) -> None:
     """Uplift a render/token-budget-only confidence clamp for a CORROBORATED resolution -- never
     for a genuine misroute or a genuine ambiguity (see `_capsule_token_budget_uplift_eligible`).
@@ -1688,6 +1727,15 @@ def _apply_capsule_token_budget_confidence_uplift(
     render/token-budget artifacts, not resolution-quality signals, so both are eligible for the
     same corroborated-resolution relief up to `_CAPSULE_GRAPH_CORROBORATED_CONFIDENCE_CAP`.
 
+    Dogfood #84: eligibility is now shared by TWO corroboration channels -- verified call-site
+    evidence (the original, strongest signal) and targeted validation evidence (a scoped pytest/
+    jest/etc step that actually names the primary as its target). They are NOT treated as equally
+    strong: the call-site channel keeps the higher `_CAPSULE_GRAPH_CORROBORATED_CONFIDENCE_CAP`
+    (0.8), while a targeted-validation-only corroboration is capped at the lower, historical
+    `_CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP` (0.75) -- still enough to clear the >=0.75
+    no-ask threshold, but deliberately short of the graph-corroborated ceiling. Each channel also
+    gets its own channel-distinct downgrade-reason text for telemetry.
+
     STRUCTURAL note: this must run AFTER `_collect_capsule_call_site_evidence` (agent_capsule.py
     call order), since verified caller evidence -- the corroboration this uplift depends on --
     isn't available until that call returns. It mutates `confidence`, `target`, `alternatives`,
@@ -1695,8 +1743,8 @@ def _apply_capsule_token_budget_confidence_uplift(
     reflects the uplift without re-deriving `ask_user_before_editing` from scratch.
     """
     current_overall = float(confidence.get("overall", 0.0))
-    uplift_cap = _CAPSULE_GRAPH_CORROBORATED_CONFIDENCE_CAP
-    if current_overall >= uplift_cap:
+    max_possible_uplift_cap = _CAPSULE_GRAPH_CORROBORATED_CONFIDENCE_CAP
+    if current_overall >= max_possible_uplift_cap:
         return
     if not _capsule_token_budget_uplift_eligible(
         query=query,
@@ -1705,8 +1753,23 @@ def _apply_capsule_token_budget_confidence_uplift(
         consistency=consistency,
         call_site_evidence=call_site_evidence,
         scan_truncated=scan_truncated,
+        targeted_validation_evidence=targeted_validation_evidence,
+        validation_alignment_status=validation_alignment_status,
+        validation_kept_count=validation_kept_count,
     ):
         return
+    call_site_corroborated = call_site_evidence.get("status") == "collected"
+    if call_site_corroborated:
+        uplift_cap = _CAPSULE_GRAPH_CORROBORATED_CONFIDENCE_CAP
+        channel_reason = (
+            "token budget limited rendering only; confidence reflects graph-corroborated resolution"
+        )
+    else:
+        uplift_cap = _CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP
+        channel_reason = (
+            "token budget limited rendering only; confidence reflects validation-corroborated "
+            "resolution"
+        )
     uplifted = round(min(uplift_cap, confidence_cap), 3)
     if uplifted <= current_overall:
         return
@@ -1716,9 +1779,7 @@ def _apply_capsule_token_budget_confidence_uplift(
         for reason in confidence.get("downgrade_reasons", [])
         if reason not in _CAPSULE_BUDGET_ONLY_DOWNGRADE_REASONS
     ]
-    remaining_reasons.append(
-        "token budget limited rendering only; confidence reflects graph-corroborated resolution"
-    )
+    remaining_reasons.append(channel_reason)
     confidence["downgrade_reasons"] = remaining_reasons
     consistency["capsule_token_budget_confidence_uplifted"] = True
     consistency["confidence_basis"] = "resolution-quality"
@@ -2100,6 +2161,9 @@ def build_agent_capsule(
         call_site_evidence=call_site_evidence,
         ask_reasons=ask_reasons,
         scan_truncated=scan_truncated,
+        targeted_validation_evidence=targeted_validation_evidence,
+        validation_alignment_status=validation_alignment_status,
+        validation_kept_count=validation_kept_count,
     )
     # DAR (arxiv steal #4): runs AFTER call-site collection so it can dedupe against
     # `related_call_sites`, and deliberately does NOT touch `target`/`confidence`/`consistency`/

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -3686,7 +3686,13 @@ def _discover_validation_tests_for_primary_file(
             str(resolved)
         ):
             continue
-        if current.suffix.lower() not in _JS_TS_SUFFIXES:
+        # F84 Fix B: discovery used to be JS/TS-only -- every non-JS/TS candidate (including a
+        # `.py` test file that already passed the `_is_test_file` gate above) was silently
+        # dropped here, so a scoped python primary never got a targeted per-file validation
+        # step even once Fix A let the walk reach the real root. `.py` test files now fall
+        # through to the language-neutral scoring below; the JS/TS node:test gate above is
+        # unchanged, and every other language is still excluded.
+        if current.suffix.lower() not in _JS_TS_SUFFIXES and current.suffix.lower() != ".py":
             continue
         current_path = str(resolved)
         score = _score_file_path(current_path, terms)
@@ -8285,7 +8291,16 @@ def _validation_repo_root(repo_root: str | Path) -> Path:
             break
         if any((current / marker).exists() for marker in markers):
             return current
-        if any((current / marker).exists() for marker in boundary_markers):
+        # F84 Fix A: a directory is only a STRONG boundary -- and thus allowed to trap the
+        # walk-up before its parent is examined -- when it has `.git` (dir or file, the
+        # definitive repo-root signal every other tool uses) OR carries >=2 distinct boundary
+        # markers. A LONE README.md/.gitignore/LICENSE/AGENTS.md living in a scoped
+        # subdirectory used to trap the walk one level too early (the boundary-README trap),
+        # so a single marker is no longer sufficient on its own.
+        matched_boundary_markers = sum(
+            1 for marker in boundary_markers if (current / marker).exists()
+        )
+        if (current / ".git").exists() or matched_boundary_markers >= 2:
             boundary_candidate = current
         if current.parent == current:
             break

--- a/tests/unit/test_agent_capsule_token_budget_confidence.py
+++ b/tests/unit/test_agent_capsule_token_budget_confidence.py
@@ -216,3 +216,162 @@ def test_capsule_keeps_safety_floor_for_genuine_misroute_even_with_corroboration
     assert payload["context_consistency"]["primary_file_included"] is False
     assert payload["confidence"]["overall"] <= 0.55
     assert payload["ask_user_before_editing"]["required"] is True
+
+
+# --- Dogfood #84: budget-only confidence drag, corroborated by TARGETED validation evidence ---
+# The uplift above only fires when blast-radius call-site collection succeeds, which itself
+# requires the query to EXACTLY name the primary symbol (`_target_symbol_was_explicitly_requested`
+# -> `repo_map._symbol_name_matches_query_exactly`). A natural-language query like "update the
+# request handler" never earns that exact match, so a populated, targeted validation_plan bought
+# nothing -- the capsule sat at the 0.55 floor and demanded confirmation even though a real,
+# scoped test file corroborates the primary target. Fix: `_capsule_token_budget_uplift_eligible`
+# also accepts non-empty `targeted_validation_evidence` (scope in {symbol,file}, non-empty target,
+# confidence>=0.7) with an "aligned"/"mismatch-filtered-with-kept" alignment as an alternative
+# corroboration channel, capped at the LOWER `_CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP` (0.75)
+# -- below the call-site channel's 0.8 -- with its own channel-distinct downgrade reason. Every
+# other disqualifier (scan-truncation, no-snippets, genuine-misroute, tie, non-budget reasons,
+# query-overlap) is retained VERBATIM and gates this new channel exactly like the old one.
+
+_TARGETED_VALIDATION_STEP = {
+    "runner": "pytest",
+    "scope": "file",
+    "target": "tests/test_handler.py",
+    "command": "uv run pytest tests/test_handler.py -q",
+    "confidence": 0.82,
+    "detection": "detected",
+}
+_REPO_SCOPE_VALIDATION_STEP = {
+    "runner": "pytest",
+    "scope": "repo",
+    "target": "",
+    "command": "uv run pytest -q",
+    "confidence": 0.55,
+    "detection": "detected",
+}
+# Query deliberately does NOT exactly name `_PRIMARY_SYMBOL` (proven by
+# `test_capsule_keeps_safety_floor_when_symbol_not_named_and_no_call_sites` above to leave
+# call_site_evidence uncollected) while still token-overlapping the "handler" file stem, so the
+# shared query-overlap disqualifier (`_primary_target_matches_query`) still passes.
+_NON_SYMBOL_QUERY = "update the request handler"
+
+
+def _context_payload_with_validation_plan(
+    *,
+    primary_file: Path,
+    caller_file: Path,
+    primary_symbol: str,
+    validation_plan: list[dict[str, Any]],
+    validation_alignment: dict[str, Any],
+) -> dict[str, Any]:
+    payload = _context_payload(
+        primary_file=primary_file,
+        caller_file=caller_file,
+        primary_symbol=primary_symbol,
+    )
+    commands = [str(step["command"]) for step in validation_plan]
+    payload["validation_commands"] = commands
+    payload["edit_plan_seed"]["validation_plan"] = validation_plan
+    payload["edit_plan_seed"]["validation_commands"] = commands
+    payload["edit_plan_seed"]["validation_alignment"] = validation_alignment
+    return payload
+
+
+def test_capsule_uplifts_confidence_for_corroborated_targeted_validation_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _write_project(tmp_path)
+    monkeypatch.setattr(
+        repo_map,
+        "build_context_render",
+        lambda *args, **kwargs: _context_payload_with_validation_plan(
+            primary_file=paths["handler"].resolve(),
+            caller_file=paths["caller"].resolve(),
+            primary_symbol=_PRIMARY_SYMBOL,
+            validation_plan=[_TARGETED_VALIDATION_STEP],
+            validation_alignment={"status": "aligned", "kept_count": 1, "filtered_count": 0},
+        ),
+    )
+
+    payload = agent_capsule.build_agent_capsule(
+        _NON_SYMBOL_QUERY,
+        paths["project"],
+        max_tokens=200,
+    )
+
+    # Corroboration held via the validation channel, not call-site evidence.
+    assert payload["context_consistency"]["capsule_primary_file_omitted"] is True
+    assert payload["call_site_evidence"]["status"] != "collected"
+    # Capped at the LOWER targeted-validation ceiling, not the 0.8 graph-corroborated one.
+    assert payload["confidence"]["overall"] == 0.75
+    assert payload["primary_target"]["confidence"] == 0.75
+    assert payload["ask_user_before_editing"]["required"] is False
+    assert any(
+        "validation-corroborated" in reason for reason in payload["confidence"]["downgrade_reasons"]
+    )
+
+
+def test_capsule_repo_scope_step_never_earns_targeted_validation_uplift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard paired with the positive case above: an UN-targeted repo-scope step (the same shape
+    `_ensure_primary_language_validation_fallback` emits, e.g. `uv run pytest -q` @ 0.55) must
+    NEVER qualify as targeted evidence, even under the exact same corroboration-permissive query
+    and fixture -- this is the trap the confidence fix must not reopen."""
+    paths = _write_project(tmp_path)
+    monkeypatch.setattr(
+        repo_map,
+        "build_context_render",
+        lambda *args, **kwargs: _context_payload_with_validation_plan(
+            primary_file=paths["handler"].resolve(),
+            caller_file=paths["caller"].resolve(),
+            primary_symbol=_PRIMARY_SYMBOL,
+            validation_plan=[_REPO_SCOPE_VALIDATION_STEP],
+            validation_alignment={"status": "aligned", "kept_count": 1, "filtered_count": 0},
+        ),
+    )
+
+    payload = agent_capsule.build_agent_capsule(
+        _NON_SYMBOL_QUERY,
+        paths["project"],
+        max_tokens=200,
+    )
+
+    assert payload["context_consistency"]["capsule_primary_file_omitted"] is True
+    assert payload["call_site_evidence"]["status"] != "collected"
+    assert payload["confidence"]["overall"] <= 0.55
+    assert payload["ask_user_before_editing"]["required"] is True
+
+
+def test_capsule_keeps_safety_floor_for_misroute_even_with_targeted_validation_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuine misroute (`primary_file_included` False) must stay floored even when a strong
+    targeted validation step is present -- the new channel must not leak through the
+    genuine-misroute disqualifier any more than the call-site channel could."""
+    paths = _write_project(tmp_path)
+
+    def fake_context_render(*args: object, **kwargs: object) -> dict[str, Any]:
+        payload = _context_payload_with_validation_plan(
+            primary_file=paths["handler"].resolve(),
+            caller_file=paths["caller"].resolve(),
+            primary_symbol=_PRIMARY_SYMBOL,
+            validation_plan=[_TARGETED_VALIDATION_STEP],
+            validation_alignment={"status": "aligned", "kept_count": 1, "filtered_count": 0},
+        )
+        payload["context_consistency"] = {
+            "primary_file_included": False,
+            "rendered_context_includes_primary": False,
+        }
+        return payload
+
+    monkeypatch.setattr(repo_map, "build_context_render", fake_context_render)
+
+    payload = agent_capsule.build_agent_capsule(
+        _PRIMARY_SYMBOL,
+        paths["project"],
+        max_tokens=200,
+    )
+
+    assert payload["context_consistency"]["primary_file_included"] is False
+    assert payload["confidence"]["overall"] <= 0.55
+    assert payload["ask_user_before_editing"]["required"] is True

--- a/tests/unit/test_validation_commands.py
+++ b/tests/unit/test_validation_commands.py
@@ -1128,3 +1128,231 @@ def test_agent_capsule_scoped_python_repo_yields_root_test_suggestion(tmp_path: 
     assert suggested[0]["target_test"] == "tests/test_foo.py"
     assert suggested[0]["verified"] is False
     assert suggested[0]["command"] not in payload["validation_commands"]
+
+
+# --- Dogfood #84: scoped-agent / edit-plan validation_plan parity ---------------------------
+# Bug A (README boundary-trap): `_validation_repo_root`'s walk-up used to stop at the FIRST
+# directory carrying even a single boundary marker (README.md/.gitignore/LICENSE/AGENTS.md)
+# before ever examining that directory's parent -- so a scoped subdirectory with its own
+# README.md never reached the real project root (pyproject.toml etc.), and validation discovery
+# silently early-returned []. Fix A: a directory only becomes a strong `boundary_candidate` when
+# it has `.git` (dir/file) OR >=2 distinct boundary markers -- a lone README no longer traps the
+# walk, while a genuine repo/package boundary still does.
+
+
+def test_validation_repo_root_lone_boundary_marker_does_not_trap_walk(tmp_path: Path) -> None:
+    """Bug A headline repro: a README.md living IN the scoped directory used to trap the walk
+    before it ever reached the root pyproject.toml two levels up."""
+    project = tmp_path / "project"
+    hooks_dir = project / "core" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        "[project]\nname = 'sample'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+    (hooks_dir / "README.md").write_text("hooks module\n", encoding="utf-8")
+
+    result = repo_map._validation_repo_root(hooks_dir)
+
+    assert result == project.resolve()
+
+
+def test_validation_repo_root_git_directory_alone_is_a_strong_boundary(tmp_path: Path) -> None:
+    """Companion (git-top-stop): unlike a lone README, a `.git` directory by itself IS a strong
+    boundary -- the walk must stop there even though a grandparent also carries a project
+    marker, matching how every other tool treats `.git` as the definitive repo-root signal."""
+    project = tmp_path / "project"
+    hooks_dir = project / "core" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (project / ".git").mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'outside'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+
+    result = repo_map._validation_repo_root(hooks_dir)
+
+    assert result == project.resolve()
+
+
+def test_validation_repo_root_two_boundary_markers_still_trap_walk(tmp_path: Path) -> None:
+    """Companion: a directory with TWO distinct boundary markers is a genuinely strong boundary
+    (e.g. a vendored subtree carrying its own README + LICENSE) and must still trap the walk --
+    Fix A only exempts a LONE marker, it does not remove the boundary-trap mechanism entirely."""
+    project = tmp_path / "project"
+    hooks_dir = project / "core" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        "[project]\nname = 'sample'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+    (hooks_dir / "README.md").write_text("hooks module\n", encoding="utf-8")
+    (hooks_dir / "LICENSE").write_text("MIT\n", encoding="utf-8")
+
+    result = repo_map._validation_repo_root(hooks_dir)
+
+    assert result == hooks_dir.resolve()
+
+
+def test_validation_repo_root_tempdir_guard_blocks_marker_above_temp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Companion (tempdir guard): the walk must never climb PAST the OS temp root looking for a
+    marker, even when Fix A's relaxed single-marker rule would otherwise let it keep going."""
+    fake_temp_root = tmp_path / "faketemp"
+    fake_temp_root.mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'outside'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+    scoped = fake_temp_root / "scoped"
+    scoped.mkdir()
+    monkeypatch.setattr(repo_map.tempfile, "gettempdir", lambda: str(fake_temp_root))
+
+    result = repo_map._validation_repo_root(scoped)
+
+    assert result == scoped.resolve()
+
+
+# Bug B (JS/TS-only discovery): `_discover_validation_tests_for_primary_file` skipped every
+# candidate test file whose suffix wasn't JS/TS, so a scoped python run never found its sibling
+# `tests/test_<stem>.py` even once Fix A let the walk reach the real root. Fix B: let `.py` test
+# files (already `_is_test_file`-gated) fall through to the language-neutral scoring; the JS/TS
+# node:test gate is untouched.
+
+
+def test_discover_validation_tests_for_primary_file_finds_python_sibling_test(
+    tmp_path: Path,
+) -> None:
+    """Bug B headline repro: with Fix A in place the walk reaches `project` (root pyproject.toml)
+    from a README-carrying scoped directory, but discovery still needs Fix B to actually return
+    the sibling python test instead of silently dropping every non-JS/TS candidate."""
+    project = tmp_path / "project"
+    scoped = project / "scoped"
+    scoped.mkdir(parents=True)
+    (scoped / "README.md").write_text("scoped readme\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text(
+        "[project]\nname = 'sample'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+    tests_dir = project / "tests"
+    tests_dir.mkdir()
+    primary_file = scoped / "widget.py"
+    primary_file.write_text("def create_widget():\n    return 1\n", encoding="utf-8")
+    test_file = tests_dir / "test_widget.py"
+    test_file.write_text("def test_create_widget():\n    assert True\n", encoding="utf-8")
+
+    discovered = repo_map._discover_validation_tests_for_primary_file(
+        scoped,
+        str(primary_file),
+        primary_symbol_name="create_widget",
+        query="create widget",
+        limit=5,
+    )
+
+    assert str(test_file.resolve()) in discovered
+
+
+def test_discover_validation_tests_for_primary_file_still_gates_non_node_test_js_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Companion: Fix B must not loosen the pre-existing JS/TS node:test gate -- a JS/TS test
+    file that does NOT use node:test is still excluded from discovery."""
+    project = tmp_path / "project"
+    scoped = project / "scoped"
+    scoped.mkdir(parents=True)
+    (project / "package.json").write_text("{}\n", encoding="utf-8")
+    tests_dir = project / "tests"
+    tests_dir.mkdir()
+    primary_file = scoped / "widget.ts"
+    primary_file.write_text("export function createWidget() { return 1; }\n", encoding="utf-8")
+    test_file = tests_dir / "widget.test.ts"
+    test_file.write_text("test('widget', () => expect(1).toBe(1));\n", encoding="utf-8")
+    monkeypatch.setattr(repo_map, "_javascript_test_file_uses_node_test", lambda _path: False)
+
+    discovered = repo_map._discover_validation_tests_for_primary_file(
+        scoped,
+        str(primary_file),
+        primary_symbol_name="createWidget",
+        query="create widget",
+        limit=5,
+    )
+
+    assert str(test_file.resolve()) not in discovered
+
+
+# E2E headline (both fixes together) + the edit-plan surface mirror -- Fix A + Fix B both land in
+# the shared `_build_edit_plan_seed` builder, so a single fix heals `tg agent <scope>` (via
+# `build_agent_capsule` -> `build_context_render`) AND `tg edit-plan` (via
+# `build_context_edit_plan`) at once.
+
+
+def test_agent_capsule_scoped_python_readme_trap_yields_targeted_validation_plan(
+    tmp_path: Path,
+) -> None:
+    """E2E headline for dogfood #84: before both fixes, a scoped `tg agent core/hooks ...` run
+    on a repo with a hooks-local README.md got an EMPTY validation_plan (Bug A trapped discovery
+    at the scoped dir; Bug B would have dropped the python sibling test even if it hadn't)."""
+    from tensor_grep.cli.agent_capsule import build_agent_capsule
+
+    project = tmp_path / "project"
+    hooks_dir = project / "core" / "hooks"
+    tests_dir = project / "tests" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        "[project]\nname = 'sample'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+    (hooks_dir / "README.md").write_text("hooks module\n", encoding="utf-8")
+    (hooks_dir / "hook_handler.py").write_text(
+        "def do_thing():\n    return True\n", encoding="utf-8"
+    )
+    (tests_dir / "test_hook_handler.py").write_text(
+        "def test_do_thing():\n    assert True\n", encoding="utf-8"
+    )
+
+    payload = build_agent_capsule("do thing", str(hooks_dir))
+
+    validation_plan = payload["validation_plan"]
+    pytest_file_steps = [
+        step
+        for step in validation_plan
+        if step.get("runner") == "pytest" and step.get("scope") == "file"
+    ]
+    assert pytest_file_steps, f"expected a file-scoped pytest step, got {validation_plan!r}"
+    target = str(pytest_file_steps[0]["target"])
+    assert not Path(target).is_absolute(), f"target must be root-relative, got {target!r}"
+    assert pytest_file_steps[0]["detection"] == "detected"
+    assert payload["validation_commands"]
+    ask_reasons = payload["ask_user_before_editing"]["reasons"]
+    assert "no validation command evidence" not in ask_reasons
+
+
+def test_build_context_edit_plan_mirrors_scoped_python_readme_trap_fix(tmp_path: Path) -> None:
+    """Finding-2 parity: `tg edit-plan` (`build_context_edit_plan`) flows through the same shared
+    seed builder as `build_agent_capsule` above, so the same scoped README-trap fixture must heal
+    there too."""
+    project = tmp_path / "project"
+    hooks_dir = project / "core" / "hooks"
+    tests_dir = project / "tests" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        "[project]\nname = 'sample'\nversion = '0.1.0'\n", encoding="utf-8"
+    )
+    (hooks_dir / "README.md").write_text("hooks module\n", encoding="utf-8")
+    (hooks_dir / "hook_handler.py").write_text(
+        "def do_thing():\n    return True\n", encoding="utf-8"
+    )
+    (tests_dir / "test_hook_handler.py").write_text(
+        "def test_do_thing():\n    assert True\n", encoding="utf-8"
+    )
+
+    payload = repo_map.build_context_edit_plan("do thing", hooks_dir)
+
+    validation_plan = payload["edit_plan_seed"]["validation_plan"]
+    pytest_file_steps = [
+        step
+        for step in validation_plan
+        if step.get("runner") == "pytest" and step.get("scope") == "file"
+    ]
+    assert pytest_file_steps, f"expected a file-scoped pytest step, got {validation_plan!r}"
+    assert not Path(pytest_file_steps[0]["target"]).is_absolute()
+    assert payload["validation_commands"]


### PR DESCRIPTION
## What

Dogfood #84 (gotcontext-saddle, CEO-relayed on tg 1.51.7 + re-confirmed on 1.54.0): `tg agent <scoped-dir>` and `tg edit-plan` emitted an **empty `validation_plan`** and a **budget-floored `confidence` (0.55)** with `ask_user_before_editing: required ("no validation command evidence")` — even though the repo has a full pytest suite. Root-caused to two bugs plus a confidence-channel gap; all three fixed here behind the shared seed builder (heals `tg agent`, `tg edit-plan`, and the session/daemon/MCP edit-plan paths at once).

## The two bugs (both live-reproduced) + the confidence gap

- **Bug A — boundary-README trap in `_validation_repo_root`** (`src/tensor_grep/cli/repo_map.py:8263`). The walk-up broke at the first dir carrying *any* boundary marker (README.md/.gitignore/LICENSE/AGENTS.md) before checking its parent, so `core/hooks/README.md` trapped the walk at `core/hooks` and never reached the root `pyproject.toml` → discovery early-returned `[]`. **Fix:** a dir arms the boundary break only if **strong** — has `.git` OR ≥2 distinct boundary markers (`:8300-8303`). Project markers still win first; tempdir guard retained.
- **Bug B — discovery was JS/TS-only** (`_discover_validation_tests_for_primary_file`, `repo_map.py:3641`). Non-JS/TS files hit a blanket `continue`, so Python per-file tests were never discovered. **Fix:** `.py` test files (already `_is_test_file`-gated) proceed to scoring; JS/TS keep the `node:test` gate (`:3695`).
- **Confidence — capped corroboration channel** (`src/tensor_grep/cli/agent_capsule.py`). A budget-truncated primary snippet floored `confidence.overall` at 0.55, and the existing uplift required collected call-site evidence a non-symbol query can't earn. **Fix:** new `_targeted_validation_corroboration_qualifies` channel (`:1606`) accepts non-empty targeted validation evidence (steps scoped to symbol/file, non-empty target, ≥0.7, alignment aligned/kept>0), capped at the pre-existing-but-dead `_CAPSULE_TOKEN_BUDGET_CONFIDENCE_UPLIFT_CAP = 0.75` (below the 0.8 graph-corroborated cap). Every genuine-ambiguity disqualifier (scan-truncation, no-snippets, misroute, tie, non-budget reasons, query-overlap) is retained verbatim and gates **both** channels.

Design + seam citations: `docs/plans/design-tensor-grep-84-validation-plan-parity-2026-07-09.md`.

## Real-binary dogfood (the definitive proof — actual gotcontext-saddle repo)

`tg agent core/hooks "audit gotcontext read gate" --json`:

| field | before (CEO report) | after (this branch) |
|---|---|---|
| `validation_plan` | empty | **5 steps** (file + symbol-scoped pytest, root-relative targets, `detection: detected`) |
| `confidence.overall` | 0.55 | **0.9** (plan corroborates; floor lifted) |
| `ask_user_before_editing` | required — "no validation command evidence" | **required: False, reasons: []** |

## Tests (TDD, RED-before / GREEN-after)

+11 tests: `test_validation_commands.py` (T1 boundary-trap repro + git-top/two-marker/tempdir companions; T3 python-sibling discovery + JS/TS-gate-unchanged; T5 E2E via `build_agent_capsule` + mirror via `build_context_edit_plan`) and `test_agent_capsule_token_budget_confidence.py` (6a uplift-to-0.75 + `required=False` + channel reason; 6b repo-scope step never qualifies; 6c targeted-evidence + misroute stays floored). Existing pins all green (fail-closed no-evidence, scoped fixtures, trust-planning, the 3 original uplift/floor tests, session no-walk).

## Verification (real `.venv`, `uv run --no-sync`)

- 158 targeted + pin tests pass (24.85s).
- `ruff check` ✓, `ruff format --preview --check` ✓, `mypy` (agent_capsule.py + repo_map.py) ✓.
- Scope: exactly the 2 src + 2 test files + the design doc. **No** registration sites touched (`main.rs`/`bootstrap.py`/`config.py`/mcp/backends untouched — additive-value-only envelope, no schema change).

Closes #84 (the validation-plan-parity portion of the dogfood; lower P2/P3 items — imports/importers sys.path-blindness, suggested_scope hints — remain tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
