### PR TITLE
feat(orient): suggested_scope hint on truncated scans (centrality dir-rollup, degrade-to-null) — audit #93 SUB-2

### DIFF
--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -280,6 +280,7 @@ this document it does **not** carry the common envelope fields (`version`/`routi
 | `token_budget_label` | `string` | Human-readable summary of `token_estimate` and the snippet token budget. |
 | `truncated` | `boolean` | `true` when the snippet token budget clipped or dropped a snippet. |
 | `scan_limit` | `integer` | The effective `max_repo_files` used to build the underlying repo map. |
+| `suggested_scope` | `object \| null` | Additive (audit #93 SUB-2). Present only when the underlying repo scan itself was truncated (distinct from `truncated` above, which is snippet/token-budget only) AND a centrality-weighted directory rollup found a clear winner: `{dirs: [absolute_path], confidence: "heuristic"}`. `null` on a complete scan, or when the top two directories are tied/near-tied (degrade rather than guess). |
 
 `ignore` (repeatable glob, matches basename or repo-relative path) excludes a subtree from the
 **centrality ranking** only -- the files are still walked, just kept out of the central-files/

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -66,11 +66,14 @@ _ENTRY_NAMES = {
 }
 
 
-def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> list[dict[str, Any]]:
-    """Rank source files by import in-degree (foundational = imported-by-many); top-N with symbols."""
+def _file_centrality_scores(rm: dict[str, Any]) -> tuple[list[str], dict[str, float]]:
+    """Composite per-file centrality (capped fan-in + fan-out + symbol density) over the non-doc,
+    non-config code files in `rm`. Shared by `_central_files_from_map` (top-N central-file ranking)
+    and `_suggested_scope_from_map` (directory rollup, audit #93 SUB-2) so both features read off
+    the exact same score -- never a second, driftable scoring system."""
     all_files = [str(f) for f in rm.get("files", [])]
     if not all_files:
-        return []
+        return [], {}
     # "Central files" surface CODE architecture. Documentation files (heavily cross-referenced in
     # doc-heavy repos — e.g. 36 CLAUDE.md files) must not rank as central, and must not absorb a code
     # import via a stem collision (config.md shadowing config.py in by_stem). Exclude docs from the
@@ -117,6 +120,14 @@ def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> li
         fan_out = len(resolved_imports.get(source, []))
         density = min(symbol_counts.get(source, 0), _CENTRAL_SYMBOL_DENSITY_CAP)
         centrality[source] = float(fan_in + fan_out + density)
+    return code_files, centrality
+
+
+def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> list[dict[str, Any]]:
+    """Rank source files by import in-degree (foundational = imported-by-many); top-N with symbols."""
+    code_files, centrality = _file_centrality_scores(rm)
+    if not code_files:
+        return []
     ranked = sorted(code_files, key=lambda source: (-centrality[source], source))
     result: list[dict[str, Any]] = []
     for file_path in ranked[:max_central_files]:
@@ -136,6 +147,62 @@ def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> li
             "symbols": file_symbols,
         })
     return result
+
+
+# suggested_scope (audit #93 SUB-2): a truncated scan gives an agent an incomplete map with no
+# guidance on how to narrow it. When the top-level-directory rollup of `_file_centrality_scores`
+# shows a clear winner, suggest re-scoping to it; a tie or near-tie degrades to None rather than
+# guess (ranking-safety-floor discipline, memory: tensor-grep-idf-ranking-fragility-2026-06-29 --
+# this inherits the same flat, no-IDF-style composite score as central_files, so a wrong scope
+# guess would actively misdirect an agent, which is worse than no hint at all). The margin is a
+# ratio, not a fixed delta, so it scales with repos of very different absolute centrality sizes.
+_SUGGESTED_SCOPE_MIN_MARGIN_RATIO = 1.5
+
+
+def _top_level_dir(file_path: str, root: Path) -> str | None:
+    """First path component of `file_path` relative to `root`, or None for a file that lives
+    directly at the repo root (no subdirectory exists there to re-scope into)."""
+    try:
+        relative = Path(file_path).relative_to(root)
+    except ValueError:
+        return None
+    parts = relative.parts
+    if len(parts) < 2:
+        return None
+    return parts[0]
+
+
+def _suggested_scope_from_map(rm: dict[str, Any]) -> dict[str, Any] | None:
+    """Centrality-weighted directory rollup: sum each code file's composite centrality
+    (`_file_centrality_scores`) up to its top-level directory, rank directories, and suggest the
+    top one only when it clearly outranks the runner-up. Returns None (never a guess) when there
+    are no candidate subdirectories, the signal is entirely flat (all zero), or the top two
+    directories are tied/near-tied. Callers gate the call itself on the repo map's
+    ``scan_limit.possibly_truncated`` -- a complete scan has nothing left to narrow."""
+    code_files, centrality = _file_centrality_scores(rm)
+    if not code_files:
+        return None
+    root = Path(str(rm.get("path", ".")))
+    dir_scores: dict[str, float] = {}
+    for file_path in code_files:
+        top_dir = _top_level_dir(file_path, root)
+        if top_dir is None:
+            continue
+        dir_scores[top_dir] = dir_scores.get(top_dir, 0.0) + centrality.get(file_path, 0.0)
+    if not dir_scores:
+        return None
+    ranked_dirs = sorted(dir_scores, key=lambda d: (-dir_scores[d], d))
+    top_score = dir_scores[ranked_dirs[0]]
+    if top_score <= 0:
+        return None  # no signal at all -- nothing to distinguish a "highest-value" directory
+    if len(ranked_dirs) > 1:
+        runner_up_score = dir_scores[ranked_dirs[1]]
+        if runner_up_score > 0 and top_score < runner_up_score * _SUGGESTED_SCOPE_MIN_MARGIN_RATIO:
+            return None  # no clear winner -- degrade to null rather than risk a misleading guess
+    return {
+        "dirs": [str(root / ranked_dirs[0])],
+        "confidence": "heuristic",
+    }
 
 
 def _detect_entry_points(rm: dict[str, Any]) -> list[dict[str, Any]]:
@@ -218,6 +285,16 @@ def build_orient_capsule(
     central_files = _central_files_from_map(rm, max_central_files=max_central_files)
     entry_points = _detect_entry_points(rm)
 
+    # suggested_scope (audit #93 SUB-2): gate on the underlying repo map's OWN scan_limit dict
+    # (`rm["scan_limit"]["possibly_truncated"]`, set by `repo_map.build_repo_map` -- NOT this
+    # capsule's own simplified `scan_limit` int returned below, and NOT the snippet/token-budget
+    # `truncated` flag computed further down). A complete scan has no incomplete map to narrow.
+    scan_limit_info = rm.get("scan_limit")
+    scan_possibly_truncated = bool(
+        isinstance(scan_limit_info, dict) and scan_limit_info.get("possibly_truncated")
+    )
+    suggested_scope = _suggested_scope_from_map(rm) if scan_possibly_truncated else None
+
     symbol_map: dict[str, list[dict[str, Any]]] = {}
     for cf in central_files:
         file_path = cf["file"]
@@ -294,6 +371,7 @@ def build_orient_capsule(
         ),
         "truncated": truncated,
         "scan_limit": effective_max_repo_files,
+        "suggested_scope": suggested_scope,
         "routing_reason": "orient",
     }
 

--- a/tests/unit/test_orient_suggested_scope.py
+++ b/tests/unit/test_orient_suggested_scope.py
@@ -1,0 +1,209 @@
+"""Tests for build_orient_capsule's `suggested_scope` hint (audit #93 SUB-2).
+
+A truncated `tg orient` scan gives an agent an incomplete map with no guidance on how to narrow
+it. `suggested_scope` rolls each scanned code file's composite centrality (the same score
+`central_files` ranks on -- `_file_centrality_scores`) up to its top-level directory and suggests
+the clear winner -- but ONLY when the underlying repo scan was actually truncated
+(``rm["scan_limit"]["possibly_truncated"]``, from `repo_map.build_repo_map`; NOT this capsule's
+own simplified ``scan_limit`` int, and NOT the snippet/token-budget ``truncated`` flag), and ONLY
+when there IS a clear winner. A flat/tied signal degrades to None rather than risk a misleading
+guess (ranking-safety-floor discipline, memory: tensor-grep-idf-ranking-fragility-2026-06-29 -- a
+wrong scope suggestion actively misdirects an agent, worse than no hint at all)."""
+
+from pathlib import Path
+from typing import Any
+
+import tensor_grep.cli.orient_capsule as oc
+from tensor_grep.cli.orient_capsule import _suggested_scope_from_map, build_orient_capsule
+
+# ---------------------------------------------------------------------------
+# Unit tests: _suggested_scope_from_map (hand-built repo maps, no filesystem)
+# ---------------------------------------------------------------------------
+
+
+def test_suggested_scope_picks_clear_centrality_winner() -> None:
+    # core/ has a real hub (imported by 2 siblings, 6 symbols); misc/ has one isolated, symbol-less
+    # file. core/'s rolled-up centrality (10) clearly beats misc/'s (0) -> suggest core/.
+    root = Path("/repo")
+    rm = {
+        "path": str(root),
+        "files": [
+            str(root / "core" / "hub.py"),
+            str(root / "core" / "a.py"),
+            str(root / "core" / "b.py"),
+            str(root / "misc" / "lonely.py"),
+        ],
+        "imports": [
+            {"file": str(root / "core" / "a.py"), "imports": ["hub"]},
+            {"file": str(root / "core" / "b.py"), "imports": ["hub"]},
+        ],
+        "symbols": [
+            {"name": f"Sym{i}", "kind": "function", "file": str(root / "core" / "hub.py")}
+            for i in range(6)
+        ],
+    }
+    scope = _suggested_scope_from_map(rm)
+    assert scope is not None
+    assert scope["confidence"] == "heuristic"
+    assert scope["dirs"] == [str(root / "core")]
+
+
+def test_suggested_scope_none_on_tied_centrality() -> None:
+    # Two directories, each a single file with exactly one symbol and no import edges -> equal
+    # rolled-up centrality (1 == 1). No clear winner -> degrade to None, never guess.
+    root = Path("/repo")
+    rm = {
+        "path": str(root),
+        "files": [str(root / "dira" / "a.py"), str(root / "dirb" / "b.py")],
+        "imports": [],
+        "symbols": [
+            {"name": "A", "kind": "function", "file": str(root / "dira" / "a.py")},
+            {"name": "B", "kind": "function", "file": str(root / "dirb" / "b.py")},
+        ],
+    }
+    assert _suggested_scope_from_map(rm) is None
+
+
+def test_suggested_scope_none_when_no_subdirectories() -> None:
+    # Every file lives directly at the repo root -- there is no subdirectory to re-scope into.
+    root = Path("/repo")
+    rm = {
+        "path": str(root),
+        "files": [str(root / "a.py"), str(root / "b.py")],
+        "imports": [{"file": str(root / "b.py"), "imports": ["a"]}],
+        "symbols": [{"name": "A", "kind": "function", "file": str(root / "a.py")}],
+    }
+    assert _suggested_scope_from_map(rm) is None
+
+
+def test_suggested_scope_none_when_centrality_all_zero() -> None:
+    # Two candidate directories exist, but neither has any import edges or symbols -- a flat
+    # zero signal is exactly as "no clear winner" as a tie, and must also degrade to None.
+    root = Path("/repo")
+    rm = {
+        "path": str(root),
+        "files": [str(root / "dira" / "a.py"), str(root / "dirb" / "b.py")],
+        "imports": [],
+        "symbols": [],
+    }
+    assert _suggested_scope_from_map(rm) is None
+
+
+def test_suggested_scope_none_on_empty_map() -> None:
+    assert _suggested_scope_from_map({"path": "/repo", "files": []}) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: build_orient_capsule's truncation gate
+# ---------------------------------------------------------------------------
+
+
+def _fake_rm(*, root: Path, possibly_truncated: bool, tied: bool) -> dict[str, Any]:
+    """A hand-controlled repo_map.build_repo_map() result -- deterministic centrality (winner or
+    exact tie) and an explicit scan_limit.possibly_truncated, decoupled from real-filesystem walk
+    order so the GATING behavior can be tested precisely."""
+    if tied:
+        files = [str(root / "dira" / "a.py"), str(root / "dirb" / "b.py")]
+        symbols = [
+            {"name": "A", "kind": "function", "file": str(root / "dira" / "a.py")},
+            {"name": "B", "kind": "function", "file": str(root / "dirb" / "b.py")},
+        ]
+        imports: list[dict[str, Any]] = []
+    else:
+        files = [
+            str(root / "core" / "hub.py"),
+            str(root / "core" / "a.py"),
+            str(root / "core" / "b.py"),
+            str(root / "misc" / "lonely.py"),
+        ]
+        symbols = [
+            {"name": f"Sym{i}", "kind": "function", "file": str(root / "core" / "hub.py")}
+            for i in range(6)
+        ]
+        imports = [
+            {"file": str(root / "core" / "a.py"), "imports": ["hub"]},
+            {"file": str(root / "core" / "b.py"), "imports": ["hub"]},
+        ]
+    return {
+        "path": str(root),
+        "files": files,
+        "imports": imports,
+        "symbols": symbols,
+        "tests": [],
+        "scan_limit": {
+            "max_repo_files": len(files),
+            "scanned_files": len(files),
+            "possibly_truncated": possibly_truncated,
+            "truncation_cause": "project-files" if possibly_truncated else None,
+        },
+    }
+
+
+def test_build_orient_capsule_suggests_scope_when_truncated_with_clear_winner(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    fake_rm = _fake_rm(root=tmp_path, possibly_truncated=True, tied=False)
+    monkeypatch.setattr(oc._repo_map, "build_repo_map", lambda *_a, **_k: fake_rm)
+
+    payload = build_orient_capsule(tmp_path, max_snippet_files=0)
+
+    assert payload["suggested_scope"] is not None
+    assert payload["suggested_scope"]["confidence"] == "heuristic"
+    assert payload["suggested_scope"]["dirs"] == [str(tmp_path / "core")]
+
+
+def test_build_orient_capsule_suggested_scope_absent_on_complete_scan(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    # Same clear-winner file structure as above, but the scan is COMPLETE: there is nothing to
+    # narrow, so no suggestion must be emitted even though the centrality signal is strong.
+    fake_rm = _fake_rm(root=tmp_path, possibly_truncated=False, tied=False)
+    monkeypatch.setattr(oc._repo_map, "build_repo_map", lambda *_a, **_k: fake_rm)
+
+    payload = build_orient_capsule(tmp_path, max_snippet_files=0)
+
+    assert payload["suggested_scope"] is None
+
+
+def test_build_orient_capsule_suggested_scope_null_when_truncated_but_flat(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    # Truncated AND a real (tied) centrality signal -- must degrade to None, not guess.
+    fake_rm = _fake_rm(root=tmp_path, possibly_truncated=True, tied=True)
+    monkeypatch.setattr(oc._repo_map, "build_repo_map", lambda *_a, **_k: fake_rm)
+
+    payload = build_orient_capsule(tmp_path, max_snippet_files=0)
+
+    assert payload["suggested_scope"] is None
+
+
+def test_build_orient_capsule_suggested_scope_absent_on_real_small_repo(tmp_path: Path) -> None:
+    # No monkeypatching -- a genuinely small repo (well under the default scan cap) never
+    # truncates, so suggested_scope must be None end-to-end through the real build_repo_map walk.
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (tmp_path / "helper.py").write_text("def helper():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_scope"] is None
+
+
+def test_build_orient_capsule_suggested_scope_is_well_formed_on_real_truncated_scan(
+    tmp_path: Path,
+) -> None:
+    # Real (non-mocked) truncation via a small --max-repo-files: whichever directory ends up
+    # "winning" the real walk, the field must be either None or a well-formed {dirs, confidence}
+    # hint -- never a raw exception, never a malformed shape.
+    for sub in ("alpha", "beta"):
+        d = tmp_path / sub
+        d.mkdir()
+        for i in range(6):
+            (d / f"m{i}.py").write_text(f"def f_{sub}_{i}():\n    return {i}\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_repo_files=4, max_snippet_files=0)
+
+    assert payload["scan_limit"] == 4
+    scope = payload["suggested_scope"]
+    if scope is not None:
+        assert scope["confidence"] == "heuristic"
+        assert isinstance(scope["dirs"], list) and scope["dirs"]


### PR DESCRIPTION
## What

Closes audit #93 SUB-2 (dogfood #84 P2/P3 tail). `tg orient` on a repo whose scan TRUNCATED gave an agent an incomplete map with no guidance on how to narrow it. Adds an additive `suggested_scope` hint: when the scan truncated, suggest the highest-centrality subdirectory to re-scope to.

## Fix

`orient_capsule.py`: new `_suggested_scope_from_map` (centrality-weighted top-level-dir rollup with a clear-winner margin check, `_SUGGESTED_SCOPE_MIN_MARGIN_RATIO = 1.5`), wired into `build_orient_capsule` behind a truncation gate. `_central_files_from_map` refactored to share a `_file_centrality_scores(rm)` helper (byte-identical behavior; all pre-existing orient tests pass unchanged).

Three load-bearing constraints, all tested:
1. **Gated on real truncation.** VERIFY-AGAINST-CODE caught a design mismatch: the capsule's public `scan_limit` is just the effective `max_repo_files` int; the real truncation signal (`possibly_truncated`) lives on the repo-map dict (`repo_map.build_repo_map`, `repo_map.py:5944-5954`). Gated on `rm["scan_limit"]["possibly_truncated"]`, NOT the capsule int or the unrelated snippet/token-budget `truncated` flag -- confirmed by dogfood where top-level `truncated=False` but the suggestion still fired correctly. Complete scans emit NO suggestion.
2. **confidence: "heuristic"** on the field (it inherits the flat no-IDF scorer's fragility).
3. **DEGRADE-TO-NULL** (ranking-safety-floor): flat/tied centrality with no clear winner -> `suggested_scope: null`, never a misleading guess (a wrong scope actively sends an agent down the wrong path).

## Verification

TDD RED->GREEN: 10 new tests in `test_orient_suggested_scope.py` (clear-winner -> suggests; complete-scan -> null; **tied/flat -> null degrade**; all-zero + empty-map edge cases). ruff / ruff format --preview / `mypy src/tensor_grep` (77 files) clean; orient + harness-doc + MCP-orient + repo_map/mcp_caps regression sweeps green (192 tests).

**Real-binary dogfood** (via `python -m tensor_grep`, not CliRunner): `C:\dev\projects` (2000+ files) -> truncated but `suggested_scope: null` (flat centrality across unrelated projects -> the safety floor held on REAL data); a synthetic 2250-file hot/cold repo -> `{"dirs": ["...hot"], "confidence": "heuristic"}` (correct winner); a 2-file complete repo -> null.

Additive schema; updated the `docs/harness_api.md` Orient Capsule JSON table (doc-parity contract). No mandatory gate (orient_capsule.py is not mcp/backends/session_daemon/apply_policy/index_lock/cpu_backend; only 3 files touched).

`fix:` -> patch. Closes #93 (SUB-2). SUB-3 (unscoped-refuse, main.py) tracked separately -- blocked on #501 (shares main.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
