### PR TITLE
fix(mcp): default tg_repo_map max_repo_files to 2000 like its siblings (audit #114)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -2148,13 +2148,13 @@ def tg_ruleset_scan(
 
 
 @mcp.tool()  # type: ignore
-def tg_repo_map(path: str = ".", max_repo_files: int | None = 512) -> str:
+def tg_repo_map(path: str = ".", max_repo_files: int | None = _DEFAULT_MCP_REPO_SCAN_LIMIT) -> str:
     """
     Return a deterministic repository inventory for agent context selection.
 
     Args:
         path: File or directory to inventory.
-        max_repo_files: Maximum repo files to scan before returning. Defaults to 512.
+        max_repo_files: Maximum repo files to scan before returning.
     """
     # round-8 security (audit #95 gate): confine the primary path/root param to the MCP root
     # before any scan -- unconfined it is an arbitrary-directory-read primitive over the MCP

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -5125,7 +5125,7 @@ def test_tg_repo_map_returns_json_inventory(tmp_path, monkeypatch):
     assert payload["sidecar_used"] is False
     assert payload["coverage"]["language_scope"] == "python-js-ts-rust"
     assert payload["path"] == str(project.resolve())
-    assert payload["scan_limit"]["max_repo_files"] == 512
+    assert payload["scan_limit"]["max_repo_files"] == mcp_server._DEFAULT_MCP_REPO_SCAN_LIMIT
     assert payload["scan_limit"]["possibly_truncated"] is False
     assert str(module_path.resolve()) in payload["files"]
     assert str(test_path.resolve()) in payload["tests"]
@@ -5146,6 +5146,37 @@ def test_tg_repo_map_returns_json_inventory(tmp_path, monkeypatch):
         for entry in payload["imports"]
     )
     assert str(module_path.resolve()) in payload["related_paths"]
+
+
+def test_tg_repo_map_defaults_to_shared_mcp_repo_scan_limit(tmp_path, monkeypatch):
+    """audit #114: tg_repo_map's signature hardcoded `max_repo_files: int | None = 512`
+    while every sibling MCP scan tool (tg_symbol_defs, tg_edit_plan, tg_context_pack, etc.)
+    defaults to the shared `_DEFAULT_MCP_REPO_SCAN_LIMIT` (2000). The effective-limit calc
+    `max_repo_files or DEFAULT_AGENT_REPO_MAP_LIMIT` only reaches 2000 when a caller
+    EXPLICITLY passes `None` -- the 512 signature default was truthy, so omitting the param
+    (the normal agent-call case) silently capped the scan at 512 instead of 2000. Pin the
+    argument actually forwarded to build_repo_map so this cannot regress to a hardcoded
+    literal that drifts from the shared constant."""
+    monkeypatch.chdir(tmp_path)
+    from tensor_grep.cli import mcp_server
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "sample.py").write_text("def add(x, y):\n    return x + y\n", encoding="utf-8")
+
+    seen: dict[str, object] = {}
+    real_build_repo_map = mcp_server.build_repo_map
+
+    def _spy_build_repo_map(path, max_repo_files=None, **kwargs):
+        seen["max_repo_files"] = max_repo_files
+        return real_build_repo_map(path, max_repo_files=max_repo_files, **kwargs)
+
+    monkeypatch.setattr(mcp_server, "build_repo_map", _spy_build_repo_map)
+
+    payload = json.loads(mcp_server.tg_repo_map(str(project)))
+
+    assert seen["max_repo_files"] == mcp_server._DEFAULT_MCP_REPO_SCAN_LIMIT
+    assert payload["scan_limit"]["max_repo_files"] == mcp_server._DEFAULT_MCP_REPO_SCAN_LIMIT
 
 
 def test_tg_repo_map_includes_typescript_and_rust_inventory(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Closes audit #114 (found by the #98 MCP-consolidation design). The MCP tool `tg_repo_map` hardcoded `max_repo_files=512` in its signature default (mcp_server.py:2151) while its ~16 sibling MCP tools default to `_DEFAULT_MCP_REPO_SCAN_LIMIT=2000`. The effective calc `max_repo_files or DEFAULT_AGENT_REPO_MAP_LIMIT` only reached 2000 if a caller explicitly passed `null` -- OMITTING the param (the normal case) silently capped the scan at 512. So agents calling `tg_repo_map` on a repo >512 files got a SILENTLY TRUNCATED map -- the exact silent-512-truncation audit #57 fixed for the CLI, missed on this one MCP tool.

## Fix

Change `tg_repo_map`'s `max_repo_files` signature default 512 -> `_DEFAULT_MCP_REPO_SCAN_LIMIT`, matching every sibling. Dropped the stale "Defaults to 512" docstring line (siblings don't hardcode the number, so it can't drift again). `tg_session_open`'s 512 (intentional "agent-safe cold opens") left untouched.

## Verification

Caught + corrected a pre-existing test (`test_tg_repo_map_returns_json_inventory`) that had PINNED the buggy 512 as "correct". New spy test `test_tg_repo_map_defaults_to_shared_mcp_repo_scan_limit` pins the actually-forwarded arg to the shared constant (regression guard). RED->GREEN (both failed `assert 512==2000` pre-fix). Full `test_mcp_server.py` 325 passed; ruff/format/mypy clean; the confinement ratchet is structurally unaffected (a default-VALUE change adds no param).

## Security gate (mcp_server.py surface) -- SHIP

Focused Opus review: only-a-default-value change (confinement + effective-calc untouched); NO new DoS (2000 is the measured-safe knee -- repo_map.py:148: 512=1.48s, 2000=3.51s OK, 4000=10.35s superlinear -- and 16 siblings + the CLI already run at 2000); the test-update strengthens coverage.

`fix:` -> patch. Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
