### PR TITLE
fix(index): close 5 silent-wrong-result bugs in --index search (fail-closed + FullScan + no_ignore + smart_case, audit H1, Opus-gated)

### DIFF
--- a/docs/routing_policy.md
+++ b/docs/routing_policy.md
@@ -72,6 +72,17 @@ itself, *after* routing, before running the query:
   `TrigramIndex::search` falls back to scanning every indexed file directly instead of trusting an
   empty/mismatched trigram candidate set as "no match" (`index.rs`,
   `fixed_string_candidate_selection`).
+- **`--smart-case` (`-S`) honored per pattern:** `-S` is not diverted to ripgrep in JSON/NDJSON
+  output mode (`search_requires_ripgrep_passthrough` gates it behind `!json && !ndjson`), so it
+  reaches the index. `run_index_query` resolves case-sensitivity per pattern
+  (`args.ignore_case || (args.smart_case && smart_case_pattern_is_case_insensitive(pattern))`)
+  before calling `index.search`, so an all-lowercase `-S` pattern searches case-insensitively
+  (matching an uppercase occurrence) and a pattern containing an uppercase char stays
+  case-sensitive -- identical to native smart-case. This is honored rather than refused because
+  it is index-doable and reuses the same `ignore_case` path (and its H1b/H1c full-scan safety
+  nets); before this fix `-S` was silently dropped to a case-sensitive query (a false negative,
+  exit 0). Covers both explicit `--index` and warm auto-routing, since both reach
+  `run_index_query`.
 - **`--no-ignore` mode tracking:** the on-disk index format records the `no_ignore` mode it was
   built with (`INDEX_FORMAT_VERSION` 4). A query whose `--no-ignore` request disagrees with the
   stored build mode is treated as stale and triggers a rebuild under the query's requested mode --

--- a/docs/routing_policy.md
+++ b/docs/routing_policy.md
@@ -24,7 +24,7 @@ route_search(config, calibration_data, index_state, gpu_available) -> RoutingDec
 | --- | --- | --- |
 | `NativeCpuBackend` | `force_cpu`, `json_output`, `cpu-auto-size-threshold`, `gpu-auto-fallback-cpu`, `rg_unavailable` | Native Rust text search is used for structured explicit `--cpu`, JSON/NDJSON output, GPU fallback, and when `rg` is unavailable. |
 | `NativeGpuBackend` | `gpu-device-ids-explicit-native`, `gpu-auto-size-threshold` | Native Rust CUDA search. Explicit `--gpu-device-ids` always targets this route first; calibrated auto-routing can also choose it. |
-| `TrigramIndex` | `index-accelerated` | Explicit `--index` and warm compatible `.tg_index` auto-routing both land here. |
+| `TrigramIndex` | `index-accelerated` | Explicit `--index` and warm compatible `.tg_index` auto-routing both land here. Explicit `--index` is gated the same way warm auto-routing is (see the fail-closed note below) -- it is not an unconditional override. |
 | `AstBackend` | `ast-native` | Native Rust AST search/rewrite path for `tg run`. |
 | `GpuSidecar` | `gpu-device-ids-explicit` | Python sidecar fallback used when an explicit GPU request cannot stay on the native GPU path (for example non-CUDA builds or unsupported GPU-native search features). |
 | `RipgrepBackend` | `rg_passthrough` | Default cold-path backend for generic text search when `rg` is available and the request does not require native structured output. Also used as the final fallback after a forced native CPU route fails. |
@@ -45,7 +45,7 @@ The router's priority order is now explicit and shared:
 
 ### Notes on the tree
 
-- `--index` is the highest priority override.
+- `--index` is the highest priority override for the *routing decision* (which backend gets picked). It is not an override of *search semantics* -- see the fail-closed note below for what happens once `TrigramIndex` is selected.
 - `--gpu-device-ids` overrides warm-index and size-based routing.
 - `--force-cpu` overrides auto GPU routing, but not an explicit `--gpu-device-ids` request.
 - Plain `--cpu` / `--force-cpu` may still use `RipgrepBackend` for rg-compatible text output parity.
@@ -53,6 +53,32 @@ The router's priority order is now explicit and shared:
 - JSON and NDJSON output do **not** bypass a warm compatible index anymore.
 - Auto GPU routing is conservative: no fresh positive calibration means stay on the CPU-side cold path.
 - `rg` is again the normal cold-path choice for generic text search when available. Native CPU remains the default only for structured outputs, explicit `--cpu`, warm index, AST, and GPU fallback cases.
