### PR TITLE
feat(orient): auto de-weight bundled vendor/skill/generated CODE subtrees in centrality (#132)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7574,6 +7574,16 @@ def orient(
             "otherwise rank as 'central' on a harness repo. Repeatable."
         ),
     ),
+    no_auto_deweight: bool = typer.Option(
+        False,
+        "--no-auto-deweight",
+        help=(
+            "Disable auto de-weighting of detected vendor/skill/generated CODE subtrees (nested "
+            "package manifest + import-island or name prior). De-weighting is ON by default and "
+            "only LOWERS a subtree's centrality score -- it never excludes files; use --ignore for "
+            "a hard exclude."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit the capsule as JSON"),
 ) -> None:
     """Emit a one-call codebase orientation capsule (central files, entry points, AST snippets)."""
@@ -7587,11 +7597,16 @@ def orient(
                     max_tokens=max_tokens,
                     max_central_files=max_central_files,
                     ignore=tuple(ignore),
+                    auto_deweight=not no_auto_deweight,
                 )
             )
             return
         payload = build_orient_capsule(
-            path, max_tokens=max_tokens, max_central_files=max_central_files, ignore=tuple(ignore)
+            path,
+            max_tokens=max_tokens,
+            max_central_files=max_central_files,
+            ignore=tuple(ignore),
+            auto_deweight=not no_auto_deweight,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)
@@ -7601,6 +7616,10 @@ def orient(
     typer.echo(f"central files ({len(payload['central_files'])}):")
     for cf in payload["central_files"]:
         typer.echo(f"  {cf['file']}  (in-degree={cf['graph_score']})")
+    if payload["deweighted_trees"]:
+        typer.echo(f"deweighted_trees ({len(payload['deweighted_trees'])}):")
+        for tree in payload["deweighted_trees"]:
+            typer.echo(f"  {tree['path']}  ({', '.join(tree['reasons'])})")
     typer.echo(
         f"entry_points={len(payload['entry_points'])} "
         f"snippets={len(payload['snippets'])} ~{payload['token_estimate']} tokens"

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -44,6 +44,28 @@ _CENTRAL_NON_CODE_SUFFIXES = _CENTRAL_DOC_SUFFIXES | _CENTRAL_CONFIG_DATA_SUFFIX
 _CENTRAL_FAN_IN_CAP = 12
 _CENTRAL_SYMBOL_DENSITY_CAP = 25
 
+# Auto de-weight (never hard-exclude) bundled vendor/skill/generated CODE subtrees so `tg orient`/
+# `tg agent` surface real product code without a manual `--ignore` (#55 PR6). A subtree fires ONLY on
+# STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK (name prior)):
+#   STRONG-1 -- a directory below the repo root contains its own manifest, reusing the same marker
+#     set `_path_has_project_marker` (main.py) uses for broad-scan workspace-project detection.
+#   STRONG-2 -- an import island: no file OUTSIDE the subtree resolves an import INTO it (computed
+#     from the same resolved-import graph the centrality ranking builds).
+#   WEAK -- a name prior (vendor/, third_party/, skills/, external_repos/, _vendored/, node_modules/):
+#     a TIE-BREAKER only, never sufficient alone.
+# A monorepo subproject that HAS a manifest but IS imported across the repo is protected by STRONG-2
+# (not an island) -- de-weight, never exclude, is what keeps a false positive from hiding real product
+# code (the file can still surface if it is genuinely central even after the multiplier).
+_DEWEIGHT_FACTOR = 0.25
+_VENDOR_NAME_PRIOR = frozenset({
+    "vendor",
+    "third_party",
+    "skills",
+    "external_repos",
+    "_vendored",
+    "node_modules",
+})
+
 _ENTRY_NAMES = {
     "main.py",
     "__main__.py",
@@ -66,14 +88,15 @@ _ENTRY_NAMES = {
 }
 
 
-def _file_centrality_scores(rm: dict[str, Any]) -> tuple[list[str], dict[str, float]]:
-    """Composite per-file centrality (capped fan-in + fan-out + symbol density) over the non-doc,
-    non-config code files in `rm`. Shared by `_central_files_from_map` (top-N central-file ranking)
-    and `_suggested_scope_from_map` (directory rollup, audit #93 SUB-2) so both features read off
-    the exact same score -- never a second, driftable scoring system."""
+def _code_files_and_import_graph(
+    rm: dict[str, Any],
+) -> tuple[list[str], dict[str, list[str]], dict[str, set[str]]]:
+    """Shared code-only import graph (docs/config/data suffixes excluded): returns
+    ``(code_files, resolved_imports, reverse_importers)``. Used by both the centrality ranking and
+    the vendored-subtree import-island detection so the two heuristics see the identical graph."""
     all_files = [str(f) for f in rm.get("files", [])]
     if not all_files:
-        return [], {}
+        return [], {}, {}
     # "Central files" surface CODE architecture. Documentation files (heavily cross-referenced in
     # doc-heavy repos — e.g. 36 CLAUDE.md files) must not rank as central, and must not absorb a code
     # import via a stem collision (config.md shadowing config.py in by_stem). Exclude docs from the
@@ -102,6 +125,107 @@ def _file_centrality_scores(rm: dict[str, Any]) -> tuple[list[str], dict[str, fl
                 targets.append(candidate)
         resolved_imports[source] = targets
     reverse_importers = _repo_map._reverse_importers(code_files, resolved_imports)
+    return code_files, resolved_imports, reverse_importers
+
+
+def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Auto-detect bundled vendor/skill/generated CODE subtrees to DE-WEIGHT (never hard-exclude).
+
+    Returns ``{tree_path: {"reasons": [...]}}``. Fires ONLY on STRONG-1 (nested package manifest)
+    AND (STRONG-2 (import island) OR WEAK (name prior)) -- see the module-level comment above
+    ``_DEWEIGHT_FACTOR`` for the full rule. Requires ``rm["path"]`` to point at a real, existing
+    directory (a synthetic/relative-path test fixture with no "path" key returns ``{}`` rather than
+    guessing against the process CWD)."""
+    path_value = rm.get("path")
+    if not path_value:
+        return {}
+    try:
+        root = Path(str(path_value)).resolve()
+    except OSError:
+        return {}
+    if not root.is_dir():
+        return {}
+
+    all_files = [str(f) for f in rm.get("files", [])]
+    if not all_files:
+        return {}
+
+    from tensor_grep.cli.main import _BROAD_WORKSPACE_PROJECT_MARKERS
+
+    # Candidate directories: every ancestor (strictly below root) of every scanned file. Bounded by
+    # the already-scanned file set -- never an independent filesystem walk.
+    candidate_dirs: set[Path] = set()
+    for file_str in all_files:
+        try:
+            rel = Path(file_str).relative_to(root)
+        except ValueError:
+            continue
+        parts = rel.parts[:-1]
+        for i in range(1, len(parts) + 1):
+            candidate_dirs.add(Path(*parts[:i]))
+    if not candidate_dirs:
+        return {}
+
+    # STRONG-1: directory contains its own manifest.
+    manifest_dirs: dict[Path, str] = {}
+    for rel_dir in candidate_dirs:
+        abs_dir = root / rel_dir
+        for marker in sorted(_BROAD_WORKSPACE_PROJECT_MARKERS):
+            try:
+                if (abs_dir / marker).exists():
+                    manifest_dirs[rel_dir] = marker
+                    break
+            except OSError:
+                continue
+    if not manifest_dirs:
+        return {}
+
+    # Keep only the OUTERMOST manifest directory in any nested chain -- a deeper manifest inside an
+    # already-flagged subtree does not start a second, overlapping subtree.
+    subtree_rel_roots: list[Path] = []
+    for rel_dir in sorted(manifest_dirs, key=lambda p: len(p.parts)):
+        if any(
+            _repo_map._path_is_relative_to(root / rel_dir, root / existing)
+            for existing in subtree_rel_roots
+        ):
+            continue
+        subtree_rel_roots.append(rel_dir)
+
+    _code_files, _resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
+    code_file_set = set(_code_files)
+
+    result: dict[str, dict[str, Any]] = {}
+    for rel_dir in subtree_rel_roots:
+        abs_dir = root / rel_dir
+        tree_files = {f for f in code_file_set if _repo_map._path_is_relative_to(Path(f), abs_dir)}
+        if not tree_files:
+            continue
+        is_island = all(reverse_importers.get(f, set()) <= tree_files for f in tree_files)
+        name_hits = sorted({part.lower() for part in rel_dir.parts} & _VENDOR_NAME_PRIOR)
+
+        if not (is_island or name_hits):
+            continue
+
+        reasons = [f"nested-manifest:{manifest_dirs[rel_dir]}"]
+        if is_island:
+            reasons.append("import-island")
+        if name_hits:
+            reasons.append(f"name-prior:{name_hits[0]}")
+
+        result[str(abs_dir)] = {"reasons": reasons}
+
+    return result
+
+
+def _file_centrality_scores(rm: dict[str, Any]) -> tuple[list[str], dict[str, float]]:
+    """Composite per-file centrality (capped fan-in + fan-out + symbol density) over the non-doc,
+    non-config code files in `rm`. Shared by `_central_files_from_map` (top-N central-file ranking)
+    and `_suggested_scope_from_map` (directory rollup, audit #93 SUB-2) so both features read off
+    the exact same score -- never a second, driftable scoring system."""
+    code_files, resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
+    if not code_files:
+        return [], {}
+    code_file_set = set(code_files)
     # Composite centrality (dogfood 2026-07-03, v1.19.9): pure import in-degree surfaced LEAF data
     # files (constants.ts / figures.ts / barrel index.ts imported by many) at the top and buried the
     # real hubs (QueryEngine.ts, state.ts). A real architectural hub both RECEIVES and SENDS import
@@ -123,11 +247,35 @@ def _file_centrality_scores(rm: dict[str, Any]) -> tuple[list[str], dict[str, fl
     return code_files, centrality
 
 
-def _central_files_from_map(rm: dict[str, Any], *, max_central_files: int) -> list[dict[str, Any]]:
-    """Rank source files by import in-degree (foundational = imported-by-many); top-N with symbols."""
+def _central_files_from_map(
+    rm: dict[str, Any],
+    *,
+    max_central_files: int,
+    auto_deweight: bool = True,
+    deweighted_trees: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Rank source files by import in-degree (foundational = imported-by-many); top-N with symbols.
+
+    Files inside a detected vendored/skill subtree (see ``_detect_vendored_subtrees``) have their
+    composite score multiplied by ``_DEWEIGHT_FACTOR`` -- DE-WEIGHTED, never removed, so a genuinely
+    central file inside such a tree can still surface. The de-weight is applied HERE (not in
+    `_file_centrality_scores`) so `_suggested_scope_from_map` keeps reading the raw, un-de-weighted
+    score -- matching the WIP's original scope (central_files only)."""
     code_files, centrality = _file_centrality_scores(rm)
     if not code_files:
         return []
+    if deweighted_trees is None:
+        deweighted_trees = _detect_vendored_subtrees(rm) if auto_deweight else {}
+    tree_roots = list(deweighted_trees.keys())
+    for source in list(centrality):
+        candidate = Path(source)
+        for tree_root in tree_roots:
+            try:
+                candidate.relative_to(tree_root)
+            except ValueError:
+                continue
+            centrality[source] *= _DEWEIGHT_FACTOR
+            break
     ranked = sorted(code_files, key=lambda source: (-centrality[source], source))
     result: list[dict[str, Any]] = []
     for file_path in ranked[:max_central_files]:
@@ -272,8 +420,14 @@ def build_orient_capsule(
     max_repo_files: int | None = None,
     render_profile: str = "compact",
     ignore: tuple[str, ...] = (),
+    auto_deweight: bool = True,
 ) -> dict[str, Any]:
-    """Build a bounded codebase orientation capsule (no API key, no GPU)."""
+    """Build a bounded codebase orientation capsule (no API key, no GPU).
+
+    ``auto_deweight`` (default on) DE-WEIGHTS -- never hard-excludes -- auto-detected bundled
+    vendor/skill/generated CODE subtrees in the centrality ranking (see
+    ``_detect_vendored_subtrees``); pass ``auto_deweight=False`` (CLI: ``--no-auto-deweight``) to
+    disable. This is independent of ``--ignore``, which still hard-excludes explicit globs."""
     from tensor_grep.cli.repo_map import DEFAULT_AGENT_REPO_MAP_LIMIT
 
     effective_max_repo_files = (
@@ -282,7 +436,10 @@ def build_orient_capsule(
     rm = _repo_map.build_repo_map(path, max_repo_files=effective_max_repo_files)
     rm = _apply_ignore_globs(rm, ignore)
 
-    central_files = _central_files_from_map(rm, max_central_files=max_central_files)
+    deweighted_trees = _detect_vendored_subtrees(rm) if auto_deweight else {}
+    central_files = _central_files_from_map(
+        rm, max_central_files=max_central_files, deweighted_trees=deweighted_trees
+    )
     entry_points = _detect_entry_points(rm)
 
     # suggested_scope (audit #93 SUB-2): gate on the underlying repo map's OWN scan_limit dict
@@ -338,10 +495,19 @@ def build_orient_capsule(
         snippets.append({"file": file_path, "source": snippet_text, "truncated": False})
         token_budget_used += snippet_tokens
 
+    deweighted_trees_list = [
+        {"path": tree_path, "reasons": list(info["reasons"])}
+        for tree_path, info in sorted(deweighted_trees.items())
+    ]
+
     lines: list[str] = [f"# Codebase orientation: {rm['path']}"]
     lines.append("\n## Central files (by import-graph centrality)")
     for cf in central_files:
         lines.append(f"- {cf['file']}  graph_score={cf['graph_score']}")
+    if deweighted_trees_list:
+        lines.append("\n## De-weighted vendor/skill subtrees (auto-detected, NOT excluded)")
+        for tree in deweighted_trees_list:
+            lines.append(f"- {tree['path']}  ({', '.join(tree['reasons'])})")
     if entry_points:
         lines.append("\n## Entry points (heuristic name detection)")
         for ep in entry_points:
@@ -373,6 +539,8 @@ def build_orient_capsule(
         "scan_limit": effective_max_repo_files,
         "suggested_scope": suggested_scope,
         "routing_reason": "orient",
+        "deweighted_trees": deweighted_trees_list,
+        "auto_deweight": auto_deweight,
     }
 
 

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -200,7 +200,15 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
         tree_files = {f for f in code_file_set if _repo_map._path_is_relative_to(Path(f), abs_dir)}
         if not tree_files:
             continue
-        is_island = all(reverse_importers.get(f, set()) <= tree_files for f in tree_files)
+        # An import-island needs POSITIVE evidence of an internally-cohesive-but-externally-isolated
+        # cluster: some file in the subtree is imported by ANOTHER file in it, AND no file outside it
+        # imports in. A subtree with ZERO import edges -- a non-Python crate like `rust_core/`, invisible
+        # to this Python-centric stem graph -- trivially satisfies "externally isolated" but is NOT an
+        # island, just graph-invisible; it must NOT be de-weighted on STRONG-2 alone (else a legitimate
+        # Rust/Go subproject with its own manifest gets buried). It can still fire on a name prior.
+        externally_isolated = all(reverse_importers.get(f, set()) <= tree_files for f in tree_files)
+        has_internal_edge = any(reverse_importers.get(f, set()) & tree_files for f in tree_files)
+        is_island = externally_isolated and has_internal_edge
         name_hits = sorted({part.lower() for part in rel_dir.parts} & _VENDOR_NAME_PRIOR)
 
         if not (is_island or name_hits):

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -11968,7 +11968,7 @@ def _fallback_file_source(
 
 
 _COMPACT_CONTEXT_RENDER_PROFILES = {"compact", "llm"}
-_COMPACT_CONTEXT_RENDER_OMITTED_KEYS = ("symbols", "imports", "related_paths")
+_COMPACT_CONTEXT_RENDER_OMITTED_KEYS = ("symbols", "imports", "related_paths", "deweighted_trees")
 _LLM_CONTEXT_RENDER_OMITTED_KEYS = (
     "candidate_edit_targets",
     "coverage",

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7537,10 +7537,16 @@ def _build_context_pack_from_map(
     payload["related_paths"] = related_paths
     payload["ranking_quality"] = _ranking_quality(file_matches, test_matches)
     payload["coverage_summary"] = _coverage_summary(payload)
-    payload["deweighted_trees"] = [
-        {"path": tree_path, "reasons": list(info["reasons"])}
-        for tree_path, info in sorted(deweighted_trees.items())
-    ]
+    # Only emit when non-empty. An empty `deweighted_trees` still costs ~20 bytes in every
+    # context-pack payload, and (since compaction records dropped keys in omitted_keys) omitting it
+    # saves nothing -- enough to tip the macOS llm-compact token-budget test, whose long temp paths
+    # leave a ~5-byte margin under the < 9000 ceiling, over the edge (#525 CI). Consumers treat a
+    # missing key as "nothing de-weighted".
+    if deweighted_trees:
+        payload["deweighted_trees"] = [
+            {"path": tree_path, "reasons": list(info["reasons"])}
+            for tree_path, info in sorted(deweighted_trees.items())
+        ]
     return payload
 
 
@@ -11968,7 +11974,7 @@ def _fallback_file_source(
 
 
 _COMPACT_CONTEXT_RENDER_PROFILES = {"compact", "llm"}
-_COMPACT_CONTEXT_RENDER_OMITTED_KEYS = ("symbols", "imports", "related_paths", "deweighted_trees")
+_COMPACT_CONTEXT_RENDER_OMITTED_KEYS = ("symbols", "imports", "related_paths")
 _LLM_CONTEXT_RENDER_OMITTED_KEYS = (
     "candidate_edit_targets",
     "coverage",

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7238,6 +7238,7 @@ def _build_context_pack_from_map(
     payload: dict[str, Any],
     query: str,
     *,
+    auto_deweight: bool = True,
     _test_source_limit: int | None = None,
     deadline_monotonic: float | None = None,
     deadline_hit: _DeadlineBreakFlag | None = None,
@@ -7459,6 +7460,31 @@ def _build_context_pack_from_map(
                     )
                     _append_reason(file_reasons, current_path, "validation-direct-definition")
 
+        # Auto de-weight (never hard-exclude) auto-detected vendor/skill/generated CODE subtrees
+        # (#55 PR6) -- same import-island heuristic `tg orient` applies, reused here so `tg agent`'s
+        # primary-target ranking benefits too. Local import avoids a module-level circular import
+        # (orient_capsule imports this module), mirroring the existing `_apply_ignore_globs` reuse
+        # a few lines up in `build_context_render`.
+        deweighted_trees: dict[str, dict[str, Any]] = {}
+        if auto_deweight:
+            from tensor_grep.cli.orient_capsule import _DEWEIGHT_FACTOR, _detect_vendored_subtrees
+
+            deweighted_trees = _detect_vendored_subtrees(payload)
+            if deweighted_trees:
+                tree_roots = list(deweighted_trees.keys())
+                for current_path, score in list(file_scores.items()):
+                    if score <= 0:
+                        continue
+                    candidate = Path(current_path)
+                    for tree_root in tree_roots:
+                        try:
+                            candidate.relative_to(tree_root)
+                        except ValueError:
+                            continue
+                        file_scores[current_path] = max(0, round(score * _DEWEIGHT_FACTOR))
+                        _append_reason(file_reasons, current_path, "vendored-subtree-deweighted")
+                        break
+
         scored_files = [(score, path) for path, score in file_scores.items() if score > 0]
         scored_files.sort(key=lambda item: (-item[0], item[1]))
         ranked_files = [path for _, path in scored_files]
@@ -7511,6 +7537,10 @@ def _build_context_pack_from_map(
     payload["related_paths"] = related_paths
     payload["ranking_quality"] = _ranking_quality(file_matches, test_matches)
     payload["coverage_summary"] = _coverage_summary(payload)
+    payload["deweighted_trees"] = [
+        {"path": tree_path, "reasons": list(info["reasons"])}
+        for tree_path, info in sorted(deweighted_trees.items())
+    ]
     return payload
 
 
@@ -12776,6 +12806,7 @@ def build_context_pack_from_map(
     repo_map: dict[str, Any],
     query: str,
     *,
+    auto_deweight: bool = True,
     _test_source_limit: int | None = None,
     deadline_monotonic: float | None = None,
     deadline_hit: _DeadlineBreakFlag | None = None,
@@ -12791,6 +12822,7 @@ def build_context_pack_from_map(
     payload = _build_context_pack_from_map(
         payload,
         query,
+        auto_deweight=auto_deweight,
         _test_source_limit=_test_source_limit,
         deadline_monotonic=deadline_monotonic,
         deadline_hit=deadline_hit,

--- a/tests/unit/test_orient_deweight_vendored.py
+++ b/tests/unit/test_orient_deweight_vendored.py
@@ -139,3 +139,25 @@ def test_file_centrality_scores_are_raw_not_deweighted(tmp_path: Path) -> None:
     hub = str(root / "bundled" / "hub.py")
     # hub.py: fan_in=2 (a,b import it) + fan_out=0 + density=0 = 2.0, RAW (not * _DEWEIGHT_FACTOR)
     assert centrality[hub] == 2.0
+
+
+def test_skips_graph_invisible_subproject_with_no_import_edges(tmp_path: Path) -> None:
+    # A non-Python subproject -- e.g. `rust_core/` with its own Cargo.toml + .rs files -- is INVISIBLE
+    # to the Python-centric stem import graph, so it has ZERO import edges. That trivially satisfies
+    # "externally isolated" but is NOT an import island (no internal cohesion), so with a neutral name
+    # it must NOT be de-weighted -- else a legitimate Rust/Go crate at the repo root gets buried.
+    # Regression for the agent-capsule rust-language-hint hardcase (#525 CI: rust_core was falsely
+    # de-weighted, so a Python file won primary_target over src/lib.rs).
+    root = tmp_path.resolve()
+    (root / "rust_core").mkdir()
+    (root / "rust_core" / "Cargo.toml").write_text("[package]\nname = 'rc'\nversion = '0.1.0'\n")
+    rm = _rm(
+        root,
+        [
+            root / "app.py",
+            root / "rust_core" / "src" / "lib.rs",
+            root / "rust_core" / "src" / "mod.rs",
+        ],
+        {},  # no resolvable import edges anywhere (Rust files; the Python stem graph is blind)
+    )
+    assert _detect_vendored_subtrees(rm) == {}

--- a/tests/unit/test_orient_deweight_vendored.py
+++ b/tests/unit/test_orient_deweight_vendored.py
@@ -1,0 +1,141 @@
+"""Tests for auto-de-weighting of bundled vendor/skill/generated CODE subtrees in `tg orient`
+centrality (#132 / #55 PR6).
+
+A subtree fires ONLY on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK
+(name prior)). The de-weight multiplies a subtree file's composite centrality by
+``_DEWEIGHT_FACTOR`` -- it LOWERS the score, it never EXCLUDES the file, so a genuinely central
+vendored file can still surface. A monorepo subproject that has a manifest but IS imported across
+the repo is protected by the import-island test (de-weight would hide real product code).
+
+`_detect_vendored_subtrees` reads the real filesystem (it checks ``root.is_dir()`` and each
+candidate directory for a manifest via ``.exists()``), so these tests build real ``tmp_path``
+trees with on-disk manifests -- unlike the hand-built-``rm`` centrality tests which never touch
+disk.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli.orient_capsule import (
+    _DEWEIGHT_FACTOR,
+    _central_files_from_map,
+    _detect_vendored_subtrees,
+    _file_centrality_scores,
+)
+
+
+def _rm(root: Path, files: list[Path], imports: dict[Path, list[str]]) -> dict[str, Any]:
+    """Build a repo-map dict rooted at a real (resolved) directory."""
+    return {
+        "path": str(root),
+        "files": [str(f) for f in files],
+        "imports": [{"file": str(f), "imports": mods} for f, mods in imports.items()],
+        "symbols": [],
+    }
+
+
+def test_fires_on_manifest_plus_import_island(tmp_path: Path) -> None:
+    # `bundled/` has its own pyproject.toml (STRONG-1). No file OUTSIDE bundled/ imports into it,
+    # and its name is NOT a vendor-prior -> fires on manifest + import-island (STRONG-2) alone.
+    root = tmp_path.resolve()
+    (root / "bundled").mkdir()
+    (root / "bundled" / "pyproject.toml").write_text("[project]\nname = 'bundled'\n")
+    rm = _rm(
+        root,
+        [root / "app.py", root / "bundled" / "lib.py", root / "bundled" / "helper.py"],
+        {root / "bundled" / "lib.py": ["helper"]},  # internal edge only
+    )
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / "bundled") in trees
+    reasons = trees[str(root / "bundled")]["reasons"]
+    assert any(r.startswith("nested-manifest:") for r in reasons)
+    assert "import-island" in reasons
+    assert not any(r.startswith("name-prior:") for r in reasons)
+
+
+def test_fires_on_manifest_plus_name_prior_even_when_not_island(tmp_path: Path) -> None:
+    # `node_modules/` has a manifest AND is imported from outside (app.js imports its module, so it
+    # is NOT an island) -- but "node_modules" is a name-prior, so it still fires.
+    root = tmp_path.resolve()
+    (root / "node_modules").mkdir()
+    (root / "node_modules" / "package.json").write_text('{"name": "dep"}\n')
+    rm = _rm(
+        root,
+        [root / "app.js", root / "node_modules" / "dep.js"],
+        {root / "app.js": ["dep"]},  # OUTSIDE importer -> not an island
+    )
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / "node_modules") in trees
+    reasons = trees[str(root / "node_modules")]["reasons"]
+    assert any(r.startswith("name-prior:") for r in reasons)
+    assert "import-island" not in reasons
+
+
+def test_skips_manifest_only_monorepo_subproject(tmp_path: Path) -> None:
+    # THE false-positive guard: `packages/core/` has a manifest but is imported across the repo
+    # (app.py imports its module) AND has a neutral name (no vendor-prior) -> NOT an island, NO
+    # name prior -> NOT de-weighted. De-weighting a genuine subproject would hide real product code.
+    root = tmp_path.resolve()
+    (root / "packages" / "core").mkdir(parents=True)
+    (root / "packages" / "core" / "pyproject.toml").write_text("[project]\nname = 'core'\n")
+    rm = _rm(
+        root,
+        [root / "app.py", root / "packages" / "core" / "mod.py"],
+        {root / "app.py": ["mod"]},  # imported from outside the subtree
+    )
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / "packages" / "core") not in trees
+    assert trees == {}
+
+
+def test_skips_when_no_manifest(tmp_path: Path) -> None:
+    # `vendor/` matches a name-prior but has NO manifest -> STRONG-1 fails -> never fires. The name
+    # prior is only a tie-breaker, never sufficient on its own.
+    root = tmp_path.resolve()
+    (root / "vendor").mkdir()
+    rm = _rm(root, [root / "app.py", root / "vendor" / "lib.py"], {})
+    assert _detect_vendored_subtrees(rm) == {}
+
+
+def test_central_files_deweights_but_keeps_the_file(tmp_path: Path) -> None:
+    # `bundled/hub.py` is highly central WITHIN its island (imported by two siblings). With
+    # de-weight ON its composite score is multiplied by _DEWEIGHT_FACTOR -- but it is still PRESENT
+    # in central_files (de-weight != exclude).
+    root = tmp_path.resolve()
+    (root / "bundled").mkdir()
+    (root / "bundled" / "pyproject.toml").write_text("[project]\nname = 'bundled'\n")
+    rm = _rm(
+        root,
+        [
+            root / "bundled" / "hub.py",
+            root / "bundled" / "a.py",
+            root / "bundled" / "b.py",
+        ],
+        {root / "bundled" / "a.py": ["hub"], root / "bundled" / "b.py": ["hub"]},
+    )
+    raw = _central_files_from_map(rm, max_central_files=10, auto_deweight=False)
+    dew = _central_files_from_map(rm, max_central_files=10, auto_deweight=True)
+
+    hub = str(root / "bundled" / "hub.py")
+    raw_hub = next(f for f in raw if f["file"] == hub)
+    dew_hub = next(f for f in dew if f["file"] == hub)  # still present -> de-weight, not exclude
+    assert raw_hub["score"] > 0
+    assert dew_hub["score"] == round(raw_hub["score"] * _DEWEIGHT_FACTOR, 6)
+
+
+def test_file_centrality_scores_are_raw_not_deweighted(tmp_path: Path) -> None:
+    # `_file_centrality_scores` (which `_suggested_scope_from_map` reads) must return the RAW
+    # composite score -- the de-weight lives in `_central_files_from_map`, so suggested_scope keeps
+    # its unmodified signal.
+    root = tmp_path.resolve()
+    (root / "bundled").mkdir()
+    (root / "bundled" / "pyproject.toml").write_text("[project]\nname = 'bundled'\n")
+    rm = _rm(
+        root,
+        [root / "bundled" / "hub.py", root / "bundled" / "a.py", root / "bundled" / "b.py"],
+        {root / "bundled" / "a.py": ["hub"], root / "bundled" / "b.py": ["hub"]},
+    )
+    _code_files, centrality = _file_centrality_scores(rm)
+    hub = str(root / "bundled" / "hub.py")
+    # hub.py: fan_in=2 (a,b import it) + fan_out=0 + density=0 = 2.0, RAW (not * _DEWEIGHT_FACTOR)
+    assert centrality[hub] == 2.0


### PR DESCRIPTION
## What

`tg orient` / `tg agent` centrality now auto-DE-WEIGHTS (never hard-excludes) bundled vendor/skill/generated CODE subtrees, so real product code surfaces without a manual `--ignore`.

A subtree's composite centrality is multiplied by **0.25** ONLY on **STRONG-1** (a nested package manifest: `pyproject.toml`/`package.json`/`Cargo.toml`/...) AND either **STRONG-2** (an import island — no file *outside* the subtree imports *into* it) or **WEAK** (a vendor name prior: `vendor`/`third_party`/`skills`/`external_repos`/`_vendored`/`node_modules`). Default ON; `tg orient --no-auto-deweight` opts out. The capsule payload gains a `deweighted_trees` list (path + reasons) for transparency.

## Why the false-positive guard matters

A monorepo subproject that *has* a manifest but *is* imported across the repo is **not** an island → **not** de-weighted. And de-weight-not-exclude means a genuinely central vendored file can still surface. Hiding real product code is the failure mode this protects against (memory: `idf-ranking-fragility` — a wrong ranking actively misdirects an agent, worse than no hint).

## Rebase reconciliation

The preserved WIP branch (v1.40.3-based) rebased onto current main. The WIP had extracted a shared `_code_files_and_import_graph` helper from v1.40.3's `_central_files_from_map`, while main had separately split that code into `_file_centrality_scores` (#93 SUB-2). Reconciled by keeping **main's** architecture: the shared graph helper feeds both scoring and detection; `_file_centrality_scores` returns **raw** scores (so `_suggested_scope_from_map` is unaffected); the de-weight is applied in `_central_files_from_map` (central_files only, matching the WIP's original scope).

## Tests

- **6 new** — each heuristic branch + the monorepo false-positive guard + the de-weight-is-not-exclude invariant + the raw-suggested-scope invariant.
- **29 existing** orient/centrality tests stay green (behavior-preserving refactor).
- ruff (`format --preview` + `check`) and `py_compile` clean.

Gate-free surface (orient/cli — not apply_policy/mcp/backends). Release pipe: merges after the v1.61.2 + no-release drain → v1.62.0.

**Follow-up (deferred, YAGNI):** an explicit `.claude/worktrees` name prior is moot while worktrees are gitignored (never scanned); a scanned worktree is already caught by the generic manifest+import-island path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
