### PR TITLE
fix(install): collapse the bash launcher-shim 2-hop chain + builtin WSL probe (audit #94 Part B, ~150ms/call)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -652,8 +652,6 @@ try {
     $msysInstallDir = Convert-ToMsysPath $installDir
     $frontdoorArgBridgePath = Join-Path $frontdoorDir "tg-cmd-bridge.py"
     $wslInstallDir = Convert-ToWslPath $installDir
-    $msysFrontdoorPath = Convert-ToMsysPath $frontdoorBashPath
-    $wslFrontdoorPath = Convert-ToWslPath $frontdoorBashPath
     $stagingFrontdoorCmdPath = Join-Path $stagingFrontdoorDir "tg.cmd"
     $stagingFrontdoorPs1Path = Join-Path $stagingFrontdoorDir "tg.ps1"
     $stagingFrontdoorBashPath = Join-Path $stagingFrontdoorDir "tg"
@@ -732,12 +730,12 @@ runpy.run_module("tensor_grep", run_name="__main__")
 '@
     $frontdoorBashContent = @"
 #!/usr/bin/env bash
-if grep -qi microsoft /proc/version 2>/dev/null; then
-    TG_NATIVE="$wslInstallDir/bin/tg.exe"
-    TG_PYTHON="$wslInstallDir/.venv/Scripts/python.exe"
-else
+if [ -f "$msysInstallDir/.venv/Scripts/python.exe" ]; then
     TG_NATIVE="$msysInstallDir/bin/tg.exe"
     TG_PYTHON="$msysInstallDir/.venv/Scripts/python.exe"
+else
+    TG_NATIVE="$wslInstallDir/bin/tg.exe"
+    TG_PYTHON="$wslInstallDir/.venv/Scripts/python.exe"
 fi
 export PYTHONUTF8=1
 export PYTHONIOENCODING=utf-8
@@ -802,15 +800,9 @@ exec "`$TG_PYTHON" -X utf8 -m tensor_grep "`$@"
 & "$frontdoorPs1Path" @args
 exit `$LASTEXITCODE
 "@
-    $bashShimContent = @"
-#!/usr/bin/env bash
-if grep -qi microsoft /proc/version 2>/dev/null; then
-    TG_FRONTDOOR="$wslFrontdoorPath"
-else
-    TG_FRONTDOOR="$msysFrontdoorPath"
-fi
-exec "`$TG_FRONTDOOR" "`$@"
-"@
+    # Bash shims carry the front-door's own MSYS/WSL-detection + native-or-python exec logic
+    # directly (identical to $frontdoorBashContent) instead of exec-chaining to the front-door
+    # script. This collapses the compat-shim invocation from 2 bash-process hops to 1.
     $installedShimPaths = @()
     foreach ($shimDir in $shimDirs) {
         if (!(Test-Path $shimDir)) {
@@ -857,7 +849,7 @@ exec "`$TG_FRONTDOOR" "`$@"
             Write-Warning "Python subprocess tg.exe bridge was not installed because a foreign tg.exe already exists: $exeShimPath"
         }
         Write-AsciiFile -Path $ps1ShimPath -Value $ps1ShimContent
-        Write-BashFile -Path $bashShimPath -Value $bashShimContent
+        Write-BashFile -Path $bashShimPath -Value $frontdoorBashContent
         $installedShimPaths += $cmdShimPath
         $installedShimPaths += $ps1ShimPath
         $installedShimPaths += $bashShimPath

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -389,13 +389,13 @@ fi
 
 SHIM_DIRS=("$HOME/.local/bin" "$HOME/bin")
 INSTALLED_SHIMS=()
+# The shim is a byte-identical copy of the already-committed front-door script (same
+# native-or-python exec logic) rather than a wrapper that re-execs the front door as a second
+# bash process: 1 bash hop per invocation, not 2.
 for SHIM_DIR in "${SHIM_DIRS[@]}"; do
     mkdir -p "$SHIM_DIR"
     SHIM_PATH="$SHIM_DIR/tg"
-    cat > "$SHIM_PATH" << EOF
-#!/usr/bin/env bash
-"$INSTALL_DIR/bin/tg" "\$@"
-EOF
+    cp "$INSTALL_DIR/bin/tg" "$SHIM_PATH"
     chmod +x "$SHIM_PATH"
     INSTALLED_SHIMS+=("$SHIM_PATH")
 done

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -280,6 +280,7 @@ def test_install_ps1_should_create_git_bash_shims_without_pathext():
 
     assert "$frontdoorBashPath" in content
     assert "$msysInstallDir" in content
+    assert 'if [ -f "$msysInstallDir/.venv/Scripts/python.exe" ]; then' in content
     assert 'TG_NATIVE="$msysInstallDir/bin/tg.exe"' in content
     assert 'TG_PYTHON="$msysInstallDir/.venv/Scripts/python.exe"' in content
     assert 'export TG_SIDECAR_PYTHON="`$TG_PYTHON"' in content
@@ -287,8 +288,6 @@ def test_install_ps1_should_create_git_bash_shims_without_pathext():
     assert 'if [ -f "`$TG_NATIVE" ]; then' in content
     assert '    exec "`$TG_NATIVE" "`$@"' in content
     assert 'exec "`$TG_PYTHON" -X utf8 -m tensor_grep "`$@"' in content
-    assert 'TG_FRONTDOOR="$msysFrontdoorPath"' in content
-    assert 'exec "`$TG_FRONTDOOR" "`$@"' in content
 
 
 def test_install_ps1_should_create_wsl_aware_bash_shims():
@@ -296,11 +295,41 @@ def test_install_ps1_should_create_wsl_aware_bash_shims():
 
     assert "function Convert-ToWslPath" in content
     assert "$wslInstallDir = Convert-ToWslPath $installDir" in content
-    assert "$wslFrontdoorPath = Convert-ToWslPath $frontdoorBashPath" in content
-    assert "grep -qi microsoft /proc/version" in content
     assert 'TG_NATIVE="$wslInstallDir/bin/tg.exe"' in content
     assert 'TG_PYTHON="$wslInstallDir/.venv/Scripts/python.exe"' in content
-    assert 'TG_FRONTDOOR="$wslFrontdoorPath"' in content
+    # The MSYS-native-path existence check (git-bash/MSYS: "/c/..." resolves) is tried FIRST;
+    # only a miss falls through to the WSL-style "/mnt/c/..." paths in the else branch, since on
+    # real WSL "/c/..." does not exist so the builtin `[ -f ]` test correctly fails closed to WSL.
+    msys_check_index = content.index('if [ -f "$msysInstallDir/.venv/Scripts/python.exe" ]; then')
+    wsl_branch_index = content.index('TG_NATIVE="$wslInstallDir/bin/tg.exe"')
+    assert msys_check_index < wsl_branch_index
+
+
+def test_install_ps1_bash_shim_is_single_hop_with_no_grep_wsl_probe():
+    """Audit #94 Part B: the compat-shim bash files (~/bin/tg, ~/.local/bin/tg) must embed the
+    front door's own MSYS-vs-WSL detection + native-or-python exec logic directly instead of
+    exec-chaining to a second script, and that detection must be a builtin `[ -f ... ]` test, never
+    a `grep` subprocess fork. Both were a per-invocation process-spawn tax paid on every bash `tg`
+    call from git-bash/MSYS (~90-110ms for the extra hop, ~64-66ms/hop for the grep fork)."""
+    content = _read_script("scripts/install.ps1")
+
+    # No grep-based /proc/version probe anywhere in the generated shim/front-door content.
+    assert "grep -qi microsoft" not in content
+    assert "/proc/version" not in content
+
+    # No exec-chain from the compat shim to a separately-templated front-door script. The old
+    # 2-hop shape used a dedicated TG_FRONTDOOR variable + a second $bashShimContent template to
+    # `exec` from the shim into $frontdoorBashPath; both are gone.
+    assert "TG_FRONTDOOR" not in content
+    assert "$bashShimContent" not in content
+    assert "$wslFrontdoorPath" not in content
+    assert "$msysFrontdoorPath" not in content
+
+    # The compat-shim write reuses the SAME content variable as the staged front-door write, so
+    # both files carry identical single-hop logic by construction (a shared source, not a
+    # duplicated template that could drift out of sync).
+    assert "Write-BashFile -Path $stagingFrontdoorBashPath -Value $frontdoorBashContent" in content
+    assert "Write-BashFile -Path $bashShimPath -Value $frontdoorBashContent" in content
 
 
 def test_install_ps1_should_write_bash_shims_without_windows_newline_append():
@@ -314,7 +343,21 @@ def test_install_ps1_should_write_bash_shims_without_windows_newline_append():
     assert "Set-Content -Path $frontdoorBashPath" not in content
     assert "Set-Content -Path $bashShimPath" not in content
     assert "Write-BashFile -Path $stagingFrontdoorBashPath -Value $frontdoorBashContent" in content
-    assert "Write-BashFile -Path $bashShimPath -Value $bashShimContent" in content
+    assert "Write-BashFile -Path $bashShimPath -Value $frontdoorBashContent" in content
+
+
+def test_install_sh_bash_shim_is_single_hop_copy_of_frontdoor():
+    """Audit #94 Part B (symmetry check): install.sh's compat shims ($HOME/.local/bin/tg,
+    $HOME/bin/tg) never had install.ps1's grep-based WSL probe (Linux/macOS have one canonical
+    path convention, so there is no MSYS-vs-WSL branch to replace), but they DID re-exec the
+    already-committed front door as a second bash process. The shim must instead be a
+    byte-identical copy of the committed front door: 1 bash hop per invocation, not 2."""
+    content = _read_script("scripts/install.sh")
+
+    assert 'cp "$INSTALL_DIR/bin/tg" "$SHIM_PATH"' in content
+    # The old wrapper-shim heredoc (a second bash process re-invoking the committed front door)
+    # must be gone.
+    assert '"$INSTALL_DIR/bin/tg" "\\$@"' not in content
 
 
 def test_install_ps1_should_place_extras_before_pinned_version_specifier():


### PR DESCRIPTION
## What

Audit #94 Part B — the launcher shim-tax (the #1 "tg feels slow per call" preference-killer). Two contained levers on the bash launcher shims that `scripts/install.ps1`/`install.sh` generate:

1. **Collapse 2 bash hops into 1.** The compat-dir shims (`~/bin/tg`, `~/.local/bin/tg`) used to WSL-probe then `exec` a SECOND shim (`~/.tensor-grep/bin/tg`). Now the shim-dir files are written from the SAME `$frontdoorBashContent` variable as the staged front door — one hop, and identical by construction (no duplicated template to drift). `install.sh` does the equivalent (`cp` the front door into the shim path).
2. **Replace the `grep` WSL probe with a builtin.** `grep -qi microsoft /proc/version` (a subprocess fork on every call) → a builtin `[ -f "$msysInstallDir/.venv/Scripts/python.exe" ]` MSYS-first test with a WSL fallback. (Used `python.exe` — always created by `uv venv` — not `tg.exe`, which is absent on no-native-asset installs.)

## Why

Measured on this box: ~258ms launcher tax → ~85-90ms — inside the `rg` baseline (~102ms), flipping "tg slower than rg per bash-mediated call" to faster. `grep` fork ~45ms/call → builtin ~1ms; +1 fewer bash hop ~90ms. Same-methodology full-path benchmark: 415ms → 263ms (~152ms / 36.5% win). Empirical breakdown + the design: `docs/plans/design-tensor-grep-94-latency-daemon-shim-2026-07-09.md`.

## Contracts preserved

Native-binary preference, `TG_SIDECAR_PYTHON`/`TG_NATIVE_TG_BINARY` env, `python -m tensor_grep` fallback — all still set (just directly in the shim, not via a chain). The **foreign-`tg.exe` guard** (install-time, `install.ps1`) is untouched. Staged-install atomic-swap ordering unchanged.

## Verify (real venv)

- `test_install_scripts.py`: 46 pass (44 pre-existing + 2 new — a single-hop/no-grep assertion for `.ps1` and a single-hop-copy assertion for `.sh`). Governance-test assertions updated consciously (the removed `grep`/`TG_FRONTDOOR`/`$bashShimContent` strings are confirmed absent in source).
- `bash -n install.sh` + PowerShell parse of `install.ps1` clean. No residual `grep -qi microsoft` / `TG_FRONTDOOR` in `install.ps1`.

## Caveat (flagged, not blocking)

The **WSL branch** of the builtin probe is logic-verified only — no WSL environment on the build/verify box. The MSYS-first-else-WSL fallback is sound by construction (real WSL has no `/c/...` mount, only `/mnt/c/...`, so the `[ -f ]` test correctly misses and falls through) and mirrors the existing `Convert-ToWslPath` logic, but a real-WSL smoke test is worth doing post-merge. The git-bash path (this session's harness) is verified. Multi-platform CI runs the install-script tests on Linux/macOS/Windows.

Part of #94 (Part A daemon-default is a separate, council-gated PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
