### PR TITLE
fix(checkpoint): tg checkpoint create no longer crashes on a git submodule/embedded repo + discloses skipped nested repos (dogfood #130d, Opus-gated)

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -158,6 +158,10 @@ class CheckpointCreateResult:
     file_count: int
     undo_argv: list[str]
     undo_command: str
+    # audit #130d: paths skipped because they are a nested repo (a git submodule / embedded
+    # repo tracked as a gitlink, mode 160000) rather than a plain tracked file. Additive
+    # field, default-empty, so every existing caller/serializer stays backward-compatible.
+    skipped_nested_repos: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -534,7 +538,26 @@ def _write_index(root: Path, records: list[CheckpointRecord]) -> None:
     _write_json_atomic(index_path, [asdict(record) for record in records])
 
 
-def _git_snapshot_entries(root: Path) -> dict[str, bool]:
+def _git_snapshot_entries(root: Path) -> tuple[dict[str, bool], list[str]]:
+    """Return (entries, skipped_nested_repos) for a git-worktree-snapshot checkpoint scope.
+
+    audit #130d: `git ls-files` reports a submodule / embedded repo (any path tracked as a
+    gitlink, mode 160000 -- e.g. `benchmarks/external_repos/chalk`) as ONE path; it is never
+    expanded into the nested repo's own tracked files. That path is a real DIRECTORY on disk,
+    so treating it like an ordinary file entry marks a directory as an existing entry, and
+    `create_checkpoint`'s copy loop then calls `shutil.copy2()` on a directory and crashes
+    (`IsADirectoryError` on POSIX, `PermissionError` on Windows). Skip any entry that is a
+    real directory on disk -- it can never be a plain tracked file -- and report it separately
+    so the gap is DISCLOSED (never a silent under-cover), instead of raising or silently
+    dropping it with no trace.
+
+    The directory check excludes symlinks (`is_dir() and not is_symlink()`): a tracked
+    SYMLINK whose target happens to be a directory is a normal file entry (git stores it as a
+    mode-120000 blob, not a gitlink) and was already handled correctly by the copy loop's
+    `shutil.copy2(..., follow_symlinks=False)`, which copies the link itself rather than
+    opening its target. Treating that case as a "nested repo" would silently drop a
+    legitimately tracked path instead of skipping only genuine gitlink directories.
+    """
     git_timeout = configured_git_timeout_seconds()
     tracked = run_subprocess(
         ["git", "-C", str(root), "ls-files", "-z"],
@@ -552,14 +575,19 @@ def _git_snapshot_entries(root: Path) -> dict[str, bool]:
     ).stdout.split(b"\x00")
 
     entries: dict[str, bool] = {}
+    skipped_nested_repos: list[str] = []
     for raw in [*tracked, *untracked]:
         if not raw:
             continue
         rel = raw.decode("utf-8", errors="surrogateescape")
         if _CHECKPOINT_DIRNAME in Path(rel).parts:
             continue
-        entries[rel] = (root / rel).exists()
-    return dict(sorted(entries.items()))
+        candidate = root / rel
+        if candidate.is_dir() and not candidate.is_symlink():
+            skipped_nested_repos.append(rel)
+            continue
+        entries[rel] = candidate.exists()
+    return dict(sorted(entries.items())), sorted(skipped_nested_repos)
 
 
 def _filesystem_snapshot_entries(root: Path) -> dict[str, bool]:
@@ -585,12 +613,19 @@ def _filesystem_snapshot_entries(root: Path) -> dict[str, bool]:
     return dict(sorted(entries.items()))
 
 
-def _snapshot_entries(scope: _CheckpointScope) -> dict[str, bool]:
+def _snapshot_entries(scope: _CheckpointScope) -> tuple[dict[str, bool], list[str]]:
+    """Return (entries, skipped_nested_repos) for the given checkpoint scope.
+
+    Only the git-worktree-snapshot path can produce a nonempty ``skipped_nested_repos``
+    (audit #130d) -- a single-file scope has nothing to skip, and the filesystem-snapshot
+    walk (`os.walk`, non-git-toplevel scopes) only ever adds filenames, never a gitlink-shaped
+    directory entry, so it has no equivalent hazard.
+    """
     if scope.target_relative is not None:
-        return {scope.target_relative.as_posix(): (scope.root / scope.target_relative).exists()}
+        return {scope.target_relative.as_posix(): (scope.root / scope.target_relative).exists()}, []
     if scope.mode == "git-worktree-snapshot":
         return _git_snapshot_entries(scope.root)
-    return _filesystem_snapshot_entries(scope.root)
+    return _filesystem_snapshot_entries(scope.root), []
 
 
 def _checkpoint_dir(root: Path, checkpoint_id: str) -> Path:
@@ -630,6 +665,11 @@ def _write_checkpoint_metadata(
         "created_at": result.created_at,
         "file_count": result.file_count,
         "entries": entries,
+        # audit #130d: disclose what create_checkpoint skipped (nested repos / submodules)
+        # so `tg checkpoint create --json` and a later `load_checkpoint_metadata` never
+        # silently under-cover -- mirrors the honesty culture of resolution_gaps /
+        # deadline_limit / possibly_truncated elsewhere in this codebase.
+        "skipped_nested_repos": result.skipped_nested_repos,
         "active": True,
     }
     _write_json_atomic(_metadata_path(root, result.checkpoint_id), payload)
@@ -789,7 +829,7 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
     mode = scope.mode
     created_at = datetime.now(UTC).isoformat()
     checkpoint_id = f"ckpt-{datetime.now(UTC).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:8]}"
-    entries = _snapshot_entries(scope)
+    entries, skipped_nested_repos = _snapshot_entries(scope)
 
     # audit H4: refuse BEFORE any snapshot directory exists if the copy would blow a
     # configured size/free-space budget -- see _check_checkpoint_disk_budget.
@@ -830,6 +870,7 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
         file_count=len(entries),
         undo_argv=_undo_argv(scope, checkpoint_id),
         undo_command=_display_command(_undo_argv(scope, checkpoint_id)),
+        skipped_nested_repos=skipped_nested_repos,
     )
     _write_checkpoint_metadata(
         root,
@@ -1219,7 +1260,11 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
     if scope_kind == "file":
         current_entries: dict[str, bool] = {}
     elif mode == "git-worktree-snapshot":
-        current_entries = _git_snapshot_entries(root)
+        # audit #130d: the is_dir() gitlink skip lives inside _git_snapshot_entries itself
+        # (not just the create-time copy loop), so a nested-repo directory is excluded from
+        # this re-scan too -- otherwise it would show up as "in the tree but not in the
+        # snapshot" below and the removal branch would try to unlink() a directory.
+        current_entries, _skipped_nested_repos_now = _git_snapshot_entries(root)
     else:
         current_entries = _filesystem_snapshot_entries(root)
     expected_paths = set(entries.keys())

--- a/tests/unit/test_checkpoint_cli.py
+++ b/tests/unit/test_checkpoint_cli.py
@@ -914,3 +914,207 @@ def test_checkpoint_create_and_undo_reports_git_mode(tmp_path: Path) -> None:
     assert restored["mode"] == "git-worktree-snapshot"
     assert source_file.read_text(encoding="utf-8") == "print('before')\n"
     assert not untracked.exists()
+
+
+# --- audit #130d: checkpoint create on a repo containing a git submodule / embedded repo ---
+#
+# `git ls-files` reports a submodule (or any nested repo tracked as a gitlink, mode 160000)
+# as ONE path -- it never expands into the submodule's own tracked files -- and that path is
+# a real directory on disk (e.g. `benchmarks/external_repos/chalk` in this very repo). Before
+# the fix, `_git_snapshot_entries` had no `is_dir()` guard, so the gitlink path was recorded
+# as an existing entry and `create_checkpoint`'s copy loop tried `shutil.copy2()` on a
+# directory, crashing (`IsADirectoryError` on POSIX, `PermissionError` on Windows -- the OS
+# error class differs by platform, but both are avoided entirely by skipping the entry).
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tg@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "tensor-grep"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_commit_all(path: Path, message: str) -> None:
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _add_nested_repo_as_gitlink(project: Path, rel_path: str) -> Path:
+    """Create a standalone nested git repo at ``project/rel_path`` and register it in
+    ``project``'s index as a gitlink (mode 160000) -- the same on-disk shape as a real
+    ``git submodule add`` (a tracked directory containing its own ``.git``), without needing
+    submodule/protocol machinery in the test fixture.
+
+    Reproduces the ``benchmarks/external_repos/chalk``-style embedded-repo layout that
+    crashes ``checkpoint create`` (audit #130d): the gitlink path is a real directory on
+    disk that ``git ls-files`` reports as a single tracked path, never expanded.
+    """
+    nested = project / rel_path
+    nested.mkdir(parents=True)
+    _init_git_repo(nested)
+    (nested / "file.txt").write_text("nested\n", encoding="utf-8")
+    _git_commit_all(nested, "nested-init")
+    nested_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=nested,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "update-index", "--add", "--cacheinfo", f"160000,{nested_sha},{rel_path}"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return nested
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for git checkpoint tests")
+def test_create_checkpoint_skips_git_submodule_without_crashing(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "tracked.py").write_text("print('hi')\n", encoding="utf-8")
+    _init_git_repo(project)
+    _git_commit_all(project, "init")
+    _add_nested_repo_as_gitlink(project, "vendor/nested_repo")
+    _git_commit_all(project, "add gitlink")
+
+    from tensor_grep.cli import checkpoint_store
+
+    result = checkpoint_store.create_checkpoint(str(project))
+
+    assert result.mode == "git-worktree-snapshot"
+    assert result.file_count == 1
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for git checkpoint tests")
+def test_create_checkpoint_discloses_skipped_nested_repo(tmp_path: Path) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "tracked.py").write_text("print('hi')\n", encoding="utf-8")
+    _init_git_repo(project)
+    _git_commit_all(project, "init")
+    _add_nested_repo_as_gitlink(project, "vendor/nested_repo")
+    _git_commit_all(project, "add gitlink")
+
+    from tensor_grep.cli import checkpoint_store
+
+    result = checkpoint_store.create_checkpoint(str(project))
+
+    assert result.skipped_nested_repos == ["vendor/nested_repo"]
+
+    metadata = checkpoint_store.load_checkpoint_metadata(result.checkpoint_id, str(project))
+    assert metadata["skipped_nested_repos"] == ["vendor/nested_repo"]
+    # The excluded entry must never reach `entries` -- that's what `undo_checkpoint`'s
+    # pre-flight iterates, and a phantom directory entry there would choke it on undo.
+    assert "vendor/nested_repo" not in metadata["entries"]
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for git checkpoint tests")
+def test_create_checkpoint_scoped_to_subdir_still_captures_all_files(tmp_path: Path) -> None:
+    """Regression: checkpointing a subdirectory (not git top-level) takes the
+    filesystem-snapshot path (_filesystem_snapshot_entries), which the new is_dir() gitlink
+    skip in _git_snapshot_entries never touches -- it must keep capturing every file exactly
+    as it did before this fix."""
+    project = tmp_path / "repo"
+    project.mkdir()
+    source_dir = project / "src"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("print('a')\n", encoding="utf-8")
+    (source_dir / "b.py").write_text("print('b')\n", encoding="utf-8")
+    nested_dir = source_dir / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "c.py").write_text("print('c')\n", encoding="utf-8")
+    _init_git_repo(project)
+    _git_commit_all(project, "init")
+
+    from tensor_grep.cli import checkpoint_store
+
+    result = checkpoint_store.create_checkpoint(str(source_dir))
+
+    assert result.mode == "filesystem-snapshot"
+    assert result.file_count == 3
+    metadata = checkpoint_store.load_checkpoint_metadata(result.checkpoint_id, str(source_dir))
+    assert sorted(metadata["entries"].keys()) == ["a.py", "b.py", "nested/c.py"]
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for git checkpoint tests")
+def test_create_checkpoint_then_undo_is_clean_with_skipped_submodule(tmp_path: Path) -> None:
+    """e2e: the excluded gitlink entry is absent from metadata, so undo_checkpoint's
+    pre-flight (which iterates every metadata entry) never chokes on a phantom directory --
+    and undo's restore/removal sweep must leave the nested repo itself untouched."""
+    project = tmp_path / "repo"
+    project.mkdir()
+    tracked_file = project / "tracked.py"
+    tracked_file.write_text("print('before')\n", encoding="utf-8")
+    _init_git_repo(project)
+    _git_commit_all(project, "init")
+    _add_nested_repo_as_gitlink(project, "vendor/nested_repo")
+    _git_commit_all(project, "add gitlink")
+
+    from tensor_grep.cli import checkpoint_store
+
+    result = checkpoint_store.create_checkpoint(str(project))
+    tracked_file.write_text("print('after')\n", encoding="utf-8")
+
+    restored = checkpoint_store.undo_checkpoint(result.checkpoint_id, str(project))
+
+    assert restored.mode == "git-worktree-snapshot"
+    assert tracked_file.read_text(encoding="utf-8") == "print('before')\n"
+    assert (project / "vendor" / "nested_repo" / "file.txt").exists()
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for git checkpoint tests")
+def test_create_checkpoint_does_not_skip_tracked_symlink_to_directory(tmp_path: Path) -> None:
+    """The is_dir() gitlink-skip guard must not swallow a legitimately tracked SYMLINK whose
+    target happens to be a directory -- git stores that as a mode-120000 blob (a normal file
+    entry), not a gitlink, and it was already handled correctly by the copy loop's
+    `shutil.copy2(..., follow_symlinks=False)` (copies the link itself). Only a genuine
+    nested-repo directory (no .git-boundary symlink involved) should ever be skipped."""
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "tracked.py").write_text("print('hi')\n", encoding="utf-8")
+    outside_target = tmp_path / "outside_target"
+    outside_target.mkdir()
+    (outside_target / "inner.txt").write_text("target content\n", encoding="utf-8")
+    try:
+        (project / "link_to_dir").symlink_to(outside_target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+    _init_git_repo(project)
+    _git_commit_all(project, "init")
+
+    from tensor_grep.cli import checkpoint_store
+
+    result = checkpoint_store.create_checkpoint(str(project))
+
+    assert result.skipped_nested_repos == []
+    assert result.file_count == 2
+
+    snapshot = checkpoint_store._snapshot_path(project, result.checkpoint_id)
+    snapshotted_link = snapshot / "link_to_dir"
+    assert snapshotted_link.is_symlink()
+    # audit HIGH (symlink disclosure, pre-existing contract): the snapshot must never contain
+    # the out-of-root target's content under a regular file.
+    for path in snapshot.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            assert "target content" not in path.read_text(encoding="utf-8", errors="ignore")


### PR DESCRIPTION
## What

Closes #130 item **(d)** [P1 dogfood]. `tg checkpoint create` on a repo containing a git submodule / embedded repo **crashed** — `_git_snapshot_entries` marked the gitlink **directory** as a file entry, and `create_checkpoint`'s copy loop did `shutil.copy2(<dir>)` → crash (`IsADirectoryError` on POSIX / `PermissionError` on Windows). #508 made the failure non-littering but did **not** fix the crash (distinct from #508's confinement/disk-budget work).

## Fix

`checkpoint_store.py`: `_git_snapshot_entries` now skips entries that are `is_dir() and not is_symlink()` (nested-repo gitlinks), collects them into a new `skipped_nested_repos` list threaded up through `_snapshot_entries` → `create_checkpoint` → an **additive** `CheckpointCreateResult.skipped_nested_repos` field + a `metadata.json` key. It surfaces automatically in `--json` and MCP output (both spread `result.__dict__`) — the checkpoint **discloses** what it skipped instead of silently under-covering.

Two proactive hardenings beyond the finding (both Opus-gate-verified):
- **`not is_symlink()`** in the guard: `Path.is_dir()` *follows* symlinks, so a legitimately tracked symlink-to-a-directory (git mode 120000, correctly stored by the existing `copy2(follow_symlinks=False)`) must NOT be reclassified as a nested repo and dropped — closing a would-be silent-data-loss vector.
- The fix lives in the **shared** `_git_snapshot_entries`, so the `undo_checkpoint` re-scan path (which would otherwise `unlink()` a gitlink directory) is fixed too.

## Verification

- **TDD RED→GREEN**: fixture with a real gitlink (mode 160000, via `git update-index --cacheinfo`); 3/4 new tests crashed at the pinned copy line on the unmodified tree; all pass after. Plus a 5th test proving a tracked dir-symlink is preserved (not skipped/disclosed) and an e2e `create → undo` test proving the nested repo survives untouched.
- **72 checkpoint tests + 565 blast-radius tests** (every consumer of `create_checkpoint`/`undo_checkpoint`/MCP `tg_checkpoint_create`) + `ruff` + `ruff format --check --preview` + `mypy src/tensor_grep` (77 files) clean.
- **Mandatory adversarial Opus gate (checkpoint_store is MCP-reachable + #508-adjacent): SHIP** — all 5 checks pass: guard correct with no new disclosure/TOCTOU vector (empirically Windows-validated: tracked symlink-to-dir preserved, out-of-root symlink target not leaked); tuple-threading complete across all 3 call sites with no fail-open; disclosure repo-relative + confined; undo correct (no phantom `unlink`); #508 H3 (`_resolve_within_root`) / H4 (disk budget) intact.

`fix(checkpoint):` → patch. Closes #130 (d). (b) doctor tracked on #130 (builds after #515 merges — same `ast_wrapper_backend.py` file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