+
+### `--index` fail-closed compatibility contract (audit H1, 2026-07-10)
+
+`route_search` selects `TrigramIndex` for explicit `--index` before any compatibility check
+runs (`routing.rs:234-236`), so `handle_index_search` (`main.rs`) enforces the following
+itself, *after* routing, before running the query:
+
+- **Refused (fails closed with a non-zero exit and an error naming the flag):** `-v`/`--invert-match`,
+  context (`-C`/`-A`/`-B`), `-m`/`--max-count`, `-w`/`--word-regexp`, `-g`/`--glob`, and multiple
+  `-e` patterns. These are the same conditions `detect_warm_index_state` already enforces for
+  warm-index auto-routing (`main.rs`) -- `run_index_query` never consults any of them, so honoring
+  `--index` together with one of them used to silently drop the flag instead of honoring or
+  refusing it (for example, `--index -v` returned the *non-inverted* result set with exit 0).
+- **Transparently handled via an internal full-scan fallback (no error, correct results):**
+  fixed-string patterns shorter than the 3-byte trigram length, and non-ASCII `--ignore-case`
+  fixed-string patterns. Both cases have zero or mismatched trigrams to prefilter on, so
+  `TrigramIndex::search` falls back to scanning every indexed file directly instead of trusting an
+  empty/mismatched trigram candidate set as "no match" (`index.rs`,
+  `fixed_string_candidate_selection`).
+- **`--no-ignore` mode tracking:** the on-disk index format records the `no_ignore` mode it was
+  built with (`INDEX_FORMAT_VERSION` 4). A query whose `--no-ignore` request disagrees with the
+  stored build mode is treated as stale and triggers a rebuild under the query's requested mode --
+  this closes both an information-disclosure gap (an index built with `--no-ignore` silently
+  leaking gitignored content into a later default query) and a false-negative gap (an index built
+  without `--no-ignore` silently missing gitignored files a later `--no-ignore` query asked for).
+  This applies to warm auto-routing too, via the same `is_stale`/`staleness_reason` check.
 
 ## GPU-specific behavior
 

--- a/rust_core/src/index.rs
+++ b/rust_core/src/index.rs
@@ -139,12 +139,19 @@ pub struct TrigramIndex {
     files: Vec<FileEntry>,
     file_trigrams: Vec<FileTrigramHits>,
     postings: HashMap<[u8; 3], Vec<PostingEntry>>,
+    /// Whether this index was built with `--no-ignore` (gitignored files included).
+    /// Persisted so a query whose --no-ignore mode differs from the build mode is
+    /// detected as stale (audit H1d) instead of silently serving the wrong file set --
+    /// either leaking gitignored content into a default query, or missing gitignored
+    /// files a --no-ignore query asked for.
+    no_ignore: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SerializableIndex {
     files: Vec<FileEntry>,
     postings: HashMap<String, Vec<PostingEntry>>,
+    no_ignore: bool,
 }
 
 impl TrigramIndex {
@@ -160,6 +167,7 @@ impl TrigramIndex {
         SerializableIndex {
             files: self.files.clone(),
             postings,
+            no_ignore: self.no_ignore,
         }
     }
 
@@ -179,12 +187,18 @@ impl TrigramIndex {
             files: s.files,
             file_trigrams,
             postings,
+            no_ignore: s.no_ignore,
         })
     }
 }
 
 const INDEX_MAGIC: &[u8; 4] = b"TGI\x00";
-const INDEX_FORMAT_VERSION: u8 = 3;
+// Bumped 3 -> 4 (audit H1d) to add the `no_ignore` build-mode byte below; any index
+// written by an older binary fails the version check in bincode_deserialize and is
+// rebuilt from scratch by every caller of TrigramIndex::load (main.rs's
+// detect_warm_index_state and handle_index_search both already treat a load error as
+// "stale, rebuild"), so the bump is safe.
+const INDEX_FORMAT_VERSION: u8 = 4;
 
 fn normalize_postings(postings: &mut HashMap<[u8; 3], Vec<PostingEntry>>) {
     for entries in postings.values_mut() {
@@ -252,6 +266,7 @@ fn bincode_serialize(index: &TrigramIndex) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     buf.extend_from_slice(INDEX_MAGIC);
     buf.push(INDEX_FORMAT_VERSION);
+    buf.push(u8::from(index.no_ignore));
 
     let root_bytes = index.root.to_string_lossy().as_bytes().to_vec();
     buf.extend_from_slice(&(root_bytes.len() as u32).to_le_bytes());
@@ -334,6 +349,8 @@ fn bincode_deserialize(data: &[u8]) -> Result<TrigramIndex> {
         );
     }
 
+    let no_ignore = read_u8(data, &mut pos)? != 0;
+
     let root_len = read_u32_le(data, &mut pos)? as usize;
     let root_str = String::from_utf8_lossy(read_exact(data, &mut pos, root_len)?).to_string();
 
@@ -396,6 +413,7 @@ fn bincode_deserialize(data: &[u8]) -> Result<TrigramIndex> {
         files,
         file_trigrams,
         postings,
+        no_ignore,
     })
 }
 
@@ -449,6 +467,7 @@ impl TrigramIndex {
             files: file_entries,
             file_trigrams,
             postings,
+            no_ignore,
         })
     }
 
@@ -563,6 +582,10 @@ impl TrigramIndex {
 
         normalize_affected_postings(&mut self.postings, &affected_trigrams);
         self.root = root.to_path_buf();
+        // H1d: persist the query's no_ignore mode onto the rebuilt index so a subsequent
+        // staleness check compares against what this rebuild actually walked with, not a
+        // stale build-time value.
+        self.no_ignore = no_ignore;
 
         Ok(IncrementalUpdateResult { index: self, stats })
     }
