### PR TITLE
fix(apply-policy): confine validation-command executables beneath-or-equal the repo root (RCE, audit H2, Opus-gated)

### DIFF
--- a/src/tensor_grep/cli/apply_policy.py
+++ b/src/tensor_grep/cli/apply_policy.py
@@ -386,6 +386,32 @@ def _path_is_under(path: Path, root: Path) -> bool:
         return False
 
 
+def _abspath_beneath_or_equal(path: Path, root: Path) -> bool:
+    """True if ``path`` is ``root`` itself or nested anywhere beneath it (any depth).
+
+    Deliberately independent of ``_path_is_under()``/``Path.relative_to()``: the
+    shadow-executable guard in ``_run_policy_command`` must run this check on an
+    ``os.path.abspath``'d path that has NOT been passed through ``Path.resolve()`` --
+    resolve() follows symlinks, which is exactly how the audit #35 / #453 symlink
+    shadow (`repo/tool.cmd -> repo/sub/evil.cmd`) escaped an earlier version of this
+    guard (its resolved target's parent no longer lexically starts with the repo
+    root). Callers must pass the same abspath-only ``path`` value used for spawning.
+
+    Comparison uses ``os.path.normcase(os.path.normpath(...))`` on both sides (not
+    ``Path`` equality/``relative_to``) so a Windows case or separator mismatch between
+    the PATH-resolved directory and the untrusted root can't produce a false
+    "outside root" negative. The beneath check requires a ``os.sep`` boundary after
+    the root prefix, so a sibling directory that merely shares a string prefix with
+    the root (e.g. ``repo-other`` next to ``repo``) is never wrongly treated as
+    nested inside it.
+    """
+    normalized_path = os.path.normcase(os.path.normpath(str(path)))
+    normalized_root = os.path.normcase(os.path.normpath(str(root)))
+    if normalized_path == normalized_root:
+        return True
+    return normalized_path.startswith(normalized_root + os.sep)
+
+
 def _policy_file_arg(path_value: object, *, working_root: Path) -> str | None:
     if not isinstance(path_value, (str, os.PathLike)):
         return None
@@ -460,8 +486,8 @@ def _policy_command_instances(
 
 
 def _search_path_without_cwd() -> str:
-    """Build the ``path=`` string passed to ``shutil.which()``, with cwd-equivalent
-    PATH entries stripped.
+    """Build the ``path=`` string passed to ``shutil.which()``, with cwd-equivalent AND
+    cwd-nested PATH entries stripped.
 
     Defense-in-depth only -- see the load-bearing guard in ``_run_policy_command``.
     On Python < 3.12 + Windows, ``shutil.which()`` unconditionally re-inserts the
@@ -471,7 +497,16 @@ def _search_path_without_cwd() -> str:
     cpython#91558). So stripping "." from our own PATH cannot, by itself, stop that
     implicit prepend. It still closes a narrower, distinct vector: an untrusted
     entry planted directly in the *environment* PATH string itself (an explicit
-    ``.`` / empty / cwd-resolving segment), rather than the implicit Windows search.
+    ``.`` / empty / cwd-resolving, OR cwd-nested, segment), rather than the implicit
+    Windows search.
+
+    codex audit H2 follow-up: originally only an entry resolving EXACTLY to cwd was
+    stripped. An untrusted repo's own dependency-manager shim directory --
+    ``<repo>/node_modules/.bin``, ``<repo>/.venv/Scripts``, and similar -- is an
+    extremely common PATH entry (many build/lint tools prepend it) and is just as
+    untrusted as cwd itself, so it must be stripped too. ``_path_is_under()`` covers
+    both cases (it treats an exact match as trivially "under" itself as well as any
+    depth of descendant), so the two checks collapse into one.
     """
     raw_path = os.environ.get("PATH", "")
     if not raw_path:
@@ -487,7 +522,7 @@ def _search_path_without_cwd() -> str:
             continue
         if cwd is not None:
             try:
-                if Path(entry).resolve() == cwd:
+                if _path_is_under(Path(entry), cwd):
                     continue
             except (OSError, RuntimeError, ValueError):
                 pass
@@ -523,7 +558,17 @@ def _run_policy_command(name: str, command: str, cwd: Path, timeout: int) -> dic
     #   2) reject the resolution outright if it lands inside the untrusted target root (`cwd`) --
     #      the load-bearing guard. It compares os.path.abspath, NOT Path.resolve: resolve() FOLLOWS
     #      symlinks, which let a `repo/tool.cmd -> repo/sub/evil.cmd` symlink land its parent
-    #      OUTSIDE cwd and slip the parent==cwd check (caught by the adversarial security gate).
+    #      OUTSIDE cwd and slip a parent==cwd check (caught by the adversarial security gate).
+    #
+    # codex audit H2 (CWE-427 further refinement): "lands inside cwd" means BENEATH cwd at any
+    # depth, not merely "cwd is its immediate parent". An earlier version of this guard checked
+    # `resolved_path.parent == untrusted_root`, which only catches a shadow planted directly at
+    # the repo root -- a shadow resolved to `<repo>/nested/dir/tool.exe` has
+    # `.parent == <repo>/nested/dir`, never equal to `<repo>`, so it slipped through to
+    # subprocess.run. _abspath_beneath_or_equal() checks the full resolved_path (not just its
+    # parent) against untrusted_root using relative-containment, so any depth is caught; it keeps
+    # operating on the same abspath-only (non-symlink-following) resolved_path as before, so the
+    # #453 symlink-escape fix above still holds.
     resolved_executable = shutil.which(argv[0], path=_search_path_without_cwd()) if argv else None
     if resolved_executable is None:
         return _command_result(
@@ -535,7 +580,7 @@ def _run_policy_command(name: str, command: str, cwd: Path, timeout: int) -> dic
         untrusted_root = cwd.resolve()
     except OSError:
         untrusted_root = cwd
-    if os.path.normcase(str(resolved_path.parent)) == os.path.normcase(str(untrusted_root)):
+    if _abspath_beneath_or_equal(resolved_path, untrusted_root):
         return _command_result(
             passed=False,
             detail=(

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -1381,19 +1381,37 @@ def test_run_policy_command_prefers_trusted_path_entry_over_cwd_shadow(
 def test_run_policy_command_rejects_symlink_shadow_resolving_outside_cwd(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """Regression (adversarial security gate): a repo-local shadow that is a SYMLINK into a subdir
