### PR TITLE
docs: refresh BACKLOG ledger to v1.63.4 + scope-to-src/WSL agent guidance (#135)

### DIFF
--- a/.claude/skills/tensor-grep-large-repo-scale-campaign/SKILL.md
+++ b/.claude/skills/tensor-grep-large-repo-scale-campaign/SKILL.md
@@ -52,6 +52,21 @@ skill without beating a measurable gate and a conscious flag-flip** (Phase 4).
   a vendored tree were not auto-excluded) — that doc lags. The fix, **#400**, shipped in
   **v1.40.4** (`bb14abe`) and was hardened further by **#413** (v1.42.0) and **#428**; see
   §1 below. Do not present this as an open bug or an unmerged PR.
+- **Whole-repo GRAPH commands (agent / callers / blast-radius / orient) are SLOW AT SCALE, not
+  hung — scope to a package root.** On a big tree the graph is O(files): `tg agent .` / `tg orient .`
+  walk + parse the whole repo. Native Windows they COMPLETE (agent ~18s on an 872-file repo,
+  workspace `orient .` ~48s on 50k files) but they are not fast. The agent-honest usage on large
+  trees is a package root — `tg agent REPO/src "task"`, `tg callers REPO/src SYMBOL` — 3-5x faster.
+  Two CPU latency wins shipped 2026-07-11 (v1.63.3 deweight #534 removed a per-file `resolve()` hot
+  loop from the shared hot path; v1.63.4 parse-cache #535 deduped the 2-3x Python parse, **36%
+  faster on a warm re-query**); the remaining scan cost is inherent and is the warm-daemon's job (#94).
+- **A "whole-repo hang past 60-90s" reported from WSL over `/mnt/c` is a 9p-filesystem ARTIFACT,
+  NOT a tg deadlock.** WSL reading a Windows-mounted tree is ~3-5x slower than native NTFS at the
+  file-walk + `stat()`/`realpath()` these commands do, which tips scope-proportional work past a test
+  timeout. **Reproduce a WSL latency report NATIVELY (Windows or native Linux, not `/mnt/c`) before
+  treating it as a tg bug** — the 2026-07-11 v1.63.2 "10-timeout P0 regression" dogfood was exactly
+  this (native: every flagged command completed). Memory:
+  `tensor-grep-wsl-mnt-c-latency-artifact-2026-07-11`.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,7 @@
 > **Canonical prioritized work list.** Kept in sync with the CLI task store (`TaskUpdate`) and
 > GitHub (`gh pr list` is the source of truth for PRs). **CEO status** = summarize SHIPPING + P0/P1.
 > Update whenever a PR opens/merges or the queue changes. Task-store IDs (`#NNN`) cross-referenced.
