### PR TITLE
fix(inventory): --deadline no longer returns files=0 on a large tree (reserve phase-2 budget) + exit-2 on truncation (dogfood #130a)

### DIFF
--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -39,6 +39,13 @@ INVENTORY_SCHEMA_VERSION = 1
 # files and defeat the "whole-repo manifest" purpose.
 DEFAULT_MAX_INVENTORY_FILES = 50_000
 _LARGEST_FILES_LIMIT = 10
+# #130(a): the walk phase (_iter_repo_files) and the per-file stat/categorize loop below used to
+# share ONE deadline. On a big tree the walk alone can burn the entire --deadline budget, so the
+# per-file loop's very first `time.monotonic() >= deadline` check fires before it processes a
+# single file -- totals.files stays 0 even though the walk DID discover files (a misleading
+# silent-empty result). Reserving a fraction of the budget for the walk phase guarantees the
+# per-file loop always gets a real slice of wall-clock time to work with.
+_WALK_PHASE_DEADLINE_FRACTION = 0.7
 
 # Extension -> language label. Kept LOCAL rather than reusing repo_map._target_language_for_path
 # (python/js/ts/rust only, with 10 narrow symbol-navigation callers we must not perturb).
@@ -200,7 +207,19 @@ def build_inventory(
     # --deadline budget before the per-file loop further down even started (the 76s dogfood gap
     # on `tg inventory --deadline 30`). walk_deadline_hit folds into the per-file loop's own
     # deadline_hit local below, just like build_repo_map folds in its own walk-phase flag.
-    deadline = time.monotonic() + deadline_seconds if deadline_seconds is not None else None
+    #
+    # #130(a) fix: the walk phase gets only a FRACTION of the budget (walk_deadline), not the
+    # full deadline -- reserving the remainder for the per-file stat/categorize loop below, which
+    # still checks the FULL deadline. Without this split, a walk that (worst case) consumes its
+    # entire allotted time before returning leaves the per-file loop zero budget, so its first
+    # deadline check fires immediately and totals.files reads 0 despite a non-empty walk result.
+    start = time.monotonic()
+    deadline = start + deadline_seconds if deadline_seconds is not None else None
+    walk_deadline = (
+        start + deadline_seconds * _WALK_PHASE_DEADLINE_FRACTION
+        if deadline_seconds is not None
+        else None
+    )
     walk_deadline_hit = _DeadlineBreakFlag()
 
     # Probe one file past the cap: _iter_repo_files' bucketed early-stop (repo_map.py)
@@ -210,7 +229,10 @@ def build_inventory(
     # max_files files exist" apart from "more files exist" for the truncation notice,
     # without ever walking further than one file past the cap.
     walked = _iter_repo_files(
-        root, max_files=max_files + 1, deadline_monotonic=deadline, deadline_hit=walk_deadline_hit
+        root,
+        max_files=max_files + 1,
+        deadline_monotonic=walk_deadline,
+        deadline_hit=walk_deadline_hit,
     )
     possibly_truncated = False
     truncation_cause: str | None = None

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7455,8 +7455,15 @@ def inventory(
 
     if json_output:
         typer.echo(_json.dumps(payload))
-        return
-    typer.echo(render_inventory_text(payload))
+    else:
+        typer.echo(render_inventory_text(payload))
+
+    # #130(a) optional bundle: mirror `map`'s exit-2-on-scan-truncation contract (:7418-7419)
+    # -- a truncated scan (scan_limit.possibly_truncated, e.g. a fired --deadline) previously
+    # always exited 0, indistinguishable from a genuinely complete inventory. _scan_incomplete
+    # already checks exactly this payload's scan_limit.possibly_truncated shape.
+    if _scan_incomplete(payload):
+        raise typer.Exit(2)
 
 
 @app.command(name="docs-coverage")

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -273,6 +273,70 @@ class TestDeadline:
         assert inv["scan_limit"]["truncation_cause"] is None
         assert inv["totals"]["files"] == 10
 
+    def test_inventory_deadline_never_zero_when_files_were_discovered(self, tmp_path, monkeypatch):
+        # #130(a): live-repro'd bug -- `tg inventory PATH --deadline N` on a large workspace
+        # returns totals.files=0 despite the walk having discovered files. ROOT: build_inventory
+        # computed ONE deadline shared by the walk phase (_iter_repo_files) and the per-file
+        # stat/categorize loop. A walk that (worst case) burns 100% of its allotted budget before
+        # returning leaves nothing for the per-file loop -- its very first
+        # `time.monotonic() >= deadline` check fires immediately -- totals.files stays 0 even
+        # though `walked` is non-empty. This simulates exactly that worst case: the walk consumes
+        # whatever deadline it is handed, in full, then still returns discovered files.
+        real_files = [_write(tmp_path, f"f{i}.py", "x=1\n") for i in range(5)]
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(inventory_module.time, "monotonic", lambda: clock["t"])
+
+        def fake_iter_repo_files(
+            root, *, max_files=None, deadline_monotonic=None, deadline_hit=None, **kwargs
+        ):
+            # Worst-case walk: burns 100% of whatever budget it was given before returning,
+            # exactly like a huge tree eating the whole --deadline window -- yet still
+            # discovers (and returns) real files.
+            if deadline_monotonic is not None:
+                clock["t"] = deadline_monotonic
+            if deadline_hit is not None:
+                deadline_hit.hit = True
+            return list(real_files)
+
+        monkeypatch.setattr(inventory_module, "_iter_repo_files", fake_iter_repo_files)
+
+        inv = build_inventory(str(tmp_path), deadline_seconds=2.0)
+
+        assert inv["scan_limit"]["possibly_truncated"] is True
+        assert inv["scan_limit"]["truncation_cause"] == "deadline"
+        # The core bug under test: files WERE discovered (the walk returned a non-empty list)
+        # but the per-file loop got zero time to process any of them -- a misleading silent-empty
+        # result rather than an honest partial floor.
+        assert inv["totals"]["files"] > 0
+
+    def test_inventory_walk_phase_reserves_stat_loop_budget(self, tmp_path, monkeypatch):
+        # #130(a): the fix reserves a SLICE of deadline_seconds for phase 2 (the per-file stat
+        # loop) by passing a smaller walk_deadline -- not the full deadline -- into
+        # _iter_repo_files. Freeze the clock so "the overall deadline" is a known, exact value:
+        # a loose "< now + deadline_seconds" bound measured around the call would pass even
+        # pre-fix, since some real wall-clock time always elapses during the call itself.
+        monkeypatch.setattr(inventory_module.time, "monotonic", lambda: 1000.0)
+        seen_deadlines: list[float | None] = []
+
+        def spy_iter_repo_files(root, *, max_files=None, deadline_monotonic=None, **kwargs):
+            seen_deadlines.append(deadline_monotonic)
+            return []
+
+        monkeypatch.setattr(inventory_module, "_iter_repo_files", spy_iter_repo_files)
+
+        deadline_seconds = 10.0
+        build_inventory(str(tmp_path), deadline_seconds=deadline_seconds)
+
+        assert seen_deadlines, "the walker was never called"
+        walk_deadline = seen_deadlines[0]
+        overall_deadline = 1000.0 + deadline_seconds
+        assert walk_deadline is not None
+        # Phase 2 must be guaranteed a real, non-zero slice of the budget: the walk's own
+        # deadline must be a genuine reservation, not the full overall deadline.
+        assert walk_deadline < overall_deadline
+        assert walk_deadline > 1000.0  # phase 1 still gets a positive slice, not zero
+
 
 class TestRegistration:
     def test_cli_default_max_files_matches_module_constant(self):
@@ -334,3 +398,94 @@ class TestDeadlineCliWiring:
             tg_main.app, ["inventory", str(tmp_path), "--deadline", "0.001"]
         )
         assert result.exit_code == 2
+
+    def test_inventory_exits_2_when_scan_possibly_truncated_json(self, tmp_path, monkeypatch):
+        # #130(a) optional bundle: the CLI never inspected scan_limit.possibly_truncated and
+        # always exited 0, mirroring neither `map`'s nor the symbol-command exit-2 contract for a
+        # truncated (e.g. --deadline-fired) scan. This is agent-observable: a script that only
+        # checks $? cannot tell "complete inventory" from "silently truncated inventory".
+        from typer.testing import CliRunner
+
+        from tensor_grep.cli import main as tg_main
+
+        def _spy(path, *, max_files=None, deadline_seconds=None):
+            return {
+                "totals": {"files": 3, "bytes": 30},
+                "binary": {"files": 0, "bytes": 0},
+                "languages": [],
+                "categories": [],
+                "top_level_dirs": [],
+                "largest_files": [],
+                "path": str(path),
+                "scan_limit": {
+                    "max_files": 50_000,
+                    "scanned_files": 3,
+                    "possibly_truncated": True,
+                    "truncation_cause": "deadline",
+                },
+            }
+
+        monkeypatch.setattr("tensor_grep.cli.inventory.build_inventory", _spy)
+        result = CliRunner().invoke(
+            tg_main.app, ["inventory", str(tmp_path), "--deadline", "5", "--json"]
+        )
+        assert result.exit_code == 2
+        # The payload must still be emitted (exit 2 signals "partial", not "nothing produced") --
+        # same "output the full payload FIRST, then exit 2" contract as `map`.
+        payload = json.loads(result.output)
+        assert payload["scan_limit"]["possibly_truncated"] is True
+
+    def test_inventory_exits_0_when_scan_not_truncated_json(self, tmp_path, monkeypatch):
+        # Regression pin: a complete (non-truncated) scan must stay exit 0.
+        from typer.testing import CliRunner
+
+        from tensor_grep.cli import main as tg_main
+
+        def _spy(path, *, max_files=None, deadline_seconds=None):
+            return {
+                "totals": {"files": 1, "bytes": 10},
+                "binary": {"files": 0, "bytes": 0},
+                "languages": [],
+                "categories": [],
+                "top_level_dirs": [],
+                "largest_files": [],
+                "path": str(path),
+                "scan_limit": {
+                    "max_files": 50_000,
+                    "scanned_files": 1,
+                    "possibly_truncated": False,
+                    "truncation_cause": None,
+                },
+            }
+
+        monkeypatch.setattr("tensor_grep.cli.inventory.build_inventory", _spy)
+        result = CliRunner().invoke(tg_main.app, ["inventory", str(tmp_path), "--json"])
+        assert result.exit_code == 0, result.output
+
+    def test_inventory_exits_2_when_scan_possibly_truncated_text_mode(self, tmp_path, monkeypatch):
+        # The exit-2 gate must fire in text-output mode too, not just --json.
+        from typer.testing import CliRunner
+
+        from tensor_grep.cli import main as tg_main
+
+        def _spy(path, *, max_files=None, deadline_seconds=None):
+            return {
+                "totals": {"files": 3, "bytes": 30},
+                "binary": {"files": 0, "bytes": 0},
+                "languages": [],
+                "categories": [],
+                "top_level_dirs": [],
+                "largest_files": [],
+                "path": str(path),
+                "scan_limit": {
+                    "max_files": 50_000,
+                    "scanned_files": 3,
+                    "possibly_truncated": True,
+                    "truncation_cause": "deadline",
+                },
+            }
+
+        monkeypatch.setattr("tensor_grep.cli.inventory.build_inventory", _spy)
+        result = CliRunner().invoke(tg_main.app, ["inventory", str(tmp_path), "--deadline", "5"])
+        assert result.exit_code == 2
+        assert "inventory:" in result.output  # render_inventory_text output still printed


### PR DESCRIPTION
## What

Closes #130 item **(a)** [P0 dogfood, CEO-relayed 2026-07-10]. `tg inventory PATH --deadline N` on a large workspace returned `totals.files=0` with `truncation_cause=deadline` — a **misleading silent-empty**. Root cause: `build_inventory` shared ONE deadline between phase-1 (the `_iter_repo_files` discovery walk) and phase-2 (the per-file stat/count loop, where `total_files` increments); on a big tree the walk consumed the entire budget, so phase-2's `if time.monotonic() >= deadline: break` fired on iteration 1 → `files=0` despite a non-empty walk.

## Fix

`src/tensor_grep/cli/inventory.py`: reserve a slice of the budget for phase-2 — new `_WALK_PHASE_DEADLINE_FRACTION = 0.7`; `build_inventory` now passes `walk_deadline = start + deadline_seconds * 0.7` into `_iter_repo_files`, while the per-file loop keeps checking the **full** deadline. Total wall-clock stays capped at `deadline_seconds`, but phase-2 is guaranteed ~30% of it. **`_iter_repo_files`'s signature/contract is untouched** (12 call sites).

Plus the honesty bundle: the `inventory()` CLI command now **exits 2 on `possibly_truncated`** (via the existing `_scan_incomplete` helper, mirroring `map`/`context-render`/`blast-radius`) instead of a silent exit-0 — so an agent gating on the exit code sees the truncation.

## Verification

- **TDD RED→GREEN**: both new tests failed on the unmodified tree exactly as predicted (`files=0`; the reserved `walk_deadline` == the full deadline, i.e. no reservation existed); both pass after the fix.
- 33 inventory tests + **66 blast-radius tests** (the `_iter_repo_files` contract consumers — `test_repo_map_deadline`/`test_repo_map_targets`) pass, confirming the walk contract is genuinely unchanged; `ruff check` + `ruff format --check --preview` + `mypy src/tensor_grep` (77 files) clean.
- **Live real-binary dogfood** (the spec's exact repro, not CliRunner): `tg inventory C:/dev/projects --deadline 5 --json` → `scanned_files` went **0 → 341**, exit code **0 → 2**.

Gate-free (`inventory.py` + `cli/main.py` — not a gated surface: not apply_policy/mcp/cpu_backend/index_lock/session_daemon/backends). `fix(inventory):` → patch. Closes #130 (a); (b) doctor / (d) checkpoint tracked on #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
