### PR TITLE
fix(rust): refuse symlink/reparse-point on the audit-manifest write to close the cross-process TOCTOU (audit #110)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -7653,6 +7653,78 @@ fn emit_rollback_status(summary: &ValidationRollbackSummary) {
     }
 }
 
+/// Writes `bytes` to `path`, refusing to follow a symlink/reparse point at the final path
+/// component (audit #110 Gap 1). Closes a cross-process TOCTOU: the Python front door
+/// resolves and confines the `--audit-manifest` target before invoking this native binary,
+/// but a symlink swapped into that path between the Python check and this write was
+/// previously followed by a plain `std::fs::write` -- a confined write could escape its
+/// anchor. Mirrors the confine-then-open discipline `_write_json_refuse_symlink` already
+/// uses on the Python side (`src/tensor_grep/cli/main.py`).
+fn write_bytes_refuse_symlink(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::fs::OpenOptions;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // O_NOFOLLOW makes the open() itself fail (ELOOP) if the final path component is
+        // a symlink -- atomic, no separate check->open window.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .with_context(|| format!("refusing to write through symlink at {}", path.display()))?;
+        file.write_all(bytes)?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+        // Not in a dependency here (neither `windows` nor `winapi` is in Cargo.toml) -- these
+        // are the real documented values (winnt.h / fileapi.h), kept as local consts rather
+        // than pulling in a crate for two flag bits.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+        // FILE_FLAG_OPEN_REPARSE_POINT makes CreateFile open the reparse point entry
+        // itself instead of traversing it -- so if `path` is a symlink, we open the link,
+        // not its target. Deliberately no truncate-at-open: on a real reparse point that
+        // would touch the reparse buffer before we get to check it below.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        let attributes = file.metadata()?.file_attributes();
+        if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            anyhow::bail!(
+                "refusing to write through symlink/reparse point at {}",
+                path.display()
+            );
+        }
+        // Confirmed a regular file (or a freshly created one) -- now safe to truncate and
+        // write, preserving create-or-overwrite semantics for a legitimate rerun.
+        file.set_len(0)?;
+        file.write_all(bytes)?;
+        Ok(())
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        if std::fs::symlink_metadata(path)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            anyhow::bail!("refusing to write through symlink at {}", path.display());
+        }
+        std::fs::write(path, bytes)?;
+        Ok(())
+    }
+}
+
 struct AuditManifestWriteInput<'a> {
     path: &'a Path,
     lang: &'a str,
@@ -7756,7 +7828,7 @@ fn write_audit_manifest_for_plan(
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create audit manifest dir {}", parent.display()))?;
     }
