### PR TITLE
fix(reranker): give the late-rerank budget a REAL wall-clock deadline (audit A3)

### DIFF
--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import sys
-import time
+import threading
 from collections import defaultdict
 
 from tensor_grep.core.result import SearchResult
@@ -212,26 +212,55 @@ def rerank_hybrid(
         )
         budget_ms = _int_env(_RERANK_BUDGET_MS_ENV, _DEFAULT_RERANK_BUDGET_MS)
         head = fused_order[:pool_k]
-        late_rerank_start = time.perf_counter()
-        try:
-            reranked_head = late_reranker.rerank(query, [chunks[i].text for i in head], head)
-        except LateRerankUnavailableError as exc:
-            # RECOVERABLE (e.g. a malformed embedding shape from the injected encoder): degrade
-            # to the plain RRF order for this pool, never crash. A genuine BackendExecutionError
-            # (a real encode-time fault) is deliberately NOT caught here -- it propagates to the
-            # CLI boundary (cli/main.py ~:6804-6813) per the Backend Fail-Closed Contract.
-            late_rank_fallback_reason = str(exc)
-            sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
-        else:
-            elapsed_ms = (time.perf_counter() - late_rerank_start) * 1000.0
-            if elapsed_ms > budget_ms:
-                late_rank_fallback_reason = (
-                    "late rerank unavailable: budget exceeded "
-                    f"({elapsed_ms:.0f}ms > {budget_ms}ms at pool_k={pool_k})"
+        # Real wall-clock deadline (A3, external audit 2026-07-11): the previous post-hoc
+        # `elapsed > budget` check could only DISCARD a rerank that had already RETURNED -- a HUNG
+        # encoder (a wedged model, an infinite loop in the injected reranker) never returns, so
+        # `late_reranker.rerank` blocked `tg search --rank` indefinitely with no bound. Run it on a
+        # daemon thread and `join` on the budget: if it overruns, abandon the thread (it dies with
+        # this short-lived CLI process) and degrade. The Backend Fail-Closed Contract is PRESERVED
+        # across the thread boundary -- a LateRerankUnavailableError (recoverable) degrades to the
+        # plain RRF order; ANYTHING ELSE (a genuine BackendExecutionError encode fault, or a
+        # KeyboardInterrupt/SystemExit user-abort) is re-raised on this thread so it still
+        # propagates to the CLI boundary (cli/main.py ~:6804-6813), exactly as the synchronous
+        # version did. Capturing BaseException (not just Exception) is deliberate: it keeps a
+        # user-abort from being silently swallowed into an RRF degrade AND guarantees exactly one
+        # of the two result holders is populated when the worker finishes (so the `else` splice
+        # below can never IndexError on an empty result).
+        rerank_result: list[list[int]] = []
+        rerank_error: list[BaseException] = []
+
+        def _run_late_rerank() -> None:
+            try:
+                rerank_result.append(
+                    late_reranker.rerank(query, [chunks[i].text for i in head], head)
                 )
+            except BaseException as exc:  # classified + re-raised (if non-recoverable) by the caller
+                rerank_error.append(exc)
+
+        worker = threading.Thread(target=_run_late_rerank, name="tg-late-rerank", daemon=True)
+        worker.start()
+        worker.join(timeout=budget_ms / 1000.0)
+
+        if worker.is_alive():
+            # Still running at the deadline (hung or merely too slow): do NOT wait -- abandon the
+            # daemon thread and degrade. This is the only branch that bounds a genuinely HUNG
+            # encoder; the old post-hoc check could never run for one.
+            late_rank_fallback_reason = (
+                f"late rerank unavailable: budget exceeded (>{budget_ms}ms at pool_k={pool_k})"
+            )
+            sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
+        elif rerank_error:
+            exc = rerank_error[0]
+            if isinstance(exc, LateRerankUnavailableError):
+                # RECOVERABLE (e.g. a malformed embedding shape): degrade, never crash.
+                late_rank_fallback_reason = str(exc)
                 sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
             else:
-                fused_order = reranked_head + fused_order[pool_k:]
+                # A genuine encode-time fault -> propagate (Backend Fail-Closed Contract): never
+                # silently degrade a real error into a plausible-but-wrong ranking.
+                raise exc
+        else:
+            fused_order = rerank_result[0] + fused_order[pool_k:]
 
     # Position in the fused order is a monotonic proxy for the underlying RRF score: RRF ties are
     # already broken by ascending chunk index before this list is built, so using position

--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -234,7 +234,9 @@ def rerank_hybrid(
                 rerank_result.append(
                     late_reranker.rerank(query, [chunks[i].text for i in head], head)
                 )
-            except BaseException as exc:  # classified + re-raised (if non-recoverable) by the caller
+            except (
+                BaseException
+            ) as exc:  # classified + re-raised (if non-recoverable) by the caller
                 rerank_error.append(exc)
 
         worker = threading.Thread(target=_run_late_rerank, name="tg-late-rerank", daemon=True)

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -4,7 +4,9 @@ import time
 from pathlib import Path
 
 import numpy as np
+import pytest
 
+from tensor_grep.backends.base import BackendExecutionError
 from tensor_grep.core.reranker import rerank_by_bm25, rerank_hybrid
 from tensor_grep.core.result import MatchLine, SearchResult
 from tensor_grep.core.retrieval_chunker import Chunk
@@ -240,3 +242,70 @@ def test_late_rerank_appends_to_existing_fallback_reason() -> None:
     assert out.rank_fallback_reason is not None
     assert "model2vec not installed" in out.rank_fallback_reason
     assert "model not fetched" in out.rank_fallback_reason
+
+
+def test_late_reranker_hung_encoder_degrades_within_budget_not_blocked(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A3 real wall-clock deadline (external audit 2026-07-11): a genuinely HUNG encoder must NOT
+    block `tg search --rank` indefinitely. The old post-hoc `elapsed > budget` check could only
+    DISCARD a rerank that had already returned; a wedged encoder never returns, so it hung forever.
+    The daemon-thread `join(budget)` bounds it: the call returns near the budget and degrades to the
+    plain RRF order, never after the (here 10s) encode."""
+    monkeypatch.setenv("TG_RERANK_BUDGET_MS", "100")
+    result, bm25_index = _four_chunk_scenario()
+    baseline = rerank_hybrid(result, "q", [], bm25_index=bm25_index)
+
+    def _hung_encode(text: str) -> np.ndarray:
+        time.sleep(10.0)  # simulate a wedged encoder; the join(0.1s) MUST abandon it
+        return np.array([[1.0, 0.0]], dtype=np.float32)
+
+    start = time.perf_counter()
+    out = rerank_hybrid(
+        result, "q", [], bm25_index=bm25_index, late_reranker=LateReranker(encode=_hung_encode)
+    )
+    elapsed = time.perf_counter() - start
+
+    # The pre-A3 code would have blocked ~10s (per hung encode); the deadline must bound it well
+    # under that. Generous margin for Windows thread-spawn contention, still far below 10s.
+    assert elapsed < 4.0, f"late rerank ignored the wall-clock deadline (took {elapsed:.1f}s)"
+    assert [m.file for m in out.matches] == [m.file for m in baseline.matches]
+    assert out.rank_fallback_reason is not None
+    assert "budget exceeded" in out.rank_fallback_reason
+
+
+def test_late_reranker_backend_execution_error_propagates_not_degrades() -> None:
+    """A3 Fail-Closed Contract ACROSS the daemon-thread boundary: a genuine BackendExecutionError
+    from the encoder (a real encode-time fault) must PROPAGATE to the caller, never be silently
+    degraded into a plausible-but-wrong ranking. Only the RECOVERABLE LateRerankUnavailableError
+    degrades; every other exception is re-raised on the worker thread's behalf."""
+    result, bm25_index = _four_chunk_scenario()
+
+    def _faulting_encode(text: str) -> np.ndarray:
+        raise BackendExecutionError("native encode fault (test stub)")
+
+    with pytest.raises(BackendExecutionError, match="native encode fault"):
+        rerank_hybrid(
+            result,
+            "q",
+            [],
+            bm25_index=bm25_index,
+            late_reranker=LateReranker(encode=_faulting_encode),
+        )
+
+
+def test_late_reranker_base_exception_user_abort_propagates_not_swallowed() -> None:
+    """A3 hardening: a BaseException (a KeyboardInterrupt user-abort / SystemExit) raised on the
+    worker thread must PROPAGATE, never be silently swallowed into an RRF degrade -- and the empty
+    result holder must never IndexError. Only LateRerankUnavailableError degrades; a Ctrl-C aborts."""
+    result, bm25_index = _four_chunk_scenario()
+
+    def _aborting_encode(text: str) -> np.ndarray:
+        raise KeyboardInterrupt("user abort (test stub)")
+
+    with pytest.raises(KeyboardInterrupt):
+        rerank_hybrid(
+            result,
+            "q",
+            [],
+            bm25_index=bm25_index,
+            late_reranker=LateReranker(encode=_aborting_encode),
+        )


### PR DESCRIPTION
## External audit 2026-07-11 (A3): late-rerank real wall-clock deadline

### Bug (caller-triggerable hang)
The late-interaction rerank budget (`TG_RERANK_BUDGET_MS`) was enforced **post-hoc** — it measured
`elapsed` only *after* `late_reranker.rerank` had already returned. That could discard a slow-but-
**completed** rerank, but a genuinely **hung** encoder (a wedged model, an infinite loop in the
injected reranker) never returns, so `tg search --rank` / `--semantic` blocked **indefinitely**
with no bound.

### Fix
Run the rerank on a daemon thread and `join` on the budget. If it overruns, abandon the thread (it
dies with the short-lived CLI process) and degrade to the plain RRF order. This is now the only
path that bounds a hung encoder.

### Fail-Closed Contract — preserved across the thread boundary
| Encoder outcome | Behavior |
|---|---|
| completes within budget | splice the reranked head (unchanged) |
| overruns budget / hangs | degrade to RRF, `rank_fallback_reason` set (**now bounds a true hang**) |
| `LateRerankUnavailableError` | degrade to RRF (recoverable, unchanged) |
| `BackendExecutionError` | **propagate** (never silently degrade a real fault) |
| `KeyboardInterrupt` / `SystemExit` | **propagate** (user-abort not swallowed; no IndexError) |

`BaseException` is captured (not just `Exception`) so a user-abort propagates and exactly one result
holder is always populated — the splice can never `IndexError`.

### Tests
3 new cases in `test_reranker.py`: a hung (10s) encoder degrades **within** the 100ms budget
(returns in <4s, not ~10s); `BackendExecutionError` propagates; `KeyboardInterrupt` propagates. The
existing budget / shape-mismatch / append-reason / byte-identical tests stay green.

Gate-free (`core/reranker.py`). Load-bearing (semantic hot path + Fail-Closed Contract), so the
contract is encoded as tests in lieu of the adversarial council (Opus dispatch weekly-limited until
Jul 13); self-adversarial review caught the `BaseException`/IndexError edge before commit. Part of
the #134 external-audit batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
