### PR TITLE
fix(evidence): nudge `tg evidence <path>` toward the `emit` subcommand (dogfood)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -257,12 +257,16 @@ class _EvidenceGroup(TyperGroup):
                 and not token.startswith("-")
                 and ("/" in token or "\\" in token or Path(token).exists())
             ):
-                exc.message = (
-                    f"{exc.message}\n"
+                # Re-raise a NEW UsageError with the hint appended -- `UsageError.message` is a
+                # Final attribute (cannot be reassigned in place); a fresh error carrying the same
+                # `ctx` renders identically (Usage + "Try --help" + Error:) and keeps exit code 2.
+                raise click.exceptions.UsageError(
+                    f"{exc.format_message()}\n"
                     "Hint: `tg evidence` is a command group; its receipt action is "
                     f"`emit`. Did you mean `tg evidence emit {token}`? "
-                    "(run `tg evidence emit --help`)"
-                )
+                    "(run `tg evidence emit --help`)",
+                    ctx=exc.ctx,
+                ) from exc
             raise
 
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -22,7 +22,9 @@ from uuid import uuid4
 if sys.platform.startswith("win") and not sys.stdout.isatty():
     os.environ.setdefault("TYPER_USE_RICH", "0")
 
+import click
 import typer
+from typer.core import TyperGroup
 
 from tensor_grep.backends.base import BackendExecutionError
 from tensor_grep.cli import ast_workflows
@@ -230,7 +232,42 @@ review_bundle_app = typer.Typer(
     help="Create and verify enterprise review bundles.",
     no_args_is_help=True,
 )
+
+
+class _EvidenceGroup(TyperGroup):
+    """Nudge `tg evidence <path>` toward the `emit` subcommand.
+
+    Dogfood trap (v1.61.2): an agent reaches for `tg evidence <PATH> <query>` by
+    analogy with `tg defs`/`tg orient` (which take a path directly), but `evidence`
+    is a command GROUP whose only action is `emit`. Click's default
+    "No such command 'src/...'" is correct (exit 2) but unhelpful -- when the unknown
+    subcommand looks like a filesystem path, append the concrete fix so the caller
+    does not have to re-read `--help`.
+    """
+
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        try:
+            return super().resolve_command(ctx, args)
+        except click.exceptions.UsageError as exc:
+            token = args[0] if args else ""
+            if (
+                token
+                and not token.startswith("-")
+                and ("/" in token or "\\" in token or Path(token).exists())
+            ):
+                exc.message = (
+                    f"{exc.message}\n"
+                    "Hint: `tg evidence` is a command group; its receipt action is "
+                    f"`emit`. Did you mean `tg evidence emit {token}`? "
+                    "(run `tg evidence emit --help`)"
+                )
+            raise
+
+
 evidence_app = typer.Typer(
+    cls=_EvidenceGroup,
     help="Emit a versioned EvidenceReceipt aggregating tg's existing outputs.",
     no_args_is_help=True,
 )

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -15231,3 +15231,27 @@ def test_tg_test_uses_typer_help():
     assert "Usage: " in result.stdout
     assert "Options" in result.stdout.lower() or "options" in result.stdout.lower()
     assert "positional arguments:" not in result.stdout
+
+
+def test_evidence_group_hints_emit_when_given_a_path_like_subcommand(tmp_path: Path) -> None:
+    # Dogfood trap (v1.61.2): an agent reaches for `tg evidence <PATH> <query>` by analogy
+    # with `tg defs`/`tg orient` (which take a path directly), but `evidence` is a command
+    # GROUP whose only action is `emit`. The error stays exit 2 (correct) but must now nudge
+    # the caller toward `emit` so they do not have to re-read --help.
+    src = tmp_path / "main.py"
+    src.write_text("x = 1\n", encoding="utf-8")
+    result = CliRunner().invoke(app, ["evidence", str(src), "search"])
+    assert result.exit_code == 2
+    combined = result.output
+    assert "No such command" in combined
+    assert "tg evidence emit" in combined
+
+
+def test_evidence_group_does_not_hint_emit_for_a_non_path_subcommand() -> None:
+    # A bare non-path token (a genuine subcommand typo) gets the standard error only -- the
+    # emit hint must not fire on every mistyped subcommand, just the path-shaped ones.
+    result = CliRunner().invoke(app, ["evidence", "boguscmd"])
+    assert result.exit_code == 2
+    combined = result.output
+    assert "No such command" in combined
+    assert "tg evidence emit" not in combined


### PR DESCRIPTION
## Dogfood v1.61.2: `tg evidence <path>` UX nudge toward `emit`

### Problem (dogfood-flagged)
An agent reaches for `tg evidence <PATH> <query>` by analogy with `tg defs` / `tg orient`
(which take a path directly), but `evidence` is a command **group** whose only action is
`emit`. Click's default `No such command 'src/...'` is correct (exit 2) but unhelpful — the
caller has to re-read `--help` to discover `emit`.

### Fix
Wrap `evidence_app` in a `TyperGroup` subclass whose `resolve_command` catches the
`UsageError` and, when the unknown subcommand **looks like a filesystem path** (contains a
separator or resolves on disk), appends a concrete hint:

```
Error: No such command 'src/tensor_grep/cli/main.py'.
Hint: `tg evidence` is a command group; its receipt action is `emit`. Did you mean
`tg evidence emit src/tensor_grep/cli/main.py`? (run `tg evidence emit --help`)
```

Exit code stays **2**. A genuine non-path subcommand typo (`tg evidence boguscmd`) gets the
standard error with **no hint noise**.

### Validation (real front door, not just CliRunner)
Ran `bootstrap:main_entry` directly:
- `tg evidence src/... search` → exit 2 + emit hint ✓
- `tg evidence boguscmd` → exit 2, no hint ✓
- `tg evidence emit` / `tg evidence --help` → unchanged (exit 0) ✓

### Tests
2 TDD cases in `test_cli_modes.py` — hint fires for a path-like token; no hint for a plain typo.

Gate-free (CLI evidence group). Part of the #133 v1.61.2 dogfood fix-queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
