### PR TITLE
fix(search): honor multiple -e patterns + read -f on the native/CPU path (audit #69, re-do of #441)

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -444,11 +444,34 @@ def _can_delegate_to_native_tg_search(search_args: list[str]) -> bool:
         "--stats",
         "-l",
         "-r",
+        # audit #69 (re-do of #441): the separately-compiled native binary has its OWN,
+        # independent multi-pattern bugs (verified via direct invocation: a `-f` pattern
+        # file is silently never read at all -- an even more severe flood than the pre-fix
+        # Python bug -- and multiple `-e` patterns are not deduplicated when a single line
+        # matches more than one). This outer argv fast path must never delegate `-e`/`-f`
+        # searches to it; route them through the full CLI instead, which now combines
+        # multi-pattern correctly and already refuses this exact case in its OWN inner
+        # native-delegation gate (`regexp`/`file_patterns` are both in
+        # `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS`, cli/main.py) -- excluding them
+        # here too keeps the two front doors in parity for -e/-f, even a single one.
+        "-e",
+        "--regexp",
+        "-f",
+        "--file",
     }
-    unsupported_prefixes = ("--format=", "--lang=", "--replace=")
-    return not any(
-        arg in unsupported_flags or arg.startswith(unsupported_prefixes) for arg in search_args
-    )
+    unsupported_prefixes = ("--format=", "--lang=", "--replace=", "--regexp=", "--file=")
+    if any(arg in unsupported_flags or arg.startswith(unsupported_prefixes) for arg in search_args):
+        return False
+    # Attached short-flag value form (`-efoo` == `-e foo`, `-fpats.txt` == `-f pats.txt`).
+    # The bare `-e`/`-f` tokens are already covered by `unsupported_flags` above; `-F`
+    # (fixed-strings, uppercase) and `--file`/`--regexp=...` (double-dash) are untouched by
+    # this lowercase single-dash prefix check.
+    if any(
+        arg.startswith(("-e", "-f")) and not arg.startswith("--") and arg not in {"-e", "-f"}
+        for arg in search_args
+    ):
+        return False
+    return True
 
 
 def _search_args_include_guarded_broad_root(search_args: list[str]) -> bool:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3835,6 +3835,62 @@ def _validate_search_regex(pattern: str, config: "SearchConfig") -> None:
         raise InvalidRegexError(f"error parsing regex: {exc}") from exc
 
 
+_LEADING_INLINE_FLAG_RE = re.compile(r"^\(\?([aiLmsux]+)\)")
+
+
+def _scope_leading_inline_flag(pattern: str) -> str:
+    """Rewrite a GLOBAL leading inline flag group (``(?i)foo``) to the SCOPED form
+    (``(?i:foo)``) so it stays legal -- and stays scoped to its own branch, never leaking
+    case-insensitivity/etc. across the rest of the alternation -- once it is no longer the
+    first thing in a combined multi-pattern regex (audit #69, re-do of #441)."""
+    match = _LEADING_INLINE_FLAG_RE.match(pattern)
+    if not match:
+        return pattern
+    flags = match.group(1)
+    rest = pattern[match.end() :]
+    return f"(?{flags}:{rest})"
+
+
+def _combine_multi_patterns(patterns: list[str], *, fixed_strings: bool) -> str:
+    """OR-combine multiple ``-e``/``-f`` patterns into one rg-parity alternation regex: a
+    line matches if ANY pattern matches (rg's own multi-pattern semantics), reported once
+    even when more than one pattern matches the same line -- never N independent passes.
+    Each pattern becomes its own non-capturing-group branch (never a bare top-level ``|``
+    join), and the whole alternation gets one more enclosing group, so downstream
+    ``-w``/``-x``/``--line-regexp`` wrapping (which wraps the WHOLE pattern string, e.g.
+    ``rf"\\b{pattern}\\b"``) applies to the entire alternation rather than mis-scoping to
+    just the first/last branch via ``|``'s low precedence."""
+    branches = []
+    for raw_pattern in patterns:
+        candidate = (
+            re.escape(raw_pattern) if fixed_strings else _scope_leading_inline_flag(raw_pattern)
+        )
+        branches.append(f"(?:{candidate})")
+    return "(?:" + "|".join(branches) + ")"
+
+
+def _read_patterns_from_file_list(file_paths: list[str], *, json_mode: bool) -> list[str]:
+    """Read ``-f``/``--file`` pattern files, one pattern per line (rg parity: a genuinely
+    blank line is an EMPTY pattern that matches every line, so it is intentionally NOT
+    filtered out here). A missing/unreadable file fails loud with exit 2 -- per the Backend
+    Fail-Closed Contract -- instead of the pre-fix silent flood (an unread ``-f`` collapsed
+    to an empty ``pattern`` that matched every line in every file)."""
+    patterns: list[str] = []
+    for file_path in file_paths:
+        try:
+            content = Path(file_path).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            _exit_search_error(
+                "pattern_file_error",
+                f"failed to read pattern file: {file_path} ({exc})",
+                json_mode=json_mode,
+                exit_code=2,
+            )
+            return []  # pragma: no cover -- _exit_search_error always calls sys.exit
+        patterns.extend(content.splitlines())
+    return patterns
+
+
 def _search_paths_include_guarded_broad_root(paths: list[str]) -> bool:
     for path in paths:
         if not path or path == "-" or path.startswith("-"):
