### PR TITLE
fix(semantic): cap-degrade reuses accumulated chunks, no full-corpus re-chunk (audit A2)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3636,7 +3636,15 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
             all_results.rank_fallback_reason = _maybe_append_late_skip(str(exc))
             sys.stderr.write(f"tg: {exc}\n")
             return rerank_hybrid(
-                all_results, pattern, all_results.matched_file_paths, dense_index=None
+                all_results,
+                pattern,
+                all_results.matched_file_paths,
+                # A2 (external audit 2026-07-11): reuse the chunks accumulated so far (already bounded
+                # by the corpus cap / the file that raised) -- passing a prebuilt index stops
+                # rerank_hybrid re-reading + re-chunking the FULL corpus UNCAPPED, which turned this
+                # safety guard into the expensive op it exists to prevent. Mirrors the F1 retry below.
+                bm25_index=Bm25Index(chunks),
+                dense_index=None,
             )
         chunks.extend(file_chunks)
         if len(chunks) > _SEMANTIC_CORPUS_CHUNK_CAP:
@@ -3648,7 +3656,15 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
             all_results.rank_fallback_reason = _maybe_append_late_skip(reason)
             sys.stderr.write(f"tg: {reason}\n")
             return rerank_hybrid(
-                all_results, pattern, all_results.matched_file_paths, dense_index=None
+                all_results,
+                pattern,
+                all_results.matched_file_paths,
+                # A2 (external audit 2026-07-11): reuse the chunks accumulated so far (already bounded
+                # by the corpus cap / the file that raised) -- passing a prebuilt index stops
+                # rerank_hybrid re-reading + re-chunking the FULL corpus UNCAPPED, which turned this
+                # safety guard into the expensive op it exists to prevent. Mirrors the F1 retry below.
+                bm25_index=Bm25Index(chunks),
+                dense_index=None,
             )
 
     bm25_index = Bm25Index(chunks)

--- a/tests/integration/test_semantic_search_flag.py
+++ b/tests/integration/test_semantic_search_flag.py
@@ -214,6 +214,44 @@ def test_search_semantic_corpus_chunk_cap_exceeded_degrades_to_bm25(
     assert semantic_files == rank_files
 
 
+def test_search_semantic_cap_fallback_does_not_rechunk_full_corpus(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A2 (external audit 2026-07-11): when the corpus-chunk cap trips, the BM25-only degrade must
+    reuse the chunks already accumulated -- NOT fall into rerank_hybrid's `bm25_index=None` branch,
+    which re-reads + re-chunks the FULL matched-file set UNCAPPED, turning the safety guard into the
+    expensive op it exists to prevent. Regression: with the cap forced to 1, no file may be chunked
+    a SECOND time by the degrade path (mirrors the F1 retry's "reuse the SAME bm25_index")."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+    monkeypatch.setattr("tensor_grep.cli.main._SEMANTIC_CORPUS_CHUNK_CAP", 1)
+
+    from tensor_grep.core import retrieval_chunker
+
+    real_chunk_file = retrieval_chunker.chunk_file
+    calls: list[str] = []
+
+    def _counting_chunk_file(path: str, **kwargs: object):
+        calls.append(str(path))
+        return real_chunk_file(path, **kwargs)
+
+    # Patch BOTH bind sites: a re-chunk regression would call reranker.py's module-level name.
+    monkeypatch.setattr("tensor_grep.core.retrieval_chunker.chunk_file", _counting_chunk_file)
+    monkeypatch.setattr("tensor_grep.core.reranker.chunk_file", _counting_chunk_file)
+
+    for i in range(3):
+        (tmp_path / f"f{i}.py").write_text(
+            f"def make_invoice_{i}(invoice_id):\n    return invoice_id\n", encoding="utf-8"
+        )
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    payload = json.loads(result.stdout)
+    assert "corpus chunk cap" in payload.get("rank_fallback_reason", "")
+    # The fix: the cap degrade reuses the accumulated chunks, so no file is chunked a SECOND time.
+    assert len(calls) == len(set(calls)), f"a file was re-chunked after the cap tripped: {calls}"
+
+
 def test_search_semantic_chunker_runtime_error_degrades_to_bm25(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
**External audit A2 (DoS).** When the semantic corpus-chunk cap trips, the BM25 degrade called `rerank_hybrid(dense_index=None)` with no `bm25_index` -> `rerank_hybrid` re-reads + re-chunks the *entire* matched-file set **uncapped**, turning the safety guard into the expensive op it prevents.

**Fix:** pass `bm25_index=Bm25Index(chunks)` (the already-accumulated, cap-bounded chunks) to both degrade sites -- mirrors the existing F1 retry's "reuse the SAME bm25_index (no second chunk pass)". Also fixes a latent re-raise on the per-file pathological case. No `reranker.py` change.

**Test:** `test_search_semantic_cap_fallback_does_not_rechunk_full_corpus` (cap forced to 1, counts `chunk_file` at both bind sites, asserts no double-chunk). Gate-free (cli semantic path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)