### PR TITLE
fix(test): assert the reclaim OUTCOME instead of a fragile wall-clock bound in test_index_lock (de-risks the release pipe) — audit #120

### DIFF
--- a/tests/unit/test_index_lock.py
+++ b/tests/unit/test_index_lock.py
@@ -34,23 +34,57 @@ def test_fresh_stale_lock_is_reclaimed_before_the_waiter_gives_up(tmp_path: Path
 
     Pre-fix ratio (timeout_s=0.5 < stale_after_s=1.0) would ALWAYS time out here:
     age + timeout = 0.3 + 0.5 = 0.8 < 1.0, so the lock can never reach the staleness
-    threshold before the waiter's deadline fires. Post-fix ratio (timeout_s=1.2 >
-    stale_after_s=1.0) guarantees reclaim: the lock reaches staleness at age=1.0 (elapsed
-    0.7s from the waiter's start), comfortably inside the 1.2s deadline.
+    threshold before the waiter's deadline fires (the ratio invariant itself is pinned by
+    ``test_default_timeout_exceeds_stale_threshold`` above). Post-fix ratio
+    (timeout_s=1.2 > stale_after_s=1.0) guarantees reclaim: the lock reaches staleness at
+    age=1.0 (elapsed ~0.7s from the waiter's start), comfortably inside the 1.2s deadline.
+
+    Release-blocking flake fixed here: this test used to ALSO assert a hardcoded
+    ``elapsed < 1.2`` wall-clock bound. A loaded macOS CI runner measured 1.68s and failed
+    it -- not because reclaim was broken, but because ``index_lock``'s acquire loop checks
+    staleness *before* it checks its own deadline: the ``except FileExistsError`` branch
+    ``continue``s straight back to the top of the loop on a stale hit, skipping the
+    deadline check for that iteration entirely. A single overshot
+    ``time.sleep(poll_interval_s)`` on a starved scheduler can push real wall-clock past
+    ``timeout_s`` while that very wake-up still finds the lock stale and reclaims it
+    correctly -- correct self-healing, misread as a failure by a tight wall-clock assert.
+
+    The real H9 invariant -- "reclaimed before giving up", not a specific latency -- is now
+    asserted as an OUTCOME instead of a stopwatch reading:
+      1. no ``IndexLockTimeoutError`` escapes the ``with`` (a never-reclaims regression
+         raises here and fails the test before the body below ever runs);
+      2. the lock's owner inside the ``with`` is THIS process, not the planted fake pid
+         99999 (proves a reclaim actually happened, not merely that some file exists);
+      3. the lock file is gone after release.
+    A generous, CI-jitter-tolerant wall-clock ceiling remains as a backstop against a
+    "technically reclaims, but pathologically slow" regression in the reclaim path itself
+    (which -- unlike the plain wait above -- is NOT bounded by ``timeout_s``, per the
+    ``continue`` above): several multiples of the waiter's own give-up deadline, so routine
+    CI scheduling jitter (the observed 1.68s against a 1.2s bound, ~1.4x) can never trip it.
     """
     index_path = tmp_path / "index.json"
     lock_path = _index_lock._lock_path_for(index_path)
     lock_path.write_text("99999\n", encoding="utf-8")
-    fresh_mtime = time.time() - 0.3  # "crashed" 0.3s ago: well under stale_after_s (1.0s)
+    stale_after_s = 1.0
+    timeout_s = 1.2  # H9 ratio: must exceed stale_after_s -- see module docstring above
+    fresh_mtime = time.time() - 0.3  # "crashed" 0.3s ago: well under stale_after_s
     os.utime(lock_path, (fresh_mtime, fresh_mtime))
 
     start = time.monotonic()
-    with _index_lock.index_lock(index_path, timeout_s=1.2, stale_after_s=1.0):
-        pass
+    # A never-reclaims (or reclaims-only-after-giving-up) regression raises
+    # IndexLockTimeoutError out of __enter__ here, failing the test before the body runs.
+    with _index_lock.index_lock(index_path, timeout_s=timeout_s, stale_after_s=stale_after_s):
+        # The reclaim genuinely happened: THIS process's pid displaced the planted fake
+        # "dead holder" pid (99999), not just "a lock file happens to exist".
+        owner_pid = lock_path.read_text(encoding="utf-8").splitlines()[0]
+        assert owner_pid == str(os.getpid())
     elapsed = time.monotonic() - start
 
-    assert elapsed < 1.2
     assert not lock_path.exists()
+    # Generous CI-jitter backstop (secondary -- see docstring): catches a "reclaims, but
+    # pathologically slow" regression in the reclaim path itself, which the deadline check
+    # above does not bound.
+    assert elapsed < timeout_s * 5
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

De-risks the release pipe. `tests/unit/test_index_lock.py::test_fresh_stale_lock_is_reclaimed_before_the_waiter_gives_up` asserted a HARDCODED wall-clock bound (`assert elapsed < 1.2`s). On a loaded macOS CI runner the reclaim took 1.68s -> `AssertionError 1.68 < 1.2` -> failed the test-python gate -> the **v1.58.5 release's** semantic-release + publish-pypi jobs were SKIPPED (the publish only recovered on a manual re-run). An absolute wall-clock assertion on shared CI is intrinsically flaky and here it blocked a release.

## Root cause (why <1.2s was never a real contract)

`_index_lock.py` acquire loop checks staleness BEFORE the deadline; a stale hit `continue`s, skipping that iteration's deadline check. If `time.sleep(poll_interval_s)` overshoots on a starved scheduler, the loop can wake after wall-clock has passed both the staleness threshold AND `timeout_s`, but -- staleness-first -- it reclaims CORRECTLY rather than raising. That is correct self-healing; the old `< 1.2` was a low-jitter artifact, not a property of the implementation.

## Fix (test-only -- `_index_lock.py` source untouched, no gate)

Assert the REAL invariant (H9: "reclaimed before giving up") as OUTCOMES, not a latency number:
1. No `IndexLockTimeoutError` escapes the `with` (a never-reclaims regression still fails here).
2. The lock owner INSIDE the `with` is `os.getpid()`, not the planted fake pid -> proves a genuine reclaim happened.
3. `not lock_path.exists()` after release.
4. A generous CI-jitter-tolerant backstop `elapsed < timeout_s * 5` (6.0s vs the 1.68s incident) -- kept deliberately so a "reclaims but pathologically slow" regression is still caught (outcome-only checks would miss it).

## Verification (bidirectional -- proved it still catches regressions, not just that it passes)

- 20x-repeat of the target test: PASS=20 FAIL=0.
- `test_index_lock.py` + `test_index_lock_concurrency.py`: 23 passed.
- Regression proof (a): inverted the ratio to `timeout_s < stale_after_s` -> test FAILED with `IndexLockTimeoutError` (never-reclaims class still caught).
- Regression proof (b): monkeypatched `Path.unlink` to sleep 8s in the reclaim path -> the outcome checks passed but the new `< timeout_s*5` backstop FAILED (16.7s > 6.0s) -> the backstop is live and catches the slow-reclaim class.
- ruff check + ruff format --preview + mypy clean.

`fix:` -> patch. Closes the flaky-test root cause behind the v1.58.5 release stall. Tracked as backlog #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
