### PR TITLE
feat(mcp): confine every MCP tool primary path to the server root + TG_MCP_ROOT override (audit #95 security core)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -71,7 +71,13 @@ def _mcp_server_version() -> str:
 # Stable contract version for the tg MCP server surface.
 # Bump only on intentional breaking changes to the MCP tool/resource shape.
 # CLI version is exposed separately via `tg_mcp_capabilities` -> `cli_version`.
-_TG_MCP_SERVER_CONTRACT_VERSION = "1.0.0"
+# 1.0.0 -> 1.1.0 (round-8, audit #95): every tool's PRIMARY path/root param is now
+# confined to _mcp_root() (default cwd, override via TG_MCP_ROOT) -- a caller that
+# previously relied on an out-of-cwd path succeeding (e.g. a monorepo fleet pointing an
+# MCP tool at a sibling repo) now gets a structured invalid_input refusal instead of a
+# result, unless TG_MCP_ROOT is set to widen the anchor. Breaking-behavior change, not a
+# breaking shape change -- bump per the gate's should-fix.
+_TG_MCP_SERVER_CONTRACT_VERSION = "1.1.0"
 
 
 def _apply_mcp_server_metadata(server: FastMCP) -> None:
@@ -1610,12 +1616,20 @@ def _finalize_aggregate_result(all_results: SearchResult) -> None:
 # omitted `path` are indistinguishable here -- treat the literal default value "." as
 # "defaulted" (the conservative, safe reading) so a bare `tg_search(pattern=..., glob=...)` MCP
 # call gets the same protection as the CLI's bare `tg search --glob ... PATTERN`.
+#
+# round-8 security (audit #95): `paths_defaulted` is now a REQUIRED param the caller computes
+# from the RAW path BEFORE `_confine_mcp_path` resolves it to an absolute string -- deriving it
+# internally here (the original `path == "."`) would silently and permanently read False once
+# callers started reassigning `path` to its confined (absolute) form, defeating this whole
+# bug #88 guard for every default-path call (caught by test_tg_search_refuses_glob_with_
+# default_path_on_large_root going from a refusal to a real unbounded scan).
 def _mcp_broad_root_scan_refusal(
     path: str,
     config: "SearchConfig",
     *,
     normalized_max_repo_files: int,
     check_large_root: bool,
+    paths_defaulted: bool,
 ) -> tuple[str | None, "DirectoryScanner", Iterator[str]]:
     """Cheap pre-walk safety guard ported from the CLI `tg search` command.
 
@@ -1627,7 +1641,6 @@ def _mcp_broad_root_scan_refusal(
     """
     scanner = DirectoryScanner(config)
     walker: Iterator[str] = iter(scanner.walk(path))
-    paths_defaulted = path == "."
 
     refuse_vendored, vendored_dirs = _should_refuse_unbounded_vendored_root_scan(
         [path],
@@ -1750,6 +1763,68 @@ def _confine_read_path(candidate: str, anchor: Path, *, label: str) -> Path:
     return _confine_write_path(candidate, anchor, label=label)
 
 
+def _mcp_root() -> Path:
+    """Return the confinement anchor for every MCP tool's PRIMARY path/root parameter.
+
+    Round-8 (audit #95 gate must-fix): every symbol/session/search/rewrite/checkpoint tool
+    took its scan/session root straight from the caller-supplied ``path``/``root`` argument
+    with NO confinement at all -- only secondary params (baseline_path, manifest_path, ...)
+    were anchored via `_confine_write_path`/`_confine_read_path`. Defaults to the server
+    process's current working directory (the same anchor those secondary confinements
+    already use), so the default-config behavior is unchanged. An operator running the MCP
+    server against a repo other than cwd (a monorepo subtree, a fleet of repos) can move the
+    anchor via the ``TG_MCP_ROOT`` environment variable -- this WIDENS or RELOCATES where
+    reads/writes are permitted, it never disables confinement.
+
+    Two fail-closed guards, both required by the gate:
+    - An unset OR empty/whitespace-only ``TG_MCP_ROOT`` is treated as "not configured" and
+      falls back to cwd, rather than letting ``Path("")`` resolve to the filesystem root
+      (which would silently confine every tool call to "anywhere").
+    - A configured override that does not resolve to a real, existing directory (typo,
+      not-yet-mounted path, a file instead of a directory) is refused and falls back to cwd
+      -- narrowing to the always-valid default is the safe failure mode; crashing the whole
+      MCP server over one bad env var (or worse, silently confining to a non-existent path,
+      which `_confine_read_path`'s `.resolve()` would still do without erroring) is not.
+    """
+    raw = os.environ.get("TG_MCP_ROOT", "").strip()
+    if not raw:
+        return Path.cwd()
+    try:
+        resolved = Path(raw).expanduser().resolve()
+    except OSError:
+        print(
+            f"[tensor-grep-mcp] TG_MCP_ROOT={raw!r} could not be resolved; "
+            "falling back to the current working directory.",
+            file=sys.stderr,
+        )
+        return Path.cwd()
+    if not resolved.is_dir():
+        print(
+            f"[tensor-grep-mcp] TG_MCP_ROOT={raw!r} is not an existing directory "
+            f"(resolved: {resolved}); falling back to the current working directory.",
+            file=sys.stderr,
+        )
+        return Path.cwd()
+    return resolved
+
+
+def _confine_mcp_path(candidate: str, *, label: str) -> Path:
+    """Confine an MCP tool's PRIMARY path/root parameter to `_mcp_root()` (round-8, audit
+    #95 gate must-fix #1/#2/#3).
+
+    Thin wrapper over `_confine_read_path` anchored at `_mcp_root()` (instead of a
+    per-tool-hardcoded `Path.cwd()`), so the one `TG_MCP_ROOT` override relocates every
+    primary-path tool's anchor together. Raises ``ValueError`` (fail closed) on an
+    out-of-root candidate; callers MUST forward the resolved ``Path`` this returns
+    (`str()`'d) as their new ``path``, and MUST do so as the very first operation in the
+    tool body, BEFORE any secondary anchor (session_root, scan_root, policy_anchor, ...) is
+    derived from ``path`` -- otherwise that secondary anchor still derives from the raw,
+    unconfined candidate and the confinement is cosmetic (this exact bug was the gate's
+    LIVE VULN finding on `tg_session_file_importers`'s `session_root`).
+    """
+    return _confine_read_path(candidate, _mcp_root(), label=label)
+
+
 @mcp.tool()  # type: ignore
 def tg_ruleset_scan(
     ruleset: str,
@@ -1806,6 +1881,12 @@ def tg_ruleset_scan(
             (evidence cap). Defaults to 120.
     """
     try:
+        # round-8 security (audit #95 gate must-fix #3, LIVE-VULN-adjacent): confine path to
+        # the MCP root BEFORE root_dir/scan_root below derive anything from it. Both anchor
+        # baseline_path/suppressions_path/write_baseline/write_suppressions confinement AND
+        # the scan itself -- an unconfined path was a full arbitrary-directory scan/read
+        # (and, via write_baseline/write_suppressions, write) primitive over the MCP surface.
+        path = str(_confine_mcp_path(path, label="path"))
         ruleset_meta, rules = resolve_rule_pack(ruleset, language)
     except ValueError as exc:
         return _ruleset_scan_error(
@@ -1895,6 +1976,22 @@ def tg_repo_map(path: str = ".", max_repo_files: int | None = 512) -> str:
         path: File or directory to inventory.
         max_repo_files: Maximum repo files to scan before returning. Defaults to 512.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- unconfined it is an arbitrary-directory-read primitive over the MCP
+    # protocol (systemic finding: every path/root-taking tool except the file-scoped
+    # tg_file_imports/tg_classify_logs lacked this).
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="repo-map",
+            include_schema_version=False,
+        )
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         from tensor_grep.cli.repo_map import DEFAULT_AGENT_REPO_MAP_LIMIT
 
@@ -1944,6 +2041,21 @@ def tg_context_pack(
         path: File or directory to inventory.
         max_tokens: Bound the pack for prompt injection (default ~16000; 0/None = unbounded).
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="context-pack",
+            include_schema_version=False,
+        )
+        payload["query"] = query
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(build_context_pack(query, path, max_tokens=max_tokens), indent=2)
@@ -2002,6 +2114,21 @@ def tg_edit_plan(
         provider: Semantic provider for primary target proof: native, lsp, or hybrid.
     """
     from tensor_grep.cli.repo_map import build_context_edit_plan
+
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="context-edit-plan",
+            include_schema_version=False,
+        )
+        payload["query"] = query
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
 
     try:
         return _inject_mcp_contract_fields(
@@ -2073,6 +2200,21 @@ def tg_context_render(
         max_repo_files: Maximum repository files to scan before ranking context.
         provider: Semantic provider for primary target proof: native, lsp, or hybrid.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="context-render",
+            include_schema_version=False,
+        )
+        payload["query"] = query
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -2151,6 +2293,13 @@ def tg_agent_capsule(
         gpu_device_ids: Optional selected GPU IDs for native route evidence.
         gpu_timeout_s: Maximum seconds for each opt-in GPU evidence command.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _agent_capsule_error(str(exc), code="invalid_input", query=query, path=path)
+
     if not Path(path).expanduser().exists():
         return _agent_capsule_error(
             f"Path not found: {Path(path).expanduser().resolve()}",
@@ -2229,6 +2378,20 @@ def tg_session_edit_plan(
         max_symbols: Maximum ranked symbols to retain.
     """
     from tensor_grep.cli.session_store import SessionStaleError, session_context_edit_plan
+
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"query": query, "max_files": max_files, "max_symbols": max_symbols},
+            query=query,
+        )
 
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
     try:
@@ -2310,6 +2473,20 @@ def tg_session_context_render(
     """
     from tensor_grep.cli.session_store import SessionStaleError, session_context_render
 
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"query": query, "render_profile": render_profile},
+            query=query,
+        )
+
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
     try:
         return json.dumps(
@@ -2380,6 +2557,21 @@ def tg_session_blast_radius(
     """
     from tensor_grep.cli.session_store import SessionStaleError, session_blast_radius
 
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"symbol": symbol, "max_depth": max(0, int(max_depth))},
+            symbol=symbol,
+            max_depth=max(0, int(max_depth)),
+        )
+
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
     try:
         return json.dumps(
@@ -2443,6 +2635,26 @@ def tg_session_file_importers(
         path: File or directory rooted at the session scope.
     """
     from tensor_grep.cli.session_store import SessionStaleError, session_file_importers
+
+    # round-8 security (audit #95 gate must-fix #3, LIVE VULN): confine path to the MCP root
+    # BEFORE session_root below derives from it. Previously session_root = Path(path).resolve()
+    # used the RAW caller-supplied path with NO confinement at all, so path="/etc" made
+    # session_root="/etc" and the "confine file to session_root" check just below then let
+    # file="/etc/passwd" straight through -- an arbitrary-directory-read primitive reachable
+    # from any MCP client today. Confining path here (rather than re-anchoring file's
+    # confinement below to cwd) is deliberate: it keeps a legitimate relative `file` working
+    # when session_root != cwd -- see the comment on the file confinement immediately below.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"file": file},
+            file=file,
+        )
 
     # round-7 security (audit #81 Opus gate #2 follow-up): confine file to the session root
     # (path) before any read, same class/rationale as tg_file_imports/tg_file_importers above.
@@ -2528,6 +2740,22 @@ def tg_symbol_blast_radius_plan(
     """
     from tensor_grep.cli.repo_map import build_symbol_blast_radius_plan
 
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-blast-radius-plan",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["max_depth"] = max(0, int(max_depth))
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return json.dumps(
             build_symbol_blast_radius_plan(
@@ -2606,6 +2834,25 @@ def tg_session_blast_radius_render(
         SessionStaleError,
         session_blast_radius_render,
     )
+
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={
+                "symbol": symbol,
+                "max_depth": max(0, int(max_depth)),
+                "render_profile": render_profile,
+            },
+            symbol=symbol,
+            max_depth=max(0, int(max_depth)),
+        )
 
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
     try:
@@ -2693,6 +2940,26 @@ def tg_session_blast_radius_plan(
     """
     from tensor_grep.cli.session_store import SessionStaleError, session_blast_radius_plan
 
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={
+                "symbol": symbol,
+                "max_depth": max(0, int(max_depth)),
+                "max_files": max_files,
+                "max_symbols": max_symbols,
+            },
+            symbol=symbol,
+            max_depth=max(0, int(max_depth)),
+        )
+
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
     try:
         return json.dumps(
@@ -2769,6 +3036,21 @@ def tg_symbol_defs(
         path: File or directory to inventory.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-defs",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -2822,6 +3104,21 @@ def tg_symbol_source(
         path: File or directory to inventory.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-source",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -2869,6 +3166,21 @@ def tg_symbol_impact(symbol: str, path: str = ".", provider: str = "native") -> 
         symbol: Exact symbol name to evaluate.
         path: File or directory to inventory.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-impact",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -2925,6 +3237,21 @@ def tg_symbol_refs(
         path: File or directory to inventory.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-refs",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -2978,6 +3305,21 @@ def tg_symbol_callers(
         path: File or directory to inventory.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-callers",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -3104,6 +3446,23 @@ def tg_file_importers(
         payload["path"] = str(Path(path).expanduser())
         payload["error"] = {"code": "invalid_input", "message": str(exc)}
         return json.dumps(payload, indent=2)
+
+    # round-8 security (audit #95 gate): confine the secondary root param to the MCP root too
+    # -- unconfined it is an arbitrary-directory-read primitive over the MCP protocol (the
+    # design's proven example: `path` here resolved raw).
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="file-importers",
+            include_schema_version=False,
+        )
+        payload["file"] = file
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -3153,6 +3512,22 @@ def tg_symbol_blast_radius(
         max_depth: Maximum reverse-import depth to include.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-blast-radius",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["max_depth"] = max(0, int(max_depth))
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -3227,6 +3602,22 @@ def tg_symbol_blast_radius_render(
         render_profile: Render profile to use: full, compact, or llm.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="symbol-blast-radius-render",
+            include_schema_version=False,
+        )
+        payload["symbol"] = symbol
+        payload["max_depth"] = max(0, int(max_depth))
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
@@ -3325,6 +3716,35 @@ def tg_search(
     search_pattern = pattern or query
     if not search_pattern:
         return "Search failed: either pattern or query is required."
+
+    # Bug #88: capture the "was path left at its default" signal from the RAW caller-supplied
+    # value BEFORE confinement below reassigns `path` to its confined (absolute) form -- once
+    # reassigned, `path == "."` would always read False and silently defeat the large-root/
+    # vendored-root refusal guard's paths_defaulted logic for every default-path call.
+    paths_defaulted = path == "."
+
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        if structured_json:
+            payload = {
+                "pattern": search_pattern,
+                "path": path,
+                "total_matches": 0,
+                "total_files": 0,
+                "rendered_match_count": 0,
+                "rendered_file_count": 0,
+                "matches": [],
+                "truncated": False,
+                "result_incomplete": True,
+                "incomplete_reason": str(exc),
+                "error": {"code": "invalid_input", "message": str(exc)},
+            }
+            return json.dumps(payload, indent=2)
+        return f"Search failed: {exc}"
+
     rendered_file_limit = max(0, max_files if max_files is not None else 15)
     rendered_result_limit = max(0, max_results if max_results is not None else 150)
     normalized_max_repo_files = max(1, int(max_repo_files))
@@ -3374,6 +3794,7 @@ def tg_search(
                 config,
                 normalized_max_repo_files=normalized_max_repo_files,
                 check_large_root=True,
+                paths_defaulted=paths_defaulted,
             )
             if refusal_message is not None:
                 return _broad_root_scan_refusal_result(
@@ -3610,6 +4031,28 @@ def tg_ast_search(
         max_repo_files: Maximum files the directory walk parses before the scan is
             capped (protects against an unscoped full-monorepo AST parse).
     """
+    # Bug #88: capture the "was path left at its default" signal from the RAW caller-supplied
+    # value BEFORE confinement below reassigns `path` to its confined (absolute) form -- see
+    # tg_search's identical comment for the full rationale.
+    paths_defaulted = path == "."
+
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        if structured_json:
+            return json.dumps(
+                {
+                    "pattern": pattern,
+                    "lang": lang,
+                    "path": path,
+                    "error": {"code": "invalid_input", "message": str(exc)},
+                },
+                indent=2,
+            )
+        return f"AST search failed: {exc}"
+
     normalized_max_repo_files = max(1, int(max_repo_files))
     config = SearchConfig(ast=True, lang=lang, no_messages=True)
     pipeline = Pipeline(config=config)
@@ -3654,6 +4097,7 @@ def tg_ast_search(
             config,
             normalized_max_repo_files=normalized_max_repo_files,
             check_large_root=True,
+            paths_defaulted=paths_defaulted,
         )
         if refusal_message is not None:
             return _broad_root_scan_refusal_result(
@@ -4011,6 +4455,13 @@ def tg_index_search(pattern: str, path: str = ".") -> str:
         pattern: Regex or literal search pattern.
         path: File or directory to search.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _index_search_error(str(exc), code="invalid_input", pattern=pattern, path=path)
+
     validation_error = _validate_index_search_inputs(pattern, path)
     if validation_error:
         return _index_search_error(
@@ -4042,6 +4493,13 @@ def tg_rewrite_plan(pattern: str, replacement: str, lang: str, path: str = ".") 
         lang: Tree-sitter language name.
         path: File or directory to scan.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _rewrite_error(str(exc), code="invalid_input")
+
     validation_error = _validate_rewrite_inputs(pattern, lang, path)
     if validation_error:
         return _rewrite_error(validation_error, code="invalid_input")
@@ -4105,6 +4563,16 @@ def tg_rewrite_apply(
             When supplied, the apply is refused with code="plan_drift" if the current
             tree no longer yields exactly this many edits.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # BEFORE any of the checks below -- execute_rewrite_apply_json derives policy's
+    # confinement anchor from this same `path` (policy_anchor), so an unconfined path here
+    # would make that downstream anchor unconfined too (see tg_repo_map for the systemic
+    # rationale, and tg_session_file_importers for the exact class of bug this order avoids).
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _rewrite_error(str(exc), code="invalid_input")
+
     # Audit HIGH (2026-06-24): lint_cmd/test_cmd execute a free-form shell command
     # in the native apply path. Over the MCP trust boundary (agent-steerable args)
     # that is an RCE primitive, so refuse them unless the operator explicitly opts in.
@@ -4216,6 +4684,13 @@ def tg_audit_history(path: str = ".") -> str:
 
     if not path.strip():
         return _audit_history_error("path must not be empty.", code="invalid_input")
+
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _audit_history_error(str(exc), code="invalid_input")
 
     try:
         return _inject_mcp_contract_fields(json.dumps(list_audit_history_payload(path), indent=2))
@@ -4434,6 +4909,23 @@ def tg_checkpoint_create(path: str = ".") -> str:
     Args:
         path: File or directory rooted at the checkpoint scope.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read/write -- see tg_repo_map for the systemic-finding rationale. Checkpoint
+    # create/undo write rollback state rooted at `path`, so unconfined this was also an
+    # arbitrary-directory-WRITE primitive, not just a read.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return json.dumps(
+            {
+                "version": _json_output_version(),
+                "mcp_contract_version": _TG_MCP_SERVER_CONTRACT_VERSION,
+                "error": {"code": "invalid_input", "message": str(exc)},
+                "path": path,
+            },
+            indent=2,
+        )
+
     from tensor_grep.cli.checkpoint_store import create_checkpoint
 
     try:
@@ -4468,6 +4960,21 @@ def tg_checkpoint_list(path: str = ".") -> str:
     Args:
         path: File or directory rooted at the checkpoint scope.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return json.dumps(
+            {
+                "version": _json_output_version(),
+                "mcp_contract_version": _TG_MCP_SERVER_CONTRACT_VERSION,
+                "error": {"code": "invalid_input", "message": str(exc)},
+                "path": path,
+            },
+            indent=2,
+        )
+
     from tensor_grep.cli.checkpoint_store import list_checkpoints
 
     try:
@@ -4502,6 +5009,24 @@ def tg_checkpoint_undo(checkpoint_id: str, path: str = ".") -> str:
         checkpoint_id: Checkpoint ID to restore.
         path: File or directory rooted at the checkpoint scope.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read/write -- see tg_repo_map for the systemic-finding rationale. Checkpoint
+    # undo restores files rooted at `path`, so unconfined this was also an
+    # arbitrary-directory-WRITE primitive, not just a read.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return json.dumps(
+            {
+                "version": _json_output_version(),
+                "mcp_contract_version": _TG_MCP_SERVER_CONTRACT_VERSION,
+                "error": {"code": "invalid_input", "message": str(exc)},
+                "path": path,
+                "checkpoint_id": checkpoint_id,
+            },
+            indent=2,
+        )
+
     from tensor_grep.cli.checkpoint_store import undo_checkpoint
 
     try:
@@ -4539,6 +5064,16 @@ def tg_session_open(path: str = ".", max_repo_files: int | None = 512) -> str:
         max_repo_files: Optional cap for files scanned into the initial session repo map.
             Defaults to 512 for agent-safe cold opens.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before opening a session rooted there -- see tg_repo_map for the systemic-finding
+    # rationale. A session persists a cached repo-map keyed to `path`, so unconfined this was
+    # also an arbitrary-directory-read primitive (the cached repo_map content is later
+    # returned verbatim by tg_session_show/tg_session_context/etc.).
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_exception_payload(path=path, message=str(exc), detail={})
+
     from tensor_grep.cli.session_store import get_session, open_session
 
     try:
@@ -4576,6 +5111,13 @@ def tg_session_list(path: str = ".") -> str:
     Args:
         path: File or directory rooted at the session scope.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_exception_payload(path=path, message=str(exc), detail={})
+
     from tensor_grep.cli.session_store import list_sessions
 
     try:
@@ -4602,6 +5144,18 @@ def tg_session_show(session_id: str, path: str = ".") -> str:
         session_id: Session ID to inspect.
         path: File or directory rooted at the session scope.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_exception_payload(
+            session_id=session_id,
+            path=path,
+            message=str(exc),
+            detail={},
+        )
+
     from tensor_grep.cli.session_store import get_session
 
     try:
@@ -4626,6 +5180,18 @@ def tg_session_refresh(session_id: str, path: str = ".") -> str:
         session_id: Session ID to refresh.
         path: File or directory rooted at the session scope.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_exception_payload(
+            session_id=session_id,
+            path=path,
+            message=str(exc),
+            detail={},
+        )
+
     from tensor_grep.cli.session_store import refresh_session
 
     try:
@@ -4659,6 +5225,20 @@ def tg_session_context(
         path: File or directory rooted at the session scope.
         max_tokens: Bound the pack for prompt injection (default ~16000; 0/None = unbounded).
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any read -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _session_error_payload(
+            session_id=session_id,
+            path=path,
+            code="invalid_input",
+            message=str(exc),
+            detail={"query": query},
+            query=query,
+        )
+
     from tensor_grep.cli.session_store import SessionStaleError, session_context
 
     effective_refresh = _effective_auto_refresh(refresh_on_stale, auto_refresh)
@@ -4714,6 +5294,13 @@ def tg_rewrite_diff(pattern: str, replacement: str, lang: str, path: str = ".") 
         lang: Tree-sitter language name.
         path: File or directory to scan.
     """
+    # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
+    # before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        return _rewrite_error(str(exc), code="invalid_input")
+
     validation_error = _validate_rewrite_inputs(pattern, lang, path)
     if validation_error:
         return _rewrite_error(validation_error, code="invalid_input")

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1813,8 +1813,15 @@ def _confine_mcp_path(candidate: str, *, label: str) -> Path:
     #95 gate must-fix #1/#2/#3).
 
     Thin wrapper over `_confine_read_path` anchored at `_mcp_root()` (instead of a
-    per-tool-hardcoded `Path.cwd()`), so the one `TG_MCP_ROOT` override relocates every
-    primary-path tool's anchor together. Raises ``ValueError`` (fail closed) on an
+    per-tool-hardcoded `Path.cwd()`), so the one `TG_MCP_ROOT` override relocates the anchor
+    of every tool confined THROUGH THIS HELPER together. NOTE: a residual set of round-6/7
+    file/manifest/bundle params (tg_file_imports/importers `file`, tg_classify_logs
+    `file_path`, the tg_audit_*/tg_review_bundle_* manifest+bundle params, tg_rewrite_apply
+    `audit_manifest`) still anchor directly at `Path.cwd()` and do NOT yet move with a
+    `TG_MCP_ROOT` that narrows/relocates relative to cwd -- bounded to the server cwd
+    (fail-closed, never arbitrary-FS; identical to `_mcp_root()` in the default unset
+    config), tracked to route through `_mcp_root()` before TG_MCP_ROOT is advertised as the
+    fleet boundary. Raises ``ValueError`` (fail closed) on an
     out-of-root candidate; callers MUST forward the resolved ``Path`` this returns
     (`str()`'d) as their new ``path``, and MUST do so as the very first operation in the
     tool body, BEFORE any secondary anchor (session_root, scan_root, policy_anchor, ...) is

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -56,7 +56,7 @@ from tensor_grep.cli.runtime_paths import resolve_native_tg_binary
 from tensor_grep.cli.scan_guardrails import BroadScanRefusedError
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.hardware.device_inventory import collect_device_inventory
-from tensor_grep.core.pipeline import Pipeline
+from tensor_grep.core.pipeline import ConfigurationError, Pipeline
 from tensor_grep.core.result import SearchResult, merge_runtime_routing
 from tensor_grep.io.directory_scanner import DirectoryScanner
 
@@ -4062,8 +4062,30 @@ def tg_ast_search(
 
     normalized_max_repo_files = max(1, int(max_repo_files))
     config = SearchConfig(ast=True, lang=lang, no_messages=True)
-    pipeline = Pipeline(config=config)
-    backend = pipeline.get_backend()
+    try:
+        pipeline = Pipeline(config=config)
+        backend = pipeline.get_backend()
+    except ConfigurationError as exc:
+        # Fail closed with a STRUCTURED "unavailable" error instead of letting the
+        # ConfigurationError escape as an unwrapped FastMCP ToolError (Backend Fail-Closed
+        # Contract). `Pipeline(ast=True)` construction itself raises when the ast-grep /
+        # tree-sitter deps are absent for this pattern (e.g. a Linux runner without ast-grep),
+        # which is EARLIER than the backend-type check below -- mirror that branch's response
+        # so a valid in-root path returns a clean "unavailable" rather than a raw exception.
+        if structured_json:
+            return json.dumps(
+                {
+                    "pattern": pattern,
+                    "lang": lang,
+                    "path": path,
+                    "error": {
+                        "code": "unavailable",
+                        "message": f"AstBackend is not available on this system: {exc}",
+                    },
+                },
+                indent=2,
+            )
+        return f"Error: AstBackend is not available on this system: {exc}"
 
     backend_name = type(backend).__name__
     if backend_name not in {"AstBackend", "AstGrepWrapperBackend"}:

--- a/tests/integration/test_mcp_stdio_protocol.py
+++ b/tests/integration/test_mcp_stdio_protocol.py
@@ -40,7 +40,8 @@ async def _stdio_protocol_roundtrip() -> None:
         async with ClientSession(read_stream, write_stream) as session:
             initialized = await session.initialize()
             assert initialized.serverInfo.name == "tensor-grep"
-            assert initialized.serverInfo.version == "1.0.0"
+            # round-8 (audit #95): _TG_MCP_SERVER_CONTRACT_VERSION bumped 1.0.0 -> 1.1.0.
+            assert initialized.serverInfo.version == "1.1.0"
 
             listed = await session.list_tools()
             tool_names = {tool.name for tool in listed.tools}
@@ -111,7 +112,8 @@ async def _stdio_content_length_initialize_roundtrip() -> None:
         server_info = result["serverInfo"]
         assert isinstance(server_info, dict)
         assert server_info["name"] == "tensor-grep"
-        assert server_info["version"] == "1.0.0"
+        # round-8 (audit #95): _TG_MCP_SERVER_CONTRACT_VERSION bumped 1.0.0 -> 1.1.0.
+        assert server_info["version"] == "1.1.0"
     finally:
         if process.stdin is not None:
             process.stdin.close()

--- a/tests/unit/test_mcp_caps.py
+++ b/tests/unit/test_mcp_caps.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import inspect
 import json
+from pathlib import Path
 
 import pytest
 
@@ -38,7 +39,9 @@ def test_mcp_symbol_defs_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 17
 
 
@@ -67,7 +70,9 @@ def test_mcp_symbol_source_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 41
 
 
@@ -93,7 +98,9 @@ def test_mcp_symbol_refs_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 19
 
 
@@ -119,7 +126,9 @@ def test_mcp_symbol_callers_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 23
 
 
@@ -149,7 +158,9 @@ def test_mcp_symbol_blast_radius_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 29
 
 
@@ -183,7 +194,9 @@ def test_mcp_symbol_blast_radius_plan_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 31
 
 
@@ -215,7 +228,9 @@ def test_mcp_symbol_blast_radius_render_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["symbol"] == "create_invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 37
 
 

--- a/tests/unit/test_mcp_context_default_cap.py
+++ b/tests/unit/test_mcp_context_default_cap.py
@@ -20,19 +20,24 @@ def _project(tmp_path):
     return str(tmp_path)
 
 
-def test_tg_context_render_bounds_by_default(tmp_path):
+def test_tg_context_render_bounds_by_default(tmp_path, monkeypatch):
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so the
+    # tmp_path-derived project root is in-root.
+    monkeypatch.chdir(tmp_path)
     payload = json.loads(mcp_server.tg_context_render("create invoice", _project(tmp_path)))
     assert payload["max_tokens"] == mcp_server._DEFAULT_MCP_CONTEXT_MAX_TOKENS
 
 
-def test_tg_context_render_zero_is_unbounded_opt_out(tmp_path):
+def test_tg_context_render_zero_is_unbounded_opt_out(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     payload = json.loads(
         mcp_server.tg_context_render("create invoice", _project(tmp_path), max_tokens=0)
     )
     assert payload["max_tokens"] is None  # normalized <=0 -> unbounded
 
 
-def test_tg_context_pack_accepts_and_defaults_max_tokens(tmp_path):
+def test_tg_context_pack_accepts_and_defaults_max_tokens(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     # tg_context_pack had NO max_tokens param at all -> always unbounded. It now accepts one and
     # defaults to the bound (call succeeds + emits the pack).
     out = mcp_server.tg_context_pack("create invoice", _project(tmp_path))

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -952,6 +952,32 @@ def test_tg_ast_search_backend_execution_error_skips_file_and_keeps_partial_resu
     assert "b.py" in payload["incomplete_reason"]
 
 
+def test_tg_ast_search_returns_structured_unavailable_when_pipeline_construction_raises(
+    tmp_path, monkeypatch
+):
+    """Regression (CI 2026-07-10, PR #484): ``Pipeline(ast=True)`` construction itself raises
+    ``ConfigurationError`` when the ast-grep/tree-sitter deps are absent for the pattern (e.g. a
+    Linux runner without ast-grep) -- EARLIER than the backend-type check. tg_ast_search must
+    fail closed with a STRUCTURED ``unavailable`` error, never let it escape as a raw FastMCP
+    ToolError (Backend Fail-Closed Contract). Without the catch, a valid in-root call raised,
+    which broke the confinement ratchet's positive (in-root-accepted) probe on Linux CI."""
+    from tensor_grep.cli import mcp_server
+    from tensor_grep.core.pipeline import ConfigurationError
+
+    monkeypatch.chdir(tmp_path)  # an in-root path so the confinement check passes first
+    with patch(
+        "tensor_grep.cli.mcp_server.Pipeline",
+        side_effect=ConfigurationError(
+            "Explicit AST search requires AST dependencies: ast-grep wrapper backend is required"
+        ),
+    ):
+        out = mcp_server.tg_ast_search("def $A():", "python", ".")
+
+    payload = json.loads(out)
+    assert payload["error"]["code"] == "unavailable"
+    assert "not available" in payload["error"]["message"]
+
+
 def test_tg_ast_search_refuses_vendored_root_scan_with_actionable_message(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -263,7 +263,9 @@ def test_tg_ast_search_accepts_ast_wrapper_backend():
 
         out = mcp_server.tg_ast_search("def $A():", "python", ".", structured_json=False)
 
-    assert out.startswith("No AST matches found for pattern in ..")
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being echoed back, so only the message PREFIX (not the exact trailing path) is stable.
+    assert out.startswith("No AST matches found for pattern in ")
     assert "Routing: backend=" in out
 
 
@@ -448,7 +450,8 @@ def test_tg_search_can_return_bounded_structured_json():
 
     payload = json.loads(out)
     assert payload["pattern"] == "ERROR"
-    assert payload["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path.
+    assert payload["path"] == str(Path.cwd().resolve())
     assert payload["total_matches"] == 3
     assert payload["total_files"] == 2
     assert payload["rendered_match_count"] == 2
@@ -497,7 +500,9 @@ def test_tg_search_uses_single_aggregate_ripgrep_search_for_cli_parity():
         out = mcp_server.tg_search("ERROR", ".")
 
     backend.search.assert_called_once()
-    assert backend.search.call_args.args[:2] == (".", "ERROR")
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the backend.
+    assert backend.search.call_args.args[:2] == (str(Path.cwd().resolve()), "ERROR")
     payload = json.loads(out)
     assert payload["total_matches"] == 1
     assert payload["total_files"] == 1
@@ -610,7 +615,9 @@ def test_tg_search_count_matches_should_respect_total_files_without_materialized
 
         out = mcp_server.tg_search("ERROR", ".", count_matches=True, structured_json=False)
 
-    assert out.startswith("Found a total of 3 matches across 1 files in ..")
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path, so only
+    # the message PREFIX (not the exact trailing path) is stable.
+    assert out.startswith("Found a total of 3 matches across 1 files in ")
     assert "Routing: backend=RustCoreBackend reason=rust_count" in out
     assert "gpu_device_ids=[]" in out
     assert "gpu_chunk_plan_mb=[]" in out
@@ -823,7 +830,8 @@ def test_tg_search_walk_deadline_exceeded_preserves_partial_results_and_flags_in
     assert payload["truncated"] is True
 
 
-def test_tg_search_refuses_vendored_root_scan_with_actionable_message(tmp_path):
+def test_tg_search_refuses_vendored_root_scan_with_actionable_message(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     (tmp_path / "vendor").mkdir()
@@ -944,7 +952,8 @@ def test_tg_ast_search_backend_execution_error_skips_file_and_keeps_partial_resu
     assert "b.py" in payload["incomplete_reason"]
 
 
-def test_tg_ast_search_refuses_vendored_root_scan_with_actionable_message(tmp_path):
+def test_tg_ast_search_refuses_vendored_root_scan_with_actionable_message(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     (tmp_path / "third_party").mkdir()
@@ -1066,7 +1075,8 @@ def test_tg_classify_logs_defaults_to_local_heuristics(monkeypatch, tmp_path):
     assert any("error" in lbl.lower() for lbl in anomaly_labels)
 
 
-def test_tg_edit_plan_exposes_ranking_quality_and_coverage_summary(tmp_path: Path):
+def test_tg_edit_plan_exposes_ranking_quality_and_coverage_summary(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -1101,7 +1111,8 @@ def test_tg_edit_plan_exposes_ranking_quality_and_coverage_summary(tmp_path: Pat
     assert payload["edit_plan_seed"]["plan_trust_summary"]
 
 
-def test_tg_session_context_supports_auto_refresh_alias(tmp_path: Path):
+def test_tg_session_context_supports_auto_refresh_alias(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server, session_store
 
     project = tmp_path / "project"
@@ -1138,10 +1149,13 @@ def test_tg_session_context_returns_uniform_error_detail(tmp_path: Path):
     assert "detail" in payload["error"]
 
 
-def test_tg_session_context_default_max_tokens_matches_sibling_context_tools(tmp_path: Path):
+def test_tg_session_context_default_max_tokens_matches_sibling_context_tools(
+    tmp_path: Path, monkeypatch
+):
     # H4: `tg_session_context` used to call `session_context` (-> `build_context_pack_from_map`)
     # with NO token bound at all, unlike every sibling context tool. It must now default to the
     # same `_DEFAULT_MCP_CONTEXT_MAX_TOKENS` and emit the `token_budget` field.
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -1158,7 +1172,8 @@ def test_tg_session_context_default_max_tokens_matches_sibling_context_tools(tmp
     assert payload["token_budget"]["truncated"] is False
 
 
-def test_tg_session_context_bounds_pack_by_max_tokens(tmp_path: Path):
+def test_tg_session_context_bounds_pack_by_max_tokens(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -1213,7 +1228,8 @@ def test_tg_session_lifecycle_errors_return_uniform_error_detail(tmp_path: Path)
             assert "detail" in payload["error"]
 
 
-def test_tg_session_open_accepts_initial_repo_map_cap(tmp_path: Path):
+def test_tg_session_open_accepts_initial_repo_map_cap(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -1235,7 +1251,8 @@ def test_tg_session_open_accepts_initial_repo_map_cap(tmp_path: Path):
     assert payload["build_seconds"] >= 0
 
 
-def test_tg_session_open_defaults_to_agent_safe_repo_map_cap(tmp_path: Path):
+def test_tg_session_open_defaults_to_agent_safe_repo_map_cap(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -1311,6 +1328,7 @@ def test_tg_ruleset_scan_returns_structured_findings(monkeypatch, tmp_path):
 
 
 def test_tg_ruleset_scan_refuses_direct_temp_root_before_walking(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
     from tests.unit.test_cli_modes import _ExplodingAstScanner
 
@@ -1552,6 +1570,8 @@ def test_tg_rewrite_plan_returns_native_plan_json_shape():
     assert isinstance(parsed["plan_digest"], str) and parsed["plan_digest"]
     assert parsed["match_count"] == payload["total_edits"]
     assert parsed["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv.
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -1563,7 +1583,7 @@ def test_tg_rewrite_plan_returns_native_plan_json_shape():
         # round-3 security: `--` ends options so a pattern beginning with `-` is a positional.
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((Path.cwd() / "src").resolve()),
     ]
 
 
@@ -1611,7 +1631,7 @@ def test_mcp_server_initialization_version_tracks_mcp_contract() -> None:
     options = mcp_server.mcp._mcp_server.create_initialization_options()
 
     assert options.server_name == "tensor-grep"
-    assert options.server_version == "1.0.0"
+    assert options.server_version == "1.1.0"
     assert options.server_version == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
     assert mcp_server._mcp_server_version() == version("tensor-grep")
 
@@ -1648,6 +1668,7 @@ def test_tg_mcp_capabilities_reports_bad_native_override(monkeypatch, tmp_path):
 
 
 def test_tg_rewrite_plan_uses_embedded_fallback_without_native_binary(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     expected = {
@@ -1681,6 +1702,7 @@ def test_tg_rewrite_plan_uses_embedded_fallback_without_native_binary(monkeypatc
 
 
 def test_tg_rewrite_plan_reports_unavailable_without_native_or_embedded(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     monkeypatch.setattr(mcp_server, "resolve_native_tg_binary", lambda: None)
@@ -1703,6 +1725,7 @@ def test_tg_rewrite_plan_reports_unavailable_without_native_or_embedded(monkeypa
 
 
 def test_tg_rewrite_apply_verify_returns_unavailable_without_native_binary(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     monkeypatch.setattr(mcp_server, "resolve_native_tg_binary", lambda: None)
@@ -1727,6 +1750,7 @@ def test_tg_rewrite_apply_verify_returns_unavailable_without_native_binary(monke
 
 
 def test_tg_rewrite_diff_returns_unavailable_without_native_binary(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     monkeypatch.setattr(mcp_server, "resolve_native_tg_binary", lambda: None)
@@ -1749,6 +1773,7 @@ def test_tg_rewrite_diff_returns_unavailable_without_native_binary(monkeypatch, 
 
 
 def test_tg_rewrite_diff_returns_unavailable_for_bad_native_override(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     monkeypatch.setenv("TG_NATIVE_TG_BINARY", str(tmp_path / "missing-tg.exe"))
@@ -1771,6 +1796,7 @@ def test_tg_rewrite_diff_returns_unavailable_for_bad_native_override(monkeypatch
 
 
 def test_tg_index_search_returns_unavailable_without_native_binary(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     monkeypatch.setattr(mcp_server, "resolve_native_tg_binary", lambda: None)
@@ -1898,6 +1924,8 @@ def test_tg_rewrite_apply_supports_optional_verify_flag():
     # apply fields are otherwise unchanged.
     assert {key: parsed[key] for key in payload} == payload
     assert parsed["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv.
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -1910,7 +1938,7 @@ def test_tg_rewrite_apply_supports_optional_verify_flag():
         "--json",
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((Path.cwd() / "src").resolve()),
     ]
 
 
@@ -1978,6 +2006,8 @@ def test_tg_rewrite_apply_supports_optional_validation_commands(monkeypatch):
     # audit A4: tolerate the added mcp_contract_version envelope key.
     assert {key: parsed[key] for key in payload} == payload
     assert parsed["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv.
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -1994,7 +2024,7 @@ def test_tg_rewrite_apply_supports_optional_validation_commands(monkeypatch):
         "--json",
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((Path.cwd() / "src").resolve()),
     ]
 
 
@@ -2122,6 +2152,7 @@ def test_tg_rewrite_apply_gates_policy_file_validation_commands(tmp_path, monkey
     gate OFF the policy's lint_cmd must be refused (code=unsupported_option) BEFORE
     any command runs (load_apply_policy fails closed before native/command execution).
     """
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     monkeypatch.delenv("TG_MCP_ALLOW_VALIDATION_COMMANDS", raising=False)
@@ -2151,7 +2182,8 @@ def test_tg_rewrite_apply_gates_policy_file_validation_commands(tmp_path, monkey
     assert parsed["error"]["retryable"] is False
 
 
-def test_tg_rewrite_apply_returns_structured_invalid_policy_error(tmp_path):
+def test_tg_rewrite_apply_returns_structured_invalid_policy_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     policy_path = tmp_path / "apply-policy.json"
@@ -2235,6 +2267,8 @@ def test_tg_rewrite_apply_supports_optional_checkpoint_flag():
     # M12: applied_edits count is stamped at the top level
     assert "applied_edits" in parsed
     assert isinstance(parsed["applied_edits"], int)
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv.
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -2247,11 +2281,12 @@ def test_tg_rewrite_apply_supports_optional_checkpoint_flag():
         "--json",
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((Path.cwd() / "src").resolve()),
     ]
 
 
 def test_tg_rewrite_apply_supports_optional_audit_manifest_flag(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     # round-5 security: audit_manifest is confined to cwd (see the round-5 confinement
@@ -2307,6 +2342,8 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag(tmp_path, monkey
     # audit A4: tolerate the added mcp_contract_version envelope key.
     assert {key: parsed[key] for key in payload} == payload
     assert parsed["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv (mirrors resolved_manifest's own confinement).
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -2320,7 +2357,7 @@ def test_tg_rewrite_apply_supports_optional_audit_manifest_flag(tmp_path, monkey
         "--json",
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((cwd / "src").resolve()),
     ]
 
 
@@ -2391,6 +2428,7 @@ def test_tg_rewrite_apply_records_generated_audit_manifest_in_history_index(tmp_
 
 
 def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     # round-5 security: audit_manifest is confined to cwd, and audit_signing_key (a secret
@@ -2448,6 +2486,8 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag(tmp_path, mon
     # audit A4: tolerate the added mcp_contract_version envelope key.
     assert {key: parsed[key] for key in payload} == payload
     assert parsed["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv (mirrors resolved_manifest's own confinement).
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -2463,7 +2503,7 @@ def test_tg_rewrite_apply_supports_optional_audit_signing_key_flag(tmp_path, mon
         "--json",
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((cwd / "src").resolve()),
     ]
 
 
@@ -2496,7 +2536,8 @@ def test_tg_audit_manifest_verify_supports_signed_manifests(tmp_path, monkeypatc
     assert parsed["errors"] == []
 
 
-def test_tg_audit_history_matches_cli_json_schema(tmp_path):
+def test_tg_audit_history_matches_cli_json_schema(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import audit_manifest, mcp_server
 
     project = tmp_path / "project"
@@ -2514,7 +2555,8 @@ def test_tg_audit_history_matches_cli_json_schema(tmp_path):
     assert payload["history"] == audit_manifest.list_audit_history(project)
 
 
-def test_tg_audit_history_returns_empty_array_for_empty_directory(tmp_path):
+def test_tg_audit_history_returns_empty_array_for_empty_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3511,6 +3553,11 @@ def _read_path_case_file_importers(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 def _read_path_case_session_file_importers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
     from tensor_grep.cli import mcp_server
 
+    # round-8 (audit #95): tg_session_open's `path` is now confined to the MCP root (cwd);
+    # chdir to tmp_path so `project` (a subdirectory) is in-root while `escape` (a SIBLING of
+    # project, still under tmp_path/cwd) stays correctly outside the session_root=project
+    # anchor this case is actually testing.
+    monkeypatch.chdir(tmp_path)
     project = tmp_path / "project"
     project.mkdir()
     (project / "app.py").write_text("x = 1\n", encoding="utf-8")
@@ -3611,7 +3658,8 @@ def test_tg_file_importers_accepts_in_root_path(tmp_path, monkeypatch):
     assert parsed["importer_files"] == [str(consumer.resolve())]
 
 
-def test_tg_session_file_importers_accepts_in_root_path(tmp_path):
+def test_tg_session_file_importers_accepts_in_root_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3631,12 +3679,13 @@ def test_tg_session_file_importers_accepts_in_root_path(tmp_path):
     assert parsed["importer_files"] == [str(consumer.resolve())]
 
 
-def test_tg_rewrite_apply_accepts_policy_within_scan_root(tmp_path):
+def test_tg_rewrite_apply_accepts_policy_within_scan_root(tmp_path, monkeypatch):
     """VERIFY confining `policy` (round-7 fix, Opus gate item #2) does not regress a
     legitimate in-root policy: a policy file inside the scan root must reach
     load_apply_policy's OWN schema validation (code="invalid_policy") rather than being
     refused by the new confinement check (which would instead surface code="invalid_input"
     with a "must stay within" message)."""
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     proj = tmp_path / "proj"
@@ -3667,12 +3716,13 @@ def test_tg_rewrite_apply_accepts_policy_within_scan_root(tmp_path):
     assert any(detail["field"] == "on_failure" for detail in parsed["error"]["details"])
 
 
-def test_tg_rewrite_apply_accepts_co_located_policy_for_single_file_target(tmp_path):
+def test_tg_rewrite_apply_accepts_co_located_policy_for_single_file_target(tmp_path, monkeypatch):
     """audit #76 (Opus-gate nit on #464): when `path` is a single FILE (a targeted rewrite),
     a policy co-located in the file's directory must reach load_apply_policy's schema
     validation (code="invalid_policy"), NOT be fail-closed-refused by confinement
     (code="invalid_input"). Pre-fix the policy anchor was the file itself, which has no
     descendants, so any co-located policy was rejected."""
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     proj = tmp_path / "proj"
@@ -3731,7 +3781,8 @@ def test_tg_rewrite_apply_still_rejects_policy_outside_single_file_target_dir(tm
     assert parsed["error"]["code"] == "invalid_input"
 
 
-def test_tg_checkpoint_mcp_tools_wrap_checkpoint_store(tmp_path):
+def test_tg_checkpoint_mcp_tools_wrap_checkpoint_store(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3755,7 +3806,8 @@ def test_tg_checkpoint_mcp_tools_wrap_checkpoint_store(tmp_path):
     assert target.read_text(encoding="utf-8") == "value = 1\n"
 
 
-def test_tg_session_mcp_tools_wrap_session_store(tmp_path):
+def test_tg_session_mcp_tools_wrap_session_store(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3784,7 +3836,8 @@ def test_tg_session_mcp_tools_wrap_session_store(tmp_path):
     assert context["files"] == [str((src_dir / "sample.py").resolve())]
 
 
-def test_tg_session_context_render_uses_cached_repo_map(tmp_path):
+def test_tg_session_context_render_uses_cached_repo_map(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3817,7 +3870,10 @@ def test_tg_session_context_render_uses_cached_repo_map(tmp_path):
     assert "rendered_context" in rendered
 
 
-def test_tg_session_context_render_profile_includes_profiling_without_changing_output(tmp_path):
+def test_tg_session_context_render_profile_includes_profiling_without_changing_output(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3847,7 +3903,8 @@ def test_tg_session_context_render_profile_includes_profiling_without_changing_o
     assert _without_profiling(profiled) == _without_profiling(baseline)
 
 
-def test_tg_session_blast_radius_uses_cached_repo_map(tmp_path):
+def test_tg_session_blast_radius_uses_cached_repo_map(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3894,7 +3951,8 @@ def test_tg_session_blast_radius_uses_cached_repo_map(tmp_path):
     assert "Depth 0:" in payload["rendered_caller_tree"]
 
 
-def test_tg_symbol_blast_radius_render_returns_prompt_ready_radius_bundle(tmp_path):
+def test_tg_symbol_blast_radius_render_returns_prompt_ready_radius_bundle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3944,7 +4002,9 @@ def test_tg_symbol_blast_radius_render_returns_prompt_ready_radius_bundle(tmp_pa
 
 def test_tg_symbol_blast_radius_render_profile_includes_profiling_without_changing_output(
     tmp_path,
+    monkeypatch,
 ):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -3993,7 +4053,8 @@ def test_tg_symbol_blast_radius_render_profile_includes_profiling_without_changi
     assert _without_profiling(profiled) == baseline
 
 
-def test_tg_symbol_blast_radius_plan_returns_machine_readable_bundle(tmp_path):
+def test_tg_symbol_blast_radius_plan_returns_machine_readable_bundle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4037,7 +4098,8 @@ def test_tg_symbol_blast_radius_plan_returns_machine_readable_bundle(tmp_path):
     )
 
 
-def test_tg_session_blast_radius_render_uses_cached_repo_map(tmp_path):
+def test_tg_session_blast_radius_render_uses_cached_repo_map(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4148,7 +4210,8 @@ def test_session_serve_render_commands_include_enriched_edit_plan_seed(tmp_path)
     assert str(service_path.resolve()) in responses[1]["edit_plan_seed"]["dependent_files"]
 
 
-def test_tg_session_refresh_updates_cached_session_payload(tmp_path):
+def test_tg_session_refresh_updates_cached_session_payload(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4173,7 +4236,8 @@ def test_tg_session_refresh_updates_cached_session_payload(tmp_path):
     assert str(second_path.resolve()) in shown["repo_map"]["files"]
 
 
-def test_tg_session_context_reports_stale_session_until_refreshed(tmp_path):
+def test_tg_session_context_reports_stale_session_until_refreshed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4199,7 +4263,8 @@ def test_tg_session_context_reports_stale_session_until_refreshed(tmp_path):
     assert context["routing_reason"] == "session-context"
 
 
-def test_tg_session_context_can_auto_refresh_stale_session(tmp_path):
+def test_tg_session_context_can_auto_refresh_stale_session(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4258,6 +4323,8 @@ def test_tg_rewrite_diff_wraps_unified_diff_with_routing_metadata():
     assert parsed["routing_reason"] == "ast-native"
     assert parsed["sidecar_used"] is False
     assert parsed["diff"] == diff_preview
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv.
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "run",
@@ -4268,18 +4335,21 @@ def test_tg_rewrite_diff_wraps_unified_diff_with_routing_metadata():
         "--diff",
         "--",
         "def $F($$$ARGS): return $EXPR",
-        "src",
+        str((Path.cwd() / "src").resolve()),
     ]
 
 
 def test_tg_rewrite_plan_returns_structured_error_for_missing_path():
     from tensor_grep.cli import mcp_server
 
+    # round-8 (audit #95): an absolute out-of-cwd path is now refused by CONFINEMENT before
+    # ever reaching the "Path not found" existence check this test exercises -- use a
+    # relative, in-root-but-nonexistent path so the existence check is still what fires.
     out = mcp_server.tg_rewrite_plan(
         pattern="def $F($$$ARGS): return $EXPR",
         replacement="lambda $$$ARGS: $EXPR",
         lang="python",
-        path="C:/definitely-missing-for-mcp-server-tests",
+        path="definitely-missing-for-mcp-server-tests",
     )
 
     parsed = json.loads(out)
@@ -4329,6 +4399,8 @@ def test_tg_index_search_returns_native_index_search_json_shape():
     # audit A4: tolerate the added mcp_contract_version envelope key.
     assert {key: parsed[key] for key in payload} == payload
     assert parsed["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # round-8 (audit #95): path="src" is now confined+resolved to an absolute cwd-relative
+    # path before it reaches the native argv.
     assert mock_run.call_args.args[0] == [
         "tg.exe",
         "search",
@@ -4336,16 +4408,19 @@ def test_tg_index_search_returns_native_index_search_json_shape():
         "--json",
         "--",
         "ERROR",
-        "src",
+        str((Path.cwd() / "src").resolve()),
     ]
 
 
 def test_tg_index_search_returns_structured_error_for_missing_path():
     from tensor_grep.cli import mcp_server
 
+    # round-8 (audit #95): an absolute out-of-cwd path is now refused by CONFINEMENT before
+    # ever reaching the "Path not found" existence check this test exercises -- use a
+    # relative, in-root-but-nonexistent path so the existence check is still what fires.
     out = mcp_server.tg_index_search(
         pattern="ERROR",
-        path="C:/definitely-missing-for-mcp-server-tests",
+        path="definitely-missing-for-mcp-server-tests",
     )
 
     parsed = json.loads(out)
@@ -4356,7 +4431,8 @@ def test_tg_index_search_returns_structured_error_for_missing_path():
     assert "Traceback" not in parsed["error"]["message"]
 
 
-def test_tg_repo_map_returns_json_inventory(tmp_path):
+def test_tg_repo_map_returns_json_inventory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4404,7 +4480,8 @@ def test_tg_repo_map_returns_json_inventory(tmp_path):
     assert str(module_path.resolve()) in payload["related_paths"]
 
 
-def test_tg_repo_map_includes_typescript_and_rust_inventory(tmp_path):
+def test_tg_repo_map_includes_typescript_and_rust_inventory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4469,7 +4546,8 @@ def test_tg_repo_map_includes_typescript_and_rust_inventory(tmp_path):
     )
 
 
-def test_tg_context_pack_returns_ranked_inventory(tmp_path):
+def test_tg_context_pack_returns_ranked_inventory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4504,7 +4582,8 @@ def test_tg_context_pack_returns_ranked_inventory(tmp_path):
     assert payload["files"][0] == str(module_path.resolve())
 
 
-def test_tg_context_render_returns_prompt_ready_context(tmp_path):
+def test_tg_context_render_returns_prompt_ready_context(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4571,7 +4650,10 @@ def test_tg_context_render_returns_prompt_ready_context(tmp_path):
     assert "create_invoice" in payload["rendered_context"]
 
 
-def test_tg_context_render_profile_includes_profiling_without_changing_output(tmp_path):
+def test_tg_context_render_profile_includes_profiling_without_changing_output(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4608,7 +4690,8 @@ def test_tg_context_render_profile_includes_profiling_without_changing_output(tm
     assert _without_profiling(profiled) == baseline
 
 
-def test_tg_context_render_includes_exact_caller_update_lines(tmp_path):
+def test_tg_context_render_includes_exact_caller_update_lines(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4650,7 +4733,8 @@ def test_tg_context_render_includes_exact_caller_update_lines(tmp_path):
         assert f"calls create_invoice() on line {entry['start_line']}" in entry["rationale"]
 
 
-def test_tg_context_render_mcp_preserves_invoice_tax_body_and_primary_target(tmp_path):
+def test_tg_context_render_mcp_preserves_invoice_tax_body_and_primary_target(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4694,7 +4778,8 @@ def test_tg_context_render_mcp_preserves_invoice_tax_body_and_primary_target(tmp
     assert payload["context_consistency"]["primary_file_included"] is True
 
 
-def test_tg_agent_capsule_returns_actionable_context_capsule(tmp_path: Path):
+def test_tg_agent_capsule_returns_actionable_context_capsule(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4739,6 +4824,7 @@ def test_tg_agent_capsule_returns_actionable_context_capsule(tmp_path: Path):
 
 
 def test_tg_agent_capsule_accepts_gpu_evidence_options(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import agent_capsule, mcp_server
 
     project = tmp_path / "project"
@@ -4776,7 +4862,8 @@ def test_tg_agent_capsule_accepts_gpu_evidence_options(monkeypatch, tmp_path: Pa
     assert acceleration["sidecar_used"] is True
 
 
-def test_tg_agent_capsule_returns_invalid_input_for_missing_path(tmp_path: Path):
+def test_tg_agent_capsule_returns_invalid_input_for_missing_path(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     payload = json.loads(
@@ -4791,7 +4878,8 @@ def test_tg_agent_capsule_returns_invalid_input_for_missing_path(tmp_path: Path)
     assert "Path not found" in payload["error"]["message"]
 
 
-def test_tg_edit_plan_returns_machine_readable_plan_bundle(tmp_path):
+def test_tg_edit_plan_returns_machine_readable_plan_bundle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4857,7 +4945,8 @@ def test_tg_edit_plan_returns_machine_readable_plan_bundle(tmp_path):
     assert "rendered_context" not in payload["plan"]
 
 
-def test_tg_edit_plan_prefers_targeted_vitest_validation_commands(tmp_path):
+def test_tg_edit_plan_prefers_targeted_vitest_validation_commands(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4904,7 +4993,8 @@ def test_tg_edit_plan_prefers_targeted_vitest_validation_commands(tmp_path):
     )
 
 
-def test_tg_context_render_honors_max_render_chars(tmp_path):
+def test_tg_context_render_honors_max_render_chars(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4931,7 +5021,8 @@ def test_tg_context_render_honors_max_render_chars(tmp_path):
     assert payload["sources"][0]["name"] == "create_invoice"
 
 
-def test_tg_context_render_accepts_max_tokens_and_model(tmp_path):
+def test_tg_context_render_accepts_max_tokens_and_model(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -4970,7 +5061,8 @@ def test_tg_context_render_accepts_max_tokens_and_model(tmp_path):
     )
 
 
-def test_tg_context_render_can_optimize_source_blocks_for_llm_use(tmp_path):
+def test_tg_context_render_can_optimize_source_blocks_for_llm_use(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5010,7 +5102,8 @@ def test_tg_context_render_can_optimize_source_blocks_for_llm_use(tmp_path):
     assert "create_invoice" in payload["rendered_context"]
 
 
-def test_tg_context_render_strips_python_docstrings_and_pass_boilerplate(tmp_path):
+def test_tg_context_render_strips_python_docstrings_and_pass_boilerplate(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5064,7 +5157,8 @@ def test_tg_context_render_strips_python_docstrings_and_pass_boilerplate(tmp_pat
     assert create_invoice["line_map"][0]["rendered_start_line"] == 1
 
 
-def test_tg_session_context_render_accepts_max_tokens_and_model(tmp_path):
+def test_tg_session_context_render_accepts_max_tokens_and_model(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5102,7 +5196,8 @@ def test_tg_session_context_render_accepts_max_tokens_and_model(tmp_path):
     )
 
 
-def test_tg_symbol_defs_returns_exact_definition_matches(tmp_path):
+def test_tg_symbol_defs_returns_exact_definition_matches(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5127,7 +5222,8 @@ def test_tg_symbol_defs_returns_exact_definition_matches(tmp_path):
     assert payload["graph_completeness"] == "strong"
 
 
-def test_tg_symbol_defs_can_find_rust_and_typescript_symbols(tmp_path):
+def test_tg_symbol_defs_can_find_rust_and_typescript_symbols(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5155,7 +5251,8 @@ def test_tg_symbol_defs_can_find_rust_and_typescript_symbols(tmp_path):
     assert rust_payload["definitions"][0]["kind"] == "function"
 
 
-def test_tg_symbol_source_returns_exact_python_function_body(tmp_path):
+def test_tg_symbol_source_returns_exact_python_function_body(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5179,7 +5276,8 @@ def test_tg_symbol_source_returns_exact_python_function_body(tmp_path):
     assert "subtotal = total + tax" in payload["sources"][0]["source"]
 
 
-def test_tg_symbol_source_can_extract_typescript_and_rust_blocks(tmp_path):
+def test_tg_symbol_source_can_extract_typescript_and_rust_blocks(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5209,7 +5307,8 @@ def test_tg_symbol_source_can_extract_typescript_and_rust_blocks(tmp_path):
     assert "let subtotal = 1;" in rust_payload["sources"][0]["source"]
 
 
-def test_tg_symbol_impact_returns_related_files_and_tests(tmp_path):
+def test_tg_symbol_impact_returns_related_files_and_tests(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5250,6 +5349,7 @@ def test_tg_symbol_impact_returns_related_files_and_tests(tmp_path):
 
 
 def test_tg_symbol_impact_uses_bounded_repo_scan_by_default(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     seen: dict[str, object] = {}
@@ -5293,7 +5393,8 @@ def test_tg_symbol_impact_uses_bounded_repo_scan_by_default(monkeypatch, tmp_pat
     assert seen["max_repo_files"] == mcp_server._DEFAULT_MCP_REPO_SCAN_LIMIT
 
 
-def test_tg_symbol_impact_prefers_import_linked_typescript_and_rust_tests(tmp_path):
+def test_tg_symbol_impact_prefers_import_linked_typescript_and_rust_tests(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5336,7 +5437,10 @@ def test_tg_symbol_impact_prefers_import_linked_typescript_and_rust_tests(tmp_pa
     assert rust_payload["tests"][0] == str(rust_test_path.resolve())
 
 
-def test_tg_symbol_impact_prefers_import_linked_source_files_over_name_only_matches(tmp_path):
+def test_tg_symbol_impact_prefers_import_linked_source_files_over_name_only_matches(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5365,7 +5469,10 @@ def test_tg_symbol_impact_prefers_import_linked_source_files_over_name_only_matc
     assert str(noisy_path.resolve()) not in payload["files"][:2]
 
 
-def test_tg_context_pack_prefers_import_linked_files_for_ranked_symbol_queries(tmp_path):
+def test_tg_context_pack_prefers_import_linked_files_for_ranked_symbol_queries(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5405,7 +5512,8 @@ def test_tg_context_pack_prefers_import_linked_files_for_ranked_symbol_queries(t
     assert {item["name"] for item in payload["file_summaries"][0]["symbols"]} == {"create_invoice"}
 
 
-def test_tg_symbol_refs_returns_python_reference_sites(tmp_path):
+def test_tg_symbol_refs_returns_python_reference_sites(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5433,7 +5541,8 @@ def test_tg_symbol_refs_returns_python_reference_sites(tmp_path):
     assert any(ref["file"] == str(other_path.resolve()) for ref in payload["references"])
 
 
-def test_tg_symbol_refs_and_callers_include_typescript_and_rust_heuristics(tmp_path):
+def test_tg_symbol_refs_and_callers_include_typescript_and_rust_heuristics(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5479,7 +5588,8 @@ def test_tg_symbol_refs_and_callers_include_typescript_and_rust_heuristics(tmp_p
     assert any(caller["file"] == str(rust_path.resolve()) for caller in rust_callers["callers"])
 
 
-def test_tg_symbol_callers_returns_python_call_sites(tmp_path):
+def test_tg_symbol_callers_returns_python_call_sites(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5522,7 +5632,8 @@ def test_tg_symbol_callers_returns_python_call_sites(tmp_path):
     assert str(other_path.resolve()) not in payload["related_paths"][:1]
 
 
-def test_tg_symbol_callers_prefers_import_linked_typescript_tests(tmp_path):
+def test_tg_symbol_callers_prefers_import_linked_typescript_tests(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5555,7 +5666,8 @@ def test_tg_symbol_callers_prefers_import_linked_typescript_tests(tmp_path):
     assert payload["tests"][0] == str(ts_test_path.resolve())
 
 
-def test_tg_symbol_blast_radius_returns_transitive_call_tree(tmp_path):
+def test_tg_symbol_blast_radius_returns_transitive_call_tree(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5623,7 +5735,10 @@ def test_tg_symbol_blast_radius_returns_transitive_call_tree(tmp_path):
 # structured error, not propagate a raw traceback out of the MCP call. ---
 
 
-def test_tg_symbol_blast_radius_returns_structured_error_on_unexpected_exception(tmp_path):
+def test_tg_symbol_blast_radius_returns_structured_error_on_unexpected_exception(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     with patch(
@@ -5640,7 +5755,9 @@ def test_tg_symbol_blast_radius_returns_structured_error_on_unexpected_exception
 
 def test_tg_symbol_blast_radius_render_returns_structured_error_on_unexpected_exception(
     tmp_path,
+    monkeypatch,
 ):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     with patch(
@@ -5654,7 +5771,8 @@ def test_tg_symbol_blast_radius_render_returns_structured_error_on_unexpected_ex
     assert payload["error"]["retryable"] is False
 
 
-def test_tg_repo_map_returns_structured_error_on_unexpected_exception(tmp_path):
+def test_tg_repo_map_returns_structured_error_on_unexpected_exception(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     with patch(
@@ -5668,7 +5786,8 @@ def test_tg_repo_map_returns_structured_error_on_unexpected_exception(tmp_path):
     assert payload["error"]["retryable"] is False
 
 
-def test_tg_context_pack_returns_structured_error_on_unexpected_exception(tmp_path):
+def test_tg_context_pack_returns_structured_error_on_unexpected_exception(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     with patch(
@@ -5682,7 +5801,8 @@ def test_tg_context_pack_returns_structured_error_on_unexpected_exception(tmp_pa
     assert payload["error"]["retryable"] is False
 
 
-def test_tg_agent_capsule_returns_structured_error_on_unexpected_exception(tmp_path):
+def test_tg_agent_capsule_returns_structured_error_on_unexpected_exception(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     with patch(
@@ -5695,7 +5815,10 @@ def test_tg_agent_capsule_returns_structured_error_on_unexpected_exception(tmp_p
     assert payload["error"]["code"] == "internal_error"
 
 
-def test_tg_session_edit_plan_returns_structured_error_on_unexpected_exception(tmp_path):
+def test_tg_session_edit_plan_returns_structured_error_on_unexpected_exception(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5717,7 +5840,8 @@ def test_tg_session_edit_plan_returns_structured_error_on_unexpected_exception(t
     assert payload["session_id"] == session_id
 
 
-def test_tg_symbol_impact_can_rank_tests_through_transitive_import_chain(tmp_path):
+def test_tg_symbol_impact_can_rank_tests_through_transitive_import_chain(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5763,7 +5887,10 @@ def test_tg_symbol_impact_can_rank_tests_through_transitive_import_chain(tmp_pat
     assert payload["test_matches"][0]["association"]["confidence"] in {"strong", "moderate"}
 
 
-def test_tg_context_pack_prefers_more_central_importers_over_tied_leaf_importers(tmp_path):
+def test_tg_context_pack_prefers_more_central_importers_over_tied_leaf_importers(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5813,7 +5940,8 @@ def test_tg_context_pack_prefers_more_central_importers_over_tied_leaf_importers
     assert central_match["graph_score"] > leaf_match["graph_score"]
 
 
-def test_tg_symbol_impact_orders_tests_by_graph_score(tmp_path):
+def test_tg_symbol_impact_orders_tests_by_graph_score(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5872,7 +6000,10 @@ def test_tg_symbol_impact_orders_tests_by_graph_score(tmp_path):
     assert cli_match["association"]["confidence"] in {"strong", "moderate"}
 
 
-def test_tg_symbol_callers_uses_parser_backed_javascript_calls_not_string_noise(tmp_path):
+def test_tg_symbol_callers_uses_parser_backed_javascript_calls_not_string_noise(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5904,7 +6035,10 @@ def test_tg_symbol_callers_uses_parser_backed_javascript_calls_not_string_noise(
     assert consumer_calls[0]["line"] == 5
 
 
-def test_tg_symbol_callers_uses_parser_backed_typescript_calls_not_string_noise(tmp_path):
+def test_tg_symbol_callers_uses_parser_backed_typescript_calls_not_string_noise(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5936,7 +6070,8 @@ def test_tg_symbol_callers_uses_parser_backed_typescript_calls_not_string_noise(
     assert consumer_calls[0]["line"] == 5
 
 
-def test_tg_symbol_callers_uses_parser_backed_rust_calls_not_string_noise(tmp_path):
+def test_tg_symbol_callers_uses_parser_backed_rust_calls_not_string_noise(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5967,7 +6102,8 @@ def test_tg_symbol_callers_uses_parser_backed_rust_calls_not_string_noise(tmp_pa
     assert consumer_calls[0]["line"] == 4
 
 
-def test_tg_symbol_callers_resolves_javascript_namespace_import_aliases(tmp_path):
+def test_tg_symbol_callers_resolves_javascript_namespace_import_aliases(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -5997,7 +6133,8 @@ def test_tg_symbol_callers_resolves_javascript_namespace_import_aliases(tmp_path
     assert consumer_calls[0]["line"] == 3
 
 
-def test_tg_symbol_callers_resolves_rust_module_alias_use_chains(tmp_path):
+def test_tg_symbol_callers_resolves_rust_module_alias_use_chains(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -6027,7 +6164,10 @@ def test_tg_symbol_callers_resolves_rust_module_alias_use_chains(tmp_path):
     assert consumer_calls[0]["line"] == 4
 
 
-def test_tg_symbol_callers_prefers_typescript_definition_selected_by_namespace_import(tmp_path):
+def test_tg_symbol_callers_prefers_typescript_definition_selected_by_namespace_import(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -6068,7 +6208,10 @@ def test_tg_symbol_callers_prefers_typescript_definition_selected_by_namespace_i
     )
 
 
-def test_tg_symbol_callers_prefers_rust_definition_selected_by_module_alias_use_chain(tmp_path):
+def test_tg_symbol_callers_prefers_rust_definition_selected_by_module_alias_use_chain(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -6109,7 +6252,8 @@ def test_tg_symbol_callers_prefers_rust_definition_selected_by_module_alias_use_
     )
 
 
-def test_tg_symbol_callers_prefers_typescript_tests_importing_direct_callers(tmp_path):
+def test_tg_symbol_callers_prefers_typescript_tests_importing_direct_callers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -6159,7 +6303,8 @@ def test_tg_symbol_callers_prefers_typescript_tests_importing_direct_callers(tmp
     )
 
 
-def test_tg_symbol_callers_prefers_rust_tests_importing_direct_callers(tmp_path):
+def test_tg_symbol_callers_prefers_rust_tests_importing_direct_callers(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -6212,7 +6357,8 @@ def test_tg_symbol_callers_prefers_rust_tests_importing_direct_callers(tmp_path)
     )
 
 
-def test_tg_symbol_source_ignores_comment_noise_for_typescript_and_rust(tmp_path):
+def test_tg_symbol_source_ignores_comment_noise_for_typescript_and_rust(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
 
     project = tmp_path / "project"
@@ -6565,3 +6711,353 @@ def test_ruleset_scan_write_baseline_overwrites_on_rerun(monkeypatch, tmp_path):
     assert written["fingerprints"] == [first["findings"][0]["fingerprint"]]
     # round-5: the write lands under the validated anchor (scan_root == cwd here, path=".").
     assert baseline_file.resolve().parent == tmp_path.resolve()
+
+
+# ============================================================================================
+# round-8 ratchet (audit #95 gate-corrected version): every MCP tool's PRIMARY path/root
+# param was UNCONFINED (only secondary params like manifest_path/baseline_path/policy were
+# confined by the round-6/7 work above) -- an arbitrary-directory READ (and, on the rewrite/
+# checkpoint family, WRITE) primitive reachable from any MCP client. `_mcp_root()`/
+# `_confine_mcp_path()` (mcp_server.py) close this. This ratchet enumerates the LIVE
+# registered schema (mcp.list_tools()), NOT a hand-maintained name-matched list like
+# _READ_PATH_COVERAGE_CASES above -- a name-matched list only catches an escape on a param
+# someone remembered to add a case for. A future tool with an unclassified string param
+# (e.g. named "directory"/"target") FAILS this test until it is consciously confined (a real
+# _confine_mcp_path/_confine_write_path/_confine_read_path call, plus a _RATCHET_BASE_KWARGS
+# entry below) or allowlisted with a documented, genuinely-non-path reason.
+# ============================================================================================
+
+# Every string/string|None param NAME that is not a filesystem path, keyed by parameter name
+# (not tool) since the same name means the same thing everywhere it appears in this file. Two
+# exemption REASONS show up: (1) genuinely not a path (an identifier, pattern, or enum-like
+# mode name); (2) deliberately gated by a DIFFERENT mechanism than path confinement (an
+# operator opt-in env var) where confining it would be wrong, not a gap.
+CONFINEMENT_EXEMPT: dict[str, str] = {
+    "pattern": "a regex/literal search pattern, not a path",
+    "query": "a free-text ranking query, not a path",
+    "symbol": "an exact symbol name to resolve, not a path",
+    "session_id": "an opaque session identifier, not a path",
+    "lang": "a tree-sitter language name, not a path",
+    "ruleset": "a built-in ruleset NAME resolved via resolve_rule_pack, not a path",
+    "replacement": "a rewrite template string, not a path",
+    "glob": "a glob pattern fragment (tg_search), not a path",
+    "type_filter": "a file-type filter token e.g. 'py' (tg_search), not a path",
+    "file_type": (
+        "a file-type filter token e.g. 'py' (tg_ruleset_scan's sibling of type_filter), not a path"
+    ),
+    "language": "a ruleset language override name, not a path",
+    "justification": "free-text audit-suppression rationale, not a path",
+    "model": "a model name used for local token estimation, not a path",
+    "provider": "a semantic-provider mode name (native/lsp/hybrid), not a path",
+    "render_profile": "an enum-like render mode name (full/compact/llm), not a path",
+    "inline_rules": (
+        "reserved for a future inline ast-grep rule-source param (#95 follow-up, not yet "
+        "shipped) -- listed now so it does not need re-litigating when it lands"
+    ),
+    "signing_key": (
+        "a READ of secret HMAC key material, deliberately gated by the "
+        "TG_MCP_ALLOW_AUDIT_SIGNING_KEY_READ opt-in env var instead of path confinement -- "
+        "operators legitimately keep HMAC keys outside the repo (e.g. ~/.config)"
+    ),
+    "audit_signing_key": (
+        "tg_rewrite_apply's sibling of signing_key above; same opt-in-env-var gate, not "
+        "path confinement"
+    ),
+    "checkpoint_id": "an opaque checkpoint identifier, not a path",
+    "expected_plan_digest": "a hex content digest from a prior tg_rewrite_plan call, not a path",
+    "lint_cmd": (
+        "a shell command string, refused outright unless TG_MCP_ALLOW_VALIDATION_COMMANDS=1 "
+        "(a stronger, independent gate) -- not a path, and not confinable as one"
+    ),
+    "test_cmd": "tg_rewrite_apply's sibling of lint_cmd above; same validation-commands gate",
+}
+
+# Minimal valid kwargs per tool so a targeted param's confinement check is actually REACHED
+# during the test call instead of short-circuiting on an earlier missing-required-arg or
+# unrelated validation error. None of these values need to exist on disk -- confinement is
+# pure path resolution/ancestry, never an existence check -- except where a tool's OWN
+# downstream loader reads the file directly with no FileNotFoundError guard (see
+# _ratchet_positive_value below for the two params that need a real file).
+_RATCHET_BASE_KWARGS: dict[str, dict[str, object]] = {
+    "tg_ruleset_scan": {"ruleset": "secrets-basic", "path": "."},
+    "tg_repo_map": {"path": "."},
+    "tg_context_pack": {"query": "x", "path": "."},
+    "tg_edit_plan": {"query": "x", "path": "."},
+    "tg_context_render": {"query": "x", "path": "."},
+    "tg_agent_capsule": {"query": "x", "path": "."},
+    "tg_session_edit_plan": {"session_id": "nonexistent-session", "query": "x", "path": "."},
+    "tg_session_context_render": {
+        "session_id": "nonexistent-session",
+        "query": "x",
+        "path": ".",
+    },
+    "tg_session_blast_radius": {
+        "session_id": "nonexistent-session",
+        "symbol": "Foo",
+        "path": ".",
+    },
+    "tg_session_file_importers": {
+        "session_id": "nonexistent-session",
+        "file": "dummy.py",
+        "path": ".",
+    },
+    "tg_symbol_blast_radius_plan": {"symbol": "Foo", "path": "."},
+    "tg_session_blast_radius_render": {
+        "session_id": "nonexistent-session",
+        "symbol": "Foo",
+        "path": ".",
+    },
+    "tg_session_blast_radius_plan": {
+        "session_id": "nonexistent-session",
+        "symbol": "Foo",
+        "path": ".",
+    },
+    "tg_symbol_defs": {"symbol": "Foo", "path": "."},
+    "tg_symbol_source": {"symbol": "Foo", "path": "."},
+    "tg_symbol_impact": {"symbol": "Foo", "path": "."},
+    "tg_symbol_refs": {"symbol": "Foo", "path": "."},
+    "tg_symbol_callers": {"symbol": "Foo", "path": "."},
+    "tg_file_imports": {"file": "dummy.py"},
+    "tg_file_importers": {"file": "dummy.py", "path": "."},
+    "tg_symbol_blast_radius": {"symbol": "Foo", "path": "."},
+    "tg_symbol_blast_radius_render": {"symbol": "Foo", "path": "."},
+    "tg_search": {"pattern": "x", "path": "."},
+    "tg_ast_search": {"pattern": "x", "lang": "python", "path": "."},
+    "tg_classify_logs": {"file_path": "dummy.log"},
+    "tg_index_search": {"pattern": "x", "path": "."},
+    "tg_rewrite_plan": {"pattern": "x", "replacement": "y", "lang": "python", "path": "."},
+    "tg_rewrite_apply": {"pattern": "x", "replacement": "y", "lang": "python", "path": "."},
+    "tg_audit_manifest_verify": {"manifest_path": "manifest.json"},
+    "tg_audit_history": {"path": "."},
+    "tg_audit_diff": {
+        "previous_manifest": "previous.json",
+        "current_manifest": "current.json",
+    },
+    "tg_review_bundle_create": {"manifest_path": "manifest.json"},
+    "tg_review_bundle_verify": {"bundle_path": "bundle.json"},
+    "tg_checkpoint_create": {"path": "."},
+    "tg_checkpoint_list": {"path": "."},
+    "tg_checkpoint_undo": {"checkpoint_id": "cp-1", "path": "."},
+    "tg_session_open": {"path": "."},
+    "tg_session_list": {"path": "."},
+    "tg_session_show": {"session_id": "nonexistent-session", "path": "."},
+    "tg_session_refresh": {"session_id": "nonexistent-session", "path": "."},
+    "tg_session_context": {"session_id": "nonexistent-session", "query": "x", "path": "."},
+    "tg_rewrite_diff": {"pattern": "x", "replacement": "y", "lang": "python", "path": "."},
+}
+
+
+def _tool_string_param_names(tool) -> list[str]:
+    """Every param name in `tool`'s live input schema typed `str` or `str | None`."""
+    properties = tool.inputSchema.get("properties", {})
+    names = []
+    for param_name, schema in properties.items():
+        types_seen = set()
+        if "type" in schema:
+            types_seen.add(schema["type"])
+        for sub in schema.get("anyOf", ()):
+            if "type" in sub:
+                types_seen.add(sub["type"])
+        if "string" in types_seen:
+            names.append(param_name)
+    return names
+
+
+def _enumerate_confinement_ratchet_cases() -> list[tuple[str, str]]:
+    """(tool_name, param_name) for every non-exempt string param on every registered tool."""
+    from tensor_grep.cli import mcp_server
+
+    cases: list[tuple[str, str]] = []
+    for tool in asyncio.run(mcp_server.mcp.list_tools()):
+        for param_name in _tool_string_param_names(tool):
+            if param_name in CONFINEMENT_EXEMPT:
+                continue
+            cases.append((tool.name, param_name))
+    return sorted(cases)
+
+
+_CONFINEMENT_RATCHET_CASES = _enumerate_confinement_ratchet_cases()
+
+
+def _ratchet_positive_value(tool_name: str, param_name: str, root: Path) -> str:
+    """The 'valid in-root' value for a (tool, param) ratchet case.
+
+    Defaults to a nonexistent in-root relative name -- confinement never requires
+    existence, and every tool's OWN not-found handling for that param is already covered
+    by its existing tests. Two params are special-cased: tg_ruleset_scan's baseline_path/
+    suppressions_path loaders (`_load_ruleset_baseline`/`_load_ruleset_suppressions` in
+    cli/main.py) call `.read_text()` directly with no FileNotFoundError guard in
+    tg_ruleset_scan's own except clauses (only ValueError/BroadScanRefusedError are caught
+    there), so a missing file would raise past this test instead of exercising the
+    confinement layer -- pre-create a minimal valid file for those two.
+    """
+    if param_name == "path":
+        return "."
+    if tool_name == "tg_ruleset_scan" and param_name == "baseline_path":
+        (root / "ratchet_baseline.json").write_text(
+            json.dumps({"fingerprints": []}), encoding="utf-8"
+        )
+        return "ratchet_baseline.json"
+    if tool_name == "tg_ruleset_scan" and param_name == "suppressions_path":
+        (root / "ratchet_suppressions.json").write_text(json.dumps({}), encoding="utf-8")
+        return "ratchet_suppressions.json"
+    return "ratchet_ok_target"
+
+
+@pytest.mark.parametrize(
+    "tool_name,param_name",
+    _CONFINEMENT_RATCHET_CASES,
+    ids=[f"{t}.{p}" for t, p in _CONFINEMENT_RATCHET_CASES],
+)
+def test_mcp_primary_path_confinement_ratchet(
+    tool_name, param_name, tmp_path, tmp_path_factory, monkeypatch
+):
+    """Every non-exempt string param on every registered MCP tool must reject an
+    out-of-root candidate AND accept an in-root one (audit #95 gate-corrected ratchet).
+
+    Schema-driven (mcp.list_tools()), not a hand-maintained name-matched list: a NEW tool
+    with an unclassified string param fails here (or errors loudly via the assertion
+    below) until it is consciously confined or added to CONFINEMENT_EXEMPT with a reason.
+    """
+    monkeypatch.chdir(tmp_path)
+    assert tool_name in _RATCHET_BASE_KWARGS, (
+        f"{tool_name} has a non-exempt string param {param_name!r} this ratchet does not "
+        "know how to reach. Either confine it (_confine_mcp_path for a primary path/root "
+        "param, _confine_write_path/_confine_read_path for a secondary one) and add a "
+        "_RATCHET_BASE_KWARGS entry, or add it to CONFINEMENT_EXEMPT with a reason if it "
+        "is genuinely not a path."
+    )
+    base_kwargs = dict(_RATCHET_BASE_KWARGS[tool_name])
+
+    outside_dir = tmp_path_factory.mktemp("ratchet_outside")
+
+    # --- negative: an out-of-root candidate must be refused, fail-closed, structured.
+    rejected = _call_mcp_tool_text(tool_name, {**base_kwargs, param_name: str(outside_dir)})
+    assert "must stay within" in rejected, (
+        f"{tool_name}.{param_name} accepted an out-of-root path without rejecting it "
+        f"(response: {rejected[:500]!r}). Confine it via _confine_mcp_path (primary path/"
+        "root param) or _confine_write_path/_confine_read_path (secondary param), or add "
+        "it to CONFINEMENT_EXEMPT above if it is genuinely not a path."
+    )
+    try:
+        rejected_payload = json.loads(rejected)
+    except json.JSONDecodeError:
+        rejected_payload = None
+    if isinstance(rejected_payload, dict) and isinstance(rejected_payload.get("error"), dict):
+        assert rejected_payload["error"].get("code") == "invalid_input"
+
+    # --- positive: an in-root candidate must NOT trip the confinement check. Bidirectional
+    # on purpose -- the negative case alone only proves *some* rejection fires; it would
+    # stay green even if confinement were entirely absent, as long as some OTHER error
+    # happened to fire for an out-of-root value. This half proves the "must stay within"
+    # signal specifically tracks confinement, not noise.
+    positive_value = _ratchet_positive_value(tool_name, param_name, tmp_path)
+    accepted = _call_mcp_tool_text(tool_name, {**base_kwargs, param_name: positive_value})
+    assert "must stay within" not in accepted, (
+        f"{tool_name}.{param_name} rejected an in-root path as if it were out-of-root "
+        f"(response: {accepted[:500]!r}); the confinement anchor is probably wrong."
+    )
+
+
+def test_confinement_exempt_allowlist_has_no_unused_entries():
+    """Every CONFINEMENT_EXEMPT entry must correspond to a real param somewhere in the live
+    schema, except the one documented forward-looking reservation (inline_rules, a future
+    tool addition) -- otherwise a stale allowlist entry could mask a real future gap."""
+    from tensor_grep.cli import mcp_server
+
+    all_param_names: set[str] = set()
+    for tool in asyncio.run(mcp_server.mcp.list_tools()):
+        all_param_names.update(tool.inputSchema.get("properties", {}))
+
+    forward_looking = {"inline_rules"}
+    stale = set(CONFINEMENT_EXEMPT) - all_param_names - forward_looking
+    assert not stale, f"CONFINEMENT_EXEMPT has stale/unused entries: {sorted(stale)}"
+
+
+def test_mcp_root_defaults_to_cwd(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.delenv("TG_MCP_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert mcp_server._mcp_root() == tmp_path.resolve()
+
+
+def test_mcp_root_empty_env_treated_as_unset(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.setenv("TG_MCP_ROOT", "")
+    monkeypatch.chdir(tmp_path)
+
+    assert mcp_server._mcp_root() == tmp_path.resolve()
+
+
+def test_mcp_root_whitespace_env_treated_as_unset(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.setenv("TG_MCP_ROOT", "   ")
+    monkeypatch.chdir(tmp_path)
+
+    assert mcp_server._mcp_root() == tmp_path.resolve()
+
+
+def test_mcp_root_honors_valid_override(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    override = tmp_path / "override-root"
+    override.mkdir()
+    monkeypatch.setenv("TG_MCP_ROOT", str(override))
+
+    assert mcp_server._mcp_root() == override.resolve()
+
+
+def test_mcp_root_falls_back_to_cwd_on_nonexistent_override(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    missing = tmp_path / "does-not-exist"
+    monkeypatch.setenv("TG_MCP_ROOT", str(missing))
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    assert mcp_server._mcp_root() == cwd.resolve()
+
+
+def test_mcp_root_falls_back_to_cwd_when_override_is_a_file(tmp_path, monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    a_file = tmp_path / "not-a-dir.txt"
+    a_file.write_text("x", encoding="utf-8")
+    monkeypatch.setenv("TG_MCP_ROOT", str(a_file))
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    assert mcp_server._mcp_root() == cwd.resolve()
+
+
+def test_confine_mcp_path_uses_mcp_root_override(tmp_path, monkeypatch):
+    """TG_MCP_ROOT relocates the primary-path confinement anchor for a real tool call --
+    a path outside cwd but inside the configured override must now be ACCEPTED."""
+    from tensor_grep.cli import mcp_server
+
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    override_root = tmp_path / "fleet-root"
+    other_repo = override_root / "other-repo"
+    other_repo.mkdir(parents=True)
+    monkeypatch.setenv("TG_MCP_ROOT", str(override_root))
+    monkeypatch.chdir(cwd)
+
+    # other_repo is outside cwd but inside the TG_MCP_ROOT override -- must be accepted.
+    out = mcp_server.tg_repo_map(str(other_repo))
+    parsed = json.loads(out)
+    assert parsed.get("error") is None
+
+    # A path outside the override entirely must still be refused.
+    outside_override = tmp_path / "outside-override"
+    outside_override.mkdir()
+    refused = mcp_server.tg_repo_map(str(outside_override))
+    refused_parsed = json.loads(refused)
+    assert refused_parsed["error"]["code"] == "invalid_input"
+    assert "must stay within" in refused_parsed["error"]["message"]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -6978,7 +6978,17 @@ def test_mcp_primary_path_confinement_ratchet(
     # happened to fire for an out-of-root value. This half proves the "must stay within"
     # signal specifically tracks confinement, not noise.
     positive_value = _ratchet_positive_value(tool_name, param_name, tmp_path)
-    accepted = _call_mcp_tool_text(tool_name, {**base_kwargs, param_name: positive_value})
+    try:
+        accepted = _call_mcp_tool_text(tool_name, {**base_kwargs, param_name: positive_value})
+    except Exception as exc:
+        # A tool may fail for a NON-confinement reason on a given runner: e.g. the ast-grep /
+        # tree-sitter deps are absent (Linux CI without ast-grep), so an ast-backed tool
+        # (tg_ast_search, tg_ruleset_scan, ...) raises a wrapped ToolError BEFORE it would run.
+        # That is NOT a confinement rejection -- confinement rejections RETURN structured text
+        # (see the negative probe above), they never raise. So a raised error still satisfies
+        # the positive half (the anchor did not reject the in-root path); assert only that it is
+        # not specifically the confinement "must stay within" signal.
+        accepted = str(exc)
     assert "must stay within" not in accepted, (
         f"{tool_name}.{param_name} rejected an in-root path as if it were out-of-root "
         f"(response: {accepted[:500]!r}); the confinement anchor is probably wrong."

--- a/tests/unit/test_profiling_cli_mcp.py
+++ b/tests/unit/test_profiling_cli_mcp.py
@@ -270,7 +270,9 @@ def test_mcp_context_render_exposes_and_forwards_max_repo_files(
 
     assert payload["ok"] is True
     assert captured["query"] == "create invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 17
 
 
@@ -316,5 +318,7 @@ def test_mcp_session_edit_plan_exposes_and_forwards_max_repo_files(
     assert payload == {"ok": True}
     assert captured["session_id"] == "session-1"
     assert captured["query"] == "create invoice"
-    assert captured["path"] == "."
+    # round-8 (audit #95): path="." is now confined+resolved to an absolute cwd path before
+    # being forwarded to the builder.
+    assert captured["path"] == str(Path.cwd().resolve())
     assert captured["max_repo_files"] == 23

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -1778,6 +1778,9 @@ def test_cli_blast_radius_render_accepts_provider_option(tmp_path: Path, monkeyp
 
 
 def test_mcp_defs_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> None:
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
     module_path = tmp_path / "module.py"
     module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
 
@@ -1798,6 +1801,9 @@ def test_mcp_defs_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> Non
 
 
 def test_mcp_impact_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> None:
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         mcp_server,
         "build_symbol_impact",
@@ -1823,6 +1829,9 @@ def test_mcp_impact_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> N
 
 
 def test_mcp_source_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> None:
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         mcp_server,
         "build_symbol_source",
@@ -1844,6 +1853,9 @@ def test_mcp_source_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> N
 
 
 def test_mcp_blast_radius_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> None:
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         mcp_server,
         "build_symbol_blast_radius",
@@ -1869,6 +1881,9 @@ def test_mcp_blast_radius_accepts_provider_parameter(tmp_path: Path, monkeypatch
 
 
 def test_mcp_blast_radius_plan_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> None:
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         repo_map,
         "build_symbol_blast_radius_plan",
@@ -1896,6 +1911,10 @@ def test_mcp_blast_radius_plan_accepts_provider_parameter(tmp_path: Path, monkey
 
 
 def test_mcp_blast_radius_render_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> None:
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
+
     def fake_build_symbol_blast_radius_render(
         symbol,
         path,

--- a/tests/unit/test_typed_ref_kinds.py
+++ b/tests/unit/test_typed_ref_kinds.py
@@ -174,11 +174,16 @@ def test_rust_ref_kind_classification_five_positions(tmp_path: Path) -> None:
     assert all(row["ref_kind"] == "call" for row in callers_payload["callers"])
 
 
-def test_mcp_agent_capsule_related_call_sites_carry_ref_kind(tmp_path: Path) -> None:
+def test_mcp_agent_capsule_related_call_sites_carry_ref_kind(
+    tmp_path: Path, monkeypatch
+) -> None:
     """The ``tg_agent_capsule`` MCP tool surfaces ``related_call_sites`` built from blast-radius
     callers -- confirm ref_kind survives that hop too (moat closer: an agent consuming the MCP
     capsule can tell a real call site from a type/field/value mention without re-parsing).
     """
+    # round-8 (audit #95): path is now confined to the MCP root (cwd); chdir so tmp_path
+    # is in-root.
+    monkeypatch.chdir(tmp_path)
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     module_path = src_dir / "payments.py"

--- a/tests/unit/test_typed_ref_kinds.py
+++ b/tests/unit/test_typed_ref_kinds.py
@@ -174,9 +174,7 @@ def test_rust_ref_kind_classification_five_positions(tmp_path: Path) -> None:
     assert all(row["ref_kind"] == "call" for row in callers_payload["callers"])
 
 
-def test_mcp_agent_capsule_related_call_sites_carry_ref_kind(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_mcp_agent_capsule_related_call_sites_carry_ref_kind(tmp_path: Path, monkeypatch) -> None:
     """The ``tg_agent_capsule`` MCP tool surfaces ``related_call_sites`` built from blast-radius
     callers -- confirm ref_kind survives that hop too (moat closer: an agent consuming the MCP
     capsule can tell a real call site from a type/field/value mention without re-parsing).


### PR DESCRIPTION
## What

Confine **every** MCP tool's primary `path=`/`root=`/`file=` parameter to the server root (`Path.cwd()`, or the new `TG_MCP_ROOT` override) via `_confine_mcp_path` + `_mcp_root`. Previously every tool's PRIMARY path was UNCONFINED — a shipping arbitrary-directory READ across ~35 tools (`tg_search`/`tg_repo_map`/`tg_agent_capsule`/every `tg_symbol_*`/`tg_session_*`/`tg_rewrite_*`/`tg_checkpoint_*`), and a WRITE surface on rewrite/checkpoint. Audit item #95, the systemic security prerequisite (design steps 1-4). Design: `docs/plans/design-tensor-grep-95-mcp-moat-exposure-2026-07-09.md`.

**Closes a LIVE VULN:** `tg_session_file_importers` with `path=/etc` resolved its `session_root` to `/etc`, then confined `file` to `/etc` -> read `/etc/*`. Now `path` is confined at the top of the function BEFORE `session_root` derives -> `invalid_input` (traced + runtime-confirmed by the security gate).

## How it was built (recovery note)

Built by a Sonnet worktree agent that DIED on a session-usage limit right before its final verify+commit ("run the complete unit test suite"). Its 1268 uncommitted lines were preserved, harvested to this branch, and fully re-verified in the real venv. Nothing was lost.

## Security gate: VERDICT SHIP (adversarial Opus, read + runtime-probed)

- **Fail-closed, no escape found.** `_confine_write_path` uses `.resolve()` (follows symlinks) + `.parents` ancestry (NOT string-prefix, so the `/repo` vs `/repo-secret` sibling bypass fails closed). Tried `../`, absolute, symlink-inside->outside, UNC/`\\?\`, `~`; all rejected.
- **Full coverage.** 36 `_confine_mcp_path` call-sites; the schema-driven ratchet test enumerated **55 (tool,param) cases** at runtime; no unconfined path param remains. Non-path primaries (`file`, manifest/bundle params) confined too.
- **Real ratchet, bidirectional.** Enumerates every `str` param from the LIVE `mcp.list_tools()` `inputSchema`; a new UNCLASSIFIED str param FAILS the test until consciously confined or added to the closed `CONFINEMENT_EXEMPT` allowlist. Probes both out-of-root (rejected with the specific `invalid_input`) and in-root (accepted).
- `_mcp_root()`: unset/empty/whitespace `TG_MCP_ROOT` -> cwd (closes the `""`->filesystem-root trap); override validated `is_dir()` else falls back to cwd + stderr warning.
- `_TG_MCP_SERVER_CONTRACT_VERSION` bumped 1.0.0 -> 1.1.0 + pin updated.

## Tests

Real-venv: **3924 unit passed / 10 skipped / 0 failures**; 363 MCP unit + 2 integration (my harvest verify); 292 MCP (gate's run). ruff check + `ruff format --preview --check` + mypy clean. Import OK. (The IDE Pyright "unresolved import" warnings are venv-unaware false positives — the runtime import + full suite prove resolution.)

## BEHAVIOR CHANGE + versioning (please read)

This **rejects out-of-cwd MCP reads** that previously succeeded. In-cwd callers (the overwhelming majority) are unaffected. A legit monorepo/fleet caller reading sibling repos must now set `TG_MCP_ROOT=<parent>` to relocate the boundary. This is intentional fail-closed hardening.

Shipping as a **minor `feat`, not a major bump** — a security hardening with a documented override, in-cwd callers unaffected. If you'd rather signal it as breaking, re-title with `feat!:` before merge. Flagging per the design's "bump is a judgment call."

## Scope: this is the confinement ONLY (the security floor)

The agent died after the confinement (design steps 1-4). The MOAT-EXPOSURE features of #95 — `tg_orient` tool, `--rank/--semantic` on `tg_search`, `tg_doctor`/`deadline` params, `inline_rules` custom rules (design steps 5-10) — are a SEPARATE follow-up (#95 remainder), correctly sequenced to build ON this confinement floor.

## Non-blocking follow-ups (filed, not in this PR)

1. **Anchor split** — 13 params on 8 round-6/7 tools (`tg_file_imports/importers.file`, `tg_classify_logs.file_path`, the `tg_audit_*`/`tg_review_bundle_*` manifest/bundle params, `tg_rewrite_apply.audit_manifest`) confine at `Path.cwd()` not `_mcp_root()` -> they don't move with a narrowed `TG_MCP_ROOT` (bounded to cwd, fail-closed, identical in default config; NOT the #95 vuln). Route through `_mcp_root()` before advertising `TG_MCP_ROOT` as the fleet boundary. Docstring corrected here to flag it.
2. Ratchet test doesn't `delenv("TG_MCP_ROOT")` (CI-safe; non-hermetic for a dev who set it).
3. Residual native-side symlink-swap TOCTOU on the `audit_manifest` write (Rust `O_NOFOLLOW`) — pre-existing, out of #95 scope.

Part of #95.
