### PR TITLE
feat(mcp): expose the moat via MCP -- orient/doctor tools, rank/semantic/inline-rules, deadline; 6-round-hardened (audit #95 Part 2)

### DIFF
--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -187,17 +187,52 @@ Use this shape when a harness wants structured findings from a built-in security
 | --- | --- | --- |
 | `version` | `integer` | Contract version. |
 | `routing_backend` | `string` | `AstBackend`. |
-| `routing_reason` | `string` | `builtin-ruleset-scan`. |
+| `routing_reason` | `string` | `builtin-ruleset-scan` for a built-in pack, or `ast-inline-rules-scan` for `--inline-rules`/`inline_rules` (see "Inline Rules" below). |
 | `sidecar_used` | `boolean` | Always `false`. |
-| `config_path` | `string` | Built-in config reference such as `builtin:crypto-safe`. |
+| `config_path` | `string` | Built-in config reference such as `builtin:crypto-safe`, the literal string `inline-rules` for an inline-rules scan, or the resolved rule/config file path for the other CLI-only sources. |
 | `path` | `string` | Scan root. |
-| `ruleset` | `string` | Selected ruleset name. |
-| `language` | `string` | Effective language used to resolve the built-in pack. |
+| `ruleset` | `string \| null` | Selected built-in ruleset name, or `null` for an inline-rules scan. |
+| `language` | `string` | Effective language used to resolve the rule set. |
 | `rule_count` | `integer` | Total rules executed. |
 | `matched_rules` | `integer` | Number of rules that matched at least once. |
 | `total_matches` | `integer` | Aggregate matches across every rule. |
 | `backends` | `array<string>` | Backends used during the scan. |
 | `findings` | `array<object>` | Stable per-rule finding summaries. |
+
+### Inline Rules
+
+`tg.exe scan --inline-rules <yaml>` (CLI) and `tg_ruleset_scan(inline_rules=<yaml>, ...)` (MCP)
+run one or more `---`-separated ast-grep rule YAML documents supplied directly as a string --
+no built-in pack, no rule file, no sgconfig, zero file I/O for the rule source itself. Exactly
+one of `--ruleset`/`ruleset` or `--inline-rules`/`inline_rules` is required; supplying both, or
+neither, is a fail-closed `invalid_input` error (`ruleset and inline_rules are mutually
+exclusive.` / `Exactly one of ruleset or inline_rules is required.`).
+
+Each document may set `id`, `language` (falls back to the tool's `language`/`--language`
+override, then `python`), `severity`, `message`, and either a top-level `rule.pattern` (or
+bare `pattern`), or a `rules: [...]` list of the same shape for multiple rules in one document:
+
+```yaml
+id: no-print
+language: python
+severity: warning
+message: Avoid print in library code.
+rule:
+  pattern: print($A)
+```
+
+Invalid YAML, a document with no extractable pattern, or an unsupported language all fail
+closed with a structured `invalid_input` error (never a raw traceback). The MCP tool
+additionally bounds the raw `inline_rules` string to 64KiB (`_MAX_INLINE_RULES_CHARS` in
+`mcp_server.py`) before it ever reaches the YAML loader -- PyYAML's `SafeLoader` still resolves
+anchors/aliases, so an unbounded string is a "billion laughs"-style expansion-bomb DoS surface
+on an (LLM-influenceable) MCP tool call even though it cannot execute arbitrary code.
+
+The CLI additionally supports `--rule <file>` (a single rule file, no sgconfig required) and
+the full `--config sgconfig.yml` project-config workflow; neither is exposed over MCP yet
+(`--rule` is a deferred follow-up; `--config` is deferred because its `ruleDirs`/`testDirs` do
+an **unconfined** recursive directory walk that confining only the top-level scan root would
+not close).
 
 Each `findings[]` object has:
 
@@ -221,6 +256,35 @@ Optional top-level baseline fields:
 | `baseline_written` | `object` | Present when `--write-baseline` is used. Includes the output `path`, written `fingerprints`, and `count`. |
 | `suppressions` | `object` | Present when `--suppressions` is used. Includes the suppression file `path` and `suppressed_findings`. |
 | `suppressions_written` | `object` | Present when `--write-suppressions` is used. Includes the written suppression file `path`, `fingerprints`, and `count`. |
+
+## Orient Capsule JSON
+
+Emitted by `tg.exe orient <path> --json` and `tg_orient(...)` (MCP). Call this FIRST when
+orienting on an unfamiliar repo -- it answers "what is this codebase and where do I start" in
+one bounded call, cheaper than a full `tg_repo_map`/`tg_context_pack` walk.
+
+Built by `build_orient_capsule_json` (`orient_capsule.py`); unlike most other JSON shapes in
+this document it does **not** carry the common envelope fields (`version`/`routing_backend`/
+`sidecar_used`) -- only `routing_reason`. The MCP tool still injects `mcp_contract_version` and
+`schema_version` via the same `_inject_mcp_contract_fields` wrapper every tool uses.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `routing_reason` | `string` | Always `orient`. |
+| `path` | `string` | Absolute root path oriented on. |
+| `central_files` | `array<object>` | Top files ranked by import-graph in-degree centrality, each `{file, graph_score}`. |
+| `entry_points` | `array<object>` | Heuristically detected entry points, each `{file, reason}`. |
+| `symbol_map` | `object` | Top symbols per central file, keyed by file path; each entry an array of `{name, kind, line}` (bounded to 8 per file). |
+| `snippets` | `array<object>` | Bounded AST-boundary source snippets for the highest-ranked central files, each `{file, source, truncated}`. |
+| `token_estimate` | `integer` | Heuristic token estimate (`len/3.5`) for the full rendered capsule. |
+| `token_budget_label` | `string` | Human-readable summary of `token_estimate` and the snippet token budget. |
+| `truncated` | `boolean` | `true` when the snippet token budget clipped or dropped a snippet. |
+| `scan_limit` | `integer` | The effective `max_repo_files` used to build the underlying repo map. |
+
+`ignore` (repeatable glob, matches basename or repo-relative path) excludes a subtree from the
+**centrality ranking** only -- the files are still walked, just kept out of the central-files/
+snippet selection. Useful for keeping a vendor or skill-code tree from crowding out the real
+architecture hubs on a harness or monorepo.
 
 ## Repo Map JSON
 
@@ -1388,7 +1452,9 @@ These examples reuse the existing public contracts above; they are not separate 
 The MCP server exposes stable tool contracts layered on top of the native CLI outputs.
 
 `serverInfo.name` is `tensor-grep` and `serverInfo.version` is the stable tg MCP
-server contract version (`1.0.0`), not the installed CLI/package version and not
+server contract version (`_TG_MCP_SERVER_CONTRACT_VERSION` in `mcp_server.py`, currently
+`1.2.0` -- re-check the constant before citing a version number, it has already moved once
+from `1.0.0`), not the installed CLI/package version and not
 the bundled MCP SDK protocol version. The initialize response top-level
 `protocolVersion` is the authoritative negotiated MCP protocol for that session.
 `tg_mcp_capabilities()` also exposes `mcp_protocol_version`,
@@ -1402,24 +1468,28 @@ PyPI wheel installs can serve simple `tg_rewrite_plan(...)` and `tg_rewrite_appl
 
 Call `tg_mcp_capabilities()` first when a client might be running in a PyPI wheel, sandbox, or other runtime where the standalone native binary is uncertain.
 
-Current tool set:
+Current tool set (47 tools; re-derive with `grep -n "^def tg_\|^async def tg_" src/tensor_grep/cli/mcp_server.py | wc -l` and cross-check names against `test_harness_api_doc_lists_every_registered_tool_name`, which enumerates the live registry so this list can't silently drift again):
 
 - `tg_mcp_capabilities()`
 - `tg_rulesets()`
-- `tg_ruleset_scan(ruleset, path=".", language=None, baseline_path=None, write_baseline=None, suppressions_path=None, write_suppressions=None, include_evidence_snippets=False, max_evidence_snippets_per_file=1, max_evidence_snippet_chars=120)`
+- `tg_ruleset_scan(ruleset=None, inline_rules=None, path=".", language=None, glob=None, file_type=None, max_depth=None, allow_broad_generated_scan=False, baseline_path=None, write_baseline=None, suppressions_path=None, write_suppressions=None, justification=None, include_evidence_snippets=False, max_evidence_snippets_per_file=1, max_evidence_snippet_chars=120)` -- exactly one of `ruleset`/`inline_rules` is required; see "Inline Rules" below.
 - `tg_repo_map(path=".")`
+- `tg_orient(path=".", max_tokens=3000, max_central_files=10, ignore=None)` -- call FIRST for orientation; see "Orient Capsule JSON" below.
+- `tg_doctor(path=".", config="sgconfig.yml", with_lsp=True)`
 - `tg_context_pack(query, path=".")`
 - `tg_edit_plan(query, path=".", max_files=3, max_sources=5, max_tokens=None, max_symbols=5)`
 - `tg_context_render(query, path=".", max_files=3, max_sources=5, max_symbols_per_file=6, max_render_chars=None, optimize_context=False, render_profile="full")`
-- `tg_agent_capsule(query, path=".", max_files=3, max_sources=5, max_tokens=1200, max_repo_files=512, model=None, gpu_device_ids=None, gpu_timeout_s=5.0)`
+- `tg_agent_capsule(query, path=".", max_files=3, max_sources=5, max_tokens=1200, max_repo_files=2000, model=None, gpu_device_ids=None, gpu_timeout_s=5.0)`
 - `tg_symbol_defs(symbol, path=".")`
 - `tg_symbol_source(symbol, path=".")`
-- `tg_symbol_impact(symbol, path=".")`
-- `tg_symbol_refs(symbol, path=".")`
-- `tg_symbol_callers(symbol, path=".")`
-- `tg_symbol_blast_radius(symbol, path=".", max_depth=3)`
+- `tg_symbol_impact(symbol, path=".", deadline=None)`
+- `tg_symbol_refs(symbol, path=".", deadline=None)`
+- `tg_symbol_callers(symbol, path=".", deadline=None)`
+- `tg_symbol_blast_radius(symbol, path=".", max_depth=3, deadline=None)`
 - `tg_symbol_blast_radius_plan(symbol, path=".", max_depth=3, max_files=3, max_symbols=5)`
 - `tg_symbol_blast_radius_render(symbol, path=".", max_depth=3, max_files=3, max_sources=5, max_symbols_per_file=6, max_render_chars=None, optimize_context=False, render_profile="full")`
+- `tg_file_imports(file)`
+- `tg_file_importers(file, path=".", max_repo_files=2000, deadline=None)`
 - `tg_checkpoint_create(path=".")`
 - `tg_checkpoint_list(path=".")`
 - `tg_checkpoint_undo(checkpoint_id, path=".")`
@@ -1433,9 +1503,14 @@ Current tool set:
 - `tg_session_blast_radius(session_id, symbol, path=".", max_depth=3, refresh_on_stale=False, auto_refresh=None)`
 - `tg_session_blast_radius_plan(session_id, symbol, path=".", max_depth=3, max_files=3, max_symbols=5, refresh_on_stale=False, auto_refresh=None)`
 - `tg_session_blast_radius_render(session_id, symbol, path=".", max_depth=3, max_files=3, max_sources=5, max_symbols_per_file=6, max_render_chars=None, optimize_context=False, render_profile="full", refresh_on_stale=False, auto_refresh=None)`
+- `tg_session_file_importers(session_id, file, path=".", refresh_on_stale=False, auto_refresh=None)`
+- `tg_search(pattern=None, path=".", case_sensitive=False, ignore_case=False, fixed_strings=False, word_regexp=False, context=None, max_count=None, max_results=None, max_files=None, count_matches=False, glob=None, type_filter=None, query=None, structured_json=True, max_repo_files=2000, rank=False, semantic=False)`
+- `tg_ast_search(pattern, lang, path=".", structured_json=True, max_repo_files=2000)`
 - `tg_index_search(pattern, path=".")`
+- `tg_classify_logs(file_path, structured_json=True)`
+- `tg_devices(json_output=True)`
 - `tg_rewrite_plan(pattern, replacement, lang, path=".")`
-- `tg_rewrite_apply(pattern, replacement, lang, path=".", verify=False, checkpoint=False, lint_cmd=None, test_cmd=None)`
+- `tg_rewrite_apply(pattern, replacement, lang, path=".", verify=False, checkpoint=False, audit_manifest=None, audit_signing_key=None, lint_cmd=None, test_cmd=None, policy=None, expected_plan_digest=None, expected_match_count=None)`
 - `tg_audit_manifest_verify(manifest_path, signing_key=None, previous_manifest=None)`
 - `tg_audit_history(path=".")`
 - `tg_audit_diff(previous_manifest, current_manifest)`
@@ -1478,7 +1553,9 @@ Response mapping:
 
 - `tg_mcp_capabilities()` returns the MCP runtime capability envelope described above
 - `tg_rulesets()` returns the same v1 envelope and payload shape as [`examples/rulesets.json`](examples/rulesets.json)
-- `tg_ruleset_scan(...)` returns the same v1 envelope and payload shape as [`examples/ruleset_scan.json`](examples/ruleset_scan.json)
+- `tg_ruleset_scan(...)` returns the same v1 envelope and payload shape as [`examples/ruleset_scan.json`](examples/ruleset_scan.json) for a built-in `ruleset`, or the same shape with `routing_reason = "ast-inline-rules-scan"` and `ruleset = null` for `inline_rules` -- see "Inline Rules" under Ruleset Scan JSON above
+- `tg_orient(...)` returns the same shape as `tg.exe orient --json` -- see "Orient Capsule JSON" above
+- `tg_doctor(...)` returns the same v2 doctor schema as `tg.exe doctor --json` -- see "Doctor JSON" above
 - `tg_index_search(...)` returns the same v1 envelope and payload shape as [`examples/index_search.json`](examples/index_search.json)
 - `tg_edit_plan(...)` returns the same v1 envelope and payload shape as [`examples/edit_plan.json`](examples/edit_plan.json)
 - `tg_context_render(...)` returns the same v1 envelope and payload shape as [`examples/context_render.json`](examples/context_render.json)

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4652,9 +4652,9 @@ def _load_inline_rule_specs(
         (not CSafeLoader) so ``compose_node`` is overridable -- inline payloads are small
         (length-capped) so the perf cost is negligible."""
 
-        def compose_node(self, parent, index):  # type: ignore[override]
-            if self.check_event(yaml.events.AliasEvent):
-                event = self.get_event()
+        def compose_node(self, parent, index):  # type: ignore[override,no-untyped-def]
+            if self.check_event(yaml.events.AliasEvent):  # type: ignore[no-untyped-call]
+                event = self.get_event()  # type: ignore[no-untyped-call]
                 raise yaml.composer.ComposerError(
                     None,
                     None,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4781,6 +4781,12 @@ def _ruleset_finding_fingerprint(
 
 
 def _truncate_evidence_snippet(text: str, max_chars: int) -> dict[str, object]:
+    # Defense-in-depth: coerce to int so a direct (non-MCP) caller passing a fractional float
+    # cannot crash the slice below (`normalized[:max_chars]` requires an int index). The MCP
+    # surface already rejects non-int max_evidence_snippet_chars at the tool inputSchema + FastMCP
+    # pydantic boundary, so this is not a reachable vuln -- it hardens the helper for any future
+    # in-process caller. (audit #95 Part-2 round-6 gate: non-blocking hardening note.)
+    max_chars = int(max_chars)
     normalized = " ".join(text.split())
     if max_chars <= 0:
         return {"text": "", "truncated": bool(normalized)}

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4639,11 +4639,34 @@ def _load_inline_rule_specs(
 ) -> list[dict[str, str]]:
     import yaml
 
-    loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+    class _NoAliasSafeLoader(yaml.SafeLoader):
+        """SafeLoader that REJECTS YAML aliases. Inline ast-grep rules never legitimately
+        need anchors/aliases, and an aliased node graph is a billion-laughs
+        memory-exhaustion vector: the downstream ``str()`` coercions on ``id``/``severity``/
+        ``message`` (below) deep-walk the SHARED alias graph and expand it ~9^depth. Audit
+        #95 Part-2 Opus gate BLOCK proved a 469-byte aliased payload hangs >15s -- the
+        ``_MAX_INLINE_RULES_CHARS`` length cap admits depth ~1000 while detonation is at
+        depth ~9, so the length cap alone is insufficient; reject at the loader level. This
+        shared helper guards BOTH the MCP ``tg_ruleset_scan(inline_rules=...)`` tool and the
+        CLI ``--inline-rules`` twin (identical mechanism). Uses the pure-Python SafeLoader
+        (not CSafeLoader) so ``compose_node`` is overridable -- inline payloads are small
+        (length-capped) so the perf cost is negligible."""
+
+        def compose_node(self, parent, index):  # type: ignore[override]
+            if self.check_event(yaml.events.AliasEvent):
+                event = self.get_event()
+                raise yaml.composer.ComposerError(
+                    None,
+                    None,
+                    "YAML aliases are not allowed in inline rules",
+                    event.start_mark,
+                )
+            return super().compose_node(parent, index)
+
     specs: list[dict[str, str]] = []
 
     try:
-        documents = list(yaml.load_all(inline_rules_text, Loader=loader))
+        documents = list(yaml.load_all(inline_rules_text, Loader=_NoAliasSafeLoader))
     except yaml.YAMLError as exc:
         detail = str(exc).splitlines()[0] if str(exc).strip() else "parse error"
         raise ValueError(f"Invalid inline rules YAML: {detail}") from exc

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4667,8 +4667,14 @@ def _load_inline_rule_specs(
 
     try:
         documents = list(yaml.load_all(inline_rules_text, Loader=_NoAliasSafeLoader))
-    except yaml.YAMLError as exc:
-        detail = str(exc).splitlines()[0] if str(exc).strip() else "parse error"
+    except (yaml.YAMLError, RecursionError) as exc:
+        # RecursionError: a deeply-nested ALIAS-FREE payload (e.g. "["*20000) recurses the YAML
+        # parser/composer past the interpreter limit. The _NoAliasSafeLoader cannot reject it (no
+        # alias), but the pure-Python SafeLoader raises a *catchable* RecursionError where the C
+        # loader would hard-crash the process (native stack overflow). Catch it here so this path
+        # also fails closed as a structured invalid_input rather than escaping as a raw traceback
+        # -- the tool's fail-closed contract (audit #95 Part-2 re-gate).
+        detail = str(exc).splitlines()[0] if str(exc).strip() else "input nesting too deep"
         raise ValueError(f"Invalid inline rules YAML: {detail}") from exc
 
     for document_index, payload in enumerate(documents, start=1):

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import anyio
 from mcp import types
@@ -20,6 +20,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.shared.message import SessionMessage
 from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
 
+from tensor_grep.backends.ast_backend import normalize_ast_language
 from tensor_grep.backends.base import BackendExecutionError
 from tensor_grep.backends.cpu_backend import (
     compute_native_walk_deadline,
@@ -28,14 +29,19 @@ from tensor_grep.backends.cpu_backend import (
 from tensor_grep.backends.ripgrep_backend import RipgrepBackend
 from tensor_grep.cli.main import (
     _LARGE_ROOT_SCAN_FILE_CEILING,
+    _apply_semantic_rerank,
+    _build_doctor_payload,
     _build_rulesets_payload,
     _format_unbounded_large_root_scan_error,
     _format_unbounded_vendored_root_scan_error,
+    _load_inline_rule_specs,
     _run_ast_scan_payload,
     _search_with_cpu_fallback,
+    _set_semantic_rank_fallback_reason,
     _should_refuse_unbounded_large_root_scan,
     _should_refuse_unbounded_vendored_root_scan,
 )
+from tensor_grep.cli.orient_capsule import build_orient_capsule_json
 from tensor_grep.cli.repo_map import (
     _apply_context_token_budget,
     build_context_pack,
@@ -69,15 +75,22 @@ def _mcp_server_version() -> str:
 
 
 # Stable contract version for the tg MCP server surface.
-# Bump only on intentional breaking changes to the MCP tool/resource shape.
+# Bump on intentional breaking changes to the MCP tool/resource shape, OR (round-9) on a
+# tool-SET shape change (new tools / new params) worth flagging to a version-pinning client.
 # CLI version is exposed separately via `tg_mcp_capabilities` -> `cli_version`.
-# 1.0.0 -> 1.1.0 (round-8, audit #95): every tool's PRIMARY path/root param is now
+# 1.0.0 -> 1.1.0 (round-8, audit #95 Part 1): every tool's PRIMARY path/root param is now
 # confined to _mcp_root() (default cwd, override via TG_MCP_ROOT) -- a caller that
 # previously relied on an out-of-cwd path succeeding (e.g. a monorepo fleet pointing an
 # MCP tool at a sibling repo) now gets a structured invalid_input refusal instead of a
 # result, unless TG_MCP_ROOT is set to widen the anchor. Breaking-behavior change, not a
 # breaking shape change -- bump per the gate's should-fix.
-_TG_MCP_SERVER_CONTRACT_VERSION = "1.1.0"
+# 1.1.0 -> 1.2.0 (round-9, audit #95 Part 2): additive tool-set shape change, not a breaking
+# one -- 2 new tools (tg_orient, tg_doctor) and new optional params on existing tools
+# (tg_search rank/semantic, the 5 symbol/file-dependency tools' deadline, tg_ruleset_scan's
+# inline_rules + ruleset now optional). Every existing caller's behavior is unchanged when
+# the new params are simply not passed; bumped anyway because `tg_mcp_capabilities()`'s
+# `tools[]` array itself grew, which a version-pinning client may reasonably want to detect.
+_TG_MCP_SERVER_CONTRACT_VERSION = "1.2.0"
 
 
 def _apply_mcp_server_metadata(server: FastMCP) -> None:
@@ -114,6 +127,8 @@ _PYTHON_LOCAL_MCP_TOOLS = (
     "tg_rulesets",
     "tg_ruleset_scan",
     "tg_repo_map",
+    "tg_orient",
+    "tg_doctor",
     "tg_context_pack",
     "tg_edit_plan",
     "tg_context_render",
@@ -518,7 +533,7 @@ def _review_bundle_error(message: str, *, code: str, routing_reason: str) -> str
     return json.dumps(payload, indent=2)
 
 
-def _ruleset_scan_error(message: str, *, code: str, ruleset: str, path: str) -> str:
+def _ruleset_scan_error(message: str, *, code: str, ruleset: str | None, path: str) -> str:
     payload = _envelope_base(
         routing_backend="AstBackend",
         routing_reason="builtin-ruleset-scan",
@@ -1226,7 +1241,7 @@ def execute_rewrite_apply_json(
     if audit_manifest is not None:
         try:
             audit_manifest = str(
-                _confine_write_path(audit_manifest, Path.cwd(), label="audit_manifest")
+                _confine_write_path(audit_manifest, _mcp_root(), label="audit_manifest")
             )
         except ValueError as exc:
             return _rewrite_error(str(exc), code="invalid_input"), 1
@@ -1814,27 +1829,43 @@ def _confine_mcp_path(candidate: str, *, label: str) -> Path:
 
     Thin wrapper over `_confine_read_path` anchored at `_mcp_root()` (instead of a
     per-tool-hardcoded `Path.cwd()`), so the one `TG_MCP_ROOT` override relocates the anchor
-    of every tool confined THROUGH THIS HELPER together. NOTE: a residual set of round-6/7
-    file/manifest/bundle params (tg_file_imports/importers `file`, tg_classify_logs
-    `file_path`, the tg_audit_*/tg_review_bundle_* manifest+bundle params, tg_rewrite_apply
-    `audit_manifest`) still anchor directly at `Path.cwd()` and do NOT yet move with a
-    `TG_MCP_ROOT` that narrows/relocates relative to cwd -- bounded to the server cwd
-    (fail-closed, never arbitrary-FS; identical to `_mcp_root()` in the default unset
-    config), tracked to route through `_mcp_root()` before TG_MCP_ROOT is advertised as the
-    fleet boundary. Raises ``ValueError`` (fail closed) on an
-    out-of-root candidate; callers MUST forward the resolved ``Path`` this returns
+    of every tool confined THROUGH THIS HELPER together. Raises ``ValueError`` (fail closed)
+    on an out-of-root candidate; callers MUST forward the resolved ``Path`` this returns
     (`str()`'d) as their new ``path``, and MUST do so as the very first operation in the
     tool body, BEFORE any secondary anchor (session_root, scan_root, policy_anchor, ...) is
     derived from ``path`` -- otherwise that secondary anchor still derives from the raw,
     unconfined candidate and the confinement is cosmetic (this exact bug was the gate's
     LIVE VULN finding on `tg_session_file_importers`'s `session_root`).
+
+    ROUND-9 (audit #95 Part 2 / #102 fold-in): the round-6/7 residual set this docstring
+    used to name as still anchored directly at `Path.cwd()` (tg_file_imports/importers
+    `file`, tg_classify_logs `file_path`, the tg_audit_*/tg_review_bundle_* manifest+bundle
+    params, tg_rewrite_apply `audit_manifest`) now ALSO route through `_mcp_root()` via
+    `_confine_read_path`/`_confine_write_path` directly (they do not call this specific
+    wrapper since they anchor to `_mcp_root()` without the PRIMARY-path semantics this
+    function documents, but the anchor itself is the same `_mcp_root()` call) -- every
+    confined param in this file now moves uniformly with `TG_MCP_ROOT`. See
+    test_round8_residual_cwd_params_move_with_tg_mcp_root for the regression coverage.
     """
     return _confine_read_path(candidate, _mcp_root(), label=label)
 
 
+# [SEC] audit #95 Part 2: bound the raw `inline_rules` string BEFORE it ever reaches
+# yaml.safe_load. PyYAML's SafeLoader still resolves anchors/aliases (`&`/`*`); a small
+# document can construct a "billion laughs"-style combinatorial blowup in memory even
+# without executing arbitrary code, and the MCP surface accepts this string directly from an
+# (LLM/attacker-influenceable) tool call rather than a human-typed CLI argv. This length cap
+# is a cheap, unconditional first line of defense -- it does not fully close an anchor/alias
+# expansion bomb (that needs a depth/complexity-limited loader), but it blunts the attack
+# surface and matches the codebase's existing `_MAX_MCP_STDIO_MESSAGE_BYTES` precedent for
+# bounding an untrusted MCP-supplied payload before it is parsed.
+_MAX_INLINE_RULES_CHARS = 64 * 1024
+
+
 @mcp.tool()  # type: ignore
 def tg_ruleset_scan(
-    ruleset: str,
+    ruleset: str | None = None,
+    inline_rules: str | None = None,
     path: str = ".",
     language: str | None = None,
     glob: str | None = None,
@@ -1851,16 +1882,26 @@ def tg_ruleset_scan(
     max_evidence_snippet_chars: int = 120,
 ) -> str:
     """
-    Execute a built-in ruleset scan and return structured findings.
+    Execute a built-in or inline-YAML ast-grep ruleset scan and return structured findings.
 
     This tool is read-only by default. Some optional parameters write files to disk
     when supplied: ``write_baseline`` and ``write_suppressions`` create or overwrite
     the file at the given path. Leave them unset for a pure read-only scan.
 
+    Exactly one of ``ruleset`` or ``inline_rules`` is required.
+
     Args:
-        ruleset: Built-in ruleset name to execute.
+        ruleset: Built-in ruleset name to execute. Mutually exclusive with ``inline_rules``.
+        inline_rules: Inline ast-grep rule YAML (one or more `---`-separated documents,
+            each with `id`/`rule.pattern`/optional `language`/`severity`/`message`) to
+            execute WITHOUT a built-in pack or any file I/O -- mirrors the CLI's
+            ``--inline-rules``. Mutually exclusive with ``ruleset``. Bounded to
+            64KiB to blunt a YAML anchor/alias expansion-bomb before it reaches the
+            parser; fails closed (a structured ``invalid_input`` error, never a raw
+            traceback) on invalid YAML or a language ast-grep does not support.
         path: Root path to scan.
-        language: Optional language override for the ruleset.
+        language: Optional language override for the ruleset, or the default language
+            for any inline rule that does not specify its own.
         glob: Optional include/exclude glob for bounded scans.
         file_type: Optional extension/type filter for bounded scans.
         max_depth: Optional traversal depth limit for broad roots.
@@ -1894,7 +1935,6 @@ def tg_ruleset_scan(
         # the scan itself -- an unconfined path was a full arbitrary-directory scan/read
         # (and, via write_baseline/write_suppressions, write) primitive over the MCP surface.
         path = str(_confine_mcp_path(path, label="path"))
-        ruleset_meta, rules = resolve_rule_pack(ruleset, language)
     except ValueError as exc:
         return _ruleset_scan_error(
             str(exc),
@@ -1903,13 +1943,80 @@ def tg_ruleset_scan(
             path=path,
         )
 
-    project_cfg: dict[str, object] = {
-        "config_path": f"builtin:{ruleset_meta['name']}",
-        "root_dir": Path(path).expanduser().resolve(),
-        "rule_dirs": [],
-        "test_dirs": [],
-        "language": ruleset_meta["language"],
-    }
+    # Mirrors main.py scan()'s mutual-exclusivity guard (`--rule`/`--inline-rules`/`--ruleset`)
+    # narrowed to the two sources this MCP tool exposes today -- `--rule` (a single rule FILE)
+    # and `--config` sgconfig are deliberately deferred (the latter does an unconfined
+    # recursive rglob over ruleDirs/testDirs; confining only the top-level path is
+    # insufficient, see _confine_mcp_path's sibling design doc).
+    inline_source_count = sum(item is not None for item in (ruleset, inline_rules))
+    if inline_source_count == 0:
+        return _ruleset_scan_error(
+            "Exactly one of ruleset or inline_rules is required.",
+            code="invalid_input",
+            ruleset=ruleset,
+            path=path,
+        )
+    if inline_source_count > 1:
+        return _ruleset_scan_error(
+            "ruleset and inline_rules are mutually exclusive.",
+            code="invalid_input",
+            ruleset=ruleset,
+            path=path,
+        )
+
+    if inline_rules is not None:
+        # [SEC] bound BEFORE parsing -- see _MAX_INLINE_RULES_CHARS docstring.
+        if len(inline_rules) > _MAX_INLINE_RULES_CHARS:
+            return _ruleset_scan_error(
+                f"inline_rules exceeds the {_MAX_INLINE_RULES_CHARS}-character limit "
+                f"({len(inline_rules)} chars).",
+                code="invalid_input",
+                ruleset=ruleset,
+                path=path,
+            )
+        try:
+            rules = _load_inline_rule_specs(inline_rules, default_language=language)
+        except ValueError as exc:
+            return _ruleset_scan_error(str(exc), code="invalid_input", ruleset=ruleset, path=path)
+        if not rules:
+            return _ruleset_scan_error(
+                "No valid inline rules were found.",
+                code="invalid_input",
+                ruleset=ruleset,
+                path=path,
+            )
+        inferred_language = (
+            normalize_ast_language(language) if language else str(rules[0]["language"])
+        )
+        project_cfg: dict[str, object] = {
+            "config_path": "inline-rules",
+            "root_dir": Path(path).expanduser().resolve(),
+            "rule_dirs": [],
+            "test_dirs": [],
+            "language": inferred_language,
+        }
+        scan_ruleset_name: str | None = None
+        scan_routing_reason = "ast-inline-rules-scan"
+    else:
+        try:
+            ruleset_meta, rules = resolve_rule_pack(cast(str, ruleset), language)
+        except ValueError as exc:
+            return _ruleset_scan_error(
+                str(exc),
+                code="invalid_input",
+                ruleset=ruleset,
+                path=path,
+            )
+        project_cfg = {
+            "config_path": f"builtin:{ruleset_meta['name']}",
+            "root_dir": Path(path).expanduser().resolve(),
+            "rule_dirs": [],
+            "test_dirs": [],
+            "language": ruleset_meta["language"],
+        }
+        scan_ruleset_name = ruleset_meta["name"]
+        scan_routing_reason = "builtin-ruleset-scan"
+
     # round-4/5 security: confine the two write paths to the scan root before any scan/write —
     # unconfined, they are an arbitrary-file-write primitive reachable from any MCP client.
     # round-5: consume the RESOLVED absolute path (not the raw candidate) below so the
@@ -1942,8 +2049,8 @@ def tg_ruleset_scan(
         payload = _run_ast_scan_payload(
             project_cfg,
             rules,
-            routing_reason="builtin-ruleset-scan",
-            ruleset_name=ruleset_meta["name"],
+            routing_reason=scan_routing_reason,
+            ruleset_name=scan_ruleset_name,
             scan_globs=[glob] if glob else None,
             scan_types=[file_type] if file_type else None,
             scan_max_depth=max_depth,
@@ -2033,6 +2140,151 @@ def tg_repo_map(path: str = ".", max_repo_files: int | None = 512) -> str:
             "message": str(exc),
             "retryable": False,
         }
+        return json.dumps(payload, indent=2)
+
+
+@mcp.tool()  # type: ignore
+def tg_orient(
+    path: str = ".",
+    max_tokens: int = 3000,
+    max_central_files: int = 10,
+    ignore: list[str] | None = None,
+) -> str:
+    """
+    Call FIRST for orientation: return a one-call codebase orientation capsule.
+
+    Mirrors `tg orient` (build_orient_capsule_json): the most central files by import-graph
+    centrality, heuristically detected entry points, a symbol map, and bounded AST-boundary
+    source snippets within a token budget. Pure-CPU, no API key, no GPU. Prefer this before
+    tg_repo_map/tg_context_pack/tg_agent_capsule when orienting on an unfamiliar repo for the
+    first time -- it answers "what is this codebase and where do I start" in one call.
+
+    Args:
+        path: File or directory to orient on. Confined to the MCP server root (cwd, or
+            TG_MCP_ROOT if set); a path outside it is refused.
+        max_tokens: Snippet token budget for the capsule. Defaults to 3000.
+        max_central_files: Number of top central files to surface. Defaults to 10.
+        ignore: Glob(s) to exclude from the centrality ranking (basename or repo-relative
+            path), e.g. ["seo/**", "core/skills/**"]. Excludes vendor/skill CODE trees that
+            otherwise rank as "central" on a harness repo.
+    """
+    # round-9 security (audit #95 Part 2): confine the primary path/root param to the MCP
+    # root before any scan -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="orient",
+            include_schema_version=False,
+        )
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
+    try:
+        return _inject_mcp_contract_fields(
+            build_orient_capsule_json(
+                path,
+                max_tokens=max_tokens,
+                max_central_files=max_central_files,
+                ignore=tuple(ignore or ()),
+            )
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        # Mirrors the CLI `orient` command's except clause (main.py) -- a bad path or
+        # unresolvable root must return a clean structured error, never a raw traceback.
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="orient",
+            include_schema_version=False,
+        )
+        payload["path"] = str(Path(path).expanduser())
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+    except Exception as exc:  # propagate as structured error, never a raw exception
+        payload = _envelope_base(
+            routing_backend="RepoMap",
+            routing_reason="orient",
+            include_schema_version=False,
+        )
+        payload["path"] = str(Path(path).expanduser())
+        payload["error"] = _sanitized_tool_error("tg_orient", exc)
+        return json.dumps(payload, indent=2)
+
+
+@mcp.tool()  # type: ignore
+def tg_doctor(
+    path: str = ".",
+    config: str | None = "sgconfig.yml",
+    with_lsp: bool = True,
+) -> str:
+    """
+    Return system, GPU, cache, AST, daemon, shell-escaping, and LSP-provider diagnostics.
+
+    Mirrors `tg doctor` (_build_doctor_payload). Provider availability
+    (lsp_provider_items/lsp_providers) is not navigation proof -- inspect health_status/
+    health_check before trusting an LSP-confirmed evidence label.
+
+    Args:
+        path: Workspace root to inspect. Confined to the MCP server root (cwd, or
+            TG_MCP_ROOT if set); a path outside it is refused.
+        config: Path to an ast-grep root config, resolved relative to path when not
+            absolute. Confined to the (already-confined) path; a config that legitimately
+            lives outside path must be copied in first (fail-closed, not a silent drop).
+            Defaults to "sgconfig.yml".
+        with_lsp: Include external LSP provider diagnostics. Defaults to true.
+    """
+    # round-9 security (audit #95 Part 2): confine the primary path/root param to the MCP
+    # root before any probe -- see tg_repo_map for the systemic-finding rationale.
+    try:
+        path = str(_confine_mcp_path(path, label="path"))
+    except ValueError as exc:
+        payload = _envelope_base(
+            routing_backend="Doctor",
+            routing_reason="doctor",
+            include_schema_version=False,
+        )
+        payload["path"] = path
+        payload["error"] = {"code": "invalid_input", "message": str(exc)}
+        return json.dumps(payload, indent=2)
+
+    # New hardening (beyond the design's literal "wrap it" ask): `config` is a SECONDARY
+    # param that `_build_doctor_payload` uses to relocate its own `root` (config's resolved
+    # parent directory) for every downstream diagnostic probe -- unconfined, a caller could
+    # point every probe at an arbitrary directory via `config=/some/other/place/x.yml`, the
+    # same "secondary anchor derived from an unconfined param" class the #95 gate's MUST-FIX
+    # #3 closed for tg_session_file_importers. Confine to the already-confined `path`,
+    # mirroring tg_ruleset_scan's baseline_path/suppressions_path anchor-to-scan-root
+    # pattern. `if config:` (not `is not None`) matches _build_doctor_payload's OWN
+    # truthiness check so an empty string is treated identically to "not provided" on both
+    # sides -- confining "" would otherwise turn a no-op default into a real (and wrong)
+    # root-parent relocation.
+    if config:
+        try:
+            config = str(_confine_read_path(config, Path(path), label="config"))
+        except ValueError as exc:
+            payload = _envelope_base(
+                routing_backend="Doctor",
+                routing_reason="doctor",
+                include_schema_version=False,
+            )
+            payload["path"] = path
+            payload["error"] = {"code": "invalid_input", "message": str(exc)}
+            return json.dumps(payload, indent=2)
+
+    try:
+        return _inject_mcp_contract_fields(
+            json.dumps(_build_doctor_payload(path, config=config, with_lsp=with_lsp), indent=2)
+        )
+    except Exception as exc:  # propagate as structured error, never a raw exception
+        payload = _envelope_base(
+            routing_backend="Doctor",
+            routing_reason="doctor",
+            include_schema_version=False,
+        )
+        payload["path"] = str(Path(path).expanduser())
+        payload["error"] = _sanitized_tool_error("tg_doctor", exc)
         return json.dumps(payload, indent=2)
 
 
@@ -3165,13 +3417,18 @@ def tg_symbol_source(
 
 
 @mcp.tool()  # type: ignore
-def tg_symbol_impact(symbol: str, path: str = ".", provider: str = "native") -> str:
+def tg_symbol_impact(
+    symbol: str, path: str = ".", provider: str = "native", deadline: float | None = None
+) -> str:
     """
     Return likely impacted files and tests for a symbol change.
 
     Args:
         symbol: Exact symbol name to evaluate.
         path: File or directory to inventory.
+        deadline: Optional wall-clock budget in seconds for the underlying repo scan. When
+            exceeded, the scan stops and returns a flagged partial result instead of running
+            unbounded.
     """
     # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
     # before any scan -- see tg_repo_map for the systemic-finding rationale.
@@ -3196,6 +3453,7 @@ def tg_symbol_impact(symbol: str, path: str = ".", provider: str = "native") -> 
                     path,
                     semantic_provider=provider,
                     max_repo_files=_DEFAULT_MCP_REPO_SCAN_LIMIT,
+                    deadline_seconds=deadline,
                 ),
                 indent=2,
             )
@@ -3235,6 +3493,7 @@ def tg_symbol_refs(
     path: str = ".",
     provider: str = "native",
     max_repo_files: int = _DEFAULT_MCP_REPO_SCAN_LIMIT,
+    deadline: float | None = None,
 ) -> str:
     """
     Return Python-first symbol references across the inventory root.
@@ -3243,6 +3502,9 @@ def tg_symbol_refs(
         symbol: Exact symbol name to resolve.
         path: File or directory to inventory.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
+        deadline: Optional wall-clock budget in seconds for the underlying repo scan. When
+            exceeded, the scan stops and returns a flagged partial result instead of running
+            unbounded.
     """
     # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
     # before any scan -- see tg_repo_map for the systemic-finding rationale.
@@ -3263,7 +3525,11 @@ def tg_symbol_refs(
         return _inject_mcp_contract_fields(
             json.dumps(
                 build_symbol_refs(
-                    symbol, path, semantic_provider=provider, max_repo_files=max_repo_files
+                    symbol,
+                    path,
+                    semantic_provider=provider,
+                    max_repo_files=max_repo_files,
+                    deadline_seconds=deadline,
                 ),
                 indent=2,
             )
@@ -3303,6 +3569,7 @@ def tg_symbol_callers(
     path: str = ".",
     provider: str = "native",
     max_repo_files: int = _DEFAULT_MCP_REPO_SCAN_LIMIT,
+    deadline: float | None = None,
 ) -> str:
     """
     Return Python-first symbol call sites and likely impacted tests.
@@ -3311,6 +3578,9 @@ def tg_symbol_callers(
         symbol: Exact symbol name to resolve.
         path: File or directory to inventory.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
+        deadline: Optional wall-clock budget in seconds for the underlying repo scan. When
+            exceeded, the scan stops and returns a flagged partial result instead of running
+            unbounded.
     """
     # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
     # before any scan -- see tg_repo_map for the systemic-finding rationale.
@@ -3331,7 +3601,11 @@ def tg_symbol_callers(
         return _inject_mcp_contract_fields(
             json.dumps(
                 build_symbol_callers(
-                    symbol, path, semantic_provider=provider, max_repo_files=max_repo_files
+                    symbol,
+                    path,
+                    semantic_provider=provider,
+                    max_repo_files=max_repo_files,
+                    deadline_seconds=deadline,
                 ),
                 indent=2,
             )
@@ -3385,7 +3659,7 @@ def tg_file_imports(file: str) -> str:
     # tg_classify_logs.file_path above. Forward the RESOLVED path so build_file_imports sees
     # the same anchor-validated location this check validated.
     try:
-        file = str(_confine_read_path(file, Path.cwd(), label="file"))
+        file = str(_confine_read_path(file, _mcp_root(), label="file"))
     except ValueError as exc:
         payload = _envelope_base(
             routing_backend="RepoMap",
@@ -3425,6 +3699,7 @@ def tg_file_importers(
     file: str,
     path: str = ".",
     max_repo_files: int = _DEFAULT_MCP_REPO_SCAN_LIMIT,
+    deadline: float | None = None,
 ) -> str:
     """
     Return the files that import a single FILE (the reverse #74 file-dependency primitive).
@@ -3438,11 +3713,14 @@ def tg_file_importers(
             not a silent drop).
         path: Root to scan for importers.
         max_repo_files: Maximum repository files to scan before resolving importers.
+        deadline: Optional wall-clock budget in seconds for the underlying repo scan. When
+            exceeded, the scan stops and returns a flagged partial result instead of running
+            unbounded.
     """
     # round-7 security (audit #81 Opus gate #2 follow-up): confine file to the project root
     # (cwd) before any read, same class/rationale as tg_file_imports above.
     try:
-        file = str(_confine_read_path(file, Path.cwd(), label="file"))
+        file = str(_confine_read_path(file, _mcp_root(), label="file"))
     except ValueError as exc:
         payload = _envelope_base(
             routing_backend="RepoMap",
@@ -3473,7 +3751,9 @@ def tg_file_importers(
     try:
         return _inject_mcp_contract_fields(
             json.dumps(
-                build_file_importers(file, path, max_repo_files=max_repo_files),
+                build_file_importers(
+                    file, path, max_repo_files=max_repo_files, deadline_seconds=deadline
+                ),
                 indent=2,
             )
         )
@@ -3509,6 +3789,7 @@ def tg_symbol_blast_radius(
     max_depth: int = 3,
     provider: str = "native",
     max_repo_files: int = _DEFAULT_MCP_REPO_SCAN_LIMIT,
+    deadline: float | None = None,
 ) -> str:
     """
     Return exact callers plus a transitive file/test blast radius for a symbol.
@@ -3518,6 +3799,9 @@ def tg_symbol_blast_radius(
         path: File or directory to inventory.
         max_depth: Maximum reverse-import depth to include.
         max_repo_files: Maximum repository files to scan before resolving the symbol.
+        deadline: Optional wall-clock budget in seconds for the underlying graph traversal.
+            When exceeded, the scan stops and returns a flagged partial result instead of
+            running unbounded.
     """
     # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
     # before any scan -- see tg_repo_map for the systemic-finding rationale.
@@ -3544,6 +3828,7 @@ def tg_symbol_blast_radius(
                     max_depth=max_depth,
                     semantic_provider=provider,
                     max_repo_files=max_repo_files,
+                    deadline_seconds=deadline,
                 ),
                 indent=2,
             )
@@ -3694,9 +3979,11 @@ def tg_search(
     query: str | None = None,
     structured_json: bool = True,
     max_repo_files: int = _DEFAULT_MCP_REPO_SCAN_LIMIT,
+    rank: bool = False,
+    semantic: bool = False,
 ) -> str:
     """
-    Search files for a regex pattern using tensor-grep's high-speed GPU or CPU engine.
+    Search files for a regex pattern, with GPU acceleration when applicable.
 
     Args:
         pattern: A regular expression or exact string used for searching.
@@ -3719,6 +4006,13 @@ def tg_search(
             ripgrep (rg absent / GPU / hybrid / python-regex). Ignored when RipgrepBackend
             handles the whole-path search natively. Protects against an unscoped full-repo
             per-file search loop.
+        rank: Re-rank results by BM25 lexical relevance to the query terms instead of grep
+            order (pure-CPU ranking; no API key, no model download).
+        semantic: Re-rank results by a hybrid of BM25 + local CPU dense-embedding relevance
+            (RRF fusion), instead of grep order. No API key, no GPU. Requires the `semantic`
+            extra and a fetched model; falls back to BM25-only (visibly, never silently, via
+            `rank_fallback_reason`) when either is missing. Takes priority over `rank` when
+            both are set.
     """
     search_pattern = pattern or query
     if not search_pattern:
@@ -3860,6 +4154,48 @@ def tg_search(
         )
         _finalize_aggregate_result(all_results)
 
+        # audit #95 Part 2: mirror main.py search_command's --rank/--semantic post-processing
+        # (`if config.semantic_rank: ... elif config.rank_bm25 and all_results.matches:`) so an
+        # MCP agent caller gets the same BM25/hybrid-semantic relevance reordering as the CLI.
+        # Applied once here, before the empty/count/full-result branches below, so every render
+        # path sees the same reranked all_results -- matches main.py's ordering (rerank runs
+        # before any output-mode branching, not duplicated per branch).
+        if semantic:
+            if all_results.matches:
+                try:
+                    all_results = _apply_semantic_rerank(all_results, search_pattern)
+                except BackendExecutionError as exc:
+                    # Backend Fail-Closed Contract boundary (mirrors main.py's search_command):
+                    # _apply_semantic_rerank deliberately does NOT catch a genuine dense-backend
+                    # fault (e.g. a corrupt model directory) -- it must surface here as a
+                    # distinguishable structured error, never fall through to the generic
+                    # internal_error catch-all at the bottom of this tool, which would lose the
+                    # fail-closed signal (an agent needs to tell "the backend broke" apart from
+                    # an ordinary internal_error).
+                    if structured_json:
+                        error_payload = {
+                            "pattern": search_pattern,
+                            "path": path,
+                            "error": {
+                                "code": "semantic_backend_error",
+                                "message": str(exc),
+                                "retryable": False,
+                            },
+                        }
+                        return json.dumps(error_payload, indent=2)
+                    return f"Search failed: semantic backend error: {exc}"
+            else:
+                # F16 parity (main.py _set_semantic_rank_fallback_reason): probe dense-leg
+                # availability even on a 0-match search so rank_fallback_reason is set whenever
+                # the leg is unavailable, regardless of match count.
+                _set_semantic_rank_fallback_reason(all_results)
+        elif rank and all_results.matches:
+            from tensor_grep.core.reranker import rerank_by_bm25
+
+            all_results = rerank_by_bm25(
+                all_results, search_pattern, all_results.matched_file_paths
+            )
+
         empty_scan_capped = bool(scan_limit_payload and scan_limit_payload["possibly_truncated"])
         if all_results.is_empty:
             if structured_json:
@@ -3882,6 +4218,11 @@ def tg_search(
                 }
                 if scan_limit_payload is not None:
                     payload["scan_limit"] = scan_limit_payload
+                # `--semantic` fail-closed degrade signal (audit #95 Part 2): emitted ONLY when
+                # set, mirroring json_fmt.py's own "omitted entirely, not null" rule so every
+                # OTHER (non-rank/non-semantic) search's envelope shape stays byte-identical.
+                if all_results.rank_fallback_reason:
+                    payload["rank_fallback_reason"] = all_results.rank_fallback_reason
                 return json.dumps(payload, indent=2)
             capped_note = (
                 f"\nScan capped at {normalized_max_repo_files} files; results may be incomplete."
@@ -3910,6 +4251,8 @@ def tg_search(
                 }
                 if scan_limit_payload is not None:
                     count_payload["scan_limit"] = scan_limit_payload
+                if all_results.rank_fallback_reason:
+                    count_payload["rank_fallback_reason"] = all_results.rank_fallback_reason
                 return json.dumps(count_payload, indent=2)
             return (
                 f"Found a total of {all_results.total_matches} matches across {all_results.total_files} files in {path}.\n"
@@ -3969,6 +4312,8 @@ def tg_search(
             }
             if scan_limit_payload is not None:
                 payload["scan_limit"] = scan_limit_payload
+            if all_results.rank_fallback_reason:
+                payload["rank_fallback_reason"] = all_results.rank_fallback_reason
             return json.dumps(payload, indent=2)
 
         # Format the results into a readable string for the LLM
@@ -4350,7 +4695,7 @@ def tg_classify_logs(file_path: str, structured_json: bool = True) -> str:
     # are echoed back verbatim in anomalies[].text below). Forward the RESOLVED path so the
     # downstream read below sees the same anchor-validated location this check validated.
     try:
-        file_path = str(_confine_read_path(file_path, Path.cwd(), label="file_path"))
+        file_path = str(_confine_read_path(file_path, _mcp_root(), label="file_path"))
     except ValueError as exc:
         if structured_json:
             return json.dumps(
@@ -4679,10 +5024,10 @@ def tg_audit_manifest_verify(
     # the same anchor-validated location this check validated (closes the discard/TOCTOU
     # class), mirroring the write-side _confine_write_path precedent (round-4/5).
     try:
-        manifest_path = str(_confine_write_path(manifest_path, Path.cwd(), label="manifest_path"))
+        manifest_path = str(_confine_write_path(manifest_path, _mcp_root(), label="manifest_path"))
         if previous_manifest is not None:
             previous_manifest = str(
-                _confine_write_path(previous_manifest, Path.cwd(), label="previous_manifest")
+                _confine_write_path(previous_manifest, _mcp_root(), label="previous_manifest")
             )
     except ValueError as exc:
         return _audit_manifest_error(str(exc), code="invalid_input")
@@ -4758,10 +5103,10 @@ def tg_audit_diff(previous_manifest: str, current_manifest: str) -> str:
     # tg_audit_manifest_verify above / _confine_write_path docstring).
     try:
         previous_manifest = str(
-            _confine_write_path(previous_manifest, Path.cwd(), label="previous_manifest")
+            _confine_write_path(previous_manifest, _mcp_root(), label="previous_manifest")
         )
         current_manifest = str(
-            _confine_write_path(current_manifest, Path.cwd(), label="current_manifest")
+            _confine_write_path(current_manifest, _mcp_root(), label="current_manifest")
         )
     except ValueError as exc:
         return _audit_diff_error(str(exc), code="invalid_input")
@@ -4820,12 +5165,12 @@ def tg_review_bundle_create(
     # audit_manifest.py see the same anchor-validated locations this check validated
     # (closes the discard/TOCTOU class), mirroring the output_path write-confinement below.
     try:
-        manifest_path = str(_confine_write_path(manifest_path, Path.cwd(), label="manifest_path"))
+        manifest_path = str(_confine_write_path(manifest_path, _mcp_root(), label="manifest_path"))
         if scan_path is not None:
-            scan_path = str(_confine_write_path(scan_path, Path.cwd(), label="scan_path"))
+            scan_path = str(_confine_write_path(scan_path, _mcp_root(), label="scan_path"))
         if previous_manifest is not None:
             previous_manifest = str(
-                _confine_write_path(previous_manifest, Path.cwd(), label="previous_manifest")
+                _confine_write_path(previous_manifest, _mcp_root(), label="previous_manifest")
             )
     except ValueError as exc:
         return _review_bundle_error(
@@ -4841,7 +5186,7 @@ def tg_review_bundle_create(
     # validated (closes the discard/TOCTOU class).
     if output_path is not None:
         try:
-            output_path = str(_confine_write_path(output_path, Path.cwd(), label="output_path"))
+            output_path = str(_confine_write_path(output_path, _mcp_root(), label="output_path"))
         except ValueError as exc:
             return _review_bundle_error(
                 str(exc),
@@ -4900,7 +5245,7 @@ def tg_review_bundle_verify(bundle_path: str) -> str:
     # unconfined it is an arbitrary-file-read/exfil primitive (see the audit #7 note on
     # tg_review_bundle_create above / _confine_write_path docstring).
     try:
-        bundle_path = str(_confine_write_path(bundle_path, Path.cwd(), label="bundle_path"))
+        bundle_path = str(_confine_write_path(bundle_path, _mcp_root(), label="bundle_path"))
     except ValueError as exc:
         return _review_bundle_error(
             str(exc),

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -1861,6 +1861,15 @@ def _confine_mcp_path(candidate: str, *, label: str) -> Path:
 # bounding an untrusted MCP-supplied payload before it is parsed.
 _MAX_INLINE_RULES_CHARS = 64 * 1024
 
+# [SEC] Cap the NUMBER of inline rules, not just the total byte length. Each inline rule is scanned
+# as a SEPARATE ast-grep invocation (~40 ms/rule), so an attacker-influenceable payload that stays
+# well under _MAX_INLINE_RULES_CHARS can still drive an unbounded multi-minute scan fan-out (~1000
+# tiny rules -> a >40 s hang; a ~33 KB payload is a multi-minute scan). The length cap admits ~4000
+# minimal rules, so it is NOT the binding bound on fan-out -- this count cap is. Legitimate ad-hoc
+# inline scanning uses a handful of rules; a large trusted rule set belongs in a named `ruleset=`
+# pack, not inline. (audit #95 Part-2 re-gate: unbounded inline-rules scan fan-out DoS.)
+_MAX_INLINE_RULES = 100
+
 
 @mcp.tool()  # type: ignore
 def tg_ruleset_scan(
@@ -1985,6 +1994,17 @@ def tg_ruleset_scan(
                 ruleset=ruleset,
                 path=path,
             )
+        # [SEC] bound the scan fan-out -- each rule is a separate ast-grep pass; see
+        # _MAX_INLINE_RULES. Reject a rule COUNT the length cap alone would admit into a
+        # multi-minute scan.
+        if len(rules) > _MAX_INLINE_RULES:
+            return _ruleset_scan_error(
+                f"inline_rules has {len(rules)} rules, exceeding the {_MAX_INLINE_RULES}-rule "
+                "limit (each rule is a separate scan pass). Use a named ruleset or split the scan.",
+                code="invalid_input",
+                ruleset=ruleset,
+                path=path,
+            )
         inferred_language = (
             normalize_ast_language(language) if language else str(rules[0]["language"])
         )
@@ -2075,6 +2095,18 @@ def tg_ruleset_scan(
         return _ruleset_scan_error(
             str(exc),
             code="invalid_input",
+            ruleset=ruleset,
+            path=path,
+        )
+    except BackendExecutionError as exc:
+        # Backend Fail-Closed Contract: a runtime backend fault (e.g. ast-grep failing on an
+        # over-long pattern -- WinError 206 "command line too long" on Windows) is a RuntimeError,
+        # NOT a ValueError, so it escaped the two handlers above as a RAW TRACEBACK, violating the
+        # tool's "never a raw traceback" contract on a trivial valid payload. Surface it as a
+        # structured backend_error instead. (audit #95 Part-2 re-gate: scan-execution fail-closed.)
+        return _ruleset_scan_error(
+            f"scan backend failed: {exc}",
+            code="backend_error",
             ruleset=ruleset,
             path=path,
         )

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -2005,9 +2005,18 @@ def tg_ruleset_scan(
                 ruleset=ruleset,
                 path=path,
             )
-        inferred_language = (
-            normalize_ast_language(language) if language else str(rules[0]["language"])
-        )
+        try:
+            inferred_language = (
+                normalize_ast_language(language) if language else str(rules[0]["language"])
+            )
+        except ValueError as exc:
+            # [SEC] normalize_ast_language raises ValueError on an unsupported `language` override.
+            # A rule carrying its OWN valid `language:` short-circuits the loader's guarded
+            # default_language normalization (mcp_server.py:1986-1989), so an invalid top-level
+            # `language=` override reaches here UNGUARDED -- a raw traceback on a valid-but-bogus
+            # payload, violating the tool's fail-closed contract. (audit #95 Part-2 round-5 gate:
+            # demonstrated with language="zzznotalang" + a rule that sets its own language.)
+            return _ruleset_scan_error(str(exc), code="invalid_input", ruleset=ruleset, path=path)
         project_cfg: dict[str, object] = {
             "config_path": "inline-rules",
             "root_dir": Path(path).expanduser().resolve(),

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -2098,12 +2098,37 @@ def tg_ruleset_scan(
             ruleset=ruleset,
             path=path,
         )
-    except BackendExecutionError as exc:
-        # Backend Fail-Closed Contract: a runtime backend fault (e.g. ast-grep failing on an
-        # over-long pattern -- WinError 206 "command line too long" on Windows) is a RuntimeError,
-        # NOT a ValueError, so it escaped the two handlers above as a RAW TRACEBACK, violating the
-        # tool's "never a raw traceback" contract on a trivial valid payload. Surface it as a
-        # structured backend_error instead. (audit #95 Part-2 re-gate: scan-execution fail-closed.)
+    except ConfigurationError as exc:
+        # [SEC] ast-grep toolchain not available. ast-grep is NOT a declared dependency, so a
+        # DEFAULT `pip install tensor-grep` has no ast-grep binary -- and on that install a trivial
+        # one-line inline rule reaches _select_ast_backend_for_pattern, which raises
+        # ConfigurationError (a RuntimeError, NOT a ValueError/BackendExecutionError). It was
+        # escaping as a RAW TRACEBACK on the common default-install path. Surface it structured.
+        # (audit #95 Part-2 round-4 gate; mirrors tg_ast_search's ConfigurationError handling.)
+        return _ruleset_scan_error(
+            str(exc),
+            code="unavailable",
+            ruleset=ruleset,
+            path=path,
+        )
+    except OSError as exc:
+        # [SEC] a caller-supplied baseline_path/suppressions_path that is unreadable (a directory,
+        # permission-denied, a race-deleted file) makes _load_ruleset_baseline/_load_ruleset_
+        # suppressions' read_text raise OSError/PermissionError/IsADirectoryError (NOT a
+        # ValueError) -- was a raw traceback. Fail closed. (audit #95 Part-2 round-4 gate.)
+        return _ruleset_scan_error(
+            f"unreadable scan path: {exc}",
+            code="invalid_input",
+            ruleset=ruleset,
+            path=path,
+        )
+    except RuntimeError as exc:
+        # [SEC] Backend Fail-Closed backstop: BackendExecutionError (e.g. ast-grep failing on an
+        # over-long pattern, WinError 206) AND any OTHER runtime-fault sibling must be a structured
+        # error, never a raw traceback. Broadened from a BackendExecutionError-only catch to the
+        # whole RuntimeError class, mirroring the CLI twin's `except (ValueError, RuntimeError)`
+        # (main.py). Logic bugs (KeyError/TypeError/AttributeError) are NOT RuntimeError and still
+        # surface. (audit #95 Part-2 round-4 gate: BLOCK on the incomplete fault class.)
         return _ruleset_scan_error(
             f"scan backend failed: {exc}",
             code="backend_error",

--- a/tests/integration/test_mcp_stdio_protocol.py
+++ b/tests/integration/test_mcp_stdio_protocol.py
@@ -40,8 +40,8 @@ async def _stdio_protocol_roundtrip() -> None:
         async with ClientSession(read_stream, write_stream) as session:
             initialized = await session.initialize()
             assert initialized.serverInfo.name == "tensor-grep"
-            # round-8 (audit #95): _TG_MCP_SERVER_CONTRACT_VERSION bumped 1.0.0 -> 1.1.0.
-            assert initialized.serverInfo.version == "1.1.0"
+            # round-9 (audit #95 Part 2): _TG_MCP_SERVER_CONTRACT_VERSION bumped 1.1.0 -> 1.2.0.
+            assert initialized.serverInfo.version == "1.2.0"
 
             listed = await session.list_tools()
             tool_names = {tool.name for tool in listed.tools}
@@ -112,8 +112,8 @@ async def _stdio_content_length_initialize_roundtrip() -> None:
         server_info = result["serverInfo"]
         assert isinstance(server_info, dict)
         assert server_info["name"] == "tensor-grep"
-        # round-8 (audit #95): _TG_MCP_SERVER_CONTRACT_VERSION bumped 1.0.0 -> 1.1.0.
-        assert server_info["version"] == "1.1.0"
+        # round-9 (audit #95 Part 2): _TG_MCP_SERVER_CONTRACT_VERSION bumped 1.1.0 -> 1.2.0.
+        assert server_info["version"] == "1.2.0"
     finally:
         if process.stdin is not None:
             process.stdin.close()

--- a/tests/unit/test_harness_api_docs.py
+++ b/tests/unit/test_harness_api_docs.py
@@ -216,6 +216,41 @@ def test_harness_api_doc_covers_all_required_json_shapes() -> None:
     assert '"command":"context"' in doc
     assert "invalid_request" in doc
     assert "--refresh-on-stale" in doc
+    assert "tg_orient" in doc
+    assert "tg_doctor" in doc
+
+
+def test_harness_api_doc_lists_every_registered_mcp_tool_name() -> None:
+    """Hardened gate (audit #95 Part 2): the coverage test above hand-lists specific tool
+    names as individual `assert "tg_x" in doc` lines -- a substring check that silently
+    tolerates a NEW tool never being added to the doc. That is exactly how 7 tools (tg_search,
+    tg_ast_search, tg_classify_logs, tg_devices, tg_file_imports, tg_file_importers,
+    tg_session_file_importers) went undocumented for multiple releases before this test
+    existed. Derive the tool name list from the LIVE MCP tool registry instead (the same
+    source test_mcp_server.py's hard capabilities gate uses) and assert every single one has
+    a `` `name(...)` `` bullet entry in the doc's "Current tool set" list, so a newly
+    added/renamed tool that isn't documented fails CI immediately instead of silently
+    drifting again.
+    """
+    import asyncio
+
+    from tensor_grep.cli import mcp_server
+
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    live_tool_names = {tool.name for tool in asyncio.run(mcp_server.mcp.list_tools())}
+
+    assert live_tool_names, "the live MCP tool registry returned zero tools -- broken probe"
+
+    # Match `name(` (backtick + exact name + immediate open-paren) rather than a bare
+    # substring: several tool names are prefixes of others (tg_symbol_blast_radius vs
+    # tg_symbol_blast_radius_plan/_render), and a bare `name in doc` check would false-pass a
+    # tool that is only ever mentioned as part of a LONGER sibling name's entry.
+    missing = sorted(name for name in live_tool_names if f"`{name}(" not in doc)
+    assert not missing, (
+        f"harness_api.md's 'Current tool set' is missing {len(missing)} live MCP tool(s): "
+        f"{missing}. Add a `name(...)` bullet entry under '## MCP Tool Responses' -> "
+        "'Current tool set'."
+    )
 
 
 def test_harness_api_doc_links_failure_mode_examples() -> None:

--- a/tests/unit/test_mcp_caps.py
+++ b/tests/unit/test_mcp_caps.py
@@ -424,3 +424,133 @@ def test_mcp_search_folds_scanner_scan_truncated_into_possibly_truncated(
     assert payload["scan_limit"]["scanned_files"] == 2
     assert payload["scan_limit"]["possibly_truncated"] is True
     assert payload["truncated"] is True
+
+
+# audit #95 Part 2: `deadline` on the 5 MCP symbol tools that already accepted
+# `max_repo_files` but not `deadline` -- every underlying repo_map.py builder already accepts
+# `deadline_seconds: float | None = None` (zero new builder logic), so this is a pure
+# expose-and-forward, same shape as the max_repo_files tests above.
+
+
+def test_mcp_symbol_impact_exposes_and_forwards_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tensor_grep.cli import mcp_server
+
+    signature = inspect.signature(mcp_server.tg_symbol_impact)
+    assert signature.parameters["deadline"].default is None
+
+    captured: dict[str, object] = {}
+
+    def fake_build_symbol_impact(symbol: str, path: str, **kwargs: object) -> dict[str, object]:
+        captured["symbol"] = symbol
+        captured["path"] = path
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "build_symbol_impact", fake_build_symbol_impact)
+
+    payload = json.loads(mcp_server.tg_symbol_impact("create_invoice", ".", deadline=8.5))
+
+    assert payload["ok"] is True
+    assert captured["deadline_seconds"] == 8.5
+
+
+def test_mcp_symbol_impact_deadline_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tensor_grep.cli import mcp_server
+
+    captured: dict[str, object] = {}
+
+    def fake_build_symbol_impact(symbol: str, path: str, **kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "build_symbol_impact", fake_build_symbol_impact)
+
+    mcp_server.tg_symbol_impact("create_invoice", ".")
+
+    assert captured["deadline_seconds"] is None
+
+
+def test_mcp_symbol_refs_exposes_and_forwards_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tensor_grep.cli import mcp_server
+
+    signature = inspect.signature(mcp_server.tg_symbol_refs)
+    assert signature.parameters["deadline"].default is None
+
+    captured: dict[str, object] = {}
+
+    def fake_build_symbol_refs(symbol: str, path: str, **kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "build_symbol_refs", fake_build_symbol_refs)
+
+    payload = json.loads(mcp_server.tg_symbol_refs("create_invoice", ".", deadline=4.0))
+
+    assert payload["ok"] is True
+    assert captured["deadline_seconds"] == 4.0
+
+
+def test_mcp_symbol_callers_exposes_and_forwards_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tensor_grep.cli import mcp_server
+
+    signature = inspect.signature(mcp_server.tg_symbol_callers)
+    assert signature.parameters["deadline"].default is None
+
+    captured: dict[str, object] = {}
+
+    def fake_build_symbol_callers(symbol: str, path: str, **kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "build_symbol_callers", fake_build_symbol_callers)
+
+    payload = json.loads(mcp_server.tg_symbol_callers("create_invoice", ".", deadline=12.0))
+
+    assert payload["ok"] is True
+    assert captured["deadline_seconds"] == 12.0
+
+
+def test_mcp_file_importers_exposes_and_forwards_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tensor_grep.cli import mcp_server
+
+    signature = inspect.signature(mcp_server.tg_file_importers)
+    assert signature.parameters["deadline"].default is None
+
+    captured: dict[str, object] = {}
+
+    def fake_build_file_importers(file: str, path: str, **kwargs: object) -> dict[str, object]:
+        captured["file"] = file
+        captured["path"] = path
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "build_file_importers", fake_build_file_importers)
+
+    payload = json.loads(mcp_server.tg_file_importers("dummy.py", ".", deadline=6.5))
+
+    assert payload["ok"] is True
+    assert captured["deadline_seconds"] == 6.5
+
+
+def test_mcp_symbol_blast_radius_exposes_and_forwards_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tensor_grep.cli import mcp_server
+
+    signature = inspect.signature(mcp_server.tg_symbol_blast_radius)
+    assert signature.parameters["deadline"].default is None
+
+    captured: dict[str, object] = {}
+
+    def fake_build_symbol_blast_radius(
+        symbol: str, path: str, **kwargs: object
+    ) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_server, "build_symbol_blast_radius", fake_build_symbol_blast_radius)
+
+    payload = json.loads(mcp_server.tg_symbol_blast_radius("create_invoice", ".", deadline=15.0))
+
+    assert payload["ok"] is True
+    assert captured["deadline_seconds"] == 15.0

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1807,6 +1807,35 @@ def test_tg_ruleset_scan_inline_rules_rejects_yaml_alias_bomb(tmp_path, monkeypa
     assert "Traceback" not in payload["error"]["message"]
 
 
+def test_tg_ruleset_scan_inline_rules_rejects_deep_nested_yaml(tmp_path, monkeypatch):
+    """[SEC] Deep-nested ALIAS-FREE YAML DoS residual -- audit #95 Part-2 re-gate BLOCK.
+
+    A ~40 KB payload of 20000 nested flow-sequences (`"["*20000 + "]"*20000`) is UNDER the 64 KiB
+    length cap and has NO aliases, so `_NoAliasSafeLoader` cannot reject it -- but it recurses the
+    YAML parser/composer past the interpreter's recursion limit. The pure-Python SafeLoader raises
+    a CATCHABLE `RecursionError` (the old CSafeLoader hard-crashed the whole process, exit
+    0xC00000FD); the fix catches `RecursionError` at the load site so this path also fails closed
+    as a structured `invalid_input` instead of escaping as a raw traceback (the tool's fail-closed
+    contract). Fast (<1s, O(input) memory, process survives). On revert the assertion fails (or the
+    call raises) fast -- never hangs (anti-hang-test-protocol)."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+
+    deep = "rules:\n  - pattern: " + ("[" * 20000) + ("]" * 20000) + '\n    severity: "s"\n'
+    assert len(deep) < mcp_server._MAX_INLINE_RULES_CHARS, (
+        "payload must be sub-cap to test the loader, not the length bound"
+    )
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules=deep, path="."))
+
+    assert payload.get("error", {}).get("code") == "invalid_input", (
+        f"deep-nested YAML must fail closed as invalid_input, not a raw traceback; got: {payload}"
+    )
+    assert "YAML" in payload["error"]["message"]
+    assert "Traceback" not in payload["error"]["message"]
+
+
 def test_tg_ruleset_scan_inline_rules_at_length_boundary_still_parses(monkeypatch, tmp_path):
     """Boundary correctness for the length bound: a payload AT the cap must still reach the
     parser (not be off-by-one refused) and behave exactly like any other invalid-but-in-budget

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1730,12 +1730,14 @@ def test_tg_ruleset_scan_inline_rules_honors_explicit_language_override(monkeypa
 
 
 def test_tg_ruleset_scan_inline_rules_rejects_oversized_input(tmp_path, monkeypatch):
-    """[SEC] YAML expansion-bomb DoS mitigation: SafeLoader still parses anchors/aliases, so a
-    small document can still expand combinatorially in memory. Bounding the raw string length
-    before it ever reaches the YAML loader is a cheap, unconditional first line of defense --
+    """[SEC] YAML expansion-bomb DoS -- DEFENSE-IN-DEPTH layer 1 (the length cap). Bounding the
+    raw string length before it reaches the YAML loader is a cheap, unconditional guard --
     verify the tool actually enforces the cap (not merely documents it) and that the rejection
     happens BEFORE any YAML parsing (a bomb payload well past the cap must still be refused
-    fast, not hang trying to parse it)."""
+    fast, not hang trying to parse it). NOTE: the length cap ALONE does NOT stop the bomb -- an
+    aliased payload detonates by depth ~9 while the cap admits depth ~1000, so the real fix is
+    the loader-level alias rejection; see test_tg_ruleset_scan_inline_rules_rejects_yaml_alias_bomb
+    (audit #95 Part-2 Opus-gate BLOCK)."""
     from tensor_grep.cli import mcp_server
 
     monkeypatch.chdir(tmp_path)
@@ -1746,6 +1748,63 @@ def test_tg_ruleset_scan_inline_rules_rejects_oversized_input(tmp_path, monkeypa
     assert payload["error"]["code"] == "invalid_input"
     assert "exceeds" in payload["error"]["message"].lower()
     assert str(mcp_server._MAX_INLINE_RULES_CHARS) in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_inline_rules_rejects_yaml_alias_bomb(tmp_path, monkeypatch):
+    """[SEC] YAML alias-expansion DoS (billion-laughs) -- audit #95 Part-2 Opus-gate BLOCK.
+
+    SafeLoader SHARES alias nodes, so the load itself is linear -- but the downstream ``str()``
+    coercions on ``id``/``severity``/``message`` in ``_load_inline_rule_specs`` deep-walk that
+    shared graph and expand it ~9^depth. A sub-64 KiB nested-alias payload therefore detonates by
+    depth ~9 (the gate proved a 469-byte payload hung >15s), completely under the length cap
+    (which admits depth ~1000). The fix rejects YAML aliases at the loader level
+    (``_NoAliasSafeLoader.compose_node`` raises on the first ``AliasEvent``, before any expansion),
+    so the bomb is refused as ``invalid_input`` fast.
+
+    Kept SHALLOW (depth 5) on purpose: the fix rejects at the FIRST alias regardless of depth, so
+    shallow still proves it, and if the loader-level rejection ever regresses this test FAILS FAST
+    on the assertion (the scan returns a non-``invalid_input`` result) instead of OOM/hanging the
+    suite. A watchdog thread is the belt-and-suspenders anti-hang guard (anti-hang-test-protocol).
+    """
+    import threading
+
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+
+    # Nested YAML aliases -- the billion-laughs vector. a0 is the anchored seed; each level
+    # aliases the previous 9x. WELL under _MAX_INLINE_RULES_CHARS, so ONLY the _NoAliasSafeLoader
+    # alias rejection -- not the length bound -- can stop it. The `severity: *a4` reaches the
+    # str()-coercion detonation point.
+    lines = ['a0: &a0 ["lol", "lol", "lol", "lol", "lol", "lol", "lol", "lol", "lol"]']
+    for depth in range(1, 5):
+        refs = ", ".join([f"*a{depth - 1}"] * 9)
+        lines.append(f"a{depth}: &a{depth} [{refs}]")
+    lines += ["rules:", '  - pattern: "print($X)"', "    severity: *a4"]
+    bomb = "\n".join(lines)
+    assert len(bomb) < mcp_server._MAX_INLINE_RULES_CHARS, (
+        "payload must be sub-cap to test the loader, not the length bound"
+    )
+
+    result: dict[str, str] = {}
+
+    def _run() -> None:
+        result["payload"] = mcp_server.tg_ruleset_scan(inline_rules=bomb, path=".")
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(timeout=15.0)
+    assert not worker.is_alive(), (
+        "tg_ruleset_scan HUNG on a sub-64 KiB YAML alias bomb -- the _NoAliasSafeLoader alias "
+        "rejection regressed; the _MAX_INLINE_RULES_CHARS length cap alone does NOT stop this DoS."
+    )
+
+    payload = json.loads(result["payload"])
+    assert payload.get("error", {}).get("code") == "invalid_input", (
+        f"alias bomb must be refused as invalid_input (loader-level alias rejection); got: {payload}"
+    )
+    assert "YAML" in payload["error"]["message"]
+    assert "Traceback" not in payload["error"]["message"]
 
 
 def test_tg_ruleset_scan_inline_rules_at_length_boundary_still_parses(monkeypatch, tmp_path):

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1936,6 +1936,31 @@ def test_tg_ruleset_scan_baseline_io_error_fails_closed(tmp_path, monkeypatch):
     assert "Traceback" not in payload["error"]["message"]
 
 
+def test_tg_ruleset_scan_inline_rules_bad_language_override_fails_closed(tmp_path, monkeypatch):
+    """[SEC] round-5 gate: a rule carrying its OWN valid `language:` short-circuits the loader's
+    guarded default_language normalization, so an unsupported top-level `language=` override reaches
+    normalize_ast_language (mcp_server.py:2008) UNGUARDED -- it was a raw ValueError traceback on a
+    valid-but-bogus payload. Must fail closed as structured invalid_input. (The control -- a rule
+    that OMITS its own language -- was already caught by the loader; this is the short-circuit gap.)
+    """
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+
+    # rule sets language=python (so the loader succeeds) + a bogus top-level override reaches 2008.
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(
+            inline_rules="rules:\n  - id: x\n    language: python\n    pattern: print($A)\n",
+            path=".",
+            language="zzznotalang",
+        )
+    )
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "Unsupported AST language" in payload["error"]["message"]
+    assert "Traceback" not in payload["error"]["message"]
+
+
 def test_tg_ruleset_scan_inline_rules_at_length_boundary_still_parses(monkeypatch, tmp_path):
     """Boundary correctness for the length bound: a payload AT the cap must still reach the
     parser (not be off-by-one refused) and behave exactly like any other invalid-but-in-budget

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1836,6 +1836,57 @@ def test_tg_ruleset_scan_inline_rules_rejects_deep_nested_yaml(tmp_path, monkeyp
     assert "Traceback" not in payload["error"]["message"]
 
 
+def test_tg_ruleset_scan_inline_rules_rejects_excessive_rule_count(tmp_path, monkeypatch):
+    """[SEC] Unbounded scan fan-out DoS -- audit #95 Part-2 re-gate. Each inline rule is a SEPARATE
+    ast-grep pass (~40 ms/rule), so a payload UNDER the 64 KiB length cap can still drive a
+    multi-minute scan (~1000 rules -> a >40s hang). The rule COUNT cap (_MAX_INLINE_RULES) is the
+    binding bound; a payload exceeding it must be refused fast as invalid_input, BEFORE any scan
+    (no ast-grep is invoked -- the count check precedes _run_ast_scan_payload)."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+
+    # _MAX_INLINE_RULES + 1 valid rules, well under the 64 KiB length cap.
+    n = mcp_server._MAX_INLINE_RULES + 1
+    rules_yaml = "rules:\n" + "".join(
+        f"  - id: r{i}\n    pattern: print($A{i})\n" for i in range(n)
+    )
+    assert len(rules_yaml) < mcp_server._MAX_INLINE_RULES_CHARS
+
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(inline_rules=rules_yaml, path=".", language="python")
+    )
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert str(n) in payload["error"]["message"]
+    assert str(mcp_server._MAX_INLINE_RULES) in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_backend_execution_error_fails_closed(tmp_path, monkeypatch):
+    """[SEC] Backend Fail-Closed Contract -- audit #95 Part-2 re-gate. A runtime backend fault
+    (BackendExecutionError, a RuntimeError -- e.g. ast-grep failing on an over-long pattern,
+    WinError 206) was escaping tg_ruleset_scan's `except (BroadScanRefusedError, ValueError)` as a
+    RAW TRACEBACK on a valid payload. It must surface as a structured backend_error instead."""
+    from tensor_grep.backends.base import BackendExecutionError
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise BackendExecutionError("ast-grep failed: [WinError 206] the filename is too long")
+
+    monkeypatch.setattr(mcp_server, "_run_ast_scan_payload", _boom)
+
+    inline_rules = "rules:\n  - id: x\n    pattern: print($A)\n"
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(inline_rules=inline_rules, path=".", language="python")
+    )
+
+    assert payload["error"]["code"] == "backend_error"
+    assert "backend failed" in payload["error"]["message"].lower()
+    assert "Traceback" not in payload["error"]["message"]
+
+
 def test_tg_ruleset_scan_inline_rules_at_length_boundary_still_parses(monkeypatch, tmp_path):
     """Boundary correctness for the length bound: a payload AT the cap must still reach the
     parser (not be off-by-one refused) and behave exactly like any other invalid-but-in-budget

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1887,6 +1887,55 @@ def test_tg_ruleset_scan_backend_execution_error_fails_closed(tmp_path, monkeypa
     assert "Traceback" not in payload["error"]["message"]
 
 
+def test_tg_ruleset_scan_configuration_error_fails_closed(tmp_path, monkeypatch):
+    """[SEC] round-4 gate: ast-grep is NOT a declared dependency, so on a DEFAULT
+    `pip install tensor-grep` a trivial one-line inline rule reaches
+    _select_ast_backend_for_pattern, which raises ConfigurationError (a RuntimeError, NOT a
+    ValueError/BackendExecutionError). That escaped tg_ruleset_scan as a RAW TRACEBACK on the
+    common default-install path. Must fail closed as a structured 'unavailable'."""
+    from tensor_grep.cli import mcp_server
+    from tensor_grep.core.pipeline import ConfigurationError
+
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(*a, **k):
+        raise ConfigurationError("ast-grep binary not found on PATH; install ast-grep")
+
+    monkeypatch.setattr(mcp_server, "_run_ast_scan_payload", _boom)
+
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(
+            inline_rules="rules:\n  - id: x\n    pattern: print($A)\n", path=".", language="python"
+        )
+    )
+
+    assert payload["error"]["code"] == "unavailable"
+    assert "Traceback" not in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_baseline_io_error_fails_closed(tmp_path, monkeypatch):
+    """[SEC] round-4 gate: an unreadable caller-supplied baseline/suppressions path (e.g. a
+    directory) makes _load_ruleset_baseline's read_text raise OSError/IsADirectoryError (NOT a
+    ValueError). That escaped as a RAW TRACEBACK. Must fail closed structured, never a traceback."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(*a, **k):
+        raise IsADirectoryError("[Errno 21] Is a directory: 'baseline'")
+
+    monkeypatch.setattr(mcp_server, "_run_ast_scan_payload", _boom)
+
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(
+            inline_rules="rules:\n  - id: x\n    pattern: print($A)\n", path=".", language="python"
+        )
+    )
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "Traceback" not in payload["error"]["message"]
+
+
 def test_tg_ruleset_scan_inline_rules_at_length_boundary_still_parses(monkeypatch, tmp_path):
     """Boundary correctness for the length bound: a payload AT the cap must still reach the
     parser (not be off-by-one refused) and behave exactly like any other invalid-but-in-budget

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -915,6 +915,227 @@ def test_tg_search_refuses_glob_with_default_path_on_large_root():
     assert "1500" in payload["error"]["message"]
 
 
+def _tg_search_rank_fixture():
+    """Shared Pipeline/DirectoryScanner mock producing 2 matches for --rank/--semantic tests."""
+    fake_backend = MagicMock()
+    fake_backend.search.return_value = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR here", file="a.log")],
+        matched_file_paths=["a.log"],
+        total_files=1,
+        total_matches=1,
+    )
+    return fake_backend
+
+
+def test_tg_search_rank_reranks_by_bm25(monkeypatch):
+    """audit #95 Part 2: `rank` mirrors main.py's `--rank`/`--bm25` post-processing --
+    inserted after _finalize_aggregate_result, before the empty/count/full-result branches
+    (main.py's `elif config.rank_bm25 and all_results.matches:` ordering)."""
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = _tg_search_rank_fixture()
+    reranked = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR here", file="a.log")],
+        matched_file_paths=["a.log"],
+        total_files=1,
+        total_matches=1,
+    )
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+        patch("tensor_grep.core.reranker.rerank_by_bm25", return_value=reranked) as mock_rerank,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        out = mcp_server.tg_search("ERROR", ".", rank=True)
+
+    mock_rerank.assert_called_once()
+    assert mock_rerank.call_args.args[0].total_matches == 1
+    assert mock_rerank.call_args.args[1] == "ERROR"
+    assert mock_rerank.call_args.args[2] == ["a.log"]
+    payload = json.loads(out)
+    assert payload["total_matches"] == 1
+
+
+def test_tg_search_semantic_applies_hybrid_rerank(monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = _tg_search_rank_fixture()
+    reranked = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR here", file="a.log")],
+        matched_file_paths=["a.log"],
+        total_files=1,
+        total_matches=1,
+        rank_fallback_reason=None,
+    )
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+        patch(
+            "tensor_grep.cli.mcp_server._apply_semantic_rerank", return_value=reranked
+        ) as mock_semantic,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        out = mcp_server.tg_search("ERROR", ".", semantic=True)
+
+    mock_semantic.assert_called_once()
+    assert mock_semantic.call_args.args[1] == "ERROR"
+    payload = json.loads(out)
+    assert payload["total_matches"] == 1
+
+
+def test_tg_search_semantic_takes_priority_over_rank_when_both_set(monkeypatch):
+    """Mirrors main.py's `if config.semantic_rank: ... elif config.rank_bm25:` ordering --
+    semantic wins when both flags are requested; the BM25-only path must not also fire."""
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = _tg_search_rank_fixture()
+    reranked = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR here", file="a.log")],
+        matched_file_paths=["a.log"],
+        total_files=1,
+        total_matches=1,
+    )
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+        patch(
+            "tensor_grep.cli.mcp_server._apply_semantic_rerank", return_value=reranked
+        ) as mock_semantic,
+        patch("tensor_grep.core.reranker.rerank_by_bm25") as mock_bm25,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        mcp_server.tg_search("ERROR", ".", rank=True, semantic=True)
+
+    mock_semantic.assert_called_once()
+    mock_bm25.assert_not_called()
+
+
+def test_tg_search_semantic_backend_execution_error_returns_distinguishable_error(monkeypatch):
+    """Must catch BackendExecutionError EXPLICITLY (mirrors main.py's search_command boundary)
+    -- a genuine dense-backend fault (corrupt model dir) must surface as a distinguishable
+    structured error, not fall through to the generic internal_error catch-all at the bottom
+    of tg_search (which would lose the fail-closed signal an agent needs to tell "the backend
+    itself broke" apart from "some other internal_error")."""
+    from tensor_grep.backends.base import BackendExecutionError
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = _tg_search_rank_fixture()
+    fault = BackendExecutionError("corrupt dense model directory")
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+        patch("tensor_grep.cli.mcp_server._apply_semantic_rerank", side_effect=fault),
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        out = mcp_server.tg_search("ERROR", ".", semantic=True)
+
+    payload = json.loads(out)
+    assert payload["error"]["code"] == "semantic_backend_error"
+    assert payload["error"]["code"] != "internal_error"
+    assert "corrupt dense model directory" in payload["error"]["message"]
+
+
+def test_tg_search_semantic_probes_fallback_reason_on_empty_matches(monkeypatch):
+    """F16 parity (main.py _set_semantic_rank_fallback_reason): even a 0-match search must
+    still probe dense-leg availability so rank_fallback_reason is set whenever the leg is
+    unavailable, regardless of match count."""
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = MagicMock()
+    fake_backend.search.return_value = SearchResult(matches=[], total_files=0, total_matches=0)
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+        patch("tensor_grep.cli.mcp_server._set_semantic_rank_fallback_reason") as mock_probe,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        mcp_server.tg_search("NOPE", ".", semantic=True)
+
+    mock_probe.assert_called_once()
+
+
+def test_tg_search_rank_fallback_reason_surfaces_in_json_payload(monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    fake_backend = _tg_search_rank_fixture()
+    reranked = SearchResult(
+        matches=[MatchLine(line_number=1, text="ERROR here", file="a.log")],
+        matched_file_paths=["a.log"],
+        total_files=1,
+        total_matches=1,
+        rank_fallback_reason="semantic ranking unavailable: the `semantic` extra is not installed",
+    )
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+        patch("tensor_grep.cli.mcp_server._apply_semantic_rerank", return_value=reranked),
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = ["a.log"]
+
+        out = mcp_server.tg_search("ERROR", ".", semantic=True)
+
+    payload = json.loads(out)
+    assert payload["rank_fallback_reason"] == (
+        "semantic ranking unavailable: the `semantic` extra is not installed"
+    )
+
+
+def test_tg_search_docstring_does_not_oversell_gpu():
+    """The docstring previously read 'high-speed GPU or CPU engine', overselling a paused,
+    non-default, usually-dormant GPU path (architecture-contract known-weak-point #2: GPU is
+    slower than CPU with no promotion-ready path; auto-GPU stays dormant when rg is
+    installed). Mirror the CLI's own qualified phrasing ('with GPU acceleration when
+    applicable') instead of an unqualified speed claim."""
+    from tensor_grep.cli import mcp_server
+
+    doc = mcp_server.tg_search.__doc__ or ""
+    assert "high-speed GPU" not in doc
+    assert "when applicable" in doc.lower()
+
+
 def test_tg_ast_search_backend_execution_error_skips_file_and_keeps_partial_results():
     from tensor_grep.backends.base import BackendExecutionError
     from tensor_grep.cli import mcp_server
@@ -1353,6 +1574,214 @@ def test_tg_ruleset_scan_returns_structured_findings(monkeypatch, tmp_path):
     assert payload["findings"][0]["evidence"] == [{"file": "a.py", "match_count": 1}]
 
 
+# audit #95 Part 2 [SEC]: `inline_rules` on tg_ruleset_scan -- the `--inline-rules` CLI source
+# (a string of ast-grep rule YAML, ZERO file I/O), mirrored via _load_inline_rule_specs (never
+# reimplemented). `ruleset` becomes optional; exactly one of ruleset/inline_rules is required.
+
+
+def test_tg_ruleset_scan_supports_inline_rules(monkeypatch, tmp_path):
+    from tensor_grep.cli import mcp_server
+    from tests.unit.test_cli_modes import _FakeAstPipeline, _FakeAstScanner
+
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
+    monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
+    monkeypatch.chdir(tmp_path)
+
+    Path("a.py").write_text("print($A)\n", encoding="utf-8")
+    Path("b.py").write_text("ok\n", encoding="utf-8")
+
+    inline_rules = "\n".join([
+        "id: no-print",
+        "language: python",
+        "rule:",
+        "  pattern: print($A)",
+    ])
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules=inline_rules, path="."))
+
+    assert payload["routing_reason"] == "ast-inline-rules-scan"
+    assert payload["config_path"] == "inline-rules"
+    assert payload["ruleset"] is None
+    assert payload["rule_count"] == 1
+    assert payload["matched_rules"] == 1
+    assert payload["findings"][0]["rule_id"] == "no-print"
+    assert payload["findings"][0]["files"] == ["a.py"]
+
+
+def test_tg_ruleset_scan_inline_rules_preserves_severity_and_message(monkeypatch, tmp_path):
+    from tensor_grep.cli import mcp_server
+    from tests.unit.test_cli_modes import _FakeAstPipeline, _FakeAstScanner
+
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
+    monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
+    monkeypatch.chdir(tmp_path)
+
+    Path("a.py").write_text("print($A)\n", encoding="utf-8")
+
+    inline_rules = "\n".join([
+        "id: no-print",
+        "language: python",
+        "severity: warning",
+        "message: Avoid print in library code.",
+        "rule:",
+        "  pattern: print($A)",
+    ])
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules=inline_rules, path="."))
+
+    finding = payload["findings"][0]
+    assert finding["rule_id"] == "no-print"
+    assert finding["severity"] == "warning"
+    assert finding["message"] == "Avoid print in library code."
+
+
+def test_tg_ruleset_scan_ruleset_and_inline_rules_are_mutually_exclusive(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(
+            ruleset="crypto-safe",
+            inline_rules="id: x\nrule:\n  pattern: y\n",
+            path=".",
+        )
+    )
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "mutually exclusive" in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_requires_ruleset_or_inline_rules(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(path="."))
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "one of ruleset or inline_rules" in payload["error"]["message"].lower()
+
+
+def test_tg_ruleset_scan_inline_rules_invalid_yaml_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules="id: broken\nrule: [", path="."))
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "YAML" in payload["error"]["message"]
+    assert "Traceback" not in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_inline_rules_no_valid_rules_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    # Valid YAML, but no `rule.pattern`/`pattern` field anywhere -- _load_inline_rule_specs
+    # extracts zero specs from this document.
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules="id: no-pattern-here\n", path="."))
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "no valid inline rules" in payload["error"]["message"].lower()
+
+
+def test_tg_ruleset_scan_inline_rules_unsupported_language_fails_closed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    inline_rules = "\n".join([
+        "id: unsupported-language",
+        "language: Dart",
+        "rule:",
+        "  pattern: print($A)",
+    ])
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules=inline_rules, path="."))
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "Unsupported AST language Dart" in payload["error"]["message"]
+    assert "Traceback" not in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_inline_rules_honors_explicit_language_override(monkeypatch, tmp_path):
+    """The `inferred_language = normalize_ast_language(language) if language else
+    str(rules[0]["language"]) else` branch only runs when the caller passes `language=`
+    explicitly (the rule's OWN embedded `language:` field, and the no-override default, take
+    a different path entirely) -- exercise it directly so a regression there (e.g. a missing
+    normalize_ast_language import) is actually caught."""
+    from tensor_grep.cli import mcp_server
+    from tests.unit.test_cli_modes import _FakeAstPipeline, _FakeAstScanner
+
+    monkeypatch.setattr("tensor_grep.core.pipeline.Pipeline", _FakeAstPipeline)
+    monkeypatch.setattr("tensor_grep.io.directory_scanner.DirectoryScanner", _FakeAstScanner)
+    monkeypatch.chdir(tmp_path)
+
+    Path("a.py").write_text("print($A)\n", encoding="utf-8")
+
+    # No `language:` field on the rule itself -- the explicit `language=` override must supply
+    # it via the `if language:` branch, not the rule's own per-document field.
+    inline_rules = "id: no-print\nrule:\n  pattern: print($A)\n"
+
+    payload = json.loads(
+        mcp_server.tg_ruleset_scan(inline_rules=inline_rules, path=".", language="python")
+    )
+
+    assert payload["language"] == "python"
+    assert payload["findings"][0]["rule_id"] == "no-print"
+
+
+def test_tg_ruleset_scan_inline_rules_rejects_oversized_input(tmp_path, monkeypatch):
+    """[SEC] YAML expansion-bomb DoS mitigation: SafeLoader still parses anchors/aliases, so a
+    small document can still expand combinatorially in memory. Bounding the raw string length
+    before it ever reaches the YAML loader is a cheap, unconditional first line of defense --
+    verify the tool actually enforces the cap (not merely documents it) and that the rejection
+    happens BEFORE any YAML parsing (a bomb payload well past the cap must still be refused
+    fast, not hang trying to parse it)."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    oversized = "a" * (mcp_server._MAX_INLINE_RULES_CHARS + 1)
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules=oversized, path="."))
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "exceeds" in payload["error"]["message"].lower()
+    assert str(mcp_server._MAX_INLINE_RULES_CHARS) in payload["error"]["message"]
+
+
+def test_tg_ruleset_scan_inline_rules_at_length_boundary_still_parses(monkeypatch, tmp_path):
+    """Boundary correctness for the length bound: a payload AT the cap must still reach the
+    parser (not be off-by-one refused) and behave exactly like any other invalid-but-in-budget
+    input -- i.e. still get the ordinary 'no valid inline rules' error, not the length error."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    at_cap = "#" + "a" * (mcp_server._MAX_INLINE_RULES_CHARS - 1)
+    assert len(at_cap) == mcp_server._MAX_INLINE_RULES_CHARS
+
+    payload = json.loads(mcp_server.tg_ruleset_scan(inline_rules=at_cap, path="."))
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert "exceeds" not in payload["error"]["message"].lower()
+
+
+def test_tg_ruleset_scan_inline_rules_confines_path(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
+    outside.mkdir(exist_ok=True)
+    try:
+        payload = json.loads(
+            mcp_server.tg_ruleset_scan(
+                inline_rules="id: x\nrule:\n  pattern: y\n", path=str(outside)
+            )
+        )
+        assert payload["error"]["code"] == "invalid_input"
+        assert "must stay within" in payload["error"]["message"]
+    finally:
+        outside.rmdir()
+
+
 def test_tg_ruleset_scan_refuses_direct_temp_root_before_walking(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
@@ -1657,7 +2086,7 @@ def test_mcp_server_initialization_version_tracks_mcp_contract() -> None:
     options = mcp_server.mcp._mcp_server.create_initialization_options()
 
     assert options.server_name == "tensor-grep"
-    assert options.server_version == "1.1.0"
+    assert options.server_version == "1.2.0"
     assert options.server_version == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
     assert mcp_server._mcp_server_version() == version("tensor-grep")
 
@@ -4572,6 +5001,180 @@ def test_tg_repo_map_includes_typescript_and_rust_inventory(tmp_path, monkeypatc
     )
 
 
+def test_tg_orient_returns_json_capsule(tmp_path, monkeypatch):
+    """audit #95 Part 2: tg_orient mirrors `tg orient --json` -> build_orient_capsule_json."""
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    (tmp_path / "hub.py").write_text("def hub():\n    pass\n", encoding="utf-8")
+    (tmp_path / "leaf.py").write_text("import hub\n\n\ndef leaf():\n    pass\n", encoding="utf-8")
+
+    payload = json.loads(mcp_server.tg_orient(str(tmp_path)))
+
+    assert payload["routing_reason"] == "orient"
+    assert payload["path"] == str(tmp_path.resolve())
+    assert "central_files" in payload
+    assert any(
+        cf["file"] == str((tmp_path / "hub.py").resolve()) for cf in payload["central_files"]
+    )
+    assert "entry_points" in payload
+    assert "snippets" in payload
+    assert payload["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    assert isinstance(payload["schema_version"], int)
+
+
+def test_tg_orient_docstring_directs_agent_to_call_first(tmp_path):
+    """Design instruction: the docstring must close the 'run orient first is unreachable via
+    MCP' gap by explicitly telling an agent to call this FIRST for orientation."""
+    from tensor_grep.cli import mcp_server
+
+    assert "call first for orientation" in (mcp_server.tg_orient.__doc__ or "").lower()
+
+
+def test_tg_orient_forwards_max_tokens_max_central_files_and_ignore(monkeypatch):
+    from tensor_grep.cli import mcp_server
+
+    captured: dict[str, object] = {}
+
+    def fake_build_orient_capsule_json(path, **kwargs):
+        captured["path"] = path
+        captured.update(kwargs)
+        return json.dumps({"path": path, "routing_reason": "orient"})
+
+    monkeypatch.setattr(mcp_server, "build_orient_capsule_json", fake_build_orient_capsule_json)
+
+    mcp_server.tg_orient(
+        ".",
+        max_tokens=5000,
+        max_central_files=25,
+        ignore=["vendor/**", "core/skills/**"],
+    )
+
+    assert captured["max_tokens"] == 5000
+    assert captured["max_central_files"] == 25
+    assert captured["ignore"] == ("vendor/**", "core/skills/**")
+
+
+def test_tg_orient_reports_structured_error_for_missing_path():
+    from tensor_grep.cli import mcp_server
+
+    # round-8 (audit #95): a relative, in-root-but-nonexistent path so the confinement check
+    # (which fires first) is not what's being exercised here -- see the analogous
+    # tg_index_search missing-path test above.
+    out = mcp_server.tg_orient("definitely-missing-for-mcp-server-tests")
+
+    parsed = json.loads(out)
+    assert parsed["routing_backend"] == "RepoMap"
+    assert parsed["routing_reason"] == "orient"
+    assert parsed["error"]["code"] == "invalid_input"
+    assert "Traceback" not in parsed["error"]["message"]
+
+
+def test_tg_orient_confines_path_to_mcp_root(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
+    outside.mkdir(exist_ok=True)
+    try:
+        out = mcp_server.tg_orient(str(outside))
+        parsed = json.loads(out)
+        assert parsed["error"]["code"] == "invalid_input"
+        assert "must stay within" in parsed["error"]["message"]
+    finally:
+        outside.rmdir()
+
+
+def test_tg_doctor_returns_json_payload(tmp_path, monkeypatch):
+    """audit #95 Part 2: tg_doctor wraps _build_doctor_payload (main.py:2790)."""
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    payload = json.loads(mcp_server.tg_doctor(str(tmp_path), with_lsp=False))
+
+    assert payload["root"] == str(tmp_path.resolve())
+    assert payload["config"] == str((tmp_path / "sgconfig.yml").resolve())
+    assert payload["lsp"]["enabled"] is False
+    assert "native_tg_binary_exists" in payload
+    assert "search_acceleration_backend" in payload
+    assert payload["mcp_contract_version"] == mcp_server._TG_MCP_SERVER_CONTRACT_VERSION
+    # _build_doctor_payload's OWN "version"/"schema_version" (the tensor-grep semver / doctor
+    # schema int) must survive untouched -- _inject_mcp_contract_fields uses setdefault so it
+    # must never clobber a key the underlying payload already set.
+    assert payload["version"] == mcp_server._mcp_server_version()
+    assert payload["schema_version"] == payload["doctor_schema_version"]
+
+
+def test_tg_doctor_confines_path_to_mcp_root(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
+    outside.mkdir(exist_ok=True)
+    try:
+        out = mcp_server.tg_doctor(str(outside), with_lsp=False)
+        parsed = json.loads(out)
+        assert parsed["error"]["code"] == "invalid_input"
+        assert "must stay within" in parsed["error"]["message"]
+    finally:
+        outside.rmdir()
+
+
+def test_tg_doctor_confines_config_param(tmp_path, monkeypatch):
+    """New hardening beyond the literal ask: `config` is a SECONDARY param that
+    `_build_doctor_payload` uses to relocate its `root` (config's parent dir) for every
+    downstream diagnostic probe -- unconfined, it is the exact 'secondary anchor derived from
+    an unconfined param' bug class #95's gate flagged (see tg_session_file_importers). Confine
+    it to the (already-confined) doctor root, mirroring tg_ruleset_scan's baseline_path."""
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    outside_config = tmp_path.parent / f"outside-cfg-{tmp_path.name}" / "sgconfig.yml"
+    outside_config.parent.mkdir(exist_ok=True)
+    outside_config.write_text("", encoding="utf-8")
+    try:
+        out = mcp_server.tg_doctor(str(tmp_path), config=str(outside_config), with_lsp=False)
+        parsed = json.loads(out)
+        assert parsed["error"]["code"] == "invalid_input"
+        assert "must stay within" in parsed["error"]["message"]
+    finally:
+        outside_config.unlink()
+        outside_config.parent.rmdir()
+
+
+def test_tg_doctor_empty_string_config_falls_back_like_cli(tmp_path, monkeypatch):
+    """Edge case for the config-confinement addition above: CLI `doctor` treats an empty
+    `--config ""` as "not provided" (falls back to root/sgconfig.yml) via a plain `if config:`
+    truthiness check -- config confinement must preserve that, not treat "" as a real
+    (trivially in-root) value that would overwrite the default resolution."""
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    payload = json.loads(mcp_server.tg_doctor(str(tmp_path), config="", with_lsp=False))
+
+    assert payload["root"] == str(tmp_path.resolve())
+    assert payload["config"] == str((tmp_path / "sgconfig.yml").resolve())
+
+
+def test_tg_doctor_forwards_with_lsp_true_by_default(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    captured: dict[str, object] = {}
+
+    def fake_build_doctor_payload(path, config=None, *, with_lsp):
+        captured["path"] = path
+        captured["config"] = config
+        captured["with_lsp"] = with_lsp
+        return {"root": path}
+
+    monkeypatch.setattr(mcp_server, "_build_doctor_payload", fake_build_doctor_payload)
+
+    mcp_server.tg_doctor(".")
+
+    assert captured["with_lsp"] is True
+
+
 def test_tg_context_pack_returns_ranked_inventory(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     from tensor_grep.cli import mcp_server
@@ -5386,11 +5989,13 @@ def test_tg_symbol_impact_uses_bounded_repo_scan_by_default(monkeypatch, tmp_pat
         *,
         semantic_provider="native",
         max_repo_files=None,
+        deadline_seconds=None,
     ):
         seen["symbol"] = symbol
         seen["path"] = path
         seen["semantic_provider"] = semantic_provider
         seen["max_repo_files"] = max_repo_files
+        seen["deadline_seconds"] = deadline_seconds
         return {
             "version": 1,
             "routing_backend": "RepoMap",
@@ -6777,8 +7382,10 @@ CONFINEMENT_EXEMPT: dict[str, str] = {
     "provider": "a semantic-provider mode name (native/lsp/hybrid), not a path",
     "render_profile": "an enum-like render mode name (full/compact/llm), not a path",
     "inline_rules": (
-        "reserved for a future inline ast-grep rule-source param (#95 follow-up, not yet "
-        "shipped) -- listed now so it does not need re-litigating when it lands"
+        "a string of inline ast-grep rule YAML (tg_ruleset_scan, mirrors CLI --inline-rules), "
+        "not a path -- parsed via _load_inline_rule_specs with zero file I/O; length-bounded "
+        "by _MAX_INLINE_RULES_CHARS to blunt a YAML anchor/alias expansion-bomb before it ever "
+        "reaches the parser"
     ),
     "signing_key": (
         "a READ of secret HMAC key material, deliberately gated by the "
@@ -6807,6 +7414,8 @@ CONFINEMENT_EXEMPT: dict[str, str] = {
 _RATCHET_BASE_KWARGS: dict[str, dict[str, object]] = {
     "tg_ruleset_scan": {"ruleset": "secrets-basic", "path": "."},
     "tg_repo_map": {"path": "."},
+    "tg_orient": {"path": "."},
+    "tg_doctor": {"path": "."},
     "tg_context_pack": {"query": "x", "path": "."},
     "tg_edit_plan": {"query": "x", "path": "."},
     "tg_context_render": {"query": "x", "path": "."},
@@ -6945,6 +7554,14 @@ def test_mcp_primary_path_confinement_ratchet(
     with an unclassified string param fails here (or errors loudly via the assertion
     below) until it is consciously confined or added to CONFINEMENT_EXEMPT with a reason.
     """
+    # #102 fold-in (ratchet hermeticity): without this, a REAL TG_MCP_ROOT set in the
+    # operator's/CI's own shell environment (not just a monkeypatch-scoped one from another
+    # test -- pytest's monkeypatch fixture already auto-reverts those) would silently relocate
+    # the confinement anchor away from tmp_path below, so the negative probe's "outside_dir"
+    # might land INSIDE the real TG_MCP_ROOT and false-pass, or the positive probe's in-root
+    # relative value might land OUTSIDE it and false-fail -- a "passes in CI, false result
+    # locally" trap. Hermetic tests must not depend on ambient external environment state.
+    monkeypatch.delenv("TG_MCP_ROOT", raising=False)
     monkeypatch.chdir(tmp_path)
     assert tool_name in _RATCHET_BASE_KWARGS, (
         f"{tool_name} has a non-exempt string param {param_name!r} this ratchet does not "
@@ -6997,16 +7614,16 @@ def test_mcp_primary_path_confinement_ratchet(
 
 def test_confinement_exempt_allowlist_has_no_unused_entries():
     """Every CONFINEMENT_EXEMPT entry must correspond to a real param somewhere in the live
-    schema, except the one documented forward-looking reservation (inline_rules, a future
-    tool addition) -- otherwise a stale allowlist entry could mask a real future gap."""
+    schema -- otherwise a stale allowlist entry could mask a real future gap. (inline_rules
+    shipped as a real tg_ruleset_scan param in audit #95 Part 2; no forward-looking
+    reservation remains.)"""
     from tensor_grep.cli import mcp_server
 
     all_param_names: set[str] = set()
     for tool in asyncio.run(mcp_server.mcp.list_tools()):
         all_param_names.update(tool.inputSchema.get("properties", {}))
 
-    forward_looking = {"inline_rules"}
-    stale = set(CONFINEMENT_EXEMPT) - all_param_names - forward_looking
+    stale = set(CONFINEMENT_EXEMPT) - all_param_names
     assert not stale, f"CONFINEMENT_EXEMPT has stale/unused entries: {sorted(stale)}"
 
 
@@ -7097,3 +7714,84 @@ def test_confine_mcp_path_uses_mcp_root_override(tmp_path, monkeypatch):
     refused_parsed = json.loads(refused)
     assert refused_parsed["error"]["code"] == "invalid_input"
     assert "must stay within" in refused_parsed["error"]["message"]
+
+
+# #102 fold-in: the 13 round-6/7 params `_confine_mcp_path`'s docstring names as a residual
+# cwd-hardcoded set (tg_file_imports/importers `file`, tg_classify_logs `file_path`, the
+# tg_audit_*/tg_review_bundle_* manifest/bundle params, tg_rewrite_apply `audit_manifest`) now
+# route through `_mcp_root()` too, so TG_MCP_ROOT relocates them exactly like every primary
+# path/root param. (tool_name, param_name, base_kwargs) -- base_kwargs supplies every OTHER
+# required param with a value that either doesn't need to exist on disk (confinement is pure
+# path resolution) or is pre-created in the test body when the tool's own loader reads it
+# directly (mirrors _RATCHET_BASE_KWARGS / _ratchet_positive_value above).
+_ANCHOR_SPLIT_CASES: list[tuple[str, str, dict[str, object]]] = [
+    ("tg_file_imports", "file", {}),
+    ("tg_file_importers", "file", {"path": "."}),
+    ("tg_classify_logs", "file_path", {}),
+    ("tg_audit_manifest_verify", "manifest_path", {}),
+    ("tg_audit_manifest_verify", "previous_manifest", {"manifest_path": "manifest.json"}),
+    ("tg_audit_diff", "previous_manifest", {"current_manifest": "current.json"}),
+    ("tg_audit_diff", "current_manifest", {"previous_manifest": "previous.json"}),
+    ("tg_review_bundle_create", "manifest_path", {}),
+    ("tg_review_bundle_create", "scan_path", {"manifest_path": "manifest.json"}),
+    ("tg_review_bundle_create", "previous_manifest", {"manifest_path": "manifest.json"}),
+    ("tg_review_bundle_create", "output_path", {"manifest_path": "manifest.json"}),
+    ("tg_review_bundle_verify", "bundle_path", {}),
+    (
+        "tg_rewrite_apply",
+        "audit_manifest",
+        {"pattern": "x", "replacement": "y", "lang": "python", "path": "."},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "tool_name,param_name,base_kwargs",
+    _ANCHOR_SPLIT_CASES,
+    ids=[f"{t}.{p}" for t, p, _ in _ANCHOR_SPLIT_CASES],
+)
+def test_round8_residual_cwd_params_move_with_tg_mcp_root(
+    tool_name, param_name, base_kwargs, tmp_path, monkeypatch
+):
+    """The residual params still hardcoded to Path.cwd() as of the #95 gate report must be
+    fixed to anchor at _mcp_root() -- an operator who relocates TG_MCP_ROOT to point an MCP
+    server at a fleet repo other than its own cwd must get the SAME relocated confinement on
+    these params as every primary path/root param already gets."""
+    real_root = tmp_path / "real_root"
+    real_root.mkdir()
+    other_cwd = tmp_path / "other_cwd"
+    other_cwd.mkdir()
+
+    monkeypatch.setenv("TG_MCP_ROOT", str(real_root))
+    monkeypatch.chdir(other_cwd)  # cwd != TG_MCP_ROOT so a leftover cwd anchor is caught.
+
+    # ABSOLUTE path, not relative: a bare relative filename resolves safely under ANY anchor
+    # (anchor / "target.json" always stays "within" whatever the anchor happens to be), so it
+    # cannot distinguish the old Path.cwd()-anchored behavior from the fixed _mcp_root()
+    # behavior. An absolute path inside real_root but outside other_cwd can: it is only
+    # accepted when the anchor is really real_root (mirrors test_confine_mcp_path_uses_
+    # mcp_root_override's own absolute-path probe style above).
+    in_root_target = real_root / "target.json"
+    in_root_target.write_text("{}", encoding="utf-8")
+
+    kwargs = {**base_kwargs, param_name: str(in_root_target)}
+    result = _call_mcp_tool_text(tool_name, kwargs)
+
+    assert "must stay within" not in result, (
+        f"{tool_name}.{param_name} rejected a path inside TG_MCP_ROOT while cwd differed from "
+        f"TG_MCP_ROOT -- still anchored to Path.cwd() instead of _mcp_root() "
+        f"(response: {result[:400]!r})"
+    )
+
+    # And a path outside BOTH cwd and TG_MCP_ROOT must still be refused -- this proves the
+    # positive case above is really exercising confinement, not an accidental no-op check.
+    outside = tmp_path / "outside_both"
+    outside.mkdir()
+    (outside / "target.json").write_text("{}", encoding="utf-8")
+    rejected = _call_mcp_tool_text(
+        tool_name, {**base_kwargs, param_name: str(outside / "target.json")}
+    )
+    assert "must stay within" in rejected, (
+        f"{tool_name}.{param_name} accepted a path outside TG_MCP_ROOT (response: "
+        f"{rejected[:400]!r})"
+    )

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -253,7 +253,14 @@ def test_m15_detector_keys_on_child_project_markers(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_l10_calibrate_exits_one_when_unsupported() -> None:
+def test_l10_calibrate_exits_one_when_unsupported(monkeypatch) -> None:
+    # Hermetic: force the no-native-binary branch so this asserts the exit-1 "unsupported"
+    # convention DETERMINISTICALLY, regardless of whether a native tg binary happens to be
+    # present in the runner env. A present binary runs the native `calibrate`, which exits 2
+    # on a no-CUDA box -- an env-dependent FALSE failure of this test's intent (this test
+    # false-failed on all CI platforms when a native binary was present; banked lesson: a test
+    # must not depend on operator-real / env-resolved binary presence).
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)
     runner = CliRunner()
     result = runner.invoke(app, ["calibrate"])
     # On a box without the native binary / CUDA, calibrate is a runtime/unsupported

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -1807,7 +1807,7 @@ def test_mcp_impact_accepts_provider_parameter(tmp_path: Path, monkeypatch) -> N
     monkeypatch.setattr(
         mcp_server,
         "build_symbol_impact",
-        lambda symbol, path, semantic_provider="native", max_repo_files=None: {
+        lambda symbol, path, semantic_provider="native", max_repo_files=None, deadline_seconds=None: {
             "symbol": symbol,
             "path": str(path),
             "semantic_provider": semantic_provider,


### PR DESCRIPTION
## What

Exposes tensor-grep's moat capabilities on the MCP surface (audit #95 Part 2, P0-3 -- the single highest-leverage agentic-audit block; moat features were CLI-only and unreachable to MCP agents). Adds:

- **`tg_orient`** + **`tg_doctor`** MCP tools (were CLI-only).
- **`--rank` / `--semantic`** + **`inline_rules`** on `tg_search` / `tg_ruleset_scan`.
- **`deadline`** on 5 symbol tools (`tg_symbol_impact` / `refs` / `callers` / `file_importers` / `symbol_blast_radius`).
- Contract version `1.1.0 -> 1.2.0`.
- #102 anchor-split (13 residual cwd-anchored params -> `_mcp_root()`).

Closes #102.

## Security hardening -- 6-round adversarial Opus gate

The new `inline_rules` surface is LLM-facing (an MCP client supplies the rule YAML + scan params), so it went through a mandatory adversarial security gate. Six rounds found + closed **6 distinct, reachable issues -- every one of which the build's own 93 security tests passed straight through**:

1. **YAML alias billion-laughs DoS** -- a 469-byte aliased payload hung >15s (downstream `str()` coercions deep-walk the shared alias graph ~9^depth; the 64 KiB length cap admits depth ~1000, detonation is at depth ~9). Fix: reject YAML aliases at the loader (`5dd76a7`).
2. **Deep-nested alias-free `RecursionError`** -- raw traceback. Fix: catch `RecursionError` (`ac976e2`).
3. **Unbounded scan fan-out DoS** -- ~1000 tiny rules (a ~33 KB payload, under the length cap) hung >40s (each rule is a separate ast-grep pass). Fix: `_MAX_INLINE_RULES=100` count cap (`296e90f`).
4. **`BackendExecutionError` raw traceback** on a valid payload. Fix: structured `backend_error` (`296e90f`).
5. **Incomplete fault class** -- `ConfigurationError` (ast-grep is not a declared dependency -> absent on the DEFAULT install, so a trivial one-line rule threw a raw traceback) + `OSError` (unreadable baseline/suppressions path) escaped. Fix: broadened to the whole runtime/IO fault class, mirroring the CLI twin (`f447a4d`).
6. **Unguarded `language` override** -- a rule with its own `language:` short-circuited the loader guard, so a bad top-level `language=` reached `normalize_ast_language` raw. Fix: `try/except` (`f59f42b`).

Plus a non-blocking defense-in-depth `int()`-coerce in `_truncate_evidence_snippet` (`6a033c6`).

**Closeout sweep:** 9- then 50+-payload adversarial sweeps across parse + scan + setup -> **0 reachable raw-traceback escapes**. Round-6 gate verdict: **SHIP** (the one residual it found -- a fractional-float evidence cap -- is double-gated by the MCP inputSchema + FastMCP pydantic int validation and is not reachable over MCP).

## Tests

~40 new SEC/feature tests; **324 `test_mcp_server.py` tests green**; `ruff check` + `ruff format --preview --check` clean; `mypy` Success. Every fix proven with a real adversarial payload run through the shipped tool (e.g. a depth-11 bomb -> `invalid_input` in 0.031s). The one local `test_cli_modes` failure is pre-existing test-ordering pollution (passes in isolation; CI is green on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
