### PR TITLE
fix(checkpoint): confine undo snapshot-source reads + add create disk budgets (audit H3+H4, Opus-gated SHIP)

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -31,6 +31,17 @@ _DISCOVERY_CACHE_TTL_SECONDS = 300.0
 # new snapshot dir, so an uncapped store grows without limit. Keep only the newest N.
 _CHECKPOINT_MAX_ENV = "TG_CHECKPOINT_MAX"
 _DEFAULT_CHECKPOINT_MAX = 64
+# audit H4: create_checkpoint() copied every entry with no per-file cap, no cumulative-size
+# budget, and no free-space check, so a single huge file (or a large scope) could exhaust disk
+# in one `tg checkpoint create` -- reachable from the CLI, the MCP tg_checkpoint_create tool, and
+# tg_rewrite_apply(checkpoint=true). All three knobs are env-configurable so a repo with
+# legitimately large tracked assets is not permanently blocked.
+_CHECKPOINT_MAX_FILE_BYTES_ENV = "TG_CHECKPOINT_MAX_FILE_BYTES"
+_DEFAULT_CHECKPOINT_MAX_FILE_BYTES = 512 * 1024 * 1024  # 512 MiB per file
+_CHECKPOINT_MAX_TOTAL_BYTES_ENV = "TG_CHECKPOINT_MAX_TOTAL_BYTES"
+_DEFAULT_CHECKPOINT_MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024  # 4 GiB per checkpoint
+_CHECKPOINT_FREE_SPACE_MARGIN_BYTES_ENV = "TG_CHECKPOINT_FREE_SPACE_MARGIN_BYTES"
+_DEFAULT_CHECKPOINT_FREE_SPACE_MARGIN_BYTES = 256 * 1024 * 1024  # keep >=256 MiB free after copy
 _NON_GIT_IGNORED_DIRS = {
     ".git",
     ".hg",
@@ -67,6 +78,18 @@ class CheckpointCorruptError(RuntimeError):
     def __init__(self, message: str, missing_files: list[str] | None = None) -> None:
         super().__init__(message)
         self.missing_files: list[str] = missing_files or []
+
+
+class CheckpointBudgetExceededError(RuntimeError):
+    """Raised when create_checkpoint() would exceed a configured disk-usage budget (audit H4).
+
+    Guards against unbounded disk exhaustion: the copy loop previously had no per-file cap,
+    no cumulative-size cap, and no free-space check, so a single ``tg checkpoint create`` could
+    fill the disk. Always raised BEFORE the copy loop creates a snapshot directory (the
+    per-file/total-bytes/free-space pre-flight); a mid-copy failure of any kind (this error or
+    an ordinary OSError) also removes the partial snapshot directory before re-raising, so a
+    refused or interrupted checkpoint never leaves partial state on disk.
+    """
 
 
 def _is_generated_discovery_dir(path: Path) -> bool:
@@ -678,6 +701,88 @@ def _prune_checkpoint_records(
     return retained
 
 
+def _configured_positive_int(env_var: str, default: int) -> int:
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _configured_checkpoint_max_file_bytes() -> int:
+    return _configured_positive_int(
+        _CHECKPOINT_MAX_FILE_BYTES_ENV, _DEFAULT_CHECKPOINT_MAX_FILE_BYTES
+    )
+
+
+def _configured_checkpoint_max_total_bytes() -> int:
+    return _configured_positive_int(
+        _CHECKPOINT_MAX_TOTAL_BYTES_ENV, _DEFAULT_CHECKPOINT_MAX_TOTAL_BYTES
+    )
+
+
+def _configured_checkpoint_free_space_margin_bytes() -> int:
+    return _configured_positive_int(
+        _CHECKPOINT_FREE_SPACE_MARGIN_BYTES_ENV, _DEFAULT_CHECKPOINT_FREE_SPACE_MARGIN_BYTES
+    )
+
+
+def _check_checkpoint_disk_budget(root: Path, entries: dict[str, bool]) -> None:
+    """Pre-flight disk-usage budget for create_checkpoint (audit H4).
+
+    Stats every entry that will be copied (cheap; no copying yet) and refuses BEFORE any
+    snapshot directory is created if a single file exceeds the per-file cap, the cumulative
+    snapshot size exceeds the total-per-checkpoint cap, or performing the copy would leave
+    less than the configured free-space margin on the destination filesystem. All three caps
+    are env-configurable (sane defaults) so a repo with legitimately large tracked assets can
+    raise the limit instead of being permanently blocked.
+    """
+    max_file_bytes = _configured_checkpoint_max_file_bytes()
+    max_total_bytes = _configured_checkpoint_max_total_bytes()
+    free_margin_bytes = _configured_checkpoint_free_space_margin_bytes()
+
+    total_bytes = 0
+    for rel_path, exists in entries.items():
+        if not exists:
+            continue
+        try:
+            size = (root / rel_path).stat().st_size
+        except OSError:
+            # A vanished/unreadable source is reported by the copy loop itself; the budget
+            # pre-flight only needs a best-effort size estimate, not definitive readability.
+            continue
+        if size > max_file_bytes:
+            raise CheckpointBudgetExceededError(
+                f"Checkpoint refused: {rel_path!r} is {size} bytes, over the per-file limit "
+                f"of {max_file_bytes} bytes (raise {_CHECKPOINT_MAX_FILE_BYTES_ENV} to allow "
+                "larger files)."
+            )
+        total_bytes += size
+        if total_bytes > max_total_bytes:
+            raise CheckpointBudgetExceededError(
+                "Checkpoint refused: snapshot size exceeds the per-checkpoint limit of "
+                f"{max_total_bytes} bytes (raise {_CHECKPOINT_MAX_TOTAL_BYTES_ENV} to allow a "
+                "larger checkpoint)."
+            )
+
+    try:
+        free_bytes = shutil.disk_usage(root).free
+    except OSError:
+        # Cannot introspect free space on this filesystem; do not block the checkpoint on a
+        # diagnostic we could not compute -- the per-file/total-bytes caps above still apply.
+        return
+    required_bytes = total_bytes + free_margin_bytes
+    if free_bytes < required_bytes:
+        raise CheckpointBudgetExceededError(
+            f"Checkpoint refused: only {free_bytes} bytes free, but this checkpoint needs "
+            f"{total_bytes} bytes plus a {free_margin_bytes}-byte safety margin (lower "
+            f"{_CHECKPOINT_FREE_SPACE_MARGIN_BYTES_ENV} to change the margin)."
+        )
+
+
 def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
     scope = _detect_checkpoint_scope(Path(path))
     root = scope.root
@@ -685,6 +790,10 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
     created_at = datetime.now(UTC).isoformat()
     checkpoint_id = f"ckpt-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
     entries = _snapshot_entries(scope)
+
+    # audit H4: refuse BEFORE any snapshot directory exists if the copy would blow a
+    # configured size/free-space budget -- see _check_checkpoint_disk_budget.
+    _check_checkpoint_disk_budget(root, entries)
 
     # Create the storage root up front so its resolve() is stable: under concurrent first-time
     # creates, resolving _snapshot_path while another writer is still mkdir-ing .tensor-grep/
@@ -694,15 +803,24 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
     snapshot_dir = _snapshot_path(root, checkpoint_id)
     snapshot_dir.mkdir(parents=True, exist_ok=True)
 
-    for rel_path, exists in entries.items():
-        if not exists:
-            continue
-        source = root / rel_path
-        destination = snapshot_dir / rel_path
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        # follow_symlinks=False: store a symlink AS a link, never copy its (possibly
-        # out-of-root) target content into the snapshot (audit HIGH — symlink disclosure).
-        shutil.copy2(source, destination, follow_symlinks=False)
+    try:
+        for rel_path, exists in entries.items():
+            if not exists:
+                continue
+            source = root / rel_path
+            destination = snapshot_dir / rel_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            # follow_symlinks=False: store a symlink AS a link, never copy its (possibly
+            # out-of-root) target content into the snapshot (audit HIGH — symlink disclosure).
+            shutil.copy2(source, destination, follow_symlinks=False)
+    except Exception:
+        # audit H4: never leave a half-copied checkpoint dir behind on any abort, budget-
+        # related or not (e.g. disk fills mid-copy despite the pre-flight, or a file
+        # vanishes/grows mid-loop). Remove the WHOLE per-checkpoint dir (metadata.json has not
+        # been written yet at this point, but snapshot_dir's own parent must go too, not just
+        # the snapshot/ subdir) -- matches how _prune_checkpoint_records removes a checkpoint.
+        shutil.rmtree(snapshot_dir.parent, ignore_errors=True)
+        raise
 
     result = CheckpointCreateResult(
         checkpoint_id=checkpoint_id,
@@ -1041,12 +1159,26 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
     entries: dict[str, bool] = metadata["entries"]
     snapshot_dir = _snapshot_path(root, checkpoint_id)
     root_resolved = root.resolve()
+    snapshot_dir_resolved = snapshot_dir.resolve()
 
     # --- PRE-FLIGHT PHASE (read-only; abort before touching any working-tree file) ---
 
-    # 1. Validate every metadata entry stays inside the checkpoint root (S1).
+    # 1. Validate every metadata entry stays inside the checkpoint root (S1) AND that its
+    #    snapshot SOURCE stays inside the snapshot dir (audit H3). Target containment alone
+    #    left the source composition (`snapshot_dir / rel_path`) unguarded: shutil.copy2(...,
+    #    follow_symlinks=False) only refuses a symlink at the FINAL path component, so a
+    #    snapshot tree with a symlinked (or, on Windows, junctioned) ANCESTOR directory --
+    #    e.g. `snapshot/subdir` pointing outside the snapshot -- is transparently traversed by
+    #    the OS, reading host-file content through the link and copying it into a confined
+    #    working-tree target (arbitrary-file-read-into-working-tree). Reuse the same
+    #    containment helper used for targets, scoped to snapshot_dir, so any entry whose
+    #    resolved source escapes the snapshot is refused before any file is touched.
     resolved_targets = {
         rel_path: _resolve_within_root(root, root_resolved, rel_path) for rel_path in entries
+    }
+    resolved_sources = {
+        rel_path: _resolve_within_root(snapshot_dir, snapshot_dir_resolved, rel_path)
+        for rel_path in entries
     }
 
     # 2. Verify every snapshot source that should exist is present and readable BEFORE
@@ -1057,7 +1189,7 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
     for rel_path, exists in entries.items():
         if not exists:
             continue
-        source = snapshot_dir / Path(rel_path)
+        source = resolved_sources[rel_path]
         if not source.exists():
             missing.append(rel_path)
         else:
@@ -1102,12 +1234,13 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
         for rel_path, exists in entries.items():
             target = resolved_targets[rel_path]
             if exists:
-                source = snapshot_dir / Path(rel_path)
+                source = resolved_sources[rel_path]
                 staged = staging_root / Path(rel_path)
                 staged.parent.mkdir(parents=True, exist_ok=True)
-                # This copy is safe: source existence was verified in pre-flight.
-                # follow_symlinks=False: a stored symlink stays a link and is never followed to
-                # re-materialize out-of-root content on undo (audit HIGH — symlink disclosure).
+                # This copy is safe: source existence AND containment were verified in
+                # pre-flight (H2 + H3). follow_symlinks=False: a stored symlink stays a link
+                # and is never followed to re-materialize out-of-root content on undo
+                # (audit HIGH — symlink disclosure).
                 shutil.copy2(source, staged, follow_symlinks=False)
                 staging_pairs.append((staged, target))
                 restored_files += 1

--- a/tests/unit/test_checkpoint_containment.py
+++ b/tests/unit/test_checkpoint_containment.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -234,3 +235,149 @@ def test_select_retained_checkpoints_prunes_by_created_at_not_insert_position(
     # created_at-based (fixed) pruning must keep the two NEWEST: {"newest", "middle"}.
     assert retained_ids == {"newest", "middle"}
     assert "oldest" not in retained_ids
+
+
+# ---------------------------------------------------------------------------
+# H3: snapshot SOURCE containment (symlinked/junctioned ancestor directory)
+# ---------------------------------------------------------------------------
+#
+# S1 (above) confines the undo TARGET (`root / rel_path`) via `_resolve_within_root`.
+# The snapshot SOURCE composition (`snapshot_dir / rel_path`) had no equivalent guard:
+# `shutil.copy2(source, ..., follow_symlinks=False)` only refuses a symlink at the FINAL
+# path component. A snapshot tree whose ANCESTOR directory is a symlink (or, on Windows, a
+# directory junction) pointing outside the snapshot is transparently traversed by the OS --
+# `tg checkpoint undo` then reads host-file content THROUGH the link and copies it into an
+# otherwise validly-confined working-tree target: arbitrary-file-read-into-working-tree. A
+# malicious repo can ship a pre-crafted `.tensor-grep/checkpoints/<id>/` (metadata.json +
+# a snapshot tree with a symlinked ancestor) that a victim's `tg checkpoint undo <id>`
+# then reads through.
+
+
+def test_undo_refuses_source_with_symlinked_ancestor_directory(tmp_path: Path) -> None:
+    """A symlinked ANCESTOR dir inside the snapshot tree must be refused, not traversed."""
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    outside = tmp_path / "outside_secret_dir"
+    outside.mkdir()
+    (outside / "id_rsa").write_text("-----BEGIN PRIVATE KEY-----\nSECRET\n", encoding="utf-8")
+
+    checkpoint_id = "ckpt-evil-ancestor-symlink"
+    snapshot_dir = checkpoint_store._snapshot_path(root, checkpoint_id)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    evil_ancestor = snapshot_dir / "subdir"
+    try:
+        evil_ancestor.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+
+    # `subdir/id_rsa` is itself a perfectly ordinary, non-traversal, in-root TARGET path --
+    # S1's target containment alone has nothing to object to here.
+    _write_metadata(root, checkpoint_id, {"subdir/id_rsa": True})
+
+    with pytest.raises(ValueError):
+        checkpoint_store.undo_checkpoint(checkpoint_id, str(root))
+
+    # The host secret must never have been copied into the working tree.
+    leaked_target = root / "subdir" / "id_rsa"
+    assert not leaked_target.exists(), "host file content was copied into the working tree"
+
+
+def test_undo_refuses_source_with_junctioned_ancestor_directory(tmp_path: Path) -> None:
+    """Windows variant: a directory JUNCTION as the snapshot ancestor.
+
+    Junctions are the more realistic Windows attack surface than symlinks: creating one
+    needs no elevated privilege / Developer Mode (unlike `CreateSymbolicLink`), so this
+    works for any local attacker on any Windows box. `Path.resolve()` follows a junction
+    exactly like a symlink (both are NTFS reparse points resolved the same way by
+    `GetFinalPathNameByHandle`), but `Path.is_symlink()` returns False for a junction -- so
+    any guard that only checked `is_symlink()` on an ancestor would silently miss this.
+    Proves the fix (`_resolve_within_root` via `Path.resolve()`) catches both mechanisms.
+    """
+    if os.name != "nt":
+        pytest.skip("junctions are a Windows-only reparse-point mechanism")
+
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    outside = tmp_path / "outside_secret_dir"
+    outside.mkdir()
+    (outside / "id_rsa").write_text("SECRET-VIA-JUNCTION\n", encoding="utf-8")
+
+    checkpoint_id = "ckpt-evil-junction"
+    snapshot_dir = checkpoint_store._snapshot_path(root, checkpoint_id)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    evil_ancestor = snapshot_dir / "subdir"
+
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(evil_ancestor), str(outside)],
+        check=True,
+        capture_output=True,
+    )
+    assert not evil_ancestor.is_symlink(), "sanity: a junction must NOT read as is_symlink()"
+
+    _write_metadata(root, checkpoint_id, {"subdir/id_rsa": True})
+
+    with pytest.raises(ValueError):
+        checkpoint_store.undo_checkpoint(checkpoint_id, str(root))
+
+    leaked_target = root / "subdir" / "id_rsa"
+    assert not leaked_target.exists(), (
+        "host file content was copied into the working tree via a junction"
+    )
+
+
+def test_undo_refuses_source_escape_without_touching_other_valid_entries(tmp_path: Path) -> None:
+    """A malicious entry must abort the WHOLE undo before mutating any file -- including
+    other, perfectly legitimate entries in the same checkpoint (matches the H2 all-or-nothing
+    pre-flight contract: undo must not partially apply)."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    legit_target = root / "legit.py"
+    legit_target.write_text("ORIGINAL\n", encoding="utf-8")
+
+    outside = tmp_path / "outside_secret_dir"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("SECRET\n", encoding="utf-8")
+
+    checkpoint_id = "ckpt-mixed-legit-and-evil"
+    snapshot_dir = checkpoint_store._snapshot_path(root, checkpoint_id)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    (snapshot_dir / "legit.py").write_text("SNAPSHOTTED\n", encoding="utf-8")
+    evil_ancestor = snapshot_dir / "subdir"
+    try:
+        evil_ancestor.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+
+    _write_metadata(
+        root,
+        checkpoint_id,
+        {"legit.py": True, "subdir/secret.txt": True},
+    )
+
+    with pytest.raises(ValueError):
+        checkpoint_store.undo_checkpoint(checkpoint_id, str(root))
+
+    # The legit file must be untouched -- the whole undo aborted pre-flight.
+    assert legit_target.read_text(encoding="utf-8") == "ORIGINAL\n"
+    assert not (root / "subdir" / "secret.txt").exists()
+
+
+def test_undo_still_restores_normal_nested_snapshot_after_source_containment_fix(
+    tmp_path: Path,
+) -> None:
+    """Baseline: an ordinary multi-level nested checkpoint (no symlinks anywhere) must keep
+    round-tripping after source containment is enforced -- the fix must not be over-strict."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    nested = root / "a" / "b" / "c" / "deep.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("deep-original\n", encoding="utf-8")
+
+    created = checkpoint_store.create_checkpoint(str(root))
+    nested.write_text("deep-MUTATED\n", encoding="utf-8")
+
+    result = checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+    assert result.restored_files == 1
+    assert nested.read_text(encoding="utf-8") == "deep-original\n"

--- a/tests/unit/test_checkpoint_disk_budget.py
+++ b/tests/unit/test_checkpoint_disk_budget.py
@@ -1,0 +1,157 @@
+"""Disk-usage budget regression tests for checkpoint creation (audit H4).
+
+``create_checkpoint()`` copied the WHOLE scope into a new snapshot dir on every call with
+no file-count cap, no per-file size cap, no running-byte budget, and no free-space check.
+The only existing control (``TG_CHECKPOINT_MAX``) bounds RETAINED checkpoint COUNT, and
+pruning runs AFTER the full copy, so peak transient disk usage was unbounded per call --
+reachable via ``tg checkpoint create``, the MCP ``tg_checkpoint_create`` tool, and
+``tg_rewrite_apply(checkpoint=true)``.
+
+These tests import only ``checkpoint_store`` (no ``cli.main`` / rust_core), so they run
+standalone and in CI without any compiled extension present.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import checkpoint_store
+from tensor_grep.cli.checkpoint_store import CheckpointBudgetExceededError
+
+
+def _storage_dir_entries(root: Path) -> list[Path]:
+    storage_dir = checkpoint_store._checkpoint_storage_dir(root)
+    if not storage_dir.exists():
+        return []
+    return list(storage_dir.iterdir())
+
+
+def test_create_checkpoint_succeeds_under_default_budget(tmp_path: Path) -> None:
+    """Baseline: an ordinary small checkpoint is unaffected by the new default budgets."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "a.py").write_text("small file\n", encoding="utf-8")
+
+    created = checkpoint_store.create_checkpoint(str(root))
+
+    assert created.file_count == 1
+    snapshot = checkpoint_store._snapshot_path(root, created.checkpoint_id)
+    assert (snapshot / "a.py").read_text(encoding="utf-8") == "small file\n"
+
+
+def test_create_checkpoint_refuses_file_over_per_file_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single file over the configured per-file cap must refuse the whole checkpoint,
+    and no half-created checkpoint directory may be left behind."""
+    monkeypatch.setenv("TG_CHECKPOINT_MAX_FILE_BYTES", "1024")
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "big.bin").write_bytes(b"x" * 4096)  # 4 KiB, over the 1 KiB cap
+
+    with pytest.raises(CheckpointBudgetExceededError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], "a checkpoint dir was left behind on refusal"
+
+
+def test_create_checkpoint_refuses_when_total_bytes_exceed_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Many small files whose SUM exceeds the total-per-checkpoint cap must also refuse,
+    even though no single file trips the per-file cap."""
+    monkeypatch.setenv("TG_CHECKPOINT_MAX_FILE_BYTES", "1000000")  # generous per-file
+    monkeypatch.setenv("TG_CHECKPOINT_MAX_TOTAL_BYTES", "2048")  # tiny total cap
+    root = tmp_path / "repo"
+    root.mkdir()
+    for i in range(5):
+        (root / f"f{i}.bin").write_bytes(b"y" * 1000)  # 5 x 1000 = 5000 > 2048 total
+
+    with pytest.raises(CheckpointBudgetExceededError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], "a checkpoint dir was left behind on refusal"
+
+
+def test_create_checkpoint_refuses_when_free_space_margin_violated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A destination filesystem reporting too little free space must refuse the checkpoint
+    even when the per-file/total caps alone would allow it."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "f.bin").write_bytes(b"z" * 1000)
+
+    real_usage = shutil.disk_usage(tmp_path)
+    fake_usage = real_usage._replace(free=500)  # far below any sane margin
+    monkeypatch.setattr(checkpoint_store.shutil, "disk_usage", lambda _path: fake_usage)
+
+    with pytest.raises(CheckpointBudgetExceededError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], "a checkpoint dir was left behind on refusal"
+
+
+def test_create_checkpoint_cleans_up_snapshot_dir_on_mid_copy_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure DURING the copy loop (after the pre-flight budget check passed) must not
+    leave a half-copied snapshot directory behind -- e.g. a file grows or a permission
+    error appears between the pre-flight stat and the actual copy."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "a.py").write_text("a\n", encoding="utf-8")
+    (root / "b.py").write_text("b\n", encoding="utf-8")
+
+    original_copy2 = checkpoint_store.shutil.copy2
+    calls = {"n": 0}
+
+    def _boom_on_second_copy(src, dst, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError("simulated mid-copy failure")
+        return original_copy2(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(checkpoint_store.shutil, "copy2", _boom_on_second_copy)
+
+    with pytest.raises(OSError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], "a half-copied checkpoint dir was left behind"
+
+
+def test_create_checkpoint_respects_raised_env_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The caps are env-configurable: a repo with legitimately large tracked assets can
+    raise the limit instead of being permanently blocked."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "big.bin").write_bytes(b"x" * 4096)
+
+    monkeypatch.setenv("TG_CHECKPOINT_MAX_FILE_BYTES", "1024")
+    with pytest.raises(CheckpointBudgetExceededError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    monkeypatch.setenv("TG_CHECKPOINT_MAX_FILE_BYTES", "8192")  # raise the cap
+    created = checkpoint_store.create_checkpoint(str(root))
+    assert created.file_count == 1
+
+
+def test_create_checkpoint_undo_roundtrip_still_works_after_budget_fix(tmp_path: Path) -> None:
+    """Baseline: a normal create -> modify -> undo roundtrip is unaffected by the budget
+    pre-flight (default budgets are generous relative to test-sized fixtures)."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    target = root / "pkg" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("original\n", encoding="utf-8")
+
+    created = checkpoint_store.create_checkpoint(str(root))
+    target.write_text("MUTATED\n", encoding="utf-8")
+
+    checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+    assert target.read_text(encoding="utf-8") == "original\n"


### PR DESCRIPTION
Closes codex-audit H3 (arbitrary host-file read into working tree) + H4 (disk-exhaustion DoS) in `checkpoint_store.py`. Both MCP-reachable (tg_checkpoint_undo / tg_rewrite_apply) and adversarial-Opus-gated SHIP.

**H3** -- `undo_checkpoint` confined the restore TARGET but composed the snapshot SOURCE as a raw `snapshot_dir / rel_path` join; a symlinked/junctioned ANCESTOR redirected the read outside the snapshot. **Live exploit proof:** pre-fix, a malicious-repo-shipped checkpoint with a symlinked ancestor exfiltrated a planted `id_rsa` into the working tree; post-fix -> clean `ValueError`, no write. Fix: route both source reads through the existing `_resolve_within_root` scoped to `snapshot_dir` (pre-flight dict -> whole undo aborts atomically if any entry escapes). **Windows junctions handled** (they resolve like symlinks but `is_symlink()` returns False -- a naive guard would miss them; real `mklink /J` test added).

**H4** -- `create_checkpoint` copied with no budget. Fix: pre-flight per-file (512MiB) / total (4GiB) / free-space-margin (256MiB) caps (all `TG_CHECKPOINT_*` env-overridable), enforced BEFORE any dir is created, + `try/except -> rmtree(per-checkpoint dir)` cleanup-on-abort (gate-verified surgical: a mid-copy failure leaves siblings + index.json intact). Fail-closed structured errors, never a silent partial checkpoint.

Opus gate SHIP (couldn't break H3 confinement or under-count H4; cleanup scope proven surgical). 67 checkpoint tests + 947-test regression sweep green; ruff/format/mypy clean. 2 optional non-blocking follow-ups tracked separately.

`fix:` -> patch. Closes audit H3+H4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)