-> Last refreshed 2026-07-10 (drain @ v1.58.11).
+> Last refreshed 2026-07-11 (drain @ v1.63.4).
 
 **Process:** deep-dive/audit (cite `file:line`) → verify-against-code → Sonnet TDD build in
 `isolation:'worktree'` → real-venv verify (`uv run --active --no-sync`; copy `rust_core.pyd`, set
@@ -23,17 +23,19 @@ wheel compile (~65min normal), don't panic-rerun. **WIP CAP: no new build while 
 
 ---
 
-## ⭐ CURRENT STATE (2026-07-12) — authoritative; every section BELOW is HISTORICAL until the next full refresh
+## ⭐ CURRENT STATE (2026-07-11) — authoritative; every section BELOW is HISTORICAL until the next full refresh
 
-- **0 open PRs** (`gh pr list` = 0, the source of truth). **WIP=0 — drain FULLY CLEAR.** Live PyPI **v1.63.1**; **v1.63.2 releasing** (main `36da19d`; #531 late-rerank real deadline).
-- **This session drained the full v1.61.2-dogfood + external-audit batch — 5 releases (v1.62.2 → v1.63.2), zero broken releases, every fix real-binary-verified (not just CliRunner):**
-  - **v1.62.0** (#525 orient auto-deweight) · **v1.62.1** (#527 = audit **A2** semantic-cap self-bypass DoS) · **v1.62.2** (#528 = dogfood **P0** unscoped-search refuse-fast — the FULL-CLI `--rank`/`--semantic` path; the native binary already guarded the plain path, corrected by real-binary dogfood) · **v1.63.0** (#530 = `suggested_scope` on the agent capsule, no second scan) · **v1.63.1** (#529 = `tg evidence <path>` → `emit` UX hint) · **v1.63.2 releasing** (#531 = audit **A3** late-rerank REAL wall-clock deadline; a hung encoder no longer blocks `tg search --rank` forever; Fail-Closed Contract preserved across the thread boundary).
+- **0 open PRs** (`gh pr list` = 0, the source of truth). **WIP=0 — drain clear.** Live PyPI **v1.63.3**; **v1.63.4 releasing** (main `8e3e625`; #535 content-addressed AST parse-cache).
+- **This session shipped 7 releases (v1.62.0 → v1.63.4), zero broken, every fix real-binary-verified (not just CliRunner):**
+  - **v1.62.0** (#525 orient auto-deweight) · **v1.62.1** (#527 = audit **A2** semantic-cap self-bypass DoS) · **v1.62.2** (#528 = dogfood **P0** unscoped-search refuse-fast, FULL-CLI `--rank`/`--semantic` path) · **v1.63.0** (#530 = `suggested_scope` on the agent capsule, no second scan) · **v1.63.1** (#529 = `tg evidence <path>` → `emit` hint) · **v1.63.2** (#531 = audit **A3** late-rerank real wall-clock deadline) · **v1.63.3** (#534 = deweight O(subtrees×files)→one-pass lexical membership) · **v1.63.4 releasing** (#535 = content-addressed AST parse-cache).
+  - **LATENCY (the #1 moat lever) — two profiled wins this session:** #534 deweight removed 2 filesystem `resolve()`/pair from the shared agent/orient hot path (~16% of agent wall, worst on WSL 9p); #535 parse-cache deduped the 2-3x Python file parses (**36% faster WARM agent re-query 11.4s→7.4s** — the daemon-persistence enabler). **CPU-side dedup wins now EXHAUSTED** — the remaining `ast.walk` caller-scan is inherent (once per file, not duplicated), so the next latency lever is the warm-daemon / import-index = **#94 (Opus-gated → Jul-13)**.
+  - **The v1.63.2 dogfood "P0 whole-repo hang" alarm was a WSL /mnt/c 9p ARTIFACT, not a tg bug** — native, the flagged commands COMPLETE (agent 17.6s, callers 13.3s, workspace orient 48s). Reproduce WSL latency reports natively first (memory: `tensor-grep-wsl-mnt-c-latency-artifact-2026-07-11`).
 - **Remaining backlog (authoritative; gated as noted):**
-  - **#134 external audit** — SHIPPED: A2 (#527), A3 (#531). **Opus-gated → Jul-13** (weekly limit; mandatory adversarial gate before load-bearing security code): A1 (explicit `--index` drops CLI options / default-deny validator, rust_core), A4 (index-persistence load-once+atomic+lock, index.rs), GPU capability-validator + NVIDIA-artifact-without-native-CUDA packaging-matrix removal.
-  - **#133 v1.61.2 dogfood** — P0/UX DRAINED. Remaining polish-tail: edit-plan `validation_plan` (verified gap = `tg context` surface only; `tg agent` already emits it → marginal), dynamic-imports (extends #93). Held per the CEO's churn steer.
-  - **#94 latency (the #1 "make models prefer tg" lever)** — warm-daemon default fast path. **Opus-gated → Jul-13** (session_daemon surface).
+  - **#134 external audit** — SHIPPED: A2 (#527), A3 (#531); the re-relayed audit was STALE (both already fixed, verified vs live code). **VERIFY-PLANNED + Opus-gated → Jul-13:** A1 (explicit `--index` deny-list incomplete `main.rs:5908`; silently drops `--hidden`/`--max-depth`/`-l`/`-o`/`--replace` → default-deny capability validator) · A4 (index-persistence non-atomic `std::fs::write` `index.rs:856` + zero locking → temp→fsync→rename + O_EXCL lock). GPU capability-validator + NVIDIA-without-native-CUDA packaging-matrix removal is **CEO-gated** (GPU program vs no-SaaS).
+  - **#135 docs** — add scope-to-src + WSL-caveat agent guidance (THIS PR). **#133 dogfood polish-tail** (edit-plan `validation_plan` = marginal `tg context`-only gap; dynamic-imports extends #93) held per the CEO churn steer.
+  - **#94 latency warm-daemon default** — the next moat step now that CPU dedup is exhausted. **Opus-gated → Jul-13** (session_daemon surface).
 - **CEO-gated (the CEO's call):** benchmark publish #72 (the 7.5x-fewer-tokens-than-grep proof) · `tg ledger` #77 (local agent coordination) · GPU multi-week rebuild #131 (conflicts with no-SaaS).
-- **Strategic (audit + CEO steer 2026-07-11):** tool WORKS (477 releases, moat = **7.5x fewer tokens than grep on definition-lookup**, benchmark-proven); near-term product = signed PR evidence + change-governance; finish the moat (latency) + shift to gotcontext wiring vs draining the self-refilling tail; no-SaaS (gotcontext.ai is the SaaS shell, not tg).
+- **Strategic (CEO steer 2026-07-11):** tool WORKS (moat = **7.5x fewer tokens than grep on definition-lookup**, benchmark-proven); finish the moat (latency — 2 CPU wins shipped, next lever Jul-13-gated) + shift to gotcontext wiring vs draining the self-refilling tail; no-SaaS (gotcontext.ai is the SaaS shell, not tg).
 
 ---
 


### PR DESCRIPTION
Cron STEP 2/3 docs cycle — no release.

**BACKLOG CURRENT STATE** refreshed v1.63.1 -> v1.63.4 (was 5 versions stale):
- This session's 7 releases (v1.62.0 -> v1.63.4), incl the two profiled latency wins: **#534 deweight** (removed a per-file `resolve()` hot loop, ~16% of agent wall) + **#535 parse-cache** (36% faster warm agent re-query).
- The **CPU-dedup-EXHAUSTED** finding: the remaining `ast.walk` caller-scan is inherent (once per file), so the next latency lever is the warm-daemon/import-index = #94 (Opus-gated Jul-13).
- The v1.63.2 "P0 whole-repo hang" alarm = a **WSL /mnt/c 9p artifact** (native: all flagged commands complete).
- #134 A1/A4 verify-planned with `file:line`.

**#135 skill guidance** (`tensor-grep-large-repo-scale-campaign`): scope-to-src on big trees (graph is O(files); native `tg agent` ~18s/872 files, workspace `orient .` ~48s/50k -- complete not hung; `REPO/src` is 3-5x faster) + the WSL /mnt/c 9p latency-artifact caveat.

Docs-only. Agent-readiness governance test green (39 passed). Merges after v1.63.4 publishes (push-race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)