### PR TITLE
feat(repo-map): answer-first payloads + --max-tokens/--max-tests on defs/refs/callers/impact (audit #96, 90-97% payload cut)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -66,6 +66,10 @@ if TYPE_CHECKING:
 _DEFAULT_AGENT_REPO_SCAN_LIMIT = 2000
 _DEFAULT_BLAST_RADIUS_JSON_MAX_CALLERS = 25
 _DEFAULT_BLAST_RADIUS_JSON_MAX_FILES = 25
+# audit #96 (answer-first payloads): defs/refs/callers/impact's own DEDICATED tests-cap, wired
+# on-by-default like blast-radius's --max-callers/--max-files precedent above (not an opt-in-only
+# flag -- the audit's "95% payload filler" bug needs a default that actually fixes it).
+_DEFAULT_SYMBOL_MAX_TESTS = 25
 _DOCTOR_LSP_PROBE_TIMEOUT_SECONDS = 15.0
 _DOCTOR_LSP_WINDOWS_PROBE_TIMEOUT_SECONDS = 15.0
 _DOCTOR_LSP_PROBE_TIMEOUT_ENV = "TG_DOCTOR_LSP_PROBE_TIMEOUT_SECONDS"
@@ -8490,6 +8494,74 @@ def _annotate_result_completeness(
     return caveat, truncation is not None
 
 
+def _attach_symbol_omissions(
+    payload: dict[str, Any],
+    *,
+    command_name: str,
+    path: str,
+    symbol: str,
+    max_tests: int | None,
+    max_tokens: int | None,
+    primary_field: str,
+) -> None:
+    """Stamp an additive, agent-facing ``omissions`` envelope (design #96 item 3).
+
+    Mirrors ``agent_capsule.py``'s ``omissions:{token_budget, omitted_section_count,
+    omitted_sections[], follow_up_reads[]}`` shape (``agent_capsule.py:2262-2267``) as a sibling
+    key on defs/refs/callers/impact, summarizing what the tests-cap (``output_limit``, set by
+    ``repo_map._apply_symbol_field_output_limit``) and the token budget (``token_budget``, set by
+    ``repo_map._apply_symbol_token_budget``) trimmed. Unlike the capsule's follow-up reads (which
+    point at a DIFFERENT command to read more source), the follow-up pointer here is
+    SELF-referential: re-run this SAME command with a bigger ``--max-tests``/``--max-tokens``,
+    since there is nothing else to point at. ALWAYS present (even with nothing omitted, in which
+    case ``omitted_sections``/``follow_up_reads`` are simply empty) so the shape is stable at v1.
+
+    Purely additive/descriptive: never reads or writes ``result_incomplete``/``partial``/
+    ``caller_scan_limit``, so it cannot affect the scan-truncation exit-2 contract.
+    """
+    omitted_sections: list[dict[str, Any]] = []
+    retry_argv: list[str] = ["tg", command_name, path, symbol, "--json"]
+    retry_needed = False
+
+    output_limit = payload.get("output_limit")
+    if isinstance(output_limit, dict) and output_limit.get("tests_truncated"):
+        omitted_sections.append({
+            "section": "tests",
+            "omitted_count": int(output_limit.get("omitted_tests", 0)),
+            "reason": "max-tests cap",
+        })
+        retry_argv.extend(["--max-tests", str(output_limit.get("total_tests", 0))])
+        retry_needed = True
+
+    token_budget = payload.get("token_budget")
+    if isinstance(token_budget, dict) and token_budget.get("primary_truncated"):
+        omitted_sections.append({
+            "section": primary_field,
+            "omitted_count": int(token_budget.get("primary_omitted", 0)),
+            "reason": "max-tokens budget",
+        })
+        retry_argv.extend(["--max-tokens", "0"])
+        retry_needed = True
+
+    follow_up_reads: list[dict[str, Any]] = []
+    if retry_needed:
+        follow_up_reads.append({
+            "file": None,
+            "symbol": symbol,
+            "role": "retry-bigger-budget",
+            "command": subprocess.list2cmdline(retry_argv),
+            "argv": retry_argv,
+        })
+
+    payload["omissions"] = {
+        "token_budget": max_tokens,
+        "max_tests": max_tests,
+        "omitted_section_count": len(omitted_sections),
+        "omitted_sections": omitted_sections,
+        "follow_up_reads": follow_up_reads,
+    }
+
+
 def _emit_symbol_command_result(
     payload: dict[str, Any],
     *,
@@ -8693,10 +8765,25 @@ def defs(
             "(case-insensitive). Disambiguates common method names like 'search'."
         ),
     ),
+    max_tests: int | None = typer.Option(
+        _DEFAULT_SYMBOL_MAX_TESTS,
+        "--max-tests",
+        min=1,
+        help="Maximum relevant test files to include in output; raise for full coverage.",
+    ),
+    max_tokens: int = typer.Option(
+        # Mirrors repo_map._DEFAULT_CONTEXT_MAX_TOKENS (literal keeps the heavy repo_map import
+        # lazy). Answer-first: secondary fields (tests/related_paths) are trimmed before
+        # `definitions` itself. 0 = unbounded opt-out.
+        16000,
+        "--max-tokens",
+        min=0,
+        help="Approximate maximum payload size in tokens (0 = unbounded).",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return exact definition locations for a symbol."""
-    from tensor_grep.cli.repo_map import build_symbol_defs
+    from tensor_grep.cli.repo_map import _apply_symbol_token_budget, build_symbol_defs
 
     try:
         resolved_path, resolved_symbol = _resolve_path_and_symbol(
@@ -8710,6 +8797,7 @@ def defs(
             resolved_path,
             semantic_provider=provider,
             max_repo_files=max_repo_files,
+            max_tests=max_tests,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
@@ -8717,6 +8805,17 @@ def defs(
 
     if class_filter is not None:
         _apply_defs_class_filter(payload, class_filter)
+
+    payload = _apply_symbol_token_budget(payload, max_tokens, primary_field="definitions")
+    _attach_symbol_omissions(
+        payload,
+        command_name="defs",
+        path=resolved_path,
+        symbol=resolved_symbol,
+        max_tests=max_tests,
+        max_tokens=max_tokens,
+        primary_field="definitions",
+    )
 
     def _emit_text(current: dict[str, Any]) -> None:
         typer.echo(f"Definitions for {current['symbol']} in {current['path']}")
@@ -8812,10 +8911,29 @@ def impact(
             "whatever was found so far, instead of running unbounded."
         ),
     ),
+    max_tests: int | None = typer.Option(
+        _DEFAULT_SYMBOL_MAX_TESTS,
+        "--max-tests",
+        min=1,
+        help="Maximum relevant test files to include in output; raise for full coverage.",
+    ),
+    max_tokens: int = typer.Option(
+        # Mirrors repo_map._DEFAULT_CONTEXT_MAX_TOKENS (literal keeps the heavy repo_map import
+        # lazy). Answer-first: secondary fields (tests/related_paths) are trimmed before `files`
+        # itself. 0 = unbounded opt-out.
+        16000,
+        "--max-tokens",
+        min=0,
+        help="Approximate maximum payload size in tokens (0 = unbounded).",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return likely impacted files and tests for a symbol change."""
-    from tensor_grep.cli.repo_map import build_symbol_callers, build_symbol_impact
+    from tensor_grep.cli.repo_map import (
+        _apply_symbol_token_budget,
+        build_symbol_callers,
+        build_symbol_impact,
+    )
 
     try:
         resolved_path, resolved_symbol = _resolve_path_and_symbol(
@@ -8830,6 +8948,7 @@ def impact(
             semantic_provider=provider,
             max_repo_files=max_repo_files,
             deadline_seconds=deadline,
+            max_tests=max_tests,
         )
         # H5: impact previously surfaced only definition/import-derived `files` and so
         # under-reported call sites relative to `tg callers` (which finds the CLI
@@ -8863,6 +8982,19 @@ def impact(
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
+
+    payload = _apply_symbol_token_budget(
+        payload, max_tokens, primary_field="files", companion_fields=("file_matches",)
+    )
+    _attach_symbol_omissions(
+        payload,
+        command_name="impact",
+        path=resolved_path,
+        symbol=resolved_symbol,
+        max_tests=max_tests,
+        max_tokens=max_tokens,
+        primary_field="files",
+    )
 
     def _emit_text(current: dict[str, Any]) -> None:
         typer.echo(f"Impact for {current['symbol']} in {current['path']}")
@@ -8908,10 +9040,25 @@ def refs(
             "whatever was found so far, instead of running unbounded."
         ),
     ),
+    max_tests: int | None = typer.Option(
+        _DEFAULT_SYMBOL_MAX_TESTS,
+        "--max-tests",
+        min=1,
+        help="Maximum relevant test files to include in output; raise for full coverage.",
+    ),
+    max_tokens: int = typer.Option(
+        # Mirrors repo_map._DEFAULT_CONTEXT_MAX_TOKENS (literal keeps the heavy repo_map import
+        # lazy). Answer-first: secondary fields (tests/related_paths) are trimmed before
+        # `references` itself. 0 = unbounded opt-out.
+        16000,
+        "--max-tokens",
+        min=0,
+        help="Approximate maximum payload size in tokens (0 = unbounded).",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return Python-first symbol references across the inventory root."""
-    from tensor_grep.cli.repo_map import build_symbol_refs
+    from tensor_grep.cli.repo_map import _apply_symbol_token_budget, build_symbol_refs
 
     try:
         resolved_path, resolved_symbol = _resolve_path_and_symbol(
@@ -8926,10 +9073,22 @@ def refs(
             semantic_provider=provider,
             max_repo_files=max_repo_files,
             deadline_seconds=deadline,
+            max_tests=max_tests,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
+
+    payload = _apply_symbol_token_budget(payload, max_tokens, primary_field="references")
+    _attach_symbol_omissions(
+        payload,
+        command_name="refs",
+        path=resolved_path,
+        symbol=resolved_symbol,
+        max_tests=max_tests,
+        max_tokens=max_tokens,
+        primary_field="references",
+    )
 
     def _emit_text(current: dict[str, Any]) -> None:
         typer.echo(f"References for {current['symbol']} in {current['path']}")
@@ -8972,10 +9131,25 @@ def callers(
             "whatever was found so far, instead of running unbounded."
         ),
     ),
+    max_tests: int | None = typer.Option(
+        _DEFAULT_SYMBOL_MAX_TESTS,
+        "--max-tests",
+        min=1,
+        help="Maximum relevant test files to include in output; raise for full coverage.",
+    ),
+    max_tokens: int = typer.Option(
+        # Mirrors repo_map._DEFAULT_CONTEXT_MAX_TOKENS (literal keeps the heavy repo_map import
+        # lazy). Answer-first: secondary fields (tests/related_paths) are trimmed before
+        # `callers` itself. 0 = unbounded opt-out.
+        16000,
+        "--max-tokens",
+        min=0,
+        help="Approximate maximum payload size in tokens (0 = unbounded).",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return Python-first call sites and likely impacted tests for a symbol."""
-    from tensor_grep.cli.repo_map import build_symbol_callers
+    from tensor_grep.cli.repo_map import _apply_symbol_token_budget, build_symbol_callers
 
     try:
         resolved_path, resolved_symbol = _resolve_path_and_symbol(
@@ -8990,10 +9164,22 @@ def callers(
             semantic_provider=provider,
             max_repo_files=max_repo_files,
             deadline_seconds=deadline,
+            max_tests=max_tests,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
+
+    payload = _apply_symbol_token_budget(payload, max_tokens, primary_field="callers")
+    _attach_symbol_omissions(
+        payload,
+        command_name="callers",
+        path=resolved_path,
+        symbol=resolved_symbol,
+        max_tests=max_tests,
+        max_tokens=max_tokens,
+        primary_field="callers",
+    )
 
     def _emit_text(current: dict[str, Any]) -> None:
         typer.echo(f"Callers for {current['symbol']} in {current['path']}")

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7416,6 +7416,124 @@ def _apply_context_token_budget(payload: dict[str, Any], max_tokens: int | None)
     return capped
 
 
+# Secondary (supporting-context) fields trimmed BEFORE the primary answer array when a
+# defs/refs/callers/impact payload exceeds --max-tokens (design #96, answer-first shrink order).
+_SYMBOL_TOKEN_BUDGET_SECONDARY_FIELDS: tuple[str, ...] = ("tests", "related_paths")
+
+
+def _apply_symbol_token_budget(
+    payload: dict[str, Any],
+    max_tokens: int | None,
+    *,
+    primary_field: str,
+    companion_fields: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Bound a defs/refs/callers/impact payload to ~``max_tokens`` (design #96 item 4).
+
+    Modeled on ``_apply_context_token_budget``'s serialize-then-measure approach, but with an
+    ANSWER-FIRST shrink order: SECONDARY fields (``tests``, ``related_paths`` -- whichever are
+    present; each field's ``{field}_matches`` companion, e.g. impact's ``test_matches``, is
+    cleared alongside it so the real bloat source is not left untouched) are cleared FIRST since
+    they are supporting context, not the answer itself. Only if the payload is STILL over budget
+    after zeroing every secondary field is the PRIMARY answer array (``primary_field`` --
+    ``definitions``/``references``/``callers``/``files``) trimmed, and that is flagged distinctly
+    (``token_budget.primary_truncated``/``primary_omitted``) so an agent trusting "here are all N
+    callers" can tell N was cut for space, not because there were only N. ``companion_fields``
+    (e.g. impact's ``file_matches``, which shares ``files``'s exact order/length by construction)
+    are sliced to the same length as the trimmed primary array so the two never disagree.
+
+    ``max_tokens`` of None/<=0 is a no-op (unbounded opt-out), matching
+    ``_apply_context_token_budget``. This is an OUTPUT-cap, never a scan-truncation signal: it
+    must never set ``result_incomplete``/``partial``/``caller_scan_limit`` (design #96 contract
+    safety section) -- achieved simply by never touching those keys.
+    """
+    if max_tokens is None or max_tokens <= 0:
+        return payload
+    estimated = _estimate_payload_tokens(payload)
+    if estimated <= max_tokens:
+        capped = dict(payload)
+        capped["token_budget"] = {
+            "max_tokens": max_tokens,
+            "estimated_tokens": estimated,
+            "truncated": False,
+            "primary_truncated": False,
+        }
+        return capped
+
+    capped = dict(payload)
+    secondary_trimmed: list[str] = []
+    for field_name in _SYMBOL_TOKEN_BUDGET_SECONDARY_FIELDS:
+        if estimated <= max_tokens:
+            break
+        current_value = capped.get(field_name)
+        if isinstance(current_value, list) and current_value:
+            capped[field_name] = []
+            companion = f"{field_name}_matches"
+            if isinstance(capped.get(companion), list):
+                capped[companion] = []
+            secondary_trimmed.append(field_name)
+            estimated = _estimate_payload_tokens(capped)
+
+    primary_truncated = False
+    primary_omitted = 0
+    if estimated > max_tokens:
+        primary_list = list(capped.get(primary_field) or [])
+        original_primary_count = len(primary_list)
+        count = original_primary_count
+        # Floor at 1, never 0 (mirrors _apply_context_token_budget's file-shrink floor): trimming
+        # the primary answer array all the way to an EMPTY list is indistinguishable from a
+        # genuine "not found" (the exact "confident false zero" this codebase's own
+        # _scan_truncation_warning docstring calls "the single most dangerous output for a
+        # refactor-safety tool") -- _emit_symbol_command_result reads an empty primary field as
+        # not_found and exits 1, which would silently relabel a budget trim as an absence.
+        while count > 1 and estimated > max_tokens:
+            # Proportional first guess, then strictly shrink so we always make progress (mirrors
+            # _apply_context_token_budget's file-shrink loop).
+            guess = max(1, min(count - 1, count * max_tokens // max(estimated, 1)))
+            capped[primary_field] = primary_list[:guess]
+            estimated = _estimate_payload_tokens(capped)
+            count = guess
+        # count/original_primary_count already <=1 (0 or 1 entries): nothing left to trim without
+        # zeroing the answer out, so best-effort stop here even if still over budget -- keeping a
+        # truthful non-empty answer outranks strictly honoring the token cap.
+        new_primary_len = len(capped.get(primary_field) or [])
+        primary_omitted = max(0, original_primary_count - new_primary_len)
+        primary_truncated = primary_omitted > 0
+        if primary_truncated:
+            surviving_primary = capped.get(primary_field) or []
+            # Filter by PATH MEMBERSHIP (not index/length slicing): a companion like impact's
+            # `file_matches` is not guaranteed to stay index-aligned with `files` once the CLI
+            # layer has post-processed the primary field (e.g. impact's own caller-merge step
+            # appends extra file paths to `files` with no matching `file_matches` entry) -- a
+            # length-slice would silently keep the WRONG entries in that case.
+            if surviving_primary and all(isinstance(item, str) for item in surviving_primary):
+                surviving_set = set(surviving_primary)
+                for companion in companion_fields:
+                    companion_value = capped.get(companion)
+                    if isinstance(companion_value, list):
+                        capped[companion] = [
+                            entry
+                            for entry in companion_value
+                            if not (isinstance(entry, dict) and "path" in entry)
+                            or str(entry["path"]) in surviving_set
+                        ]
+            else:
+                for companion in companion_fields:
+                    companion_value = capped.get(companion)
+                    if isinstance(companion_value, list):
+                        capped[companion] = companion_value[:new_primary_len]
+
+    capped["token_budget"] = {
+        "max_tokens": max_tokens,
+        "estimated_tokens": estimated,
+        "truncated": True,
+        "secondary_fields_trimmed": secondary_trimmed,
+        "primary_truncated": primary_truncated,
+        "primary_omitted": primary_omitted,
+    }
+    return capped
+
+
 def build_context_pack(
     query: str,
     path: str | Path = ".",
@@ -13339,15 +13457,58 @@ def _definition_confidence_score(definition: dict[str, Any], symbol: str) -> flo
     return round(max(0.0, min(1.0, score)), 3)
 
 
+def _apply_symbol_field_output_limit(
+    payload: dict[str, Any],
+    *,
+    field_name: str,
+    max_count: int | None,
+) -> dict[str, Any]:
+    """Cap ``payload[field_name]`` (a flat list) to ``max_count`` entries, stamping ``output_limit``.
+
+    Generalizes ``_apply_blast_radius_output_limits``'s tests-cap + ``output_limit`` stamping
+    (design #96 item 2) to any flat-list field -- giving defs/refs/callers/impact a DEDICATED
+    ``--max-tests`` instead of blast-radius's conflated ``--max-files``, and leaving the helper
+    ``field_name``-generic so a follow-up can reuse it for ``import_graph_consumers``.
+
+    Deliberately field-NAME-scoped output_limit keys (``{field_name}_truncated``, e.g.
+    ``tests_truncated`` -- never blast-radius's own ``callers_truncated``/``files_truncated``
+    names, which ``main._scan_truncation_warning`` DOES recognize as a SCAN truncation). An
+    output cap here is a COMPLETE analysis capped for display and must stay exit-0 (design #96
+    contract-safety section; see ``main._scan_incomplete``'s docstring for the scan-vs-output-cap
+    split this deliberately avoids colliding with).
+
+    ``max_count=None`` is a no-op: the field and ``output_limit`` are left untouched, so an
+    uncapped library/MCP caller sees byte-identical output to before this cap existed (mirrors
+    ``_apply_context_token_budget``'s ``None``-is-unbounded contract).
+    """
+    if max_count is None:
+        return payload
+    normalized_max = max(0, int(max_count))
+    original = list(payload.get(field_name) or [])
+    capped_list = original[:normalized_max]
+    payload[field_name] = capped_list
+    output_limit = dict(payload.get("output_limit") or {})
+    output_limit[f"max_{field_name}"] = normalized_max
+    output_limit[f"{field_name}_truncated"] = len(capped_list) < len(original)
+    output_limit[f"total_{field_name}"] = len(original)
+    output_limit[f"returned_{field_name}"] = len(capped_list)
+    output_limit[f"omitted_{field_name}"] = max(0, len(original) - len(capped_list))
+    payload["output_limit"] = output_limit
+    return payload
+
+
 def build_symbol_defs(
     symbol: str,
     path: str | Path = ".",
     *,
     semantic_provider: str = "native",
     max_repo_files: int | None = None,
+    max_tests: int | None = None,
 ) -> dict[str, Any]:
     payload = build_repo_map(path, max_repo_files=max_repo_files)
-    return build_symbol_defs_from_map(payload, symbol, semantic_provider=semantic_provider)
+    return build_symbol_defs_from_map(
+        payload, symbol, semantic_provider=semantic_provider, max_tests=max_tests
+    )
 
 
 def build_symbol_defs_from_map(
@@ -13355,12 +13516,12 @@ def build_symbol_defs_from_map(
     symbol: str,
     *,
     semantic_provider: str = "native",
+    max_tests: int | None = None,
 ) -> dict[str, Any]:
     payload = dict(repo_map)
     payload["files"] = list(repo_map.get("files", []))
     payload["symbols"] = [dict(current) for current in repo_map.get("symbols", [])]
     payload["imports"] = [dict(current) for current in repo_map.get("imports", [])]
-    payload["tests"] = list(repo_map.get("tests", []))
     payload["related_paths"] = list(repo_map.get("related_paths", []))
     native_definitions = [
         {
@@ -13411,6 +13572,13 @@ def build_symbol_defs_from_map(
             definition["score"] = _definition_confidence_score(definition, symbol)
 
     definition_files = [str(current["file"]) for current in definitions]
+    # Root-cause fix (audit #96): defs used to shallow-copy the WHOLE-REPO test manifest into
+    # `tests` (every _is_test_file up to the repo-map scan cap), regardless of relevance -- the
+    # "69KB for a 1-symbol answer" bug. Route through the SAME relevance filter callers/impact
+    # already use so defs stops dumping the manifest, then cap it BEFORE `related_paths` derives
+    # below (a leak-back through the second field is the same bug one layer down).
+    payload["tests"] = _relevant_tests_for_symbol(repo_map, symbol, definition_files)
+    _apply_symbol_field_output_limit(payload, field_name="tests", max_count=max_tests)
     related_paths = []
     for current in [*definition_files, *payload["tests"]]:
         if current not in related_paths:
@@ -13621,6 +13789,7 @@ def build_symbol_impact(
     semantic_provider: str = "native",
     max_repo_files: int | None = None,
     deadline_seconds: float | None = None,
+    max_tests: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     # moat P0-6 step 3: convert the relative --deadline once to an ABSOLUTE monotonic timestamp so
@@ -13637,6 +13806,7 @@ def build_symbol_impact(
         symbol,
         semantic_provider=semantic_provider,
         deadline_monotonic=deadline_monotonic,
+        max_tests=max_tests,
         _profiling_collector=_profiling_collector,
     )
     _copy_partial_signal(
@@ -13651,6 +13821,7 @@ def build_symbol_impact_from_map(
     *,
     semantic_provider: str = "native",
     deadline_monotonic: float | None = None,
+    max_tests: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
@@ -13728,6 +13899,15 @@ def build_symbol_impact_from_map(
         deadline_hit=related_tests_deadline_hit,
         _profiling_collector=_profiling_collector,
     )
+    # impact's own DEDICATED --max-tests (design #96 item 2): cap BEFORE related_paths/test_matches
+    # derive below (both are indexed off `related_tests`), or the omitted tests leak back in via
+    # the second field. `payload` does not exist yet at this point, so cap through a scratch dict.
+    impact_tests_limit_scratch: dict[str, Any] = {"tests": related_tests}
+    _apply_symbol_field_output_limit(
+        impact_tests_limit_scratch, field_name="tests", max_count=max_tests
+    )
+    related_tests = cast(list[str], impact_tests_limit_scratch["tests"])
+    impact_tests_output_limit = impact_tests_limit_scratch.get("output_limit")
 
     definition_file_set = set(definition_files)
     file_matches_by_path: dict[str, dict[str, Any]] = {}
@@ -13809,6 +13989,8 @@ def build_symbol_impact_from_map(
     payload["file_summaries"] = _file_summaries(repo_map.get("symbols", []), impacted_files)
     payload["tests"] = related_tests
     payload["test_matches"] = [test_matches_by_path[str(current)] for current in related_tests]
+    if impact_tests_output_limit is not None:
+        payload["output_limit"] = impact_tests_output_limit
     payload["imports"] = context_payload["imports"]
     payload["symbols"] = context_payload["symbols"]
     payload["related_paths"] = related_paths
@@ -13945,13 +14127,18 @@ def build_symbol_refs(
     semantic_provider: str = "native",
     max_repo_files: int | None = None,
     deadline_seconds: float | None = None,
+    max_tests: int | None = None,
 ) -> dict[str, Any]:
     deadline_monotonic = _deadline_monotonic_from_seconds(deadline_seconds)
     repo_map = build_repo_map(
         path, max_repo_files=max_repo_files, deadline_monotonic=deadline_monotonic
     )
     result = build_symbol_refs_from_map(
-        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+        repo_map,
+        symbol,
+        semantic_provider=semantic_provider,
+        deadline_monotonic=deadline_monotonic,
+        max_tests=max_tests,
     )
     _copy_partial_signal(result, repo_map)
     return result
@@ -13963,6 +14150,7 @@ def build_symbol_refs_from_map(
     *,
     semantic_provider: str = "native",
     deadline_monotonic: float | None = None,
+    max_tests: int | None = None,
 ) -> dict[str, Any]:
     payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
     if payload.get("no_match"):
@@ -14167,6 +14355,11 @@ def build_symbol_refs_from_map(
     )
 
     referenced_files = sorted(dict.fromkeys(str(current["file"]) for current in references))
+    # refs' own DEDICATED --max-tests (design #96 item 2), independent of defs' -- the nested
+    # build_symbol_defs_from_map call above passes no max_tests, so `payload["tests"]` here is
+    # still the full relevance-filtered (uncapped) list; cap it now, BEFORE related_paths derives
+    # below, or the omitted tests leak back in via the second field.
+    _apply_symbol_field_output_limit(payload, field_name="tests", max_count=max_tests)
     related_paths: list[str] = []
     for current in [*payload["files"], *referenced_files, *payload["tests"]]:
         if current not in related_paths:
@@ -14592,6 +14785,7 @@ def build_symbol_callers(
     semantic_provider: str = "native",
     max_repo_files: int | None = None,
     deadline_seconds: float | None = None,
+    max_tests: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     deadline_monotonic = _deadline_monotonic_from_seconds(deadline_seconds)
@@ -14606,6 +14800,7 @@ def build_symbol_callers(
         symbol,
         semantic_provider=semantic_provider,
         deadline_monotonic=deadline_monotonic,
+        max_tests=max_tests,
         _profiling_collector=_profiling_collector,
     )
     _copy_partial_signal(result, repo_map)
@@ -14618,6 +14813,7 @@ def build_symbol_callers_from_map(
     *,
     semantic_provider: str = "native",
     deadline_monotonic: float | None = None,
+    max_tests: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
@@ -14967,6 +15163,14 @@ def build_symbol_callers_from_map(
         deadline_hit=related_tests_deadline_hit,
         _profiling_collector=_profiling_collector,
     )
+    # callers' own DEDICATED --max-tests (design #96 item 2): cap BEFORE related_paths derives
+    # below, or the omitted tests leak back in via the second field. `payload` does not exist yet
+    # at this point (built via _envelope below), so cap through a scratch dict and read the
+    # (possibly capped) list + stamped output_limit back out.
+    tests_limit_scratch: dict[str, Any] = {"tests": related_tests}
+    _apply_symbol_field_output_limit(tests_limit_scratch, field_name="tests", max_count=max_tests)
+    related_tests = cast(list[str], tests_limit_scratch["tests"])
+    tests_output_limit = tests_limit_scratch.get("output_limit")
 
     related_paths: list[str] = []
     for related_path in [
@@ -14988,6 +15192,8 @@ def build_symbol_callers_from_map(
     payload["import_graph_consumer_count"] = len(import_graph_consumers)
     payload["files"] = caller_files
     payload["tests"] = related_tests
+    if tests_output_limit is not None:
+        payload["output_limit"] = tests_output_limit
     payload["imports"] = context_payload["imports"]
     payload["symbols"] = context_payload["symbols"]
     payload["related_paths"] = related_paths

--- a/tests/unit/test_answer_first_symbol_payloads.py
+++ b/tests/unit/test_answer_first_symbol_payloads.py
@@ -1,0 +1,455 @@
+"""TDD for audit #96: answer-first payloads + universal ``--max-tokens`` on defs/refs/callers.
+
+Root cause (design ``docs/plans/design-tensor-grep-96-answer-first-payloads-2026-07-09.md``):
+``defs``/``refs``/``source`` did not compute "related" tests at all -- they shallow-copied the
+WHOLE-REPO test manifest verbatim into ``payload["tests"]`` (and again into ``related_paths``),
+regardless of whether any given test file had anything to do with the requested symbol.
+``callers``/``impact`` DID compute relevance (via ``_relevant_tests_for_symbol``) but never
+count-capped the result. ``blast-radius`` was the one command already fixed
+(``_apply_blast_radius_output_limits``) -- this suite proves defs/refs/callers/impact now match
+that bar: relevance-filtered, count-capped (``--max-tests``), token-budgeted (``--max-tokens``),
+with an additive agent-facing ``omissions`` envelope, and WITHOUT ever tripping the
+scan-truncation exit-2 contract (an output cap is a COMPLETE analysis capped for display, not an
+incomplete scan).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import tensor_grep.cli.repo_map as repo_map
+from tensor_grep.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_module_with_symbol(project: Path, symbol: str) -> Path:
+    src_dir = project / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    module_path = src_dir / "payments.py"
+    module_path.write_text(
+        f"def {symbol}(total, tax):\n    return total + tax\n",
+        encoding="utf-8",
+    )
+    return module_path
+
+
+def _write_relevant_test(tests_dir: Path, name: str, symbol: str) -> Path:
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    test_path = tests_dir / name
+    # Import-only, deliberately NOT calling `symbol`: relevance detection
+    # (_file_imports_symbol_from_definition) is import-based, so this is enough to land in
+    # `tests`, while keeping `tests` and `callers` counts orthogonal in fixtures that combine
+    # both (a test file that also CALLS the symbol shows up in `callers` too, which would make
+    # caller/test counts interact in confusing ways for the --max-tokens fanout fixtures below).
+    test_path.write_text(f"from src.payments import {symbol}\n", encoding="utf-8")
+    return test_path
+
+
+def _write_unrelated_test(tests_dir: Path, name: str, index: int) -> Path:
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    test_path = tests_dir / name
+    test_path.write_text(
+        f"def test_unrelated_{index}():\n    assert {index} == {index}\n",
+        encoding="utf-8",
+    )
+    return test_path
+
+
+# --------------------------------------------------------------------------------------- item 1
+# relevance-filter regression: defs must stop dumping the whole-repo test manifest.
+
+
+def test_defs_tests_field_is_relevance_filtered_not_whole_manifest(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    relevant_test = _write_relevant_test(tests_dir, "test_payments.py", "create_invoice")
+    for index in range(5):
+        _write_unrelated_test(tests_dir, f"test_unrelated_{index}.py", index)
+
+    payload = repo_map.build_symbol_defs("create_invoice", str(project))
+
+    # Sanity: the whole-repo manifest really does contain all 6 test files (proves the fixture
+    # would have failed under the OLD raw-copy behavior, not just an empty-tests coincidence).
+    repo_payload = repo_map.build_repo_map(project)
+    assert len(repo_payload.get("tests", [])) == 6
+
+    assert payload["tests"] == [str(relevant_test.resolve())]
+
+
+def test_refs_and_source_inherit_the_defs_relevance_filter(tmp_path: Path) -> None:
+    # refs/source pull `tests` straight from build_symbol_defs_from_map's payload -- fixing defs
+    # must fix them too, with no separate relevance-filter code of their own.
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    relevant_test = _write_relevant_test(tests_dir, "test_payments.py", "create_invoice")
+    for index in range(5):
+        _write_unrelated_test(tests_dir, f"test_unrelated_{index}.py", index)
+
+    refs_payload = repo_map.build_symbol_refs("create_invoice", str(project))
+    source_payload = repo_map.build_symbol_source("create_invoice", str(project))
+
+    assert refs_payload["tests"] == [str(relevant_test.resolve())]
+    assert source_payload["tests"] == [str(relevant_test.resolve())]
+
+
+def test_callers_and_impact_relevance_filter_unchanged_by_the_defs_fix(tmp_path: Path) -> None:
+    # callers/impact already relevance-filtered via _relevant_tests_for_symbol before this change
+    # -- confirm the root-cause fix to defs did not regress their (already correct) behavior.
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    relevant_test = _write_relevant_test(tests_dir, "test_payments.py", "create_invoice")
+    for index in range(5):
+        _write_unrelated_test(tests_dir, f"test_unrelated_{index}.py", index)
+
+    callers_payload = repo_map.build_symbol_callers("create_invoice", str(project))
+    impact_payload = repo_map.build_symbol_impact("create_invoice", str(project))
+
+    assert callers_payload["tests"] == [str(relevant_test.resolve())]
+    assert impact_payload["tests"] == [str(relevant_test.resolve())]
+
+
+# --------------------------------------------------------------------------------------- item 2
+# shared output-limit helper + dedicated --max-tests count-cap.
+
+
+def _write_many_relevant_tests(tests_dir: Path, symbol: str, count: int) -> list[Path]:
+    return [
+        _write_relevant_test(tests_dir, f"test_relevant_{index:02d}.py", symbol)
+        for index in range(count)
+    ]
+
+
+def test_defs_max_tests_caps_count_and_stamps_output_limit(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    test_paths = _write_many_relevant_tests(tests_dir, "create_invoice", 8)
+
+    payload = repo_map.build_symbol_defs("create_invoice", str(project), max_tests=3)
+
+    assert len(payload["tests"]) == 3
+    output_limit = payload["output_limit"]
+    assert output_limit["max_tests"] == 3
+    assert output_limit["tests_truncated"] is True
+    assert output_limit["total_tests"] == 8
+    assert output_limit["returned_tests"] == 3
+    assert output_limit["omitted_tests"] == 5
+
+    # every retained test path is a real fixture path (not a fabricated/duplicated entry)
+    all_test_paths = {str(path.resolve()) for path in test_paths}
+    assert set(payload["tests"]) <= all_test_paths
+
+
+def test_builder_level_max_tests_none_is_unbounded_no_output_limit_key(tmp_path: Path) -> None:
+    # Library/MCP callers that do not opt in must see byte-identical output to before this cap
+    # existed (mirrors _apply_context_token_budget's "None is a no-op" contract).
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_many_relevant_tests(tests_dir, "create_invoice", 8)
+
+    payload = repo_map.build_symbol_defs("create_invoice", str(project))
+
+    assert len(payload["tests"]) == 8
+    assert "output_limit" not in payload
+
+
+def test_callers_and_impact_get_their_own_dedicated_max_tests(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_many_relevant_tests(tests_dir, "create_invoice", 8)
+
+    callers_payload = repo_map.build_symbol_callers("create_invoice", str(project), max_tests=2)
+    impact_payload = repo_map.build_symbol_impact("create_invoice", str(project), max_tests=4)
+
+    assert len(callers_payload["tests"]) == 2
+    assert callers_payload["output_limit"]["omitted_tests"] == 6
+    assert len(impact_payload["tests"]) == 4
+    assert impact_payload["output_limit"]["omitted_tests"] == 4
+
+
+def test_refs_gets_its_own_dedicated_max_tests_independent_of_defs(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_many_relevant_tests(tests_dir, "create_invoice", 8)
+
+    refs_payload = repo_map.build_symbol_refs("create_invoice", str(project), max_tests=1)
+
+    assert len(refs_payload["tests"]) == 1
+    assert refs_payload["output_limit"]["omitted_tests"] == 7
+
+
+# --------------------------------------------------------------------------------------- item 3
+# related_paths must not leak the capped-out (or filtered-out) tests back in via the 2nd field.
+
+
+def test_capped_tests_are_absent_from_related_paths(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    test_paths = _write_many_relevant_tests(tests_dir, "create_invoice", 8)
+
+    payload = repo_map.build_symbol_defs("create_invoice", str(project), max_tests=3)
+
+    all_test_paths = {str(path.resolve()) for path in test_paths}
+    omitted_test_paths = all_test_paths - set(payload["tests"])
+    assert omitted_test_paths  # sanity: something really was omitted
+    assert not (omitted_test_paths & set(payload["related_paths"]))
+    # the retained tests DO still show up in related_paths
+    assert set(payload["tests"]) <= set(payload["related_paths"])
+
+
+def test_filtered_out_unrelated_tests_are_absent_from_related_paths(tmp_path: Path) -> None:
+    # The root-cause (relevance-filter) leak, not just the count-cap leak: an unrelated test that
+    # never belonged in `tests` must not sneak into `related_paths` either.
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_relevant_test(tests_dir, "test_payments.py", "create_invoice")
+    unrelated_paths = [
+        _write_unrelated_test(tests_dir, f"test_unrelated_{index}.py", index) for index in range(5)
+    ]
+
+    payload = repo_map.build_symbol_defs("create_invoice", str(project))
+
+    unrelated_str = {str(path.resolve()) for path in unrelated_paths}
+    assert not (unrelated_str & set(payload["related_paths"]))
+
+
+# --------------------------------------------------------------------------------------- item 4
+# universal --max-tokens: secondary fields trimmed before the primary answer array.
+
+
+def _write_fanout_project(tmp_path: Path, *, callers: int, tests: int) -> Path:
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    for index in range(callers):
+        (src_dir / f"caller_{index:03d}.py").write_text(
+            "from src.payments import create_invoice\n\n"
+            f"def use_invoice_{index}(total, tax):\n"
+            "    return create_invoice(total, tax)\n",
+            encoding="utf-8",
+        )
+    _write_many_relevant_tests(tests_dir, "create_invoice", tests)
+    return project
+
+
+def test_max_tokens_trims_secondary_fields_before_primary_callers_array(tmp_path: Path) -> None:
+    project = _write_fanout_project(tmp_path, callers=10, tests=10)
+
+    # First: measure the REAL (untrimmed) and secondary-only-trimmed payload sizes so the budgets
+    # below are chosen relative to real numbers, not a guess (this payload carries a large
+    # irreducible floor from `symbols`/`imports`/`provider_status` that dwarfs a small guess).
+    baseline = runner.invoke(
+        app, ["callers", str(project), "create_invoice", "--json", "--max-tests", "50"]
+    )
+    assert baseline.exit_code == 0, baseline.output
+    baseline_payload = json.loads(baseline.stdout)
+    caller_count = len(baseline_payload["callers"])
+    assert caller_count == 10
+    assert len(baseline_payload["tests"]) == 10
+    full_size = repo_map._estimate_payload_tokens(baseline_payload)
+    secondary_cleared = dict(baseline_payload)
+    secondary_cleared["tests"] = []
+    secondary_cleared["related_paths"] = []
+    secondary_only_size = repo_map._estimate_payload_tokens(secondary_cleared)
+    assert secondary_only_size < full_size  # sanity: clearing secondary really shrinks it
+
+    # A budget between the secondary-only-cleared size and the full size: dropping `tests` +
+    # `related_paths` alone must suffice -- the caller primary array must survive intact.
+    budget = (secondary_only_size + full_size) // 2
+    result = runner.invoke(
+        app,
+        [
+            "callers",
+            str(project),
+            "create_invoice",
+            "--json",
+            "--max-tests",
+            "50",
+            "--max-tokens",
+            str(budget),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    token_budget = payload["token_budget"]
+    assert token_budget["truncated"] is True
+    assert "tests" in token_budget["secondary_fields_trimmed"]
+    assert token_budget["primary_truncated"] is False
+    assert len(payload["callers"]) == caller_count  # the answer itself was never touched
+    assert payload["tests"] == []
+
+
+def test_max_tokens_trims_primary_when_still_over_budget_after_secondary(tmp_path: Path) -> None:
+    project = _write_fanout_project(tmp_path, callers=10, tests=10)
+
+    result = runner.invoke(
+        app,
+        [
+            "callers",
+            str(project),
+            "create_invoice",
+            "--json",
+            "--max-tests",
+            "50",
+            "--max-tokens",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    token_budget = payload["token_budget"]
+    assert token_budget["truncated"] is True
+    assert token_budget["primary_truncated"] is True
+    assert token_budget["primary_omitted"] > 0
+    assert len(payload["callers"]) < 10
+    # Floor at 1, never 0 (design #96 fix): a budget trim must never look like "no callers found".
+    assert len(payload["callers"]) >= 1
+    assert payload["not_found"] is False
+
+
+def test_max_tokens_zero_is_unbounded_opt_out(tmp_path: Path) -> None:
+    project = _write_fanout_project(tmp_path, callers=10, tests=10)
+
+    result = runner.invoke(
+        app,
+        ["callers", str(project), "create_invoice", "--json", "--max-tokens", "0"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert "token_budget" not in payload
+    assert len(payload["callers"]) == 10
+
+
+# --------------------------------------------------------------------------------------- item 5
+# contract safety: an output-cap trim must NEVER trip the scan-truncation exit-2 signal.
+
+
+def test_max_tests_and_max_tokens_trim_never_sets_result_incomplete_or_partial(
+    tmp_path: Path,
+) -> None:
+    project = _write_fanout_project(tmp_path, callers=10, tests=10)
+
+    result = runner.invoke(
+        app,
+        [
+            "callers",
+            str(project),
+            "create_invoice",
+            "--json",
+            "--max-tests",
+            "1",
+            "--max-tokens",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    # Sanity: this really did trim something on both axes -- a no-op trim proves nothing.
+    assert payload["output_limit"]["tests_truncated"] is True
+    assert payload["token_budget"]["primary_truncated"] is True
+    assert payload.get("result_incomplete") is not True
+    assert "partial" not in payload
+    caller_scan_limit = payload.get("caller_scan_limit")
+    if isinstance(caller_scan_limit, dict):
+        assert caller_scan_limit.get("possibly_truncated") is not True
+    assert "caveat" not in payload
+    assert payload["not_found"] is False
+
+
+def test_defs_max_tests_trim_never_sets_result_incomplete(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_many_relevant_tests(tests_dir, "create_invoice", 8)
+
+    result = runner.invoke(
+        app,
+        ["defs", str(project), "create_invoice", "--json", "--max-tests", "1"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["output_limit"]["tests_truncated"] is True
+    assert payload.get("result_incomplete") is not True
+
+
+# --------------------------------------------------------------------------------------- item 3b
+# the answer-first `omissions` envelope, incl. its own self-referential follow-up pointer test.
+
+
+def test_omissions_envelope_always_present_and_empty_when_nothing_omitted(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_relevant_test(tests_dir, "test_payments.py", "create_invoice")
+
+    result = runner.invoke(app, ["defs", str(project), "create_invoice", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["omissions"]["omitted_section_count"] == 0
+    assert payload["omissions"]["omitted_sections"] == []
+    assert payload["omissions"]["follow_up_reads"] == []
+
+
+def test_omissions_self_referential_follow_up_read_suggests_bigger_budget(tmp_path: Path) -> None:
+    project = _write_fanout_project(tmp_path, callers=10, tests=10)
+
+    result = runner.invoke(
+        app,
+        [
+            "callers",
+            str(project),
+            "create_invoice",
+            "--json",
+            "--max-tests",
+            "1",
+            "--max-tokens",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    omissions = payload["omissions"]
+    assert omissions["omitted_section_count"] >= 2  # tests AND callers were both cut
+    section_names = {entry["section"] for entry in omissions["omitted_sections"]}
+    assert "tests" in section_names
+    assert "callers" in section_names
+    assert len(omissions["follow_up_reads"]) >= 1
+    follow_up = omissions["follow_up_reads"][0]
+    assert follow_up["symbol"] == "create_invoice"
+    assert "callers" in follow_up["argv"]
+    # self-referential: it points back at THIS command, not a different one (contrast with the
+    # capsule's cross-command follow-up reads)
+    assert "--max-tests" in follow_up["argv"] or "--max-tokens" in follow_up["argv"]
+
+
+# --------------------------------------------------------------------------------------- item extra
+# schema-shape pins: tests stays a flat list of strings; JSON_OUTPUT_VERSION stays 1.
+
+
+def test_tests_field_stays_a_flat_list_of_strings_not_restructured(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    tests_dir = project / "tests"
+    _write_module_with_symbol(project, "create_invoice")
+    _write_many_relevant_tests(tests_dir, "create_invoice", 3)
+
+    payload = repo_map.build_symbol_defs("create_invoice", str(project), max_tests=2)
+
+    assert isinstance(payload["tests"], list)
+    assert all(isinstance(entry, str) for entry in payload["tests"])
+
+
+def test_json_output_version_not_bumped() -> None:
+    assert repo_map.JSON_OUTPUT_VERSION == 1


### PR DESCRIPTION
## What

Answer-first payloads + universal `--max-tokens`/`--max-tests` on `tg defs`/`refs`/`callers`/`impact` (audit #96). Closes the "95% payload filler" preference-killer. Design: `docs/plans/design-tensor-grep-96-answer-first-payloads-2026-07-09.md`.

## Why (real-binary dogfood, gotcontext-main)

- `tg defs require_admin`: **46,148 -> 4,370 chars (90.5% reduction).** Build measured `tg defs ... --json` at **155,671 -> 3,831 bytes (97.5%)** on another symbol. Same mechanism.

## Root cause (not a missing cap)

`build_symbol_defs_from_map` shallow-copied the WHOLE-repo test manifest into `payload["tests"]` regardless of relevance, then leaked it a second time into `related_paths`. `refs`/`source` inherit defs' payload, and MCP imports the outer builders directly -> the dump reached every surface. Fix: compute `_relevant_tests_for_symbol` (the fn `callers`/`impact` already used) after `definition_files` and BEFORE `related_paths` derives -> the fix reaches refs/source/MCP for free.

## New primitives (repo_map.py)

- `_apply_symbol_field_output_limit(payload, field_name, max_count)` — generic count-cap + `output_limit` stamper (`tests_truncated`/`total_tests`/`omitted_tests`), generalizing `_apply_blast_radius_output_limits` without its `--max-files` conflation. New `--max-tests` (default 25) on all 4 commands.
- `_apply_symbol_token_budget(...)` — answer-first `--max-tokens`: clears SECONDARY fields (`tests`/`related_paths`/`*_matches`) first, only then trims the PRIMARY answer array, **floored at 1** (a real bug found mid-build: trimming to 0 made `_emit_symbol_command_result` read `not_found` -> exit 1, the "confident false zero" the codebase warns against).
- `_attach_symbol_omissions` (main.py) — additive `omissions:{token_budget, max_tests, omitted_sections[], follow_up_reads[]}` mirroring the agent-capsule shape, with a SELF-referential retry command.

## Contract safety (verified, not assumed)

`_emit_symbol_command_result` exits 2 on `result_incomplete=True` regardless of cause. This change uses field-name-scoped keys (`tests_truncated`, NOT the `files_truncated`/`callers_truncated` that `main._scan_truncation_warning` recognizes) so a token/tests TRIM stays **exit 0** (a complete-but-capped display), never conflated with a scan-truncation (exit 2). Negative-contract tests confirm. `JSON_OUTPUT_VERSION` stays 1 (omissions is additive; test-confirmed).

## Tests + verify

- New `tests/unit/test_answer_first_symbol_payloads.py` (18 tests, RED-verified 15/18 failed pre-impl).
- Build: mandated 868-test sweep + full unit suite **3872 passed** (2 pre-existing fails = missing `model2vec` semantic extra, confirmed unrelated via git-stash), ruff/format/mypy clean.
- Harvest re-verify (real venv, `uv run --no-sync`): `test_answer_first_symbol_payloads` + `test_cli_modes` + `test_main_cli_contracts` -> **540 passed**; ruff check + format-check clean.

## Perf (the design's mandatory gate)

`defs` on gotcontext-main (830 test files): ~60ms -> ~460-600ms mean (worst ~2.7s cold) — the relevance-filter adds PageRank work defs previously skipped. Context: `callers`/`impact` ALREADY pay 6.5-15.8s for the same underlying computation today (pre-existing), so defs' new cost is 10-20x cheaper than that existing precedent -> no lazy/fallback mitigation needed.

## Flagged

- `docs/CONTRACTS.md`/CHANGELOG not updated (out of the build's TDD scope) — CHANGELOG is semantic-release-generated from the commit anyway.
- **`callers`/`impact` cost 6.5-15.8s on an 830-test repo — a real, PRE-EXISTING perf concern (not touched here), filed as a separate task.**

Not security-sensitive (repo_map.py + main.py; no mcp/apply_policy/backends) -> no adversarial-gate requirement.

Closes #96.
