### PR TITLE
fix(bench): GPU benchmark tg-extractor reads native `line` key, not `line_number` (#131 F2)

### DIFF
--- a/benchmarks/run_gpu_native_benchmarks.py
+++ b/benchmarks/run_gpu_native_benchmarks.py
@@ -421,7 +421,11 @@ def _extract_tg_match_signatures(payload: dict[str, object]) -> list[tuple[str, 
     for match in matches:
         if not isinstance(match, dict):
             continue
-        line_number = match.get("line_number")
+        # Native tg search JSON (SearchMatchJson in rust_core/src/main.rs) emits
+        # the line number under the key `line`; the rg-passthrough serializer uses
+        # `line_number`. Read `line` first, fall back to `line_number` so both the
+        # native `--gpu-device-ids` path and the CPU/rg path parse correctly (#131 F2).
+        line_number = match.get("line", match.get("line_number"))
         if not isinstance(line_number, int):
             line_number = 0
         signatures.append((


### PR DESCRIPTION
## What

Closes #131 item **F2** [GPU benchmark correctness]. The GPU-native benchmark's tg-match extractor read the **wrong JSON key**, so its GPU-vs-baseline line-number identity check silently compared all-zeros against real line numbers — invalidating the correctness comparison the benchmark exists to prove.

## Root cause

`benchmarks/run_gpu_native_benchmarks.py::_extract_tg_match_signatures` read `match.get("line_number")`. But the **native** tg search serializer — `SearchMatchJson` in `rust_core/src/main.rs` (constructed at :5464/:5487/:5994, value from `matched.line_number`) — emits the line number under the JSON key **`line`**, not `line_number`. The native path is exactly what `tg search --gpu-device-ids --json` hits, so every native match's line number parsed as `None` → coerced to `0`.

(The CPU/rg-passthrough serializer *does* use `line_number`, which is why this went unnoticed on non-native runs.)

## Fix

Read `line` first, fall back to `line_number`:

```python
line_number = match.get("line", match.get("line_number"))
```

This makes the native `--gpu-device-ids` path parse correctly while keeping the CPU/rg path and the existing `MatchLine` integration fixtures (which use `line_number`) working. The sibling `_extract_rg_json_match_signatures` is intentionally left on `line_number` — ripgrep's `--json` genuinely uses that key.

## Verification

- No test directly exercises the JSON extractor's field (grep-confirmed: `test_multi_gpu_distribution.py` uses the `MatchLine` dataclass path, `line_number=1`, not the JSON parser) — so the fallback is purely additive, nothing regresses.
- `py_compile` OK; `ruff check` + `ruff format --check --preview` clean on the file.

`fix(bench):` → patch (benchmark-only, no shipped-package change). Closes #131 (F2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
