### PR TITLE
fix(mcp): byte-exact stdio JSON-RPC framing + bounded reads (fail-closed) — audit #49

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -5767,39 +5767,113 @@ def tg_rewrite_diff(pattern: str, replacement: str, lang: str, path: str = ".") 
 # unbounded stdin.read (memory DoS). Mirrors lsp_external_provider._MAX_LSP_MESSAGE_BYTES.
 _MAX_MCP_STDIO_MESSAGE_BYTES = 64 * 1024 * 1024
 
+# Bound the header preamble itself (audit #49 part 2): a hostile/buggy client that streams endless
+# header lines, or one that never sends the blank-line terminator, must not hang the reader or
+# exhaust memory BEFORE the Content-Length size check above even gets a chance to run. Both a hard
+# iteration cap (number of header lines) and a hard byte cap (any single line, and the cumulative
+# preamble) apply -- fail closed on either, mirroring the body-size cap's fail-closed shape.
+_MAX_MCP_STDIO_HEADER_LINES = 128
+_MAX_MCP_STDIO_HEADER_BYTES = 64 * 1024
 
-async def _read_stdio_message_payload(stdin: anyio.AsyncFile[str]) -> str | None:
-    line = await stdin.readline()
-    if line == "":
+# Bound the FIRST line too (audit #49 part 3, gate must-fix): the first read carries either the
+# `Content-Length:` header (framed shim) OR -- in the newline-delimited transport, which is the
+# OFFICIAL/primary MCP stdio path -- the ENTIRE JSON-RPC message. `_MAX_MCP_STDIO_MESSAGE_BYTES`
+# above caps only the framed body, so without this the newline path had NO message-size cap at all,
+# and a `Content-Length` line with no newline could grow memory unbounded BEFORE the size check.
+# Cap line 1 at the full message budget (+1 so a maximal message keeps room for its trailing
+# newline); a legit MCP message is far under 64MB and a framed header line is tiny, so nothing valid
+# is truncated. A first line that reaches this cap with no newline is refused (fail closed).
+_MAX_MCP_STDIO_FIRST_LINE_BYTES = _MAX_MCP_STDIO_MESSAGE_BYTES + 1
+
+
+async def _read_bounded_line(stdin: anyio.AsyncFile[bytes], limit: int) -> bytes:
+    """``readline()``, but never buffer more than `limit` bytes for a single line.
+
+    ``anyio.AsyncFile.readline()`` does not forward a size bound to the wrapped sync file, so this
+    reaches into ``.wrapped`` -- the same underlying binary buffered stream `stdin` already reads
+    through, with no text-decoder layer involved, so there is no read-ahead/desync risk in doing
+    so -- to call the stdlib's own size-bounded ``readline(limit)``.
+    """
+    return await anyio.to_thread.run_sync(stdin.wrapped.readline, limit)
+
+
+async def _read_stdio_message_payload(stdin: anyio.AsyncFile[bytes]) -> str | None:
+    line = await _read_bounded_line(stdin, _MAX_MCP_STDIO_FIRST_LINE_BYTES)
+    if line == b"":
+        return None
+    if len(line) >= _MAX_MCP_STDIO_FIRST_LINE_BYTES and not line.endswith(b"\n"):
+        # Fail closed: line 1 reached the read cap with no newline terminator. This is the last
+        # unbounded-read vector -- either a `Content-Length:` header line with no newline (memory
+        # growth BEFORE the size check below), or a newline-delimited message larger than
+        # _MAX_MCP_STDIO_MESSAGE_BYTES (that transport has no other size cap). A complete line that
+        # happens to be exactly the cap length still ends in "\n", so this rejects only the
+        # over-cap / newline-less case, never truncates a valid message.
         return None
     if not line.strip():
         return ""
-    if not line.lower().startswith("content-length:"):
-        return line
+    if not line.lower().startswith(b"content-length:"):
+        try:
+            return line.decode("utf-8")
+        except UnicodeDecodeError:
+            # Fail closed: a non-UTF-8 line is a framing error, not a silent-wrong parse.
+            return None
 
     try:
-        content_length = int(line.split(":", 1)[1].strip())
+        content_length = int(line.split(b":", 1)[1].strip())
     except (IndexError, ValueError):
-        return line
+        try:
+            return line.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
     if content_length <= 0 or content_length > _MAX_MCP_STDIO_MESSAGE_BYTES:
         # Fail closed: a non-positive or oversized frame is refused rather than read unbounded.
         return None
