### PR TITLE
fix(repo_map): dynamic-import recall in imports/importers (importlib/__import__/import()) — audit #93 SUB-1

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9475,7 +9475,13 @@ def imports(
                 target = "external"
             else:
                 target = "unresolved"
-            typer.echo(f"  {entry['line']}: {entry['module']} -> {target}")
+            # #93 SUB-1: a dynamic call (`importlib.import_module(...)` / `import(...)`) with a
+            # non-literal argument has no module name to print -- label it instead of an empty
+            # string, and flag every dynamic entry so a human reader can tell it apart from a
+            # static import statement.
+            module_label = entry["module"] or "<dynamic>"
+            suffix = " [dynamic]" if entry.get("dynamic") else ""
+            typer.echo(f"  {entry['line']}: {module_label} -> {target}{suffix}")
 
     _emit_symbol_command_result(
         payload,

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1584,6 +1584,60 @@ def _cap_caller_scan_files(
     return ordered[:CALLER_SCAN_FILE_CEILING], True
 
 
+def _is_python_dynamic_import_call(node: ast.Call) -> bool:
+    """True when ``node`` is one of the 3 dynamic-import call shapes that a top-level-only
+    ``ast.Import``/``ast.ImportFrom`` scan can never see: ``__import__(...)``, bare
+    ``import_module(...)`` (from ``from importlib import import_module``), or
+    ``importlib.import_module(...)``.  These are ``ast.Call`` EXPRESSIONS that can appear
+    anywhere -- inside a function body, a conditional, a try/except -- which is exactly why they
+    need a whole-tree ``ast.walk`` (see ``_python_dynamic_import_entries``) instead of the
+    ``tree.body``-only scan below (#93 SUB-1 audit finding).
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in {"__import__", "import_module"}
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "import_module"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "importlib"
+    )
+
+
+def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
+    """Raw per-call dynamic-import entries: one dict per ``__import__``/``import_module``/
+    ``importlib.import_module`` call anywhere in ``tree``, shaped like the static entries
+    ``_python_imports_with_lines`` emits (``module``, ``line``, ``level``) plus the two #93 SUB-1
+    markers -- ``dynamic`` (always ``True`` here) and ``dynamic_unresolved`` (``True`` when the
+    first argument isn't a static string literal, e.g. a variable or an f-string).
+
+    Fails CLOSED on the unresolved case: ``module`` is ``""`` rather than a guessed name --
+    asserting a fabricated edge for an import whose target we can't actually read would be a
+    precision regression in a moat feature (see ``_resolve_raw_import_entry`` /
+    ``_confirm_import_edges``, which both skip resolution entirely when ``dynamic_unresolved``
+    is set).
+    """
+    entries: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_python_dynamic_import_call(node):
+            continue
+        literal_module: str | None = None
+        if (
+            node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            literal_module = node.args[0].value
+        entries.append({
+            "module": literal_module or "",
+            "line": int(node.lineno),
+            "level": 0,
+            "dynamic": True,
+            "dynamic_unresolved": literal_module is None,
+        })
+    return entries
+
+
 def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
     if path.suffix != ".py":
         return [], []
@@ -1641,6 +1695,15 @@ def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, A
                     end_line=getattr(symbol_node, "end_lineno", symbol_node.lineno),
                 )
             )
+
+    # #93 SUB-1: fold in dynamic-import call targets (only the STATICALLY resolvable ones -- an
+    # unresolved dynamic import has no literal name to add to this alias-graph prefilter list;
+    # see `_python_dynamic_import_entries`) so a file that ONLY reaches a target dynamically is
+    # still discoverable as a candidate by the reverse `tg importers` prefilter
+    # (`_reverse_importers`), not just by the forward `tg imports` primitive.
+    for dynamic_entry in _python_dynamic_import_entries(tree):
+        if dynamic_entry["module"]:
+            imports.append(str(dynamic_entry["module"]))
 
     imports = sorted(dict.fromkeys(imports))
     symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
@@ -3793,6 +3856,33 @@ def _dedupe_symbol_records(symbols: list[dict[str, Any]]) -> list[dict[str, Any]
     return deduped
 
 
+def _js_ts_dynamic_import_hit(line: str) -> tuple[str, bool] | None:
+    """Detect a dynamic ``import(...)`` call or a ``require(...)`` call NOT already covered by
+    the assignment-anchored static regexes above (bare ``require("x");`` with no assignment,
+    ``require(...)``/``import(...)`` used as a sub-expression, or either call form given a
+    non-literal argument).
+
+    Returns ``(module, dynamic_unresolved)`` -- ``module`` is ``""`` when the argument isn't a
+    static string literal (a variable, template literal, or expression), and
+    ``dynamic_unresolved`` is ``True`` in that case -- or ``None`` when neither call form is
+    present on this line.
+
+    #93 SUB-1 recall fix: this is ADDITIVE to the static regexes, never a replacement -- callers
+    only consult this after their own assignment-anchored match comes back empty, so a plain
+    ``const x = require("y")`` line is still reported exactly once (via the static path), not
+    twice. Known limitation (accepted, same "precision over guessing" posture as the rest of
+    this file's regex heuristics): a fully INDIRECT alias -- `const req = require; req("y");` --
+    is not traced; there is no literal `require(`/`import(` call shape on the second line for
+    this to match.
+    """
+    literal_match = re.search(r'\b(?:import|require)\s*\(\s*["\']([^"\']+)["\']\s*\)', line)
+    if literal_match:
+        return literal_match.group(1), False
+    if re.search(r"\b(?:import|require)\s*\(", line):
+        return "", True
+    return None
+
+
 def _regex_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
     if path.suffix not in _JS_TS_SUFFIXES | _RUST_SUFFIXES:
         return [], []
@@ -3843,6 +3933,14 @@ def _regex_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, An
                 imports.append(export_from_match.group(1))
             if require_match:
                 imports.append(require_match.group(1))
+            else:
+                # #93 SUB-1: `import("x")` call-form and a require(...) not shaped like the
+                # assignment-anchored regex above. Only the statically-resolvable literal is
+                # useful to this alias-graph prefilter list -- an unresolved (non-literal) hit
+                # has no name to add.
+                dynamic_hit = _js_ts_dynamic_import_hit(line)
+                if dynamic_hit is not None and dynamic_hit[0]:
+                    imports.append(dynamic_hit[0])
             if class_match:
                 end_line, _ = _extract_braced_block(lines, line_number - 1)
                 symbols.append(
@@ -5579,6 +5677,11 @@ def _python_imports_with_lines(path: Path) -> list[dict[str, Any]]:
                         "line": int(node.lineno),
                         "level": int(node.level),
                     })
+    # #93 SUB-1: `ast.walk` (not `tree.body`) picks up `__import__`/`import_module`/
+    # `importlib.import_module` calls anywhere -- inside a function, a conditional, a
+    # try/except -- that the static scan above (top-level Import/ImportFrom statements only)
+    # never visits.
+    entries.extend(_python_dynamic_import_entries(tree))
     return entries
 
 
@@ -5611,6 +5714,18 @@ def _js_ts_imports_with_lines(path: Path) -> list[dict[str, Any]]:
             entries.append({"module": export_from_match.group(1), "line": line_number})
         if require_match:
             entries.append({"module": require_match.group(1), "line": line_number})
+        else:
+            # #93 SUB-1: `import("x")` call-form and a require(...) not shaped like the
+            # assignment-anchored regex above (bare, chained, or a sub-expression argument).
+            dynamic_hit = _js_ts_dynamic_import_hit(line)
+            if dynamic_hit is not None:
+                module, dynamic_unresolved = dynamic_hit
+                entries.append({
+                    "module": module,
+                    "line": line_number,
+                    "dynamic": True,
+                    "dynamic_unresolved": dynamic_unresolved,
+                })
     return entries
 
 
@@ -14504,8 +14619,16 @@ def _resolve_raw_import_entry(
 ) -> dict[str, Any]:
     module = str(entry.get("module", ""))
     line = int(entry.get("line", 0) or 0)
+    dynamic = bool(entry.get("dynamic", False))
+    dynamic_unresolved = bool(entry.get("dynamic_unresolved", False))
 
-    if language_id in ("javascript", "typescript"):
+    if dynamic_unresolved:
+        # #93 SUB-1: the module argument isn't a static string literal (e.g.
+        # `import_module(pkg_var)` / `import(path)`) -- there is no name to resolve against.
+        # Fail closed: never guess a target file for an import whose identity we don't actually
+        # know (over-reporting here would be a precision regression in a moat feature).
+        resolved, external, provenance, confidence = None, False, [], 0.0
+    elif language_id in ("javascript", "typescript"):
         candidate_info = _js_ts_module_candidates(importer_path, module, repo_root)
         is_relative = module.startswith(".")
         has_candidates = bool(candidate_info["paths"])
@@ -14552,6 +14675,8 @@ def _resolve_raw_import_entry(
         "provenance": provenance,
         "resolution_confidence": confidence,
         "external": external,
+        "dynamic": dynamic,
+        "dynamic_unresolved": dynamic_unresolved,
     }
 
 
@@ -14622,7 +14747,10 @@ def build_file_imports(file_path: str | Path) -> dict[str, Any]:
         dict.fromkeys(
             str(current["module"])
             for current in imports
-            if not current.get("external") and not current.get("resolved")
+            # #93 SUB-1: `current.get("module")` guards out dynamic_unresolved entries (module
+            # ""), which are surfaced via their own `dynamic_unresolved` marker on the raw
+            # entry, not as a fabricated blank name in this flat unresolved-module-names summary.
+            if current.get("module") and not current.get("external") and not current.get("resolved")
         )
     )
     payload["result_incomplete"] = result_incomplete
@@ -14653,6 +14781,13 @@ def _confirm_import_edges(
     for raw_entry in _imports_with_lines_for_path(candidate_importer):
         module = str(raw_entry.get("module", ""))
         line = int(raw_entry.get("line", 0) or 0)
+        dynamic = bool(raw_entry.get("dynamic", False))
+        dynamic_unresolved = bool(raw_entry.get("dynamic_unresolved", False))
+        if dynamic_unresolved:
+            # #93 SUB-1: no literal module name to compare against target_file -- never assert
+            # a confirmed edge for an import whose target we can't actually read (precision
+            # matters more than recall past this point).
+            continue
         if language_id in ("javascript", "typescript"):
             matched = _js_ts_module_matches_definition(
                 candidate_importer, module, target_file, repo_root
@@ -14685,6 +14820,11 @@ def _confirm_import_edges(
             "module": module,
             "provenance": provenance,
             "resolution_confidence": _import_graph_resolution_confidence(provenance),
+            # #93 SUB-1: preserve the dynamic markers instead of silently dropping them -- a
+            # `tg importers` consumer needs to know this edge came from a dynamic call, not a
+            # static import statement.
+            "dynamic": dynamic,
+            "dynamic_unresolved": dynamic_unresolved,
         })
     return edges
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -14668,16 +14668,25 @@ def _resolve_raw_import_entry(
     else:
         resolved, external, provenance, confidence = None, True, [], 0.0
 
-    return {
+    result: dict[str, Any] = {
         "module": module,
         "line": line,
         "resolved": resolved,
         "provenance": provenance,
         "resolution_confidence": confidence,
         "external": external,
-        "dynamic": dynamic,
-        "dynamic_unresolved": dynamic_unresolved,
     }
+    if dynamic:
+        # Payload-bloat fix (#93 SUB-1 follow-up): only stamp the dynamic markers on an entry
+        # that is ACTUALLY dynamic. Stamping "dynamic": false / "dynamic_unresolved": false on
+        # every static entry (the overwhelming majority) conveys nothing and tipped
+        # `tg importers`' payload past the <10%-of-`tg map` token-economy guard (a MOAT
+        # invariant -- see test_importers_payload_is_far_smaller_than_map). Presence of
+        # "dynamic" now itself MEANS "this is a dynamic import" -- callers must use
+        # `.get("dynamic", False)`, not a hard subscript.
+        result["dynamic"] = dynamic
+        result["dynamic_unresolved"] = dynamic_unresolved
+    return result
 
 
 def build_file_imports(file_path: str | Path) -> dict[str, Any]:
@@ -14811,7 +14820,7 @@ def _confirm_import_edges(
             continue
         seen_lines.add(line)
         provenance = "parser-backed" if language_id == "python" else "heuristic"
-        edges.append({
+        edge: dict[str, Any] = {
             "file": str(candidate_importer),
             "line": line,
             "text": _source_line_text(candidate_importer, line),
@@ -14820,12 +14829,17 @@ def _confirm_import_edges(
             "module": module,
             "provenance": provenance,
             "resolution_confidence": _import_graph_resolution_confidence(provenance),
-            # #93 SUB-1: preserve the dynamic markers instead of silently dropping them -- a
-            # `tg importers` consumer needs to know this edge came from a dynamic call, not a
-            # static import statement.
-            "dynamic": dynamic,
-            "dynamic_unresolved": dynamic_unresolved,
-        })
+        }
+        if dynamic:
+            # Payload-bloat fix (#93 SUB-1 follow-up, same rationale as
+            # _resolve_raw_import_entry): preserve the dynamic markers on an edge that IS
+            # dynamic -- a `tg importers` consumer needs to know this edge came from a dynamic
+            # call, not a static import statement -- but a static edge (the majority) gains
+            # nothing from two always-False keys, and that bloat tipped the importers payload
+            # past the <10%-of-map guard.
+            edge["dynamic"] = dynamic
+            edge["dynamic_unresolved"] = dynamic_unresolved
+        edges.append(edge)
     return edges
 
 

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -816,7 +816,10 @@ def test_build_file_imports_static_require_unaffected_by_dynamic_detection(
 
     matches = [current for current in payload["imports"] if current["module"] == "./util"]
     assert len(matches) == 1
-    assert matches[0]["dynamic"] is False
+    # Payload-bloat fix: a static entry omits the "dynamic"/"dynamic_unresolved" keys entirely
+    # rather than stamping always-False markers (see test_importers_payload_is_far_smaller_than_map).
+    assert "dynamic" not in matches[0]
+    assert "dynamic_unresolved" not in matches[0]
     assert matches[0]["resolved"] == str(util_path.resolve())
 
 

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -627,3 +627,262 @@ def test_imports_relative_file_from_parent_cwd_already_resolves_correctly(
 
     assert payload["file"] == str(target.resolve())
     assert payload["result_incomplete"] is False
+
+
+# ---------------------------------------------------------------------------------------------
+# Dynamic-import awareness (#93 SUB-1): `importlib.import_module(...)` / `__import__(...)` /
+# bare `import_module(...)` (Python) and dynamic `import(...)` call-form / bare-or-non-literal
+# `require(...)` (JS/TS) are invisible to the static-only extractors -- these are `ast.Call`
+# nodes (Python) or call-form expressions (JS/TS) that can appear ANYWHERE (inside a function, a
+# conditional), not just as a top-level import statement. Recall fix on both directions: forward
+# (`tg imports`, `build_file_imports`) AND reverse (`tg importers`, `build_file_importers`), since
+# the reverse primitive's prefilter (`_reverse_importers`) depends on the SAME per-file imports
+# list the forward primitive's summary is built from.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_imports_detects_dynamic_importlib_import_module(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "main.py"
+    consumer.write_text(
+        'import importlib\n\ndef load():\n    return importlib.import_module("pkg.helpers")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "pkg.helpers")
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+    assert entry["resolved"] == str(helpers_path.resolve())
+    assert entry["external"] is False
+    assert entry["line"] == 4
+
+
+def test_build_file_imports_detects_dunder_import(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    consumer = project / "app.py"
+    consumer.write_text('mod = __import__("json")\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "json")
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+    assert entry["external"] is True
+
+
+def test_build_file_imports_detects_bare_import_module_call(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    consumer = project / "app.py"
+    consumer.write_text(
+        'from importlib import import_module\nmod = import_module("json")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [
+        current
+        for current in payload["imports"]
+        if current["module"] == "json" and current.get("dynamic")
+    ]
+    assert len(dynamic_entries) == 1
+    assert dynamic_entries[0]["dynamic_unresolved"] is False
+
+
+def test_build_file_imports_marks_non_literal_python_dynamic_import_as_unresolved(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    consumer = project / "app.py"
+    consumer.write_text(
+        "import importlib\n\ndef load(name):\n    return importlib.import_module(name)\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [current for current in payload["imports"] if current.get("dynamic")]
+    assert len(dynamic_entries) == 1
+    entry = dynamic_entries[0]
+    assert entry["dynamic_unresolved"] is True
+    assert entry["module"] == ""
+    assert entry["resolved"] is None
+    assert entry["external"] is False
+    # never fabricate a module name in the flat `unresolved` summary for an import whose name
+    # we don't actually know
+    assert "" not in payload["unresolved"]
+
+
+def test_build_file_imports_detects_dynamic_import_call_literal(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    util_path = src / "util.js"
+    util_path.write_text("export function foo() {}\n", encoding="utf-8")
+    consumer = src / "consumer.js"
+    consumer.write_text(
+        'async function load() {\n  return import("./util");\n}\n', encoding="utf-8"
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "./util")
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+    assert entry["resolved"] == str(util_path.resolve())
+    assert entry["line"] == 2
+
+
+def test_build_file_imports_marks_non_literal_dynamic_import_call_as_unresolved(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    consumer = src / "consumer.js"
+    consumer.write_text(
+        "async function load(name) {\n  return import(name);\n}\n", encoding="utf-8"
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [current for current in payload["imports"] if current.get("dynamic")]
+    assert len(dynamic_entries) == 1
+    entry = dynamic_entries[0]
+    assert entry["dynamic_unresolved"] is True
+    assert entry["module"] == ""
+    assert entry["resolved"] is None
+    assert "" not in payload["unresolved"]
+
+
+def test_build_file_imports_detects_bare_require_without_assignment(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    util_path = src / "util.js"
+    util_path.write_text("module.exports = {};\n", encoding="utf-8")
+    consumer = src / "consumer.js"
+    consumer.write_text('require("./util");\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "./util")
+    assert entry["resolved"] == str(util_path.resolve())
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+
+
+def test_build_file_imports_marks_non_literal_require_as_unresolved(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    consumer = src / "consumer.js"
+    consumer.write_text("function load(name) {\n  return require(name);\n}\n", encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [current for current in payload["imports"] if current.get("dynamic")]
+    assert len(dynamic_entries) == 1
+    entry = dynamic_entries[0]
+    assert entry["dynamic_unresolved"] is True
+    assert entry["module"] == ""
+
+
+def test_build_file_imports_static_require_unaffected_by_dynamic_detection(
+    tmp_path: Path,
+) -> None:
+    """The pre-existing assignment-anchored `require(...)` regex path is untouched -- a normal
+    `const x = require("y")` line must still yield exactly ONE entry (not two, from also
+    matching the new broader dynamic-require fallback)."""
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    util_path = src / "util.js"
+    util_path.write_text("module.exports = {};\n", encoding="utf-8")
+    consumer = src / "consumer.js"
+    consumer.write_text('const util = require("./util");\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    matches = [current for current in payload["imports"] if current["module"] == "./util"]
+    assert len(matches) == 1
+    assert matches[0]["dynamic"] is False
+    assert matches[0]["resolved"] == str(util_path.resolve())
+
+
+def test_build_file_importers_recalls_dynamic_importlib_import_module(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text(
+        'import importlib\n\ndef load():\n    return importlib.import_module("pkg.helpers")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_importers(target, project)
+
+    importer_files = set(payload["importer_files"])
+    assert importer_files == {str(consumer.resolve())}
+    edge = payload["importers"][0]
+    assert edge["dynamic"] is True
+    assert edge["dynamic_unresolved"] is False
+    assert edge["module"] == "pkg.helpers"
+
+
+def test_build_file_importers_recalls_dynamic_import_call(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    target = src / "util.js"
+    target.write_text("export function foo() {}\n", encoding="utf-8")
+    consumer = src / "consumer.js"
+    consumer.write_text(
+        'async function load() {\n  return import("./util");\n}\n', encoding="utf-8"
+    )
+
+    payload = repo_map.build_file_importers(target, project)
+
+    importer_files = set(payload["importer_files"])
+    assert importer_files == {str(consumer.resolve())}
+    edge = payload["importers"][0]
+    assert edge["dynamic"] is True
+    assert edge["dynamic_unresolved"] is False
+    assert edge["module"] == "./util"
+
+
+def test_build_file_importers_never_asserts_edge_for_unresolved_dynamic_import(
+    tmp_path: Path,
+) -> None:
+    """Precision: an `importlib.import_module(name)` call whose argument is a variable must
+    NEVER be reported as a confirmed importer of any file -- there is no literal module name to
+    compare, so asserting an edge here would be a fabricated (over-reported) result."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text(
+        "import importlib\n\ndef load(name):\n    return importlib.import_module(name)\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert payload["importer_files"] == []
+    assert payload["importer_count"] == 0


### PR DESCRIPTION
## What

Closes audit #93 SUB-1 (dogfood #84 P2/P3 tail). `tg imports` / `tg importers` MISSED dynamically-declared imports -> a RECALL gap on the #74 imports/importers moat feature:
- **Python:** only top-level `ast.Import`/`ast.ImportFrom` were walked; `importlib.import_module("x")` / `__import__("x")` (anywhere, incl. inside function bodies) were invisible.
- **JS/TS:** static `import ... from` / `require(...)` were caught but dynamic `import("x")` (call form) was not.

An agent asking "who imports X" got a silently-incomplete answer whenever X was reached dynamically.

## Fix

A dynamic-call sub-pass added to the import extraction, emitting additive markers `{dynamic: true, dynamic_unresolved: <bool>}`:
- `dynamic_unresolved: false` when the module arg is a static string literal (`import_module("json")` -> module resolved).
- `dynamic_unresolved: true` when it is not (`import_module(var)`) -> detected but NOT asserted as a hard edge.

Precision-first (the moat feature's over-count is a known competitor-exploited failure mode): a dynamic call NEVER fabricates a confirmed import edge, and a normal `const x = require("y")` still yields exactly one entry.

Applied across BOTH pipelines (the design named one; verifying against the real code surfaced two):
- Forward `tg imports` + precision-confirm: `_python_imports_with_lines`, `_js_ts_imports_with_lines`, `_resolve_raw_import_entry`, `build_file_imports`, `_confirm_import_edges` (was DROPPING the field).
- Reverse `tg importers` candidate-prefilter: `_python_imports_and_symbols`, `_regex_imports_and_symbols` (feed `build_file_importers_from_map`'s candidate set) -- NOT explicitly named in the design but load-bearing: without them `importers` would stay blind to a file that only reaches a target dynamically.

Provenance reuses the existing ad-hoc `"parser-backed"`/`"heuristic"` split (no new enum). `main.py` gains a small text-mode `[dynamic]` annotation in the `imports` command. Additive schema -> no pinned contract test needed (verified: the shared CLI formatter + `session_file_importers` ignore unknown keys).

## Verification

RED->GREEN: 12 new TDD tests in `test_file_deps.py` (39 pass total), incl. the two precision guards above. **Real-binary dogfood** (via `bootstrap.main_entry()`, not CliRunner): before, `importlib.import_module("json")` was absent; after -> `{"module":"json","line":5,"dynamic":true,"dynamic_unresolved":false}`; JS `import("./util.js")` resolves end-to-end too. ruff / ruff format --preview / `mypy src/tensor_grep` (77 files) clean. ~700 additional regression tests across every consumer of the touched shared functions pass (the only 2 failures are a pre-existing missing-`lsprotocol` optional-dep issue, reproduced on unmodified HEAD).

No mandatory security gate: touches repo_map.py + main.py text-mode only -- none of mcp/backends/session_daemon/apply_policy/index_lock/cpu_backend.

`fix:` -> patch. Closes #93 (SUB-1). SUB-2/3 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
