### PR TITLE
fix(lsp): bound the external-LSP header read (unbounded-read DoS residual, #49-sibling) — audit #116

### DIFF
--- a/src/tensor_grep/cli/lsp_external_provider.py
+++ b/src/tensor_grep/cli/lsp_external_provider.py
@@ -90,12 +90,51 @@ def _configured_positive_int(env_var: str, default: int) -> int:
 # provider cannot declare a huge Content-Length and force an unbounded read/allocation.
 _MAX_LSP_MESSAGE_BYTES = 64 * 1024 * 1024
 
+# Audit #116 (DoS): bound the header preamble itself -- mirrors mcp_server.py's audit #49 fix
+# for the identical unbounded-header-skip shape in the MCP stdio reader. A malformed or
+# malicious language-server subprocess that streams endless header lines, or a single giant
+# line with no newline terminator, or one that never sends the blank-line terminator, must not
+# hang the reader or exhaust memory BEFORE the Content-Length size check below ever runs.
+# Three caps apply, fail-closed on any breach: a hard iteration cap on the NUMBER of header
+# lines (_MAX_LSP_HEADER_LINES), a hard byte cap on any SINGLE line (enforced by the bounded
+# readline() below), and a cumulative byte cap across the whole preamble -- the two byte caps
+# reuse one constant (_MAX_LSP_HEADER_BYTES), mirroring #49's reuse of a single constant for
+# both roles.
+_MAX_LSP_HEADER_LINES = 128
+_MAX_LSP_HEADER_BYTES = 64 * 1024
+
+
+def _read_bounded_line(stream: Any, limit: int) -> Any:
+    """``stream.readline()``, but never buffer more than ``limit`` bytes/chars for one line.
+
+    Named to mirror mcp_server.py's ``_read_bounded_line`` (audit #49). That MCP reader wraps
+    an ``anyio.AsyncFile``, whose ``readline()`` does not forward a size bound -- it needs a
+    reach-into-``.wrapped`` thread trick to get one. ``_read_message`` here is a plain
+    synchronous function reading a subprocess pipe (or a test double), and both
+    ``io.BufferedReader.readline(size)`` and text-stream ``readline(size)`` already accept a
+    size bound directly, so this is a direct pass-through -- kept as a named helper purely to
+    mirror the #49 shape for anyone diffing the two readers.
+    """
+    return stream.readline(limit)
+
 
 def _read_message(stream: Any) -> dict[str, Any] | None:
     headers: dict[str, str] = {}
-    while True:
-        line = stream.readline()
+    header_bytes_total = 0
+    for _ in range(_MAX_LSP_HEADER_LINES):
+        line = _read_bounded_line(stream, _MAX_LSP_HEADER_BYTES)
         if line in ("", b""):
+            return None
+        ends_with_newline = line.endswith(b"\n") if isinstance(line, bytes) else line.endswith("\n")
+        if len(line) >= _MAX_LSP_HEADER_BYTES and not ends_with_newline:
+            # Fail closed: this single line reached the per-line read cap with no newline
+            # terminator -- a giant or never-terminating header line. A complete line exactly
+            # at the cap still ends in "\n", so a legitimate message is never truncated.
+            return None
+        header_bytes_total += len(line)
+        if header_bytes_total > _MAX_LSP_HEADER_BYTES:
+            # Fail closed: too many header lines summed past the cumulative byte budget
+            # before a blank-line terminator ever showed up.
             return None
         if line in ("\r\n", "\n", b"\r\n", b"\n"):
             break
@@ -105,6 +144,9 @@ def _read_message(stream: Any) -> dict[str, Any] | None:
             continue
         key, value = line.split(":", 1)
         headers[key.strip().lower()] = value.strip()
+    else:
+        # Fail closed: too many header lines without a blank-line terminator.
+        return None
     try:
         content_length = int(headers.get("content-length", "0"))
     except (TypeError, ValueError):

--- a/tests/unit/test_lsp_external_provider_hardening.py
+++ b/tests/unit/test_lsp_external_provider_hardening.py
@@ -1,13 +1,27 @@
-"""Hardening regression tests for the external-LSP-provider message reader (audit MED).
+"""Hardening regression tests for the external-LSP-provider message reader (audit MED, #116).
 
 ``_read_message`` trusted the framed ``Content-Length`` header with no upper bound before
 allocating/reading the body from the provider subprocess's stdout, so a malicious or buggy
 provider could force an unbounded read. It must refuse oversized (and malformed) frames.
+
+Audit #116 extends this to the HEADER preamble itself (the same unbounded-header-skip shape
+fixed for the MCP stdio reader in audit #49, ``mcp_server.py``): the loop that reads header
+lines between the start of a message and the blank-line terminator had no per-line byte cap
+and no iteration cap, so a malformed/malicious language-server subprocess streaming a single
+giant no-newline line, or endless small header lines, could force an unbounded read/allocation
+before the ``Content-Length`` size check ever ran.
 """
 
 from __future__ import annotations
 
-from tensor_grep.cli.lsp_external_provider import _MAX_LSP_MESSAGE_BYTES, _read_message
+from io import BytesIO
+
+from tensor_grep.cli.lsp_external_provider import (
+    _MAX_LSP_HEADER_BYTES,
+    _MAX_LSP_HEADER_LINES,
+    _MAX_LSP_MESSAGE_BYTES,
+    _read_message,
+)
 
 
 class _FakeStream:
@@ -15,7 +29,13 @@ class _FakeStream:
         self._lines = list(header_lines)
         self.read_called_with: int | None = None
 
-    def readline(self) -> str:
+    def readline(self, size: int = -1) -> str:
+        # `size` is accepted (not `readline()`-only) to match the real stream interface
+        # `_read_message` now calls via `_read_bounded_line` (audit #116) -- ignored here
+        # since this fake always hands back a whole pre-chopped line regardless of the
+        # requested bound; the boundedness tests below use a real `BytesIO` instead, whose
+        # `readline(size)` truly truncates.
+        del size
         return self._lines.pop(0) if self._lines else ""
 
     def read(self, n: int) -> str:
@@ -33,6 +53,56 @@ def test_read_message_refuses_malformed_content_length() -> None:
     stream = _FakeStream(["Content-Length: not-a-number\r\n", "\r\n"])
     assert _read_message(stream) is None
     assert stream.read_called_with is None
+
+
+def test_read_message_bounds_giant_no_newline_header_line() -> None:
+    """A single header line with no newline terminator, far larger than the per-line header
+    cap, must not force an unbounded single ``readline()`` buffer allocation (audit #116;
+    mirrors the MCP stdio audit #49 header-line byte bound).
+
+    Pre-fix, ``stream.readline()`` took no size argument: fed a newline-free buffer, it reads
+    every byte up to EOF in ONE call. The plain ``_read_message(stream) is None`` assertion
+    alone would pass even pre-fix (the loop still terminates once the fake stream hits EOF on
+    its *next* call) -- the ``stream.tell()`` bound below is what actually proves the read was
+    capped rather than draining the whole buffer, and is the assertion that is RED pre-fix.
+    """
+    oversized = b"X" * (_MAX_LSP_HEADER_BYTES * 4)
+    stream = BytesIO(oversized)
+
+    assert _read_message(stream) is None
+    assert stream.tell() <= _MAX_LSP_HEADER_BYTES
+
+
+def test_read_message_bounds_header_line_count() -> None:
+    """More header lines than the iteration cap, each individually tiny and well-formed, with
+    no blank-line terminator anywhere, must not be drained without limit (audit #116; mirrors
+    the MCP stdio audit #49 header-line-count bound).
+
+    Pre-fix, the header loop had no iteration cap: fed enough small, colon-bearing lines it
+    keeps consuming (and dict-inserting) every one of them until the fake stream's buffer runs
+    dry. As with the giant-line case, ``stream.tell()`` -- not just the ``is None`` return --
+    is what proves the loop stopped at the cap instead of just running out of fake data.
+    """
+    one_line = b"X-Pad: 1\r\n"
+    stream = BytesIO(one_line * (_MAX_LSP_HEADER_LINES * 4))
+
+    assert _read_message(stream) is None
+    assert stream.tell() <= _MAX_LSP_HEADER_LINES * len(one_line)
+
+
+def test_read_message_parses_small_message_with_multiple_headers() -> None:
+    """Happy-path regression guard: the new bounded header loop must not disturb normal
+    framing -- a small message with more than one header line (an extra ``Content-Type``
+    header ahead of ``Content-Length``) still parses correctly."""
+    body = b'{"jsonrpc": "2.0", "id": 1, "result": null}'
+    framed = (
+        b"Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"
+        + f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        + body
+    )
+    stream = BytesIO(framed)
+
+    assert _read_message(stream) == {"jsonrpc": "2.0", "id": 1, "result": None}
 
 
 def test_notify_document_closed_evicts_doc_version(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Closes audit #116 (the #49 gate residual). `lsp_external_provider._read_message` had an unbounded header-skip loop (`while True: readline()` with no per-line or iteration cap) -- same DoS shape as the MCP stdio bug fixed in #502, but for the spawned language-server subprocess. A malformed/malicious LSP server (giant no-newline header line, or endless header lines) could force an unbounded read/loop before the body-size check.

Fix mirrors #502's pattern: `_read_bounded_line` + `_MAX_LSP_HEADER_LINES=128` + `_MAX_LSP_HEADER_BYTES=64KB` (per-line + cumulative), fail-closed (returns None -> the caller's existing `_broadcast_closed()` clean-close path, verified unchanged at lsp_external_provider.py:942-945).

TDD RED->GREEN with `stream.tell()` boundedness assertions (genuinely RED: pre-fix drained the full buffer / all lines): giant-header-line + header-line-count both bounded; oversized/malformed Content-Length regression-safe; small multi-header happy path unaffected. ruff/format/mypy clean; 44 lsp tests pass. Only 2 files (lsp_external_provider.py + new test); NO mandatory-gate surface.

`fix:` -> patch. Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)