### PR TITLE
test(evidence): de-flake receipt json-vs-dict test (release-blocker on windows py3.12)

### DIFF
--- a/tests/unit/test_evidence_receipt.py
+++ b/tests/unit/test_evidence_receipt.py
@@ -206,7 +206,14 @@ def test_receipt_top_level_blocks_are_all_present_even_when_every_source_is_abse
         assert block_name in receipt, f"missing stable block: {block_name}"
 
 
-def test_build_evidence_receipt_json_matches_python_payload(git_repo: Path) -> None:
+def test_build_evidence_receipt_json_matches_python_payload(git_repo: Path, monkeypatch) -> None:
+    # Freeze the timestamp: the dict build and the JSON build are two SEPARATE calls, each
+    # stamping created_at = _utc_now_iso() at its own moment. Under CI load the two calls can
+    # straddle a clock-tick, giving different created_at values -> the dicts differ and the
+    # equality assertion fails intermittently (observed on windows-latest py3.12, blocking a
+    # release). Pinning _utc_now_iso makes both builds deterministic without weakening the check.
+    monkeypatch.setattr(evidence_receipt, "_utc_now_iso", lambda: "2026-01-01T00:00:00+00:00")
+
     receipt = evidence_receipt.build_evidence_receipt(git_repo)
     receipt_json = evidence_receipt.build_evidence_receipt_json(git_repo)
 


### PR DESCRIPTION
## What
Hotfix for a **release-blocking flake**: `test_build_evidence_receipt_json_matches_python_payload` failed on `windows-latest py3.12` in the **v1.61.1 release run**, blocking publish.

## Root cause
The test builds the receipt **twice** -- `build_evidence_receipt` (dict) then `build_evidence_receipt_json` (JSON) -- and asserts equality. Each call stamps `created_at = _utc_now_iso()` at its own moment (evidence_receipt.py:613). Under CI load the two builds straddle a clock-tick -> different `created_at` -> the dicts differ -> intermittent failure. (Passes locally / on fast machines where both builds land in the same second.)

## Fix
`monkeypatch` `_utc_now_iso` to a fixed value so both builds are deterministic. The assertion (JSON round-trips the dict) is unchanged.

## Verification
Passes **3x** locally (deterministic by construction); **39/39** `test_evidence_receipt` tests pass; ruff clean. Meanwhile I re-ran the failed v1.61.1 job to unblock the immediate release.

`test:` -> no release. Prevents this flake from re-blocking future release runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)