-    while True:
-        header = await stdin.readline()
-        if header == "":
+
+    header_bytes_total = 0
+    for _ in range(_MAX_MCP_STDIO_HEADER_LINES):
+        header = await _read_bounded_line(stdin, _MAX_MCP_STDIO_HEADER_BYTES)
+        if header == b"":
+            return None
+        header_bytes_total += len(header)
+        if header_bytes_total > _MAX_MCP_STDIO_HEADER_BYTES:
+            # Fail closed: the header preamble (one oversized line, or too many small ones)
+            # exceeded its byte budget before a blank-line terminator ever showed up. Worst case
+            # here is bounded to ~2x the byte cap (the over-budget line that tripped this check),
+            # never unbounded.
             return None
         if not header.strip():
             break
-    return await stdin.read(content_length)
+    else:
+        # Fail closed: too many header lines without a blank-line terminator.
+        return None
+
+    # Read the body as EXACTLY `content_length` BYTES off the binary stream -- not characters off
+    # a text-decoding wrapper. A multi-byte UTF-8 payload has fewer characters than its
+    # Content-Length-declared byte count, so a char-count read desyncs every subsequent framed
+    # message on the same connection (audit #49).
+    body = await stdin.read(content_length)
+    if len(body) != content_length:
+        # Fail closed: EOF before the declared byte count arrived is a framing error, not a hang
+        # or a silently-truncated parse.
+        return None
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
 
 
 @asynccontextmanager
 async def _stdio_server_accepting_content_length(
-    stdin: anyio.AsyncFile[str] | None = None,
+    stdin: anyio.AsyncFile[bytes] | None = None,
     stdout: anyio.AsyncFile[str] | None = None,
 ) -> AsyncIterator[tuple[Any, Any]]:
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8"))
+        # Raw binary stream -- NOT a TextIOWrapper. `_read_stdio_message_payload` needs byte-exact
+        # control over how many bytes it consumes for a Content-Length-framed body; decoding is
+        # done once, per logical message, after the correct number of bytes has been read (see
+        # audit #49). Mixing a text-decoding wrapper with an explicit byte count desyncs the
+        # stream on any multi-byte UTF-8 payload.
+        stdin = anyio.wrap_file(sys.stdin.buffer)
     if not stdout:
         stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
 

--- a/tests/integration/test_mcp_stdio_protocol.py
+++ b/tests/integration/test_mcp_stdio_protocol.py
@@ -127,3 +127,80 @@ async def _stdio_content_length_initialize_roundtrip() -> None:
 
 def test_tg_mcp_stdio_accepts_content_length_initialize_frame() -> None:
     asyncio.run(_stdio_content_length_initialize_roundtrip())