@@ -6610,8 +6666,28 @@ def search_command(
         gpu_device_ids=parsed_gpu_device_ids,
     )
     if not files:
+        # audit #69 (re-do of #441, this time with a Windows golden from the start):
+        # `multi_pattern_source` already excludes -e-and-f-together (a single -e still makes
+        # -f a dead flag, pinned by
+        # test_search_single_regexp_with_unused_file_option_and_only_matching_still_works)
+        # and excludes -o/-r/--rank/--semantic (rejected with exit 2 above), so this is
+        # exactly the plain-search shape that used to silently drop every pattern but the
+        # first (multiple -e) or never read the file at all (-f alone). The multiple-`-e`
+        # sub-case combines EAGERLY here -- no I/O, and the rg-routed passthrough path is
+        # untouched by it either way (see the combine step below). The `-f`-alone sub-case is
+        # handled LATER, only once the search is confirmed to not be rg-passthrough
+        # (deliberately deferred: an eager read here broke
+        # test_python_search_treats_file_option_as_pattern_file_not_regex, where real `rg`
+        # itself must read the `-f` file on the passthrough path, never tg).
+        combined_multi_patterns: list[str] | None = (
+            list(regexp_patterns) if multi_pattern_source and len(regexp_patterns) > 1 else None
+        )
         try:
-            patterns_to_validate = regexp_patterns if regexp_patterns else [pattern]
+            patterns_to_validate = (
+                combined_multi_patterns
+                if combined_multi_patterns is not None
+                else (regexp_patterns if regexp_patterns else [pattern])
+            )
             for regex_pattern in patterns_to_validate:
                 _validate_search_regex(regex_pattern, config)
         except Exception as exc:
@@ -6634,6 +6710,18 @@ def search_command(
                     _exit_invalid_regex(exc, json_mode=json)
             else:
                 raise
+        if combined_multi_patterns is not None:
+            # Build one rg-parity OR-alternation and let 100% of the existing
+            # single-pattern machinery (CPUBackend, the Rust FFI, native-binary delegation)
+            # treat it exactly like a hand-typed `-e "foo|bar"` -- the rg-ROUTED passthrough
+            # path is untouched by this (it reads `config.regexp`/`config.file_patterns`
+            # directly and builds its own rg argv; see ripgrep_backend.py:788). `-F`
+            # multi-literal is `re.escape`'d per branch, so `fixed_strings` must be cleared
+            # here or the combined alternation string would be re-literal-matched whole.
+            pattern = _combine_multi_patterns(
+                combined_multi_patterns, fixed_strings=config.fixed_strings
+            )
+            config = dataclasses.replace(config, query_pattern=pattern, fixed_strings=False)
     guarded_broad_root = _search_paths_include_guarded_broad_root(paths_to_search)
     explicit_hidden_search_root = not config.hidden and any(
         _path_has_hidden_component(path) for path in paths_to_search
@@ -6776,6 +6864,38 @@ def search_command(
             with nvtx_range("search.passthrough_rg", color="green"):
                 exit_code = rg_backend.search_passthrough(passthrough_paths, pattern, config=config)
             sys.exit(exit_code)
+
+    if multi_pattern_source and not regexp_patterns:
+        # The `-f`-alone sub-case (see the comment above the earlier `combined_multi_patterns`
+        # assignment) is deferred until HERE, now that a real search is confirmed to not be
+        # rg-passthrough (the `if can_passthrough_rg: if not stats: ... sys.exit(...)` block
+        # just above already returned when it would have applied). Reading `-f` eagerly broke
+        # `test_python_search_treats_file_option_as_pattern_file_not_regex`, where real `rg`
+        # itself must read the pattern file on the passthrough path, never tg. This must land
+        # before `Pipeline(...)` below, which reads `config.query_pattern` to route (audit #69,
+        # re-do of #441).
+        file_sourced_patterns = _read_patterns_from_file_list(file or [], json_mode=json)
+        try:
+            for regex_pattern in file_sourced_patterns:
+                _validate_search_regex(regex_pattern, config)
+        except Exception as exc:
+            if _is_invalid_regex_error(exc):
+                if (
+                    _is_inline_flag_regex_error(str(exc))
+                    and _eligible_for_pcre2_inline_flag_fallback(config)
+                    and _pcre2_fallback_backend_available()
+                ):
+                    config = dataclasses.replace(config, pcre2=True)
+                    typer.echo(
+                        "note: retried with PCRE2 (-P) for inline-flag pattern",
+                        err=True,
+                    )
+                else:
+                    _exit_invalid_regex(exc, json_mode=json)
+            else:
+                raise
+        pattern = _combine_multi_patterns(file_sourced_patterns, fixed_strings=config.fixed_strings)
+        config = dataclasses.replace(config, query_pattern=pattern, fixed_strings=False)
 
     scanner = DirectoryScanner(config)
     candidate_files_ordered, candidate_files_set = _collect_candidate_files(

--- a/tests/e2e/test_multi_pattern_native.py
+++ b/tests/e2e/test_multi_pattern_native.py
@@ -1,0 +1,363 @@
+"""E2E coverage for the -e/-f multi-pattern combine on the CPU/native search path.
+
+Bug (audit #69, a re-do of the never-merged PR #441): on the CPU/native (non-rg) search
+path -- i.e. whenever `--cpu` (or another flag that routes away from ripgrep) is used --
+`tg search -e foo -e bar` silently dropped every pattern but the first
+(`regexp_patterns[0]`), and `tg search -f patterns.txt` never read the file at all (the
+placeholder empty `pattern` string). The rg-ROUTED path was always correct (rg reads
+`config.regexp`/`config.file_patterns` directly and builds its own `-e`/`--file` argv in
+`ripgrep_backend.py`), so these tests force `--cpu` to exercise the CPU/native path.
+
+Every test also sets `TG_DISABLE_NATIVE_TG=1`. This is deliberate, not a workaround: it
+pins these tests to the in-process Python combine fix in `cli/main.py` regardless of
+whether a separately-compiled native `tg` binary happens to be resolvable on the machine
+running the suite (it is, in this dev environment -- see
+`test_multi_pattern_e_f_do_not_delegate_to_native_binary` in `test_cli_bootstrap.py` for
+the DIFFERENT, environment-independent unit test that the outer bootstrap.py fast path
+correctly refuses to delegate `-e`/`-f` to that binary at all).
+
+Windows golden-parity discipline: PR #441's actual Windows CI run
+(github.com/oimiragieo/tensor-grep/actions/runs/28917558068) shows its own 18 new tests
+ALL passing on windows-latest/py3.11 and py3.12 -- the ONLY failure in that run was
+`test_output_golden_contract[json_multi_file-python-m]`, a pre-existing, unrelated
+snapshot drift (a `submatches` JSON field added by commit fa5fc23 on 2026-07-03, well
+before PR #441 existed, without updating that one fixture) reproduced independently on
+today's tree BEFORE this change. PR #441 was closed on a misdiagnosis of that failure, not
+an actual defect in its multi-pattern combine logic. `test_multi_pattern_golden_parity_*`
+below is nonetheless a hard-coded, rg-binary-independent exact-match assertion (never
+compares raw stdout byte-order, which is not guaranteed across platforms/filesystems) so a
+real future Windows-specific drift in the combine logic itself would still be caught here
+without depending on an installed `rg` binary at all.
+
+Dogfoods the REAL shipped entry point via `python -m tensor_grep` (never `CliRunner`,
+which bypasses the `bootstrap` front door).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+pytestmark = pytest.mark.acceptance
+
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+
+
+def _helpers():
+    from helpers import rg_parity
+
+    return rg_parity
+
+
+def _env() -> dict[str, str]:
+    env = os.environ.copy()
+    pythonpath_entries = [str(SRC_DIR)]
+    existing = env.get("PYTHONPATH", "")
+    if existing:
+        pythonpath_entries.extend(
+            entry for entry in existing.split(os.pathsep) if entry and entry != str(SRC_DIR)
+        )
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    # Pin these tests to the in-process Python combine fix -- see module docstring.
+    env["TG_DISABLE_NATIVE_TG"] = "1"
+    return env
+
+
+def _run(argv: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _tg(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return _run([sys.executable, "-m", "tensor_grep", "search", *args], cwd=cwd, env=env)
+
+
+def _normalize(text: str, root: Path) -> list[str]:
+    normalized: list[str] = []
+    for line in text.replace("\r\n", "\n").splitlines():
+        if not line:
+            continue
+        current = line.replace(str(root), ".").replace(root.as_posix(), ".").replace("\\", "/")
+        if current.startswith("./"):
+            current = current[2:]
+        normalized.append(current)
+    return normalized
+
+
+def _tg_json_matches(result: subprocess.CompletedProcess[str]) -> list[tuple[str, str]]:
+    payload = json.loads(result.stdout)
+    return sorted((match["file"], match["text"]) for match in payload["matches"])
+
+
+def _tg_json_files(result: subprocess.CompletedProcess[str]) -> list[str]:
+    payload = json.loads(result.stdout)
+    return sorted({match["file"] for match in payload["matches"]})
+
+
+@pytest.fixture()
+def env() -> dict[str, str]:
+    return _env()
+
+
+@pytest.fixture()
+def corpus(tmp_path: Path) -> Path:
+    # Pattern files (written by individual tests) go in `tmp_path`, one level ABOVE
+    # `root`, so a `-f ../patterns.txt` never becomes a search candidate itself.
+    root = tmp_path / "multi-pattern"
+    root.mkdir()
+    (root / "foo.txt").write_text("foo line\n", encoding="utf-8")
+    (root / "bar.txt").write_text("bar line\n", encoding="utf-8")
+    (root / "both.txt").write_text("foo and bar together\n", encoding="utf-8")
+    (root / "none.txt").write_text("nothing relevant\n", encoding="utf-8")
+    return root
+
+
+# --- (a) -e foo -e bar: both patterns must match, not just the first. -------------------
+
+
+def test_multi_e_native_matches_all_patterns_not_just_first(
+    corpus: Path, env: dict[str, str]
+) -> None:
+    result = _tg(["--cpu", "--sort", "path", "-e", "foo", "-e", "bar", "."], cwd=corpus, env=env)
+    assert result.returncode == 0, result.stderr
+    matched_files = sorted({line.split(":", 1)[0] for line in _normalize(result.stdout, corpus)})
+    assert matched_files == ["bar.txt", "both.txt", "foo.txt"]
+    assert "none.txt" not in matched_files
+
+
+def test_multi_e_native_reports_both_match_line_once(corpus: Path, env: dict[str, str]) -> None:
+    # both.txt matches "foo" AND "bar" but must be reported as ONE line, never two
+    # independent passes (rg parity: OR-combine, not N separate searches).
+    result = _tg(["--cpu", "-e", "foo", "-e", "bar", "both.txt"], cwd=corpus, env=env)
+    assert result.returncode == 0, result.stderr
+    matched_lines = _normalize(result.stdout, corpus)
+    assert len(matched_lines) == 1
+    assert matched_lines[0] == "foo and bar together"
+
+
+# --- (b) -f patterns.txt: the file must actually be read, and only its patterns match. --
+
+
+def test_pattern_file_native_reads_file_and_matches_any_pattern(
+    corpus: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8")
+    result = _tg(["--cpu", "--json", "-f", "../patterns.txt", "."], cwd=corpus, env=env)
+    assert result.returncode == 0, result.stderr
+    matched_files = _tg_json_files(result)
+    # Must NOT flood every file (the pre-fix bug: an unread `-f` collapsed to an empty
+    # pattern string that matched every line in every file).
+    assert matched_files == ["bar.txt", "both.txt", "foo.txt"]
+    assert "none.txt" not in matched_files
+
+
+def test_pattern_file_missing_exits_2(corpus: Path, env: dict[str, str]) -> None:
+    result = _tg(["--cpu", "-f", "does_not_exist.txt", "."], cwd=corpus, env=env)
+    assert result.returncode == 2
+    assert "does_not_exist.txt" in result.stderr
+
+
+def test_pattern_file_missing_exits_2_json_envelope(corpus: Path, env: dict[str, str]) -> None:
+    result = _tg(["--cpu", "--json", "-f", "does_not_exist.txt", "."], cwd=corpus, env=env)
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "pattern_file_error"
+
+
+def test_pattern_file_blank_line_matches_every_line_rg_parity(
+    corpus: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    # Documented rg behavior, pinned deliberately (not a bug to "fix"): a genuinely blank
+    # pattern-file line is an EMPTY pattern, which matches every line in every file.
+    (tmp_path / "blank.txt").write_text("\n", encoding="utf-8")
+    result = _tg(["--cpu", "--json", "-f", "../blank.txt", "."], cwd=corpus, env=env)
+    assert result.returncode == 0, result.stderr
+    matched_files = _tg_json_files(result)
+    assert matched_files == ["bar.txt", "both.txt", "foo.txt", "none.txt"]
+
+
+# --- (c) golden-parity: deterministic CPU backend, exact hard-coded match set/counts --
+# (no dependency on an installed `rg` binary at all -- Windows-safe per the module
+# docstring's PR #441 postmortem).
+
+
+def test_multi_pattern_golden_parity_deterministic_cpu_backend(
+    corpus: Path, env: dict[str, str]
+) -> None:
+    result = _tg(["--cpu", "--json", "-e", "foo", "-e", "bar", "."], cwd=corpus, env=env)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["total_files"] == 3
+    assert payload["total_matches"] == 3
+    assert _tg_json_matches(result) == [
+        ("bar.txt", "bar line"),
+        ("both.txt", "foo and bar together"),
+        ("foo.txt", "foo line"),
+    ]
+
+
+def test_multi_pattern_golden_parity_pattern_file_deterministic_cpu_backend(
+    corpus: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8")
+    result = _tg(["--cpu", "--json", "-f", "../patterns.txt", "."], cwd=corpus, env=env)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["total_files"] == 3
+    assert payload["total_matches"] == 3
+    assert _tg_json_matches(result) == [
+        ("bar.txt", "bar line"),
+        ("both.txt", "foo and bar together"),
+        ("foo.txt", "foo line"),
+    ]
+
+
+# --- -F multi-literal: each -e is re.escape'd, never interpreted as regex. --------------
+
+
+def test_fixed_strings_multi_e_native_literal_only(env: dict[str, str], tmp_path: Path) -> None:
+    root = tmp_path / "literal"
+    root.mkdir()
+    (root / "dot.txt").write_text("a.b literal\n", encoding="utf-8")
+    (root / "any.txt").write_text("axb should not match\n", encoding="utf-8")
+    (root / "zz.txt").write_text("zz here\n", encoding="utf-8")
+    result = _tg(["--cpu", "--sort", "path", "-F", "-e", "a.b", "-e", "zz", "."], cwd=root, env=env)
+    assert result.returncode == 0, result.stderr
+    matched_files = sorted({line.split(":", 1)[0] for line in _normalize(result.stdout, root)})
+    assert matched_files == ["dot.txt", "zz.txt"]
+    assert "any.txt" not in matched_files
+
+
+# --- leading (?i) inline flag stays SCOPED to its own branch, never leaking case- -------
+# insensitivity across the whole alternation. -------------------------------------------
+
+
+def test_multi_e_leading_inline_flag_is_scoped(env: dict[str, str], tmp_path: Path) -> None:
+    root = tmp_path / "scoped-flag"
+    root.mkdir()
+    (root / "upper.txt").write_text("FOO shout\n", encoding="utf-8")
+    (root / "lower.txt").write_text("bar quiet\n", encoding="utf-8")
+    (root / "upper_bar.txt").write_text("BAR shout\n", encoding="utf-8")
+    result = _tg(["--cpu", "--sort", "path", "-e", "(?i)foo", "-e", "bar", "."], cwd=root, env=env)
+    assert result.returncode == 0, result.stderr
+    matched_files = sorted({line.split(":", 1)[0] for line in _normalize(result.stdout, root)})
+    assert matched_files == ["lower.txt", "upper.txt"]
+    # BAR must NOT match: (?i) must stay scoped to the foo branch, not leak globally.
+    assert "upper_bar.txt" not in matched_files
+
+
+# --- single -e / single -F must stay BYTE-IDENTICAL to the plain-positional form (no ----
+# combine wrapping applied when there is only one total pattern). -----------------------
+
+
+def test_single_e_byte_identical_to_positional(corpus: Path, env: dict[str, str]) -> None:
+    via_flag = _tg(["--cpu", "--sort", "path", "-e", "foo", "."], cwd=corpus, env=env)
+    via_positional = _tg(["--cpu", "--sort", "path", "foo", "."], cwd=corpus, env=env)
+    assert via_flag.returncode == via_positional.returncode
+    assert via_flag.stdout == via_positional.stdout
+
+
+def test_single_fixed_strings_e_byte_identical_to_positional(
+    corpus: Path, env: dict[str, str]
+) -> None:
+    via_flag = _tg(["--cpu", "--sort", "path", "-F", "-e", "foo", "."], cwd=corpus, env=env)
+    via_positional = _tg(["--cpu", "--sort", "path", "-F", "foo", "."], cwd=corpus, env=env)
+    assert via_flag.returncode == via_positional.returncode
+    assert via_flag.stdout == via_positional.stdout
+
+
+# --- a single -e alongside an -f file stays a DEAD-flag / single-pattern search (pinned --
+# elsewhere too: test_search_single_regexp_with_unused_file_option_and_only_matching_still
+# _works in test_cli_modes.py). Deliberately NOT a union -- broadening this boundary would
+# regress that existing pinned test (confirmed by direct inspection, not assumption). -----
+
+
+def test_single_e_with_unused_f_still_dead_flag_on_cpu_path(
+    corpus: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    (tmp_path / "bar_only.txt").write_text("bar\n", encoding="utf-8")
+    result = _tg(
+        ["--cpu", "--json", "-e", "foo", "-f", "../bar_only.txt", "."],
+        cwd=corpus,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    matched_files = _tg_json_files(result)
+    # Only "foo" is searched; -f's "bar" pattern is a dead flag here (single -e wins).
+    assert matched_files == ["both.txt", "foo.txt"]
+    assert "bar.txt" not in matched_files
+
+
+# --- without --cpu, -e/-f still route through the untouched rg-passthrough path. --------
+
+
+def test_multi_e_without_cpu_matches_rg_when_available(corpus: Path, env: dict[str, str]) -> None:
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for rg-passthrough parity coverage")
+    rg_env = dict(env)
+    rg_env["TG_RG_PATH"] = str(rg_binary)
+    rg_result = _run(
+        [str(rg_binary), "-e", "foo", "-e", "bar", "--sort", "path", "."], cwd=corpus, env=rg_env
+    )
+    tg_result = _tg(["-e", "foo", "-e", "bar", "--sort", "path", "."], cwd=corpus, env=rg_env)
+    assert tg_result.returncode == rg_result.returncode
+    assert _normalize(tg_result.stdout, corpus) == _normalize(rg_result.stdout, corpus)
+
+
+def test_pattern_file_without_cpu_matches_rg_when_available(
+    corpus: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for rg-passthrough parity coverage")
+    (tmp_path / "patterns2.txt").write_text("foo\nbar\n", encoding="utf-8")
+    rg_env = dict(env)
+    rg_env["TG_RG_PATH"] = str(rg_binary)
+    rg_result = _run(
+        [str(rg_binary), "-f", "../patterns2.txt", "--sort", "path", "."], cwd=corpus, env=rg_env
+    )
+    tg_result = _tg(["-f", "../patterns2.txt", "--sort", "path", "."], cwd=corpus, env=rg_env)
+    assert tg_result.returncode == rg_result.returncode
+    assert _normalize(tg_result.stdout, corpus) == _normalize(rg_result.stdout, corpus)
+
+
+# --- -o/-r combined with multi-pattern remain rejected (unchanged pre-existing guard). ---
+
+
+def test_multi_e_with_only_matching_still_rejected_exit_2(
+    corpus: Path, env: dict[str, str]
+) -> None:
+    result = _tg(["--cpu", "-o", "-e", "foo", "-e", "bar", "both.txt"], cwd=corpus, env=env)
+    assert result.returncode == 2
+    assert "-o/--only-matching" in result.stderr
+
+
+def test_pattern_file_with_rank_still_rejected_exit_2(
+    corpus: Path, env: dict[str, str], tmp_path: Path
+) -> None:
+    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8")
+    result = _tg(["--cpu", "--rank", "-f", "../patterns.txt", "."], cwd=corpus, env=env)
+    assert result.returncode == 2
+    assert "--rank/--bm25" in result.stderr

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -1122,8 +1122,18 @@ def test_main_entry_should_fallback_to_full_cli_for_show_completion(monkeypatch)
     assert called["full_cli"] is True
 
 
-def test_main_entry_should_delegate_multi_pattern_gpu_search_to_native_tg(monkeypatch):
-    seen: dict[str, object] = {}
+def test_main_entry_should_route_multi_pattern_gpu_search_to_full_cli_not_native(monkeypatch):
+    # audit #69 (re-do of #441): this test used to pin the BUG -- multi-pattern (-e x3) +
+    # --gpu-device-ids delegating straight to the separately-compiled native tg binary,
+    # which has its OWN independent -e/-f bugs (verified via direct invocation: multiple -e
+    # patterns are not deduplicated when a single line matches more than one). The full CLI
+    # now combines multi-pattern correctly (cli/main.py's `_combine_multi_patterns`) and
+    # already refuses this exact case in its OWN inner native-delegation gate (`regexp`/
+    # `file_patterns` are both in `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS`) -- this
+    # outer bootstrap.py fast path must route it to the full CLI too, never to native.
+    # --gpu-device-ids is documented as experimental/opt-in (main.py's own `search`
+    # docstring); correctness beats speed for this already-rare combo.
+    called = {"full_cli": False}
 
     monkeypatch.setattr(
         sys,
@@ -1146,30 +1156,13 @@ def test_main_entry_should_delegate_multi_pattern_gpu_search_to_native_tg(monkey
     monkeypatch.setattr(
         bootstrap,
         "_run_native_tg_search",
-        lambda binary_name, search_args: (
-            seen.update({"binary_name": binary_name, "search_args": list(search_args)}) or 0
-        ),
+        lambda binary_name, search_args: pytest.fail("native tg should not run for -e/-f"),
     )
-    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
 
-    with pytest.raises(SystemExit) as excinfo:
-        bootstrap.main_entry()
+    bootstrap.main_entry()
 
-    assert excinfo.value.code == 0
-    assert seen == {
-        "binary_name": "tg.exe",
-        "search_args": [
-            "--gpu-device-ids",
-            "0",
-            "-e",
-            "error",
-            "-e",
-            "warn",
-            "-e",
-            "fatal",
-            "bench_data",
-        ],
-    }
+    assert called["full_cli"] is True
 
 
 def test_main_entry_should_fallback_to_full_cli_when_rg_is_unavailable(monkeypatch):
@@ -1446,3 +1439,24 @@ def test_rank_bm25_do_not_delegate_to_native_binary() -> None:
     # --ltl) so a future SEARCH_PYTHON_PASSTHROUGH_FLAGS regression cannot strand them.
     assert not bootstrap._can_delegate_to_native_tg_search(["--json", "--rank", "PATTERN"])
     assert not bootstrap._can_delegate_to_native_tg_search(["--json", "--bm25", "PATTERN"])
+
+
+def test_multi_pattern_e_f_do_not_delegate_to_native_binary() -> None:
+    # audit #69 (re-do of #441): the separately-compiled native binary has its OWN,
+    # independent -e/-f bugs (verified via direct invocation -- see cli/bootstrap.py's
+    # `_can_delegate_to_native_tg_search` comment). This outer argv fast path must refuse
+    # ANY -e/-f usage -- even a single one -- for parity with cli/main.py's OWN inner
+    # native-delegation gate, which already refuses it via
+    # `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS` (`regexp`/`file_patterns`).
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "-e", "foo", "-e", "bar", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--json", "-e", "foo", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "-f", "pats.txt", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "--file", "pats.txt", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "--regexp", "foo", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "-efoo", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "-fpats.txt", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "--regexp=foo", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "--file=pats.txt", "."])
+    # No -e/-f -> still delegates; -F (fixed-strings, uppercase) is not a -f prefix match.
+    assert bootstrap._can_delegate_to_native_tg_search(["--cpu", "foo", "."])
+    assert bootstrap._can_delegate_to_native_tg_search(["--cpu", "-F", "foo", "."])


### PR DESCRIPTION
## What

Closes audit #69 (a re-do of the closed #441). `tg search --cpu -e foo -e bar` SILENTLY searched only `"foo"` (`main.py:6338` did `pattern = regexp_patterns[0]` with no combine logic), and `--cpu -f patterns.txt` was NEVER read on the native/CPU path (`config.file_patterns` is read only by `ripgrep_backend.py:788`). Agents/users got wrong (silently-incomplete) results.

## Why #441 was closed (and why this is safe)

PR #441 (the original fix) was closed for a "Windows golden regression" -- but that was a **misdiagnosis**. Its only Windows CI failure was `test_output_golden_contract[json_multi_file-python-m]`, a JSON-multi-**file** (not multi-pattern) snapshot broken by a *pre-existing, unrelated* commit (`fa5fc23`, "json submatches", added a field without updating that fixture); #441's `Merge main` pulled that red test in. #441's combine logic was fine. This PR mirrors #441's already-Windows-validated architecture (per-branch `(?:...)` grouping, `re.escape` for `-F`, scoped `(?i:...)`) + adds **rg-binary-independent** golden-parity assertions so a real future drift is still caught.

## Fix

- `main.py`: new `_combine_multi_patterns` (OR-combine multiple `-e`), `_read_patterns_from_file_list` (read `-f` on the native/CPU path, deferred past the first rg-passthrough exit), `_scope_leading_inline_flag`. Preserves rg-compatible any-match semantics.
- `bootstrap.py`: `_can_delegate_to_native_tg_search` now excludes `-e`/`--regexp`/`-f`/`--file` (incl. attached-short and `=`-forms). **Without this the main.py fix would be dead code** on the default front door -- a `tg.exe` is resolvable, and the outer argv fast-path would delegate the multi-pattern search to the native binary that drops the extra patterns.
- Deliberately did NOT adopt #441's "-e + -f union" (it conflicts with a pinned test asserting a single `-e` wins over `-f` as a dead flag).

## Verification

RED->GREEN: 9 tests fail meaningfully against pre-fix (multi-e matches all, `-f` reads file, missing-file exit-2, both golden-parity, fixed-strings multi-e, leading-inline-flag scoping, the bootstrap delegation-exclusion) -> all GREEN post-fix; 10 pinning-unaffected tests stay green. **Golden-parity is Windows-safe** -- forces `--cpu` + `TG_DISABLE_NATIVE_TG=1` and asserts exact hard-coded match sets, zero dependency on an installed `rg` or walk-ordering. ruff/format/mypy clean; 632-test sweep green (the 1 pre-existing `json_multi_file` submatches drift + 2 lsprotocol-missing are unrelated, present before this change).

No backend files touched -> no mandatory backend security gate.

## Residuals (flagged, non-blocking)

- `TG_RUST_FIRST_SEARCH=1` (OFF by default) has a separate delegation branch that bypasses the gate and could still route a multi-pattern search to the native binary -- wide blast radius, out of scope.
- The pre-existing `json_multi_file` golden drift (submatches field, `fa5fc23`) is unrelated to this fix; flagged so it's not mistaken for a new regression.

`fix:` -> patch. Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
