### PR TITLE
fix(backends): ast-grep exit-0 stdout parsers fail-closed on malformed JSON (audit #128 MED-3, Opus-gated)

### DIFF
--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -208,34 +208,42 @@ class AstGrepWrapperBackend(ComputeBackend):
 
         try:
             data_list = json.loads(stdout)
-            for item in data_list:
-                file_path = str(item.get("file") or fallback_file or "")
-                text = item.get("text", "")
-                match_range = item.get("range")
-                if not isinstance(match_range, dict):
-                    match_range = None
-                meta_variables = item.get("metaVariables")
-                if not isinstance(meta_variables, dict):
-                    meta_variables = None
-                start = match_range.get("start", {}) if match_range is not None else {}
-                if not isinstance(start, dict):
-                    start = {}
-                line_num = int(start.get("line", 0)) + 1  # 0-indexed to 1-indexed
+        except json.JSONDecodeError as exc:
+            raise BackendExecutionError(
+                f"ast-grep returned malformed JSON on stdout (exit 0): {exc}"
+            ) from exc
+        if not isinstance(data_list, list):
+            raise BackendExecutionError(
+                "ast-grep returned an unexpected JSON shape on stdout (exit 0): "
+                f"expected a list, got {type(data_list).__name__}"
+            )
 
-                matches.append(
-                    MatchLine(
-                        line_number=line_num,
-                        text=text,
-                        file=file_path,
-                        range=match_range,
-                        meta_variables=meta_variables,
-                    )
+        for item in data_list:
+            file_path = str(item.get("file") or fallback_file or "")
+            text = item.get("text", "")
+            match_range = item.get("range")
+            if not isinstance(match_range, dict):
+                match_range = None
+            meta_variables = item.get("metaVariables")
+            if not isinstance(meta_variables, dict):
+                meta_variables = None
+            start = match_range.get("start", {}) if match_range is not None else {}
+            if not isinstance(start, dict):
+                start = {}
+            line_num = int(start.get("line", 0)) + 1  # 0-indexed to 1-indexed
+
+            matches.append(
+                MatchLine(
+                    line_number=line_num,
+                    text=text,
+                    file=file_path,
+                    range=match_range,
+                    meta_variables=meta_variables,
                 )
-                if file_path and file_path not in seen_files:
-                    seen_files.add(file_path)
-                    matched_files.append(file_path)
-        except json.JSONDecodeError:
-            pass
+            )
+            if file_path and file_path not in seen_files:
+                seen_files.add(file_path)
+                matched_files.append(file_path)
 
         return SearchResult(
             matches=matches,
@@ -271,10 +279,15 @@ class AstGrepWrapperBackend(ComputeBackend):
     def _parse_json_items(self, stdout: str) -> list[dict[str, Any]]:
         try:
             loaded = json.loads(stdout)
-        except json.JSONDecodeError:
-            return []
+        except json.JSONDecodeError as exc:
+            raise BackendExecutionError(
+                f"ast-grep returned malformed JSON on stdout (exit 0): {exc}"
+            ) from exc
         if not isinstance(loaded, list):
-            return []
+            raise BackendExecutionError(
+                "ast-grep returned an unexpected JSON shape on stdout (exit 0): "
+                f"expected a list, got {type(loaded).__name__}"
+            )
         return [item for item in loaded if isinstance(item, dict)]
 
     def _run_ast_grep_command(

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -690,3 +690,122 @@ def test_ast_wrapper_backend_tolerates_per_path_access_warnings_with_findings(ca
 
     assert result.total_matches == 1
     assert "skipped unreadable paths" in capsys.readouterr().err
+
+
+# --- Backend Fail-Closed Contract: exit-0 malformed/wrong-shape JSON must raise,
+# not silently report a clean 0-match result (MED-3 audit fix). `[]` (or any
+# string parsing to a list) remains the ONE legitimate no-match shape -- see the
+# regression guard at the bottom of this block.
+
+
+def test_ast_wrapper_backend_should_raise_on_malformed_json_at_exit_zero_for_search():
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout='[{"file":"a.py","range"', stderr=""),
+        ),
+        pytest.raises(BackendExecutionError, match="malformed JSON"),
+    ):
+        backend.search(
+            "example.py",
+            "function_definition",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+
+def test_ast_wrapper_backend_should_raise_on_malformed_json_at_exit_zero_for_search_many():
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout='[{"file":"a.py","range"', stderr=""),
+        ),
+        pytest.raises(BackendExecutionError, match="malformed JSON"),
+    ):
+        backend.search_many(
+            ["example.py"],
+            "function_definition",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+
+def test_ast_wrapper_backend_should_raise_on_malformed_json_at_exit_zero_for_search_project():
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout='[{"file":"a.py","range"', stderr=""),
+        ),
+        pytest.raises(BackendExecutionError, match="malformed JSON"),
+    ):
+        backend.search_project("project", "sgconfig.yml")
+
+
+def test_ast_wrapper_backend_should_raise_on_non_list_json_shape_at_exit_zero_for_search():
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout='{"error":"sg internal panic"}', stderr=""),
+        ),
+        pytest.raises(BackendExecutionError, match="expected a list"),
+    ):
+        backend.search(
+            "example.py",
+            "function_definition",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+
+
+def test_ast_wrapper_backend_should_raise_on_non_list_json_shape_at_exit_zero_for_search_project():
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout='{"error":"sg internal panic"}', stderr=""),
+        ),
+        pytest.raises(BackendExecutionError, match="expected a list"),
+    ):
+        backend.search_project("project", "sgconfig.yml")
+
+
+def test_ast_wrapper_backend_should_treat_valid_empty_list_as_no_match_not_error():
+    """The 'obvious fix is wrong' regression guard: a valid empty list `[]` is the
+    ONE legitimate no-match shape and must NOT raise, on both the search() path
+    (_parse_result) and the search_project() path (_parse_json_items)."""
+    backend = AstGrepWrapperBackend()
+
+    with (
+        patch.object(backend, "is_available", return_value=True),
+        patch.object(backend, "_get_binary_name", return_value="sg"),
+        patch(
+            "tensor_grep.backends.ast_wrapper_backend.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="[]", stderr=""),
+        ),
+    ):
+        result = backend.search(
+            "example.py",
+            "function_definition",
+            config=SearchConfig(ast=True, lang="python"),
+        )
+        assert result.total_matches == 0
+        assert result.matched_file_paths == []
+
+        project_result = backend.search_project("project", "sgconfig.yml")
+        assert project_result == {}


