### PR TITLE
perf(cli): dedupe tg impact double repo-map build + gate context-pack on deadline -- 28.6% faster (dogfood #103)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8931,8 +8931,11 @@ def impact(
     """Return likely impacted files and tests for a symbol change."""
     from tensor_grep.cli.repo_map import (
         _apply_symbol_token_budget,
-        build_symbol_callers,
-        build_symbol_impact,
+        _copy_partial_signal,
+        _deadline_monotonic_from_seconds,
+        build_repo_map,
+        build_symbol_callers_from_map,
+        build_symbol_impact_from_map,
     )
 
     try:
@@ -8942,26 +8945,41 @@ def impact(
             symbol_option=symbol,
             command_name="impact",
         )
-        payload = build_symbol_impact(
-            resolved_symbol,
+        # task #103: build the repo_map and convert --deadline to an absolute monotonic
+        # timestamp ONCE, then share both across the impact + callers passes below -- mirrors
+        # build_symbol_blast_radius's own shared-map pattern (repo_map.py's build_repo_map(...)
+        # once + two `_from_map` calls against it) and the daemon/MCP server, which already
+        # share one repo_map across multiple `_from_map` calls in a session. Previously each of
+        # the two independent wrapper calls (build_symbol_impact + build_symbol_callers) built
+        # its OWN repo_map from scratch -- parsing the whole repo twice -- AND independently
+        # re-derived deadline_monotonic from a fresh time.monotonic() at its own start, so
+        # --deadline silently allowed up to ~2x the requested budget for `tg impact`.
+        deadline_monotonic = _deadline_monotonic_from_seconds(deadline)
+        repo_map = build_repo_map(
             resolved_path,
-            semantic_provider=provider,
             max_repo_files=max_repo_files,
-            deadline_seconds=deadline,
+            deadline_monotonic=deadline_monotonic,
+        )
+        payload = build_symbol_impact_from_map(
+            repo_map,
+            resolved_symbol,
+            semantic_provider=provider,
+            deadline_monotonic=deadline_monotonic,
             max_tests=max_tests,
         )
+        _copy_partial_signal(payload, repo_map)
         # H5: impact previously surfaced only definition/import-derived `files` and so
         # under-reported call sites relative to `tg callers` (which finds the CLI
         # handler, RPC handler, and tests). Populate a top-level `callers` key from the
         # same caller pass so impact is a superset, not a subset, of callers.
         if not payload.get("no_match"):
-            callers_payload = build_symbol_callers(
+            callers_payload = build_symbol_callers_from_map(
+                repo_map,
                 resolved_symbol,
-                resolved_path,
                 semantic_provider=provider,
-                max_repo_files=max_repo_files,
-                deadline_seconds=deadline,
+                deadline_monotonic=deadline_monotonic,
             )
+            _copy_partial_signal(callers_payload, repo_map)
             payload["callers"] = list(callers_payload.get("callers", []))
             # Propagate the caller-scan's --deadline partial signal (cursor review 1.40.0): impact's
             # second pass can be deadline-truncated even when the first pass wasn't, so carry partial +

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7101,6 +7101,8 @@ def _build_context_pack_from_map(
     query: str,
     *,
     _test_source_limit: int | None = None,
+    deadline_monotonic: float | None = None,
+    deadline_hit: _DeadlineBreakFlag | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     with _profiling_phase(_profiling_collector, "context_scoring"):
@@ -7126,6 +7128,15 @@ def _build_context_pack_from_map(
 
         scored_symbols: list[dict[str, Any]] = []
         for symbol in payload["symbols"]:
+            # task #103: this loop iterates every symbol in the scanned repo -- the single
+            # largest repo-size-proportional loop in context-pack construction (profiled at
+            # ~13% of a `tg callers`/`tg impact` call) -- and ran fully unbounded regardless of
+            # --deadline before this fix. Mirror the same pre-iteration deadline check
+            # _preferred_definition_files/_relevant_tests_for_symbol already use.
+            if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+                if deadline_hit is not None:
+                    deadline_hit.hit = True
+                break
             score = _score_symbol(symbol, symbol_terms)
             if score <= 0:
                 continue
@@ -12628,6 +12639,8 @@ def build_context_pack_from_map(
     query: str,
     *,
     _test_source_limit: int | None = None,
+    deadline_monotonic: float | None = None,
+    deadline_hit: _DeadlineBreakFlag | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     payload = dict(repo_map)
@@ -12641,6 +12654,8 @@ def build_context_pack_from_map(
         payload,
         query,
         _test_source_limit=_test_source_limit,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=deadline_hit,
         _profiling_collector=_profiling_collector,
     )
     return _attach_profiling(payload, _profiling_collector)
@@ -13852,9 +13867,15 @@ def build_symbol_impact_from_map(
         payload["provider_status"] = dict(default_status)
         _copy_lsp_evidence_status(payload, defs_payload)
         return _attach_profiling(payload, _profiling_collector)
+    # task #103 Fix 2: thread the shared deadline into context-pack's own symbol-scoring loop too
+    # -- previously unbounded even when this same deadline_monotonic already gated the sibling
+    # scans just below (the #52 fix (loop C) comment).
+    context_pack_deadline_hit = _DeadlineBreakFlag()
     context_payload = build_context_pack_from_map(
         repo_map,
         symbol,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=context_pack_deadline_hit,
         _profiling_collector=_profiling_collector,
     )
     # #52 fix (loop C): build_symbol_impact_from_map previously threaded NO deadline at all into
@@ -14004,7 +14025,13 @@ def build_symbol_impact_from_map(
     # definition scoring + related-test matching, both unbounded before this fix) into partial --
     # mirrors the callers/blast-radius fold-in pattern (task #61) so a --deadline-truncated impact
     # result is never silently reported as complete.
-    if preferred_definition_deadline_hit.hit or related_tests_deadline_hit.hit:
+    # task #103 Fix 2: context_pack_deadline_hit joins the same fold-in -- the context-pack
+    # symbol-scoring loop is a THIRD sibling scan sharing this deadline_monotonic.
+    if (
+        preferred_definition_deadline_hit.hit
+        or related_tests_deadline_hit.hit
+        or context_pack_deadline_hit.hit
+    ):
         payload["partial"] = True
         payload["deadline_limit"] = {"deadline_exceeded": True}
     _copy_scan_limit(payload, defs_payload)
@@ -15165,9 +15192,14 @@ def build_symbol_callers_from_map(
     import_graph_consumer_files = sorted(
         dict.fromkeys(str(current["file"]) for current in import_graph_consumers)
     )
+    # task #103 Fix 2: thread the shared deadline into context-pack's own symbol-scoring loop too
+    # -- previously unbounded even though it feeds the same 4-way partial fold-in just below.
+    context_pack_deadline_hit = _DeadlineBreakFlag()
     context_payload = build_context_pack_from_map(
         repo_map,
         symbol,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=context_pack_deadline_hit,
         _profiling_collector=_profiling_collector,
     )
     # #52 fix (loop B): this sibling loop used to be unbounded even though it feeds the
@@ -15224,13 +15256,15 @@ def build_symbol_callers_from_map(
     # task #61 / #52 fix (loop B): fold ALL sibling loops' early-break signal in alongside the main
     # caller-scan loop's own flag -- a central symbol can finish the bounded main scan inside budget
     # while any sibling loop (import-graph-consumers, preferred-definition-file scoring,
-    # related-test matching) pushes wall-clock well past --deadline. Any one of the four breaking
-    # early makes this result partial.
+    # related-test matching, context-pack symbol scoring) pushes wall-clock well past --deadline.
+    # Any one of the five breaking early makes this result partial.
+    # task #103 Fix 2: context_pack_deadline_hit joins the same fold-in.
     if (
         caller_scan_deadline_hit
         or import_graph_consumers_deadline_hit.hit
         or preferred_definition_deadline_hit.hit
         or related_tests_deadline_hit.hit
+        or context_pack_deadline_hit.hit
     ):
         # moat P0-6 step 6: the caller-scan was cut short by --deadline -> partial (the callers list
         # holds what was found before the budget). graph_completeness downgrades so an agent does not

--- a/tests/unit/test_cli_deadline_flag.py
+++ b/tests/unit/test_cli_deadline_flag.py
@@ -137,26 +137,31 @@ def test_blast_radius_partial_exits_2(tmp_path: Path, monkeypatch) -> None:
 def test_impact_propagates_caller_scan_partial_exits_2(tmp_path: Path, monkeypatch) -> None:
     # cursor review 1.40.0: impact's second caller-scan pass can be deadline-truncated; impact must
     # carry that partial signal so it exits 2 like `tg callers`.
+    #
+    # task #103: impact() now builds ONE shared repo_map and calls the *_from_map variants
+    # directly (build_symbol_impact_from_map / build_symbol_callers_from_map) instead of the
+    # build_symbol_impact/build_symbol_callers wrappers -- mock at the new seam, since the old
+    # wrapper names are no longer imported/called by the CLI handler at all.
     (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
 
-    def _impact(symbol, path=".", **_kwargs):
+    def _impact_from_map(repo_map_arg, symbol, **_kwargs):
         # impact FOUND files, but its second caller-scan pass is deadline-truncated -> impact must carry
         # that partial signal and exit 2 EVEN THOUGH it found files (council-verified B: truncation trumps
         # found), so an agent never trusts a truncated impact set as exhaustive.
         return {
             "symbol": symbol,
-            "path": str(path),
+            "path": str(repo_map_arg.get("path", ".")),
             "files": ["m.py"],
             "tests": [],
             "callers": [],
             "no_match": False,
         }
 
-    def _callers(symbol, path=".", **_kwargs):
+    def _callers_from_map(repo_map_arg, symbol, **_kwargs):
         return {"callers": [], "partial": True, "deadline_limit": {"deadline_exceeded": True}}
 
-    monkeypatch.setattr(repo_map, "build_symbol_impact", _impact)
-    monkeypatch.setattr(repo_map, "build_symbol_callers", _callers)
+    monkeypatch.setattr(repo_map, "build_symbol_impact_from_map", _impact_from_map)
+    monkeypatch.setattr(repo_map, "build_symbol_callers_from_map", _callers_from_map)
     result = CliRunner().invoke(app, ["impact", "foo", str(tmp_path), "--json"])
     assert result.exit_code == 2, result.output
 

--- a/tests/unit/test_impact_callers_shared_map.py
+++ b/tests/unit/test_impact_callers_shared_map.py
@@ -1,0 +1,135 @@
+"""Task #103: `tg impact` built its whole repo_map TWICE per invocation.
+
+Root cause (profiler-confirmed, not a PageRank cost -- that's ~22ms and negligible): the CLI
+`impact()` handler called two self-contained wrappers, `build_symbol_impact(...)` and
+`build_symbol_callers(...)`, and EACH one independently called `build_repo_map(...)` from scratch
+(so the whole repo was parsed twice) AND independently converted `--deadline` into a fresh
+`deadline_monotonic = time.monotonic() + deadline_seconds` starting from ITS OWN call time (so
+`--deadline N` silently allowed up to ~2N seconds of total wall-clock across the two passes).
+
+The fix builds `repo_map` and `deadline_monotonic` ONCE in `impact()` and calls the pre-built-map
+variants (`build_symbol_impact_from_map` / `build_symbol_callers_from_map`) against that shared
+map -- the same proven pattern `build_symbol_blast_radius` already uses internally
+(repo_map.py's own `build_repo_map(...)` once + two `_from_map` calls sharing one
+`deadline_monotonic`), and the same pattern the daemon (session_store.py) and MCP server already
+use across a session's whole repo_map.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import tensor_grep.cli.repo_map as repo_map
+from tensor_grep.cli.main import app
+
+
+def _make_repo(root: Path, count: int) -> None:
+    src = root / "src"
+    src.mkdir(parents=True)
+    for index in range(count):
+        (src / f"m{index}.py").write_text(
+            f"def f{index}():\n    return {index}\n", encoding="utf-8"
+        )
+
+
+def _make_caller_repo(root: Path) -> None:
+    (root / "m.py").write_text(
+        "def widget():\n    return 1\n\n\ndef use():\n    return widget()\n", encoding="utf-8"
+    )
+
+
+def test_impact_builds_repo_map_exactly_once(tmp_path: Path, monkeypatch) -> None:
+    # THE regression: before the fix this counted 2 (one build_repo_map call inside
+    # build_symbol_impact, a second independent one inside build_symbol_callers) -- doubling
+    # _imports_and_symbols_for_path calls (2 x file count) for a single `tg impact` invocation.
+    _make_caller_repo(tmp_path)
+    call_count = {"n": 0}
+    original = repo_map.build_repo_map
+
+    def _counting_build_repo_map(*args, **kwargs):
+        call_count["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_repo_map", _counting_build_repo_map)
+
+    result = CliRunner().invoke(app, ["impact", "widget", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert call_count["n"] == 1, (
+        f"build_repo_map invoked {call_count['n']} times for one `tg impact` call -- "
+        "expected exactly 1 (a shared repo_map across the impact + callers passes)"
+    )
+
+
+def test_impact_builds_repo_map_exactly_once_even_when_symbol_not_found(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The no_match branch skips the second (callers) pass entirely, but build_repo_map must still
+    # only run once -- guards against a fix that only shares the map on the "found" path.
+    _make_caller_repo(tmp_path)
+    call_count = {"n": 0}
+    original = repo_map.build_repo_map
+
+    def _counting_build_repo_map(*args, **kwargs):
+        call_count["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_repo_map", _counting_build_repo_map)
+
+    result = CliRunner().invoke(app, ["impact", "does_not_exist_anywhere", str(tmp_path), "--json"])
+
+    assert result.exit_code == 1, result.output
+    assert call_count["n"] == 1, f"build_repo_map invoked {call_count['n']} times, expected 1"
+
+
+def test_impact_deadline_not_doubled_by_second_pass(tmp_path: Path, monkeypatch) -> None:
+    # THE deadline-doubling regression: before the fix, build_symbol_impact's own repo_map build
+    # could consume the FULL --deadline budget parsing files, then build_symbol_callers converted
+    # --deadline into a SECOND fresh deadline_monotonic (time.monotonic() + deadline_seconds,
+    # evaluated AFTER the first pass already advanced the clock) and burned a second full budget
+    # rebuilding the repo_map from scratch -- up to ~2x the requested --deadline in total
+    # wall-clock. A deterministic fake clock (advances only when a file is actually parsed) proves
+    # the TOTAL parse-clock consumed by the whole `tg impact` call stays within one shared budget.
+    _make_repo(tmp_path, 20)
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_parse = repo_map._imports_and_symbols_for_path
+
+    def _clock_advancing_parse(path, **kwargs):
+        clock["t"] += 1.0
+        return original_parse(path, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_imports_and_symbols_for_path", _clock_advancing_parse)
+
+    result = CliRunner().invoke(app, ["impact", "f1", str(tmp_path), "--deadline", "5", "--json"])
+
+    assert result.exit_code in (0, 2), result.output
+    total_ticks_consumed = clock["t"] - base
+    # One shared 5-tick budget: allow a little slack for legitimate deadline-gated sibling loops
+    # (#52/#61) that share the SAME deadline_monotonic, but nowhere near the old ~2x-budget
+    # (10-tick) double-build behavior.
+    assert total_ticks_consumed <= 7, (
+        f"consumed {total_ticks_consumed} parse-ticks against a 5-tick --deadline budget -- "
+        "deadline_monotonic was likely re-derived a second time (the pre-fix double-build bug)"
+    )
+
+
+def test_impact_deadline_none_still_builds_repo_map_once(tmp_path: Path, monkeypatch) -> None:
+    # Golden-parity guard: no --deadline supplied is unaffected by the shared-map fix.
+    _make_caller_repo(tmp_path)
+    call_count = {"n": 0}
+    original = repo_map.build_repo_map
+
+    def _counting_build_repo_map(*args, **kwargs):
+        call_count["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_repo_map", _counting_build_repo_map)
+
+    result = CliRunner().invoke(app, ["impact", "widget", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert call_count["n"] == 1

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -908,3 +908,161 @@ def test_step52_high_fan_out_symbol_no_deadline_still_completes(tmp_path: Path) 
 
     assert "partial" not in result
     assert result["graph_completeness"] == "moderate"
+
+
+# =================================================================================================
+# Task #103 Fix 2: build_context_pack_from_map / _build_context_pack_from_map accepted NO deadline
+# parameter at all and ran their full symbol-scoring cost unconditionally -- called from BOTH
+# build_symbol_impact_from_map (repo_map.py:~13855) and build_symbol_callers_from_map
+# (repo_map.py:~15168), so --deadline leaked wall-clock through this shared helper on every
+# impact/callers/blast-radius call (profiled at ~13% of callers' cost). Mirrors the #52/#61
+# _DeadlineBreakFlag idiom exactly: gate the symbol-scoring loop (the single largest
+# repo-size-proportional loop in context-pack construction), fold the early-break signal into
+# `partial` at both call sites.
+# =================================================================================================
+
+
+def _make_many_symbols_repo(root: Path, count: int) -> None:
+    src = root / "src"
+    src.mkdir(parents=True)
+    for index in range(count):
+        (src / f"m{index}.py").write_text(
+            f"def widget_{index}():\n    return {index}\n", encoding="utf-8"
+        )
+
+
+def test_step103_context_pack_honors_already_expired_deadline(tmp_path: Path) -> None:
+    _make_many_symbols_repo(tmp_path, 8)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    flag = repo_map._DeadlineBreakFlag()
+
+    result = repo_map.build_context_pack_from_map(
+        rm, "widget", deadline_monotonic=time.monotonic() - 1.0, deadline_hit=flag
+    )
+
+    assert flag.hit is True
+    assert isinstance(result, dict)  # returns a valid (partial) payload -- does not raise or hang
+
+
+def test_step103_context_pack_none_deadline_is_unaffected(tmp_path: Path) -> None:
+    # Golden-parity guard: deadline_monotonic=None (the default, and every pre-existing call site's
+    # behavior) never trips the new gate.
+    _make_many_symbols_repo(tmp_path, 8)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    flag = repo_map._DeadlineBreakFlag()
+
+    repo_map.build_context_pack_from_map(rm, "widget", deadline_hit=flag)
+
+    assert flag.hit is False
+
+
+def test_step103_context_pack_loop_breaks_mid_scan_not_just_pre_check(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The sharper claim: the deadline crosses WHILE the scoring loop is running, not merely
+    # pre-expired -- proves a PARTIAL (not zero, not full) symbol set was scored.
+    _make_many_symbols_repo(tmp_path, 10)
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_score = repo_map._score_symbol
+    call_count = {"n": 0}
+
+    def _advancing_score(*args, **kwargs):
+        call_count["n"] += 1
+        clock["t"] += 1.0
+        return original_score(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_score_symbol", _advancing_score)
+    flag = repo_map._DeadlineBreakFlag()
+
+    repo_map.build_context_pack_from_map(
+        rm, "widget", deadline_monotonic=base + 4.0, deadline_hit=flag
+    )
+
+    assert flag.hit is True
+    assert 0 < call_count["n"] < 10  # cut short mid-scan, not exhausted
+
+
+def test_step103_impact_marks_partial_on_context_pack_timeout_alone(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # Isolation test (mirrors test_step52_impact_from_map_marks_partial_on_relevant_tests_timeout_
+    # alone above): _score_symbol is unique to the context-pack scoring loop (no other sibling loop
+    # in build_symbol_impact_from_map calls it), so hooking it isolates the context-pack loop as the
+    # SOLE source of the partial signal.
+    _make_many_symbols_repo(tmp_path, 10)
+    (tmp_path / "src" / "target.py").write_text("def shared():\n    return 1\n", encoding="utf-8")
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_score = repo_map._score_symbol
+    call_count = {"n": 0}
+
+    def _advancing_score(*args, **kwargs):
+        call_count["n"] += 1
+        clock["t"] += 1.0
+        return original_score(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_score_symbol", _advancing_score)
+
+    result = repo_map.build_symbol_impact_from_map(rm, "shared", deadline_monotonic=base + 3.0)
+
+    assert call_count["n"] > 0  # the context-pack scoring loop actually ran
+    assert result.get("partial") is True
+    assert result["deadline_limit"]["deadline_exceeded"] is True
+
+
+def test_step103_callers_marks_partial_on_context_pack_timeout_alone(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _make_many_symbols_repo(tmp_path, 10)
+    (tmp_path / "src" / "target.py").write_text("def shared():\n    return 1\n", encoding="utf-8")
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_score = repo_map._score_symbol
+    call_count = {"n": 0}
+
+    def _advancing_score(*args, **kwargs):
+        call_count["n"] += 1
+        clock["t"] += 1.0
+        return original_score(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_score_symbol", _advancing_score)
+
+    result = repo_map.build_symbol_callers_from_map(rm, "shared", deadline_monotonic=base + 3.0)
+
+    assert call_count["n"] > 0  # the context-pack scoring loop actually ran
+    assert result.get("partial") is True
+    assert result["graph_completeness"] == "partial"
+    assert result["deadline_limit"]["deadline_exceeded"] is True
+
+
+def test_step103_impact_no_deadline_context_pack_stays_complete(tmp_path: Path) -> None:
+    # Golden-parity companion: without --deadline, behavior is unchanged.
+    _make_many_symbols_repo(tmp_path, 6)
+    (tmp_path / "src" / "target.py").write_text("def shared():\n    return 1\n", encoding="utf-8")
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    result = repo_map.build_symbol_impact_from_map(rm, "shared")  # no deadline
+
+    assert "partial" not in result
+    assert "deadline_limit" not in result
+
+
+def test_step103_callers_no_deadline_context_pack_stays_complete(tmp_path: Path) -> None:
+    _make_many_symbols_repo(tmp_path, 6)
+    (tmp_path / "src" / "target.py").write_text("def shared():\n    return 1\n", encoding="utf-8")
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    result = repo_map.build_symbol_callers_from_map(rm, "shared")  # no deadline
+
+    assert "partial" not in result
+    assert result["graph_completeness"] == "moderate"


### PR DESCRIPTION
## What

Fix `tg impact` / `tg callers` latency (dogfood #103, CEO-flagged 6.5-15.8s). A profiler pass -- not a guess -- **refuted** the assumed PageRank cause (that is 22ms) and found two defects:

**Fix 1 (primary): `tg impact` built the whole repo map TWICE.** The `impact()` handler called both `build_symbol_impact()` AND `build_symbol_callers()` wrappers, each independently calling `build_repo_map()` from scratch (`_imports_and_symbols_for_path` fired 2x per call), and each restarted the `--deadline` clock (so `--deadline` silently doubled). Now builds `repo_map` + `deadline_monotonic` ONCE and calls the `_from_map` variants against a shared map -- the pattern `build_symbol_blast_radius` already uses.

**Fix 2: `build_context_pack_from_map` had no deadline gate** -- it ran unconditionally, leaking wall-clock past `--deadline`. Now threads `deadline_monotonic` through and gates its symbol-scoring loop, folding the new flag into `partial` at both call sites (exit-2 contract preserved).

## Measured impact (honest)

`tg impact` on this repo (863 files): **16.42s -> 11.73s mean = 28.6% reduction** (5 runs each). Not a full halving -- the caller-scan phase (never duplicated by this bug) dominates wall-clock more than the repo-map parse; the fix eliminates exactly the duplicated work, proven deterministically by the `build_repo_map` call-count 2->1 and `--deadline` 10->5 tick tests.

## Tests

RED-then-GREEN: `test_impact_builds_repo_map_exactly_once` (2->1), `test_impact_deadline_not_doubled_by_second_pass` (10->5 ticks), + 7 deadline-gate tests + golden-parity companions. Also updated one existing test whose mock target Fix 1 bypasses (it would have silently stopped testing). 306 (`-k impact/callers/repo_map`) + 618 (at-risk files) pass; the 66 new/updated deadline+shared-map tests re-verified green in the real venv; ruff + mypy clean. Output shape + exit-2 contract unchanged by construction.

Non-security (main.py + repo_map.py orchestration) -> no adversarial gate required.

## Follow-up (not in this PR)

Deadline-gated loops check BETWEEN items, not mid-item, so worst-case overshoot is bounded by the single largest file's parse cost (this repo has 10-15k-line files). Pre-existing, shared by several loops; out of scope here -- flagged for a separate task.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