-    must still be rejected. The guard compares os.path.abspath, NOT Path.resolve -- resolve()
-    follows the symlink and would put the parent (repo/tools) outside cwd, slipping the parent==cwd
-    check and spawning the payload."""
+    """Regression (adversarial security gate, #453): a repo-local shadow that is a SYMLINK whose
+    TARGET points OUTSIDE the repo must still be rejected, because the guard confines on
+    os.path.abspath (a purely lexical normalization that does NOT follow the symlink's final
+    component), NOT Path.resolve (which follows the link out of the repo).
+
+    This test's whole job is to go RED if the guard is ever regressed from abspath to .resolve()
+    -- the exact change that would re-open the #453 RCE. That property is only pinned when the
+    symlink target is OUTSIDE the repo:
+
+      * CURRENT (correct) abspath guard: `shutil.which` yields the in-repo link `<repo>/ruff.cmd`;
+        abspath keeps it at `<repo>/ruff.cmd` (link not followed) -> BENEATH repo -> REJECTED
+        (this test passes).
+      * REGRESSED .resolve() guard: the link resolves to `<tmp>/outside/evil.cmd` -> NOT beneath
+        repo -> the beneath-or-equal check would NOT reject -> it would reach subprocess.run and
+        the shadow would be spawned (this test would FAIL on the assertions below).
+
+    (An earlier revision of this test pointed the target at `<repo>/tools/evil` -- INSIDE the
+    repo -- which under the beneath-or-equal guard is beneath repo in BOTH the abspath and the
+    resolve forms, so it passed regardless of which the guard used and no longer pinned the
+    abspath-vs-resolve property. The target must live outside the repo to keep this a real
+    regression guard.)"""
     import pytest as _pytest
 
     from tensor_grep.cli import apply_policy
 
     repo = tmp_path / "untrusted-repo"
     repo.mkdir()
-    tools = repo / "tools"
-    tools.mkdir()
-    payload = _write_fake_executable(tools, "evil", "pwned")
+    # Target OUTSIDE the repo: only .resolve() (which follows the link) would land here; abspath
+    # keeps the resolved path at the in-repo link location.
+    outside = tmp_path / "outside"
+    payload = _write_fake_executable(outside, "evil", "pwned")
     shadow = repo / "ruff.cmd"
     try:
         shadow.symlink_to(payload)
@@ -1419,7 +1437,10 @@ def test_run_policy_command_rejects_symlink_shadow_resolving_outside_cwd(
 
     result = apply_policy._run_policy_command("test", "ruff --check", repo, timeout=10)
 
-    assert result["passed"] is False, "a symlink shadow resolving into the repo must be rejected"
+    assert result["passed"] is False, (
+        "the in-repo symlink shadow must be rejected on its abspath (un-followed) location; a "
+        "regression to .resolve() would follow the link outside the repo and let it spawn"
+    )
     assert not spawn_calls, "the symlink shadow must never be spawned"
     assert "refusing a repo-local executable shadow" in str(result["detail"])
 

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import shutil
 import subprocess
@@ -1220,8 +1221,19 @@ def test_run_policy_command_resolves_relative_executable_to_absolute(
 ) -> None:
     # CWE-427: a relative argv[0] must be resolved to an absolute PATH binary before spawning,
     # so Windows CreateProcess never searches the untrusted target-repo cwd for a shadow tool.
+    #
+    # `repo` (the cwd/untrusted_root passed to _run_policy_command) is a SUBDIRECTORY of
+    # tmp_path, and the trusted binary lives at a SIBLING path (tmp_path/trusted-bin) --
+    # genuinely outside `repo`. Before the H2 beneath-or-equal fix this test passed `tmp_path`
+    # itself as cwd with the "trusted" binary nested one level under it, which the old
+    # immediate-parent-equality guard happened not to flag; under the corrected beneath-or-equal
+    # guard that fixture would itself BE the nested-shadow vulnerability, not a legitimate
+    # outside-root binary, so it must live outside the untrusted root to keep testing what its
+    # name says it tests.
     from tensor_grep.cli import apply_policy
 
+    repo = tmp_path / "repo"
+    repo.mkdir()
     fake_abs = str(tmp_path / "trusted-bin" / "ruff")
     monkeypatch.setattr(
         apply_policy.shutil,
@@ -1237,7 +1249,7 @@ def test_run_policy_command_resolves_relative_executable_to_absolute(
         return _sp.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(apply_policy.subprocess, "run", _fake_run)
-    result = apply_policy._run_policy_command("lint", "ruff check .", tmp_path, timeout=10)
+    result = apply_policy._run_policy_command("lint", "ruff check .", repo, timeout=10)
 
     assert captured["argv"][0] == fake_abs  # absolute, PATH-resolved — not a cwd search
     assert result["passed"] is True
@@ -1410,3 +1422,156 @@ def test_run_policy_command_rejects_symlink_shadow_resolving_outside_cwd(
     assert result["passed"] is False, "a symlink shadow resolving into the repo must be rejected"
     assert not spawn_calls, "the symlink shadow must never be spawned"
     assert "refusing a repo-local executable shadow" in str(result["detail"])
+
+
+def test_run_policy_command_rejects_nested_repo_shadow_executable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """H2 (CWE-427 refinement, codex audit): the shadow-executable guard used to reject a
+    resolved executable ONLY when its IMMEDIATE parent equaled the untrusted repo root
+    exactly (`resolved_path.parent == untrusted_root`). A binary resolved to
+    `<repo>/nested/dir/tool.cmd` has `.parent == <repo>/nested/dir`, which never equals
+    `<repo>` -- so the old guard let it through to subprocess.run. The guard must reject
+    ANY resolution beneath the untrusted root, at any depth, not just a direct child."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    nested = repo / "nested" / "dir"
+    shadow = _write_fake_executable(nested, "pytest", "shadow-pwned")
+
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: str(shadow) if cmd == "pytest" else None,
+    )
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("test", "pytest --check", repo, timeout=10)
+
+    assert result["passed"] is False, "a nested repo-local shadow must be rejected"
+    assert not spawn_calls, "the nested shadow binary must never be spawned"
+    assert "refusing a repo-local executable shadow" in str(result["detail"])
+    assert str(shadow) in str(result["detail"])
+
+
+def test_run_policy_command_rejects_deeply_nested_repo_shadow_executable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Same as above at greater depth (node_modules/.bin-style), proving the guard is a
+    true beneath-or-equal confinement check and not merely a two-level special case."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    nested = repo / "a" / "b" / "c" / "d"
+    shadow = _write_fake_executable(nested, "pytest", "shadow-pwned")
+
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: str(shadow) if cmd == "pytest" else None,
+    )
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("test", "pytest --check", repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls
+    assert "refusing a repo-local executable shadow" in str(result["detail"])
+
+
+def test_abspath_beneath_or_equal_matches_root_and_nested_descendants(tmp_path: Path) -> None:
+    from tensor_grep.cli.apply_policy import _abspath_beneath_or_equal
+
+    root = tmp_path / "repo"
+    assert _abspath_beneath_or_equal(root, root) is True
+    assert _abspath_beneath_or_equal(root / "tool.exe", root) is True
+    assert _abspath_beneath_or_equal(root / "nested" / "dir" / "tool.exe", root) is True
+
+
+def test_abspath_beneath_or_equal_rejects_unrelated_and_sibling_prefix_paths(
+    tmp_path: Path,
+) -> None:
+    """A sibling directory that merely shares a string PREFIX with the root (e.g.
+    `repo-other` vs `repo`) must NOT be treated as beneath it -- a naive
+    ``str.startswith(root)`` without a path-separator boundary would wrongly match this."""
+    from tensor_grep.cli.apply_policy import _abspath_beneath_or_equal
+
+    root = tmp_path / "repo"
+    assert _abspath_beneath_or_equal(tmp_path / "unrelated" / "tool.exe", root) is False
+    assert _abspath_beneath_or_equal(tmp_path / "repo-other" / "tool.exe", root) is False
+    assert _abspath_beneath_or_equal(tmp_path / "repository" / "tool.exe", root) is False
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows case-insensitive path semantics")
+def test_abspath_beneath_or_equal_is_case_insensitive_on_windows(tmp_path: Path) -> None:
+    from tensor_grep.cli.apply_policy import _abspath_beneath_or_equal
+
+    root = tmp_path / "repo"
+    upper = Path(str(tmp_path).upper()) / "REPO" / "NESTED" / "tool.EXE"
+    assert _abspath_beneath_or_equal(upper, root) is True
+
+
+def test_search_path_without_cwd_strips_entries_nested_under_cwd(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Widen (H2 follow-up, codex audit): _search_path_without_cwd previously stripped only
+    PATH entries that resolved EXACTLY to cwd. A PATH entry NESTED under cwd (e.g. the
+    extremely common `<repo>/node_modules/.bin` or `<repo>/.venv/Scripts`) must also be
+    stripped -- an untrusted repo's own dependency-manager shim directory should not be
+    handed to shutil.which() as a searchable, quasi-trusted PATH entry."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    nested_bin = repo / "node_modules" / ".bin"
+    nested_bin.mkdir(parents=True)
+    venv_scripts = repo / ".venv" / "Scripts"
+    venv_scripts.mkdir(parents=True)
+    unrelated = tmp_path / "trusted-bin"
+    unrelated.mkdir()
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join([str(nested_bin), str(venv_scripts), str(unrelated), str(repo)]),
+    )
+
+    filtered = apply_policy._search_path_without_cwd()
+    filtered_entries = filtered.split(os.pathsep) if filtered else []
+
+    assert str(nested_bin) not in filtered_entries
+    assert str(venv_scripts) not in filtered_entries
+    assert str(repo) not in filtered_entries  # pre-existing exact-match behavior, still holds
+    assert str(unrelated) in filtered_entries
+
+
+def test_search_path_without_cwd_keeps_sibling_prefix_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A PATH entry that merely shares a string prefix with cwd (e.g. `repo-tools` next to
+    `repo`) must NOT be stripped -- mirrors the separator-boundary check on the executable
+    guard, applied here to the PATH-filtering defense-in-depth layer."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sibling_prefix = tmp_path / "repo-tools"
+    sibling_prefix.mkdir()
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("PATH", str(sibling_prefix))
+
+    filtered = apply_policy._search_path_without_cwd()
+    filtered_entries = filtered.split(os.pathsep) if filtered else []
+
+    assert str(sibling_prefix) in filtered_entries


### PR DESCRIPTION
Closes codex-audit H2 (RCE-class). The exec-confinement guard used `resolved_path.parent == untrusted_root` (immediate-parent only) -> a validation-command binary resolved to `<repo>/nested/dir/tool.exe` escaped into `subprocess.run` with operator privileges against an untrusted checkout.

Fix: new `_abspath_beneath_or_equal(path, root)` replaces the equality check -- an `os.sep`-bounded beneath-OR-equal test (sibling-prefixes like `repo-other`/`repository` correctly NOT matched). Preserves the #453 abspath-not-`.resolve()` choice (switching to resolve would re-open #453). Widened `_search_path_without_cwd` to strip PATH entries nested-under-cwd (`node_modules/.bin`, `.venv/Scripts`).

**Opus security gate: SHIP-WITH-CHANGES -> must-fix applied.** The reviewer found no clean attacker-content-only bypass (nested shadow caught at any depth, verified on Windows). Must-fix (this commit): the #453 regression test's symlink target was inside the repo, so it no longer distinguished abspath from `.resolve()`; repointed it OUTSIDE the repo -> now proven RED if the guard regresses to `.resolve()` (which would re-open the #453 RCE). Guard source byte-identical to the gated commit; only the test strengthened.

Fail-open edge-case hardening (8.3/junction/\?\ -- operator-peculiarity-gated, NOT attacker-content-only; realistic RCE already closed) tracked as a MED fast-follow. 52 apply_policy tests + 4007-test sweep green; ruff/format/mypy clean.

`fix:` -> patch. Closes audit H2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)