### PR TITLE
feat(daemon): default-OFF warm-daemon fast path for the 5 symbol commands (audit #94 Part A Tier-1)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -24,14 +24,9 @@ if sys.platform.startswith("win") and not sys.stdout.isatty():
 
 import typer
 
-from tensor_grep.backends.ast_backend import is_native_ast_language, normalize_ast_language
 from tensor_grep.backends.base import BackendExecutionError
 from tensor_grep.cli import ast_workflows
 from tensor_grep.cli.formatters.base import OutputFormatter
-from tensor_grep.cli.lsp_provider_setup import (
-    install_managed_lsp_providers,
-    supported_lsp_languages,
-)
 from tensor_grep.cli.runtime_paths import (
     _native_tg_version,
     _native_tg_version_matches,
@@ -212,7 +207,8 @@ persisted repeated-query acceleration, and optional GPU routing.
 - `TG_MCP_ALLOW_VALIDATION_COMMANDS`: Set to `1` to let the `tg mcp` server's `tg_rewrite_apply` tool accept and shell-execute `lint_cmd` / `test_cmd`; default off (such requests are rejected with `code="unsupported_option"`).
 - `TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS`: Total per-command budget for optional external LSP provider requests before native fallback.
 - `TENSOR_GREP_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES`, `TENSOR_GREP_STRING_INDEX_CACHE_MAX_ENTRIES`, `TENSOR_GREP_AST_QUERY_CACHE_MAX_ENTRIES`, `TENSOR_GREP_AST_NODE_INDEX_CACHE_MAX_ENTRIES`, `TENSOR_GREP_REPO_CONTEXT_CACHE_MAX_ROOTS`: Bound long-lived in-process search and repo-context caches.
-- `TENSOR_GREP_SESSION_RESPONSE_CACHE_MAX_BYTES`, `TENSOR_GREP_LSP_PROVIDER_CLIENT_CACHE_MAX_ENTRIES`, `TENSOR_GREP_LSP_PROVIDER_OPEN_DOCUMENT_MAX_ENTRIES`: Bound agent-loop response and LSP provider caches.""",
+- `TENSOR_GREP_SESSION_RESPONSE_CACHE_MAX_BYTES`, `TENSOR_GREP_LSP_PROVIDER_CLIENT_CACHE_MAX_ENTRIES`, `TENSOR_GREP_LSP_PROVIDER_OPEN_DOCUMENT_MAX_ENTRIES`: Bound agent-loop response and LSP provider caches.
+- `TG_SESSION_DAEMON_AUTOSTART`: Set to `1` to opt `defs`/`impact`/`refs`/`callers`/`blast-radius` into a default warm-daemon fast path (probes a running `tg session daemon`; auto-spawns one non-blocking on a miss). Default off (today's cold-path behavior); always forced off when `CI` or `GITHUB_ACTIONS` is set. Querying N distinct repo roots with this on can leave up to N resident daemons; each self-shuts-down after `TG_SESSION_DAEMON_IDLE_SECONDS` (900s default) of inactivity.""",
     no_args_is_help=True,
     add_completion=True,
     rich_markup_mode="markdown",
@@ -1937,6 +1933,8 @@ def _restart_session_daemon_after_upgrade(snapshot: dict[str, Any] | None) -> st
 
 
 def _doctor_lsp_languages() -> list[str]:
+    from tensor_grep.cli.lsp_provider_setup import supported_lsp_languages
+
     return supported_lsp_languages()
 
 
@@ -4553,6 +4551,8 @@ def _load_yaml_dict(path: Path) -> dict[str, object]:
 
 
 def _load_sg_project_config(config_path: str | None) -> dict[str, object]:
+    from tensor_grep.backends.ast_backend import normalize_ast_language
+
     resolved = Path(config_path or "sgconfig.yml").resolve()
     if not resolved.exists():
         raise FileNotFoundError(f"Config file {resolved} not found. Use `tg new` to create one.")
@@ -4597,6 +4597,8 @@ def _extract_rule_pattern(rule_data: dict[str, object]) -> str | None:
 
 
 def _load_rule_specs(project_cfg: dict[str, object]) -> list[dict[str, str]]:
+    from tensor_grep.backends.ast_backend import normalize_ast_language
+
     root_dir = cast(Path, project_cfg["root_dir"])
     rule_dirs = cast(list[str], project_cfg["rule_dirs"])
     default_language = cast(str, project_cfg["language"])
@@ -4638,6 +4640,8 @@ def _load_inline_rule_specs(
     inline_rules_text: str, *, default_language: str | None = None
 ) -> list[dict[str, str]]:
     import yaml
+
+    from tensor_grep.backends.ast_backend import normalize_ast_language
 
     class _NoAliasSafeLoader(yaml.SafeLoader):
         """SafeLoader that REJECTS YAML aliases. Inline ast-grep rules never legitimately
@@ -5223,6 +5227,7 @@ def _regex_rule_targets_file(rule_language: str, file_path: str) -> bool:
     silently drop a finding for a language ``_target_language_for_path`` does not yet
     recognize.
     """
+    from tensor_grep.backends.ast_backend import normalize_ast_language
     from tensor_grep.cli.repo_map import _target_language_for_path
 
     file_language = _target_language_for_path(file_path)
@@ -5253,6 +5258,7 @@ def _run_ast_scan_payload(
     max_evidence_snippets_per_file: int = 1,
     max_evidence_snippet_chars: int = 120,
 ) -> dict[str, object]:
+    from tensor_grep.backends.ast_backend import normalize_ast_language
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.result import SearchResult
     from tensor_grep.io.directory_scanner import DirectoryScanner
@@ -5727,6 +5733,7 @@ def _select_ast_backend_for_pattern(
     pattern: str,
     backend_cache: dict[tuple[str | None, str, bool], "ComputeBackend"] | None = None,
 ) -> "ComputeBackend":
+    from tensor_grep.backends.ast_backend import is_native_ast_language
     from tensor_grep.core.pipeline import ConfigurationError, Pipeline
 
     stripped_pattern = pattern.strip()
@@ -7530,6 +7537,89 @@ def _daemon_directory_path(path: str) -> str | None:
     return str(resolved)
 
 
+def _session_daemon_autostart_enabled() -> bool:
+    """TG_SESSION_DAEMON_AUTOSTART opt-in for the default Tier-1 warm-daemon fast path.
+
+    Task #94 Part A, must-fix 4. DEFAULT OFF: unset (or any value other than 1/true/yes/on)
+    means today's behavior EXACTLY -- no daemon is probed, spawned, or routed to, for any of
+    the 5 symbol commands. Flipping this default ON is a separate, later, conscious decision
+    (per the design-gate verdict SHIP-WITH-CHANGES); this PR only wires the plumbing.
+
+    Auto-forced OFF whenever CI or GITHUB_ACTIONS is set, regardless of the flag's own value,
+    so a CI job can never leave a background session-daemon process (idle-lived up to
+    TG_SESSION_DAEMON_IDLE_SECONDS, 900s default) running past the job that spawned it.
+    """
+    if env_flag_enabled("CI") or env_flag_enabled("GITHUB_ACTIONS"):
+        return False
+    return env_flag_enabled("TG_SESSION_DAEMON_AUTOSTART")
+
+
+def _maybe_symbol_command_via_running_daemon(
+    *,
+    command: str,
+    path: str,
+    symbol: str,
+    provider: str,
+    max_repo_files: int,
+    max_tests: int | None = None,
+    max_depth: int | None = None,
+) -> dict[str, Any] | None:
+    """Fail-open Tier-1 default fast path (task #94 Part A) for defs/impact/refs/callers/
+    blast_radius.
+
+    Mirrors the existing ``_maybe_context_render_via_running_daemon`` /
+    ``_maybe_edit_plan_via_running_daemon`` fail-open shape (probe-only, ``except Exception:
+    return None``) with one addition: on a probe MISS (no daemon reachable yet) it fires a
+    non-blocking spawn so a LATER call is warm, while THIS call still returns None and the
+    caller runs the existing cold path unchanged (must-fix 3 -- cold call #1 must never block
+    on daemon warmup).
+
+    Returns None (forcing the caller's cold path) whenever: the flag is off, a non-native
+    provider was requested (the daemon session is native-only, same rule as context-render/
+    edit-plan), the path does not resolve to a directory, no daemon could be reached, or the
+    daemon responded with an error. A `refresh_on_stale=True` request (mirroring
+    ``_maybe_context_render_via_running_daemon``) means a session whose files changed on disk
+    is refreshed once before being served, so warm output matches cold output on a changed
+    tree (must-fix 5).
+    """
+    if not _session_daemon_autostart_enabled():
+        return None
+    if provider != "native":
+        return None
+    daemon_path = _daemon_directory_path(path)
+    if daemon_path is None:
+        return None
+    try:
+        from tensor_grep.cli.session_daemon import (
+            maybe_autostart_session_daemon_nonblocking,
+            request_running_session_daemon,
+        )
+
+        request: dict[str, Any] = {
+            "command": command,
+            "path": daemon_path,
+            "symbol": symbol,
+            "provider": provider,
+            "refresh_on_stale": True,
+            "max_repo_files": max_repo_files,
+        }
+        if max_tests is not None:
+            request["max_tests"] = max_tests
+        if max_depth is not None:
+            request["max_depth"] = max_depth
+        payload = request_running_session_daemon(daemon_path, request)
+        if payload is None:
+            # No daemon reachable yet. Fire-and-forget spawn so a LATER call is warm; THIS
+            # call must not block on daemon startup -- run the cold path below (must-fix 3).
+            maybe_autostart_session_daemon_nonblocking(daemon_path)
+            return None
+        if "error" in payload:
+            return None
+        return payload
+    except Exception:
+        return None
+
+
 def _maybe_context_render_via_running_daemon(
     *,
     path: str,
@@ -8827,13 +8917,25 @@ def defs(
             symbol_option=symbol,
             command_name="defs",
         )
-        payload = build_symbol_defs(
-            resolved_symbol,
-            resolved_path,
-            semantic_provider=provider,
+        # task #94 Part A Tier-1: default-OFF warm-daemon fast path. Fails open to the cold
+        # build_symbol_defs(...) call below on any miss/error -- see
+        # _maybe_symbol_command_via_running_daemon's docstring for the full contract.
+        payload = _maybe_symbol_command_via_running_daemon(
+            command="defs",
+            path=resolved_path,
+            symbol=resolved_symbol,
+            provider=provider,
             max_repo_files=max_repo_files,
             max_tests=max_tests,
         )
+        if payload is None:
+            payload = build_symbol_defs(
+                resolved_symbol,
+                resolved_path,
+                semantic_provider=provider,
+                max_repo_files=max_repo_files,
+                max_tests=max_tests,
+            )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -8990,48 +9092,106 @@ def impact(
         # re-derived deadline_monotonic from a fresh time.monotonic() at its own start, so
         # --deadline silently allowed up to ~2x the requested budget for `tg impact`.
         deadline_monotonic = _deadline_monotonic_from_seconds(deadline)
-        repo_map = build_repo_map(
-            resolved_path,
-            max_repo_files=max_repo_files,
-            deadline_monotonic=deadline_monotonic,
-        )
-        payload = build_symbol_impact_from_map(
-            repo_map,
-            resolved_symbol,
-            semantic_provider=provider,
-            deadline_monotonic=deadline_monotonic,
-            max_tests=max_tests,
-        )
-        _copy_partial_signal(payload, repo_map)
-        # H5: impact previously surfaced only definition/import-derived `files` and so
-        # under-reported call sites relative to `tg callers` (which finds the CLI
-        # handler, RPC handler, and tests). Populate a top-level `callers` key from the
-        # same caller pass so impact is a superset, not a subset, of callers.
-        if not payload.get("no_match"):
-            callers_payload = build_symbol_callers_from_map(
-                repo_map,
-                resolved_symbol,
-                semantic_provider=provider,
-                deadline_monotonic=deadline_monotonic,
-            )
-            _copy_partial_signal(callers_payload, repo_map)
-            payload["callers"] = list(callers_payload.get("callers", []))
+
+        def _merge_impact_and_callers(
+            impact_payload: dict[str, Any], callers_payload: dict[str, Any]
+        ) -> None:
+            # H5 merge (task #103): impact previously surfaced only definition/import-derived
+            # `files` and so under-reported call sites relative to `tg callers`. Shared by BOTH
+            # the cold and warm-daemon (task #94 Part A) arms below so they cannot silently
+            # diverge into two different merge behaviors.
+            impact_payload["callers"] = list(callers_payload.get("callers", []))
             # Propagate the caller-scan's --deadline partial signal (cursor review 1.40.0): impact's
             # second pass can be deadline-truncated even when the first pass wasn't, so carry partial +
             # deadline_limit onto the impact payload or _emit_symbol_command_result would exit 0 while
             # `tg callers` with the same flags exits 2.
             if callers_payload.get("partial"):
-                payload["partial"] = True
+                impact_payload["partial"] = True
                 caller_deadline_limit = callers_payload.get("deadline_limit")
                 # Don't clobber a deadline_limit the first (impact) pass already set (cursor review LOW).
-                if isinstance(caller_deadline_limit, dict) and "deadline_limit" not in payload:
-                    payload["deadline_limit"] = dict(caller_deadline_limit)
-            for caller in payload["callers"]:
+                if (
+                    isinstance(caller_deadline_limit, dict)
+                    and "deadline_limit" not in impact_payload
+                ):
+                    impact_payload["deadline_limit"] = dict(caller_deadline_limit)
+            for caller in impact_payload["callers"]:
                 caller_file = str(caller.get("file", ""))
-                if caller_file and caller_file not in payload["files"]:
-                    payload["files"].append(caller_file)
+                if caller_file and caller_file not in impact_payload["files"]:
+                    impact_payload["files"].append(caller_file)
+
+        # task #94 Part A Tier-1: default-OFF warm-daemon fast path, skipped entirely when a
+        # --deadline was requested (mirrors defs/refs/callers/blast-radius above). impact's cold
+        # path is a TWO-PASS shared-repo_map call (task #103): impact + a callers-merge. The
+        # daemon session caches ONE repo_map per (path, max_repo_files) key, so issuing TWO
+        # daemon requests (impact, then callers) against that same implicit session reuses the
+        # same cached map -- equivalent sharing to the cold path's single build_repo_map call,
+        # just over two IPC round-trips instead of two in-process calls. Both requests must
+        # succeed (or the symbol must be a confirmed no_match, which never needs a callers pass)
+        # or this falls through to the cold path entirely, so the merged result is never a
+        # warm/cold hybrid.
+        daemon_callers_payload: dict[str, Any] | None = None
+        daemon_impact_payload = (
+            _maybe_symbol_command_via_running_daemon(
+                command="impact",
+                path=resolved_path,
+                symbol=resolved_symbol,
+                provider=provider,
+                max_repo_files=max_repo_files,
+                max_tests=max_tests,
+            )
+            if deadline is None
+            else None
+        )
+        if daemon_impact_payload is not None and not daemon_impact_payload.get("no_match"):
+            daemon_callers_payload = _maybe_symbol_command_via_running_daemon(
+                command="callers",
+                path=resolved_path,
+                symbol=resolved_symbol,
+                provider=provider,
+                max_repo_files=max_repo_files,
+            )
+            if daemon_callers_payload is None:
+                daemon_impact_payload = None  # both-or-nothing -- fall through to cold below
+
+        if daemon_impact_payload is not None:
+            payload = daemon_impact_payload
+            if not payload.get("no_match"):
+                # Invariant: reaching here with daemon_impact_payload set and no_match falsy
+                # means the "both-or-nothing" check above already confirmed the callers request
+                # succeeded (any callers miss reset daemon_impact_payload to None instead).
+                assert daemon_callers_payload is not None
+                _merge_impact_and_callers(payload, daemon_callers_payload)
+            else:
+                payload.setdefault("callers", [])
         else:
-            payload.setdefault("callers", [])
+            repo_map = build_repo_map(
+                resolved_path,
+                max_repo_files=max_repo_files,
+                deadline_monotonic=deadline_monotonic,
+            )
+            payload = build_symbol_impact_from_map(
+                repo_map,
+                resolved_symbol,
+                semantic_provider=provider,
+                deadline_monotonic=deadline_monotonic,
+                max_tests=max_tests,
+            )
+            _copy_partial_signal(payload, repo_map)
+            # H5: impact previously surfaced only definition/import-derived `files` and so
+            # under-reported call sites relative to `tg callers` (which finds the CLI
+            # handler, RPC handler, and tests). Populate a top-level `callers` key from the
+            # same caller pass so impact is a superset, not a subset, of callers.
+            if not payload.get("no_match"):
+                callers_payload = build_symbol_callers_from_map(
+                    repo_map,
+                    resolved_symbol,
+                    semantic_provider=provider,
+                    deadline_monotonic=deadline_monotonic,
+                )
+                _copy_partial_signal(callers_payload, repo_map)
+                _merge_impact_and_callers(payload, callers_payload)
+            else:
+                payload.setdefault("callers", [])
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -9120,14 +9280,30 @@ def refs(
             symbol_option=symbol,
             command_name="refs",
         )
-        payload = build_symbol_refs(
-            resolved_symbol,
-            resolved_path,
-            semantic_provider=provider,
-            max_repo_files=max_repo_files,
-            deadline_seconds=deadline,
-            max_tests=max_tests,
+        # task #94 Part A Tier-1: default-OFF warm-daemon fast path, skipped entirely when a
+        # --deadline was requested (a warm session's cached repo_map cannot honor a fresh
+        # per-request scan deadline) so that flag combination always takes the cold path.
+        payload = (
+            _maybe_symbol_command_via_running_daemon(
+                command="refs",
+                path=resolved_path,
+                symbol=resolved_symbol,
+                provider=provider,
+                max_repo_files=max_repo_files,
+                max_tests=max_tests,
+            )
+            if deadline is None
+            else None
         )
+        if payload is None:
+            payload = build_symbol_refs(
+                resolved_symbol,
+                resolved_path,
+                semantic_provider=provider,
+                max_repo_files=max_repo_files,
+                deadline_seconds=deadline,
+                max_tests=max_tests,
+            )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -9211,14 +9387,30 @@ def callers(
             symbol_option=symbol,
             command_name="callers",
         )
-        payload = build_symbol_callers(
-            resolved_symbol,
-            resolved_path,
-            semantic_provider=provider,
-            max_repo_files=max_repo_files,
-            deadline_seconds=deadline,
-            max_tests=max_tests,
+        # task #94 Part A Tier-1: default-OFF warm-daemon fast path, skipped entirely when a
+        # --deadline was requested (a warm session's cached repo_map cannot honor a fresh
+        # per-request scan deadline) so that flag combination always takes the cold path.
+        payload = (
+            _maybe_symbol_command_via_running_daemon(
+                command="callers",
+                path=resolved_path,
+                symbol=resolved_symbol,
+                provider=provider,
+                max_repo_files=max_repo_files,
+                max_tests=max_tests,
+            )
+            if deadline is None
+            else None
         )
+        if payload is None:
+            payload = build_symbol_callers(
+                resolved_symbol,
+                resolved_path,
+                semantic_provider=provider,
+                max_repo_files=max_repo_files,
+                deadline_seconds=deadline,
+                max_tests=max_tests,
+            )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -9473,7 +9665,10 @@ def blast_radius(
     (~3s on a mid-size repo). Use this, not blast-radius-render, when you want the
     impact graph rather than a prose paste-in.
     """
-    from tensor_grep.cli.repo_map import build_symbol_blast_radius
+    from tensor_grep.cli.repo_map import (
+        _apply_blast_radius_output_limits,
+        build_symbol_blast_radius,
+    )
 
     try:
         resolved_path, resolved_symbol = _resolve_path_and_symbol(
@@ -9482,16 +9677,40 @@ def blast_radius(
             symbol_option=symbol,
             command_name="blast-radius",
         )
-        payload = build_symbol_blast_radius(
-            resolved_symbol,
-            resolved_path,
-            max_depth=max_depth,
-            semantic_provider=provider,
-            max_repo_files=max_repo_files,
-            max_callers=max_callers,
-            max_files=max_files,
-            deadline_seconds=deadline,
+        # task #94 Part A Tier-1: default-OFF warm-daemon fast path, skipped entirely when a
+        # --deadline was requested (a warm session's cached repo_map cannot honor a fresh
+        # per-request scan deadline) so that flag combination always takes the cold path. The
+        # daemon-served build_symbol_blast_radius_from_map does not itself apply the
+        # --max-callers/--max-files OUTPUT caps (unlike the cold build_symbol_blast_radius
+        # wrapper, which calls _apply_blast_radius_output_limits internally) -- apply the same
+        # helper here so warm output matches cold output byte-for-byte.
+        payload = (
+            _maybe_symbol_command_via_running_daemon(
+                command="blast_radius",
+                path=resolved_path,
+                symbol=resolved_symbol,
+                provider=provider,
+                max_repo_files=max_repo_files,
+                max_depth=max_depth,
+            )
+            if deadline is None
+            else None
         )
+        if payload is not None:
+            payload = _apply_blast_radius_output_limits(
+                payload, max_callers=max_callers, max_files=max_files
+            )
+        else:
+            payload = build_symbol_blast_radius(
+                resolved_symbol,
+                resolved_path,
+                max_depth=max_depth,
+                semantic_provider=provider,
+                max_repo_files=max_repo_files,
+                max_callers=max_callers,
+                max_files=max_files,
+                deadline_seconds=deadline,
+            )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(1) from exc
@@ -11080,6 +11299,7 @@ def scan(
     ),
 ) -> None:
     """Scan code with tensor-grep's bounded AST rule/config surface."""
+    from tensor_grep.backends.ast_backend import normalize_ast_language
     from tensor_grep.cli.rule_packs import resolve_rule_pack
 
     inline_source_count = sum(item is not None for item in (ruleset, inline_rules, rule_file))
@@ -11592,6 +11812,11 @@ def lsp_setup(
     `tg doctor --with-lsp --json` and inspect health_status / health_check plus
     navigation lsp_proof fields before treating LSP evidence as dependable.
     """
+    from tensor_grep.cli.lsp_provider_setup import (
+        install_managed_lsp_providers,
+        supported_lsp_languages,
+    )
+
     payload = install_managed_lsp_providers(
         python_executable=sys.executable,
         managed_root=None,

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -25,6 +25,7 @@ from tensor_grep.cli.session_store import (
     _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT,
     _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT,
     _DEFAULT_SESSION_SERVE_RESPONSE_CACHE_MAX_BYTES,
+    _DEFAULT_SESSION_SYMBOL_REPO_MAP_LIMIT,
     _SESSION_SERVE_RESPONSE_CACHE_MAX_BYTES_ENV,
     _SESSION_VERSION,
     _configured_positive_int,
@@ -601,6 +602,55 @@ def get_session_daemon_status(path: str = ".") -> dict[str, Any]:
     )
 
 
+def _spawn_daemon_subprocess(root: Path) -> None:
+    """Popen the session-daemon child process for ``root`` and return immediately.
+
+    Extracted from ``start_session_daemon`` (task #94 Part A) so the SAME spawn logic can be
+    reused by the fire-and-forget ``maybe_autostart_session_daemon_nonblocking`` below without
+    duplicating the Popen/PYTHONPATH/creationflags block. Pure side effect: does not wait for
+    ``daemon.json`` to appear and does not touch the start-lock -- the caller is responsible for
+    both (holding the lock across this call, and deciding whether/how long to wait afterward).
+    """
+    _remove_daemon_metadata(root)
+    creationflags = 0
+    env = os.environ.copy()
+    # audit B20: only inject the editable-checkout 'src' onto PYTHONPATH when it actually
+    # exists (an installed wheel has no sibling src/), and derive cwd from the session root
+    # rather than assuming a fixed Path(__file__).parents[3] repo layout.
+    repo_src = Path(__file__).resolve().parents[3] / "src"
+    if repo_src.exists():
+        python_path_parts = [str(repo_src)]
+        if env.get("PYTHONPATH"):
+            python_path_parts.append(env["PYTHONPATH"])
+        env["PYTHONPATH"] = os.pathsep.join(python_path_parts)
+    spawn_cwd = root if root.is_dir() else root.parent
+    # audit I7: detach the daemon from the launching process group/console so it is not
+    # killed by signals delivered to the parent and survives the CLI invocation.
+    popen_kwargs: dict[str, Any] = {}
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+    else:
+        popen_kwargs["start_new_session"] = True
+    subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.session_daemon",
+            "--root",
+            str(root),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        creationflags=creationflags,
+        cwd=str(spawn_cwd),
+        env=env,
+        **popen_kwargs,
+    )
+
+
 def start_session_daemon(path: str = ".") -> dict[str, Any]:
     root = _resolve_root(Path(path))
     existing = _probe_daemon(root)
@@ -638,44 +688,7 @@ def start_session_daemon(path: str = ".") -> dict[str, Any]:
         raise RuntimeError(f"session daemon did not start for {root}")
 
     try:
-        _remove_daemon_metadata(root)
-        creationflags = 0
-        env = os.environ.copy()
-        # audit B20: only inject the editable-checkout 'src' onto PYTHONPATH when it actually
-        # exists (an installed wheel has no sibling src/), and derive cwd from the session root
-        # rather than assuming a fixed Path(__file__).parents[3] repo layout.
-        repo_src = Path(__file__).resolve().parents[3] / "src"
-        if repo_src.exists():
-            python_path_parts = [str(repo_src)]
-            if env.get("PYTHONPATH"):
-                python_path_parts.append(env["PYTHONPATH"])
-            env["PYTHONPATH"] = os.pathsep.join(python_path_parts)
-        spawn_cwd = root if root.is_dir() else root.parent
-        # audit I7: detach the daemon from the launching process group/console so it is not
-        # killed by signals delivered to the parent and survives the CLI invocation.
-        popen_kwargs: dict[str, Any] = {}
-        if os.name == "nt":
-            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(
-                subprocess, "CREATE_NEW_PROCESS_GROUP", 0
-            )
-        else:
-            popen_kwargs["start_new_session"] = True
-        subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "tensor_grep.cli.session_daemon",
-                "--root",
-                str(root),
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL,
-            creationflags=creationflags,
-            cwd=str(spawn_cwd),
-            env=env,
-            **popen_kwargs,
-        )
+        _spawn_daemon_subprocess(root)
 
         deadline = time.time() + _DAEMON_START_TIMEOUT_SECONDS
         while time.time() < deadline:
@@ -696,6 +709,40 @@ def start_session_daemon(path: str = ".") -> dict[str, Any]:
         raise RuntimeError(f"session daemon did not start for {root}")
     finally:
         _release_daemon_start_lock(root)
+
+
+def maybe_autostart_session_daemon_nonblocking(path: str = ".") -> bool:
+    """Fire-and-forget daemon spawn for the default Tier-1 fast path (task #94 Part A, must-fix 3).
+
+    Unlike ``start_session_daemon``, this NEVER blocks the caller on the daemon's warmup: it
+    makes a single non-blocking attempt to acquire the start lock, ``Popen``s the daemon if it
+    got the lock, and returns immediately WITHOUT waiting for ``daemon.json`` to appear. The
+    calling request must run cold (the daemon will be warm for the NEXT call, not this one).
+
+    Double-spawn discipline (deliberately narrower than ``start_session_daemon``'s lock usage):
+    the start lock is held only across the ``Popen`` call itself, not across a warmup wait --
+    holding it any longer would make this function blocking, defeating its purpose. A losing
+    racer (lock already held) simply returns False and does not spawn a second daemon. A THIRD
+    caller arriving after the lock is released but before the just-spawned daemon's own
+    ``daemon.json`` write completes could still observe ``_probe_daemon() is None`` and spawn
+    ANOTHER daemon -- this narrow residual race is bounded and self-heals without a busier lock:
+    each daemon binds an ephemeral port (``_DAEMON_HOST``, port 0), so there is never a port
+    collision; each daemon's ``daemon.json`` write is atomic, so the LAST daemon to finish
+    starting wins the metadata race and is the one future callers discover; and any orphaned
+    duplicate (metadata overwritten, no longer discoverable) self-reaps via the existing
+    idle-shutdown timer (``_DEFAULT_DAEMON_IDLE_SHUTDOWN_SECONDS``, 900s) once it stops
+    receiving requests. Returns True only when THIS call actually issued a spawn.
+    """
+    root = _resolve_root(Path(path))
+    if _probe_daemon(root) is not None:
+        return False
+    if not _try_acquire_daemon_start_lock(root):
+        return False
+    try:
+        _spawn_daemon_subprocess(root)
+    finally:
+        _release_daemon_start_lock(root)
+    return True
 
 
 def stop_session_daemon(path: str = ".") -> dict[str, Any]:
@@ -911,6 +958,29 @@ def _optional_positive_int(value: object) -> int | None:
         return None
 
 
+# task #94 Part A -- the CORE SCOPE-FIX. Before this, _implicit_session_id_for_request only
+# recognized context_render/context_edit_plan: a symbol command (defs/impact/refs/callers/
+# blast_radius) sent with no explicit session_id fell through with session_id="" unchanged,
+# which reaches get_session("", path) -> FileNotFoundError (session_store.py get_session,
+# ~line 810) -> the daemon returns an {"error": ...} response -> every fail-open client wrapper
+# (_maybe_symbol_command_via_running_daemon in main.py) reads that as a miss and falls back to
+# the cold path FOREVER. That silently defeated the whole point of a default warm-daemon fast
+# path for these 5 commands. _IMPLICIT_SESSION_SYMBOL_COMMANDS is deliberately narrower than
+# _DAEMON_METRICS_SYMBOL_COMMANDS above (which also counts blast_radius_render/
+# blast_radius_plan for demand metrics) -- those two render/plan variants are Tier-2 scope,
+# explicitly deferred, and must not gain an implicit session as a side effect of this fix.
+_IMPLICIT_SESSION_SYMBOL_COMMANDS = frozenset({
+    "defs",
+    "impact",
+    "refs",
+    "callers",
+    "blast_radius",
+})
+_IMPLICIT_SESSION_COMMANDS = frozenset({"context_render", "context_edit_plan"}) | (
+    _IMPLICIT_SESSION_SYMBOL_COMMANDS
+)
+
+
 def _implicit_session_max_repo_files(command: str, request: dict[str, Any]) -> int | None:
     requested = _optional_positive_int(request.get("max_repo_files"))
     if requested is not None:
@@ -919,6 +989,8 @@ def _implicit_session_max_repo_files(command: str, request: dict[str, Any]) -> i
         return _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT
     if command == "context_edit_plan":
         return _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT
+    if command in _IMPLICIT_SESSION_SYMBOL_COMMANDS:
+        return _DEFAULT_SESSION_SYMBOL_REPO_MAP_LIMIT
     return None
 
 
@@ -950,7 +1022,7 @@ def _implicit_session_id_for_request(
     path: str,
     request: dict[str, Any],
 ) -> str:
-    if session_id or command not in {"context_render", "context_edit_plan"}:
+    if session_id or command not in _IMPLICIT_SESSION_COMMANDS:
         return session_id
 
     max_repo_files = _implicit_session_max_repo_files(command, request)

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -49,6 +49,11 @@ _DEFAULT_SESSION_SERVE_RESPONSE_CACHE_MAX_BYTES = 8 * 1024 * 1024
 _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
 _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
 _DEFAULT_SESSION_BLAST_RADIUS_PLAN_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
+# task #94 Part A: the implicit-session default repo-file limit for the 5 symbol commands
+# (defs/impact/refs/callers/blast_radius) opened via the daemon's no-explicit-session path.
+# Same underlying value as the context-render/edit-plan limits above (kept as a distinct name
+# for intent clarity at the call site, not a distinct behavior).
+_DEFAULT_SESSION_SYMBOL_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
 # audit I2: bound on-disk session retention; keep at most N newest explicit sessions per root
 # so per-open cost and disk usage stay bounded. Configurable via TG_SESSION_MAX.
 _SESSION_MAX_ENV = "TG_SESSION_MAX"
@@ -1229,11 +1234,20 @@ def _serve_session_request_from_payload(
     # blast-radius to native even when the client asked for lsp/hybrid. repo_map normalizes +
     # fails closed to native for an unknown value, so no re-validation here.
     provider = str(request.get("provider", "native"))
+    # task #94 Part A: forward the caller's max_tests (the same optional-int coercion used for
+    # max_repo_files elsewhere in this function) into every symbol builder below so the daemon
+    # path applies the SAME tests-field cap as the cold `build_symbol_*` callers instead of
+    # silently falling back to each builder's own unbounded default -- required for true
+    # warm-vs-cold byte identity when a caller passes a non-default --max-tests.
+    raw_max_tests = request.get("max_tests")
+    max_tests = None if raw_max_tests in (None, "") else int(cast(int | str, raw_max_tests))
     if command == "defs":
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("defs requests require a non-empty symbol")
-        response = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=provider)
+        response = build_symbol_defs_from_map(
+            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+        )
         response["session_id"] = session_id
         response["routing_reason"] = "session-defs"
         return response
@@ -1242,7 +1256,9 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("impact requests require a non-empty symbol")
-        response = build_symbol_impact_from_map(repo_map, symbol, semantic_provider=provider)
+        response = build_symbol_impact_from_map(
+            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+        )
         response["session_id"] = session_id
         response["routing_reason"] = "session-impact"
         return response
@@ -1251,7 +1267,9 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("refs requests require a non-empty symbol")
-        response = build_symbol_refs_from_map(repo_map, symbol, semantic_provider=provider)
+        response = build_symbol_refs_from_map(
+            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+        )
         response["session_id"] = session_id
         response["routing_reason"] = "session-refs"
         return response
@@ -1260,7 +1278,9 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("callers requests require a non-empty symbol")
-        response = build_symbol_callers_from_map(repo_map, symbol, semantic_provider=provider)
+        response = build_symbol_callers_from_map(
+            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+        )
         response["session_id"] = session_id
         response["routing_reason"] = "session-callers"
         return response

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2631,7 +2631,9 @@ def test_lsp_setup_runs_managed_provider_installer(
             },
         }
 
-    monkeypatch.setattr("tensor_grep.cli.main.install_managed_lsp_providers", _fake_install)
+    monkeypatch.setattr(
+        "tensor_grep.cli.lsp_provider_setup.install_managed_lsp_providers", _fake_install
+    )
 
     runner = CliRunner()
     result = runner.invoke(app, ["lsp-setup", "--json"])
@@ -2667,7 +2669,9 @@ def test_lsp_setup_can_enable_toolchain_provider_install(
             "providers": {},
         }
 
-    monkeypatch.setattr("tensor_grep.cli.main.install_managed_lsp_providers", _fake_install)
+    monkeypatch.setattr(
+        "tensor_grep.cli.lsp_provider_setup.install_managed_lsp_providers", _fake_install
+    )
 
     runner = CliRunner()
     result = runner.invoke(app, ["lsp-setup", "--json", "--include-toolchain-providers"])
@@ -2701,7 +2705,9 @@ def test_lsp_setup_json_exits_nonzero_when_install_errors(
             "install_errors": {"node": "network unavailable"},
         }
 
-    monkeypatch.setattr("tensor_grep.cli.main.install_managed_lsp_providers", _fake_install)
+    monkeypatch.setattr(
+        "tensor_grep.cli.lsp_provider_setup.install_managed_lsp_providers", _fake_install
+    )
 
     runner = CliRunner()
     result = runner.invoke(app, ["lsp-setup", "--json"])

--- a/tests/unit/test_symbol_daemon_autostart.py
+++ b/tests/unit/test_symbol_daemon_autostart.py
@@ -1,0 +1,563 @@
+"""TDD for task #94 Part A: the default-OFF warm-daemon Tier-1 fast path.
+
+Scope: the 5 symbol commands (defs/impact/refs/callers/blast-radius) gain an OPTIONAL
+default routing path through a running ``tg session daemon``, gated end-to-end behind the
+net-new ``TG_SESSION_DAEMON_AUTOSTART`` env flag (default OFF -- today's cold-path behavior
+is byte-for-byte unchanged unless a caller opts in).
+
+Covers, in file order, one section per must-fix from the design-gate verdict (SHIP-WITH-CHANGES):
+
+- Must-fix 4: TG_SESSION_DAEMON_AUTOSTART default-OFF-is-a-no-op, plus the CI/GITHUB_ACTIONS
+  force-off.
+- Must-fix 1 (CORE SCOPE-FIX): ``_implicit_session_id_for_request`` (session_daemon.py)
+  previously only recognized context_render/context_edit_plan; a symbol command sent to the
+  daemon with no explicit session_id fell through to ``get_session("", path)`` ->
+  FileNotFoundError -> an error response -> permanent cold fallback. The "no explicit session"
+  section proves the fix.
+- Must-fix 5: warm-vs-cold byte identity (all 5 commands), and the exit-2 fault-injection
+  contract (docs/CONTRACTS.md:109) via the daemon route.
+- Must-fix 3: the fire-and-forget non-blocking spawn primitive never blocks/polls waiting for
+  warmup.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from tensor_grep.cli import session_daemon
+from tensor_grep.cli.main import _session_daemon_autostart_enabled, app
+
+runner = CliRunner()
+
+
+def _project(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "m.py").write_text(
+        "def helper():\n    return 1\n\n\ndef other():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    return project.resolve()
+
+
+def _flat_repo(root: Path, count: int) -> Path:
+    """A project with `count` trivial .py files, so a small --max-repo-files genuinely
+    truncates the scan (possibly_truncated=True), not just vendor/cache files."""
+    project = root / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    for index in range(count):
+        (src / f"m{index:03d}.py").write_text(
+            f"def helper_{index}():\n    return {index}\n", encoding="utf-8"
+        )
+    return project.resolve()
+
+
+def _serve(server: session_daemon._ThreadedSessionDaemon) -> threading.Thread:
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+def _real_daemon(root: Path, token: str = "test-token") -> session_daemon._ThreadedSessionDaemon:
+    """Start a REAL (in-process, threaded, loopback) session daemon for `root`."""
+    return session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token=token)
+
+
+def _probe_fake_for(server: session_daemon._ThreadedSessionDaemon, token: str):
+    host, port = server.server_address
+
+    def _fake_probe(_root: Path) -> dict[str, Any]:
+        return {
+            "host": str(host),
+            "port": int(port),
+            "token": token,
+            "pid": 0,
+            "started_at": "test",
+        }
+
+    return _fake_probe
+
+
+def _autostart_env(monkeypatch, *, enabled: bool) -> None:
+    if enabled:
+        monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")
+    else:
+        monkeypatch.delenv("TG_SESSION_DAEMON_AUTOSTART", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+
+
+# ------------------------------------------------------------------------------------------
+# Must-fix 4: TG_SESSION_DAEMON_AUTOSTART -- default OFF, forced off in CI.
+# ------------------------------------------------------------------------------------------
+
+
+def test_autostart_disabled_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("TG_SESSION_DAEMON_AUTOSTART", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    assert _session_daemon_autostart_enabled() is False
+
+
+def test_autostart_enabled_when_flag_truthy(monkeypatch) -> None:
+    _autostart_env(monkeypatch, enabled=True)
+    assert _session_daemon_autostart_enabled() is True
+
+
+def test_autostart_forced_off_in_ci(monkeypatch) -> None:
+    monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    assert _session_daemon_autostart_enabled() is False
+
+
+def test_autostart_forced_off_in_github_actions(monkeypatch) -> None:
+    monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert _session_daemon_autostart_enabled() is False
+
+
+def test_defs_default_off_never_touches_daemon(tmp_path: Path, monkeypatch) -> None:
+    """The no-op proof: with the flag unset, the daemon module is never even called into."""
+    _autostart_env(monkeypatch, enabled=False)
+    project = _project(tmp_path)
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("daemon must not be touched when TG_SESSION_DAEMON_AUTOSTART is off")
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", _boom)
+    monkeypatch.setattr(session_daemon, "maybe_autostart_session_daemon_nonblocking", _boom)
+
+    result = runner.invoke(app, ["defs", str(project), "helper", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["symbol"] == "helper"
+    assert any(d["name"] == "helper" for d in payload["definitions"])
+
+
+# ------------------------------------------------------------------------------------------
+# Must-fix 1 (CORE SCOPE-FIX): the daemon now serves a symbol command with NO explicit
+# session_id -- previously get_session("", path) -> FileNotFoundError -> error response.
+# ------------------------------------------------------------------------------------------
+
+
+def test_daemon_serves_defs_with_no_explicit_session(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        response = session_daemon._daemon_request(
+            str(server.server_address[0]),
+            int(server.server_address[1]),
+            {"command": "defs", "path": str(project), "symbol": "helper"},
+            token="test-token",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "error" not in response, response
+    assert response["symbol"] == "helper"
+    assert any(d["name"] == "helper" for d in response["definitions"])
+
+
+def test_daemon_serves_callers_with_no_explicit_session(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        response = session_daemon._daemon_request(
+            str(server.server_address[0]),
+            int(server.server_address[1]),
+            {"command": "callers", "path": str(project), "symbol": "helper"},
+            token="test-token",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "error" not in response, response
+    assert response["symbol"] == "helper"
+    assert any(c.get("file", "").endswith("m.py") for c in response["callers"])
+
+
+def test_daemon_serves_blast_radius_with_no_explicit_session(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        response = session_daemon._daemon_request(
+            str(server.server_address[0]),
+            int(server.server_address[1]),
+            {"command": "blast_radius", "path": str(project), "symbol": "helper"},
+            token="test-token",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "error" not in response, response
+    assert response["symbol"] == "helper"
+
+
+def test_daemon_still_rejects_unknown_command_with_no_session(tmp_path: Path) -> None:
+    """Guard-rail: the fix is scoped to the 7 named commands, not "anything goes"."""
+    project = _project(tmp_path)
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        response = session_daemon._daemon_request(
+            str(server.server_address[0]),
+            int(server.server_address[1]),
+            {"command": "not_a_real_command", "path": str(project)},
+            token="test-token",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert "error" in response
+
+
+# ------------------------------------------------------------------------------------------
+# Must-fix 5: warm-vs-cold byte identity (defs + callers) via the real daemon + CLI.
+# ------------------------------------------------------------------------------------------
+
+
+def _cli_json(args: list[str]) -> dict[str, Any]:
+    result = runner.invoke(app, args)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+def _assert_warm_matches_cold(warm: dict[str, Any], cold: dict[str, Any]) -> None:
+    # session_id/serve_cache are daemon-transport-ONLY fields (cold never has them). But
+    # routing_reason exists on BOTH arms with a DIFFERENT value by design: build_symbol_*_from_map
+    # (shared by both the cold builder and the daemon dispatch) stamps "symbol-defs"; the daemon
+    # dispatch (_serve_session_request_from_payload) then overwrites it to "session-defs" to make
+    # the response's origin visible. Strip all three from BOTH sides -- a .pop on an absent key is
+    # a no-op -- so this proves the actual ANSWER is byte-identical, not that the daemon adds zero
+    # provenance metadata (it is expected to add/override session_id/routing_reason/serve_cache).
+    warm = dict(warm)
+    cold = dict(cold)
+    for extra_key in ("session_id", "routing_reason", "serve_cache"):
+        warm.pop(extra_key, None)
+        cold.pop(extra_key, None)
+    # token_budget.estimated_tokens is a byte-size ESTIMATE of the payload at the moment
+    # _apply_symbol_token_budget ran. The warm arm's raw payload already carries the 2
+    # harmless additive provenance fields above at that point (the daemon stamps them before
+    # returning), which nudges the estimate up by a few dozen tokens with ZERO effect on the
+    # actual answer content. Compare the DECISIONS the estimate drives (truncated /
+    # primary_truncated), not the raw estimate number, which is expected to differ slightly.
+    warm_budget = warm.get("token_budget")
+    cold_budget = cold.get("token_budget")
+    if isinstance(warm_budget, dict) and isinstance(cold_budget, dict):
+        assert warm_budget.get("truncated") == cold_budget.get("truncated")
+        assert warm_budget.get("primary_truncated") == cold_budget.get("primary_truncated")
+        warm.pop("token_budget", None)
+        cold.pop("token_budget", None)
+    assert warm == cold
+
+
+def test_defs_warm_matches_cold_byte_identity(tmp_path: Path, monkeypatch) -> None:
+    project = _project(tmp_path)
+    cold_payload = _cli_json(["defs", str(project), "helper", "--json"])
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        warm_payload = _cli_json(["defs", str(project), "helper", "--json"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    _assert_warm_matches_cold(warm_payload, cold_payload)
+
+
+def test_callers_warm_matches_cold_byte_identity(tmp_path: Path, monkeypatch) -> None:
+    project = _project(tmp_path)
+    cold_payload = _cli_json(["callers", str(project), "helper", "--json"])
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        warm_payload = _cli_json(["callers", str(project), "helper", "--json"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    _assert_warm_matches_cold(warm_payload, cold_payload)
+
+
+def test_refs_warm_matches_cold_byte_identity(tmp_path: Path, monkeypatch) -> None:
+    project = _project(tmp_path)
+    cold_payload = _cli_json(["refs", str(project), "helper", "--json"])
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        warm_payload = _cli_json(["refs", str(project), "helper", "--json"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    _assert_warm_matches_cold(warm_payload, cold_payload)
+
+
+def test_impact_warm_matches_cold_byte_identity(tmp_path: Path, monkeypatch) -> None:
+    project = _project(tmp_path)
+    cold_payload = _cli_json(["impact", str(project), "helper", "--json"])
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        warm_payload = _cli_json(["impact", str(project), "helper", "--json"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    _assert_warm_matches_cold(warm_payload, cold_payload)
+
+
+def test_blast_radius_warm_matches_cold_byte_identity(tmp_path: Path, monkeypatch) -> None:
+    project = _project(tmp_path)
+    cold_payload = _cli_json(["blast-radius", str(project), "helper", "--json"])
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        warm_payload = _cli_json(["blast-radius", str(project), "helper", "--json"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    _assert_warm_matches_cold(warm_payload, cold_payload)
+
+
+def test_defs_daemon_routing_skipped_for_non_native_provider(tmp_path: Path, monkeypatch) -> None:
+    """--provider lsp/hybrid must never route through the native-only daemon session."""
+    project = _project(tmp_path)
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("non-native provider must not reach the daemon")
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", _boom)
+    _autostart_env(monkeypatch, enabled=True)
+
+    result = runner.invoke(app, ["defs", str(project), "helper", "--provider", "lsp", "--json"])
+    assert result.exit_code == 0, result.output
+
+
+# ------------------------------------------------------------------------------------------
+# Must-fix 5 (second half): exit-2 fault injection -- a truncated warm payload must still
+# exit 2 (docs/CONTRACTS.md:109), exactly like the cold path.
+# ------------------------------------------------------------------------------------------
+
+
+def test_defs_daemon_exit2_on_real_scan_truncation(tmp_path: Path, monkeypatch) -> None:
+    """End-to-end: a REAL daemon whose implicit session was capped by --max-repo-files."""
+    project = _flat_repo(tmp_path, 6)
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        result = runner.invoke(
+            app,
+            ["defs", str(project), "helper_0", "--max-repo-files", "1", "--json"],
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["scan_limit"]["possibly_truncated"] is True
+    assert payload["result_incomplete"] is True
+
+
+def test_callers_daemon_exit2_on_scan_truncation(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "m.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+    _autostart_env(monkeypatch, enabled=True)
+
+    def fake_request(_path: str, request: dict[str, Any]) -> dict[str, Any]:
+        assert request["command"] == "callers"
+        return {
+            "symbol": "helper",
+            "path": str(project),
+            "callers": [],
+            "import_graph_consumers": [],
+            "import_graph_consumer_files": [],
+            "import_graph_consumer_count": 0,
+            "files": [str(project / "m.py")],
+            "tests": [],
+            "definitions": [{"name": "helper", "file": str(project / "m.py"), "line": 1}],
+            "scan_limit": {"possibly_truncated": True},
+        }
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", fake_request)
+
+    result = runner.invoke(app, ["callers", str(project), "helper", "--json"])
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["result_incomplete"] is True
+
+
+def test_blast_radius_daemon_exit2_on_scan_truncation(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "m.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+    _autostart_env(monkeypatch, enabled=True)
+
+    def fake_request(_path: str, request: dict[str, Any]) -> dict[str, Any]:
+        assert request["command"] == "blast_radius"
+        return {
+            "symbol": "helper",
+            "path": str(project),
+            "definitions": [{"name": "helper", "file": str(project / "m.py"), "line": 1}],
+            "callers": [],
+            "caller_tree": [],
+            "files": [str(project / "m.py")],
+            "tests": [],
+            "imports": [],
+            "import_graph_consumers": [],
+            "blast_radius_score": 0,
+            "scan_limit": {"possibly_truncated": True},
+        }
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", fake_request)
+
+    result = runner.invoke(app, ["blast-radius", str(project), "helper", "--json"])
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["scan_limit"]["possibly_truncated"] is True
+
+
+def test_defs_daemon_complete_stays_exit_0(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "m.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+    _autostart_env(monkeypatch, enabled=True)
+
+    def fake_request(_path: str, request: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "symbol": "helper",
+            "path": str(project),
+            "definitions": [{"name": "helper", "file": str(project / "m.py"), "line": 1}],
+            "files": [str(project / "m.py")],
+            "tests": [],
+            "scan_limit": {"possibly_truncated": False},
+        }
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", fake_request)
+
+    result = runner.invoke(app, ["defs", str(project), "helper", "--json"])
+    assert result.exit_code == 0, result.output
+
+
+# ------------------------------------------------------------------------------------------
+# Must-fix 3: the fire-and-forget spawn primitive never blocks/polls waiting for warmup.
+# ------------------------------------------------------------------------------------------
+
+
+def test_maybe_autostart_nonblocking_never_sleeps(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    spawned: list[tuple[object, ...]] = []
+
+    class _FakePopen:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            spawned.append(args)
+
+    def _boom_sleep(*args: object, **kwargs: object) -> None:
+        raise AssertionError("must not sleep/poll waiting for daemon warmup")
+
+    monkeypatch.setattr(session_daemon, "_probe_daemon", lambda _root: None)
+    monkeypatch.setattr(session_daemon.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(session_daemon.time, "sleep", _boom_sleep)
+
+    spawned_flag = session_daemon.maybe_autostart_session_daemon_nonblocking(str(root))
+
+    assert spawned_flag is True
+    assert len(spawned) == 1
+
+
+def test_maybe_autostart_nonblocking_skips_when_already_running(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+
+    def _boom_popen(*args: object, **kwargs: object) -> None:
+        raise AssertionError("must not spawn a second daemon when one is already running")
+
+    monkeypatch.setattr(
+        session_daemon, "_probe_daemon", lambda _root: {"port": 1, "pid": 1, "started_at": "x"}
+    )
+    monkeypatch.setattr(session_daemon.subprocess, "Popen", _boom_popen)
+
+    assert session_daemon.maybe_autostart_session_daemon_nonblocking(str(root)) is False
+
+
+def test_maybe_autostart_nonblocking_skips_when_lock_held(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+
+    def _boom_popen(*args: object, **kwargs: object) -> None:
+        raise AssertionError("must not spawn while another process holds the start lock")
+
+    monkeypatch.setattr(session_daemon, "_probe_daemon", lambda _root: None)
+    monkeypatch.setattr(session_daemon.subprocess, "Popen", _boom_popen)
+
+    resolved_root = session_daemon._resolve_root(root)
+    assert session_daemon._try_acquire_daemon_start_lock(resolved_root) is True
+    try:
+        assert session_daemon.maybe_autostart_session_daemon_nonblocking(str(root)) is False
+    finally:
+        session_daemon._release_daemon_start_lock(resolved_root)
+
+
+def test_defs_cold_call_not_blocked_by_autostart(tmp_path: Path, monkeypatch) -> None:
+    """Noise-band timing proof: cold call #1 must not wait on the ~5s daemon-start deadline."""
+    project = _project(tmp_path)
+    spawn_calls: list[str] = []
+
+    def _fake_spawn(path: str = ".") -> bool:
+        spawn_calls.append(path)
+        return True  # pretend a daemon was spawned, without actually launching a subprocess
+
+    monkeypatch.setattr(session_daemon, "maybe_autostart_session_daemon_nonblocking", _fake_spawn)
+    _autostart_env(monkeypatch, enabled=True)
+
+    started = time.monotonic()
+    result = runner.invoke(app, ["defs", str(project), "helper", "--json"])
+    elapsed = time.monotonic() - started
+
+    assert result.exit_code == 0, result.output
+    assert len(spawn_calls) == 1
+    # _DAEMON_START_TIMEOUT_SECONDS is 5.0s; a blocked call would take >= that. A generous
+    # noise band (well under half the blocking threshold) avoids flaking on a loaded CI box
+    # while still failing hard if the fast path regresses to the blocking start_session_daemon.
+    assert elapsed < 2.5, f"cold call took {elapsed:.2f}s -- must not block on daemon warmup"


### PR DESCRIPTION
## What

Task #94 Part A Tier-1 (the audit's #1 latency item): route the 5 symbol commands (defs/impact/refs/callers/blast_radius) through a WARM session daemon when `TG_SESSION_DAEMON_AUTOSTART` is set -- **DEFAULT-OFF**, so this PR is a **zero-behavior-change** plumbing change. Turns 6-30s cold symbol lookups sub-second when the daemon is warm. The flip to on-by-default is a separate, later decision (post-dogfood, with benchmark data). Part B (launcher shim) shipped v1.54.5.

Design-gated (SHIP-WITH-CHANGES, 7 must-fixes) + a mandatory adversarial Opus security gate (SHIP).

## What changed

- **Tier-1 routing:** the 5 symbol commands try a warm-daemon route (`_maybe_symbol_command_via_running_daemon`), **FAIL-OPEN** to the exact existing cold path on any miss / error / unhealthy daemon.
- **`TG_SESSION_DAEMON_AUTOSTART`** (net-new, DEFAULT-OFF, forced OFF under `CI`/`GITHUB_ACTIONS`). When unset, the daemon module is never touched -- byte-for-byte identical to today.
- **Core scope-fix:** extended the implicit-session guard to the 5 symbol commands (they previously fell through to `FileNotFoundError` -> cold, so the daemon would have delivered ZERO speedup -- the design-gate caught this).
- **Non-blocking spawn** (`maybe_autostart_session_daemon_nonblocking`): fire-and-forget Popen, start-lock held only across Popen, no 5s wait on the hot path.
- **Lazy imports** of `ast_backend` + `lsp_provider_setup` (removes ~54ms+ eager cold-start cost).

## Security gate (mandatory -- session_daemon surface) -- SHIP

7-axis adversarial review at 605c4b9, all cited: **default-OFF is airtight** (returns before any probe/spawn when unset; only `{1,true,yes,on}`; CI force-off); **fail-open is total** (`except Exception -> cold`, no result substitution, no hang); **resource bound holds** (implicit sessions bounded by max_repo_files=2000, 16-session LRU); **spawn is safe** (no harmful double-spawn, child detached+reaped, no new env leak, no deadlock); **auth preserved** (same HMAC gate + pre-auth bound + path confinement, no new unauth path); **byte-identity + exit-2 preserved** (warm==cold via `refresh_on_stale`; `--deadline` skips the daemon).

## Known divergence (default-OFF-gated; hard blocker on the future default-ON flip)

`blast_radius` on a repo exceeding `max_repo_files` where the symbol is outside the initial scan window: cold has a literal-seed rescue retry the warm `_from_map` path lacks, so warm can return `no_match` where cold finds it. It is **HONEST, not silent** -- the payload carries `scan_limit` -> `result_incomplete` -> **exits 2** (never a false-complete). **Zero impact by default** (default-OFF). Tracked as a hard prerequisite that must ship BEFORE any default-ON flip (fall-to-cold on a truncated no_match, or port the literal-seed retry to the warm path).

## Tests

23 RED-then-GREEN daemon tests (default-off-no-op, daemon-serves-symbol-with-no-session, warm-vs-cold byte-identity x5, exit-2 fault injection, non-blocking spawn); full `tests/unit` sweep **4036 passed**; ran the CI-parity gate (`ruff check` + `ruff format --preview --check` + `mypy src/tensor_grep`) -- all green.

`feat:` -> minor bump on merge. Advances #94 (Tier-2 orient/agent serving + the default-ON flip are separate follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