### PR DESCRIPTION
## What

Closes #128 **MED-3** (codex external audit). The two exit-0 ast-grep stdout parsers in `ast_wrapper_backend.py` silently swallowed malformed JSON into an **empty** result — a Backend Fail-Closed Contract violation. Because `search_project` backs `tg scan --ruleset` (SAST-style scanning), a corrupt exit-0 stdout meant the **entire ruleset scan silently reported zero findings** — a false-negative on a security scan. (The prior audit fix only hardened the *nonzero*-exit path; returncode==0 did zero stdout-shape validation.)

## Fix

`_parse_result` and `_parse_json_items` each split into two explicit fail-closed checks:
- `json.JSONDecodeError` → `raise BackendExecutionError("...malformed JSON on stdout (exit 0)...")`
- parsed value is not a `list` → `raise BackendExecutionError("...expected a list, got {type}...")`

A **valid empty list `[]`** (the sole legitimate no-match shape ast-grep emits) STILL returns 0 matches — this is the "obvious-fix-is-wrong" guard the design-vet flagged: a naive raise-on-any-parse-issue would have broken the legitimate no-match case. `_stdout_is_json_payload` and the per-item `isinstance(dict)` filter are untouched.

## Verification

- **TDD RED→GREEN**: 5/6 new tests failed on the unmodified tree exactly as predicted (incl. the non-list case's accidental `AttributeError` fail-closed carrying the *wrong* message); the valid-`[]` regression guard passed pre-fix; **32/32 pass after fix**.
- Full `test_ast_wrapper_backend.py` + `ruff check` + `ruff format --check --preview` + `mypy src/tensor_grep` (77 files) clean; 8 sibling test files (pipeline / mcp / ast_workflows / parity) pass — zero regressions.
- **Mandatory adversarial Opus security gate (backends): SHIP** — all 5 checks pass: the valid-empty guard holds; the loop de-indent did not re-introduce a swallow (`return SearchResult(...)` at method-body indent; raises propagate through `search`/`search_many`/`search_project`); no caller converts the raise back into a silent empty (`search_project` callers fall back to `search_many` which re-raises → the `scan` command exits nonzero); distinct correctly-ordered branches; no new crash class (scalars / whitespace / mixed-list all fail-closed or unchanged).

`fix(backends):` → patch. Closes #128 (MED-3). MED-4 (session_daemon) / MED-5 (nested-gitignore) tracked separately on #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
