### PR TITLE
perf(repo-map): raise CALLER_SCAN_FILE_CEILING 512 -> 2000 + fix latent importers scan_remediation clobber (#57)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -159,13 +159,20 @@ DEFAULT_AGENT_REPO_MAP_LIMIT = 2000
 # passthrough, so a per-command option default cannot reach it). The caller-scan functions
 # (build_symbol_callers_from_map, build_symbol_blast_radius_from_map via its callers-scan,
 # build_symbol_refs_from_map) do a slow per-file prefilter + re-parse whose wall-clock scales
-# with the file universe size (task #52: ~100s on a 1941-file repo at the old 512 cap already;
-# a naive raise to 2000 would make it worse). This ceiling bounds that ONE hot loop at a single
-# internal chokepoint, so it stays fast regardless of DEFAULT_AGENT_REPO_MAP_LIMIT / an explicit
-# --max-repo-files / a stored session map's size. When the scan is capped below the map's true
-# file count, the payload is marked result_incomplete (see _CALLER_SCAN_CEILING_REMEDIATION)
-# so the exit-2 truncation-honesty contract still fires.
-CALLER_SCAN_FILE_CEILING = 512
+# with the file universe size (task #52: ~100s on a 1941-file repo at the old 512 cap). This
+# ceiling bounds that ONE hot loop at a single internal chokepoint, so it stays fast regardless
+# of DEFAULT_AGENT_REPO_MAP_LIMIT / an explicit --max-repo-files / a stored session map's size.
+# backlog #57 (2026-07-09): raised 512 -> 2000, matching DEFAULT_AGENT_REPO_MAP_LIMIT above, now
+# that #478 threaded a --deadline hard-bound through every caller-scan loop and closed the #52
+# unbounded-hang risk that originally kept this ceiling frozen below the map default. 2000 is a
+# deliberate knee (see the map-build cost note above), not a removal of the cap: the ceiling
+# stays a hard backstop for a --max-repo-files-raised mega-repo and for the flag-less
+# (--deadline omitted) default path, which still has no other wall-clock bound. Raising past
+# 2000 needs fresh cost data plus confirming _PARSE_PRODUCT_CACHE_MAXSIZE (below) still exceeds
+# it -- otherwise the shared parse-cache guarantee silently thrashes via FIFO eviction. When the
+# scan is capped below the map's true file count, the payload is marked result_incomplete (see
+# _CALLER_SCAN_CEILING_REMEDIATION) so the exit-2 truncation-honesty contract still fires.
+CALLER_SCAN_FILE_CEILING = 2000
 # F1-review HIGH fix (task#52 shape, 2026-07-06): _order_caller_scan_candidates probes
 # _file_may_contain_literal_symbol (a stat + cached read_bytes) across the caller-scan file
 # UNIVERSE to decide ordering, BEFORE _cap_caller_scan_files slices to CALLER_SCAN_FILE_CEILING.
@@ -1237,7 +1244,14 @@ def _read_source_text_cached_bounded(path_str: str) -> str:
     return Path(path_str).read_text(encoding="utf-8")
 
 
-_PARSE_PRODUCT_CACHE_MAXSIZE = 1024
+# backlog #57 companion fix (2026-07-09): must stay >= CALLER_SCAN_FILE_CEILING (2000). This
+# cache is FIFO (insertion-order eviction, not LRU -- see _mtime_aware_cache above), so if it were
+# smaller than the caller-scan ceiling, a single callers/refs/blast-radius pass over a
+# >maxsize-eligible-file repo would silently thrash: files parsed early in the scan get evicted
+# before later consumers (refs after callers, or a second symbol lookup) can reuse them, quietly
+# defeating the "one parse per file, shared across every symbol/ref/caller extractor" guarantee
+# this cache exists to provide. 2048 keeps headroom above the 2000 ceiling.
+_PARSE_PRODUCT_CACHE_MAXSIZE = 2048
 
 
 def _parser_for_source_suffix(suffix: str) -> Any | None:
@@ -1544,9 +1558,12 @@ def _cap_caller_scan_files(
     ``files`` classified as tests), ORDER the candidates first via
     ``_order_caller_scan_candidates`` so literal symbol-hit files and a proportional share of
     tests survive the slice instead of being stranded behind a long source-file run (see that
-    function's docstring for the full rationale + trap). The ceiling itself is left at 512 on
-    purpose -- raising it reintroduces task #52's ~100s TS-regex hang, the reason
-    CALLER_SCAN_FILE_CEILING shipped (see the module note above ``CALLER_SCAN_FILE_CEILING``).
+    function's docstring for the full rationale + trap). The ceiling itself (
+    ``CALLER_SCAN_FILE_CEILING``, see the module note above) is a hard backstop, not a fixed
+    historical relic: backlog #57 (2026-07-09) raised it 512 -> 2000 now that #478's
+    --deadline hard-bound closed task #52's ~100s TS-regex hang risk for the interruptible path,
+    but a flag-less (--deadline omitted) invocation and a --max-repo-files-raised mega-repo still
+    have no other wall-clock bound, so the ceiling remains in force at the new, higher value.
     When no ``test_files`` are passed (or none exist), behavior is unchanged: a plain prefix
     slice of ``files`` in whatever order the caller already supplied.
 
@@ -14498,15 +14515,35 @@ def build_file_importers_from_map(
     payload["importers"] = edges
     payload["importer_files"] = sorted(dict.fromkeys(str(item["file"]) for item in edges))
     payload["importer_count"] = len(edges)
+    # backlog #57 companion fix: copy the (unrelated) repo-map-level scan_limit/scan_remediation
+    # BEFORE stamping the caller-scan ceiling's own remediation below -- build_symbol_callers_from_map
+    # orders it the same way (_copy_scan_limit, then its ceiling-hit _mark_result_incomplete).
+    # Reversing this order was a real bug caught while adding coverage for this branch: a COMPLETE
+    # repo-map scan always stamps `scan_remediation: None` on its own payload (see
+    # _mark_result_incomplete's docstring), and _copy_scan_limit unconditionally copies that key
+    # over when `source["scan_limit"]` is a dict -- clobbering the ceiling-hit remediation this
+    # function sets below if _copy_scan_limit ran AFTER it instead of before.
+    _copy_scan_limit(payload, repo_map)
     if ceiling_hit:
         # task #61 lesson: bound this sibling loop with the SAME ceiling the caller-scan main
         # loop uses, and mark it via the shared `caller_scan_limit` shape so the CLI's existing
         # `_scan_truncation_warning`/exit-2 contract picks it up with no bespoke wiring.
-        payload["caller_scan_limit"] = {
-            "possibly_truncated": True,
-            "ceiling": CALLER_SCAN_FILE_CEILING,
-            "files_total": len(prefiltered),
-        }
+        # backlog #57 companion fix: route through _mark_result_incomplete (as
+        # build_symbol_callers_from_map/build_symbol_refs_from_map already do at their own
+        # ceiling-hit sites) instead of setting `caller_scan_limit` alone -- the CLI's exit-2 gate
+        # already read `caller_scan_limit` directly so behavior there was unaffected, but a
+        # non-CLI consumer (MCP tools, a direct build_file_importers*/session_file_importers call)
+        # used to see the ceiling-truncation fact without the `result_incomplete`/`scan_remediation`
+        # honesty signal its callers/refs siblings always set.
+        _mark_result_incomplete(
+            payload,
+            remediation=_CALLER_SCAN_CEILING_REMEDIATION,
+            caller_scan_limit={
+                "possibly_truncated": True,
+                "ceiling": CALLER_SCAN_FILE_CEILING,
+                "files_total": len(prefiltered),
+            },
+        )
     if deadline_hit:
         payload["partial"] = True
         payload["deadline_limit"] = {
@@ -14514,7 +14551,6 @@ def build_file_importers_from_map(
             "importer_candidates_scanned": scanned_count,
             "importer_candidates_total": len(bounded_candidates),
         }
-    _copy_scan_limit(payload, repo_map)
     payload["resolution_gaps"] = list(repo_map.get("resolution_gaps", []))
     return payload
 

--- a/tests/unit/test_cap_fix_chokepoint.py
+++ b/tests/unit/test_cap_fix_chokepoint.py
@@ -16,12 +16,23 @@ Two changes, tested together because they only make sense as a pair:
    per-command cap to intercept it).
 
 Gate items (a)-(d) below map 1:1 onto the plan's TDD list.
+
+backlog #57 (2026-07-09) raised ``CALLER_SCAN_FILE_CEILING`` again, 512 -> 2000, matching
+``DEFAULT_AGENT_REPO_MAP_LIMIT``, now that #478's --deadline hard-bound closed the task #52 hang
+risk that originally kept it frozen below the map default. Tests above that assumed a 700-ish
+file fixture would exceed the (then 512) ceiling now monkeypatch ``CALLER_SCAN_FILE_CEILING``
+(and, where relevant, the derived ``CALLER_SCAN_ORDER_PROBE_CEILING``) down to a small
+test-local value instead of inflating fixtures to exceed 2000/8000 -- see the trailing
+"backlog #57" section at the bottom of this file for the new coverage the raise itself needs
+(golden-parity, the dogfood regression it fixes, the ``build_file_importers_from_map`` ceiling
+branch, and truncation at the new, real 2000 value).
 """
 
 from __future__ import annotations
 
 import json
 import math
+import time
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -88,9 +99,44 @@ def _make_flat_repo_with_tests(
     return project
 
 
+def _make_flat_repo_with_late_caller(
+    root: Path,
+    count: int,
+    *,
+    definition_index: int,
+    caller_index: int,
+    symbol: str,
+) -> Path:
+    """backlog #57 dogfood fixture: ``count`` trivial .py files in one directory; the file at
+    ``definition_index`` DEFINES ``symbol``, and the file at ``caller_index`` (independently)
+    IMPORTS + CALLS it. Unlike ``_make_flat_repo``'s ``target_index`` (which only places a
+    definition), this reproduces the actual dogfood regression: a real caller sitting past the
+    ceiling slice, not just the definition."""
+    project = root / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    width = max(5, len(str(count)))
+    definition_module = f"m{definition_index:0{width}d}"
+    for index in range(count):
+        if index == definition_index:
+            body = f"def {symbol}():\n    return True\n"
+        elif index == caller_index:
+            body = (
+                f"from src.{definition_module} import {symbol}\n\n\n"
+                f"def uses_{symbol}():\n    return {symbol}()\n"
+            )
+        else:
+            body = f"def helper_{index}():\n    return {index}\n"
+        (src / f"m{index:0{width}d}.py").write_text(body, encoding="utf-8")
+    return project
+
+
 def test_constants_locked_to_the_plan() -> None:
     assert repo_map.DEFAULT_AGENT_REPO_MAP_LIMIT == 2000
-    assert repo_map.CALLER_SCAN_FILE_CEILING == 512
+    # backlog #57 (2026-07-09): raised 512 -> 2000 (matching DEFAULT_AGENT_REPO_MAP_LIMIT) now
+    # that #478's --deadline hard-bound closed the #52 hang risk that kept this ceiling frozen
+    # below the map default; see the module-level comment above CALLER_SCAN_FILE_CEILING.
+    assert repo_map.CALLER_SCAN_FILE_CEILING == 2000
     # The CLI's shared routing/caller-scan default must track the map limit -- this is the
     # "necessary correction" over the plan's literal wording: main.py's `--max-repo-files`
     # default for defs/edit-plan/agent/context-render is a SEPARATE literal
@@ -136,6 +182,11 @@ def test_edit_plan_routes_to_symbol_past_512_at_the_new_default(tmp_path: Path) 
 
 
 def test_build_symbol_callers_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch) -> None:
+    # backlog #57: CALLER_SCAN_FILE_CEILING is now 2000 in production, well above this test's
+    # 700-file fixture -- monkeypatch it back down to a small test-local value (precedent:
+    # test_parse_product_cache.py's _SYMBOL_LITERAL_SEED_MAX_BYTES monkeypatch) so the fixture
+    # still exceeds the ceiling and exercises truncation, independent of the production constant.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 100)
     project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="target_symbol")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
     assert len(rmap["files"]) + len(rmap.get("tests", [])) >= 700
@@ -178,6 +229,8 @@ def test_build_symbol_callers_from_map_below_ceiling_stays_complete(tmp_path, mo
 
 
 def test_build_symbol_refs_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch) -> None:
+    # backlog #57: see the matching comment in test_build_symbol_callers_from_map_bounds_scan_to_ceiling.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 100)
     project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="target_symbol")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
 
@@ -196,6 +249,8 @@ def test_build_symbol_refs_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch
 
 
 def test_build_symbol_blast_radius_from_map_bounds_scan_to_ceiling(tmp_path, monkeypatch) -> None:
+    # backlog #57: see the matching comment in test_build_symbol_callers_from_map_bounds_scan_to_ceiling.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 100)
     project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="target_symbol")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
 
@@ -219,6 +274,8 @@ def test_build_symbol_blast_radius_from_map_bounds_scan_to_ceiling(tmp_path, mon
 
 
 def test_session_blast_radius_leak_fix_bounds_scan(tmp_path, monkeypatch) -> None:
+    # backlog #57: see the matching comment in test_build_symbol_callers_from_map_bounds_scan_to_ceiling.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 100)
     project = _make_flat_repo(tmp_path, 700, target_index=0, symbol="leaked_symbol")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
 
@@ -312,7 +369,11 @@ def test_blast_radius_output_cap_only_stays_exit_0(tmp_path, monkeypatch) -> Non
 # --- files + interleave tests BEFORE slicing, and stamp a structured caller_scan_limit caveat --
 
 
-def test_refs_ceiling_orders_literal_hits_and_surfaces_caller_scan_limit(tmp_path: Path) -> None:
+def test_refs_ceiling_orders_literal_hits_and_surfaces_caller_scan_limit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # backlog #57: see the matching comment in test_build_symbol_callers_from_map_bounds_scan_to_ceiling.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 50)
     project = _make_flat_repo_with_tests(tmp_path, 600, target_index=300, symbol="QueryEngine")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
     assert len(rmap.get("tests", [])) == 5
@@ -338,6 +399,12 @@ def test_callers_scan_still_bounded_at_ceiling_with_ordering_enabled(tmp_path, m
     """The ordering pass must not go UNBOUNDED: it probes at most
     CALLER_SCAN_ORDER_PROBE_CEILING files (for literal-hit ordering) and then walks the capped
     512-file window once for the real scan -- a fixed, non-quadratic cost, not a blowup."""
+    # backlog #57: CALLER_SCAN_FILE_CEILING is now 2000 in production -- monkeypatch it back down
+    # to a small test-local value so this 605-file fixture still exceeds the ceiling (the
+    # derived CALLER_SCAN_ORDER_PROBE_CEILING is left at its production value; the assertion
+    # below already only requires the universe to stay UNDER the probe ceiling, which holds
+    # trivially at the production 8000).
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 50)
     project = _make_flat_repo_with_tests(tmp_path, 600, target_index=300, symbol="QueryEngine")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=700)
     universe_size = len(rmap.get("files", [])) + len(rmap.get("tests", []))
@@ -371,7 +438,18 @@ def test_ordering_probe_bounded_on_universe_larger_than_probe_ceiling(
     via --max-repo-files), the ordering probe inside _order_caller_scan_candidates must NOT scan
     every file in the universe -- it must stop at CALLER_SCAN_ORDER_PROBE_CEILING regardless of
     how large the universe is. Total _file_may_contain_literal_symbol calls therefore bound to
-    (probe ceiling) + (scan ceiling), never O(universe size)."""
+    (probe ceiling) + (scan ceiling), never O(universe size).
+
+    backlog #57: production CALLER_SCAN_FILE_CEILING is now 2000 (CALLER_SCAN_ORDER_PROBE_CEILING
+    = 4x = 8000), which would force an ~9000+ file fixture to keep exceeding the probe ceiling --
+    slow and pointless disk I/O for a test whose CONTRACT is "the probe bounds itself regardless
+    of the production constant's value". Monkeypatch both constants down to a small test-local
+    pair (keeping the real 4x relationship) instead, mirroring the
+    test_parse_product_cache.py::test_oversize_file_bypasses_parse_product_cache precedent of
+    shrinking a production constant rather than inflating the fixture.
+    """
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 100)
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_ORDER_PROBE_CEILING", 400)
     project = _make_flat_repo_with_tests(tmp_path, 3000, target_index=1500, symbol="QueryEngine")
     rmap = repo_map.build_repo_map(str(project), max_repo_files=3100)
     universe_size = len(rmap.get("files", [])) + len(rmap.get("tests", []))
@@ -474,8 +552,14 @@ def test_order_caller_scan_candidates_reserves_proportional_test_share_in_window
     in the literal-hits block unconditionally and the assertion would pass even if
     _interleave_proportionally were entirely broken. This test forces the ONLY path into the
     bounded window to be the interleave: most source files are literal hits (crowding the front),
-    but every test file is a literal MISS, so a test can only reach the 512-file window via
-    proportional interleaving."""
+    but every test file is a literal MISS, so a test can only reach the ceiling window via
+    proportional interleaving.
+
+    backlog #57: CALLER_SCAN_FILE_CEILING is now 2000 in production, larger than this test's
+    620-file (600+20) universe -- ``ordered[:CEILING]`` would then be the WHOLE list, making the
+    "proportional share of a partial window" assertion vacuous. Monkeypatch the ceiling back down
+    to a small test-local value so the window this test slices is a genuine partial prefix."""
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 100)
     sources = [tmp_path / f"src_{i:04d}.py" for i in range(600)]
     tests = [tmp_path / f"test_{i:04d}.py" for i in range(20)]
     for current in [*sources, *tests]:
@@ -498,3 +582,190 @@ def test_order_caller_scan_candidates_reserves_proportional_test_share_in_window
     assert tests_in_window >= expected - 1
     # never drop: every file (hit or not, probed or not) remains present in the full ordering.
     assert set(ordered) == {*sources, *tests}
+
+
+# =================================================================================================
+# backlog #57 (2026-07-09): raise CALLER_SCAN_FILE_CEILING 512 -> 2000, + companion fixes.
+# =================================================================================================
+# (e) golden-parity: a repo that was ALREADY <=512 files must be byte-identical across the raise --
+#     the early-return branch in _cap_caller_scan_files is unchanged code and fires either way.
+# -------------------------------------------------------------------------------------------------
+
+
+def test_below_512_repo_caller_result_is_byte_identical_across_the_raise(
+    tmp_path, monkeypatch
+) -> None:
+    """Golden-parity gate (design doc: "<=512 repos byte-identical, early-return unchanged"):
+    _cap_caller_scan_files's early-return (`len(files) <= CEILING: return files, False`) is
+    unmodified code that fires for a <=512-file repo whether CEILING is the OLD 512 or the NEW
+    2000 (400 <= both) -- raising the ceiling must not perturb such a repo's caller-scan result
+    AT ALL. Proven empirically: run the identical fixture/map under both ceiling values and diff
+    the JSON-serialized payload byte-for-byte."""
+    production_ceiling = repo_map.CALLER_SCAN_FILE_CEILING
+    project = _make_flat_repo(tmp_path, 400, target_index=50, symbol="stable_symbol")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=400)
+
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 512)
+    old_ceiling_result = repo_map.build_symbol_callers_from_map(rmap, "stable_symbol")
+    assert old_ceiling_result.get("result_incomplete") is not True  # sanity: 400 <= 512 too
+
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", production_ceiling)
+    new_ceiling_result = repo_map.build_symbol_callers_from_map(rmap, "stable_symbol")
+    assert new_ceiling_result.get("result_incomplete") is not True
+
+    assert json.dumps(old_ceiling_result, sort_keys=True) == json.dumps(
+        new_ceiling_result, sort_keys=True
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# (f) the motivating dogfood regression: a caller sitting PAST the old 512-file index must now
+#     be found -- absent/truncated at a (simulated) 512 ceiling, present and complete at 2000.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_dogfood_caller_past_index_512_found_after_raise_absent_before(
+    tmp_path, monkeypatch
+) -> None:
+    """The dogfood shape backlog #57 exists to fix: an ~805-file repo where the ONLY caller of a
+    symbol sits past file-index 512 (alphabetically -- no ordering/interleaving in play here,
+    since this fixture has no test-named files, matching the plain prefix-slice branch of
+    _cap_caller_scan_files). RED against a mentally-512 ceiling (caller absent, result marked
+    incomplete); GREEN at the real 2000 production ceiling (caller present, result complete)."""
+    project = _make_flat_repo_with_late_caller(
+        tmp_path, 805, definition_index=0, caller_index=600, symbol="moat_symbol"
+    )
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=805)
+    assert len(rmap["files"]) + len(rmap.get("tests", [])) == 805
+
+    # RED (simulated OLD ceiling): the caller past index 512 must be dropped by the slice, and
+    # the payload must honestly flag itself incomplete.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 512)
+    old_result = repo_map.build_symbol_callers_from_map(rmap, "moat_symbol")
+    old_caller_files = {Path(str(c["file"])).name for c in old_result.get("callers", [])}
+    assert "m00600.py" not in old_caller_files, (
+        "test fixture assumption broken: the caller must NOT be visible at the old 512 ceiling"
+    )
+    assert old_result.get("result_incomplete") is True
+
+    # GREEN (the real, raised production ceiling): 805 <= 2000, so nothing is dropped at all.
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 2000)
+    new_result = repo_map.build_symbol_callers_from_map(rmap, "moat_symbol")
+    new_caller_files = {Path(str(c["file"])).name for c in new_result.get("callers", [])}
+    assert "m00600.py" in new_caller_files, new_result.get("callers")
+    assert new_result.get("result_incomplete") is not True
+
+
+# ---------------------------------------------------------------------------------------------
+# (g) the 4th consumer, build_file_importers_from_map, re-implements the ceiling INLINE and had
+#     ZERO test coverage of its ceiling branch before this backlog item.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_importers_from_map_ceiling_branch_marks_result_incomplete(
+    tmp_path, monkeypatch
+) -> None:
+    """build_file_importers_from_map (`tg importers`) re-implements the CALLER_SCAN_FILE_CEILING
+    cap inline rather than calling the shared _cap_caller_scan_files chokepoint, and had no test
+    at all for what happens when the importer-candidate count exceeds the ceiling. Prove two
+    things: (1) the ceiling branch fires (`caller_scan_limit.possibly_truncated`), the pre-#57
+    behavior; and (2) the #57 companion fix -- it now ALSO calls _mark_result_incomplete (like
+    build_symbol_callers_from_map / build_symbol_refs_from_map's own ceiling-hit sites), setting
+    `result_incomplete` + `scan_remediation`, so a non-CLI consumer (MCP tools, a direct
+    build_file_importers*/session_file_importers call) sees the same honesty signal the CLI's
+    exit-2 gate already read out of `caller_scan_limit` alone."""
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 50)
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "target.js"
+    target.write_text("export function shared() { return 1; }\n", encoding="utf-8")
+    importer_count = 60  # > the monkeypatched 50-file ceiling
+    for index in range(importer_count):
+        (src / f"importer_{index:04d}.js").write_text(
+            f'import {{ shared }} from "./target";\n'
+            f"export function use_{index}() {{ return shared(); }}\n",
+            encoding="utf-8",
+        )
+
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=importer_count + 10)
+    payload = repo_map.build_file_importers_from_map(rmap, str(target))
+
+    caller_scan_limit = payload.get("caller_scan_limit")
+    assert isinstance(caller_scan_limit, dict)
+    assert caller_scan_limit.get("possibly_truncated") is True
+    assert caller_scan_limit.get("ceiling") == 50
+    assert caller_scan_limit.get("files_total") == importer_count
+
+    assert payload.get("result_incomplete") is True
+    assert payload.get("scan_remediation")
+
+
+def test_build_file_importers_from_map_below_ceiling_stays_complete(tmp_path, monkeypatch) -> None:
+    """Parity check for the sibling above: below the ceiling, no truncation signal at all."""
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", 50)
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "target.js"
+    target.write_text("export function shared() { return 1; }\n", encoding="utf-8")
+    (src / "importer_0.js").write_text(
+        'import { shared } from "./target";\nexport function use_0() { return shared(); }\n',
+        encoding="utf-8",
+    )
+
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=10)
+    payload = repo_map.build_file_importers_from_map(rmap, str(target))
+
+    assert payload.get("caller_scan_limit") is None
+    assert payload.get("result_incomplete") is not True
+
+
+# ---------------------------------------------------------------------------------------------
+# (h) truncation past the NEW, real ceiling (2000) -- not a monkeypatched stand-in -- still
+#     fires result_incomplete/caller_scan_limit/exit-2, and stays within the latency budget.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_symbol_callers_from_map_bounds_scan_to_the_raised_ceiling(tmp_path: Path) -> None:
+    """No monkeypatch here: exercises the REAL production CALLER_SCAN_FILE_CEILING (2000) against
+    a repo that genuinely exceeds it, proving the raise didn't just move the truncation case out
+    of reach -- it still fires, at the new, bigger value."""
+    project = _make_flat_repo(tmp_path, 2500, target_index=0, symbol="target_symbol_past_2000")
+    rmap = repo_map.build_repo_map(str(project), max_repo_files=2500)
+    universe_size = len(rmap["files"]) + len(rmap.get("tests", []))
+    assert universe_size > repo_map.CALLER_SCAN_FILE_CEILING == 2000
+
+    start = time.monotonic()
+    result = repo_map.build_symbol_callers_from_map(rmap, "target_symbol_past_2000")
+    elapsed = time.monotonic() - start
+
+    assert result.get("result_incomplete") is True
+    caller_scan_limit = result.get("caller_scan_limit")
+    assert isinstance(caller_scan_limit, dict)
+    assert caller_scan_limit.get("possibly_truncated") is True
+    assert caller_scan_limit.get("ceiling") == repo_map.CALLER_SCAN_FILE_CEILING
+    assert caller_scan_limit.get("files_total") == universe_size
+    # Loose wall-clock smoke (CI-safe latency proxy, per the design doc's "no speed claim
+    # without numbers" -- but this is a synthetic proxy, NOT the real-repo Measure-Command the
+    # design also requires; start generous, learn from CHANGELOG #444's too-tight 1.0s flake).
+    assert elapsed < 30.0, f"callers scan at the raised ceiling took {elapsed:.2f}s (budget 30s)"
+
+
+def test_callers_cli_exits_2_past_the_raised_ceiling(tmp_path: Path) -> None:
+    """End-to-end companion of the test above: the CLI's exit-2 contract (main.py's
+    _scan_truncation_warning / _annotate_result_completeness) still fires off the real 2000
+    ceiling, not just off a monkeypatched stand-in."""
+    project = _make_flat_repo(tmp_path, 2500, target_index=0, symbol="target_symbol_past_2000")
+
+    result = runner.invoke(
+        app,
+        ["callers", str(project), "target_symbol_past_2000", "--max-repo-files", "2500", "--json"],
+    )
+
+    assert result.exit_code == 2, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload.get("result_incomplete") is True
+    caller_scan_limit = payload.get("caller_scan_limit")
+    assert isinstance(caller_scan_limit, dict)
+    assert caller_scan_limit.get("possibly_truncated") is True

--- a/tests/unit/test_parse_product_cache.py
+++ b/tests/unit/test_parse_product_cache.py
@@ -101,6 +101,51 @@ def test_map_then_callers_then_refs_parses_each_file_at_most_once(tmp_path, monk
     assert calls["n"] == file_count, "warm cache: a second pass must not re-parse any file"
 
 
+def test_callers_then_refs_over_1024_files_stays_one_parse_per_file(tmp_path, monkeypatch) -> None:
+    """backlog #57 companion-fix regression: _PARSE_PRODUCT_CACHE_MAXSIZE must stay >=
+    CALLER_SCAN_FILE_CEILING (2000) or this FIFO (insertion-order, not LRU -- see
+    _mtime_aware_cache) cache silently thrashes once a callers+refs pass touches more files than
+    its capacity. At the OLD 1024 cap, files parsed early in the callers pass over a >1024-file
+    universe get evicted before the refs pass (which revisits the SAME file universe) can reuse
+    them, defeating the "one parse per file, shared across every symbol/ref/caller extractor"
+    guarantee this cache exists to provide -- silently turning an O(N) scan into ~O(2N) at scale.
+    Builds 1100 (> the old 1024 cap) TS files that ALL reference the target symbol, so every one
+    of them is genuinely re-parsed by both the callers AND the refs scan, and proves the total
+    real-parse count never exceeds one per file through the full pass."""
+    root = tmp_path / "project"
+    _write(
+        root / "src" / "core.ts",
+        "export function createInvoice(total) {\n  return total + 1;\n}\n",
+    )
+    file_count = 1100
+    caller_count = file_count - 1
+    for index in range(caller_count):
+        _write(
+            root / "src" / f"caller_{index:05d}.ts",
+            'import { createInvoice } from "./core";\n\n'
+            f"export function use_{index}(total) {{\n"
+            "  return createInvoice(total);\n"
+            "}\n",
+        )
+
+    calls = _spy_parse_calls(monkeypatch)
+
+    repo_map_payload = repo_map.build_repo_map(str(root), max_repo_files=file_count + 100)
+    assert len(repo_map_payload["files"]) == file_count
+
+    repo_map.build_symbol_callers_from_map(repo_map_payload, "createInvoice")
+    assert calls["n"] == file_count, (
+        f"callers pass: expected exactly {file_count} real parses (one per file), saw {calls['n']}"
+    )
+
+    repo_map.build_symbol_refs_from_map(repo_map_payload, "createInvoice")
+    assert calls["n"] == file_count, (
+        "refs pass over the SAME >1024-file universe must be served entirely from the warm "
+        f"parse-product cache (still {file_count} total real parses, one per file) -- a FIFO "
+        f"cache smaller than the file count would force re-parses here; saw {calls['n']}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # (2) staleness
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Raise `CALLER_SCAN_FILE_CEILING` 512 -> 2000 (matches `DEFAULT_AGENT_REPO_MAP_LIMIT`) so `tg callers`/`tg refs`/`tg importers` stop falsely truncating the caller-scan on real mid-size repos. Backlog #57 (the #1 product bug: the 512 default was too small for real repos). Per `docs/plans/design-tensor-grep-57-caller-cap-raise-2026-07-09.md` (Sonnet verify-plan-against-code design). NOT a naive constant bump — 4 companion fixes + a golden-parity gate.

## Why (real-repo measurement, gotcontext-main = 611 tracked .ts/.tsx)

| run | wall-clock | signal |
|---|---|---|
| BEFORE (512) flag-less | 17.3s | **caller_scan_limit HIT** -> exit-2 "incomplete" on a valid query |
| AFTER (2000) flag-less | 19.1s | **no caller-cap** -> caller-scan complete |
| AFTER (2000) `--deadline 10` | 14.0s | bounded (interruptible, via #478 deadline threading) |

The old 512 ceiling truncated the caller-scan (611 TS files > 512) and set `caller_scan_limit`, so a legitimate `tg callers` reported incomplete/exit-2. The raise makes it complete for **+1.8s (~10%)** — the design's predicted tradeoff (more complete for marginally more time; `--deadline` is the escape hatch). The ~17-19s absolute latency is the pre-existing `tg callers` cost (audit P0 #94 daemon targets it), not introduced here.

## Changes

- `repo_map.py:175` — `CALLER_SCAN_FILE_CEILING` 512 -> 2000. Knee per the in-file cost data (512=1.48s / 2000=3.51s OK / 4000=10.35s superlinear).
- `repo_map.py:1254` — `_PARSE_PRODUCT_CACHE_MAXSIZE` 1024 -> 2048 (**non-optional companion**: it's a FIFO cache; a callers+refs pass over a >1024-eligible-file repo silently thrashes without it — empirically verified: reverting to 1024 ballooned parses 1100 -> 3299).
- Retired two now-stale comments (the "left at 512 on purpose ... reintroduces #52's TS-regex hang" claims — #478's `--deadline` hard-bound closed that; the ceiling is now a backstop for the flag-less path + `--max-repo-files`-raised mega-repos).
- **`build_file_importers_from_map` ceiling branch** — now calls `_mark_result_incomplete` (matching callers/refs) instead of setting `caller_scan_limit` alone. **Fixing this surfaced a real latent ordering bug**: `_copy_scan_limit` ran *after* the ceiling-hit block and unconditionally clobbered `scan_remediation`; reordered it *before* (mirroring the callers-function precedent). No `main.py` change needed — the CLI exit-2 contract already read `caller_scan_limit` directly; this fixes non-CLI consumers (MCP tools, direct builder calls) getting the same honesty signal.

## Tests (strict TDD, RED-before/GREEN-after each)

- Governance pins updated: `test_constants_locked_to_the_plan` 512->2000, + **8 more** that were sized against the old ceiling/probe-ceiling (fixed via `monkeypatch.setattr` of the constant to a small value, mirroring the `test_parse_product_cache` precedent — preserves each test's intent independent of the production value).
- New: below-512 byte-identical golden-parity proof; the motivating "caller past index 512 found after raise, absent before" regression; `build_file_importers` ceiling-branch `result_incomplete` coverage (zero before; RED-confirmed twice — once for the missing mark, once for the clobber-ordering bug); a real 2500-file corpus bounding at the actual 2000 ceiling + CLI exit-2; and the cross-1024 cache-capacity parse-spy.
- Verify (real venv, `uv run --no-sync`): the #57 suite (`test_cap_fix_chokepoint` + `test_parse_product_cache` + `test_repo_map_deadline` + `test_file_deps` + `test_repo_map_graph`) -> **111 passed**. Broader 26-file thematic sweep -> **573 passed, 1 skipped**. `ruff check` + `ruff format --preview --check` clean; `mypy repo_map.py` clean; ASCII+LF verified.

## Scope

Exactly `src/tensor_grep/cli/repo_map.py`, `tests/unit/test_cap_fix_chokepoint.py`, `tests/unit/test_parse_product_cache.py`. Not security-sensitive (no mcp/apply_policy/backends/index_lock/session_daemon) -> no adversarial-gate requirement; load-bearing (latency + ranking-fragility scar) -> golden-parity gate satisfied above.

Closes #57.
