### PR TITLE
fix(daemon): fall to cold blast_radius on a truncated warm no_match (audit #107, the #94 flip blocker)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9605,6 +9605,27 @@ def _render_blast_radius_mermaid(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _daemon_blast_radius_no_match_is_unreliable(payload: dict[str, Any]) -> bool:
+    """audit #107 (#94 flip blocker): True iff a warm/daemon blast_radius payload is a no_match on
+    a possibly_truncated map -- the one case where the daemon-served
+    build_symbol_blast_radius_from_map (repo_map.py, no literal-seed rescue) can disagree with
+    what the cold build_symbol_blast_radius (repo_map.py, which DOES retry via
+    _literal_symbol_seed_files) would find. The symbol may simply sit outside the daemon
+    session's scan window, so a no_match here is unreliable and the caller should fall through to
+    cold instead of trusting it. Mirrors the truncated-no_match condition in
+    repo_map.build_symbol_blast_radius verbatim (repo_map.py:~15373-15378) so the two arms agree
+    on exactly when a no_match is trustworthy.
+
+    Deliberately narrow: only fires on no_match AND possibly_truncated together. A warm no_match
+    on a COMPLETE map is a real miss -- falling back to cold there would defeat the daemon
+    speedup for every genuine no-match, not just the truncated-and-wrong ones.
+    """
+    if not payload.get("no_match"):
+        return False
+    scan_limit = payload.get("scan_limit")
+    return isinstance(scan_limit, dict) and bool(scan_limit.get("possibly_truncated"))
+
+
 @app.command(name="blast-radius")
 def blast_radius(
     path: str = typer.Argument(".", help="File or directory to inventory"),
@@ -9696,6 +9717,10 @@ def blast_radius(
             if deadline is None
             else None
         )
+        if payload is not None and _daemon_blast_radius_no_match_is_unreliable(payload):
+            # audit #107: discard the unreliable warm no_match and fall through to the cold
+            # path below, which has the literal-seed rescue the daemon route lacks.
+            payload = None
         if payload is not None:
             payload = _apply_blast_radius_output_limits(
                 payload, max_callers=max_callers, max_files=max_files

--- a/tests/unit/test_symbol_daemon_autostart.py
+++ b/tests/unit/test_symbol_daemon_autostart.py
@@ -454,6 +454,94 @@ def test_blast_radius_daemon_exit2_on_scan_truncation(tmp_path: Path, monkeypatc
     assert payload["scan_limit"]["possibly_truncated"] is True
 
 
+# ------------------------------------------------------------------------------------------
+# Audit #107 (#94 flip blocker): warm/cold blast-radius divergence on a truncated repo. The
+# daemon-served build_symbol_blast_radius_from_map has NO literal-seed rescue (unlike the cold
+# build_symbol_blast_radius, which retries via _literal_symbol_seed_files when the map-based
+# lookup misses on a truncated scan) -- so a symbol sitting outside the daemon session's scan
+# window used to come back as a FALSE no_match from the warm route where cold would find it.
+# ------------------------------------------------------------------------------------------
+
+
+def test_blast_radius_daemon_falls_to_cold_on_truncated_no_match(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """End-to-end with a REAL daemon: a truncated implicit session (--max-repo-files 1) whose
+    scan window excludes the target symbol must not report a false no_match -- the client
+    discards the unreliable warm no_match and falls through to cold, which finds it via the
+    literal-seed rescue."""
+    project = _flat_repo(tmp_path, 6)
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        # helper_5 lives in m005.py, the LAST of 6 files -- outside the 1-file scan window a
+        # max-repo-files=1 cap keeps (test_defs_daemon_exit2_on_real_scan_truncation above
+        # already proves file index 0, m000.py, is what survives that cap).
+        result = runner.invoke(
+            app,
+            ["blast-radius", str(project), "helper_5", "--max-repo-files", "1", "--json"],
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    payload = json.loads(result.stdout)
+    assert payload.get("no_match") is not True, payload
+    assert any(d.get("name") == "helper_5" for d in payload.get("definitions", [])), payload
+    # The rescued map is still scan-capped at 1 (the seed file is force-injected on top of the
+    # cap, not a cap raise) -- exit 2 (incomplete-but-found), never exit 1 (false not-found).
+    assert result.exit_code == 2, result.output
+
+
+def test_blast_radius_daemon_no_match_stays_warm_when_map_complete(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Precision guard: a warm no_match on a COMPLETE (non-truncated) map is a REAL miss and must
+    stay warm. Falling back to cold here would defeat the daemon speedup for every genuine
+    no-match, not just the truncated-and-wrong ones -- the guard fires ONLY on
+    no_match AND possibly_truncated together."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "m.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+    _autostart_env(monkeypatch, enabled=True)
+
+    def fake_request(_path: str, request: dict[str, Any]) -> dict[str, Any]:
+        assert request["command"] == "blast_radius"
+        return {
+            "symbol": "totally_missing_symbol",
+            "path": str(project),
+            "no_match": True,
+            "definitions": [],
+            "callers": [],
+            "caller_tree": [],
+            "files": [],
+            "tests": [],
+            "imports": [],
+            "import_graph_consumers": [],
+            "blast_radius_score": 0.0,
+            "scan_limit": {"possibly_truncated": False},
+        }
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", fake_request)
+
+    from tensor_grep.cli import repo_map as repo_map_module
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            "must not fall to cold when the warm map was COMPLETE (possibly_truncated=False)"
+        )
+
+    monkeypatch.setattr(repo_map_module, "build_symbol_blast_radius", _boom)
+
+    result = runner.invoke(app, ["blast-radius", str(project), "totally_missing_symbol", "--json"])
+    assert result.exit_code == 1, result.output  # genuine not-found, not a scan truncation
+    payload = json.loads(result.stdout)
+    assert payload.get("no_match") is True
+
+
 def test_defs_daemon_complete_stays_exit_0(tmp_path: Path, monkeypatch) -> None:
     project = tmp_path / "project"
     project.mkdir()


### PR DESCRIPTION
## What

Closes audit #107 -- the **hard blocker on the #94 daemon default-ON flip**. The warm/daemon-served blast_radius path diverges from the cold path on truncated repos, returning a FALSE `no_match`: the warm builder `build_symbol_blast_radius_from_map` (repo_map.py:15538) lacks the cold path's `_literal_symbol_seed_files` rescue retry (repo_map.py:15374-15402), so when a repo exceeds `max_repo_files` and the target symbol is outside the initial scan window, warm returns `no_match` where cold finds it.

## Fix

A scoped fall-to-cold guard, per the daemon fail-OPEN contract: `_daemon_blast_radius_no_match_is_unreliable(payload)` (main.py:9608-9626) returns True iff `payload.no_match` AND `scan_limit.possibly_truncated`; the `blast_radius` command (main.py:9720-9723) then discards the warm payload (`payload = None`) so it falls through to the existing cold `build_symbol_blast_radius` path (which has the rescue).

**Precision (the money property):** the guard requires BOTH conditions, so a genuine `no_match` on a COMPLETE (non-truncated) map stays warm -- the daemon speedup is preserved for every real miss; only a truncated-map miss (where cold could do better) falls through. Scoped to `blast_radius` alone because it is the only symbol command whose cold path calls the rescue (verified: `_literal_symbol_seed_files` has exactly one production call site).

## Security/correctness gate (mandatory -- daemon surface) -- SHIP

6-axis adversarial Opus review at 4a97b63, all PASS: **precision** (fault-injected an over-firing guard -> the precision test caught it, a real tripwire); **crash-safety** (all `.get()` behind an `isinstance(dict)` gate -> a missing/None `scan_limit` fails open, never throws); **fall-open integrity** (byte-identical cold path, same args, exit 2 + symbol found); **session-reuse nuance PROVEN perf-only, not a correctness bug** (the cold rescue is gated on exactly the guard's condition, and implicit sessions are keyed by `max_repo_files` so the served map's cap matches the request); **scope** (singular divergence); **fail-open contract** (no silent-empty, truncated warm hits still exit 2).

## Tests

2 RED->GREEN tests in `tests/unit/test_symbol_daemon_autostart.py` (both verified genuine by fault injection): `test_blast_radius_daemon_falls_to_cold_on_truncated_no_match` (real in-process threaded daemon, 6-file repo capped at 1, symbol outside the window -> now found, exit 2) and `test_blast_radius_daemon_no_match_stays_warm_when_map_complete` (precision boundary -- cold builder tripwire never fires on a complete-map miss). CI-parity all green (ruff check / ruff format --preview --check / mypy); broader sweep 457 passed.

## Non-blocking residuals (tracked, not in this PR)

1. Optional 1-line comment at session_store.py:1301 documenting that the implicit-session cap-keying is what makes omitting `_limited_session_repo_map` safe there (a future explicit multi-cap session would need it). Cosmetic; can follow up.
2. Feature-parity gap (separate from this divergence bug): defs/impact/refs/callers/blast_radius_plan/blast_radius_render cold paths all uniformly lack the literal-seed rescue, so a symbol outside the scan window is a consistent miss on them (warm==cold, no divergence). Worth a separate ticket if consistent "find-even-if-truncated" behavior across all symbol commands is desired.

`fix:` -> patch on merge. Advances #94 (unblocks the default-ON flip go/no-go). Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
