### PR TITLE
fix(search): bound the bare --glob walk when no PATH is given (dogfood #88)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -3,10 +3,12 @@ use anyhow::Context;
 use clap::ValueEnum;
 use clap::{Args, Parser, Subcommand};
 use hmac::{Hmac, Mac};
-// Bug #88 (dogfood v1.54.0): unconditional now -- `implicit_glob_scan_exceeds_ceiling` (the
-// bare-`--glob`-no-PATH ceiling probe) needs these on every build, not just `cuda`. Previously
-// only `count_search_corpus_bytes` (cuda-gated) used them.
-use ignore::{overrides::OverrideBuilder, WalkBuilder};
+// Bug #88 (dogfood v1.54.0): `WalkBuilder` is unconditional now -- `implicit_search_walk_
+// exceeds_ceiling` (the bare-`--glob`-no-PATH WALK-ceiling probe) needs it on every build, not
+// just `cuda`. `OverrideBuilder` stays cuda-gated: only `count_search_corpus_bytes` uses it.
+#[cfg(feature = "cuda")]
+use ignore::overrides::OverrideBuilder;
+use ignore::WalkBuilder;
 use process_control::{ChildExt, Control};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1825,27 +1827,41 @@ For intentional broad scans:\n\
     )
 }
 
-// Bug #88 (dogfood v1.54.0): a bare `tg search --glob X PATTERN` with NO explicit PATH used to
-// hand the walk straight to real `rg` via `execute_ripgrep_search` (`search_prefers_ripgrep_
-// passthrough`'s `!args.globs.is_empty()` branch in `handle_ripgrep_search`) with no ceiling
-// check at all -- `--glob` narrows WHICH files match, it does not bound how much of the tree
-// must be walked to find them. On a large/workspace/vendored cwd this ran effectively
+// Bug #88 (dogfood v1.54.0 -> v1.54.1 follow-up): a bare `tg search --glob X PATTERN` with NO
+// explicit PATH used to hand the walk straight to real `rg` via `execute_ripgrep_search`
+// (`search_prefers_ripgrep_passthrough`'s `!args.globs.is_empty()` branch in
+// `handle_ripgrep_search`) with no ceiling check at all. `--glob`/`--type` narrow WHICH files
+// MATCH, they do NOT bound how much of the tree is WALKED to find them -- only `--max-depth`
+// (and gitignore/hidden pruning) do. On a large/workspace/vendored cwd this ran effectively
 // unbounded (only the 60s `TG_RG_TIMEOUT_SECONDS` rg-subprocess timeout eventually killed it).
-// Mirrors the Python CLI's `_LARGE_ROOT_SCAN_FILE_CEILING` (`cli/main.py`) -- same threshold
-// value, same "count real post-filter candidates, refuse before the real search runs" design.
-const IMPLICIT_GLOB_SCAN_FILE_CEILING: usize = 1500;
+//
+// The first fix attempt (296cc92) had two gaps the dogfood re-harvest caught:
+//   (1) it counted post-GLOB matches, so a SELECTIVE glob (`*.rs` in a huge JS tree) counts
+//       few matches, sails under the ceiling, and proceeds into the unbounded WALK; and worse,
+//       a glob matching everything but slowly (`**/*`) made the probe itself walk the whole
+//       tree. The hang is TREE-WALK cost, independent of match count -- so this probe now
+//       counts every FILE the walker VISITS (ignoring the glob filter entirely) and early-exits
+//       the instant the WALK exceeds the ceiling. That is both robust to glob selectivity and
+//       self-bounded (never more than `ceiling + 1` files walked).
+//   (2) `request.paths` is EMPTY (not `["."]`) whenever `grep_cli::is_readable_stdin()` is true
+//       (`implicit_search_paths`), so the probe saw no root and skipped -- yet rg still walked
+//       the cwd unbounded. The caller now normalizes an implicit empty-paths search to `["."]`
+//       before probing (mirroring the Python CLI, which always guards `["."]`).
+const IMPLICIT_SEARCH_WALK_FILE_CEILING: usize = 1500;
 
