### PR TITLE
fix(repo-map): resolve tg importers FILE against cwd not ROOT — path-doubling bug (dogfood #104)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9241,8 +9241,14 @@ def imports(
 
 @app.command()
 def importers(
-    file: str = typer.Argument(..., help="File to find importers of."),
-    root: str = typer.Argument(".", help="Root to scan for importers."),
+    file: str = typer.Argument(
+        ...,
+        help=(
+            "File to find importers of. Resolved against the current directory (like any "
+            "normal path argument) whether relative or absolute -- NOT joined onto ROOT."
+        ),
+    ),
+    root: str = typer.Argument(".", help="Root to scan for importers (the scan boundary only)."),
     max_repo_files: int = typer.Option(
         _DEFAULT_AGENT_REPO_SCAN_LIMIT,
         "--max-repo-files",
@@ -9265,6 +9271,11 @@ def importers(
     Bounded reverse lookup: prefilters candidate importers via the repo's import-alias graph,
     then re-parses and CONFIRMS each candidate against FILE before reporting it as an edge (the
     alias prefilter alone over-counts -- see `tg callers`' import-consumer precision notes).
+
+    FILE is always resolved independently against the current directory (same rule as `tg
+    imports FILE`), never joined onto ROOT -- e.g. from a parent directory,
+    `tg importers myrepo/src/util.py myrepo` resolves FILE to `<cwd>/myrepo/src/util.py`, not
+    `<cwd>/myrepo/myrepo/src/util.py` (dogfood #104).
     """
     from tensor_grep.cli.repo_map import build_file_importers
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -14668,6 +14668,16 @@ def build_file_importers_from_map(
     *,
     deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
+    # A relative `file_path` here is resolved against `repo_map`'s own root, NOT process cwd --
+    # deliberate for this function's OTHER callers: `session_file_importers` and the raw
+    # `file_importers` daemon-socket command (session_store.py) pass a `file` straight from a
+    # remote/persistent-daemon request, where the daemon process's own cwd is meaningless and
+    # "relative to the session root" is the only sane interpretation (round-7 security audit
+    # #81 deliberately anchors the MCP confinement check the same way; see
+    # `tg_session_file_importers` in mcp_server.py). `build_file_importers` (the CLI/cold-tier
+    # entry point, dogfood #104) instead pre-resolves FILE to an absolute cwd-anchored path
+    # BEFORE calling here, so this join is a no-op for that caller -- do not "fix" this function
+    # to resolve against cwd instead, that would silently break the session/daemon contract.
     repo_root = Path(str(repo_map["path"])).resolve()
     resolved_file = Path(file_path).expanduser()
     if not resolved_file.is_absolute():
@@ -14761,8 +14771,21 @@ def build_file_importers(
     Cold tier: builds (or reuses a cached) repo map over ROOT, then confirms candidate importer
     edges precisely. See ``session_file_importers`` in session_store.py for the zero-reparse
     session tier, which calls ``build_file_importers_from_map`` directly on a cached map.
+
+    Dogfood #104 fix: FILE is resolved to an absolute path independently, against cwd -- the
+    SAME rule ``build_file_imports`` (``tg imports``, which takes no ROOT arg at all) already
+    uses -- before ``build_file_importers_from_map`` ever sees it. ROOT is only the scan
+    boundary. Without this, a cwd-relative FILE arg (the normal shell convention; from a parent
+    directory it is naturally prefixed with ROOT's own directory name, e.g.
+    ``myrepo/src/util.py`` when ROOT is ``myrepo``) got silently re-joined onto ROOT a second
+    time inside ``build_file_importers_from_map`` (``repo_root / resolved_file``), doubling the
+    path (``myrepo/myrepo/src/util.py``) and raising a spurious "not found". An already-absolute
+    FILE is unaffected (``.resolve()`` on an absolute path just normalizes it), so this is a
+    no-op for every caller that already passes an absolute FILE (both MCP tools always do, via
+    ``_confine_read_path``) -- only the previously-buggy cwd-relative case changes.
     """
     deadline_monotonic = _deadline_monotonic_from_seconds(deadline_seconds)
+    resolved_file_path = Path(file_path).expanduser().resolve()
     repo_map = build_repo_map(
         root,
         max_repo_files=max_repo_files,
@@ -14771,7 +14794,7 @@ def build_file_importers(
     )
     result = build_file_importers_from_map(
         repo_map,
-        file_path,
+        resolved_file_path,
         deadline_monotonic=deadline_monotonic,
     )
     _copy_partial_signal(result, repo_map)

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -451,3 +451,179 @@ def test_session_importers_matches_cold_importers(tmp_path: Path) -> None:
     assert set(warm["importer_files"]) == set(cold["importer_files"])
     assert warm["importer_count"] == cold["importer_count"]
     assert warm["importer_count"] > 0
+
+
+# ---------------------------------------------------------------------------------------------
+# Dogfood #104 (P0, CEO 1.54.6/WSL2): `tg importers` FILE-relative-to-ROOT path DOUBLING.
+#
+# `build_file_importers_from_map` used to assume ANY non-absolute FILE arg was meant relative to
+# ROOT (`repo_root / resolved_file`). From a PARENT cwd, a FILE arg typed relative to CWD (the
+# normal shell convention -- and therefore naturally prefixed with ROOT's own directory name,
+# e.g. `myrepo/src/util.js` when ROOT is `myrepo`) got joined onto ROOT a SECOND time, producing
+# a doubled, nonexistent path (`myrepo/myrepo/src/util.js`) and a false "not found". FILE must
+# resolve independently against cwd -- exactly like `tg imports FILE` (which takes no ROOT arg
+# at all, and was therefore never subject to this bug) -- while ROOT stays only the scan
+# boundary, never a prefix FILE gets joined onto.
+# ---------------------------------------------------------------------------------------------
+
+
+def _make_js_importer_fixture(base: Path) -> tuple[Path, Path, Path]:
+    """A tiny repo: BASE/repo/src/{util.js, consumer.js}; consumer imports util. Returns
+    (repo_dir, target_file, importer_file)."""
+    repo_dir = base / "repo"
+    src = repo_dir / "src"
+    src.mkdir(parents=True)
+    target = src / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    importer = src / "consumer.js"
+    importer.write_text('import { foo } from "./util";\n', encoding="utf-8")
+    return repo_dir, target, importer
+
+
+def test_build_file_importers_relative_file_and_root_from_parent_cwd_no_doubling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact #104 bug shape: FILE and ROOT both given relative to a PARENT cwd, so FILE is
+    naturally prefixed with ROOT's own directory name. Must resolve to the real file, not
+    `root/root/...`-doubled."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _repo_dir, target, importer = _make_js_importer_fixture(workspace)
+    monkeypatch.chdir(workspace)
+
+    payload = repo_map.build_file_importers("repo/src/util.js", "repo")
+
+    assert payload["file"] == str(target.resolve())
+    assert payload["importer_count"] == 1
+    assert str(importer.resolve()) in set(payload["importer_files"])
+
+
+def test_build_file_importers_file_relative_to_root_from_inside_repo_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FILE relative to ROOT, invoked from INSIDE the repo (ROOT='.'): the common case, must
+    keep working exactly as before."""
+    repo_dir, target, importer = _make_js_importer_fixture(tmp_path)
+    monkeypatch.chdir(repo_dir)
+
+    payload = repo_map.build_file_importers("src/util.js", ".")
+
+    assert payload["file"] == str(target.resolve())
+    assert payload["importer_count"] == 1
+    assert str(importer.resolve()) in set(payload["importer_files"])
+
+
+def test_build_file_importers_absolute_file_and_root_cwd_independent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absolute FILE + absolute ROOT must resolve identically regardless of cwd."""
+    repo_dir, target, importer = _make_js_importer_fixture(tmp_path)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    payload = repo_map.build_file_importers(str(target), str(repo_dir))
+
+    assert payload["file"] == str(target.resolve())
+    assert payload["importer_count"] == 1
+    assert str(importer.resolve()) in set(payload["importer_files"])
+
+
+def test_build_file_importers_absolute_file_relative_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absolute FILE + relative ROOT (from the parent cwd) must resolve identically too --
+    this combination already worked pre-fix (the join was skipped for an absolute FILE), so
+    this pins it stays correct."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _repo_dir, target, importer = _make_js_importer_fixture(workspace)
+    monkeypatch.chdir(workspace)
+
+    payload = repo_map.build_file_importers(str(target), "repo")
+
+    assert payload["file"] == str(target.resolve())
+    assert payload["importer_count"] == 1
+    assert str(importer.resolve()) in set(payload["importer_files"])
+
+
+def test_build_file_importers_outside_root_file_returns_no_importers_not_a_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file that genuinely exists but lives OUTSIDE root must resolve to its real (correct)
+    path, and honestly report zero importers -- not crash, and not silently claim a false
+    importer via a coincidentally-real doubled path (the confinement/not_found contract)."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _make_js_importer_fixture(workspace)
+    outside_dir = workspace / "other"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "thing.js"
+    outside_file.write_text("export function bar() {}\n", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    payload = repo_map.build_file_importers("other/thing.js", "repo")
+
+    assert payload["file"] == str(outside_file.resolve())
+    assert payload["importer_count"] == 0
+    assert payload["importer_files"] == []
+
+
+def test_importers_cli_relative_file_and_root_from_parent_cwd_no_doubling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI-level repro of the literal reported command:
+    `tg importers repo/src/util.js repo --json` run from the parent directory."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _repo_dir, target, importer = _make_js_importer_fixture(workspace)
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["importers", "repo/src/util.js", "repo", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["not_found"] is False
+    assert payload["file"] == str(target.resolve())
+    assert payload["importer_count"] == 1
+    assert str(importer.resolve()) in set(payload["importer_files"])
+
+
+def test_importers_cli_outside_root_file_exits_1_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI-level confinement/not_found contract: a real file outside ROOT reports honestly
+    (exit 1, not_found:true, correct `file` path) instead of crashing on a doubled path."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _make_js_importer_fixture(workspace)
+    outside_dir = workspace / "other"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "thing.js"
+    outside_file.write_text("export function bar() {}\n", encoding="utf-8")
+    monkeypatch.chdir(workspace)
+
+    result = runner.invoke(app, ["importers", "other/thing.js", "repo", "--json"])
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["not_found"] is True
+    assert payload["importer_count"] == 0
+    assert payload["file"] == str(outside_file.resolve())
+
+
+def test_imports_relative_file_from_parent_cwd_already_resolves_correctly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reference behavior: `tg imports` takes no ROOT arg at all, so a cwd-relative FILE
+    (prefixed with what would be a sibling ROOT's directory name) was never subject to the
+    doubling bug -- pin it as the correct baseline `tg importers` must match."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _repo_dir, target, _importer = _make_js_importer_fixture(workspace)
+    monkeypatch.chdir(workspace)
+
+    payload = repo_map.build_file_imports("repo/src/util.js")
+
+    assert payload["file"] == str(target.resolve())
+    assert payload["result_incomplete"] is False


### PR DESCRIPTION
## What

Fix `tg importers` relative-path DOUBLING (dogfood #104, P0). From a PARENT cwd, `tg importers tensor-grep/src/tensor_grep/cli/main.py tensor-grep` resolved the FILE to `tensor-grep/tensor-grep/src/...` → `not_found`.

## Root cause

`build_file_importers` (`repo_map.py`) passed the FILE arg UNRESOLVED into `build_file_importers_from_map`, which assumes any non-absolute FILE is relative to ROOT and joins `repo_root / resolved_file`. A shell-relative FILE from a parent cwd naturally carries ROOT's own dir name as its prefix (`tensor-grep/src/...`), so the join doubles it. `tg imports` (`build_file_imports`) never had this — it takes no ROOT and resolves the file purely against cwd (`Path(file).expanduser().resolve()`). That's the correct reference.

## Fix

`build_file_importers` now resolves FILE to an absolute path independently against cwd (matching `build_file_imports`) BEFORE calling `build_file_importers_from_map`, so the downstream join is a no-op.

**`build_file_importers_from_map` is left behaviorally unchanged** (only documented) — its root-relative join is a deliberate, round-7-security-reviewed contract for `session_file_importers` / the daemon-socket `file_importers` command ("relative to session root"), and both MCP tools already pre-resolve FILE to absolute via `_confine_read_path` before calling down, so they're unaffected. `tg importers --help` now states the resolution rule explicitly.

## Tests (RED-verified, 4/8 failed pre-fix with the exact doubled-path error)

New matrix in `test_file_deps.py`: file+root both relative from a parent cwd (the repro), file relative-to-root from inside repo, absolute+absolute, absolute file + relative root, the literal reported CLI command, an outside-root file (confinement/`not_found` contract preserved — exit 1, correct non-doubled path, no crash), and a `tg imports` pinning test.

## Verify

- Build agent: full `tests/unit` sweep 3838 passed (4 unrelated fails = missing `model2vec`/`lsprotocol` dev-only extras).
- Harvest re-verify (real venv, `uv run --no-sync`): `test_file_deps.py` 27 passed; import OK; ruff check + `ruff format --preview --check` clean.
- **Real-binary before/after** (actual `tg`, from a parent dir): before → `File not found: ...\<name>\<name>\src\...` (doubled, exit 1); after → `"file": "...\<name>\src\...", "importer_count": 1, "not_found": false` (exit 0). Also confirmed native backslash paths + from-inside-repo cwd + `tg imports` — no regressions.

Non-security (path resolution; no MCP/backend surface) -> no adversarial-gate requirement.

Closes #104.