@@ -633,7 +656,7 @@ impl TrigramIndex {
         fixed_strings: bool,
     ) -> Result<Vec<IndexQueryResult>> {
         let candidate_selection = if fixed_strings {
-            RegexCandidateSelection::Indexed(self.query_candidates_fixed(pattern, ignore_case))
+            self.fixed_string_candidate_selection(pattern, ignore_case)
         } else {
             self.regex_candidate_selection(pattern, ignore_case)
         };
@@ -672,6 +695,40 @@ impl TrigramIndex {
 
         all_results.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
         Ok(all_results)
+    }
+
+    /// Candidate selection for `--fixed-strings` queries. Falls back to a full scan
+    /// (never a silently-empty `Indexed([])`) in the two cases the trigram prefilter
+    /// cannot answer correctly:
+    ///
+    /// - H1b: a pattern shorter than TRIGRAM_LEN has no trigrams to index on, so
+    ///   `query_candidates_fixed` returns zero candidates -- `search()` would read that
+    ///   as "definitely no match" instead of "the index can't accelerate this".
+    /// - H1c: build-time trigrams are lowercased with `to_ascii_lowercase` (a no-op on
+    ///   multi-byte UTF-8, see `extract_file_trigrams`), but `query_candidates_fixed`'s
+    ///   ignore_case path lowercases with Unicode-aware `str::to_lowercase` -- a
+    ///   non-ASCII ignore-case pattern's trigrams can never line up with the index's,
+    ///   again reading as a false "no match". Same precedent as
+    ///   `normalize_prefilter_literal`'s regex-path guard just below.
+    fn fixed_string_candidate_selection(
+        &self,
+        pattern: &str,
+        ignore_case: bool,
+    ) -> RegexCandidateSelection {
+        if ignore_case && !pattern.is_ascii() {
+            return RegexCandidateSelection::FullScan;
+        }
+
+        let normalized_len = if ignore_case {
+            pattern.to_lowercase().len()
+        } else {
+            pattern.len()
+        };
+        if normalized_len < TRIGRAM_LEN {
+            return RegexCandidateSelection::FullScan;
+        }
+
+        RegexCandidateSelection::Indexed(self.query_candidates_fixed(pattern, ignore_case))
     }
 
     fn regex_candidate_selection(
@@ -715,11 +772,26 @@ impl TrigramIndex {
         Ok(matches)
     }
 
-    pub fn is_stale(&self) -> bool {
-        self.staleness_reason().is_some()
+    pub fn is_stale(&self, no_ignore: bool) -> bool {
+        self.staleness_reason(no_ignore).is_some()
     }
 
-    pub fn staleness_reason(&self) -> Option<String> {
+    /// `no_ignore` is the CURRENT query's `--no-ignore` request, compared against the
+    /// mode this index was actually built with (`self.no_ignore`).
+    pub fn staleness_reason(&self, no_ignore: bool) -> Option<String> {
+        // H1d (audit): a stored no_ignore mode that disagrees with the current query's
+        // --no-ignore request means this index was built walking a DIFFERENT file set
+        // than the one the query now expects -- reusing it as-is either leaks gitignored
+        // content into a default query (built --no-ignore, queried without) or misses
+        // gitignored files a --no-ignore query asked for (built without, queried with).
+        // Treat it as stale so the caller rebuilds under the query's requested mode.
+        if self.no_ignore != no_ignore {
+            return Some(format!(
+                "no_ignore mode changed: index built with no_ignore={}, query requested no_ignore={}",
+                self.no_ignore, no_ignore
+            ));
+        }
+
         let indexed_paths: std::collections::HashSet<&Path> = self
             .files
             .iter()
@@ -750,9 +822,12 @@ impl TrigramIndex {
         }
 
         if self.root.is_dir() {
+            // Mirror collect_file_entries' walk semantics exactly -- this was hardcoded
+            // .git_ignore(true) regardless of no_ignore (audit H1d), so the new-file scan
+            // could disagree with how this index would actually be rebuilt.
             let current_files: Vec<PathBuf> = ignore::WalkBuilder::new(&self.root)
                 .hidden(true)
-                .git_ignore(true)
+                .git_ignore(!self.no_ignore)
                 .build()
                 .filter_map(|e| e.ok())
                 .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
@@ -1301,11 +1376,11 @@ mod tests {
         write_test_file(dir.path(), "a.txt", "hello\n");
 
         let index = TrigramIndex::build(dir.path()).unwrap();
-        assert!(!index.is_stale());
+        assert!(!index.is_stale(false));
 
         std::thread::sleep(std::time::Duration::from_millis(50));
         write_test_file(dir.path(), "a.txt", "modified\n");
-        assert!(index.is_stale());
+        assert!(index.is_stale(false));
     }
 
     #[test]
@@ -1366,12 +1441,12 @@ mod tests {
         let dir = tempdir().unwrap();
         write_test_file(dir.path(), "a.txt", "hello world\n");
         let index = TrigramIndex::build(dir.path()).unwrap();
-        assert!(index.staleness_reason().is_none());
+        assert!(index.staleness_reason(false).is_none());
 
         std::thread::sleep(std::time::Duration::from_millis(50));
         write_test_file(dir.path(), "a.txt", "changed content\n");
 
-        let reason = index.staleness_reason().unwrap();
+        let reason = index.staleness_reason(false).unwrap();
         assert!(reason.contains("a.txt"), "reason={reason}");
     }
 
@@ -1383,7 +1458,7 @@ mod tests {
         let index = TrigramIndex::build(dir.path()).unwrap();
 
         fs::remove_file(dir.path().join("b.txt")).unwrap();
-        let reason = index.staleness_reason().unwrap();
+        let reason = index.staleness_reason(false).unwrap();
         assert!(reason.contains("deleted"), "reason={reason}");
         assert!(reason.contains("b.txt"), "reason={reason}");
     }
@@ -1393,10 +1468,10 @@ mod tests {
         let dir = tempdir().unwrap();
         write_test_file(dir.path(), "a.txt", "hello\n");
         let index = TrigramIndex::build(dir.path()).unwrap();
-        assert!(index.staleness_reason().is_none());
+        assert!(index.staleness_reason(false).is_none());
 
         write_test_file(dir.path(), "b.txt", "new file\n");
-        let reason = index.staleness_reason().unwrap();
+        let reason = index.staleness_reason(false).unwrap();
         assert!(reason.contains("new file"), "reason={reason}");
     }
 
@@ -1412,7 +1487,7 @@ mod tests {
             "a.txt",
             "much longer content here to change size\n",
         );
-        let reason = index.staleness_reason();
+        let reason = index.staleness_reason(false);
         assert!(reason.is_some(), "should detect change");
     }
 
@@ -1426,7 +1501,29 @@ mod tests {
 
         let data = fs::read(&index_path).unwrap();
         assert_eq!(&data[0..4], b"TGI\x00", "magic bytes");
-        assert_eq!(data[4], 3, "format version should be 3");
+        assert_eq!(data[4], 4, "format version should be 4");
+    }
+
+    #[test]
+    fn test_no_ignore_mode_change_is_stale() {
+        let dir = tempdir().unwrap();
+        write_test_file(dir.path(), "a.txt", "hello\n");
+
+        let index = TrigramIndex::build_with_options(dir.path(), false).unwrap();
+        assert!(
+            !index.is_stale(false),
+            "same no_ignore mode should not be stale"
+        );
+        assert!(
+            index.is_stale(true),
+            "a query requesting a different no_ignore mode must be treated as stale"
+        );
+
+        let reason = index.staleness_reason(true).unwrap();
+        assert!(
+            reason.contains("no_ignore"),
+            "staleness reason should name the no_ignore mismatch: reason={reason}"
+        );
     }
 
     #[test]
@@ -1496,7 +1593,7 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_millis(50));
         write_test_file(dir.path(), "a.txt", "goodbye world\n");
-        assert!(index1.is_stale());
+        assert!(index1.is_stale(false));
 
         let index2 = TrigramIndex::build(dir.path()).unwrap();
         let r2_hello = index2.search("hello", false, true).unwrap();

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -36,11 +36,9 @@ use tensor_grep_rs::gpu_native::{
     probe_device_allocation, GpuNativeSearchConfig, GpuNativeSearchStats, GpuPipelineStats,
 };
 use tensor_grep_rs::index::TrigramIndex;
-#[cfg(feature = "cuda")]
-use tensor_grep_rs::native_search::smart_case_pattern_is_case_insensitive;
 use tensor_grep_rs::native_search::{
-    run_native_fixed_multi_pattern_search, run_native_search, NativeOutputTarget,
-    NativeSearchConfig, SearchStats,
+    run_native_fixed_multi_pattern_search, run_native_search,
+    smart_case_pattern_is_case_insensitive, NativeOutputTarget, NativeSearchConfig, SearchStats,
 };
 use tensor_grep_rs::python_sidecar::{
     execute_python_passthrough_command, execute_python_passthrough_command_captured,
@@ -6033,7 +6031,18 @@ fn run_index_query(
     let include_pattern_metadata = request.patterns.len() > 1;
     let mut matches = Vec::new();
     for (pattern_id, pattern) in request.patterns.iter().enumerate() {
-        let results = index.search(pattern, args.ignore_case, args.fixed_strings)?;
+        // H1e (audit): resolve smart-case (-S) per pattern before querying the index.
+        // -S is NOT diverted to ripgrep in JSON/ndjson mode (search_requires_ripgrep_
+        // passthrough gates it behind !json && !ndjson), so it reaches the index here;
+        // passing only args.ignore_case (false for -S) would search case-sensitively and
+        // silently miss uppercase matches an all-lowercase -S pattern must find. Honoring
+        // it (smart-case IS index-doable) rather than refusing avoids a UX regression, and
+        // reuses the same ignore_case path -- including the H1b/H1c full-scan safety nets
+        // in index.rs -- for the resolved case. This single chokepoint covers BOTH explicit
+        // --index and warm auto-routing (both reach run_index_query).
+        let ignore_case = args.ignore_case
+            || (args.smart_case && smart_case_pattern_is_case_insensitive(pattern));
+        let results = index.search(pattern, ignore_case, args.fixed_strings)?;
         matches.extend(results.into_iter().map(|result| SearchMatchJson {
             file: result.file.to_string_lossy().into_owned(),
             line: result.line,

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -4904,7 +4904,11 @@ fn detect_warm_index_state(
     match TrigramIndex::load(&index_path) {
         Ok(index) => IndexRoutingState {
             exists: true,
-            is_stale: index.is_stale(),
+            // H1d (audit): a query's --no-ignore mode that disagrees with the mode this
+            // index was built under must be treated as stale so auto-routing does not
+            // silently serve gitignored content the query didn't ask for (or silently
+            // omit gitignored content a --no-ignore query did ask for).
+            is_stale: index.is_stale(args.no_ignore),
             pattern_compatible: true,
         },
         Err(_) => IndexRoutingState {
@@ -5884,6 +5888,45 @@ fn handle_index_search(
     if request.paths.len() != 1 {
         anyhow::bail!("index search currently supports exactly one path root");
     }
+
+    // Backend Fail-Closed Contract (audit H1a): route_search() (routing.rs) selects
+    // TrigramIndex for --index before any compatibility checks run, and run_index_query()
+    // below only ever reads pattern/ignore_case/fixed_strings -- every other search flag
+    // was silently dropped instead of honored or refused (e.g. --index -v used to return
+    // the NON-inverted set with exit 0). Mirror the same compatibility subset
+    // detect_warm_index_state already enforces for warm-index auto-routing and fail
+    // closed instead of silently running the query without them. Deliberately excludes
+    // the pattern-length and non-ASCII-ignore-case checks detect_warm_index_state also
+    // has -- those (H1b/H1c) are handled as a transparent full-scan fallback inside
+    // TrigramIndex::search/fixed_string_candidate_selection instead of a refusal, since
+    // the index can still honor them correctly, just without the trigram prefilter.
+    let mut unsupported_with_index: Vec<&str> = Vec::new();
+    if args.invert_match {
+        unsupported_with_index.push("-v/--invert-match");
+    }
+    if search_has_context(args) {
+        unsupported_with_index.push("-C/-A/-B (context)");
+    }
+    if args.max_count.is_some() {
+        unsupported_with_index.push("-m/--max-count");
+    }
+    if args.word_regexp {
+        unsupported_with_index.push("-w/--word-regexp");
+    }
+    if !args.globs.is_empty() {
+        unsupported_with_index.push("-g/--glob");
+    }
+    if request.patterns.len() != 1 {
+        unsupported_with_index.push("multiple patterns (-e)");
+    }
+    if !unsupported_with_index.is_empty() {
+        anyhow::bail!(
+            "--index does not support {} yet; rerun without --index (or without the \
+             flag(s) above) to search without the trigram index accelerator",
+            unsupported_with_index.join(", ")
+        );
+    }
+
     let search_path = Path::new(request.primary_path());
     if !search_path.exists() {
         anyhow::bail!(
@@ -5917,7 +5960,7 @@ fn handle_index_search(
                 return run_index_query(args, request, query, &fresh);
             }
         };
-        if let Some(reason) = loaded.staleness_reason() {
+        if let Some(reason) = loaded.staleness_reason(args.no_ignore) {
             if args.verbose {
                 eprintln!("[index] stale: {reason}");
             }

--- a/rust_core/tests/test_index.rs
+++ b/rust_core/tests/test_index.rs
@@ -1144,3 +1144,191 @@ fn test_tg_search_explicit_index_no_ignore_flip_on_to_off_does_not_leak_gitignor
         "default query must rebuild the index and exclude the gitignored file, not leak it"
     );
 }
+
+// -- H1e: smart-case (-S) silently dropped on --index --json/--ndjson (2026-07-10) --------
+//
+// The 5th silent-false-negative of the same class as H1a-d, found by the adversarial gate.
+// In JSON/ndjson mode `search_requires_ripgrep_passthrough` gates `smart_case` behind
+// `!json && !ndjson` (main.rs), so `-S` is NOT diverted to ripgrep; route_search picks
+// TrigramIndex; run_index_query passed only `args.ignore_case` (=false for `-S`) to
+// index.search -> case-SENSITIVE -> an all-lowercase `-S` pattern silently missed
+// uppercase matches (exit 0). Fixed by HONORING smart-case (it is index-doable): resolve
+// case-sensitivity per-pattern before calling index.search.
+
+#[test]
+fn test_tg_search_explicit_index_smart_case_lowercase_pattern_matches_native() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("a.txt"),
+        "foo one\nFOO two\nfoo three\nbar unrelated\n",
+    )
+    .unwrap();
+
+    // Native smart-case: an all-lowercase pattern is case-INSENSITIVE, so `foo` matches
+    // foo/FOO/foo = 3 lines. This is the ground truth --index must match.
+    let native = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("-S")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(native.status.success());
+    let native_json: Value = serde_json::from_slice(&native.stdout).unwrap();
+    assert_eq!(
+        native_json["total_matches"], 3,
+        "sanity: smart-case lowercase pattern is case-insensitive in native"
+    );
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--json")
+        .arg("-S")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // BEFORE fix: run_index_query passed ignore_case=false -> case-sensitive -> 2 matches
+    // (silently drops the uppercase FOO line). AFTER fix: honors smart-case -> 3, == native.
+    assert!(
+        indexed.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+    let indexed_json: Value = serde_json::from_slice(&indexed.stdout).unwrap();
+    assert_eq!(
+        indexed_json["total_matches"], native_json["total_matches"],
+        "--index -S (all-lowercase pattern) must honor smart-case case-insensitivity like native, not silently return fewer matches"
+    );
+    assert_eq!(match_tuples(&indexed_json), match_tuples(&native_json));
+}
+
+#[test]
+fn test_tg_search_explicit_index_smart_case_uppercase_pattern_stays_case_sensitive() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("a.txt"),
+        "foo one\nFOO two\nfoo three\nbar unrelated\n",
+    )
+    .unwrap();
+
+    // Native smart-case: a pattern containing an uppercase char is case-SENSITIVE, so
+    // `FOO` matches only the uppercase line = 1. Regression guard: proves the honor fix
+    // does NOT over-broadly make every -S query case-insensitive (which would return 3).
+    let native = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("-S")
+        .arg("FOO")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(native.status.success());
+    let native_json: Value = serde_json::from_slice(&native.stdout).unwrap();
+    assert_eq!(
+        native_json["total_matches"], 1,
+        "sanity: smart-case upper-case pattern is case-sensitive in native"
+    );
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--json")
+        .arg("-S")
+        .arg("FOO")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        indexed.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+    let indexed_json: Value = serde_json::from_slice(&indexed.stdout).unwrap();
+    assert_eq!(
+        indexed_json["total_matches"], native_json["total_matches"],
+        "--index -S (upper-case pattern) must stay case-sensitive like native"
+    );
+    assert_eq!(match_tuples(&indexed_json), match_tuples(&native_json));
+}
+
+#[test]
+fn test_tg_search_warm_auto_index_smart_case_lowercase_pattern_matches_native() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("a.txt"),
+        "foo one\nFOO two\nfoo three\nbar unrelated\n",
+    )
+    .unwrap();
+
+    // Compute the native ground truth BEFORE any .tg_index exists -- once a warm index is
+    // built, EVERY subsequent query in this dir auto-routes to it, so a "native" query run
+    // afterward would be contaminated (it would hit the index too, making the parity check
+    // vacuous). With no index present, `--json -S foo` routes to NativeCpu.
+    assert!(!dir.path().join(".tg_index").exists());
+    let native = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("-S")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(native.status.success());
+    let native_json: Value = serde_json::from_slice(&native.stdout).unwrap();
+    assert_eq!(
+        native_json["total_matches"], 3,
+        "sanity: native smart-case lowercase pattern is case-insensitive = 3"
+    );
+    assert!(
+        !dir.path().join(".tg_index").exists(),
+        "a cold native --json query must not create an index"
+    );
+
+    // Now build a warm index (plain, no -S) so the -S query below auto-routes to it.
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+    assert!(dir.path().join(".tg_index").exists());
+
+    // Warm auto-routing (NO --index) with --json -S foo must ALSO honor smart-case -- the
+    // query flows through the same run_index_query chokepoint as explicit --index, so a
+    // single fix covers both. --verbose lets us confirm it truly routed to the index (else
+    // the parity assertion would be vacuous, e.g. if it fell through to native/ripgrep).
+    let warm = tg()
+        .arg("search")
+        .arg("--json")
+        .arg("--verbose")
+        .arg("-S")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        warm.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    let warm_stderr = String::from_utf8_lossy(&warm.stderr);
+    assert!(
+        warm_stderr.contains("TrigramIndex"),
+        "expected warm auto-routing to the trigram index: stderr={warm_stderr}"
+    );
+    let warm_json: Value = serde_json::from_slice(&warm.stdout).unwrap();
+    assert_eq!(
+        warm_json["total_matches"], native_json["total_matches"],
+        "warm auto-routed -S (all-lowercase) must honor smart-case like native"
+    );
+    assert_eq!(match_tuples(&warm_json), match_tuples(&native_json));
+}

--- a/rust_core/tests/test_index.rs
+++ b/rust_core/tests/test_index.rs
@@ -26,6 +26,24 @@ fn write_corpus(dir: &std::path::Path) {
     .unwrap();
 }
 
+/// `TrigramIndex`'s file walker (`collect_file_entries` / `staleness_reason`) does not set
+/// `.require_git(false)`, so it inherits the `ignore` crate's default of only honoring
+/// `.gitignore` inside a directory the crate recognizes as an actual git repository. A bare
+/// `tempdir()` has no `.git`, so `.gitignore` is silently a no-op there regardless of
+/// `--no-ignore` -- returns `false` (and the caller should skip the test) when `git` itself
+/// isn't on PATH, mirroring the existing precedent in test_ast_rewrite.rs.
+fn init_git_repo(dir: &std::path::Path) -> bool {
+    if Command::new("git").arg("--version").output().is_err() {
+        return false;
+    }
+    let status = Command::new("git")
+        .arg("init")
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    status.status.success()
+}
+
 fn write_regex_prefilter_corpus(dir: &std::path::Path) {
     fs::write(
         dir.join("alternation.txt"),
@@ -623,7 +641,7 @@ fn test_tg_search_index_old_format_triggers_rebuild() {
     let rebuilt = fs::read(dir.path().join(".tg_index")).unwrap();
     assert_eq!(&rebuilt[0..4], b"TGI\x00");
     assert_eq!(
-        rebuilt[4], 3,
+        rebuilt[4], 4,
         "expected rebuilt index to use the new format"
     );
 
@@ -757,4 +775,372 @@ fn test_tg_search_index_survives_repeated_mutation_cycles() {
 
     fs::remove_file(dir.path().join("a.txt")).unwrap();
     expect_count(3);
+}
+
+// -- H1 audit fail-closed regressions (2026-07-10) --------------------------------------
+//
+// `--index` used to win routing before any compatibility checks and hand the query
+// straight to `run_index_query`, which only ever consulted `pattern`/`ignore_case`/
+// `fixed_strings` -- silently dropping every other search flag instead of honoring or
+// refusing it. These tests pin the fixed, fail-closed contract for each confirmed gap.
+
+#[test]
+fn test_tg_search_explicit_index_invert_match_fails_closed_instead_of_dropping_v() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    // Build the index first so a missing/stale index cannot itself explain a non-zero exit.
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-v")
+        .arg("--count")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1a (audit #79/#10): route_search() returned TrigramIndex for --index before
+    // consulting the same invert_match/context/max_count/word_regexp/glob/multi-pattern
+    // compatibility checks detect_warm_index_state already enforces for warm-index
+    // auto-routing, so run_index_query() silently ignored -v and printed the
+    // NON-inverted count with exit 0. --index combined with -v must fail closed
+    // (non-zero exit, error naming the flag) instead of silently returning the exact
+    // opposite result set.
+    assert!(
+        !indexed.status.success(),
+        "expected --index -v to fail closed instead of silently ignoring -v; stdout={} stderr={}",
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&indexed.stderr).to_lowercase();
+    assert!(
+        stderr.contains("invert") || stderr.contains("-v"),
+        "error should name the incompatible flag: stderr={stderr}"
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_word_regexp_fails_closed_instead_of_dropping_w() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-w")
+        .arg("--count")
+        .arg("hell")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1a: -w (word_regexp) is one of the compatibility checks detect_warm_index_state
+    // enforces for auto-routing; run_index_query() never consulted it at all, so
+    // "hell" (a substring of "hello", not a whole word) would have silently matched via
+    // plain substring search instead of either honoring word boundaries or refusing.
+    assert!(
+        !indexed.status.success(),
+        "expected --index -w to fail closed instead of silently ignoring -w; stdout={} stderr={}",
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_max_count_fails_closed_instead_of_dropping_m() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-m")
+        .arg("1")
+        .arg("--count")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1a: -m/--max-count is silently dropped by run_index_query today (it never reads
+    // args.max_count), so a request to cap matches per file was ignored outright.
+    assert!(
+        !indexed.status.success(),
+        "expected --index -m to fail closed instead of silently ignoring -m; stdout={} stderr={}",
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_glob_fails_closed_instead_of_dropping_g() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-g")
+        .arg("*.log")
+        .arg("--count")
+        .arg("error")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1a: -g/--glob is silently dropped by run_index_query today (it never reads
+    // args.globs), so a request scoped to *.log would have silently searched every
+    // indexed file instead.
+    assert!(
+        !indexed.status.success(),
+        "expected --index -g to fail closed instead of silently ignoring -g; stdout={} stderr={}",
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_short_fixed_string_matches_plain_search() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    // Cross-backend parity must go through --json's total_matches/matches, not --count:
+    // the plain/native path prints rg-compatible "path:count" per matching file, while
+    // run_index_query's --count prints a single aggregate number -- different shapes, not
+    // a bug, just not directly comparable (see match_tuples/total_matches usage elsewhere
+    // in this file for the established parity-check convention).
+    let plain_output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--json")
+        .arg("ok")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(plain_output.status.success());
+    let plain_json: Value = serde_json::from_slice(&plain_output.stdout).unwrap();
+    assert_eq!(
+        plain_json["total_matches"], 1,
+        "sanity: fixture should contain exactly one line matching 'ok'"
+    );
+
+    let indexed_output = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--json")
+        .arg("ok")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1b (audit): index.rs::search() hardwired fixed_strings to
+    // RegexCandidateSelection::Indexed unconditionally, even for patterns shorter than
+    // TRIGRAM_LEN (3 bytes) whose empty trigram set makes query_candidates_fixed return
+    // zero candidates -- producing a false "0 matches" instead of falling back to a full
+    // scan the way the regex branch already does via regex_candidate_selection's
+    // FullScan arm.
+    assert!(
+        indexed_output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed_output.stderr)
+    );
+    let indexed_json: Value = serde_json::from_slice(&indexed_output.stdout).unwrap();
+    assert_eq!(
+        indexed_json["total_matches"], plain_json["total_matches"],
+        "short fixed-string --index search must fall back to a full scan, not silently return 0"
+    );
+    assert_eq!(match_tuples(&indexed_json), match_tuples(&plain_json));
+}
+
+#[test]
+fn test_tg_search_explicit_index_unicode_ignore_case_matches_plain_search() {
+    let dir = tempdir().unwrap();
+    fs::write(
+        dir.path().join("unicode.txt"),
+        "Bienvenue au CAFÉ du coin\n",
+    )
+    .unwrap();
+
+    let plain_output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("-i")
+        .arg("--json")
+        .arg("café")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(plain_output.status.success());
+    let plain_json: Value = serde_json::from_slice(&plain_output.stdout).unwrap();
+    assert_eq!(
+        plain_json["total_matches"], 1,
+        "sanity: fixture line should case-insensitively contain 'café'"
+    );
+
+    let indexed_output = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-i")
+        .arg("--json")
+        .arg("café")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1c (audit): extract_file_trigrams (build side) lowercases with to_ascii_lowercase,
+    // a no-op on multi-byte UTF-8, but query_candidates_fixed (query side) lowercases
+    // with Unicode-aware str::to_lowercase -- so a non-ASCII ignore-case fixed string's
+    // query trigrams can never line up with the index's build-time trigrams for "CAFÉ",
+    // producing a false "0 matches".
+    assert!(
+        indexed_output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed_output.stderr)
+    );
+    let indexed_json: Value = serde_json::from_slice(&indexed_output.stdout).unwrap();
+    assert_eq!(
+        indexed_json["total_matches"], plain_json["total_matches"],
+        "non-ASCII ignore-case --index search must fall back to a full scan, not silently return 0"
+    );
+    assert_eq!(match_tuples(&indexed_json), match_tuples(&plain_json));
+}
+
+#[test]
+fn test_tg_search_explicit_index_no_ignore_flip_off_to_on_finds_newly_included_files() {
+    let dir = tempdir().unwrap();
+    if !init_git_repo(dir.path()) {
+        return;
+    }
+    fs::write(dir.path().join(".gitignore"), "secret.txt\n").unwrap();
+    fs::write(dir.path().join("visible.txt"), "shared_needle visible\n").unwrap();
+    fs::write(dir.path().join("secret.txt"), "shared_needle secret\n").unwrap();
+
+    // Build the index WITHOUT --no-ignore: secret.txt must not be indexed.
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("shared_needle")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+    let build_count: usize = String::from_utf8_lossy(&build.stdout)
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        build_count, 1,
+        "sanity: only visible.txt should be indexed by default"
+    );
+
+    // Re-query the SAME index directory, now WITH --no-ignore.
+    let requeried = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--no-ignore")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("shared_needle")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1d/D1 (audit): the on-disk index format never recorded the no_ignore mode it was
+    // built with, and staleness_reason()'s new-file scan was hardcoded .git_ignore(true)
+    // regardless of the current query's --no-ignore request -- so a --no-ignore query
+    // against an index built WITHOUT --no-ignore silently reused the stale index and
+    // MISSED secret.txt instead of rebuilding to include it.
+    assert!(
+        requeried.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&requeried.stderr)
+    );
+    let requeried_count: usize = String::from_utf8_lossy(&requeried.stdout)
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        requeried_count, 2,
+        "--no-ignore query must rebuild the index and include the gitignored file"
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_no_ignore_flip_on_to_off_does_not_leak_gitignored_matches() {
+    let dir = tempdir().unwrap();
+    if !init_git_repo(dir.path()) {
+        return;
+    }
+    fs::write(dir.path().join(".gitignore"), "secret.txt\n").unwrap();
+    fs::write(dir.path().join("visible.txt"), "shared_needle visible\n").unwrap();
+    fs::write(dir.path().join("secret.txt"), "shared_needle secret\n").unwrap();
+
+    // Build the index WITH --no-ignore: secret.txt is deliberately indexed.
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--no-ignore")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("shared_needle")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+    let build_count: usize = String::from_utf8_lossy(&build.stdout)
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        build_count, 2,
+        "sanity: --no-ignore build should index both visible.txt and secret.txt"
+    );
+
+    // Re-query the SAME index directory, now WITHOUT --no-ignore (the default).
+    let requeried = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("shared_needle")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // H1d/D2 (audit, info-disclosure): a default query (no --no-ignore) against an
+    // index built WITH --no-ignore silently reused the stale index and LEAKED
+    // secret.txt's gitignored content instead of rebuilding to exclude it.
+    assert!(
+        requeried.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&requeried.stderr)
+    );
+    let requeried_count: usize = String::from_utf8_lossy(&requeried.stdout)
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        requeried_count, 1,
+        "default query must rebuild the index and exclude the gitignored file, not leak it"
+    );
 }


### PR DESCRIPTION
Closes codex-audit H1 -- 5 SILENT-WRONG-RESULT bugs in `tg search --index` (exit 0, no warning -- the worst class for an agent-native tool), all empirically reproduced + fixed per the Backend Fail-Closed Contract (never silent-wrong: fail closed OR fall back visibly).

- **H1a** (main.rs handle_index_search): `--index` bypassed compat checks -> invert/context/max_count/word-regexp/globs/multi-pattern silently dropped (`-v` returned the BACKWARDS set). Now `bail!`s naming the flag, mirroring `detect_warm_index_state`.
- **H1b/H1c** (index.rs fixed_string_candidate_selection): short fixed-strings (<TRIGRAM_LEN) + non-ASCII ignore-case returned false-empty. Now FullScan-fallback (parity with native), mirroring the regex path's existing guard.
- **H1d** (index.rs): a `--no-ignore`-built index LEAKED gitignored secrets into later default queries. Now records `no_ignore` (INDEX_FORMAT_VERSION 3->4, old indexes safely rebuild) + staleness-on-mismatch, both directions closed.
- **H1e** (gate must-fix): `-S`/smart_case silently dropped on `--index --json` (native 3 vs index 2). HONORED it (index-doable): resolve case per-pattern at the `run_index_query` chokepoint (covers explicit --index AND warm auto-routing in one place).

**Opus gate: the 4 documented fixes verified correct/safe (fail-closed confirmed, format migration safe, both leak directions closed); it empirically found the 5th (smart_case) as a same-class residual -> fixed.** Real-binary RED->GREEN for every sub-bug (git-stash / before-after verified); 29 index + 81 routing tests; cargo fmt/clippy clean; docs/routing_policy.md updated with the fail-closed contract + -S-honored note. Non-blocking follow-ups tracked: #127 (require_git in non-git dirs), .ignore/.rgignore partial-parity.

`fix:` -> patch. Closes audit H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)