### PR TITLE
feat(evidence): tg evidence emit -- local EvidenceReceipt v1 (P1 schema+emitter) for gotcontext wiring

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1095,6 +1095,12 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Emit a versioned EvidenceReceipt aggregating existing tg outputs
+    #[command(name = "evidence", disable_help_flag = true)]
+    Evidence {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// List GPU devices and routing readiness
     #[command(name = "devices", disable_help_flag = true)]
     Devices {
@@ -4322,6 +4328,7 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         Commands::AuditHistory { args } => handle_python_passthrough("audit-history", args),
         Commands::AuditDiff { args } => handle_python_passthrough("audit-diff", args),
         Commands::ReviewBundle { args } => handle_python_passthrough("review-bundle", args),
+        Commands::Evidence { args } => handle_python_passthrough("evidence", args),
         Commands::Devices { args } => handle_python_passthrough("devices", args),
         Commands::Context { args } => handle_python_passthrough("context", args),
         Commands::PythonPassthrough(args) => {

--- a/src/tensor_grep/cli/commands.py
+++ b/src/tensor_grep/cli/commands.py
@@ -40,6 +40,7 @@ KNOWN_COMMANDS = {
     "audit-history",
     "audit-diff",
     "review-bundle",
+    "evidence",
     "devices",
     "context",
     "lsp",

--- a/src/tensor_grep/cli/evidence_receipt.py
+++ b/src/tensor_grep/cli/evidence_receipt.py
@@ -1,0 +1,708 @@
+"""EvidenceReceipt v1 -- Phase 1: schema + emitter (aggregator, no signing).
+
+`tg evidence emit` produces a versioned, machine-consumable JSON receipt that aggregates what tg
+*already computed* into one stable envelope: repo revision identity, files/caller/blast-radius
+evidence, ambiguity/confidence, validation plan + actual outcomes, changed files + rollback, and
+caller-supplied agent/model/cost metadata. See the design doc for the full field -> producer map.
+
+Hard contract (Backend Fail-Closed Contract, applied to receipt emission):
+  * A missing/unavailable source artifact makes ONLY that block `{"status": "unavailable",
+    "reason": "..."}` -- never a silently empty or guessed value, and never a process crash.
+  * This module is a pure aggregator: it reads already-persisted JSON (a prior `tg agent --json`
+    capsule, a prior rewrite-audit-manifest, checkpoint metadata) plus at most 2 git subprocess
+    calls. It never re-runs an expensive scan/repo-map by default; recompute is strictly opt-in
+    (`recompute=True` + a `query`), and even then it calls a single already-cited REUSE producer
+    (`repo_map.build_symbol_blast_radius`) -- never the session daemon, MCP server, or apply
+    policy (out of scope for Phase 1; see AGENTS.md "Backend Fail-Closed Contract").
+
+P2 (signing: `receipt_sha256` / `signature` / `previous_receipt_sha256` / `tg evidence verify`) is
+a separate PR -- this module intentionally does not emit those fields.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli.audit_manifest import (
+    _envelope,
+    _json_output_version,
+    _resolve_root,
+    _utc_now_iso,
+)
+from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
+
+RECEIPT_SCHEMA_VERSION = 1
+
+_AGENT_ID_ENV = "TG_EVIDENCE_AGENT_ID"
+_MODEL_ENV = "TG_EVIDENCE_MODEL"
+_COST_JSON_ENV = "TG_EVIDENCE_COST_JSON"
+
+
+# ---------------------------------------------------------------------------
+# small local helpers (kept local rather than imported cross-module: each is
+# a few lines and importing the owning module would add avoidable weight/
+# coupling for the common case -- see the docstring above each helper)
+# ---------------------------------------------------------------------------
+
+
+def _read_project_version_fallback() -> str:
+    # Mirrors main.py:237-246 _read_project_version_fallback exactly. Not imported from main.py:
+    # main.py is the top-level CLI orchestrator (imports typer/ast_workflows/etc at module level)
+    # and no lower-level cli/*.py module imports from it (matches the existing layering: e.g.
+    # audit_manifest.py has its own _utc_now_iso rather than importing main.py's helpers).
+    try:
+        pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+        for line in pyproject_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("version = "):
+                return stripped.split('"', 2)[1]
+    except Exception:
+        pass
+    return "0.0.0"
+
+
+def _cli_package_version() -> str:
+    # Mirrors main.py:249-255 _cli_package_version() exactly.
+    try:
+        from importlib.metadata import version
+
+        return version("tensor-grep")
+    except Exception:
+        return _read_project_version_fallback()
+
+
+def _as_dict(value: object) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _as_list_of_dicts(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _display_command(argv: list[str]) -> str:
+    # Mirrors checkpoint_store.py:231-234 _display_command exactly.
+    if os.name == "nt":
+        return subprocess.list2cmdline(argv)
+    return shlex.join(argv)
+
+
+def _evidence_envelope(*, routing_reason: str) -> dict[str, Any]:
+    # audit_manifest._envelope() hardcodes routing_backend="AuditManifest" (audit_manifest.py:37-44)
+    # since it backs the audit-manifest/review-bundle family; override for this receipt's own
+    # identity while reusing its version/schema_version/sidecar_used plumbing.
+    envelope = _envelope(routing_reason=routing_reason)
+    envelope["routing_backend"] = "EvidenceReceipt"
+    return envelope
+
+
+def _evidence_error_payload(message: str, *, code: str, routing_reason: str) -> dict[str, Any]:
+    # Mirrors main.py:12759-12769 _review_bundle_error_payload's shape for CLI-layer errors.
+    return {
+        "version": _json_output_version(),
+        "schema_version": _json_output_version(),
+        "routing_backend": "EvidenceReceipt",
+        "routing_reason": routing_reason,
+        "sidecar_used": False,
+        "error": {"code": code, "message": message},
+    }
+
+
+# ---------------------------------------------------------------------------
+# GAP 1: commit + dirty-worktree identity (no existing producer -- new helper)
+# ---------------------------------------------------------------------------
+
+
+def _parse_branch_header(header_text: str) -> str | None:
+    """Parse a `git status --porcelain=v1 -b` `## ...` header into a branch name."""
+    text = header_text.strip()
+    if text.startswith("No commits yet on "):
+        # unborn branch (a fresh `git init` with no commits yet)
+        branch = text[len("No commits yet on ") :].strip()
+        return branch or None
+    if text == "HEAD (no branch)":
+        return None  # detached HEAD
+    # "branch...upstream [ahead N, behind M]" -> the local branch is the segment before "..."
+    # and before any trailing whitespace/decoration.
+    local = text.split("...", 1)[0].split(" ", 1)[0].strip()
+    return local or None
+
+
+def _repo_revision_identity(root: Path) -> dict[str, Any]:
+    """`git rev-parse HEAD` + `git status --porcelain=v1 -b` -> commit/branch/dirty identity.
+
+    Exactly 2 git subprocess calls (the CEO's performance mandate): the porcelain `-b` flag folds
+    the branch name into the SAME `git status` call that reports dirty entries, so a second
+    `rev-parse --abbrev-ref HEAD` call is unnecessary. Fails closed to `status: "unavailable"` on
+    any git error (not a repo, git missing, timeout) -- never raises, never fabricates a value.
+    """
+    timeout_seconds = configured_git_timeout_seconds()
+
+    try:
+        commit_result = run_subprocess(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            timeout_seconds=timeout_seconds,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "unavailable", "reason": f"git rev-parse could not run: {exc}"}
+    if commit_result.returncode != 0:
+        return {"status": "unavailable", "reason": _last_stderr_line(commit_result.stderr)}
+    commit_sha = commit_result.stdout.strip()
+    if not commit_sha:
+        return {"status": "unavailable", "reason": "git rev-parse HEAD returned no output"}
+
+    try:
+        status_result = run_subprocess(
+            ["git", "-C", str(root), "status", "--porcelain=v1", "-b"],
+            timeout_seconds=timeout_seconds,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "unavailable", "reason": f"git status could not run: {exc}"}
+    if status_result.returncode != 0:
+        return {"status": "unavailable", "reason": _last_stderr_line(status_result.stderr)}
+
+    branch: str | None = None
+    dirty_lines: list[str] = []
+    for line in status_result.stdout.splitlines():
+        if line.startswith("## "):
+            branch = _parse_branch_header(line[3:])
+        elif line.strip():
+            dirty_lines.append(line)
+
+    dirty_tree_sha256 = hashlib.sha256("\n".join(sorted(dirty_lines)).encode("utf-8")).hexdigest()
+    return {
+        "status": "present",
+        "commit_sha": commit_sha,
+        "branch": branch,
+        "dirty": bool(dirty_lines),
+        "dirty_tree_sha256": dirty_tree_sha256,
+        "dirty_file_count": len(dirty_lines),
+    }
+
+
+def _last_stderr_line(stderr: str | None) -> str:
+    lines = (stderr or "").strip().splitlines()
+    return lines[-1] if lines else "git exited non-zero with no stderr output"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed file readers (never raise -- return (None, reason) on failure)
+# ---------------------------------------------------------------------------
+
+
+def _read_optional_json_file(
+    path: str | Path | None, *, description: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    if path is None:
+        return None, None
+    try:
+        resolved = Path(path).expanduser().resolve()
+    except OSError as exc:
+        return None, f"{description} path could not be resolved: {exc}"
+    if not resolved.exists():
+        return None, f"{description} not found: {resolved}"
+    try:
+        raw = resolved.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"{description} could not be read: {exc}"
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"{description} is not valid JSON: {exc}"
+    if not isinstance(payload, dict):
+        return None, f"{description} must be a JSON object."
+    return payload, None
+
+
+def _resolve_caller_str(flag_value: str | None, env_var: str) -> str | None:
+    if flag_value is not None:
+        stripped = flag_value.strip()
+        return stripped or None
+    env_value = os.environ.get(env_var)
+    if env_value is not None:
+        stripped = env_value.strip()
+        return stripped or None
+    return None
+
+
+def _resolve_caller_path(flag_value: str | Path | None, env_var: str) -> str | Path | None:
+    if flag_value is not None:
+        return flag_value
+    env_value = os.environ.get(env_var)
+    return env_value or None
+
+
+# ---------------------------------------------------------------------------
+# Block builders -- each REUSE producer cited in the design doc, each
+# fail-closed (`status: "unavailable"` + `reason` when its source is absent).
+# ---------------------------------------------------------------------------
+
+
+def _capsule_files_selected(capsule: dict[str, Any]) -> list[str]:
+    files: list[str] = []
+    primary_target = _as_dict(capsule.get("primary_target"))
+    if primary_target is not None:
+        primary_file = primary_target.get("file")
+        if isinstance(primary_file, str) and primary_file:
+            files.append(primary_file)
+    for alternative in _as_list_of_dicts(capsule.get("alternative_targets")):
+        alt_file = alternative.get("file")
+        if isinstance(alt_file, str) and alt_file:
+            files.append(alt_file)
+    for snippet in _as_list_of_dicts(capsule.get("snippets")):
+        snippet_file = snippet.get("file")
+        if isinstance(snippet_file, str) and snippet_file:
+            files.append(snippet_file)
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for file_path in files:
+        if file_path not in seen:
+            seen.add(file_path)
+            deduped.append(file_path)
+    return deduped
+
+
+def _completeness_block(
+    capsule: dict[str, Any] | None, manifest: dict[str, Any] | None
+) -> dict[str, Any]:
+    if capsule is None and manifest is None:
+        return {"status": "unavailable", "reason": "no --capsule or --manifest provided"}
+    completeness: dict[str, Any] = {"status": "present"}
+    if capsule is not None:
+        # agent_capsule.py:2276-2294 -- these are ADDITIVE/conditional keys on the real capsule
+        # (only stamped when truncation actually occurred), so default them in rather than KeyError.
+        completeness["result_incomplete"] = bool(capsule.get("result_incomplete", False))
+        completeness["truncated"] = bool(capsule.get("partial", False))
+        scan_limit = _as_dict(capsule.get("scan_limit"))
+        if scan_limit is not None:
+            completeness["scan_limit"] = scan_limit
+        deadline_limit = _as_dict(capsule.get("deadline_limit"))
+        if deadline_limit is not None:
+            completeness["deadline_limit"] = deadline_limit
+    if manifest is not None:
+        validation = _as_dict(manifest.get("validation"))
+        if validation is not None:
+            completeness["validation_targets_truncated"] = validation.get(
+                "validation_targets_truncated"
+            )
+    return completeness
+
+
+def _scope_block(
+    *,
+    path: str,
+    query: str | None,
+    capsule: dict[str, Any] | None,
+    capsule_error: str | None,
+    manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    block: dict[str, Any] = {"path": path, "query": query}
+    if capsule is None:
+        block["status"] = "unavailable"
+        block["reason"] = capsule_error or "no --capsule provided"
+        block["files_selected"] = None
+        block["files_omitted_count"] = None
+    else:
+        omissions = _as_dict(capsule.get("omissions")) or {}
+        block["status"] = "present"
+        block["files_selected"] = _capsule_files_selected(capsule)
+        block["files_omitted_count"] = omissions.get("omitted_section_count")
+    # A repo-wide total_files/total_matches count is a `tg search` SearchResult concept
+    # (core/result.py) -- Phase 1's inputs (--capsule/--manifest) never carry it, so these stay
+    # explicitly null (a stable, present-but-unknown field) rather than being fabricated or omitted.
+    block["total_files"] = None
+    block["total_matches"] = None
+    block["completeness"] = _completeness_block(capsule, manifest)
+    return block
+
+
+def _blast_radius_block_from_capsule(capsule: dict[str, Any]) -> dict[str, Any]:
+    call_site_evidence = _as_dict(capsule.get("call_site_evidence"))
+    if call_site_evidence is None:
+        return {"status": "unavailable", "reason": "capsule has no call_site_evidence block"}
+    status = str(call_site_evidence.get("status") or "unknown")
+    related_call_sites = capsule.get("related_call_sites")
+    block: dict[str, Any] = {
+        "status": status,
+        "source": "capsule",
+        "symbol": call_site_evidence.get("symbol"),
+        "callers": related_call_sites if isinstance(related_call_sites, list) else [],
+        "returned_call_sites": call_site_evidence.get("returned_call_sites"),
+        "omitted_callers": call_site_evidence.get("omitted_call_sites"),
+        "graph_trust_summary": call_site_evidence.get("graph_trust_summary"),
+        "resolution_gaps": call_site_evidence.get("resolution_gaps"),
+        "provenance": call_site_evidence.get("provenance"),
+    }
+    reason = call_site_evidence.get("reason")
+    if reason is not None:
+        block["reason"] = reason
+    return block
+
+
+def _blast_radius_block_recomputed(query: str, path: str) -> dict[str, Any]:
+    # Local import: repo_map.py is a large module (tree-sitter parsers etc.); only pay for it on
+    # the explicit opt-in --recompute path, matching main.py's own local-import convention for
+    # repo_map functions (e.g. main.py:9396 `from tensor_grep.cli.repo_map import ... build_symbol_callers`).
+    from tensor_grep.cli import repo_map
+
+    try:
+        radius_payload = repo_map.build_symbol_blast_radius(query, path)
+    except Exception as exc:  # defensive: an opt-in recompute must never crash the whole receipt
+        return {"status": "unavailable", "reason": f"recompute failed: {exc}"}
+    if radius_payload.get("no_match"):
+        return {
+            "status": "unavailable",
+            "reason": "recompute found no definition for the given query",
+            "symbol": query,
+        }
+    output_limit = _as_dict(radius_payload.get("output_limit")) or {}
+    callers = radius_payload.get("callers")
+    return {
+        "status": "present",
+        "source": "recomputed",
+        "symbol": query,
+        "callers": callers if isinstance(callers, list) else [],
+        "omitted_callers": output_limit.get("omitted_callers"),
+        "graph_trust_summary": radius_payload.get("graph_trust_summary"),
+        "resolution_gaps": radius_payload.get("resolution_gaps"),
+    }
+
+
+def _blast_radius_block(
+    *,
+    capsule: dict[str, Any] | None,
+    capsule_error: str | None,
+    recompute: bool,
+    query: str | None,
+    path: str,
+) -> dict[str, Any]:
+    if recompute:
+        if not query:
+            return {
+                "status": "unavailable",
+                "reason": "--recompute requested but no --query/query was given",
+            }
+        return _blast_radius_block_recomputed(query, path)
+    if capsule is None:
+        return {
+            "status": "unavailable",
+            "reason": capsule_error or "no --capsule provided and --recompute not requested",
+        }
+    return _blast_radius_block_from_capsule(capsule)
+
+
+def _confidence_block(capsule: dict[str, Any] | None, capsule_error: str | None) -> dict[str, Any]:
+    if capsule is None:
+        return {"status": "unavailable", "reason": capsule_error or "no --capsule provided"}
+    confidence = _as_dict(capsule.get("confidence"))
+    alternative_targets = capsule.get("alternative_targets")
+    return {
+        "status": "present",
+        "overall": confidence.get("overall") if confidence else None,
+        "downgrade_reasons": confidence.get("downgrade_reasons") if confidence else [],
+        "ambiguity": capsule.get("ambiguity"),
+        "alternative_targets": alternative_targets if isinstance(alternative_targets, list) else [],
+        "ask_user_before_editing": capsule.get("ask_user_before_editing"),
+    }
+
+
+def _validation_block(
+    *, capsule: dict[str, Any] | None, manifest: dict[str, Any] | None
+) -> dict[str, Any]:
+    if capsule is None and manifest is None:
+        return {
+            "status": "unavailable",
+            "reason": "no --capsule (planned commands) or --manifest (actual outcomes) provided",
+        }
+    block: dict[str, Any] = {"status": "present"}
+
+    if capsule is not None:
+        validation_commands = capsule.get("validation_commands")
+        suggested = capsule.get("suggested_validation_commands")
+        validation_plan = capsule.get("validation_plan")
+        block["planned_commands"] = (
+            validation_commands if isinstance(validation_commands, list) else []
+        )
+        block["suggested_validation_commands"] = suggested if isinstance(suggested, list) else []
+        block["validation_plan"] = validation_plan if isinstance(validation_plan, list) else []
+    else:
+        block["planned_commands"] = None
+        block["suggested_validation_commands"] = None
+        block["validation_plan"] = None
+
+    manifest_validation = _as_dict(manifest.get("validation")) if manifest is not None else None
+    if manifest_validation is not None:
+        block["success"] = manifest_validation.get("success")
+        block["commands"] = manifest_validation.get("commands")
+        block["targets_truncated"] = manifest_validation.get("validation_targets_truncated")
+        block["targets_total"] = manifest_validation.get("validation_targets_total")
+    else:
+        block["success"] = None
+        block["commands"] = None
+        block["targets_truncated"] = None
+        block["targets_total"] = None
+        if manifest is not None:
+            block["outcome_reason"] = (
+                "manifest present but has no validation block "
+                "(tg run --apply was not given --lint-cmd/--test-cmd)"
+            )
+        else:
+            block["outcome_reason"] = "no --manifest provided; only planned commands are known"
+    return block
+
+
+def _rollback_block_from_checkpoint_summary(checkpoint: dict[str, Any]) -> dict[str, Any]:
+    checkpoint_id = checkpoint.get("checkpoint_id")
+    root_value = checkpoint.get("root")
+    scope_kind = checkpoint.get("scope")
+    original_path = checkpoint.get("original_path")
+    if not checkpoint_id or not root_value:
+        return {
+            "status": "unavailable",
+            "reason": "checkpoint block is missing checkpoint_id/root",
+        }
+    # Mirrors checkpoint_store.py:237-239 _undo_argv exactly. NOT imported: undo_argv/undo_command
+    # are only present on the in-memory CheckpointCreateResult returned at *creation* time --
+    # neither the persisted checkpoint metadata JSON (checkpoint_store.py:600-611
+    # _write_checkpoint_metadata's payload) nor the rewrite-audit-manifest's checkpoint block
+    # (rust_core/src/main.rs:6136-6144 CheckpointCreateSummary) persists them. Reconstructing here
+    # from the same 4 fields both DO persist (checkpoint_id/root/scope/original_path) is the only
+    # way an emitter reading a manifest/checkpoint file after the fact can recover the undo command.
+    undo_path = original_path if scope_kind == "file" and original_path else root_value
+    argv = ["tg", "checkpoint", "undo", str(checkpoint_id), str(undo_path)]
+    return {
+        "status": "present",
+        "checkpoint_id": checkpoint_id,
+        "mode": checkpoint.get("mode"),
+        "root": root_value,
+        "scope": scope_kind,
+        "created_at": checkpoint.get("created_at"),
+        "file_count": checkpoint.get("file_count"),
+        "undo_argv": argv,
+        "undo_command": _display_command(argv),
+    }
+
+
+def _rollback_block_from_checkpoint_id(checkpoint_id: str, root: Path) -> dict[str, Any]:
+    from tensor_grep.cli.checkpoint_store import load_checkpoint_metadata
+
+    try:
+        metadata = load_checkpoint_metadata(checkpoint_id, str(root))
+    except FileNotFoundError as exc:
+        return {"status": "unavailable", "reason": str(exc)}
+    except (OSError, ValueError) as exc:
+        return {"status": "unavailable", "reason": f"checkpoint metadata unreadable: {exc}"}
+    return _rollback_block_from_checkpoint_summary(metadata)
+
+
+def _changes_block(
+    *,
+    manifest: dict[str, Any] | None,
+    manifest_error: str | None,
+    checkpoint_id: str | None,
+    root: Path,
+) -> dict[str, Any]:
+    if manifest is None:
+        if checkpoint_id is None:
+            return {"status": "unavailable", "reason": manifest_error or "no --manifest provided"}
+        # A standalone --checkpoint-id (no manifest) can still answer rollback even though the
+        # changed-files list / validation outcome are unknown without a manifest.
+        return {
+            "status": "unavailable",
+            "reason": "no --manifest provided; changed-files/validation-outcome unknown",
+            "rollback": _rollback_block_from_checkpoint_id(checkpoint_id, root),
+        }
+
+    files = manifest.get("files")
+    applied_edit_ids = manifest.get("applied_edit_ids")
+    block: dict[str, Any] = {
+        "status": "present",
+        "files": files if isinstance(files, list) else [],
+        "applied_edit_ids": applied_edit_ids if isinstance(applied_edit_ids, list) else [],
+        "plan_total_edits": manifest.get("plan_total_edits"),
+    }
+    checkpoint = _as_dict(manifest.get("checkpoint"))
+    if checkpoint is not None:
+        block["rollback"] = _rollback_block_from_checkpoint_summary(checkpoint)
+    else:
+        block["rollback"] = {
+            "status": "unavailable",
+            "reason": "manifest has no checkpoint block (tg run --apply was not given --checkpoint)",
+        }
+    # The actual triggered-rollback OUTCOME (ValidationRollbackSummary: success/files_restored/
+    # errors) lives only in `tg run --apply`'s live stdout response
+    # (rust_core/src/main.rs:6085-6098 ApplyVerifyJson.rollback) -- it is NOT a field of the
+    # persisted rewrite-audit-manifest (rust_core/src/main.rs:6210-6225 RewriteAuditManifest has
+    # no rollback field). A manifest read after the fact can never recover it; fail closed rather
+    # than guess whether an auto-rollback fired. (Producer-shape gap vs the design doc's assumption
+    # that `load_checkpoint_metadata` alone would answer this -- it does not.)
+    block["triggered_rollback"] = {
+        "status": "unavailable",
+        "reason": (
+            "not persisted in the audit manifest; only available in the live "
+            "`tg run --apply` response at the time it runs"
+        ),
+    }
+    return block
+
+
+def _caller_block(
+    *,
+    agent_id: str | None,
+    model: str | None,
+    cost: dict[str, Any] | None,
+    cost_requested: bool,
+    cost_error: str | None,
+) -> dict[str, Any]:
+    caller_metadata_present = bool(agent_id or model or cost)
+    block: dict[str, Any] = {
+        "status": "caller-supplied",
+        "provenance": "caller-supplied",
+        "caller_metadata_present": caller_metadata_present,
+        "agent_id": agent_id,
+        "model": model,
+        "cost": cost,
+    }
+    if cost_requested and cost_error is not None:
+        block["cost_source_error"] = cost_error
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Top-level assembly
+# ---------------------------------------------------------------------------
+
+
+def build_evidence_receipt(
+    path: str | Path = ".",
+    *,
+    query: str | None = None,
+    manifest_path: str | Path | None = None,
+    capsule_path: str | Path | None = None,
+    checkpoint_id: str | None = None,
+    agent_id: str | None = None,
+    model: str | None = None,
+    cost_json_path: str | Path | None = None,
+    recompute: bool = False,
+) -> dict[str, Any]:
+    """Aggregate an EvidenceReceipt v1 payload (Phase 1: no signature).
+
+    Reads at most two persisted JSON files (`--manifest`, `--capsule`) plus at most 2 git
+    subprocess calls (`_repo_revision_identity`). Never re-scans the repo unless `recompute=True`
+    AND `query` is given, in which case exactly one already-cited REUSE producer
+    (`repo_map.build_symbol_blast_radius`) is invoked for the blast_radius block only.
+    """
+    root = _resolve_root(Path(path))
+
+    receipt = _evidence_envelope(routing_reason="evidence-receipt-emit")
+    receipt["kind"] = "evidence-receipt"
+    receipt["receipt_schema_version"] = RECEIPT_SCHEMA_VERSION
+    receipt["created_at"] = _utc_now_iso()
+    receipt["tool"] = {
+        "name": "tensor-grep",
+        "version": _cli_package_version(),
+        "json_output_version": _json_output_version(),
+    }
+    receipt["revision"] = _repo_revision_identity(root)
+
+    capsule, capsule_error = _read_optional_json_file(capsule_path, description="Evidence capsule")
+    manifest, manifest_error = _read_optional_json_file(manifest_path, description="Audit manifest")
+
+    resolved_cost_path = _resolve_caller_path(cost_json_path, _COST_JSON_ENV)
+    cost, cost_error = _read_optional_json_file(resolved_cost_path, description="Cost JSON")
+
+    resolved_agent_id = _resolve_caller_str(agent_id, _AGENT_ID_ENV)
+    resolved_model = _resolve_caller_str(model, _MODEL_ENV)
+
+    receipt["scope"] = _scope_block(
+        path=str(root),
+        query=query,
+        capsule=capsule,
+        capsule_error=capsule_error,
+        manifest=manifest,
+    )
+    blast_radius = _blast_radius_block(
+        capsule=capsule,
+        capsule_error=capsule_error,
+        recompute=recompute,
+        query=query,
+        path=str(root),
+    )
+    receipt["blast_radius"] = blast_radius
+    receipt["confidence"] = _confidence_block(capsule, capsule_error)
+    receipt["validation"] = _validation_block(capsule=capsule, manifest=manifest)
+    receipt["changes"] = _changes_block(
+        manifest=manifest,
+        manifest_error=manifest_error,
+        checkpoint_id=checkpoint_id,
+        root=root,
+    )
+    receipt["caller"] = _caller_block(
+        agent_id=resolved_agent_id,
+        model=resolved_model,
+        cost=cost,
+        cost_requested=resolved_cost_path is not None,
+        cost_error=cost_error,
+    )
+
+    if capsule_path is None:
+        capsule_source = "none"
+    elif capsule is not None:
+        capsule_source = f"file:{capsule_path}"
+    else:
+        capsule_source = f"unavailable:{capsule_path}"
+
+    receipt["sources"] = {
+        "manifest_path": (
+            str(Path(manifest_path).expanduser().resolve()) if manifest_path is not None else None
+        ),
+        "manifest_sha256": manifest.get("manifest_sha256") if manifest is not None else None,
+        "capsule_path": (
+            str(Path(capsule_path).expanduser().resolve()) if capsule_path is not None else None
+        ),
+        "capsule_source": capsule_source,
+        "session_id": None,  # Phase 1 deliberately does not wire session-daemon reads (see AGENTS.md)
+        "recomputed": bool(recompute and blast_radius.get("source") == "recomputed"),
+    }
+    return receipt
+
+
+def build_evidence_receipt_json(
+    path: str | Path = ".",
+    *,
+    query: str | None = None,
+    manifest_path: str | Path | None = None,
+    capsule_path: str | Path | None = None,
+    checkpoint_id: str | None = None,
+    agent_id: str | None = None,
+    model: str | None = None,
+    cost_json_path: str | Path | None = None,
+    recompute: bool = False,
+) -> str:
+    return json.dumps(
+        build_evidence_receipt(
+            path,
+            query=query,
+            manifest_path=manifest_path,
+            capsule_path=capsule_path,
+            checkpoint_id=checkpoint_id,
+            agent_id=agent_id,
+            model=model,
+            cost_json_path=cost_json_path,
+            recompute=recompute,
+        ),
+        indent=2,
+    )

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -230,6 +230,10 @@ review_bundle_app = typer.Typer(
     help="Create and verify enterprise review bundles.",
     no_args_is_help=True,
 )
+evidence_app = typer.Typer(
+    help="Emit a versioned EvidenceReceipt aggregating tg's existing outputs.",
+    no_args_is_help=True,
+)
 
 session_app.add_typer(session_daemon_app, name="daemon")
 
@@ -11893,6 +11897,7 @@ def lsp_setup(
 app.add_typer(checkpoint_app, name="checkpoint")
 app.add_typer(session_app, name="session")
 app.add_typer(review_bundle_app, name="review-bundle")
+app.add_typer(evidence_app, name="evidence")
 
 
 @app.command(name="mcp")
@@ -13165,6 +13170,118 @@ def review_bundle_verify(
     )
     if not payload["valid"]:
         raise typer.Exit(code=1)
+
+
+def _evidence_error_payload(message: str, *, code: str, routing_reason: str) -> dict[str, object]:
+    return {
+        "version": _json_output_version(),
+        "schema_version": _json_output_version(),
+        "routing_backend": "EvidenceReceipt",
+        "routing_reason": routing_reason,
+        "sidecar_used": False,
+        "error": {"code": code, "message": message},
+    }
+
+
+@evidence_app.command("emit")
+def evidence_emit(
+    path: str = typer.Argument(
+        ".", help="Repository path to bind the receipt's revision identity to."
+    ),
+    query: str | None = typer.Option(None, "--query", help="Symbol/query this receipt is about."),
+    manifest_path: str | None = typer.Option(
+        None,
+        "--manifest",
+        help="Path to a prior rewrite-audit-manifest JSON (changes/validation-outcomes/rollback).",
+    ),
+    capsule_path: str | None = typer.Option(
+        None,
+        "--capsule",
+        help="Path to a prior `tg agent --json` capsule (blast-radius/ambiguity/confidence).",
+    ),
+    checkpoint_id: str | None = typer.Option(
+        None,
+        "--checkpoint-id",
+        help="Optional checkpoint ID for rollback info when --manifest has no checkpoint block.",
+    ),
+    agent_id: str | None = typer.Option(
+        None,
+        "--agent-id",
+        help="Caller-supplied agent identifier, recorded verbatim (never inferred). "
+        "Falls back to TG_EVIDENCE_AGENT_ID.",
+    ),
+    model: str | None = typer.Option(
+        None,
+        "--model",
+        help="Caller-supplied model identifier, recorded verbatim (never inferred). "
+        "Falls back to TG_EVIDENCE_MODEL.",
+    ),
+    cost_json: str | None = typer.Option(
+        None,
+        "--cost-json",
+        help="Path to caller-supplied cost JSON, recorded verbatim (never inferred). "
+        "Falls back to TG_EVIDENCE_COST_JSON.",
+    ),
+    recompute: bool = typer.Option(
+        False,
+        "--recompute",
+        help="OPT-IN: recompute blast-radius for --query instead of aggregating only. "
+        "OFF by default (performance contract: no re-scan unless explicitly requested).",
+    ),
+    output_path: str | None = typer.Option(
+        None, "--out", help="Optional file path where the receipt JSON should be written."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the receipt as structured JSON to stdout."
+    ),
+) -> None:
+    """Emit a versioned EvidenceReceipt aggregating tg's existing outputs (no re-scan)."""
+    from tensor_grep.cli.evidence_receipt import build_evidence_receipt
+
+    try:
+        receipt = build_evidence_receipt(
+            path,
+            query=query,
+            manifest_path=manifest_path,
+            capsule_path=capsule_path,
+            checkpoint_id=checkpoint_id,
+            agent_id=agent_id,
+            model=model,
+            cost_json_path=cost_json,
+            recompute=recompute,
+        )
+    except Exception as exc:
+        if json_output:
+            typer.echo(
+                json.dumps(
+                    _evidence_error_payload(
+                        str(exc), code="internal_error", routing_reason="evidence-receipt-emit"
+                    ),
+                    indent=2,
+                )
+            )
+        else:
+            typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    if output_path is not None:
+        resolved_output = Path(output_path).expanduser().resolve()
+        resolved_output.parent.mkdir(parents=True, exist_ok=True)
+        resolved_output.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+
+    if json_output:
+        typer.echo(json.dumps(receipt, indent=2))
+        return
+
+    target = output_path or "<stdout only>"
+    revision = cast(dict[str, object], receipt.get("revision", {}))
+    typer.echo(f"Evidence receipt ({target}):")
+    typer.echo(f"  commit_sha={revision.get('commit_sha', '<unavailable>')}")
+    typer.echo(f"  dirty={revision.get('dirty', '<unavailable>')}")
+    for block_name in ("scope", "blast_radius", "confidence", "validation", "changes", "caller"):
+        block = receipt.get(block_name)
+        status = block.get("status", "unknown") if isinstance(block, dict) else "unknown"
+        typer.echo(f"  {block_name}.status={status}")
 
 
 @app.command("update")

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -47,6 +47,7 @@ PUBLIC_TOP_LEVEL_COMMANDS = {
     "audit-history",
     "audit-diff",
     "review-bundle",
+    "evidence",
     "devices",
     "context",
     "lsp",
@@ -381,6 +382,7 @@ COMMAND_CASES = [
     (["audit-history", "--help"], 0, assert_text_lines, no_check),
     (["audit-diff", "--help"], 0, assert_text_lines, no_check),
     (["review-bundle", "--help"], 0, assert_text_lines, no_check),
+    (["evidence", "--help"], 0, assert_text_lines, no_check),
 ]
 
 

--- a/tests/unit/test_evidence_receipt.py
+++ b/tests/unit/test_evidence_receipt.py
@@ -1,0 +1,730 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tensor_grep.cli import evidence_receipt
+
+_EMPTY_SHA256 = hashlib.sha256(b"").hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a real temp git repo (for the GAP-1 revision-identity producer)
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _init_git_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _run_git(["init", "-b", "main", "."], cwd=root)
+    _run_git(["config", "user.email", "test@example.com"], cwd=root)
+    _run_git(["config", "user.name", "Test User"], cwd=root)
+    (root / "README.md").write_text("hello\n", encoding="utf-8")
+    _run_git(["add", "README.md"], cwd=root)
+    _run_git(["commit", "-m", "initial commit"], cwd=root)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: sample capsule / manifest payloads matching the real producer
+# shapes (agent_capsule.py:2227-2275 and rust_core/src/main.rs:6210 /
+# tests/unit/test_review_bundles.py's manifest fixture).
+# ---------------------------------------------------------------------------
+
+
+def _sample_capsule(**overrides: Any) -> dict[str, Any]:
+    capsule: dict[str, Any] = {
+        "version": 1,
+        "schema_version": 1,
+        "routing_backend": "RepoMap",
+        "routing_reason": "agent-context-capsule",
+        "capsule_version": 1,
+        "query": "charge_card",
+        "path": "/repo",
+        "ambiguity": {"status": "unambiguous"},
+        "primary_target": {"file": "src/billing.py", "symbol": "charge_card", "confidence": 0.9},
+        "alternative_targets": [
+            {"file": "src/legacy_billing.py", "symbol": "charge_card_legacy", "confidence": 0.4}
+        ],
+        "snippets": [
+            {"file": "src/billing.py", "source": "def charge_card(): ...", "truncated": False}
+        ],
+        "related_call_sites": [
+            {"file": "src/api.py", "line": 42, "provenance": "parser-backed"},
+        ],
+        "call_site_evidence": {
+            "status": "collected",
+            "symbol": "charge_card",
+            "routing_reason": "symbol-blast-radius",
+            "max_callers": 8,
+            "returned_call_sites": 1,
+            "omitted_call_sites": 0,
+            "provenance": ["parser-backed"],
+            "graph_trust_summary": {"trust": "high"},
+            "resolution_gaps": [],
+        },
+        "validation_plan": [{"kind": "test", "command": "pytest -q"}],
+        "validation_commands": ["pytest -q"],
+        "suggested_validation_commands": ["pytest -q -k billing"],
+        "rollback": {
+            "checkpoint_recommended": True,
+            "reason": "source edit target selected",
+            "command": "tg checkpoint undo ckpt-1 .",
+            "argv": ["tg", "checkpoint", "undo", "ckpt-1", "."],
+        },
+        "omissions": {
+            "token_budget": 1200,
+            "omitted_section_count": 2,
+            "omitted_sections": ["deep_call_graph"],
+            "follow_up_reads": ["src/legacy_billing.py"],
+        },
+        "confidence": {"overall": 0.72, "downgrade_reasons": ["ambiguous secondary match"]},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "result_incomplete": False,
+        "partial": False,
+        "scan_limit": {"max_repo_files": 4000, "possibly_truncated": False},
+    }
+    capsule.update(overrides)
+    return capsule
+
+
+def _canonical_manifest_bytes(manifest: dict[str, object]) -> bytes:
+    canonical = dict(manifest)
+    canonical.pop("manifest_sha256", None)
+    canonical.pop("signature", None)
+    return json.dumps(canonical, indent=2).encode("utf-8")
+
+
+def _sample_manifest(**overrides: Any) -> dict[str, Any]:
+    manifest: dict[str, Any] = {
+        "version": 1,
+        "kind": "rewrite-audit-manifest",
+        "created_at": "2026-07-10T12:00:00Z",
+        "lang": "python",
+        "path": "/repo",
+        "plan_total_edits": 1,
+        "applied_edit_ids": ["edit-1"],
+        "checkpoint": {
+            "checkpoint_id": "ckpt-abc123",
+            "mode": "git-worktree-snapshot",
+            "root": "/repo",
+            "scope": "tree",
+            "original_path": "/repo",
+            "created_at": "2026-07-10T11:59:00Z",
+            "file_count": 3,
+        },
+        "validation": {
+            "success": True,
+            "commands": [
+                {
+                    "kind": "test",
+                    "command": "pytest -q",
+                    "success": True,
+                    "exit_code": 0,
+                    "stdout": "",
+                    "stderr": "",
+                }
+            ],
+            "validation_targets_truncated": False,
+            "validation_targets_total": 1,
+        },
+        "files": [
+            {
+                "path": "src/billing.py",
+                "edit_ids": ["edit-1"],
+                "before_sha256": "a" * 64,
+                "after_sha256": "b" * 64,
+            }
+        ],
+        "previous_manifest_sha256": None,
+    }
+    manifest.update(overrides)
+    manifest["manifest_sha256"] = hashlib.sha256(_canonical_manifest_bytes(manifest)).hexdigest()
+    return manifest
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Envelope / schema basics
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_has_stable_envelope_and_schema_fields(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert receipt["routing_backend"] == "EvidenceReceipt"
+    assert receipt["routing_reason"] == "evidence-receipt-emit"
+    assert receipt["sidecar_used"] is False
+    assert receipt["kind"] == "evidence-receipt"
+    assert receipt["receipt_schema_version"] == 1
+    assert receipt["created_at"].endswith("Z")
+    assert receipt["tool"]["name"] == "tensor-grep"
+    assert isinstance(receipt["tool"]["version"], str) and receipt["tool"]["version"]
+    assert isinstance(receipt["tool"]["json_output_version"], int)
+
+
+def test_receipt_top_level_blocks_are_all_present_even_when_every_source_is_absent(
+    git_repo: Path,
+) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    for block_name in (
+        "revision",
+        "scope",
+        "blast_radius",
+        "confidence",
+        "validation",
+        "changes",
+        "caller",
+        "sources",
+    ):
+        assert block_name in receipt, f"missing stable block: {block_name}"
+
+
+def test_build_evidence_receipt_json_matches_python_payload(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+    receipt_json = evidence_receipt.build_evidence_receipt_json(git_repo)
+
+    assert json.loads(receipt_json) == receipt
+
+
+# ---------------------------------------------------------------------------
+# GAP 1: _repo_revision_identity
+# ---------------------------------------------------------------------------
+
+
+def test_repo_revision_identity_on_clean_repo(git_repo: Path) -> None:
+    identity = evidence_receipt._repo_revision_identity(git_repo)
+
+    expected_sha = _run_git(["rev-parse", "HEAD"], cwd=git_repo).stdout.strip()
+    assert identity["status"] == "present"
+    assert identity["commit_sha"] == expected_sha
+    assert identity["branch"] == "main"
+    assert identity["dirty"] is False
+    assert identity["dirty_file_count"] == 0
+    assert identity["dirty_tree_sha256"] == _EMPTY_SHA256
+
+
+def test_repo_revision_identity_on_dirty_repo(git_repo: Path) -> None:
+    (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
+
+    identity = evidence_receipt._repo_revision_identity(git_repo)
+
+    assert identity["status"] == "present"
+    assert identity["dirty"] is True
+    assert identity["dirty_file_count"] == 1
+    assert identity["dirty_tree_sha256"] != _EMPTY_SHA256
+
+
+def test_repo_revision_identity_dirty_tree_sha256_is_deterministic_for_same_state(
+    git_repo: Path,
+) -> None:
+    (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
+
+    first = evidence_receipt._repo_revision_identity(git_repo)
+    second = evidence_receipt._repo_revision_identity(git_repo)
+
+    assert first["dirty_tree_sha256"] == second["dirty_tree_sha256"]
+    assert first["commit_sha"] == second["commit_sha"]
+
+
+def test_repo_revision_identity_changes_hash_when_dirty_state_changes(git_repo: Path) -> None:
+    baseline = evidence_receipt._repo_revision_identity(git_repo)
+
+    (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
+    after_one_file = evidence_receipt._repo_revision_identity(git_repo)
+
+    (git_repo / "scratch2.tmp").write_text("more\n", encoding="utf-8")
+    after_two_files = evidence_receipt._repo_revision_identity(git_repo)
+
+    assert baseline["dirty_tree_sha256"] != after_one_file["dirty_tree_sha256"]
+    assert after_one_file["dirty_tree_sha256"] != after_two_files["dirty_tree_sha256"]
+    # binding key stays anchored to the same commit throughout
+    assert baseline["commit_sha"] == after_one_file["commit_sha"] == after_two_files["commit_sha"]
+
+
+def test_repo_revision_identity_fails_closed_outside_a_git_repo(tmp_path: Path) -> None:
+    non_git_dir = tmp_path / "not_a_repo"
+    non_git_dir.mkdir()
+
+    identity = evidence_receipt._repo_revision_identity(non_git_dir)
+
+    assert identity["status"] == "unavailable"
+    assert identity.get("reason")
+    assert "commit_sha" not in identity
+
+
+def test_repo_revision_identity_makes_at_most_two_git_subprocess_calls(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    call_count = 0
+    real_run_subprocess = evidence_receipt.run_subprocess
+
+    def _counting_run_subprocess(*args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_receipt, "run_subprocess", _counting_run_subprocess)
+
+    evidence_receipt._repo_revision_identity(git_repo)
+
+    assert call_count <= 2
+
+
+def test_receipt_revision_block_reflects_dirty_worktree_end_to_end(git_repo: Path) -> None:
+    (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert receipt["revision"]["status"] == "present"
+    assert receipt["revision"]["dirty"] is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed contract: missing/invalid sources -> status unavailable + reason,
+# never a silently empty/guessed value.
+# ---------------------------------------------------------------------------
+
+
+def test_scope_and_blast_radius_and_confidence_and_validation_unavailable_without_capsule(
+    git_repo: Path,
+) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert receipt["scope"]["status"] == "unavailable"
+    assert receipt["scope"]["reason"]
+    assert receipt["scope"]["files_selected"] is None
+
+    assert receipt["blast_radius"]["status"] == "unavailable"
+    assert receipt["blast_radius"]["reason"]
+
+    assert receipt["confidence"]["status"] == "unavailable"
+    assert receipt["confidence"]["reason"]
+
+    assert receipt["validation"]["status"] == "unavailable"
+    assert receipt["validation"]["reason"]
+
+
+def test_changes_unavailable_without_manifest_or_checkpoint(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert receipt["changes"]["status"] == "unavailable"
+    assert receipt["changes"]["reason"]
+
+
+def test_invalid_capsule_json_degrades_to_unavailable_not_a_crash(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    bad_capsule = tmp_path / "capsule.json"
+    bad_capsule.write_text("{not valid json", encoding="utf-8")
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, capsule_path=bad_capsule)
+
+    assert receipt["scope"]["status"] == "unavailable"
+    assert "not valid JSON" in receipt["scope"]["reason"]
+    assert receipt["blast_radius"]["status"] == "unavailable"
+
+
+def test_missing_manifest_path_degrades_to_unavailable_with_reason(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    missing = tmp_path / "does_not_exist.json"
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, manifest_path=missing)
+
+    assert receipt["changes"]["status"] == "unavailable"
+    assert "not found" in receipt["changes"]["reason"]
+
+
+def test_capsule_missing_call_site_evidence_key_is_unavailable_not_fabricated(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    capsule = _sample_capsule()
+    del capsule["call_site_evidence"]
+    capsule_path = _write_json(tmp_path / "capsule.json", capsule)
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, capsule_path=capsule_path)
+
+    assert receipt["blast_radius"]["status"] == "unavailable"
+    assert receipt["blast_radius"]["reason"]
+    assert "callers" not in receipt["blast_radius"]
+
+
+# ---------------------------------------------------------------------------
+# Capsule-sourced blocks: scope / blast_radius / confidence / validation-plan
+# ---------------------------------------------------------------------------
+
+
+def test_scope_block_sourced_from_capsule(git_repo: Path, tmp_path: Path) -> None:
+    capsule_path = _write_json(tmp_path / "capsule.json", _sample_capsule())
+
+    receipt = evidence_receipt.build_evidence_receipt(
+        git_repo, query="charge_card", capsule_path=capsule_path
+    )
+
+    scope = receipt["scope"]
+    assert scope["status"] == "present"
+    assert scope["query"] == "charge_card"
+    assert "src/billing.py" in scope["files_selected"]
+    assert scope["files_omitted_count"] == 2
+    assert scope["completeness"]["status"] == "present"
+    assert scope["completeness"]["result_incomplete"] is False
+
+
+def test_blast_radius_block_sourced_from_capsule_call_site_evidence(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    capsule_path = _write_json(tmp_path / "capsule.json", _sample_capsule())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, capsule_path=capsule_path)
+
+    blast_radius = receipt["blast_radius"]
+    assert blast_radius["status"] == "collected"
+    assert blast_radius["source"] == "capsule"
+    assert blast_radius["symbol"] == "charge_card"
+    assert blast_radius["callers"] == _sample_capsule()["related_call_sites"]
+    assert blast_radius["omitted_callers"] == 0
+    assert blast_radius["graph_trust_summary"] == {"trust": "high"}
+    assert blast_radius["resolution_gaps"] == []
+
+
+def test_confidence_block_sourced_from_capsule(git_repo: Path, tmp_path: Path) -> None:
+    capsule_path = _write_json(tmp_path / "capsule.json", _sample_capsule())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, capsule_path=capsule_path)
+
+    confidence = receipt["confidence"]
+    assert confidence["status"] == "present"
+    assert confidence["overall"] == 0.72
+    assert confidence["downgrade_reasons"] == ["ambiguous secondary match"]
+    assert confidence["ambiguity"] == {"status": "unambiguous"}
+    assert confidence["alternative_targets"] == _sample_capsule()["alternative_targets"]
+    assert confidence["ask_user_before_editing"] == {"required": False, "reasons": []}
+
+
+def test_validation_planned_commands_sourced_from_capsule_without_manifest(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    capsule_path = _write_json(tmp_path / "capsule.json", _sample_capsule())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, capsule_path=capsule_path)
+
+    validation = receipt["validation"]
+    assert validation["status"] == "present"
+    assert validation["planned_commands"] == ["pytest -q"]
+    assert validation["suggested_validation_commands"] == ["pytest -q -k billing"]
+    # no manifest -> actual outcome is unknown, not fabricated as success
+    assert validation["success"] is None
+    assert validation["commands"] is None
+
+
+# ---------------------------------------------------------------------------
+# Manifest-sourced blocks: validation outcomes / changes / rollback
+# ---------------------------------------------------------------------------
+
+
+def test_validation_actual_outcome_sourced_from_manifest(git_repo: Path, tmp_path: Path) -> None:
+    manifest_path = _write_json(tmp_path / "manifest.json", _sample_manifest())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, manifest_path=manifest_path)
+
+    validation = receipt["validation"]
+    assert validation["status"] == "present"
+    assert validation["success"] is True
+    assert validation["targets_truncated"] is False
+    assert validation["targets_total"] == 1
+    # no capsule -> planned commands are unknown, not fabricated
+    assert validation["planned_commands"] is None
+
+
+def test_changes_block_sourced_from_manifest(git_repo: Path, tmp_path: Path) -> None:
+    manifest_path = _write_json(tmp_path / "manifest.json", _sample_manifest())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, manifest_path=manifest_path)
+
+    changes = receipt["changes"]
+    assert changes["status"] == "present"
+    assert changes["files"][0]["path"] == "src/billing.py"
+    assert changes["applied_edit_ids"] == ["edit-1"]
+    assert changes["plan_total_edits"] == 1
+
+
+def test_changes_rollback_undo_command_is_reconstructed_from_manifest_checkpoint(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    manifest_path = _write_json(tmp_path / "manifest.json", _sample_manifest())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, manifest_path=manifest_path)
+
+    rollback = receipt["changes"]["rollback"]
+    assert rollback["status"] == "present"
+    assert rollback["checkpoint_id"] == "ckpt-abc123"
+    assert rollback["undo_argv"] == ["tg", "checkpoint", "undo", "ckpt-abc123", "/repo"]
+    assert "ckpt-abc123" in rollback["undo_command"]
+
+
+def test_changes_triggered_rollback_outcome_is_always_unavailable_not_persisted(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    """The rewrite-audit-manifest on disk does not persist ValidationRollbackSummary
+    (rust_core/src/main.rs:6097 ApplyVerifyJson.rollback vs :6210 RewriteAuditManifest,
+    which has no rollback field) -- this must fail closed, never guess success/failure."""
+    manifest_path = _write_json(tmp_path / "manifest.json", _sample_manifest())
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, manifest_path=manifest_path)
+
+    triggered = receipt["changes"]["triggered_rollback"]
+    assert triggered["status"] == "unavailable"
+    assert triggered["reason"]
+
+
+def test_changes_rollback_unavailable_when_manifest_has_no_checkpoint(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    manifest_path = _write_json(tmp_path / "manifest.json", _sample_manifest(checkpoint=None))
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, manifest_path=manifest_path)
+
+    assert receipt["changes"]["rollback"]["status"] == "unavailable"
+
+
+def test_standalone_checkpoint_id_without_manifest_still_answers_rollback(
+    git_repo: Path,
+) -> None:
+    """--checkpoint-id (no --manifest) can answer rollback even though the changed-files list
+    and validation outcome stay unknown -- mirrors review-bundle's own --checkpoint-id support
+    (checkpoint_store.load_checkpoint_metadata)."""
+    from tensor_grep.cli.checkpoint_store import create_checkpoint
+
+    checkpoint = create_checkpoint(str(git_repo))
+
+    receipt = evidence_receipt.build_evidence_receipt(
+        git_repo, checkpoint_id=checkpoint.checkpoint_id
+    )
+
+    changes = receipt["changes"]
+    assert changes["status"] == "unavailable"
+    assert "files" not in changes
+    rollback = changes["rollback"]
+    assert rollback["status"] == "present"
+    assert rollback["checkpoint_id"] == checkpoint.checkpoint_id
+    assert rollback["undo_argv"][:3] == ["tg", "checkpoint", "undo"]
+    assert checkpoint.checkpoint_id in rollback["undo_command"]
+
+
+def test_standalone_checkpoint_id_unknown_id_fails_closed(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, checkpoint_id="ckpt-does-not-exist")
+
+    rollback = receipt["changes"]["rollback"]
+    assert rollback["status"] == "unavailable"
+    assert rollback["reason"]
+
+
+# ---------------------------------------------------------------------------
+# GAP 2: caller-supplied agent/model/cost metadata -- never invented.
+# ---------------------------------------------------------------------------
+
+
+def test_caller_metadata_is_null_when_absent_never_invented(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("TG_EVIDENCE_AGENT_ID", raising=False)
+    monkeypatch.delenv("TG_EVIDENCE_MODEL", raising=False)
+    monkeypatch.delenv("TG_EVIDENCE_COST_JSON", raising=False)
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    caller = receipt["caller"]
+    assert caller["status"] == "caller-supplied"
+    assert caller["provenance"] == "caller-supplied"
+    assert caller["caller_metadata_present"] is False
+    assert caller["agent_id"] is None
+    assert caller["model"] is None
+    assert caller["cost"] is None
+
+
+def test_caller_metadata_from_explicit_flags(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(
+        git_repo, agent_id="claude-code", model="opus-4.8"
+    )
+
+    caller = receipt["caller"]
+    assert caller["caller_metadata_present"] is True
+    assert caller["agent_id"] == "claude-code"
+    assert caller["model"] == "opus-4.8"
+    assert caller["provenance"] == "caller-supplied"
+
+
+def test_caller_metadata_falls_back_to_env_vars(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TG_EVIDENCE_AGENT_ID", "env-agent")
+    monkeypatch.setenv("TG_EVIDENCE_MODEL", "env-model")
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert receipt["caller"]["agent_id"] == "env-agent"
+    assert receipt["caller"]["model"] == "env-model"
+
+
+def test_caller_metadata_explicit_flag_overrides_env_var(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TG_EVIDENCE_AGENT_ID", "env-agent")
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, agent_id="flag-agent")
+
+    assert receipt["caller"]["agent_id"] == "flag-agent"
+
+
+def test_caller_cost_json_read_and_recorded_verbatim(git_repo: Path, tmp_path: Path) -> None:
+    cost_path = _write_json(
+        tmp_path / "cost.json", {"input_tokens": 1234, "output_tokens": 567, "usd": 0.12}
+    )
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, cost_json_path=cost_path)
+
+    assert receipt["caller"]["cost"] == {"input_tokens": 1234, "output_tokens": 567, "usd": 0.12}
+    assert receipt["caller"]["caller_metadata_present"] is True
+
+
+def test_caller_cost_json_missing_path_is_visible_not_silently_dropped(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    missing_cost = tmp_path / "no_such_cost.json"
+
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, cost_json_path=missing_cost)
+
+    caller = receipt["caller"]
+    assert caller["cost"] is None
+    assert caller.get("cost_source_error")
+    assert "not found" in caller["cost_source_error"]
+
+
+def test_caller_cost_source_error_absent_when_no_cost_json_requested_at_all(
+    git_repo: Path,
+) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert "cost_source_error" not in receipt["caller"]
+
+
+# ---------------------------------------------------------------------------
+# Performance contract: default run never invokes an expensive recompute;
+# --recompute is opt-in.
+# ---------------------------------------------------------------------------
+
+
+def test_default_run_never_calls_repo_map_blast_radius_recompute(
+    git_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tensor_grep.cli import repo_map
+
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("build_symbol_blast_radius must not run by default (perf contract)")
+
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _explode)
+    capsule_path = _write_json(tmp_path / "capsule.json", _sample_capsule())
+
+    # No --recompute: must aggregate the capsule only, never touch repo_map.
+    evidence_receipt.build_evidence_receipt(
+        git_repo, query="charge_card", capsule_path=capsule_path, recompute=False
+    )
+
+
+def test_recompute_flag_is_opt_in_and_recomputes_blast_radius(tmp_path: Path) -> None:
+    project = tmp_path / "recompute_project"
+    project.mkdir()
+    (project / "module.py").write_text(
+        "def target_fn():\n    return 1\n\n\ndef caller_fn():\n    return target_fn()\n",
+        encoding="utf-8",
+    )
+
+    receipt = evidence_receipt.build_evidence_receipt(project, query="target_fn", recompute=True)
+
+    blast_radius = receipt["blast_radius"]
+    assert blast_radius["source"] == "recomputed"
+    assert blast_radius["status"] == "present"
+    assert receipt["sources"]["recomputed"] is True
+
+
+def test_recompute_without_query_is_unavailable_not_a_silent_no_op(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo, recompute=True)
+
+    assert receipt["blast_radius"]["status"] == "unavailable"
+    assert receipt["sources"]["recomputed"] is False
+
+
+# ---------------------------------------------------------------------------
+# sources block
+# ---------------------------------------------------------------------------
+
+
+def test_sources_block_reports_manifest_and_capsule_provenance(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    manifest = _sample_manifest()
+    manifest_path = _write_json(tmp_path / "manifest.json", manifest)
+    capsule_path = _write_json(tmp_path / "capsule.json", _sample_capsule())
+
+    receipt = evidence_receipt.build_evidence_receipt(
+        git_repo, manifest_path=manifest_path, capsule_path=capsule_path
+    )
+
+    sources = receipt["sources"]
+    assert sources["manifest_path"] == str(manifest_path.resolve())
+    assert sources["manifest_sha256"] == manifest["manifest_sha256"]
+    assert sources["capsule_path"] == str(capsule_path.resolve())
+    assert sources["capsule_source"].startswith("file:")
+    assert sources["session_id"] is None
+    assert sources["recomputed"] is False
+
+
+def test_sources_block_when_nothing_supplied(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    sources = receipt["sources"]
+    assert sources["manifest_path"] is None
+    assert sources["manifest_sha256"] is None
+    assert sources["capsule_path"] is None
+    assert sources["capsule_source"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# No P2 (signing) leakage: receipt_sha256 / signature / previous_receipt_sha256
+# must NOT appear in the Phase-1 schema.
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_receipt_has_no_signing_fields(git_repo: Path) -> None:
+    receipt = evidence_receipt.build_evidence_receipt(git_repo)
+
+    assert "receipt_sha256" not in receipt
+    assert "signature" not in receipt
+    assert "previous_receipt_sha256" not in receipt


### PR DESCRIPTION
CEO directive 2026-07-10: build a local tg output gotcontext.ai can consume (NOT the SaaS). `tg evidence emit` aggregates what tg ALREADY computes into one versioned, fail-closed JSON EvidenceReceipt: revision identity (commit+dirty-tree binding key), tool/version provenance, scope (files searched/selected/omitted), blast-radius (real AST-verified call sites), confidence/ambiguity, validation plan+outcomes, changed-files+rollback, and caller-supplied agent/model/cost.

**Phase 1 = schema + emitter only** (P2 signing + P3 MCP tool are separate PRs). Aggregates already-computed state from a prior `--capsule` (tg agent output) + `--manifest` (rewrite audit) + 2 git calls -- NO expensive re-scan (perf contract unit-tested; `--recompute` opt-in OFF by default).

**Fail-Closed:** every field is either real data OR `{status:'unavailable', reason}` -- never silent-empty, never invented (caller cost/model = null when absent). New `_repo_revision_identity` = exactly 2 subprocess calls (`rev-parse HEAD` + `status --porcelain -b`).

4 registration sites wired + VERIFIED against real code (KNOWN_COMMANDS, the Rust `Commands::Evidence` passthrough mirroring ReviewBundle, PUBLIC_TOP_LEVEL_COMMANDS + COMMAND_CASES, the `evidence` sub-app) -- proven end-to-end on a freshly-built native tg.exe (routing-parity 53 pass; registration-check 2/2). No gated surface (evidence_receipt.py new + main.py/commands.py/main.rs-passthrough). ruff/format/mypy clean; 39 evidence tests + real-binary dogfood green.

2 producer-shape gaps flagged for P2/future (not P1 bugs): checkpoint metadata doesn't persist undo_argv (reconstructed locally); the on-disk rewrite manifest has no rollback field (so changes.triggered_rollback reads unavailable from a manifest). `verify` deferred to P2 (needs the signature).

`feat:` -> MINOR. Part of #124 (EvidenceReceipt v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)