### PR TITLE
fix(test): pin --cpu on json/ndjson golden cases to kill rg-backend submatches non-determinism (unblocks #501)

### DIFF
--- a/tests/e2e/test_output_golden_contract.py
+++ b/tests/e2e/test_output_golden_contract.py
@@ -49,8 +49,15 @@ GOLDEN_CASES = [
     ("line_number_single_file", ["-n", "hello"], TEXT_FILE1_TARGET),
     ("binary_single_file", ["hello"], ["file3.bin"]),
     ("binary_text_flag", ["-a", "hello"], ["file3.bin"]),  # Treat binary as text
-    ("json_multi_file", ["--json", "hello"], TEXT_DIR_TARGET),
-    ("ndjson_multi_file", ["--ndjson", "hello"], TEXT_DIR_TARGET),
+    # Pinned to --cpu (same mechanism as cpu_multi_file/cpu_single_file below): --json/--ndjson
+    # emit an optional `submatches` field only when the RipgrepBackend supplies rg's byte-offset
+    # data (json_fmt.py:_match_payload -- "omit the key entirely ... for non-rg backends"), so an
+    # unpinned backend choice here is nondeterministic across environments (rg-on-PATH vs
+    # rg-absent) even though the match set, files, counts, and text are identical either way.
+    # Pinning keeps the JSON *shape* this case is testing fixed instead of silently depending on
+    # whether `rg` happens to be installed on the runner (was flaky on CI Windows legs).
+    ("json_multi_file", ["--cpu", "--json", "hello"], TEXT_DIR_TARGET),
+    ("ndjson_multi_file", ["--cpu", "--ndjson", "hello"], TEXT_DIR_TARGET),
 ]
 
 EXACT_OUTPUT_CASES = {


### PR DESCRIPTION
## What

Fixes a PRE-EXISTING flaky golden test (`tests/e2e/test_output_golden_contract.py`) that is env-non-deterministic and has now blocked a PR (#501 red on windows-latest py3.11+py3.12) and previously contributed to #441 being wrongly closed. NOT a product bug -- test-infra only.

## Root cause (verified, not assumed)

The `json_multi_file` / `ndjson_multi_file` golden cases ran `["--json", "hello"]` with NO search-backend pin. The `python-m` launcher sets `TG_DISABLE_NATIVE_TG=1` (disables the native tg FRONT DOOR) but does not pin the SEARCH backend -> `tg --json hello <dir>` routes to ripgrep when `rg` is on PATH, else the CPU backend. The two emit different `matches[]`: `submatches` is populated ONLY by `RipgrepBackend` (`core/result.py:17` "Populated by RipgrepBackend"; `formatters/json_fmt.py:80-88` emits it only when truthy) and intentionally OMITTED (not null) for the CPU backend. So the stored snapshot matched one backend and the field appeared/disappeared with the runner's `rg`-on-PATH state -> non-deterministic RED. Confirmed the divergence is a legit backend-representation difference (identical files/counts/match-set/line/column/text; only the extra `submatches` key differs) -- NOT a real backend-output bug.

## Fix

Pin `--cpu` on those two cases (same mechanism the adjacent `cpu_multi_file`/`cpu_single_file` cases already use), flowing uniformly into both launchers' argv. Snapshot regeneration produced an EMPTY diff -- the committed snapshots already matched the CPU-backend shape (captured in a no-rg env originally), so the pin makes that content DETERMINISTIC rather than accidental. No `src/` change; no snapshot-file change.

## Verification (determinism is the whole point)

Ran the affected parametrizations BOTH with `rg` on PATH AND with `rg` removed from PATH -> identical (`3 passed, 1 skipped` each; the skip is the pre-existing python-m-no-ndjson case). Full golden suite (43 cases x 2 launchers) 41 passed / 2 skipped with rg on PATH. ruff check + ruff format --preview clean. Test-only -> no backend/security gate.

## Adjacent finding (filed separately, NOT fixed here)

Running the suite with `rg` FULLY unresolvable (no PATH, no `TG_RG_PATH`, no bundled sibling) surfaced a pre-existing bug: native `tg.exe --count-matches` HARD-ERRORS ("ripgrep binary not found...") instead of degrading like the `--json`/default search paths do. Verified via `git stash` to reproduce on unmodified HEAD -> out of scope, ticketed.

`fix:` -> patch. Unblocks #501 (which rebases on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