+
+
+def _frame(payload: dict[str, object]) -> bytes:
+    body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+    encoded = body.encode("utf-8")
+    return f"Content-Length: {len(encoded)}\r\n\r\n".encode("ascii") + encoded
+
+
+async def _stdio_content_length_multibyte_utf8_does_not_desync_next_message() -> None:
+    """Audit #49: a Content-Length-framed message with a multi-byte UTF-8 body must not desync the
+    framed stream -- the FOLLOWING pipelined message must still parse and execute correctly. Uses a
+    real subprocess and real OS pipes (not an in-memory buffer) for maximum fidelity."""
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "tensor_grep",
+        "mcp",
+        cwd=REPO_ROOT,
+        env=_mcp_env(),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert process.stdin is not None
+    try:
+        # "e" with an acute accent (\u00e9) and "i" with a circumflex (\u00ee) are each 2 UTF-8
+        # bytes but 1 character -- escape sequences keep this source file ASCII-only (house rule).
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "t\u00e9st-cl\u00eent-\u00e9\u00e9\u00e9",
+                    "version": "1.0.0",
+                },
+            },
+        }
+        process.stdin.write(_frame(initialize))
+        await process.stdin.drain()
+        initialize_response = await _read_jsonrpc_line(process)
+        assert initialize_response["id"] == 1
+        assert "result" in initialize_response, initialize_response
+
+        # Pipeline a notification (no response expected) then a real follow-up request, all via
+        # the same Content-Length-framed path. If the first (multi-byte) body were read as
+        # characters instead of bytes, the stream would already be desynced here.
+        process.stdin.write(_frame({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+        await process.stdin.drain()
+        process.stdin.write(
+            _frame({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        )
+        await process.stdin.drain()
+
+        tools_response = await _read_jsonrpc_line(process)
+        assert tools_response["id"] == 2, tools_response
+        result = tools_response["result"]
+        assert isinstance(result, dict)
+        tools = result["tools"]
+        assert isinstance(tools, list)
+        tool_names = {tool["name"] for tool in tools}
+        assert "tg_mcp_capabilities" in tool_names
+    finally:
+        if process.stdin is not None:
+            process.stdin.close()
+            await process.stdin.wait_closed()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5.0)
+        except TimeoutError:
+            process.terminate()
+            await process.wait()
+
+
+def test_tg_mcp_stdio_multibyte_utf8_body_does_not_desync_next_message() -> None:
+    asyncio.run(_stdio_content_length_multibyte_utf8_does_not_desync_next_message())

--- a/tests/unit/test_mcp_stdio_content_length_cap.py
+++ b/tests/unit/test_mcp_stdio_content_length_cap.py
@@ -1,39 +1,267 @@
-"""Audit #6: the MCP stdio Content-Length compatibility reader must bound the framed read -- a
-hostile/buggy client sending a huge Content-Length must be refused, not drive an unbounded
-stdin.read (memory DoS). Mirrors the LSP reader's 64MB cap."""
+"""Audit #6 + audit #49: the MCP stdio Content-Length compatibility reader must be byte-exact and
+bounded.
+
+Audit #6 (shipped in #363): a hostile/buggy client sending a huge Content-Length must be refused,
+not drive an unbounded stdin.read (memory DoS). Mirrors the LSP reader's 64MB cap.
+
+Audit #49: three further defects in the same reader --
+  1. `stdin.read(content_length)` read `content_length` CHARACTERS off a text-decoding stream, but
+     Content-Length is a BYTE count -- any multi-byte UTF-8 payload desyncs the framed stream, so
+     every message after it misparses.
+  2. the header-line-skip loop (between the Content-Length line and the blank-line terminator) had
+     no iteration cap and no byte cap, so a malformed client (endless headers, or no terminator)
+     could hang the reader / exhaust memory before the body-size check ever mattered.
+  3. (gate must-fix) the FIRST line read was still unbounded. In the newline-delimited transport --
+     the OFFICIAL/primary MCP stdio path -- the whole message IS that first line, and the 64MB body
+     cap guards only the framed body, so a no-newline / multi-GB newline-delimited message had NO
+     size cap at all; and a `Content-Length:` header line with no newline grew memory before the
+     body-size check ran.
+
+All three are fixed by reading the stdio stream as raw bytes throughout (never through a
+TextIOWrapper) and bounding EVERY line -- the first line at the full message budget, the header
+lines at 64KB -- the same fail-closed way the body is bounded: never unbounded.
+"""
+
+import io
+import json
 
 import anyio
+import pytest
 
 from tensor_grep.cli import mcp_server
 
 
-class _FakeStdin:
-    def __init__(self, lines: list[str]) -> None:
-        self._lines = list(lines)
-        self.read_bytes_requested: int | None = None
+def _stdin(data: bytes) -> anyio.AsyncFile[bytes]:
+    """A real byte-oriented AsyncFile, matching the production `sys.stdin.buffer` contract."""
+    return anyio.wrap_file(io.BytesIO(data))
 
-    async def readline(self) -> str:
-        return self._lines.pop(0) if self._lines else ""
 
-    async def read(self, n: int) -> str:
-        self.read_bytes_requested = n
-        return "x" * min(n, 8)
+def _framed(body: str) -> bytes:
+    encoded = body.encode("utf-8")
+    return f"Content-Length: {len(encoded)}\r\n\r\n".encode("ascii") + encoded
+
+
+# ---------------------------------------------------------------------------
+# Audit #6 cap, re-verified against the byte-exact reader.
+# ---------------------------------------------------------------------------
 
 
 def test_oversized_content_length_is_refused_without_reading() -> None:
-    stdin = _FakeStdin([f"Content-Length: {mcp_server._MAX_MCP_STDIO_MESSAGE_BYTES + 1}\r\n"])
+    # No trailing blank-line terminator on purpose: the size check must reject right after the
+    # Content-Length line itself, never reaching (let alone unbounded-reading) anything after it.
+    header = f"Content-Length: {mcp_server._MAX_MCP_STDIO_MESSAGE_BYTES + 1}\r\n".encode("ascii")
+    stdin = _stdin(header)
     result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
     assert result is None
-    assert stdin.read_bytes_requested is None  # never attempted the unbounded read
+    # Never attempted the unbounded body read: nothing past the Content-Length line was consumed.
+    assert stdin.wrapped.tell() == len(header)
 
 
 def test_nonpositive_content_length_is_refused() -> None:
-    stdin = _FakeStdin(["Content-Length: 0\r\n"])
+    stdin = _stdin(b"Content-Length: 0\r\n")
     assert anyio.run(mcp_server._read_stdio_message_payload, stdin) is None
 
 
 def test_valid_content_length_still_reads_the_body() -> None:
-    stdin = _FakeStdin(["Content-Length: 5\r\n", "\r\n", "hello"])
+    stdin = _stdin(b"Content-Length: 5\r\n\r\nhello")
     body = anyio.run(mcp_server._read_stdio_message_payload, stdin)
-    assert stdin.read_bytes_requested == 5
-    assert body is not None
+    assert body == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Audit #49 defect 1: char-vs-byte desync on a multi-byte UTF-8 body.
+# ---------------------------------------------------------------------------
+
+
+def test_multibyte_utf8_body_frames_correctly_and_does_not_desync_next_message() -> None:
+    # "e" with an acute accent (\u00e9) and "o" with an umlaut (\u00f6) are each 2 UTF-8 bytes but
+    # 1 character -- Content-Length (a byte count) and Python's str length (a char count) diverge
+    # for this body. Escape sequences keep this source file itself ASCII-only (house rule).
+    msg1 = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": "search", "params": {"q": "h\u00e9llo w\u00f6rld"}},
+        ensure_ascii=False,
+    )
+    msg2 = json.dumps({"jsonrpc": "2.0", "id": 2, "method": "ping", "params": {}})
+    assert len(msg1) != len(msg1.encode("utf-8")), "fixture must contain multi-byte UTF-8 chars"
+
+    stdin = _stdin(_framed(msg1) + _framed(msg2))
+
+    async def _read_both() -> tuple[str | None, str | None]:
+        first = await mcp_server._read_stdio_message_payload(stdin)
+        second = await mcp_server._read_stdio_message_payload(stdin)
+        return first, second
+
+    first, second = anyio.run(_read_both)
+
+    assert first is not None
+    assert json.loads(first) == json.loads(msg1)
+    assert second is not None
+    assert json.loads(second) == json.loads(msg2)
+
+
+def test_ascii_only_body_still_frames_correctly() -> None:
+    """Control case: an ASCII-only body has char-count == byte-count, so it never exposed the bug.
+    Kept alongside the multi-byte test so a future change can't "fix" one and break the other."""
+    msg1 = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {}})
+    msg2 = json.dumps({"jsonrpc": "2.0", "id": 2, "method": "pong", "params": {}})
+    stdin = _stdin(_framed(msg1) + _framed(msg2))
+
+    async def _read_both() -> tuple[str | None, str | None]:
+        first = await mcp_server._read_stdio_message_payload(stdin)
+        second = await mcp_server._read_stdio_message_payload(stdin)
+        return first, second
+
+    first, second = anyio.run(_read_both)
+    assert first is not None and json.loads(first) == json.loads(msg1)
+    assert second is not None and json.loads(second) == json.loads(msg2)
+
+
+def test_short_body_read_is_a_clean_framing_error_not_a_hang() -> None:
+    """Content-Length declares 100 bytes but the stream only has 5 before EOF: a clean framing
+    error (None), never an exception, never a hang, never a silently-truncated parse."""
+    stdin = _stdin(b"Content-Length: 100\r\n\r\nhello")
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+    assert result is None
+
+
+def test_plain_newline_delimited_json_still_works() -> None:
+    """The non-framed (official MCP stdio) path is untouched by the byte-vs-char fix."""
+    msg = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {}})
+    stdin = _stdin((msg + "\n").encode("utf-8"))
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+    assert result is not None
+    assert json.loads(result) == json.loads(msg)
+
+
+# ---------------------------------------------------------------------------
+# Audit #49 defect 2: the header-skip loop must be bounded (iteration count AND byte length).
+# ---------------------------------------------------------------------------
+
+
+def test_endless_header_lines_without_terminator_is_bounded() -> None:
+    """A malformed/hostile client that streams far more header lines than any real client would,
+    and never sends the blank-line terminator, must be refused -- and refused WITHOUT draining the
+    whole malicious stream (proving the iteration cap fired, not just eventual EOF)."""
+    header_line_count = mcp_server._MAX_MCP_STDIO_HEADER_LINES * 20
+    headers = b"".join(f"X-Junk-{i}: v\r\n".encode("ascii") for i in range(header_line_count))
+    raw = b"Content-Length: 5\r\n" + headers  # no blank-line terminator, ever
+    stdin = _stdin(raw)
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result is None
+    # Bounded: did not consume anywhere near the full malicious header stream.
+    consumed = stdin.wrapped.tell()
+    assert consumed < len(raw) // 4, (
+        f"consumed {consumed} of {len(raw)} bytes -- header loop was not bounded"
+    )
+
+
+def test_single_oversized_header_line_is_bounded() -> None:
+    """A single pathological header line with no newline for a long time must not be buffered
+    without limit in one readline() call -- bounded to a small multiple of the header byte cap,
+    not proportional to how much the attacker sends."""
+    giant_line = b"X-Junk: " + b"A" * (mcp_server._MAX_MCP_STDIO_HEADER_BYTES * 5)  # no b"\n"
+    raw = b"Content-Length: 5\r\n" + giant_line
+    stdin = _stdin(raw)
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result is None
+    consumed = stdin.wrapped.tell()
+    assert consumed < mcp_server._MAX_MCP_STDIO_HEADER_BYTES * 3, (
+        f"consumed {consumed} bytes -- single header line was not bounded"
+    )
+
+
+def test_header_line_count_at_the_cap_still_succeeds() -> None:
+    """Boundary check: a header preamble that stays within both caps still parses normally."""
+    # A handful of small, legitimate-shaped extra headers plus the blank-line terminator.
+    headers = b"".join(f"X-Extra-{i}: v\r\n".encode("ascii") for i in range(5))
+    raw = b"Content-Length: 5\r\n" + headers + b"\r\nhello"
+    stdin = _stdin(raw)
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Audit #49 defect 3 (gate must-fix): the FIRST line must be bounded too. The cap is monkeypatched
+# DOWN so these tests prove the bounding logic without allocating the real 64MB budget (and without
+# risking an OOM against the pre-fix unbounded read).
+# ---------------------------------------------------------------------------
+
+
+def test_giant_first_line_without_newline_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hostile `Content-Length:` header line with no newline must not be read/buffered unbounded
+    BEFORE the size check -- the exact 'exhaust memory before the size check runs' hole. Bounded to
+    the (patched) first-line cap, not proportional to how much the attacker streams."""
+    # raising=False so the behavioral assertion below (not the constant's existence) is what fails
+    # against a pre-fix reader whose first read is unbounded: it would consume the whole stream.
+    monkeypatch.setattr(mcp_server, "_MAX_MCP_STDIO_FIRST_LINE_BYTES", 4096, raising=False)
+    # A single first line with no newline that far exceeds the patched cap.
+    raw = b"Content-Length: " + b"9" * (4096 * 20)
+    stdin = _stdin(raw)
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result is None
+    consumed = stdin.wrapped.tell()
+    assert consumed <= 4096, (
+        f"consumed {consumed} of {len(raw)} bytes -- the first line was not bounded"
+    )
+
+
+def test_oversized_newline_delimited_message_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The PRIMARY path: a newline-delimited message (no Content-Length framing) larger than the
+    message cap and with no newline within it must be refused -- not read unbounded. Without this
+    bound the newline-delimited transport had NO message-size cap at all."""
+    # raising=False so the behavioral assertion below (not the constant's existence) is what fails
+    # against a pre-fix reader whose first read is unbounded: it would consume the whole message.
+    monkeypatch.setattr(mcp_server, "_MAX_MCP_STDIO_FIRST_LINE_BYTES", 4096, raising=False)
+    # A big JSON-ish blob, no Content-Length prefix, no newline, exceeding the patched cap.
+    raw = b'{"jsonrpc":"2.0","method":"x","params":{"blob":"' + b"A" * (4096 * 20) + b'"}}'
+    stdin = _stdin(raw)
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result is None
+    consumed = stdin.wrapped.tell()
+    assert consumed <= 4096, (
+        f"consumed {consumed} of {len(raw)} bytes -- the newline-delimited message was not bounded"
+    )
+
+
+def test_newline_delimited_message_just_under_cap_is_not_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard against over-eager rejection: a valid newline-delimited message that fits within the
+    cap (terminated by its trailing newline) is returned intact, never truncated. A regression guard
+    -- it should hold both before and after the fix (raising=False keeps it constant-agnostic)."""
+    monkeypatch.setattr(mcp_server, "_MAX_MCP_STDIO_FIRST_LINE_BYTES", 4096, raising=False)
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {"pad": "x" * 1000}}
+    msg = json.dumps(payload)
+    assert len(msg.encode("utf-8")) < 4096, "fixture must fit under the patched cap"
+    stdin = _stdin((msg + "\n").encode("utf-8"))
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result is not None
+    assert json.loads(result) == payload
+
+
+def test_first_line_read_uses_the_full_message_budget_by_default() -> None:
+    """The real (un-patched) first-line cap is the message budget + 1 (room for a trailing newline),
+    so a legit multi-KB newline-delimited message is never truncated at the header-line 64KB cap."""
+    assert mcp_server._MAX_MCP_STDIO_FIRST_LINE_BYTES == mcp_server._MAX_MCP_STDIO_MESSAGE_BYTES + 1
+    # A message well over the 64KB header-line cap but far under the 64MB message budget must pass.
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {"pad": "x" * 200_000}}
+    msg = json.dumps(payload)
+    assert len(msg.encode("utf-8")) > mcp_server._MAX_MCP_STDIO_HEADER_BYTES
+    stdin = _stdin((msg + "\n").encode("utf-8"))
+
+    result = anyio.run(mcp_server._read_stdio_message_payload, stdin)
+
+    assert result is not None
+    assert json.loads(result) == payload


### PR DESCRIPTION
## What

Closes audit #49 (surfaced by a backlog reconciliation, self-flagged HIGH in PR #372, never fixed). The MCP server's stdio JSON-RPC framing reader had two defects + one the security gate found:
1. **char-vs-byte desync:** `stdin.read(content_length)` read N *characters* off a `TextIOWrapper`, but `Content-Length` is a *byte* count -> on any multi-byte UTF-8 payload (any non-ASCII query/result) it read the wrong number of bytes and DESYNCED the framed stream (subsequent messages misparse).
2. **unbounded header-skip loop** -> a malformed client could hang/OOM before the size check.
3. **(gate must-fix) unbounded first-line read** -> the newline-delimited transport (the *official/primary* MCP transport) had NO message-size cap at all; a no-newline multi-GB message was read unbounded.

## Fix

Read the body as bytes off the raw binary stream (`sys.stdin.buffer`) + decode UTF-8 once (byte-exact framing, no desync). New `_read_bounded_line` + caps: header lines `_MAX_MCP_STDIO_HEADER_LINES=128` / `_MAX_MCP_STDIO_HEADER_BYTES=64KB` (per-line + cumulative), and the first line `_MAX_MCP_STDIO_FIRST_LINE_BYTES=64MiB+1` (the `+1` leaves room for a maximal-message trailing newline so nothing valid truncates). Every read is now bounded; each framing error fails closed (`return None` -> clean connection close). #363's 64MiB body cap preserved.

## Security gate (mcp_server.py surface) -- SHIP (2 rounds)

Round 1: fixed the 2 named defects; gate returned SHIP-WITH-CHANGES flagging the unbounded first line (the newline-delimited primary transport had no cap). Round 2 (after the must-fix): the first-line bound is precise -- a `cap`-length line ending in `\n` is a complete <=64MiB message (accepted), a `cap`-length line without `\n` exceeds 64MiB (rejected); no legit message truncated, no DoS admitted. Bonus: the cap rejects a giant `Content-Length` line before Python's int-string-digit-limit `ValueError` would trip. Verdict: SHIP.

## Verification

RED->GREEN: the integration test (real subprocess/OS pipes driving the actual MCP SDK handshake) TIMED OUT 10s pre-fix on a multi-byte payload -> GREEN post-fix; the two DoS-vector tests (`giant_first_line`, `oversized_newline_delimited_message`) fail behaviorally against a reconstructed pre-fix reader (drain/return-whole-blob) and pass post-fix. 436 MCP unit + 3 integration tests pass (confinement ratchet + caps untouched); ruff/format/mypy clean.

## Residual (filed #116, non-blocking)

`lsp_external_provider._read_message` has the same unbounded-header-loop shape (but binary stream -> no char-vs-byte bug); different surface (a subprocess tg itself spawns), not reachable from the MCP entry point. Tracked LOW.

`fix:` -> patch. Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