-    std::fs::write(path, serde_json::to_vec_pretty(&manifest)?)
+    write_bytes_refuse_symlink(path, &serde_json::to_vec_pretty(&manifest)?)
         .with_context(|| format!("failed to write audit manifest {}", path.display()))?;
 
     Ok(AuditManifestSummary {

--- a/rust_core/tests/test_ast_rewrite.rs
+++ b/rust_core/tests/test_ast_rewrite.rs
@@ -1762,6 +1762,185 @@ fn test_tg_run_apply_verify_json_can_emit_audit_manifest() {
 }
 
 #[test]
+fn test_apply_audit_manifest_refuses_symlink_at_manifest_path() {
+    // audit #110 Gap 1: a symlink swapped into the --audit-manifest target must not be
+    // followed by the Rust-side write (a cross-process TOCTOU on the Python-side
+    // confinement check). Plant a symlink pointing OUTSIDE the workdir and confirm apply
+    // refuses to write through it, leaving the outside target untouched.
+    let (_dir, file_path) = write_source_file("py", "def add(x, y): return x + y\n");
+    let workdir = file_path.parent().unwrap();
+
+    let outside_dir = tempdir().unwrap();
+    let outside_target = outside_dir.path().join("outside-target.json");
+    fs::write(&outside_target, b"UNTOUCHED").unwrap();
+
+    let manifest_link = workdir.join("rewrite-audit.json");
+    if let Err(err) = std::os::windows::fs::symlink_file(&outside_target, &manifest_link) {
+        eprintln!(
+            "skipping test_apply_audit_manifest_refuses_symlink_at_manifest_path: \
+             cannot create a Windows symlink in this environment: {err}"
+        );
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&manifest_link)
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "apply must refuse to write the audit manifest through a symlink; stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(&outside_target).unwrap(),
+        b"UNTOUCHED",
+        "the symlink's target outside the workdir must be left untouched"
+    );
+}
+
+#[test]
+fn test_apply_audit_manifest_overwrites_regular_file_on_rerun() {
+    // Guard: the legit create-or-overwrite path (a rerun over an EXISTING, larger manifest
+    // file) must still succeed and leave no stale trailing bytes -- a regression test for
+    // the Windows set_len(0)-after-check ordering and the "create, don't require absence"
+    // (no O_EXCL) semantics in write_bytes_refuse_symlink.
+    let (_dir, file_path) = write_source_file("py", "def add(x, y): return x + y\n");
+    let audit_manifest_path = file_path.parent().unwrap().join("rewrite-audit.json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&audit_manifest_path)
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Pad the existing manifest file so it is LONGER than the next write will be -- if the
+    // write path ever regresses to "open without truncate", stale trailing bytes here would
+    // survive and the reparsed manifest would fail to parse as clean JSON.
+    let mut stale = fs::read(&audit_manifest_path).unwrap();
+    stale.extend(std::iter::repeat_n(b'X', 4096));
+    fs::write(&audit_manifest_path, &stale).unwrap();
+
+    let second_output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: ($EXPR)")
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&audit_manifest_path)
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+    assert!(
+        second_output.status.success(),
+        "the legit create-or-overwrite path must still succeed on a rerun over a stale file; stderr={}",
+        String::from_utf8_lossy(&second_output.stderr)
+    );
+
+    let rewritten_bytes = fs::read(&audit_manifest_path).unwrap();
+    assert!(
+        rewritten_bytes.len() < stale.len(),
+        "rewritten manifest ({} bytes) should be shorter than the padded stale file ({} bytes) it replaced",
+        rewritten_bytes.len(),
+        stale.len()
+    );
+    let parsed: Value = serde_json::from_slice(&rewritten_bytes).expect(
+        "manifest must parse as clean JSON with no stale trailing bytes left over from the padded write",
+    );
+    assert_eq!(parsed["kind"], "rewrite-audit-manifest");
+}
+
+#[test]
+fn test_batch_apply_audit_manifest_refuses_symlink_at_manifest_path() {
+    // audit #110 Gap 1, second call site: handle_ast_batch_rewrite_apply also routes
+    // through write_audit_manifest_for_plan -- confirm the batch-apply path is covered
+    // too, not just the single-rewrite apply path exercised above.
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("fixture.py");
+    fs::write(&file_path, "def add(x, y): return x + y\n").unwrap();
+
+    let config_path = write_batch_config(
+        dir.path(),
+        &serde_json::json!({
+            "rewrites": [
+                {
+                    "pattern": "def $F($$$ARGS): return $EXPR",
+                    "replacement": "lambda $$$ARGS: $EXPR",
+                    "lang": "python"
+                }
+            ]
+        }),
+    );
+
+    let outside_dir = tempdir().unwrap();
+    let outside_target = outside_dir.path().join("outside-target.json");
+    fs::write(&outside_target, b"UNTOUCHED").unwrap();
+
+    let manifest_link = dir.path().join("rewrite-audit.json");
+    if let Err(err) = std::os::windows::fs::symlink_file(&outside_target, &manifest_link) {
+        eprintln!(
+            "skipping test_batch_apply_audit_manifest_refuses_symlink_at_manifest_path: \
+             cannot create a Windows symlink in this environment: {err}"
+        );
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--batch-rewrite")
+        .arg(&config_path)
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&manifest_link)
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "batch-apply must refuse to write the audit manifest through a symlink; stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(&outside_target).unwrap(),
+        b"UNTOUCHED",
+        "the symlink's target outside the workdir must be left untouched"
+    );
+}
+
+#[test]
 fn test_tg_run_apply_verify_json_can_sign_audit_manifest() {
     let (_dir, file_path) = write_source_file("py", "def add(x, y): return x + y\n");
     let audit_manifest_path = file_path.parent().unwrap().join("rewrite-audit.json");

--- a/rust_core/tests/test_audit_manifest_symlink_unix.rs
+++ b/rust_core/tests/test_audit_manifest_symlink_unix.rs
@@ -1,0 +1,206 @@
+#![cfg(unix)]
+
+// audit #110 Gap 1 (Unix half): `test_ast_rewrite.rs` is `#![cfg(windows)]`-gated at the
+// top of the file, so a `#[cfg(unix)]` test placed inside it would never compile on any
+// platform -- not on Windows (doubly excluded: the inner cfg(unix) fails there too) and
+// not on Linux/macOS (the whole file is skipped before the inner cfg is even considered).
+// This sibling file carries the real-O_NOFOLLOW half of the write_bytes_refuse_symlink
+// regression coverage so it actually runs on the ubuntu-latest/macos-latest legs of the
+// `test-rust-core` CI matrix (.github/workflows/ci.yml, `cargo test --verbose
+// --no-default-features`). It mirrors the Windows tests in test_ast_rewrite.rs 1:1.
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::{tempdir, TempDir};
+
+fn write_source_file(extension: &str, content: &str) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join(format!("fixture.{extension}"));
+    fs::write(&file_path, content).unwrap();
+    (dir, file_path)
+}
+
+fn write_batch_config(dir: &std::path::Path, payload: &Value) -> PathBuf {
+    let config_path = dir.join("batch-rewrite.json");
+    fs::write(&config_path, serde_json::to_vec_pretty(payload).unwrap()).unwrap();
+    config_path
+}
+
+#[test]
+fn test_apply_audit_manifest_refuses_symlink_at_manifest_path_unix() {
+    // audit #110 Gap 1: a symlink swapped into the --audit-manifest target must not be
+    // followed by the Rust-side write (a cross-process TOCTOU on the Python-side
+    // confinement check). Plant a symlink pointing OUTSIDE the workdir and confirm apply
+    // refuses to write through it (O_NOFOLLOW), leaving the outside target untouched.
+    let (_dir, file_path) = write_source_file("py", "def add(x, y): return x + y\n");
+    let workdir = file_path.parent().unwrap();
+
+    let outside_dir = tempdir().unwrap();
+    let outside_target = outside_dir.path().join("outside-target.json");
+    fs::write(&outside_target, b"UNTOUCHED").unwrap();
+
+    let manifest_link = workdir.join("rewrite-audit.json");
+    if let Err(err) = symlink(&outside_target, &manifest_link) {
+        eprintln!(
+            "skipping test_apply_audit_manifest_refuses_symlink_at_manifest_path_unix: \
+             cannot create a symlink in this environment: {err}"
+        );
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&manifest_link)
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "apply must refuse to write the audit manifest through a symlink; stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(&outside_target).unwrap(),
+        b"UNTOUCHED",
+        "the symlink's target outside the workdir must be left untouched"
+    );
+}
+
+#[test]
+fn test_apply_audit_manifest_overwrites_regular_file_on_rerun_unix() {
+    // Guard: the legit create-or-overwrite path (a rerun over an EXISTING, larger manifest
+    // file) must still succeed -- a regression test for the O_TRUNC + O_NOFOLLOW open in
+    // write_bytes_refuse_symlink's unix branch.
+    let (_dir, file_path) = write_source_file("py", "def add(x, y): return x + y\n");
+    let audit_manifest_path = file_path.parent().unwrap().join("rewrite-audit.json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&audit_manifest_path)
+        .arg("def $F($$$ARGS): return $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut stale = fs::read(&audit_manifest_path).unwrap();
+    stale.extend(std::iter::repeat_n(b'X', 4096));
+    fs::write(&audit_manifest_path, &stale).unwrap();
+
+    let second_output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--lang")
+        .arg("python")
+        .arg("--rewrite")
+        .arg("lambda $$$ARGS: ($EXPR)")
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&audit_manifest_path)
+        .arg("lambda $$$ARGS: $EXPR")
+        .arg(&file_path)
+        .output()
+        .unwrap();
+    assert!(
+        second_output.status.success(),
+        "the legit create-or-overwrite path must still succeed on a rerun over a stale file; stderr={}",
+        String::from_utf8_lossy(&second_output.stderr)
+    );
+
+    let rewritten_bytes = fs::read(&audit_manifest_path).unwrap();
+    assert!(
+        rewritten_bytes.len() < stale.len(),
+        "rewritten manifest ({} bytes) should be shorter than the padded stale file ({} bytes) it replaced",
+        rewritten_bytes.len(),
+        stale.len()
+    );
+    let parsed: Value = serde_json::from_slice(&rewritten_bytes).expect(
+        "manifest must parse as clean JSON with no stale trailing bytes left over from the padded write",
+    );
+    assert_eq!(parsed["kind"], "rewrite-audit-manifest");
+}
+
+#[test]
+fn test_batch_apply_audit_manifest_refuses_symlink_at_manifest_path_unix() {
+    // audit #110 Gap 1, second call site: handle_ast_batch_rewrite_apply also routes
+    // through write_audit_manifest_for_plan -- confirm the batch-apply path is covered
+    // too, not just the single-rewrite apply path exercised above.
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("fixture.py");
+    fs::write(&file_path, "def add(x, y): return x + y\n").unwrap();
+
+    let config_path = write_batch_config(
+        dir.path(),
+        &serde_json::json!({
+            "rewrites": [
+                {
+                    "pattern": "def $F($$$ARGS): return $EXPR",
+                    "replacement": "lambda $$$ARGS: $EXPR",
+                    "lang": "python"
+                }
+            ]
+        }),
+    );
+
+    let outside_dir = tempdir().unwrap();
+    let outside_target = outside_dir.path().join("outside-target.json");
+    fs::write(&outside_target, b"UNTOUCHED").unwrap();
+
+    let manifest_link = dir.path().join("rewrite-audit.json");
+    if let Err(err) = symlink(&outside_target, &manifest_link) {
+        eprintln!(
+            "skipping test_batch_apply_audit_manifest_refuses_symlink_at_manifest_path_unix: \
+             cannot create a symlink in this environment: {err}"
+        );
+        return;
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tg"))
+        .arg("run")
+        .arg("--batch-rewrite")
+        .arg(&config_path)
+        .arg("--apply")
+        .arg("--json")
+        .arg("--audit-manifest")
+        .arg(&manifest_link)
+        .arg(&file_path)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "batch-apply must refuse to write the audit manifest through a symlink; stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(&outside_target).unwrap(),
+        b"UNTOUCHED",
+        "the symlink's target outside the workdir must be left untouched"
+    );
+}

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -5002,11 +5002,25 @@ def _write_json_refuse_symlink(write_path: Path, data: object) -> None:
     Two layers, because ``os.O_NOFOLLOW`` is unavailable on Windows (mirrors cpython's
     own tempfile module: ``getattr(os, "O_NOFOLLOW", 0)``, not a hard import-time
     dependency):
-      1. An explicit ``is_symlink()`` pre-check -- the authoritative guard on Windows,
-         and works there without elevated privileges (only *creating* a Windows symlink
-         needs privilege; checking for one does not).
-      2. ``O_NOFOLLOW`` on the actual open -- the authoritative guard on POSIX, closing
-         the narrow race between step 1's check and the open() call.
+      1. An explicit ``is_symlink()`` pre-check -- works without elevated privileges
+         (only *creating* a Windows symlink needs privilege; checking for one does not).
+         On Windows this is a best-effort narrowing, NOT an atomic guard: ``O_NOFOLLOW``
+         is a no-op there (see step 2), so a symlink swapped into ``write_path`` between
+         this check and the ``os.open()`` call below would still be followed -- a narrow,
+         same-process TOCTOU window. That residual window is consciously accepted rather
+         than papered over with fragile ctypes/CreateFileW handle-reopen tricks: it is a
+         single-digit-microsecond gap inside one process (not the cross-process window a
+         planted symlink usually needs), the caller has already confined ``write_path``
+         to a validated directory before this function runs, and creating a *new* Windows
+         symlink at that exact instant still requires the attacker to hold
+         symlink-creation privilege (Developer Mode or elevation). Audit #110 closed the
+         cross-process analog of this race (a symlink planted between a separate
+         confinement check and a *later* write, e.g. across a Rust subprocess boundary)
+         in the Rust audit-manifest writer via ``O_NOFOLLOW`` / Windows
+         ``FILE_FLAG_OPEN_REPARSE_POINT`` -- see ``write_bytes_refuse_symlink`` in
+         ``rust_core/src/main.rs``.
+      2. ``O_NOFOLLOW`` on the actual open -- the authoritative, atomic guard on POSIX,
+         closing the narrow race between step 1's check and the open() call.
     """
     if write_path.is_symlink():
         raise ValueError(f"Refusing to write through symlink at {write_path}")


### PR DESCRIPTION
## What

Closes audit #110 (the #102 Opus-gate residual) -- a cross-process symlink TOCTOU on the MCP rewrite audit-manifest write. The Python side confines the path (`.resolve()` + anchor check), but the native `write_audit_manifest_for_plan` then did a plain `std::fs::write` in a SEPARATE process -- a symlink planted in the check->write window was followed, letting a confined write escape the anchor.

## Fix

New `write_bytes_refuse_symlink(path, bytes)` helper (rust_core/src/main.rs), cfg-gated:
- **Unix:** `OpenOptions...custom_flags(libc::O_NOFOLLOW)` -- the kernel refuses a symlink at the final component atomically (ELOOP) before create/truncate.
- **Windows:** open with `FILE_FLAG_OPEN_REPARSE_POINT` (opens the reparse point ITSELF, no traversal), check `FILE_ATTRIBUTE_REPARSE_POINT` and bail BEFORE `set_len(0)` -- handle-bound, no second re-resolution.
- **Other:** `symlink_metadata` pre-check + write.

`write_audit_manifest_for_plan` now routes through it; both call sites (`handle_ast_rewrite_apply`, `handle_ast_batch_rewrite_apply`) covered. Fails closed via `?` (non-zero exit, no partial/corrupt manifest). Gap 2 (the Python `_write_json_refuse_symlink` Windows `O_NOFOLLOW`-no-op) is docstring-only: the residual there is a same-process microsecond window on a confined, privilege-gated path -- consciously accepted (the fragile ctypes fix isn't worth it).

## Verification

The build caught a real blocker during verify-plan: a `#[cfg(unix)]` test inside the `#![cfg(windows)]`-gated `test_ast_rewrite.rs` would be PERMANENTLY DEAD CODE -> split the Unix tests into a new `#![cfg(unix)]` sibling file (runs on CI's ubuntu/macos legs). Real-binary RED->GREEN (planted symlink followed pre-fix; refused + outside target untouched post-fix). cargo fmt / clippy -D warnings / ruff / mypy clean; `cargo test --test test_ast_rewrite` 61/61.

## Security gate (write path / native FFI) -- SHIP

Adversarial Opus review, all 6 axes correct: **Unix O_NOFOLLOW** (final-component ELOOP before truncation, legit overwrite preserved); **Windows** FILE_FLAG_OPEN_REPARSE_POINT + attribute-check + handle-bound `set_len(0)` -- **empirically verified on a real Windows box with real symlinks**; both call sites fail-closed; tests genuine + on the correct CI legs; Gap-2 docstring honest.

## Residuals (documented, non-blocking)

- Final-component-only: an intermediate-DIRECTORY symlink/junction is still traversed (fully closing needs Linux `openat2`+`RESOLVE_NO_SYMLINKS`); same limitation as the Python side -- consistent scope boundary.
- Adjacent unguarded `std::fs::write` on internal checkpoint-metadata/rollback paths (main.rs:6980/7008/7628) -- lower attacker-influence, a future symlink-sweep target (tracked).

`fix:` -> patch. Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