-/// Bounded probe: walks `paths` honoring the SAME glob/max-depth/no-ignore settings the real
-/// search would use, counting files, and returns `true` the instant the ceiling is exceeded --
-/// never a full-tree enumeration (that would just be the unbounded work this guard exists to
-/// avoid). Only meaningful when the caller has already confirmed `path_was_implicit` (no
-/// explicit PATH argument): an explicit, deliberately-scoped PATH combined with `--glob` must
-/// still run uninhibited (mirrors the CLI's `paths_defaulted`-gated guard).
-fn implicit_glob_scan_exceeds_ceiling(
+/// Bounded WALK probe: walks `paths` honoring the SAME max-depth / no-ignore / hidden traversal
+/// settings the real search would use, counting every FILE the walker VISITS (NOT filtered by
+/// the search glob -- a file glob does not prune the walk, so walk cost is glob-independent),
+/// and returns `true` the instant the WALK exceeds the ceiling. Never enumerates more than
+/// `ceiling + 1` files (that would just be the unbounded work this guard exists to avoid).
+/// Only meaningful when the caller has confirmed `path_was_implicit` (no explicit PATH): an
+/// explicit, deliberately-scoped PATH must still run uninhibited (the CLI's `paths_defaulted`
+/// gate / Trap #3).
+fn implicit_search_walk_exceeds_ceiling(
     paths: &[String],
-    globs: &[String],
     max_depth: Option<usize>,
     no_ignore: bool,
+    hidden: bool,
     ceiling: usize,
 ) -> bool {
     let roots: Vec<PathBuf> = paths
@@ -1864,27 +1880,15 @@ fn implicit_glob_scan_exceeds_ceiling(
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
     }
+    // `hidden(true)` = SKIP hidden entries (ripgrep's default). Only descend hidden when the
+    // real search was asked to (`--hidden`), so the probe's walk cost matches rg's.
+    builder.hidden(!hidden);
     if no_ignore {
         builder.ignore(false);
         builder.git_ignore(false);
         builder.git_global(false);
         builder.git_exclude(false);
         builder.parents(false);
-    }
-    if !globs.is_empty() {
-        let mut overrides = OverrideBuilder::new(first_root);
-        let mut overrides_valid = true;
-        for glob in globs {
-            if overrides.add(glob).is_err() {
-                overrides_valid = false;
-                break;
-            }
-        }
-        if overrides_valid {
-            if let Ok(built) = overrides.build() {
-                builder.overrides(built);
-            }
-        }
     }
 
     let mut file_count = 0usize;
@@ -1904,13 +1908,13 @@ fn implicit_glob_scan_exceeds_ceiling(
     false
 }
 
-fn format_unbounded_implicit_glob_scan_error(ceiling: usize) -> String {
+fn format_unbounded_implicit_search_walk_error(ceiling: usize) -> String {
     format!(
         "Error: broad root scan refused as a safety guard, not a zero-match result: \
 no PATH was given, so the search defaulted to the current directory, which is a large root \
-(over {ceiling} files); --glob only filters WHICH files match, it does not bound how much of \
-the tree must be walked to find them. Scope the search to an explicit PATH, add --max-depth, \
-or pass --allow-broad-generated-scan to opt in.\n\
+(over {ceiling} files walked); --glob/--type only filter WHICH files match, they do not bound \
+how much of the tree must be walked to find them. Scope the search to an explicit PATH, add \
+--max-depth, or pass --allow-broad-generated-scan to opt in.\n\
 For bounded output:\n\
 tg search <pattern> <root> --glob \"*.py\"\n\
 tg search <pattern> <root> --max-depth <N>\n\
@@ -3534,86 +3538,84 @@ mod tests {
     }
 
     #[test]
-    fn implicit_glob_scan_refuses_over_ceiling_candidate_count() {
-        // Bug #88 (dogfood v1.54.0): a bare `--glob` search with NO explicit PATH on a root
-        // over the ceiling must be flagged for refusal by the probe -- this is the exact gap
-        // that let a bare `tg search --glob X PATTERN` from a large/unscoped cwd walk/search
-        // unbounded via `execute_ripgrep_search`.
+    fn implicit_search_walk_refuses_over_ceiling_file_count() {
+        // Bug #88: a bare `--glob` search with NO explicit PATH on a root whose WALK exceeds the
+        // ceiling must be refused -- the exact gap that let a bare `tg search --glob X PATTERN`
+        // from a large/unscoped cwd walk/search unbounded via `execute_ripgrep_search`.
         let dir = tempfile::tempdir().unwrap();
         _make_stub_file_dir(dir.path(), 1600);
 
-        let exceeds = implicit_glob_scan_exceeds_ceiling(
+        let exceeds = implicit_search_walk_exceeds_ceiling(
             &[dir.path().to_string_lossy().to_string()],
-            &["*.py".to_string()],
             None,
             false,
-            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+            false,
+            IMPLICIT_SEARCH_WALK_FILE_CEILING,
         );
 
         assert!(
             exceeds,
-            "expected the 1600-file root to exceed the 1500 ceiling"
+            "expected the 1600-file root's WALK to exceed the 1500 ceiling"
         );
     }
 
     #[test]
-    fn implicit_glob_scan_allows_count_under_ceiling() {
+    fn implicit_search_walk_allows_count_under_ceiling() {
         let dir = tempfile::tempdir().unwrap();
         _make_stub_file_dir(dir.path(), 50);
 
-        let exceeds = implicit_glob_scan_exceeds_ceiling(
+        let exceeds = implicit_search_walk_exceeds_ceiling(
             &[dir.path().to_string_lossy().to_string()],
-            &["*.py".to_string()],
             None,
             false,
-            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+            false,
+            IMPLICIT_SEARCH_WALK_FILE_CEILING,
         );
 
         assert!(!exceeds, "a 50-file root must not be refused");
     }
 
     #[test]
-    fn implicit_glob_scan_respects_glob_filter_when_counting() {
-        // The ceiling is evaluated on the ACTUAL post-glob-filter candidate count: 1600 `.py`
-        // files plus 1600 `.txt` files exist, but a `--glob '*.txt'` search only ever counts
-        // the `.txt` files, so a glob that genuinely narrows below the ceiling must not be
-        // refused (mirrors the CLI's `test_large_root_guard_allows_scoped_glob_over_ceiling`
-        // sibling intent for the case where the filter actually narrows the walk).
+    fn implicit_search_walk_counts_the_walk_not_a_selective_glob_match() {
+        // The dogfood re-harvest's core finding (hypothesis 3): the hang is TREE-WALK cost, NOT
+        // post-glob MATCH count. This probe counts every FILE the walker VISITS (glob-independent),
+        // so a huge tree that a SELECTIVE glob would narrow to a few matches is STILL refused --
+        // because the real search must still WALK the whole tree to find those few matches. Here
+        // 1600 `.py` files exist but the search glob is `*.txt` (0 matches); the walk is still
+        // 1600 files, which must exceed the ceiling. (The old match-count probe returned false
+        // here -> proceeded -> hung; this is the RED-before case for the walk-count fix.)
         let dir = tempfile::tempdir().unwrap();
         _make_stub_file_dir(dir.path(), 1600);
-        for index in 0..50 {
-            std::fs::write(dir.path().join(format!("keep_{index}.txt")), "keep\n").unwrap();
-        }
 
-        let exceeds = implicit_glob_scan_exceeds_ceiling(
+        let exceeds = implicit_search_walk_exceeds_ceiling(
             &[dir.path().to_string_lossy().to_string()],
-            &["*.txt".to_string()],
             None,
             false,
-            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+            false,
+            IMPLICIT_SEARCH_WALK_FILE_CEILING,
         );
 
         assert!(
-            !exceeds,
-            "a glob narrowing to 50 matches must not be refused"
+            exceeds,
+            "walk cost (1600 files) must be refused regardless of how selective the glob is"
         );
     }
 
     #[test]
-    fn implicit_glob_scan_respects_max_depth_when_counting() {
-        // `--max-depth` genuinely bounds the walk: nest the 1600 stub files two levels deep
-        // and confirm `--max-depth 1` (which never reaches them) is not refused.
+    fn implicit_search_walk_respects_max_depth() {
+        // `--max-depth` genuinely bounds the WALK (unlike a file glob): nest 1600 files one dir
+        // deep and confirm `--max-depth 1` (which never descends into them) is not refused.
         let dir = tempfile::tempdir().unwrap();
         let nested = dir.path().join("nested");
         std::fs::create_dir(&nested).unwrap();
         _make_stub_file_dir(&nested, 1600);
 
-        let exceeds = implicit_glob_scan_exceeds_ceiling(
+        let exceeds = implicit_search_walk_exceeds_ceiling(
             &[dir.path().to_string_lossy().to_string()],
-            &["*.py".to_string()],
             Some(1),
             false,
-            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+            false,
+            IMPLICIT_SEARCH_WALK_FILE_CEILING,
         );
 
         assert!(
@@ -3623,11 +3625,30 @@ mod tests {
     }
 
     #[test]
-    fn handle_ripgrep_search_glob_ceiling_check_only_fires_when_path_implicit() {
-        // Non-regression (Trap #3 parity): an EXPLICIT path combined with --glob over the
-        // ceiling must not be affected by the new probe -- callers gate it on
-        // `request.path_was_implicit`, verified directly here since `handle_ripgrep_search`
-        // itself spawns a real rg subprocess and is not unit-testable in-process.
+    fn implicit_search_walk_empty_paths_probe_is_self_bounded_no_root() {
+        // Regression for the SECOND gap the re-harvest caught: `request.paths` is EMPTY (not
+        // `["."]`) when stdin is readable, so the probe saw no root and skipped. The probe itself
+        // returns false on genuinely-empty roots (nothing to walk); the FIX lives at the call
+        // site, which normalizes an implicit empty-paths search to `["."]` before calling this.
+        // This test pins the probe's empty-roots contract so a future refactor cannot make it
+        // panic or scan the process cwd unexpectedly.
+        let exceeds = implicit_search_walk_exceeds_ceiling(
+            &[],
+            None,
+            false,
+            false,
+            IMPLICIT_SEARCH_WALK_FILE_CEILING,
+        );
+        assert!(!exceeds, "no roots -> nothing to walk -> not refused");
+    }
+
+    #[test]
+    fn implicit_search_walk_only_fires_when_path_implicit() {
+        // Non-regression (Trap #3 parity): an EXPLICIT path combined with --glob over the ceiling
+        // must NOT be refused -- callers gate the probe on `request.path_was_implicit`. Verified
+        // directly here since `handle_ripgrep_search` spawns a real rg subprocess and is not
+        // unit-testable in-process. The probe WOULD flag this root; the `path_was_implicit` gate
+        // at the call site is the only thing that lets an explicit-path glob search proceed.
         let dir = tempfile::tempdir().unwrap();
         _make_stub_file_dir(dir.path(), 1600);
         let path_str = dir.path().to_string_lossy().to_string();
@@ -3639,19 +3660,16 @@ mod tests {
         };
         assert!(!request.path_was_implicit);
 
-        // Directly exercising the probe with the same over-ceiling root proves the underlying
-        // check WOULD flag it -- so the only thing standing between an explicit-path glob
-        // search and a false refusal is the `path_was_implicit` gate at the call site.
-        let exceeds = implicit_glob_scan_exceeds_ceiling(
+        let exceeds = implicit_search_walk_exceeds_ceiling(
             &request.paths,
-            &["*.py".to_string()],
             None,
             false,
-            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+            false,
+            IMPLICIT_SEARCH_WALK_FILE_CEILING,
         );
         assert!(
             exceeds,
-            "sanity: the fixture itself must exceed the ceiling"
+            "sanity: the fixture itself exceeds the ceiling, so only the path_was_implicit gate protects it"
         );
     }
 
@@ -5459,25 +5477,36 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
         // guard execute_ripgrep_search's Err bubbles via `?` to main()'s default Result
         // termination, which exits 1 -- indistinguishable from a genuine no-match (audit #81 #7).
         require_ripgrep_or_exit(rg_available, "this search's flag combination");
-        // Bug #88 (dogfood v1.54.0): with no explicit PATH, `--glob` alone must not exempt this
-        // call from a ceiling check -- see `implicit_glob_scan_exceeds_ceiling` above. Gated on
-        // `path_was_implicit` so an explicit, deliberately-scoped PATH + `--glob` still runs
-        // uninhibited (Trap #3 parity with the CLI's guard).
-        if request.path_was_implicit
-            && !args.globs.is_empty()
-            && implicit_glob_scan_exceeds_ceiling(
-                &request.paths,
-                &args.globs,
+        // Bug #88 (dogfood v1.54.0 -> v1.54.1 follow-up): with no explicit PATH, `--glob` alone
+        // must not exempt this rg-passthrough call from a WALK ceiling check -- see
+        // `implicit_search_walk_exceeds_ceiling` above. Gated on `path_was_implicit` so an
+        // explicit, deliberately-scoped PATH + `--glob` still runs uninhibited (Trap #3 parity).
+        //
+        // `request.paths` is EMPTY (not `["."]`) whenever stdin is readable
+        // (`grep_cli::is_readable_stdin()` -> `implicit_search_paths`); rg then still walks the
+        // cwd, so normalize the implicit root to `["."]` before probing (mirrors the Python CLI,
+        // which always guards `["."]`). Only probe when a glob is present: that is the flag combo
+        // that routes an unscoped implicit-path search into the unbounded rg passthrough.
+        if request.path_was_implicit && !args.globs.is_empty() {
+            let dot_root = [".".to_string()];
+            let probe_roots: &[String] = if request.paths.is_empty() {
+                &dot_root
+            } else {
+                &request.paths
+            };
+            if implicit_search_walk_exceeds_ceiling(
+                probe_roots,
                 args.max_depth,
                 args.no_ignore,
-                IMPLICIT_GLOB_SCAN_FILE_CEILING,
-            )
-        {
-            eprintln!(
-                "{}",
-                format_unbounded_implicit_glob_scan_error(IMPLICIT_GLOB_SCAN_FILE_CEILING)
-            );
-            std::process::exit(2);
+                args.hidden,
+                IMPLICIT_SEARCH_WALK_FILE_CEILING,
+            ) {
+                eprintln!(
+                    "{}",
+                    format_unbounded_implicit_search_walk_error(IMPLICIT_SEARCH_WALK_FILE_CEILING)
+                );
+                std::process::exit(2);
+            }
         }
         if args.verbose {
             emit_verbose_metadata(RoutingDecision::ripgrep());

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -3,7 +3,9 @@ use anyhow::Context;
 use clap::ValueEnum;
 use clap::{Args, Parser, Subcommand};
 use hmac::{Hmac, Mac};
-#[cfg(feature = "cuda")]
+// Bug #88 (dogfood v1.54.0): unconditional now -- `implicit_glob_scan_exceeds_ceiling` (the
+// bare-`--glob`-no-PATH ceiling probe) needs these on every build, not just `cuda`. Previously
+// only `count_search_corpus_bytes` (cuda-gated) used them.
 use ignore::{overrides::OverrideBuilder, WalkBuilder};
 use process_control::{ChildExt, Control};
 use serde::{Deserialize, Serialize};
@@ -1823,6 +1825,100 @@ For intentional broad scans:\n\
     )
 }
 
+// Bug #88 (dogfood v1.54.0): a bare `tg search --glob X PATTERN` with NO explicit PATH used to
+// hand the walk straight to real `rg` via `execute_ripgrep_search` (`search_prefers_ripgrep_
+// passthrough`'s `!args.globs.is_empty()` branch in `handle_ripgrep_search`) with no ceiling
+// check at all -- `--glob` narrows WHICH files match, it does not bound how much of the tree
+// must be walked to find them. On a large/workspace/vendored cwd this ran effectively
+// unbounded (only the 60s `TG_RG_TIMEOUT_SECONDS` rg-subprocess timeout eventually killed it).
+// Mirrors the Python CLI's `_LARGE_ROOT_SCAN_FILE_CEILING` (`cli/main.py`) -- same threshold
+// value, same "count real post-filter candidates, refuse before the real search runs" design.
+const IMPLICIT_GLOB_SCAN_FILE_CEILING: usize = 1500;
+
+/// Bounded probe: walks `paths` honoring the SAME glob/max-depth/no-ignore settings the real
+/// search would use, counting files, and returns `true` the instant the ceiling is exceeded --
+/// never a full-tree enumeration (that would just be the unbounded work this guard exists to
+/// avoid). Only meaningful when the caller has already confirmed `path_was_implicit` (no
+/// explicit PATH argument): an explicit, deliberately-scoped PATH combined with `--glob` must
+/// still run uninhibited (mirrors the CLI's `paths_defaulted`-gated guard).
+fn implicit_glob_scan_exceeds_ceiling(
+    paths: &[String],
+    globs: &[String],
+    max_depth: Option<usize>,
+    no_ignore: bool,
+    ceiling: usize,
+) -> bool {
+    let roots: Vec<PathBuf> = paths
+        .iter()
+        .map(PathBuf::from)
+        .filter(|root| root.is_dir())
+        .collect();
+    let Some(first_root) = roots.first() else {
+        return false;
+    };
+
+    let mut builder = WalkBuilder::new(first_root);
+    for root in roots.iter().skip(1) {
+        builder.add(root);
+    }
+    if let Some(depth) = max_depth {
+        builder.max_depth(Some(depth));
+    }
+    if no_ignore {
+        builder.ignore(false);
+        builder.git_ignore(false);
+        builder.git_global(false);
+        builder.git_exclude(false);
+        builder.parents(false);
+    }
+    if !globs.is_empty() {
+        let mut overrides = OverrideBuilder::new(first_root);
+        let mut overrides_valid = true;
+        for glob in globs {
+            if overrides.add(glob).is_err() {
+                overrides_valid = false;
+                break;
+            }
+        }
+        if overrides_valid {
+            if let Ok(built) = overrides.build() {
+                builder.overrides(built);
+            }
+        }
+    }
+
+    let mut file_count = 0usize;
+    for entry in builder.build() {
+        let Ok(entry) = entry else { continue };
+        if entry
+            .file_type()
+            .map(|kind| kind.is_file())
+            .unwrap_or(false)
+        {
+            file_count += 1;
+            if file_count > ceiling {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn format_unbounded_implicit_glob_scan_error(ceiling: usize) -> String {
+    format!(
+        "Error: broad root scan refused as a safety guard, not a zero-match result: \
+no PATH was given, so the search defaulted to the current directory, which is a large root \
+(over {ceiling} files); --glob only filters WHICH files match, it does not bound how much of \
+the tree must be walked to find them. Scope the search to an explicit PATH, add --max-depth, \
+or pass --allow-broad-generated-scan to opt in.\n\
+For bounded output:\n\
+tg search <pattern> <root> --glob \"*.py\"\n\
+tg search <pattern> <root> --max-depth <N>\n\
+For intentional broad scans:\n\
+--allow-broad-generated-scan"
+    )
+}
+
 fn parse_early_ripgrep_args(raw_args: &[OsString]) -> Option<RipgrepSearchArgs> {
     let mut args = RipgrepSearchArgs {
         files: false,
@@ -3429,6 +3525,134 @@ mod tests {
         let frontdoor =
             parse_default_frontdoor_args(&["tg", "search", "--glob=*.log", "ERROR", "bench_data"]);
         assert_eq!(frontdoor.globs, vec!["*.log".to_string()]);
+    }
+
+    fn _make_stub_file_dir(dir: &std::path::Path, file_count: usize) {
+        for index in 0..file_count {
+            std::fs::write(dir.join(format!("stub_{index}.py")), "TODO placeholder\n").unwrap();
+        }
+    }
+
+    #[test]
+    fn implicit_glob_scan_refuses_over_ceiling_candidate_count() {
+        // Bug #88 (dogfood v1.54.0): a bare `--glob` search with NO explicit PATH on a root
+        // over the ceiling must be flagged for refusal by the probe -- this is the exact gap
+        // that let a bare `tg search --glob X PATTERN` from a large/unscoped cwd walk/search
+        // unbounded via `execute_ripgrep_search`.
+        let dir = tempfile::tempdir().unwrap();
+        _make_stub_file_dir(dir.path(), 1600);
+
+        let exceeds = implicit_glob_scan_exceeds_ceiling(
+            &[dir.path().to_string_lossy().to_string()],
+            &["*.py".to_string()],
+            None,
+            false,
+            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+        );
+
+        assert!(
+            exceeds,
+            "expected the 1600-file root to exceed the 1500 ceiling"
+        );
+    }
+
+    #[test]
+    fn implicit_glob_scan_allows_count_under_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        _make_stub_file_dir(dir.path(), 50);
+
+        let exceeds = implicit_glob_scan_exceeds_ceiling(
+            &[dir.path().to_string_lossy().to_string()],
+            &["*.py".to_string()],
+            None,
+            false,
+            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+        );
+
+        assert!(!exceeds, "a 50-file root must not be refused");
+    }
+
+    #[test]
+    fn implicit_glob_scan_respects_glob_filter_when_counting() {
+        // The ceiling is evaluated on the ACTUAL post-glob-filter candidate count: 1600 `.py`
+        // files plus 1600 `.txt` files exist, but a `--glob '*.txt'` search only ever counts
+        // the `.txt` files, so a glob that genuinely narrows below the ceiling must not be
+        // refused (mirrors the CLI's `test_large_root_guard_allows_scoped_glob_over_ceiling`
+        // sibling intent for the case where the filter actually narrows the walk).
+        let dir = tempfile::tempdir().unwrap();
+        _make_stub_file_dir(dir.path(), 1600);
+        for index in 0..50 {
+            std::fs::write(dir.path().join(format!("keep_{index}.txt")), "keep\n").unwrap();
+        }
+
+        let exceeds = implicit_glob_scan_exceeds_ceiling(
+            &[dir.path().to_string_lossy().to_string()],
+            &["*.txt".to_string()],
+            None,
+            false,
+            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+        );
+
+        assert!(
+            !exceeds,
+            "a glob narrowing to 50 matches must not be refused"
+        );
+    }
+
+    #[test]
+    fn implicit_glob_scan_respects_max_depth_when_counting() {
+        // `--max-depth` genuinely bounds the walk: nest the 1600 stub files two levels deep
+        // and confirm `--max-depth 1` (which never reaches them) is not refused.
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        _make_stub_file_dir(&nested, 1600);
+
+        let exceeds = implicit_glob_scan_exceeds_ceiling(
+            &[dir.path().to_string_lossy().to_string()],
+            &["*.py".to_string()],
+            Some(1),
+            false,
+            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+        );
+
+        assert!(
+            !exceeds,
+            "max-depth 1 must not descend into the nested 1600-file dir"
+        );
+    }
+
+    #[test]
+    fn handle_ripgrep_search_glob_ceiling_check_only_fires_when_path_implicit() {
+        // Non-regression (Trap #3 parity): an EXPLICIT path combined with --glob over the
+        // ceiling must not be affected by the new probe -- callers gate it on
+        // `request.path_was_implicit`, verified directly here since `handle_ripgrep_search`
+        // itself spawns a real rg subprocess and is not unit-testable in-process.
+        let dir = tempfile::tempdir().unwrap();
+        _make_stub_file_dir(dir.path(), 1600);
+        let path_str = dir.path().to_string_lossy().to_string();
+
+        let request = ResolvedSearchRequest {
+            patterns: vec!["TODO".to_string()],
+            paths: vec![path_str.clone()],
+            path_was_implicit: false,
+        };
+        assert!(!request.path_was_implicit);
+
+        // Directly exercising the probe with the same over-ceiling root proves the underlying
+        // check WOULD flag it -- so the only thing standing between an explicit-path glob
+        // search and a false refusal is the `path_was_implicit` gate at the call site.
+        let exceeds = implicit_glob_scan_exceeds_ceiling(
+            &request.paths,
+            &["*.py".to_string()],
+            None,
+            false,
+            IMPLICIT_GLOB_SCAN_FILE_CEILING,
+        );
+        assert!(
+            exceeds,
+            "sanity: the fixture itself must exceed the ceiling"
+        );
     }
 
     #[test]
@@ -5235,6 +5459,26 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
         // guard execute_ripgrep_search's Err bubbles via `?` to main()'s default Result
         // termination, which exits 1 -- indistinguishable from a genuine no-match (audit #81 #7).
         require_ripgrep_or_exit(rg_available, "this search's flag combination");
+        // Bug #88 (dogfood v1.54.0): with no explicit PATH, `--glob` alone must not exempt this
+        // call from a ceiling check -- see `implicit_glob_scan_exceeds_ceiling` above. Gated on
+        // `path_was_implicit` so an explicit, deliberately-scoped PATH + `--glob` still runs
+        // uninhibited (Trap #3 parity with the CLI's guard).
+        if request.path_was_implicit
+            && !args.globs.is_empty()
+            && implicit_glob_scan_exceeds_ceiling(
+                &request.paths,
+                &args.globs,
+                args.max_depth,
+                args.no_ignore,
+                IMPLICIT_GLOB_SCAN_FILE_CEILING,
+            )
+        {
+            eprintln!(
+                "{}",
+                format_unbounded_implicit_glob_scan_error(IMPLICIT_GLOB_SCAN_FILE_CEILING)
+            );
+            std::process::exit(2);
+        }
         if args.verbose {
             emit_verbose_metadata(RoutingDecision::ripgrep());
         }

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -5485,9 +5485,10 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
         // `request.paths` is EMPTY (not `["."]`) whenever stdin is readable
         // (`grep_cli::is_readable_stdin()` -> `implicit_search_paths`); rg then still walks the
         // cwd, so normalize the implicit root to `["."]` before probing (mirrors the Python CLI,
-        // which always guards `["."]`). Only probe when a glob is present: that is the flag combo
-        // that routes an unscoped implicit-path search into the unbounded rg passthrough.
-        if request.path_was_implicit && !args.globs.is_empty() {
+        // which always guards `["."]`). Probe when a glob OR a --type filter is present: BOTH
+        // narrow WHICH files match without bounding the walk, so either routes an unscoped
+        // implicit-path search into the unbounded rg passthrough (bug #88 + its --type sibling).
+        if request.path_was_implicit && (!args.globs.is_empty() || !args.file_type.is_empty()) {
             let dot_root = [".".to_string()];
             let probe_roots: &[String] = if request.paths.is_empty() {
                 &dot_root

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -320,6 +320,20 @@ def _requires_full_cli(search_args: list[str]) -> bool:
             return True
         if arg.startswith(_TG_ONLY_SEARCH_FLAG_PREFIXES):
             return True
+        # Bundled/attached short-flag value form of the walk-scope type filters: rg accepts
+        # `-tpy` == `-t py`, `-Tpy` == `-T py`, and mid-bundle `-itpy` == `-i -t py`. The exact
+        # token / `--x=` checks above miss these, so a bare bundled type filter would slip into
+        # the unguarded rg passthrough (bundled sibling of the -t/--type walk-DoS, bug #88). Walk
+        # the short cluster: the first VALUE-CONSUMING short flag swallows the remainder, so if
+        # that flag is -t/-T it carries an attached type value -> route to the full CLI (where the
+        # walk-scope guard fires). A value-consuming flag that is NOT t/T (e.g. -f<file>) swallows
+        # the rest as its value, so any later t is data, not a flag -> stop scanning this token.
+        if len(arg) > 2 and arg.startswith("-") and not arg.startswith("--"):
+            for ch in arg[1:]:
+                if f"-{ch}" in _SEARCH_ATTACHED_VALUE_SHORT_FLAGS:
+                    if ch in ("t", "T"):
+                        return True
+                    break
     return False
 
 

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -320,18 +320,20 @@ def _requires_full_cli(search_args: list[str]) -> bool:
             return True
         if arg.startswith(_TG_ONLY_SEARCH_FLAG_PREFIXES):
             return True
-        # Bundled/attached short-flag value form of the walk-scope type filters: rg accepts
-        # `-tpy` == `-t py`, `-Tpy` == `-T py`, and mid-bundle `-itpy` == `-i -t py`. The exact
-        # token / `--x=` checks above miss these, so a bare bundled type filter would slip into
-        # the unguarded rg passthrough (bundled sibling of the -t/--type walk-DoS, bug #88). Walk
-        # the short cluster: the first VALUE-CONSUMING short flag swallows the remainder, so if
-        # that flag is -t/-T it carries an attached type value -> route to the full CLI (where the
-        # walk-scope guard fires). A value-consuming flag that is NOT t/T (e.g. -f<file>) swallows
-        # the rest as its value, so any later t is data, not a flag -> stop scanning this token.
+        # Bundled/attached short-flag value form of the walk-scope filters: rg accepts
+        # `-g*.py` == `-g *.py`, `-tpy` == `-t py`, `-Tpy` == `-T py`, and mid-bundle
+        # `-itpy` == `-i -t py`. The exact-token / `--x=` checks above miss these, so a bare
+        # bundled filter would slip into the unguarded rg passthrough (bundled sibling of the
+        # -g/-t/--type walk-DoS, bug #88). The walk-scope short flags are -g (glob), -t (type),
+        # -T (type-not); --iglob has no short form. Walk the short cluster: the first
+        # VALUE-CONSUMING short flag swallows the remainder, so if that flag is -g/-t/-T it
+        # carries an attached walk-scope value -> route to the full CLI (where the walk guard
+        # fires). A value-consuming flag that is NOT one of those (e.g. -f<file>, -C3) swallows
+        # the rest as its value, so any later g/t is data, not a flag -> stop scanning this token.
         if len(arg) > 2 and arg.startswith("-") and not arg.startswith("--"):
             for ch in arg[1:]:
                 if f"-{ch}" in _SEARCH_ATTACHED_VALUE_SHORT_FLAGS:
-                    if ch in ("t", "T"):
+                    if ch in ("g", "t", "T"):
                         return True
                     break
     return False

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -45,6 +45,16 @@ _TG_ONLY_SEARCH_FLAGS = {
     "--replace",
     "--stats",
     "--type-list",
+    # --type/-t, --type-not/-T, and --iglob narrow WHICH files match but do NOT bound the walk, so
+    # a bare `tg search PAT -t py` / `--iglob '*.py'` (no PATH) on a large root is the same
+    # unbounded-walk DoS as bare --glob (audit #88 siblings; the guard's own scope condition is
+    # glob|iglob|file_type|type_not). Force them to the full CLI where _should_refuse_unbounded_*
+    # guards fire, rather than the unguarded rg passthrough.
+    "--type",
+    "--type-not",
+    "--iglob",
+    "-t",
+    "-T",
     "-l",
     "-g",
     "-r",
@@ -55,8 +65,11 @@ _TG_ONLY_SEARCH_FLAG_PREFIXES = (
     "--generate=",
     "--glob=",
     "--gpu-device-ids=",
+    "--iglob=",
     "--lang=",
     "--replace=",
+    "--type=",
+    "--type-not=",
 )
 
 _SCAN_FULL_CLI_FLAGS = {

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3889,6 +3889,27 @@ def _has_generated_scan_bound(config: "SearchConfig") -> bool:
     )
 
 
+# Bug #88 (dogfood v1.54.0): `_has_generated_scan_bound` above answers "does this query have
+# ANY scope-narrowing flag" -- correct for `_should_refuse_unbounded_generated_scan` (its own
+# purpose: is a `--no-ignore` scan of a generated dir intentional), but WRONG when reused as
+# the escape hatch for the workspace-root / vendored-root / large-root-ceiling guards below.
+# `--glob`/`--iglob`/`--type`/`--type-not` only filter WHICH already-encountered files count
+# as candidates -- they do not reduce how much of the tree must be walked to find them, unlike
+# `--max-depth`, which genuinely bounds the walk itself. Treating a bare `--glob` as "already
+# bounded" let a `tg search --glob X PATTERN` with NO explicit PATH auto-scope to an entire
+# workspace/vendored/oversized root with all three refusal guards silently disabled -- exactly
+# the shape reported in bug #88. The fix: `--glob`/`--iglob`/`--type`/`--type-not` remain a
+# valid escape hatch ONLY when the caller also typed an explicit PATH (a deliberate, scoped
+# root deliberately narrowed further by a file filter); when PATH was left to default, only
+# `--max-depth` (or `--allow-broad-generated-scan`) may bypass these three guards.
+def _has_walk_scope_bound(config: "SearchConfig", *, paths_defaulted: bool) -> bool:
+    if config.max_depth is not None:
+        return True
+    if paths_defaulted:
+        return False
+    return bool(config.glob or config.iglob or config.file_type or config.type_not)
+
+
 def _path_has_project_marker(path: Path) -> bool:
     for marker in _BROAD_WORKSPACE_PROJECT_MARKERS:
         try:
@@ -3927,8 +3948,9 @@ def _should_refuse_unbounded_workspace_root_scan(
     config: "SearchConfig",
     *,
     allow_broad_generated_scan: bool,
+    paths_defaulted: bool,
 ) -> tuple[bool, list[str]]:
-    if allow_broad_generated_scan or _has_generated_scan_bound(config):
+    if allow_broad_generated_scan or _has_walk_scope_bound(config, paths_defaulted=paths_defaulted):
         return False, []
     project_dirs = _workspace_project_child_names(paths)
     return bool(project_dirs), project_dirs
@@ -3983,8 +4005,9 @@ def _should_refuse_unbounded_vendored_root_scan(
     config: "SearchConfig",
     *,
     allow_broad_generated_scan: bool,
+    paths_defaulted: bool,
 ) -> tuple[bool, list[str]]:
-    if allow_broad_generated_scan or _has_generated_scan_bound(config):
+    if allow_broad_generated_scan or _has_walk_scope_bound(config, paths_defaulted=paths_defaulted):
         return False, []
     vendored_dirs = _root_top_level_vendored_dir_names(paths)
     return bool(vendored_dirs), vendored_dirs
@@ -4072,6 +4095,13 @@ def _format_unbounded_vendored_root_scan_error(vendored_dirs: list[str]) -> str:
 # This guard is checked using the candidate count the real search ALREADY collected (never
 # a second scan of its own -- that would just be the unbounded work this guard exists to
 # avoid), and fires BEFORE the slow per-file loop starts.
+#
+# Bug #88 (dogfood v1.54.0): this ceiling is evaluated on the ACTUAL post-filter candidate
+# count, so a `--glob`/`--type`/`--iglob` filter is already fully reflected in
+# `candidate_file_count` -- it never needs its own bypass here (unlike the workspace/vendored
+# guards, which are cheap top-level probes that never see the real count). Bypassing on
+# `--glob` alone (the pre-fix `_has_generated_scan_bound` check) defeated this guard for
+# exactly the bare-`--glob`-no-PATH shape it exists to catch; see `_has_walk_scope_bound`.
 _LARGE_ROOT_SCAN_FILE_CEILING = 1500
 
 
@@ -4080,8 +4110,9 @@ def _should_refuse_unbounded_large_root_scan(
     config: "SearchConfig",
     *,
     allow_broad_generated_scan: bool,
+    paths_defaulted: bool,
 ) -> bool:
-    if allow_broad_generated_scan or _has_generated_scan_bound(config):
+    if allow_broad_generated_scan or _has_walk_scope_bound(config, paths_defaulted=paths_defaulted):
         return False
     return candidate_file_count > _LARGE_ROOT_SCAN_FILE_CEILING
 
@@ -4089,11 +4120,11 @@ def _should_refuse_unbounded_large_root_scan(
 def _format_unbounded_large_root_scan_error(file_count_floor: int) -> str:
     return (
         "Error: broad root scan refused as a safety guard, not a zero-match result: "
-        f"path is a large single-project root (over {file_count_floor} files) with no "
-        "--glob/--type/--max-depth scope and no fast native/rg engine available for this "
-        "query -- an unscoped scan here would burn the search deadline instead of failing "
-        "fast. Scope the path, add --glob, --type, or --max-depth, or pass "
-        "--allow-broad-generated-scan to opt in.\n"
+        f"path is a large single-project root (over {file_count_floor} files); --glob/--type/"
+        "--iglob narrow WHICH files match but do not bound how much of the tree must be "
+        "walked to find them, and no fast native/rg engine is available for this query -- an "
+        "unscoped scan here would burn the search deadline instead of failing fast. Scope the "
+        "path explicitly, add --max-depth, or pass --allow-broad-generated-scan to opt in.\n"
         "For bounded output:\n"
         'tg search <pattern> <root> --glob "*.py"\n'
         "tg search <pattern> <root> --max-depth <N>\n"
@@ -6521,6 +6552,7 @@ def search_command(
         paths_to_search,
         config,
         allow_broad_generated_scan=allow_broad_generated_scan,
+        paths_defaulted=paths_defaulted,
     )
     if refuse_workspace_scan:
         typer.echo(_format_broad_workspace_scan_error(workspace_project_dirs), err=True)
@@ -6529,6 +6561,7 @@ def search_command(
         paths_to_search,
         config,
         allow_broad_generated_scan=allow_broad_generated_scan,
+        paths_defaulted=paths_defaulted,
     )
     if refuse_vendored_scan:
         typer.echo(_format_unbounded_vendored_root_scan_error(vendored_root_dirs), err=True)
@@ -6664,6 +6697,7 @@ def search_command(
         len(candidate_files_ordered),
         config,
         allow_broad_generated_scan=allow_broad_generated_scan,
+        paths_defaulted=paths_defaulted,
     ):
         typer.echo(
             _format_unbounded_large_root_scan_error(_LARGE_ROOT_SCAN_FILE_CEILING),

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4133,6 +4133,44 @@ def _format_unbounded_large_root_scan_error(file_count_floor: int) -> str:
     )
 
 
+# Bug #88 (dogfood v1.54.1 re-harvest): the native-binary front door's implicit-`--glob`-no-PATH
+# WALK guard (`implicit_search_walk_exceeds_ceiling`, rust_core/src/main.rs) needs a Python-CLI
+# mirror, because the full CLI reaches this bug through a DIFFERENT door: `--glob` is a
+# `_TG_ONLY_SEARCH_FLAG`, so `cli/bootstrap.py`'s launcher routes a bare `tg search --glob X
+# PATTERN` to `_run_full_cli()`, which then hands the whole implicit-`.` walk to the rg
+# passthrough (`RipgrepBackend.search_passthrough`) BEFORE `_should_refuse_unbounded_large_root_scan`
+# (that guard only runs on the slow per-file Python loop, never on the rg-passthrough fast path).
+# On a large single-project root whose top level carries a project marker (e.g. a workspace dir
+# with a `package.json`), the workspace-root guard SKIPS it and the vendored-root guard finds no
+# top-level vendored dir, so the search sailed straight into an unbounded rg walk (dogfood repro:
+# `tg search "function" --glob "*"` on `C:/dev/projects` streamed 487k lines past 60s).
+#
+# Like the native probe this counts files the walker VISITS -- NOT post-glob matches: a file glob
+# does not prune the walk, so a SELECTIVE glob (`*.rs` in a huge JS tree) would sail under a
+# match-count ceiling yet still force the full unbounded walk. The glob/type filters are stripped
+# from the probe config so `DirectoryScanner.walk` yields every walked file; `--max-depth` /
+# ignore / hidden are kept because they genuinely bound how much of the tree is walked. The pull
+# is bounded to `ceiling + 1` files (never a full-tree enumeration).
+def _implicit_glob_search_walk_exceeds_ceiling(
+    paths: list[str],
+    config: "SearchConfig",
+    ceiling: int,
+) -> bool:
+    from tensor_grep.io.directory_scanner import DirectoryScanner
+
+    probe_config = dataclasses.replace(config, glob=None, iglob=None, file_type=None, type_not=None)
+    count = 0
+    for raw_path in paths:
+        if not raw_path or raw_path == "-" or raw_path.startswith("-"):
+            continue
+        scanner = DirectoryScanner(probe_config)
+        for _ in scanner.walk(raw_path):
+            count += 1
+            if count > ceiling:
+                return True
+    return False
+
+
 def _sum_total_bytes(paths: list[str]) -> int:
     total = 0
     for p in paths:
@@ -6565,6 +6603,29 @@ def search_command(
     )
     if refuse_vendored_scan:
         typer.echo(_format_unbounded_vendored_root_scan_error(vendored_root_dirs), err=True)
+        raise typer.Exit(2)
+
+    # Bug #88 (dogfood v1.54.1 re-harvest): an implicit-path `--glob`/`--type` search that the
+    # workspace/vendored guards above did not catch (a large single-project root whose top level
+    # carries a project marker, e.g. a workspace dir with a package.json) would otherwise hand the
+    # whole unbounded `.` walk to the rg passthrough / native delegation below. Mirror the native
+    # binary's WALK-ceiling guard here so the full CLI refuses fast too. Gated on `paths_defaulted`
+    # (an explicit, deliberately-scoped PATH still runs uninhibited -- Trap #3) and on a glob/type
+    # filter being present (the flag combo that routes an unscoped search into the rg passthrough);
+    # `--max-depth` and `--allow-broad-generated-scan` bypass it (a genuinely bounded walk / opt-in).
+    if (
+        paths_defaulted
+        and not allow_broad_generated_scan
+        and config.max_depth is None
+        and (config.glob or config.iglob or config.file_type or config.type_not)
+        and _implicit_glob_search_walk_exceeds_ceiling(
+            paths_to_search, config, _LARGE_ROOT_SCAN_FILE_CEILING
+        )
+    ):
+        typer.echo(
+            _format_unbounded_large_root_scan_error(_LARGE_ROOT_SCAN_FILE_CEILING),
+            err=True,
+        )
         raise typer.Exit(2)
 
     explicit_rg_format = _explicit_rg_format_requested(format_value=format_type)

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1602,6 +1602,14 @@ def _finalize_aggregate_result(all_results: SearchResult) -> None:
 # (never a full-tree enumeration -- that would just be the unbounded work this guard exists to avoid)
 # and the caller resumes iterating from those SAME already-pulled entries via the returned iterator,
 # so nothing is scanned twice.
+#
+# Bug #88 (dogfood v1.54.0): the guards below now require a `paths_defaulted` bool (a `--glob`/
+# `--type` filter no longer bypasses them when PATH was left to default -- see
+# `cli/main.py::_has_walk_scope_bound`). The MCP `path` parameter has a Python-level default
+# (`path: str = "."`) rather than the CLI's argv-shape signal, so an explicit `path="."` and an
+# omitted `path` are indistinguishable here -- treat the literal default value "." as
+# "defaulted" (the conservative, safe reading) so a bare `tg_search(pattern=..., glob=...)` MCP
+# call gets the same protection as the CLI's bare `tg search --glob ... PATTERN`.
 def _mcp_broad_root_scan_refusal(
     path: str,
     config: "SearchConfig",
@@ -1619,9 +1627,13 @@ def _mcp_broad_root_scan_refusal(
     """
     scanner = DirectoryScanner(config)
     walker: Iterator[str] = iter(scanner.walk(path))
+    paths_defaulted = path == "."
 
     refuse_vendored, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
-        [path], config, allow_broad_generated_scan=False
+        [path],
+        config,
+        allow_broad_generated_scan=False,
+        paths_defaulted=paths_defaulted,
     )
     if refuse_vendored:
         return _format_unbounded_vendored_root_scan_error(vendored_dirs), scanner, walker
@@ -1637,7 +1649,10 @@ def _mcp_broad_root_scan_refusal(
         except StopIteration:
             break
     if _should_refuse_unbounded_large_root_scan(
-        len(probe_files), config, allow_broad_generated_scan=False
+        len(probe_files),
+        config,
+        allow_broad_generated_scan=False,
+        paths_defaulted=paths_defaulted,
     ):
         return (
             _format_unbounded_large_root_scan_error(_LARGE_ROOT_SCAN_FILE_CEILING),

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -459,6 +459,54 @@ def test_requires_full_cli_ignoring_rg_json_only_exempts_json() -> None:
     ])
 
 
+def test_requires_full_cli_routes_every_walk_scope_filter_form() -> None:
+    """DIRECT bootstrap-routing guard for the bug #88 walk-DoS class (re-gate BLOCK #2/#3).
+
+    Every form of a walk-scope filter (-g/--glob/--iglob/-t/--type/-T/--type-not) that narrows
+    WHICH files match but not the WALK must route to the full CLI, where the unbounded-walk
+    guard fires. This exercises ``_requires_full_cli`` DIRECTLY -- the parametrized cases in
+    test_cli_modes use ``CliRunner().invoke(app, ...)``, which enters the Typer app past the
+    bootstrap front door (the CliRunner trap in AGENTS.md) and would stay green even if this
+    routing were reverted; they do NOT guard the fix. This does.
+    """
+    must_route = [
+        ["-t", "py"],
+        ["--type", "py"],
+        ["-T", "py"],
+        ["--type-not", "py"],
+        ["-g", "*.py"],
+        ["--glob", "*.py"],
+        ["--iglob", "*.py"],
+        ["--type=py"],
+        ["--type-not=py"],
+        ["--glob=*.py"],
+        ["--iglob=*.py"],
+        ["-tpy"],  # bundled attached-value short forms (rg idiom)
+        ["-Tpy"],
+        ["-g*.py"],
+        ["-gsrc/**/*.py"],
+        ["-itpy"],  # mid-bundle: -i then -t py
+        ["-ig*.py"],  # mid-bundle: -i then -g *.py
+    ]
+    for args in must_route:
+        assert bootstrap._requires_full_cli(args), f"walk-scope form not routed to full CLI: {args}"
+
+    # NON-walk-scope value-consuming short flags must NOT be over-routed: their leading
+    # value-consumer swallows the remainder, so a g/t inside the value is data, not a flag.
+    must_not_route = [
+        ["-C3"],
+        ["-m5"],
+        ["-A2"],
+        ["-fpat.txt"],
+        ["-jtpy"],  # -j (threads) consumes "tpy" -- not a type filter
+        ["-ftpy"],  # -f (file) consumes "tpy"
+        ["-in"],  # pure boolean cluster
+        ["TODO", "src"],  # plain pattern + path
+    ]
+    for args in must_not_route:
+        assert not bootstrap._requires_full_cli(args), f"non-scope search over-routed: {args}"
+
+
 def test_main_entry_should_strip_noop_rg_format_and_keep_sort_for_rg_passthrough(monkeypatch):
     seen: dict[str, object] = {}
 

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -307,10 +307,15 @@ def test_main_entry_should_passthrough_raw_rg_style_invocation(monkeypatch):
     assert seen == {"binary_name": "rg", "search_args": ["-i", "ERROR", "."]}
 
 
+# NOTE: `-t js` (and the other walk-scope filters -g/-T/--type/--glob/--iglob) used to be
+# listed here as an rg-passthrough case, but they now route to the full CLI so the unbounded
+# implicit-path walk guard can fire on a bare (no-PATH) filter (bug #88 walk-DoS). `-g`/`--glob`
+# already routed to the full CLI on main; `-t`/`-T`/`--type`/`--type-not` were made consistent
+# with them. The routing is now pinned directly at test_requires_full_cli_routes_every_walk_scope_filter_form.
+# This test keeps a NON-walk-scope option-first shortcut (`--count-matches`) that still passes through.
 @pytest.mark.parametrize(
     ("argv", "expected_search_args"),
     [
-        (["tg", "-t", "js", "ERROR", "."], ["-t", "js", "ERROR", "."]),
         (
             ["tg", "--count-matches", "ERROR", "."],
             ["--count-matches", "ERROR", "."],

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -690,6 +690,7 @@ def test_workspace_root_guard_allows_bounded_workspace_scan(tmp_path: Path):
         [str(workspace)],
         SearchConfig(glob=["*.py"]),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is False
@@ -708,6 +709,7 @@ def test_workspace_root_guard_allows_explicit_workspace_scan(tmp_path: Path):
         [str(workspace)],
         SearchConfig(),
         allow_broad_generated_scan=True,
+        paths_defaulted=False,
     )
 
     assert refused is False
@@ -727,6 +729,53 @@ def test_workspace_root_guard_allows_real_repo_root(tmp_path: Path):
         [str(repo)],
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
+    )
+
+    assert refused is False
+    assert project_dirs == []
+
+
+def test_workspace_root_guard_refuses_glob_with_implicit_path(tmp_path: Path):
+    """Bug #88 (dogfood v1.54.0): `--glob` narrows WHICH files match, it does not bound how
+    much of the tree must be walked to find them. When PATH was left to default (no explicit
+    PATH typed -- `paths_defaulted=True`), `--glob` alone must NOT exempt a workspace-shaped
+    root from this refusal, or a bare `tg search --glob X PATTERN` from a workspace root walks
+    every sibling project unbounded (the reported hang)."""
+    workspace = tmp_path / "projects"
+    workspace.mkdir()
+    for project_name in ("alpha", "beta", "gamma"):
+        project = workspace / project_name
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+
+    refused, project_dirs = _should_refuse_unbounded_workspace_root_scan(
+        [str(workspace)],
+        SearchConfig(glob=["*.py"]),
+        allow_broad_generated_scan=False,
+        paths_defaulted=True,
+    )
+
+    assert refused is True
+    assert project_dirs == ["alpha", "beta", "gamma"]
+
+
+def test_workspace_root_guard_allows_max_depth_with_implicit_path(tmp_path: Path):
+    """`--max-depth` genuinely bounds the WALK itself (unlike `--glob`/`--type`, which only
+    filter already-encountered files), so it remains a valid escape hatch even when PATH was
+    left to default -- this is not the bug #88 shape."""
+    workspace = tmp_path / "projects"
+    workspace.mkdir()
+    for project_name in ("alpha", "beta", "gamma"):
+        project = workspace / project_name
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+
+    refused, project_dirs = _should_refuse_unbounded_workspace_root_scan(
+        [str(workspace)],
+        SearchConfig(max_depth=1),
+        allow_broad_generated_scan=False,
+        paths_defaulted=True,
     )
 
     assert refused is False
@@ -758,6 +807,7 @@ def test_vendored_root_guard_refuses_single_project_root_with_top_level_vendor_d
         [str(repo)],
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is True
@@ -781,6 +831,7 @@ def test_vendored_root_guard_excludes_walker_skipped_node_modules(tmp_path: Path
         [str(repo)],
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is False
@@ -797,10 +848,31 @@ def test_vendored_root_guard_allows_bounded_scan(tmp_path: Path):
         [str(repo)],
         SearchConfig(glob=["*.py"]),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is False
     assert vendored_dirs == []
+
+
+def test_vendored_root_guard_refuses_glob_with_implicit_path(tmp_path: Path):
+    """Bug #88 (dogfood v1.54.0): same gap as the workspace-root guard above, but for a
+    vendored-named top-level dir -- `--glob` must not exempt an implicit-path (defaulted)
+    scan from the vendored-root refusal."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "go.mod").write_text("module example.com/repo\n", encoding="utf-8")
+    (repo / "vendor").mkdir()
+
+    refused, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
+        [str(repo)],
+        SearchConfig(glob=["*.py"]),
+        allow_broad_generated_scan=False,
+        paths_defaulted=True,
+    )
+
+    assert refused is True
+    assert vendored_dirs == ["vendor"]
 
 
 def test_vendored_root_guard_allows_normal_small_repo(tmp_path: Path):
@@ -814,6 +886,7 @@ def test_vendored_root_guard_allows_normal_small_repo(tmp_path: Path):
         [str(repo)],
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is False
@@ -887,16 +960,48 @@ def test_large_root_guard_refuses_over_ceiling_candidate_count():
         2000,
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is True
 
 
 def test_large_root_guard_allows_scoped_glob_over_ceiling():
+    """An explicit PATH combined with `--glob` is a deliberate, scoped request -- must still
+    run, not be refused (Trap #3, unchanged by bug #88's fix)."""
     refused = _should_refuse_unbounded_large_root_scan(
         2000,
         SearchConfig(glob=["*.py"]),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
+    )
+
+    assert refused is False
+
+
+def test_large_root_guard_refuses_glob_with_implicit_path_over_ceiling():
+    """Bug #88 (dogfood v1.54.0): with NO explicit PATH (`paths_defaulted=True`), `--glob`
+    alone must not exempt an over-ceiling candidate count from refusal -- the ceiling is
+    evaluated on the ACTUAL post-glob-filter count, so this never under-refuses a genuinely
+    scoped-down glob (see the ceiling docstring)."""
+    refused = _should_refuse_unbounded_large_root_scan(
+        2000,
+        SearchConfig(glob=["*.py"]),
+        allow_broad_generated_scan=False,
+        paths_defaulted=True,
+    )
+
+    assert refused is True
+
+
+def test_large_root_guard_allows_max_depth_with_implicit_path_over_ceiling():
+    """`--max-depth` genuinely bounds the walk, so it remains a valid escape hatch even with
+    an implicit (defaulted) PATH -- this is not the bug #88 shape."""
+    refused = _should_refuse_unbounded_large_root_scan(
+        2000,
+        SearchConfig(max_depth=2),
+        allow_broad_generated_scan=False,
+        paths_defaulted=True,
     )
 
     assert refused is False
@@ -907,6 +1012,7 @@ def test_large_root_guard_allows_explicit_opt_in():
         2000,
         SearchConfig(),
         allow_broad_generated_scan=True,
+        paths_defaulted=True,
     )
 
     assert refused is False
@@ -917,6 +1023,7 @@ def test_large_root_guard_allows_count_under_ceiling():
         50,
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
 
     assert refused is False
@@ -962,6 +1069,54 @@ def test_plain_search_scoped_glob_still_runs_on_large_root(monkeypatch, tmp_path
 
     assert result.exit_code == 0, result.output
     assert "broad root scan refused" not in result.output
+
+
+def test_plain_search_refuses_glob_with_implicit_path_on_large_root(monkeypatch, tmp_path: Path):
+    """Bug #88 (dogfood v1.54.0): `tg search --glob X PATTERN` with NO positional PATH used to
+    walk/search a large single-project root unbounded, because `--glob` was (wrongly) treated
+    as sufficient scoping for the large-root-ceiling guard regardless of whether PATH was
+    explicit. Reproduce the exact reported shape: no PATH argument at all (cwd supplies it),
+    `--glob` present, over the file-count ceiling. Force native+rg off (F6 precondition,
+    matching the sibling unscoped test above) and assert the guard now refuses instantly."""
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(cli_main, "resolve_ripgrep_binary", lambda: None)
+    monkeypatch.setattr("tensor_grep.cli.runtime_paths.resolve_ripgrep_binary", lambda: None)
+    repo = tmp_path / "repo"
+    _make_stub_file_repo(repo, 2000)
+    monkeypatch.chdir(repo)
+
+    start = time.perf_counter()
+    result = CliRunner().invoke(app, ["search", "TODO", "--glob", "*.py"])
+    elapsed = time.perf_counter() - start
+
+    assert result.exit_code == 2, result.output
+    assert "broad root scan refused" in result.output
+    assert "safety guard, not a zero-match result" in result.output
+    assert elapsed < 1.0, f"guard took {elapsed:.3f}s -- probe is not bounded"
+
+
+def test_plain_search_refuses_glob_with_implicit_path_on_workspace_root(
+    monkeypatch, tmp_path: Path
+):
+    """Bug #88 companion: the workspace-shaped root variant of the same gap (the actual shape
+    hit in the field -- a multi-project workspace directory, not a single oversized repo).
+    Deliberately does NOT force native/rg off: the workspace-root guard must fire BEFORE the
+    rg-passthrough fast path is ever considered, so this proves the fix closes the gap in the
+    realistic "rg is available" default configuration too."""
+    for project_name in ("alpha", "beta", "gamma"):
+        project = tmp_path / project_name
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    start = time.perf_counter()
+    result = CliRunner().invoke(app, ["search", "TODO", "--glob", "*.py"])
+    elapsed = time.perf_counter() - start
+
+    assert result.exit_code == 2, result.output
+    assert "broad workspace-root scan refused" in result.output
+    assert "safety guard, not a zero-match result" in result.output
+    assert elapsed < 1.0, f"guard took {elapsed:.3f}s -- probe is not bounded"
 
 
 def test_plain_search_unscoped_still_runs_on_small_repo(monkeypatch, tmp_path: Path):

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1119,6 +1119,96 @@ def test_plain_search_refuses_glob_with_implicit_path_on_workspace_root(
     assert elapsed < 1.0, f"guard took {elapsed:.3f}s -- probe is not bounded"
 
 
+def test_implicit_glob_walk_probe_counts_walk_not_glob_matches(tmp_path: Path):
+    """Bug #88 (v1.54.1 re-harvest): the WALK-count probe must count files the walker VISITS,
+    NOT post-glob matches -- a huge tree with a SELECTIVE glob (0 matches here) must still be
+    flagged, because the real search must WALK the whole tree to find those matches. 1600 `.py`
+    files exist; probing with a `*.nomatch` glob (0 matches) must still exceed the ceiling."""
+    from tensor_grep.cli.main import (
+        _LARGE_ROOT_SCAN_FILE_CEILING,
+        _implicit_glob_search_walk_exceeds_ceiling,
+    )
+
+    src = tmp_path / "src"
+    src.mkdir()
+    for index in range(1600):
+        (src / f"stub_{index}.py").write_text("x\n", encoding="utf-8")
+
+    exceeds = _implicit_glob_search_walk_exceeds_ceiling(
+        [str(tmp_path)],
+        SearchConfig(glob=["*.nomatch"]),
+        _LARGE_ROOT_SCAN_FILE_CEILING,
+    )
+    assert exceeds is True
+
+
+def test_implicit_glob_walk_probe_allows_small_and_max_depth(tmp_path: Path):
+    """The probe must NOT flag a small tree, and `--max-depth` (kept in the probe config) must
+    genuinely bound the walk so a deep-but-shallow-scoped search is allowed."""
+    from tensor_grep.cli.main import (
+        _LARGE_ROOT_SCAN_FILE_CEILING,
+        _implicit_glob_search_walk_exceeds_ceiling,
+    )
+
+    small = tmp_path / "small"
+    small.mkdir()
+    for index in range(50):
+        (small / f"f_{index}.py").write_text("x\n", encoding="utf-8")
+    assert not _implicit_glob_search_walk_exceeds_ceiling(
+        [str(tmp_path)], SearchConfig(glob=["*.py"]), _LARGE_ROOT_SCAN_FILE_CEILING
+    )
+
+    nested = tmp_path / "deep" / "nested"
+    nested.mkdir(parents=True)
+    for index in range(1600):
+        (nested / f"f_{index}.py").write_text("x\n", encoding="utf-8")
+    assert not _implicit_glob_search_walk_exceeds_ceiling(
+        [str(tmp_path / "deep")],
+        SearchConfig(glob=["*.py"], max_depth=1),
+        _LARGE_ROOT_SCAN_FILE_CEILING,
+    )
+
+
+def test_plain_search_refuses_glob_implicit_path_on_marked_single_root(monkeypatch, tmp_path: Path):
+    """Bug #88 (v1.54.1 re-harvest, the ACTUAL dogfood repro shape): a large single root whose TOP
+    LEVEL carries a project marker (here a `package.json`, like the real `C:/dev/projects`) is
+    SKIPPED by the workspace-root guard (`_path_has_project_marker` short-circuits it) and has no
+    top-level vendored dir, so a bare `tg search PATTERN --glob '*'` from it used to sail straight
+    into an unbounded rg passthrough (487k lines past 60s in the field). The new implicit-glob WALK
+    guard must refuse it fast. Does NOT force rg off -- proves the guard fires BEFORE the
+    rg-passthrough / native-delegation fast paths."""
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    src = tmp_path / "src"
+    src.mkdir()
+    for index in range(1600):
+        (src / f"stub_{index}.py").write_text("TODO placeholder\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    start = time.perf_counter()
+    result = CliRunner().invoke(app, ["search", "TODO", "--glob", "*"])
+    elapsed = time.perf_counter() - start
+
+    assert result.exit_code == 2, result.output
+    assert "broad root scan refused" in result.output
+    assert "safety guard, not a zero-match result" in result.output
+    assert elapsed < 3.0, f"guard took {elapsed:.3f}s -- probe is not bounded"
+
+
+def test_plain_search_glob_explicit_path_still_runs_on_marked_root(monkeypatch, tmp_path: Path):
+    """Trap #3 parity for the new guard: the SAME marked large root with an EXPLICIT path + glob
+    must still RUN (the implicit-glob walk guard is gated on `paths_defaulted`)."""
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    src = tmp_path / "src"
+    src.mkdir()
+    for index in range(1600):
+        (src / f"stub_{index}.py").write_text("TODO placeholder\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "TODO", str(tmp_path), "--glob", "*.py"])
+
+    assert result.exit_code == 0, result.output
+    assert "broad root scan refused" not in result.output
+
+
 def test_plain_search_unscoped_still_runs_on_small_repo(monkeypatch, tmp_path: Path):
     """A small repo (below the file-count ceiling) unscoped must still run normally."""
     monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1105,6 +1105,8 @@ def test_plain_search_refuses_glob_with_implicit_path_on_large_root(monkeypatch,
         ["-tpy"],  # bundled attached-value short form (rg idiom) -- re-gate BLOCK sibling
         ["-Tpy"],
         ["-itpy"],  # mid-bundle: -i then -t py
+        ["-g*.py"],  # bundled attached glob -- the -g sibling of the same form-class
+        ["-ig*.py"],  # mid-bundle: -i then -g *.py
     ],
 )
 def test_plain_search_refuses_type_and_iglob_with_implicit_path_on_large_root(

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1102,6 +1102,9 @@ def test_plain_search_refuses_glob_with_implicit_path_on_large_root(monkeypatch,
         ["--type", "py"],
         ["-T", "py"],
         ["--iglob", "*.py"],
+        ["-tpy"],  # bundled attached-value short form (rg idiom) -- re-gate BLOCK sibling
+        ["-Tpy"],
+        ["-itpy"],  # mid-bundle: -i then -t py
     ],
 )
 def test_plain_search_refuses_type_and_iglob_with_implicit_path_on_large_root(

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1095,6 +1095,40 @@ def test_plain_search_refuses_glob_with_implicit_path_on_large_root(monkeypatch,
     assert elapsed < 1.0, f"guard took {elapsed:.3f}s -- probe is not bounded"
 
 
+@pytest.mark.parametrize(
+    "scope_args",
+    [
+        ["-t", "py"],
+        ["--type", "py"],
+        ["-T", "py"],
+        ["--iglob", "*.py"],
+    ],
+)
+def test_plain_search_refuses_type_and_iglob_with_implicit_path_on_large_root(
+    monkeypatch, tmp_path: Path, scope_args: list[str]
+):
+    """Bug #88 SIBLINGS (adversarial-gate BLOCK on #480): --type/-t, --type-not/-T and --iglob
+    narrow WHICH files match but do NOT bound the walk -- the guard's own scope condition is
+    glob|iglob|file_type|type_not. Before the fix, a bare `tg search PAT -t py` (no PATH) on a
+    large root skipped the ceiling probe (native trigger only checked globs; bootstrap routed
+    bare --type/--iglob to the unguarded rg passthrough) and walked the whole tree. Same repro
+    shape as the --glob test above; must refuse instantly for every walk-scope flag."""
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(cli_main, "resolve_ripgrep_binary", lambda: None)
+    monkeypatch.setattr("tensor_grep.cli.runtime_paths.resolve_ripgrep_binary", lambda: None)
+    repo = tmp_path / "repo"
+    _make_stub_file_repo(repo, 2000)
+    monkeypatch.chdir(repo)
+
+    start = time.perf_counter()
+    result = CliRunner().invoke(app, ["search", "TODO", *scope_args])
+    elapsed = time.perf_counter() - start
+
+    assert result.exit_code == 2, result.output
+    assert "broad root scan refused" in result.output
+    assert elapsed < 1.0, f"guard took {elapsed:.3f}s -- probe is not bounded"
+
+
 def test_plain_search_refuses_glob_with_implicit_path_on_workspace_root(
     monkeypatch, tmp_path: Path
 ):

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -875,6 +875,38 @@ def test_tg_search_refuses_large_root_scan_for_non_ripgrep_backend():
     assert "1500" in payload["error"]["message"]
 
 
+def test_tg_search_refuses_glob_with_default_path_on_large_root():
+    """Bug #88 (dogfood v1.54.0): a `glob` filter narrows WHICH files match, it does not
+    bound how much of the tree must be walked to find them. The MCP `path` parameter defaults
+    to "." at the Python level, indistinguishable from an omitted argument, so `glob` alone
+    must not exempt a `path="."` call from the large-root refusal -- otherwise a bare
+    `tg_search(pattern=..., glob=...)` MCP call walks/searches an oversized root unbounded,
+    the same shape as the CLI's bare `tg search --glob ... PATTERN` hang."""
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = MagicMock()
+    many_files = [f"file_{i}.py" for i in range(2000)]
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = many_files
+
+        out = mcp_server.tg_search("ERROR", ".", glob="*.py")
+
+    fake_backend.search.assert_not_called()
+    payload = json.loads(out)
+    assert payload["error"]["code"] == "broad_scan_refused"
+    assert "1500" in payload["error"]["message"]
+
+
 def test_tg_ast_search_backend_execution_error_skips_file_and_keeps_partial_results():
     from tensor_grep.backends.base import BackendExecutionError
     from tensor_grep.cli import mcp_server

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -242,6 +242,7 @@ def test_m15_detector_keys_on_child_project_markers(tmp_path: Path) -> None:
         [str(workspace)],
         SearchConfig(),
         allow_broad_generated_scan=False,
+        paths_defaulted=False,
     )
     assert refuse is True
     assert dirs == ["a", "b", "c"]


### PR DESCRIPTION
## What

`tg search --glob '<pat>'` with **no PATH** on a large/harness repo timed out (exit 124 / hang) — dogfood #88, 1.54.0. A bare glob defaults the scan to the whole cwd tree; on a huge root the walk is unbounded.

## Root cause (two real causes + a Python front-door gap)

1. **Empty implicit paths.** `resolve_search_request` set `request.paths = []` (not `["."]`) when stdin looks readable; the first-cut ceiling probe early-returned on empty roots → never counted → rg walked the cwd unbounded (`main.rs`).
2. **Match-count vs walk-count.** The probe counted post-glob *matches*, so a selective glob (`*.rs` in a huge JS tree) sailed under the ceiling, and `**/*` made the probe itself walk the whole tree. The hang is **tree-walk cost, glob-independent** — so the probe must count files *walked*, not matched.
3. **Python front-door gap.** `--glob` is a `_TG_ONLY_SEARCH_FLAG`, so `tg search --glob X` routes to `_run_full_cli` which handed the implicit-`.` walk to rg passthrough *before* the large-root refusal. On a root with a top-level project marker (real `C:/dev/projects` has a `package.json`) the workspace guard skipped it → unbounded. Now fixed on the Python side too.

## Fix

- `rust_core/src/main.rs`: `implicit_search_walk_exceeds_ceiling` (counts files WALKED, glob filter dropped) + normalize empty `request.paths` → `["."]` before probing.
- `src/tensor_grep/cli/main.py` + `mcp_server.py`: `_implicit_glob_search_walk_exceeds_ceiling` — a bounded glob-stripped walk after the vendored guard, gated on `paths_defaulted` + glob/type present + `max_depth is None` + not `--allow-broad-generated-scan`. Refuse fast with guidance to scope a PATH (same class as the #400 unscoped-search refusal).

**Behavior note:** an unscoped implicit-path glob on a huge root now **refuses fast (exit 2)** rather than completing slowly — consistent across native + Python, matching the existing unscoped-search-on-huge-root contract. Explicit-path and scoped searches are unaffected.

## Real-binary dogfood (native ext rebuilt via maturin, on the real workspace)

| Invocation (no PATH, `C:/dev/projects`) | Before | After |
|---|---|---|
| `tg search "function" --glob "*"` | exit 124 hang | exit 2, ~0s |
| `tg search "x" --glob "**/*"` | >120s hang | exit 2, ~1s |
| `tg search "x" --glob "*.zzz"` (0 matches, huge tree) | would hang | exit 2, ~0s |
| `tg search "def main" --glob "*.py"` | 29s | exit 2, ~1s |
| `tg search "def main" . --glob "*.py"` (explicit path) | — | exit 0, correct matches |
| `tg search PATTERN src --glob "*.py"` (scoped) | — | exit 0, correct matches |

## Verify (real venv)

- Python: 684 tests pass (`test_cli_modes` + `test_mcp_server` + `test_medlow_main_cli`), incl. 4 new (`test_plain_search_refuses_glob_implicit_path_on_marked_single_root`, RED-verified). Rust: `cargo test --bin tg` 70/70, clippy + fmt clean. ruff + `ruff format --preview` + mypy clean on touched files.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
