### PR TITLE
perf(orient): drop per-pair resolve() in vendored-subtree membership (dogfood #133)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -194,10 +194,27 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
     _code_files, _resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
     code_file_set = set(_code_files)
 
+    # Precompute each code file's path-parts relative to root ONCE, on the SAME lexical basis the
+    # candidate_dirs scan above used (`Path(f).relative_to(root)`; root is already resolved). Subtree
+    # membership is then a cheap tuple-prefix test -- NO per-(subtree, file) filesystem resolve. The
+    # old `_path_is_relative_to(Path(f), abs_dir)` did two `.resolve()` (realpath) syscalls per pair,
+    # i.e. O(subtrees x files) realpath calls: ~15% of `tg agent` wall on an 872-file repo and
+    # pathological on WSL 9p mounts (profile 2026-07-11). A file not lexically under root never
+    # contributed a candidate dir, so it cannot belong to any detected subtree -- skipping it here is
+    # consistent with how the subtrees were found.
+    code_rel_parts: list[tuple[str, tuple[str, ...]]] = []
+    for f in code_file_set:
+        try:
+            code_rel_parts.append((f, Path(f).relative_to(root).parts))
+        except ValueError:
+            continue
+
     result: dict[str, dict[str, Any]] = {}
     for rel_dir in subtree_rel_roots:
         abs_dir = root / rel_dir
-        tree_files = {f for f in code_file_set if _repo_map._path_is_relative_to(Path(f), abs_dir)}
+        prefix = rel_dir.parts
+        depth = len(prefix)
+        tree_files = {f for f, parts in code_rel_parts if parts[:depth] == prefix}
         if not tree_files:
             continue
         # An import-island needs POSITIVE evidence of an internally-cohesive-but-externally-isolated

--- a/tests/unit/test_orient_deweight_vendored.py
+++ b/tests/unit/test_orient_deweight_vendored.py
@@ -161,3 +161,25 @@ def test_skips_graph_invisible_subproject_with_no_import_edges(tmp_path: Path) -
         {},  # no resolvable import edges anywhere (Rust files; the Python stem graph is blind)
     )
     assert _detect_vendored_subtrees(rm) == {}
+
+
+def test_deeply_nested_subtree_file_counts_as_a_member(tmp_path: Path) -> None:
+    # A file NESTED several levels inside a detected subtree (`bundled/pkg/mod.py`) must be counted as
+    # a tree member. The import-island verdict here HINGES on it: `lib.py` imports `mod` (an internal
+    # edge) so the island fires ONLY if the nested `mod.py` is in `tree_files`. Guards the lexical
+    # tuple-prefix membership test (`parts[:depth] == prefix`) that replaced the per-file, per-subtree
+    # `_path_is_relative_to` resolve() check (perf, 2026-07-11) -- a prefix bug that dropped nested
+    # files would silently turn this island into a non-island.
+    root = tmp_path.resolve()
+    (root / "bundled" / "pkg").mkdir(parents=True)
+    (root / "bundled" / "pyproject.toml").write_text("[project]\nname = 'bundled'\n")
+    rm = _rm(
+        root,
+        [root / "app.py", root / "bundled" / "lib.py", root / "bundled" / "pkg" / "mod.py"],
+        {
+            root / "bundled" / "lib.py": ["mod"]
+        },  # internal edge lib -> pkg/mod (both inside bundled/)
+    )
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / "bundled") in trees
+    assert "import-island" in trees[str(root / "bundled")]["reasons"]


### PR DESCRIPTION
## What

Eliminates the per-`(subtree × file)` filesystem `resolve()` in `_detect_vendored_subtrees` — the vendored-tree deweight (#525) that runs on the shared `tg agent` / `tg context` / `tg orient` hot path.

## Why (profiled, not guessed)

A CEO-relayed v1.63.2 dogfood over WSL `/mnt/c` reported whole-repo `agent`/`callers`/`orient` "hanging past 90s". **Root-caused: not a deadlock.** On native Windows the same commands complete — `tg agent .` (872-file repo) = 17.6s, `tg orient .` (50k-file workspace) = 48s. The WSL "hang" is 9p-filesystem amplification tipping past the test timeout.

But profiling `tg agent` (872 files) surfaced a real, self-inflicted cost inside that scope-proportional work:

| | calls | time |
|---|---|---|
| `_detect_vendored_subtrees` | — | **5.5s (~16% of capsule wall)** |
| `_path_is_relative_to` | 7524 | 6.2s |

`_path_is_relative_to` does **two `Path.resolve()` (realpath) syscalls per call**, invoked once per `(subtree_root × code_file)` pair at `orient_capsule.py:200`, with `abs_dir.resolve()` recomputed per file. On WSL 9p each realpath is pathologically slow — exactly the reported pain.

## Fix

Precompute each code file's path-parts relative to `root` **once** (the same lexical basis `candidate_dirs` already uses a few lines up; `root` is pre-resolved), then test membership with a tuple-prefix compare — **zero per-pair `resolve()`**.

Re-profile (872 files): `_path_is_relative_to` **7524 → 1876** calls, **6.2s → 1.7s**; `_detect_vendored_subtrees` drops out of the top-60.

## Correctness

Behavior-preserving: a file not lexically under `root` never contributed a candidate dir, so it cannot belong to a detected subtree — the lexical basis is *more* consistent with how subtrees are found, not less.

- 8 deweight tests green, incl. a **new nested-member guard** (`test_deeply_nested_subtree_file_counts_as_a_member`) whose island verdict hinges on a deeply-nested file being counted.
- 71 orient + agent-capsule consumer tests green.
- Full local gate: ruff check + ruff format --check --preview + mypy + pytest all clean.

Gate-free path (`orient_capsule.py` is not on the mandatory-adversarial-review list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
