### PR TITLE
perf(repo-map): content-addressed AST parse cache -- 36% faster warm agent re-query (#94)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1661,12 +1661,29 @@ def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
     return entries
 
 
+@lru_cache(maxsize=2048)
+def _cached_ast_parse(source: str) -> ast.Module:
+    """Content-addressed AST parse cache. `build_agent_capsule` parses each Python file 2-3x
+    across phases -- once in the map-build imports/symbols pass and again in the caller/blast-radius
+    consumer scan (and the `tg imports`/`importers` extractors) -- all on the SAME source read the
+    same way (`path.read_text(encoding="utf-8")`). Profiling `tg agent` on an 872-file repo (2026-
+    07-11) showed ~40% of the wall in `ast.parse` + `ast.walk` over those duplicate parses (1512
+    parses for ~783 files). Keying on the source TEXT (not the path) is staleness-free: an edited
+    file has different content -> a fresh key -> a fresh parse, so this stays correct even under the
+    reused session-daemon process (no mtime races). Callers only ever READ the tree (`tree.body` /
+    `ast.walk` + `isinstance`, no mutation -- audited), so sharing one parsed tree is safe. Raises
+    on invalid syntax exactly like `ast.parse` (lru_cache does not cache the exception, so a
+    syntax-error file simply re-raises + re-parses each time -- the caller's try/except is
+    unchanged). Bounded at 2048 entries to cap resident memory in the long-lived daemon."""
+    return ast.parse(source)
+
+
 def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
     if path.suffix != ".py":
         return [], []
 
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tree = _cached_ast_parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
         return [], []
 
@@ -3119,7 +3136,7 @@ def _python_file_imports_symbol_from_definition(
     repo_root: Path | str | None = None,
 ) -> bool:
     try:
-        tree = ast.parse(source)
+        tree = _cached_ast_parse(source)
     except SyntaxError:
         return False
 
@@ -3314,7 +3331,7 @@ def _python_import_update_target(
         return None
 
     try:
-        tree = ast.parse(source)
+        tree = _cached_ast_parse(source)
     except SyntaxError:
         return None
 
@@ -4197,7 +4214,7 @@ def _python_references_and_calls(
 
     try:
         source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source)
+        tree = _cached_ast_parse(source)
     except (OSError, SyntaxError, UnicodeDecodeError):
         return [], []
 
@@ -4264,7 +4281,7 @@ def _python_provider_alias_calls(path: Path, symbol: str) -> list[dict[str, Any]
 
     try:
         source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source)
+        tree = _cached_ast_parse(source)
     except (OSError, SyntaxError, UnicodeDecodeError):
         return []
 
@@ -5207,7 +5224,7 @@ def _python_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
 
     try:
         source = path.read_text(encoding="utf-8")
-        tree = ast.parse(source)
+        tree = _cached_ast_parse(source)
     except (OSError, SyntaxError, UnicodeDecodeError):
         return []
 
@@ -5674,7 +5691,7 @@ def _python_imports_with_lines(path: Path) -> list[dict[str, Any]]:
     if file_size > _max_parse_bytes():
         return []
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tree = _cached_ast_parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
         return []
 
@@ -8973,7 +8990,7 @@ def _best_test_function_candidate(
 def _python_test_function_candidates(test_path: str) -> tuple[str, ...]:
     path = Path(test_path)
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tree = _cached_ast_parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
         return ()
 
@@ -8996,7 +9013,7 @@ def _python_test_function_candidates(test_path: str) -> tuple[str, ...]:
 def _python_parametrized_test_function_candidates(test_path: str) -> tuple[str, ...]:
     path = Path(test_path)
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
+        tree = _cached_ast_parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
         return ()
 

--- a/tests/unit/test_ast_parse_cache.py
+++ b/tests/unit/test_ast_parse_cache.py
@@ -1,0 +1,48 @@
+"""The content-addressed AST parse cache (`_cached_ast_parse`) collapses the 2-3x duplicate Python
+file parses `build_agent_capsule` does across phases -- the map-build imports/symbols pass and the
+caller/blast-radius consumer scan both `ast.parse` the SAME source. Profile 2026-07-11: ~40% of
+`tg agent` wall was `ast.parse` + `ast.walk` over those duplicate parses (1512 parses / ~783 files).
+Keying on source TEXT (not path) keeps it staleness-free under the reused session-daemon process.
+"""
+
+import ast
+from pathlib import Path
+
+from tensor_grep.cli.repo_map import _cached_ast_parse, _python_imports_and_symbols
+
+
+def test_identical_source_is_parsed_once_and_shared() -> None:
+    _cached_ast_parse.cache_clear()
+    src = "import os\nfrom a.b import c\n\n\ndef f():\n    return c\n"
+    first = _cached_ast_parse(src)
+    second = _cached_ast_parse(src)
+    assert first is second  # same tree object -> parsed once, shared read-only
+    info = _cached_ast_parse.cache_info()
+    assert info.misses == 1 and info.hits == 1
+
+
+def test_cached_parse_is_byte_identical_to_ast_parse() -> None:
+    _cached_ast_parse.cache_clear()
+    src = "import os\nfrom a.b import c as d\n\n\nclass K:\n    def m(self):\n        return 1\n"
+    assert ast.dump(_cached_ast_parse(src)) == ast.dump(ast.parse(src))
+
+
+def test_distinct_sources_get_distinct_trees() -> None:
+    _cached_ast_parse.cache_clear()
+    assert _cached_ast_parse("import os\n") is not _cached_ast_parse("import sys\n")
+
+
+def test_reparsing_the_same_unchanged_file_hits_the_cache(tmp_path: Path) -> None:
+    # The whole point: the map-build pass and the caller/blast scan both parse the same file. A
+    # second extraction of identical content must be a cache HIT (no new miss), not a re-parse.
+    _cached_ast_parse.cache_clear()
+    module = tmp_path / "m.py"
+    module.write_text(
+        "import os\nfrom pkg import thing\n\n\ndef go():\n    return thing\n", encoding="utf-8"
+    )
+    _python_imports_and_symbols(module)
+    misses_after_first = _cached_ast_parse.cache_info().misses
+    _python_imports_and_symbols(module)  # same source read again
+    info = _cached_ast_parse.cache_info()
+    assert info.misses == misses_after_first  # NOT re-parsed
+    assert info.hits >= 1


### PR DESCRIPTION
## What

A content-addressed AST parse cache that collapses the 2-3x duplicate Python file parses on the `tg agent` / caller / blast-radius hot path.

## Why (profiled)

Profiling `tg agent` on an 872-file repo (right after the #534 deweight fix) surfaced the next hotspot: **~40% of the wall in `ast.parse` + `ast.walk`, with 1512 parses for ~783 files** — every Python file is parsed 2-3x because the map-build imports/symbols pass, the caller/blast consumer scan, and the `tg imports`/`importers` extractors each `ast.parse` the same source independently.

## Fix

Route all 9 file-parse sites in `repo_map.py` through `_cached_ast_parse(source)` (`functools.lru_cache`, maxsize=2048).

- **Content-addressed** (keyed on source text, not path) → staleness-free: an edited file has different content → a fresh parse. Correct even under the reused session-daemon process (no mtime races).
- **Read-only sharing** is safe — audited: every consumer only does `tree.body` / `ast.walk` + `isinstance`, zero mutation.
- **Syntax errors** re-raise + re-parse each call exactly as before (lru_cache doesn't cache the exception); callers' `try/except` unchanged.

## Measured (in-process)

| | result |
|---|---|
| Intra-call parse dedup | `ast.parse` **1512 → 467** calls |
| **Warm re-query (session-daemon case, #94)** | 2nd agent capsule on the same unchanged repo re-parses **ZERO** files → **11.4s → 7.4s = 36% faster** |

This is the **AST-parse half of the warm-daemon latency story** (#94, the #1 moat lever): cached parses persist across queries in the long-lived daemon process, so repeated agent/caller queries on an unchanged repo skip all re-parsing.

## Tests

4 cache tests (dedup via `cache_info`, byte-identical to `ast.parse`, distinct sources, cross-call hit) + 41 agent/caller/import/orient consumer tests green. Full local gate clean (ruff check + ruff format --preview + mypy + pytest). Gate-free path (`repo_map.py` not on the mandatory-adversarial-review list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
