### PR TITLE
feat(codemap): native `tg codemap` browsable folder->file->symbol code map (#137)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -955,6 +955,12 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Render a persisted, browsable folder->file->symbol code map (lean index + per-folder pages)
+    #[command(name = "codemap", disable_help_flag = true)]
+    Codemap {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Emit a single-pass repository inventory (files, bytes, languages, categories)
     #[command(name = "inventory", disable_help_flag = true)]
     Inventory {
@@ -4299,6 +4305,7 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         Commands::GpuOomProbe(args) => handle_gpu_oom_probe_command(args),
         Commands::Map { args } => handle_python_passthrough("map", args),
         Commands::Orient { args } => handle_python_passthrough("orient", args),
+        Commands::Codemap { args } => handle_python_passthrough("codemap", args),
         Commands::Inventory { args } => handle_python_passthrough("inventory", args),
         Commands::DocsCoverage { args } => handle_python_passthrough("docs-coverage", args),
         Commands::Session { args } => handle_python_passthrough("session", args),

--- a/src/tensor_grep/cli/codemap.py
+++ b/src/tensor_grep/cli/codemap.py
@@ -1,0 +1,979 @@
+"""`tg codemap`: a persisted, browsable folder->file->symbol code map (lean index + per-folder
+drill-down pages), built ENTIRELY on top of the existing `repo_map.build_repo_map()` extraction.
+
+Positioning (no overlap with sibling commands): `tg orient` is a ranked, bounded, ephemeral
+capsule; `tg map` is a raw JSON dump; `tg codemap` is an exhaustive, persisted, browsable
+inventory meant to be committed/read like docs. It never re-implements AST/tree-sitter parsing --
+that IS the point: a from-scratch code-map generator would duplicate `build_repo_map`'s extraction,
+so this module formats that extraction's output instead. Every enrichment here (signature,
+docstring-first-sentence, Class.method attribution, folder blurbs) is a FORMATTING pass over data
+`build_repo_map` already computed, or a read of the already-content-addressed-cached AST
+(`repo_map._cached_ast_parse`) -- never a second, independent `ast.parse`/tree-sitter parse, and
+never a new field on the shared `_symbol_record` payload (that payload also backs `tg map`/`tg
+agent`/`tg orient`/`tg context` and is pinned by their own contract tests; enrichment here is
+joined on ``(file, start_line)`` and stays local to this module).
+
+Freshness is a CORRECTNESS requirement, not a nicety: every generated map is stamped with a dual
+oracle (git revision identity + a content-addressed tree manifest hash), and `tg codemap --check`
+is a READ-ONLY (no re-parse) verifier that fails CLOSED -- an unverifiable map reads as stale, a
+partial map never reads as fresh, and any drift (edited/added/removed file, or a changed git
+commit/dirty-state) flips the check from fresh to stale.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import re
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from tensor_grep.cli import evidence_receipt as _evidence_receipt
+from tensor_grep.cli import lang_registry
+from tensor_grep.cli import orient_capsule as _orient_capsule
+from tensor_grep.cli import repo_map as _repo_map
+from tensor_grep.cli._index_lock import replace_with_retry
+
+# Mirrors inventory's/docs-coverage's 50000 default (NOT map's 512 or agent's 2000 -- codemap is
+# an exhaustive inventory, not an agent-context budget). Kept as a real module constant (unlike
+# main.py's CLI option, which literal-duplicates the number to keep the heavy import lazy -- the
+# established `map`/`inventory` pattern; a routing-parity/contract test is not needed for a private
+# default since nothing else reads it).
+DEFAULT_MAX_REPO_FILES = 50_000
+DEFAULT_MAX_SYMBOLS_PER_FILE = 50
+
+_COVERAGE_SCHEMA_VERSION = 1
+_COVERAGE_FILENAME = "_coverage.json"
+
+_DOCSTRING_SENTENCE_LIMIT = 220
+_SOURCE_LINE_SIGNATURE_LIMIT = 140
+_ROLE_CELL_LIMIT = 100
+
+_LANGUAGE_LABELS = {
+    "python": "Python",
+    "javascript": "JavaScript",
+    "typescript": "TypeScript",
+    "rust": "Rust",
+    "go": "Go",
+}
+_NON_CODE_LANGUAGE_LABELS = {
+    ".md": "Markdown",
+    ".markdown": "Markdown",
+    ".rst": "reStructuredText",
+    ".txt": "Text",
+    ".json": "JSON",
+    ".yaml": "YAML",
+    ".yml": "YAML",
+    ".toml": "TOML",
+    ".ini": "INI",
+    ".cfg": "Config",
+    ".adoc": "AsciiDoc",
+}
+
+_SENTENCE_END_RE = re.compile(r"[.!?](?:\s|$)")
+_SLUG_UNSAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+# ---------------------------------------------------------------------------
+# Small, pure formatting helpers (no I/O)
+# ---------------------------------------------------------------------------
+
+
+def _truncate_ascii(text: str, limit: int) -> str:
+    """Truncate to `limit` chars using an ASCII `...` marker (never U+2026 -- the cp1252 Windows
+    stdout crash class; AGENTS.md ASCII-only rule)."""
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _first_sentence(text: str | None, *, limit: int = _DOCSTRING_SENTENCE_LIMIT) -> str:
+    """First sentence of `text` (whitespace-collapsed), capped at `limit` chars. Returns "" for
+    None/empty input -- callers rely on this to render an EMPTY description cell rather than
+    fabricate filler (the old script's `_infer_from_name` name-echo anti-pattern this module must
+    never reintroduce)."""
+    if not text:
+        return ""
+    normalized = " ".join(text.split())
+    if not normalized:
+        return ""
+    match = _SENTENCE_END_RE.search(normalized)
+    sentence = normalized[: match.end()].strip() if match else normalized
+    return _truncate_ascii(sentence, limit)
+
+
+def _folder_slug(folder_rel_posix: str) -> str:
+    """Filesystem-safe page filename stem for a repo-relative POSIX folder path. `""`/"."` (files
+    living directly at the repo root) get the reserved `_root` slug."""
+    if folder_rel_posix in ("", "."):
+        return "_root"
+    return _SLUG_UNSAFE_RE.sub("_", folder_rel_posix.replace("/", "_"))
+
+
+def _escape_cell(text: str) -> str:
+    """Escape a value for embedding in a GFM table cell: a raw `|` (common in TS union types,
+    e.g. `string | number`) would otherwise silently corrupt the table structure."""
+    return text.replace("|", "\\|").replace("\r", " ").replace("\n", " ")
+
+
+def _relative_link(target: Path, *, from_dir: Path) -> str:
+    try:
+        rel = os.path.relpath(target, start=from_dir)
+    except ValueError:
+        rel = str(target)
+    return Path(rel).as_posix()
+
+
+def _repo_relative_posix(file_path: str, root: Path) -> str:
+    try:
+        return Path(file_path).resolve().relative_to(root).as_posix()
+    except (OSError, ValueError):
+        return Path(file_path).as_posix()
+
+
+def _is_under_dir(path: Path, directory: Path) -> bool:
+    try:
+        path.resolve().relative_to(directory.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _language_label(path_str: str) -> str:
+    spec = lang_registry.spec_for_path(path_str)
+    if spec is not None:
+        return _LANGUAGE_LABELS.get(spec.language_id, spec.language_id.capitalize())
+    suffix = Path(path_str).suffix.lower()
+    return _NON_CODE_LANGUAGE_LABELS.get(suffix, "Text")
+
+
+# ---------------------------------------------------------------------------
+# Python enrichment: FORMATS the already-cached AST -- never a second ast.parse.
+# ---------------------------------------------------------------------------
+
+
+_PyDefNode = ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _iter_python_defs(
+    node: ast.AST, *, parent_class: str | None = None
+) -> Iterator[tuple[_PyDefNode, str | None]]:
+    """Yield (def_node, owning_class_name_or_None) for every ClassDef/FunctionDef/AsyncFunctionDef
+    reachable from `node` -- the same exhaustive set `ast.walk` (repo_map's own symbol walker)
+    reaches, but additionally tracking DIRECT class-body membership so a method can be attributed
+    to its class (`Class.method`). A function nested inside a method (closure) is NOT itself
+    attributed as a method of the outer class (`parent_class` resets to None one level in)."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.ClassDef):
+            yield child, parent_class
+            yield from _iter_python_defs(child, parent_class=child.name)
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield child, parent_class
+            yield from _iter_python_defs(child, parent_class=None)
+        else:
+            yield from _iter_python_defs(child, parent_class=parent_class)
+
+
+def _format_python_args(args_node: ast.arguments) -> str:
+    try:
+        return ast.unparse(args_node)
+    except (ValueError, TypeError, RecursionError):
+        # Defensive fallback (names only, no defaults/annotations) -- ast.unparse is expected to
+        # handle `arguments` nodes directly, but this never lets a single odd signature crash the
+        # whole run.
+        names = [a.arg for a in (*args_node.posonlyargs, *args_node.args)]
+        if args_node.vararg:
+            names.append(f"*{args_node.vararg.arg}")
+        names.extend(a.arg for a in args_node.kwonlyargs)
+        if args_node.kwarg:
+            names.append(f"**{args_node.kwarg.arg}")
+        return ", ".join(names)
+
+
+def _format_python_signature(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, *, display_name: str
+) -> str:
+    prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+    return f"{prefix} {display_name}({_format_python_args(node.args)})"
+
+
+def _format_python_class_signature(node: ast.ClassDef, *, display_name: str) -> str:
+    try:
+        bases = [ast.unparse(base) for base in node.bases]
+    except (ValueError, TypeError, RecursionError):
+        bases = []
+    if bases:
+        return f"class {display_name}({', '.join(bases)})"
+    return f"class {display_name}"
+
+
+def _python_file_enrichment(path: Path) -> tuple[dict[int, dict[str, Any]], str]:
+    """Read `path` the SAME way `repo_map._python_imports_and_symbols` does
+    (`path.read_text(encoding="utf-8")`) and reuse the content-addressed `_cached_ast_parse` cache
+    (keyed on that exact source text) -- a cache HIT, not a re-parse, for any file already scanned
+    by `build_repo_map` earlier in this same process. Returns (enrichment keyed by
+    ``node.lineno`` == the symbol's ``start_line``, module purpose first-sentence)."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}, ""
+    try:
+        tree = _repo_map._cached_ast_parse(source)
+    except (SyntaxError, ValueError, RecursionError):
+        return {}, ""
+
+    enrichment: dict[int, dict[str, Any]] = {}
+    for node, parent_class in _iter_python_defs(tree):
+        display_name = f"{parent_class}.{node.name}" if parent_class else node.name
+        if isinstance(node, ast.ClassDef):
+            signature = _format_python_class_signature(node, display_name=display_name)
+        else:
+            signature = _format_python_signature(node, display_name=display_name)
+        docstring = ast.get_docstring(node)
+        enrichment[node.lineno] = {
+            "signature": signature,
+            "docstring": _first_sentence(docstring),
+            "parent_class": parent_class,
+        }
+    module_purpose = _first_sentence(ast.get_docstring(tree))
+    return enrichment, module_purpose
+
+
+# ---------------------------------------------------------------------------
+# JS/TS/Rust enrichment: source-line signature fallback (+ Rust `///` doc comments).
+# ---------------------------------------------------------------------------
+
+
+def _source_line_signature(
+    path_str: str, start_line: int, *, limit: int = _SOURCE_LINE_SIGNATURE_LIMIT
+) -> str:
+    try:
+        source = _repo_map._read_source_text_cached(path_str)
+    except OSError:
+        return ""
+    lines = source.splitlines()
+    if start_line < 1 or start_line > len(lines):
+        return ""
+    return _truncate_ascii(lines[start_line - 1].strip(), limit)
+
+
+def _rust_doc_comment(path_str: str, start_line: int) -> str:
+    """Collect the contiguous run of `///` lines immediately preceding `start_line` (a blank or
+    non-`///` line breaks the chain), first-sentence it. JS/TS carries no docs in v1 (spec)."""
+    try:
+        source = _repo_map._read_source_text_cached(path_str)
+    except OSError:
+        return ""
+    lines = source.splitlines()
+    doc_lines: list[str] = []
+    idx = start_line - 2  # 0-indexed line directly above start_line (start_line is 1-indexed)
+    while idx >= 0:
+        stripped = lines[idx].strip()
+        if not stripped.startswith("///"):
+            break
+        doc_lines.insert(0, stripped[3:].strip())
+        idx -= 1
+    return _first_sentence(" ".join(doc_lines)) if doc_lines else ""
+
+
+def _enrichment_for_file(
+    file_path: str, file_symbols: list[dict[str, Any]]
+) -> tuple[dict[int, dict[str, Any]], str]:
+    """Dispatch by suffix: Python reuses the cached AST (whole-file pass); JS/TS/Rust build a
+    per-symbol entry from the already-known `start_line`s via the source-line fallback (no
+    extractor of their own -- `file_symbols` already came from `build_repo_map`)."""
+    suffix = Path(file_path).suffix.lower()
+    if suffix == ".py":
+        return _python_file_enrichment(Path(file_path))
+    if suffix in _repo_map._RUST_SUFFIXES:
+        enrichment = {}
+        for symbol in file_symbols:
+            start_line = int(symbol.get("start_line", symbol.get("line", 0)) or 0)
+            enrichment[start_line] = {
+                "signature": _source_line_signature(file_path, start_line),
+                "docstring": _rust_doc_comment(file_path, start_line),
+                "parent_class": None,
+            }
+        return enrichment, ""
+    if suffix in _repo_map._JS_TS_SUFFIXES:
+        enrichment = {}
+        for symbol in file_symbols:
+            start_line = int(symbol.get("start_line", symbol.get("line", 0)) or 0)
+            enrichment[start_line] = {
+                "signature": _source_line_signature(file_path, start_line),
+                "docstring": "",
+                "parent_class": None,
+            }
+        return enrichment, ""
+    return {}, ""
+
+
+def _first_markdown_heading(path_str: str) -> str:
+    try:
+        source = _repo_map._read_source_text_cached(path_str)
+    except OSError:
+        return ""
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip()
+    return ""
+
+
+def _file_purpose(path_str: str, *, module_purpose: str, language_label: str) -> str:
+    """Module docstring first sentence (Python); `.md` first heading; else a generic
+    ``"<lang> file"`` -- never the old script's name-echo filler."""
+    suffix = Path(path_str).suffix.lower()
+    if suffix == ".py" and module_purpose:
+        return module_purpose
+    if suffix in {".md", ".markdown"}:
+        heading = _first_markdown_heading(path_str)
+        if heading:
+            return heading
+    return f"{language_label} file"
+
+
+# ---------------------------------------------------------------------------
+# Folder blurb fallback chain: overlay -> README.md -> __init__.py -> generic.
+# Works WITHOUT any migration -- the overlay directory is simply absent until one is authored.
+# ---------------------------------------------------------------------------
+
+
+def _load_enrichment_overlays(out_dir: Path) -> dict[str, str]:
+    """Merge every ``<out>/_enrichments/*.json`` file into one folder-relative-POSIX-path -> blurb
+    map. Each overlay file is a flat ``{"folder/path": "One-line blurb."}`` object (a string value)
+    or, for forward compatibility, ``{"folder/path": {"role": "One-line blurb."}}``. Missing/absent
+    directory -> empty dict (this feature must work without the `_enrichments/` migration)."""
+    overlays_dir = out_dir / "_enrichments"
+    merged: dict[str, str] = {}
+    if not overlays_dir.is_dir():
+        return merged
+    try:
+        overlay_paths = sorted(overlays_dir.glob("*.json"))
+    except OSError:
+        return merged
+    for overlay_path in overlay_paths:
+        try:
+            data = json.loads(overlay_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        for key, value in data.items():
+            if isinstance(value, str):
+                merged[key] = value
+            elif isinstance(value, dict) and isinstance(value.get("role"), str):
+                merged[key] = value["role"]
+    return merged
+
+
+def _first_readme_sentence(readme_path: Path) -> str:
+    try:
+        text = readme_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return _first_sentence(stripped)
+    return ""
+
+
+def _init_docstring_sentence(init_path: Path) -> str:
+    try:
+        source = init_path.read_text(encoding="utf-8")
+        tree = _repo_map._cached_ast_parse(source)
+    except (OSError, UnicodeDecodeError, SyntaxError, ValueError, RecursionError):
+        return ""
+    return _first_sentence(ast.get_docstring(tree))
+
+
+def _folder_blurb(folder_rel_posix: str, *, root: Path, overlays: dict[str, str]) -> str:
+    if folder_rel_posix in overlays:
+        return overlays[folder_rel_posix]
+    folder_abs = root if folder_rel_posix in ("", ".") else root / folder_rel_posix
+    readme_sentence = _first_readme_sentence(folder_abs / "README.md")
+    if readme_sentence:
+        return readme_sentence
+    init_sentence = _init_docstring_sentence(folder_abs / "__init__.py")
+    if init_sentence:
+        return init_sentence
+    display_name = folder_rel_posix if folder_rel_posix not in ("", ".") else root.name
+    return f"Project folder `{display_name}`."
+
+
+# ---------------------------------------------------------------------------
+# Universe construction: self-exclusion (--out/--index) + folder grouping.
+# ---------------------------------------------------------------------------
+
+
+def _excluded_by_output_str(file_str: str, *, out_dir: Path, index_path: Path) -> bool:
+    candidate = Path(file_str)
+    if _is_under_dir(candidate, out_dir):
+        return True
+    try:
+        return candidate.resolve() == index_path.resolve()
+    except OSError:
+        return False
+
+
+def _exclude_output_paths(rm: dict[str, Any], *, out_dir: Path, index_path: Path) -> dict[str, Any]:
+    """Post-filter the repo_map payload to drop every file under --out (incl. --index) -- mirrors
+    orient_capsule.py's `_apply_ignore_globs` (a proven precedent for this exact post-hoc payload
+    filtering). Without this, codemap's OWN previously-written `.md`/`.json` pages would be walked
+    back in as new "source files" on the next run (self-invalidation)."""
+
+    def _excluded(file_str: str) -> bool:
+        return _excluded_by_output_str(file_str, out_dir=out_dir, index_path=index_path)
+
+    filtered = dict(rm)
+    filtered["files"] = [f for f in rm.get("files", []) if not _excluded(str(f))]
+    filtered["tests"] = [f for f in rm.get("tests", []) if not _excluded(str(f))]
+    filtered["symbols"] = [
+        s for s in rm.get("symbols", []) if not _excluded(str(s.get("file", "")))
+    ]
+    filtered["imports"] = [
+        i for i in rm.get("imports", []) if not _excluded(str(i.get("file", "")))
+    ]
+    return filtered
+
+
+def _folder_for_file(file_path: str, root: Path) -> str:
+    rel = Path(_repo_relative_posix(file_path, root))
+    parent = rel.parent
+    return "" if str(parent) == "." else parent.as_posix()
+
+
+def _group_by_folder(universe: list[str], root: Path) -> dict[str, list[str]]:
+    folders: dict[str, list[str]] = {}
+    for file_path in universe:
+        folders.setdefault(_folder_for_file(file_path, root), []).append(file_path)
+    return folders
+
+
+def _self_verify_universe_coverage(universe: list[str], folders: dict[str, list[str]]) -> bool:
+    """Every universe file must appear in EXACTLY one folder bucket -- a defensive correctness
+    gate (Section 4's partial contract), not a tautology: a grouping bug (or a future refactor)
+    that double-counts or drops a file flips this to False, which flips the whole map to
+    partial:true rather than silently shipping an incomplete inventory as if it were complete."""
+    accounted: set[str] = set()
+    for files in folders.values():
+        for file_path in files:
+            if file_path in accounted:
+                return False
+            accounted.add(file_path)
+    return accounted == set(universe)
+
+
+# ---------------------------------------------------------------------------
+# Walk-only helpers (NO parsing) -- shared by the zero-mapped-file folder census (generation) and
+# the freshness re-walk (--check, which must never re-parse a single file).
+# ---------------------------------------------------------------------------
+
+
+def _walk_only_universe(root: Path, *, max_repo_files: int) -> list[str]:
+    """The exact file universe `build_repo_map`'s parse loop would consume, computed WITHOUT
+    parsing a single file: reuses `build_repo_map`'s own walk (`_iter_repo_files`) and its
+    pre-parse suffix/hidden-file gate (`_is_repo_context_file`)."""
+    context_root = root if root.is_dir() else root.parent
+    try:
+        all_files = _repo_map._iter_repo_files(root, max_files=max_repo_files)
+    except OSError:
+        return []
+    return [str(f) for f in all_files if _repo_map._is_repo_context_file(f, context_root)]
+
+
+def _all_folder_paths(root: Path, *, max_repo_files: int) -> set[str]:
+    """Every folder (repo-relative POSIX, "" for repo root) containing >=1 file the walk reaches,
+    regardless of mapped-suffix status -- used only to report how many folders were excluded from
+    the (mapped-files-only) index table because they hold nothing but unmapped extensions."""
+    try:
+        all_files = _repo_map._iter_repo_files(root, max_files=max_repo_files)
+    except OSError:
+        return set()
+    folders: set[str] = set()
+    for f in all_files:
+        try:
+            rel = f.resolve().relative_to(root)
+        except (OSError, ValueError):
+            continue
+        parent = rel.parent
+        folders.add("" if str(parent) == "." else parent.as_posix())
+    return folders
+
+
+def _tree_manifest_sha256(files: list[str], root: Path) -> str:
+    """sha256 over sorted (relpath, size, mtime_ns) of `files` -- the git-independent freshness
+    oracle. `files` must already exclude --out/--index (else self-invalidation: writing the map
+    changes the map's own freshness stamp)."""
+    entries: list[tuple[str, int, int]] = []
+    for file_str in files:
+        file_path = Path(file_str)
+        try:
+            stat_result = file_path.stat()
+        except OSError:
+            continue
+        entries.append((
+            _repo_relative_posix(file_str, root),
+            stat_result.st_size,
+            stat_result.st_mtime_ns,
+        ))
+    entries.sort(key=lambda entry: entry[0])
+    canonical = "\n".join(
+        f"{relpath}\x00{size}\x00{mtime_ns}" for relpath, size, mtime_ns in entries
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Central files (replaces the old script's tg-specific "hot-path cheat sheet"): reuse orient's
+# own composite centrality score -- never a second scoring system.
+# ---------------------------------------------------------------------------
+
+
+def _top_central_files(rm: dict[str, Any], *, limit: int = 10) -> list[tuple[str, float]]:
+    code_files, centrality = _orient_capsule._file_centrality_scores(rm)
+    if not code_files:
+        return []
+    ranked = sorted(code_files, key=lambda f: (-centrality[f], f))
+    return [(f, round(centrality[f], 6)) for f in ranked[:limit]]
+
+
+# ---------------------------------------------------------------------------
+# Stamp formatting (dual oracle: git revision identity + tree manifest hash).
+# ---------------------------------------------------------------------------
+
+
+def _format_utc_iso(moment: datetime) -> str:
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _format_stamp_line(revision: dict[str, Any], now_iso: str) -> str:
+    if revision.get("status") == "present":
+        sha12 = str(revision.get("commit_sha", ""))[:12]
+        dirty_label = "dirty" if revision.get("dirty") else "clean"
+        identity = f"{sha12} ({dirty_label})"
+    else:
+        identity = "no-git (manifest-only)"
+    return f"_Map stamp: {identity} generated {now_iso}. Verify: tg codemap --check_"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write (crash-safe: write tmp, then a Windows-hardened os.replace).
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    try:
+        replace_with_retry(tmp_path, path)
+    except OSError:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _resolve_index_path(out_dir: Path, index: str | Path | None) -> Path:
+    if index is None:
+        return out_dir / "index.md"
+    index_path = Path(index).expanduser()
+    if index_path.is_absolute():
+        return index_path
+    return out_dir / index_path
+
+
+def _render_folder_page(
+    folder_rel_posix: str,
+    files: list[str],
+    *,
+    root: Path,
+    symbols_by_file: dict[str, list[dict[str, Any]]],
+    max_symbols_per_file: int,
+    blurb: str,
+    stamp_line: str,
+    index_path: Path,
+    page_path: Path,
+) -> str:
+    display_path = folder_rel_posix if folder_rel_posix not in ("", ".") else "."
+    lines: list[str] = [f"# Folder: {display_path}", "", stamp_line, ""]
+    if blurb:
+        lines.append(blurb)
+        lines.append("")
+    lines.append(f"[Back to index]({_relative_link(index_path, from_dir=page_path.parent)})")
+    lines.append("")
+
+    for file_path in files:
+        rel_path = _repo_relative_posix(file_path, root)
+        basename = Path(file_path).name
+        file_symbols = symbols_by_file.get(file_path, [])
+        enrichment, module_purpose = _enrichment_for_file(file_path, file_symbols)
+        language_label = _language_label(file_path)
+        purpose = _file_purpose(
+            file_path, module_purpose=module_purpose, language_label=language_label
+        )
+
+        lines.append(f"### {basename}")
+        lines.append("")
+        lines.append(f"- Path: `{rel_path}`")
+        lines.append(f"- Language: {language_label}")
+        lines.append(f"- Purpose: {_escape_cell(purpose)}")
+        lines.append("")
+
+        if file_symbols:
+            lines.append("| Kind | Name | Line | Description |")
+            lines.append("| --- | --- | --- | --- |")
+            shown = file_symbols[:max_symbols_per_file]
+            for symbol in shown:
+                start_line = int(symbol.get("start_line", symbol.get("line", 0)) or 0)
+                info = enrichment.get(start_line, {})
+                parent_class = info.get("parent_class")
+                name = str(symbol.get("name", ""))
+                qualified_name = f"{parent_class}.{name}" if parent_class else name
+                signature = str(info.get("signature") or "")
+                name_cell = (
+                    f"`{_escape_cell(signature)}`" if signature else _escape_cell(qualified_name)
+                )
+                description = _escape_cell(str(info.get("docstring") or ""))
+                kind = _escape_cell(str(symbol.get("kind", "")))
+                lines.append(f"| {kind} | {name_cell} | {start_line} | {description} |")
+            overflow = len(file_symbols) - len(shown)
+            if overflow > 0:
+                lines.append("")
+                lines.append(f"... +{overflow} more (run: tg defs <name> {rel_path})")
+        else:
+            lines.append("_No indexed symbols in this file._")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_index(
+    *,
+    root: Path,
+    folders: dict[str, list[str]],
+    symbols_by_file: dict[str, list[dict[str, Any]]],
+    blurbs: dict[str, str],
+    central_files: list[tuple[str, float]],
+    stamp_line: str,
+    coverage: dict[str, Any],
+    per_page_tokens: dict[str, int],
+    page_paths: dict[str, Path],
+    index_path: Path,
+) -> str:
+    lines: list[str] = [f"# Code Map: {root}", "", stamp_line, ""]
+
+    lines.append("## How to use this map")
+    lines.append("")
+    lines.append(
+        "This is a generated, point-in-time browsable inventory (folders -> files -> symbols). "
+        "It can drift from the working tree between generations -- prefer live tg callers/defs "
+        "(and tg refs) for authoritative, current symbol data; use this map for orientation and to "
+        "find WHERE to look before running a live query. Run `tg codemap --check` to verify this "
+        "map is still fresh."
+    )
+    lines.append("")
+
+    lines.append("## Coverage")
+    lines.append("")
+    lines.append(f"- Files mapped: {coverage['files_total']}")
+    lines.append(f"- Folders mapped: {len(folders)}")
+    lines.append(f"- Symbols: {coverage['symbols_total']}")
+    lines.append(f"- Partial: {'yes' if coverage['partial'] else 'no'}")
+    if coverage.get("partial"):
+        lines.append(f"- Remediation: {coverage.get('remediation', '')}")
+    lines.append("")
+
+    if central_files:
+        lines.append("## Top central files")
+        lines.append("")
+        lines.append("| File | Score |")
+        lines.append("| --- | --- |")
+        for file_path, score in central_files:
+            rel = _repo_relative_posix(file_path, root)
+            lines.append(f"| `{_escape_cell(rel)}` | {score} |")
+        lines.append("")
+
+    lines.append("## Exclusions")
+    lines.append("")
+    lines.append(
+        f"- Output directory `{coverage.get('out', '')}` (this map's own generated pages) is "
+        "excluded from the file universe and the freshness manifest."
+    )
+    lines.append(
+        f"- Index file `{coverage.get('index', '')}` is excluded from the file universe and the "
+        "freshness manifest."
+    )
+    lines.append(
+        "- Only files under tensor-grep's mapped source/doc suffixes are included (see `tg map`); "
+        "other extensions are not walked into this inventory."
+    )
+    zero_file_folders = coverage.get("folders_with_no_mapped_files", 0)
+    if zero_file_folders:
+        lines.append(
+            f"- {zero_file_folders} folder(s) contain only unmapped-extension files and are "
+            "omitted from the table below (recorded in _coverage.json)."
+        )
+    lines.append("")
+
+    lines.append("## Folders")
+    lines.append("")
+    lines.append("| Path | Role | Map | Files | Symbols | ~Tokens |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for folder in sorted(folders):
+        files = folders[folder]
+        display_path = folder if folder not in ("", ".") else "."
+        role = _truncate_ascii(blurbs.get(folder, ""), _ROLE_CELL_LIMIT)
+        page_path = page_paths[folder]
+        map_link = f"[{page_path.stem}]({_relative_link(page_path, from_dir=index_path.parent)})"
+        symbol_count = sum(len(symbols_by_file.get(f, [])) for f in files)
+        tokens = per_page_tokens.get(str(page_path), 0)
+        lines.append(
+            f"| `{_escape_cell(display_path)}` | {_escape_cell(role)} | {map_link} | "
+            f"{len(files)} | {symbol_count} | {tokens} |"
+        )
+    lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration: generation + the read-only freshness check.
+# ---------------------------------------------------------------------------
+
+
+def build_codemap(
+    path: str | Path = ".",
+    *,
+    out: str | Path | None = None,
+    index: str | Path | None = None,
+    max_repo_files: int = DEFAULT_MAX_REPO_FILES,
+    max_symbols_per_file: int = DEFAULT_MAX_SYMBOLS_PER_FILE,
+    _revision_identity: Callable[[Path], dict[str, Any]] | None = None,
+    _now: Callable[[], datetime] | None = None,
+) -> dict[str, Any]:
+    """Build + persist the browsable code map. Returns the coverage/summary payload (also written
+    to ``<out>/_coverage.json``, minus the ``written_files`` key added only to the return value /
+    ``--json`` output). ``_revision_identity``/``_now`` are injectable so callers (tests) can force
+    byte-identical output across repeated runs -- default to the real git oracle / real UTC clock.
+    """
+    root = Path(path).expanduser().resolve()
+    if not root.exists():
+        raise FileNotFoundError(f"Path not found: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"tg codemap requires a directory, got a file: {root}")
+
+    out_dir = Path(out).expanduser().resolve() if out is not None else (root / "docs" / "code-map")
+    index_path = _resolve_index_path(out_dir, index).resolve()
+
+    revision_fn = _revision_identity or _evidence_receipt._repo_revision_identity
+    revision = revision_fn(root)
+    now = _now() if _now is not None else datetime.now(UTC)
+    now_iso = _format_utc_iso(now)
+    stamp_line = _format_stamp_line(revision, now_iso)
+
+    rm = _repo_map.build_repo_map(root, max_repo_files=max_repo_files)
+    rm = _exclude_output_paths(rm, out_dir=out_dir, index_path=index_path)
+
+    universe = sorted(set(rm.get("files", [])) | set(rm.get("tests", [])))
+
+    symbols_by_file: dict[str, list[dict[str, Any]]] = {}
+    for symbol in rm.get("symbols", []):
+        symbols_by_file.setdefault(str(symbol.get("file", "")), []).append(symbol)
+
+    folders = _group_by_folder(universe, root)
+    overlays = _load_enrichment_overlays(out_dir)
+    blurbs = {folder: _folder_blurb(folder, root=root, overlays=overlays) for folder in folders}
+    page_paths: dict[str, Path] = {
+        folder: out_dir / f"{_folder_slug(folder)}.md" for folder in folders
+    }
+    central_files = _top_central_files(rm)
+
+    scan_limit = rm.get("scan_limit")
+    possibly_truncated = bool(isinstance(scan_limit, dict) and scan_limit.get("possibly_truncated"))
+    self_verify_ok = _self_verify_universe_coverage(universe, folders)
+    partial = possibly_truncated or not self_verify_ok
+
+    partial_reason: str | None = None
+    remediation: str | None = None
+    if possibly_truncated:
+        partial_reason = "scan_limit"
+        remediation = (
+            "The scan hit --max-repo-files before covering the whole tree. Re-run with a higher "
+            "--max-repo-files, or scope PATH to a subdirectory."
+        )
+    elif not self_verify_ok:
+        partial_reason = "self_verify"
+        remediation = (
+            "Internal consistency check failed (a mapped file was not accounted for in exactly one "
+            "folder page). Please file a tensor-grep bug with the repository shape that triggered it."
+        )
+
+    coverage: dict[str, Any] = {
+        "schema_version": _COVERAGE_SCHEMA_VERSION,
+        "generated_at": now_iso,
+        "tool_version": _evidence_receipt._cli_package_version(),
+        "path": str(root),
+        "out": str(out_dir),
+        "index": str(index_path),
+        "revision": revision,
+        "tree_manifest_sha256": _tree_manifest_sha256(universe, root),
+        "files_total": len(universe),
+        "folders_total": len(folders),
+        "symbols_total": sum(len(v) for v in symbols_by_file.values()),
+        "partial": partial,
+        "partial_reason": partial_reason,
+        "remediation": remediation,
+        "scan_limit": scan_limit,
+        "max_repo_files": max_repo_files,
+    }
+
+    try:
+        all_folders = _all_folder_paths(root, max_repo_files=max_repo_files)
+        all_folders = {
+            f for f in all_folders if not _is_under_dir(root / f if f else root, out_dir)
+        }
+        coverage["folders_with_no_mapped_files"] = max(0, len(all_folders) - len(folders))
+    except OSError:
+        coverage["folders_with_no_mapped_files"] = 0
+
+    written_files: list[Path] = []
+    per_page_tokens: dict[str, int] = {}
+    for folder, files in folders.items():
+        page_path = page_paths[folder]
+        page_text = _render_folder_page(
+            folder,
+            files,
+            root=root,
+            symbols_by_file=symbols_by_file,
+            max_symbols_per_file=max_symbols_per_file,
+            blurb=blurbs.get(folder, ""),
+            stamp_line=stamp_line,
+            index_path=index_path,
+            page_path=page_path,
+        )
+        _atomic_write_text(page_path, page_text)
+        written_files.append(page_path)
+        per_page_tokens[str(page_path)] = _repo_map._estimate_tokens(page_text)
+
+    index_text = _render_index(
+        root=root,
+        folders=folders,
+        symbols_by_file=symbols_by_file,
+        blurbs=blurbs,
+        central_files=central_files,
+        stamp_line=stamp_line,
+        coverage=coverage,
+        per_page_tokens=per_page_tokens,
+        page_paths=page_paths,
+        index_path=index_path,
+    )
+    _atomic_write_text(index_path, index_text)
+    written_files.append(index_path)
+    per_page_tokens[str(index_path)] = _repo_map._estimate_tokens(index_text)
+
+    coverage["per_page_token_estimates"] = per_page_tokens
+
+    coverage_path = out_dir / _COVERAGE_FILENAME
+    _atomic_write_text(coverage_path, json.dumps(coverage, indent=2, sort_keys=True) + "\n")
+    written_files.append(coverage_path)
+
+    result = dict(coverage)
+    result["written_files"] = [str(p) for p in written_files]
+    return result
+
+
+def build_codemap_json(path: str | Path = ".", **kwargs: Any) -> str:
+    """JSON form of :func:`build_codemap` (the same payload ``--json`` emits on stdout)."""
+    return json.dumps(build_codemap(path, **kwargs), indent=2, sort_keys=True)
+
+
+def check_codemap_freshness(
+    path: str | Path = ".",
+    *,
+    out: str | Path | None = None,
+    index: str | Path | None = None,
+    max_repo_files: int = DEFAULT_MAX_REPO_FILES,
+    _revision_identity: Callable[[Path], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Read-only freshness check (Section 4 of the build spec): NEVER writes, NEVER re-parses a
+    single source file. Fails CLOSED on anything unverifiable -- a missing/corrupt/partial stamp,
+    or an inability to re-walk the tree, reads as stale, never as fresh. Returns
+    ``{"fresh": bool, "reason": str}``."""
+    root = Path(path).expanduser().resolve()
+    if not root.exists():
+        raise FileNotFoundError(f"Path not found: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"tg codemap requires a directory, got a file: {root}")
+
+    out_dir = Path(out).expanduser().resolve() if out is not None else (root / "docs" / "code-map")
+    index_path = _resolve_index_path(out_dir, index).resolve()
+    coverage_path = out_dir / _COVERAGE_FILENAME
+
+    try:
+        raw = coverage_path.read_text(encoding="utf-8")
+    except OSError:
+        return {"fresh": False, "reason": f"{_COVERAGE_FILENAME} missing at {coverage_path}"}
+    try:
+        coverage = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"fresh": False, "reason": f"{_COVERAGE_FILENAME} is not valid JSON"}
+    if not isinstance(coverage, dict):
+        return {"fresh": False, "reason": f"{_COVERAGE_FILENAME} is not a JSON object"}
+
+    if coverage.get("partial"):
+        return {"fresh": False, "reason": "map was written partial (truncated at generation)"}
+
+    stamped_revision = coverage.get("revision")
+    if isinstance(stamped_revision, dict) and stamped_revision.get("status") == "present":
+        revision_fn = _revision_identity or _evidence_receipt._repo_revision_identity
+        live_revision = revision_fn(root)
+        if live_revision.get("status") == "present":
+            if (
+                live_revision.get("commit_sha") == stamped_revision.get("commit_sha")
+                and live_revision.get("dirty") == stamped_revision.get("dirty")
+                and live_revision.get("dirty_tree_sha256")
+                == stamped_revision.get("dirty_tree_sha256")
+            ):
+                return {"fresh": True, "reason": "git revision identity matches"}
+            return {"fresh": False, "reason": "git revision identity changed since generation"}
+        # Git was available at generation time but is unavailable now -> fall through to the
+        # git-independent tree manifest instead of guessing.
+
+    stamped_manifest = coverage.get("tree_manifest_sha256")
+    if not isinstance(stamped_manifest, str) or not stamped_manifest:
+        return {"fresh": False, "reason": "no tree manifest hash recorded (unverifiable)"}
+
+    stamped_cap = coverage.get("max_repo_files")
+    walk_cap = (
+        int(stamped_cap) if isinstance(stamped_cap, int) and stamped_cap > 0 else max_repo_files
+    )
+    try:
+        live_universe = [
+            f
+            for f in _walk_only_universe(root, max_repo_files=walk_cap)
+            if not _excluded_by_output_str(f, out_dir=out_dir, index_path=index_path)
+        ]
+        live_manifest = _tree_manifest_sha256(sorted(set(live_universe)), root)
+    except OSError:
+        return {"fresh": False, "reason": "could not re-walk the tree to verify (unverifiable)"}
+
+    if live_manifest == stamped_manifest:
+        return {"fresh": True, "reason": "tree manifest matches"}
+    return {"fresh": False, "reason": "tree manifest changed since generation"}

--- a/src/tensor_grep/cli/commands.py
+++ b/src/tensor_grep/cli/commands.py
@@ -51,6 +51,7 @@ KNOWN_COMMANDS = {
     "__gpu-oom-probe",
     "map",
     "orient",
+    "codemap",
     "inventory",
     "docs-coverage",
     "session",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7694,6 +7694,90 @@ def orient(
 
 
 @app.command()
+def codemap(
+    path: str = typer.Argument(".", help="Directory to render a browsable code map for"),
+    out: str | None = typer.Option(
+        None,
+        "--out",
+        help="Output directory for pages + _coverage.json. Defaults to <path>/docs/code-map.",
+    ),
+    index_file: str = typer.Option(
+        "index.md",
+        "--index",
+        help="Index filename, resolved inside --out unless given as an absolute path.",
+    ),
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Read-only freshness check of an existing code map (no re-parse); exits 1 when stale.",
+    ),
+    max_repo_files: int = typer.Option(
+        # Literal mirrors codemap.DEFAULT_MAX_REPO_FILES (kept literal so the heavy repo_map
+        # import stays lazy, matching map's/inventory's pattern); a guard test pins them.
+        50_000,
+        "--max-repo-files",
+        min=1,
+        help="Maximum repo files to scan before truncating (walk-only; defaults to 50000).",
+    ),
+    max_symbols_per_file: int = typer.Option(
+        50,
+        "--max-symbols-per-file",
+        min=1,
+        help="Per-file symbol cap before an overflow pointer line (defaults to 50).",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+) -> None:
+    """Render a persisted, browsable folder->file->symbol code map (lean index + per-folder pages)."""
+    from tensor_grep.cli.codemap import build_codemap, check_codemap_freshness
+
+    if check:
+        try:
+            result = check_codemap_freshness(
+                path, out=out, index=index_file, max_repo_files=max_repo_files
+            )
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(1) from exc
+
+        if json_output:
+            typer.echo(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            status = "fresh" if result["fresh"] else "stale"
+            _safe_stdout_line(f"codemap --check: {status} -- {result['reason']}")
+
+        if not result["fresh"]:
+            raise typer.Exit(1)
+        return
+
+    try:
+        payload = build_codemap(
+            path,
+            out=out,
+            index=index_file,
+            max_repo_files=max_repo_files,
+            max_symbols_per_file=max_symbols_per_file,
+        )
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _safe_stdout_line(f"Code map for {payload['path']}")
+        _safe_stdout_line(f"out={payload['out']} index={payload['index']}")
+        _safe_stdout_line(
+            f"folders={payload['folders_total']} files={payload['files_total']} "
+            f"symbols={payload['symbols_total']}"
+        )
+        if payload.get("partial"):
+            _safe_stdout_line(f"PARTIAL: {payload.get('remediation', '')}")
+
+    if _scan_incomplete(payload):
+        raise typer.Exit(2)
+
+
+@app.command()
 def context(
     path: str = typer.Argument(".", help="File or directory to inventory"),
     query_arg: str | None = typer.Argument(

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -54,6 +54,7 @@ PUBLIC_TOP_LEVEL_COMMANDS = {
     "lsp-setup",
     "map",
     "orient",
+    "codemap",
     "inventory",
     "docs-coverage",
     "session",

--- a/tests/fixtures/codemap_repo/README.md
+++ b/tests/fixtures/codemap_repo/README.md
@@ -1,0 +1,8 @@
+# Codemap Fixture Repo
+
+A tiny fixture repository used by the `tg codemap` test suite. It exercises Python, TypeScript,
+and Rust symbol extraction plus the folder blurb fallback chain (README -> `__init__.py` ->
+generic).
+
+Nothing in this directory is meant to run; it exists purely as deterministic input for
+`tests/unit/test_codemap.py` and `tests/unit/test_codemap_freshness.py`.

--- a/tests/fixtures/codemap_repo/assets/logo.bin
+++ b/tests/fixtures/codemap_repo/assets/logo.bin
@@ -1,0 +1,1 @@
+not-a-real-binary-just-an-unmapped-extension-fixture

--- a/tests/fixtures/codemap_repo/native/lib.rs
+++ b/tests/fixtures/codemap_repo/native/lib.rs
@@ -1,0 +1,4 @@
+/// Parses the input and returns its length.
+pub fn parse(input: &str) -> usize {
+    input.len()
+}

--- a/tests/fixtures/codemap_repo/pkg/__init__.py
+++ b/tests/fixtures/codemap_repo/pkg/__init__.py
@@ -1,0 +1,1 @@
+"""Package pkg: a small demo package for codemap tests. This second sentence must not appear."""

--- a/tests/fixtures/codemap_repo/pkg/core.py
+++ b/tests/fixtures/codemap_repo/pkg/core.py
@@ -1,0 +1,18 @@
+"""Core module docstring sentence. A second sentence that first-sentence extraction must drop."""
+
+
+class Widget:
+    """A widget class with a documented method. More detail that must not appear."""
+
+    def render(self, size):
+        """Render the widget at the given size."""
+        return size
+
+
+def bare_documented():
+    """A bare module-level function with a docstring."""
+    return True
+
+
+def bare_undocumented(x, y):
+    return x + y

--- a/tests/fixtures/codemap_repo/pkg/many_symbols.py
+++ b/tests/fixtures/codemap_repo/pkg/many_symbols.py
@@ -1,0 +1,241 @@
+"""Module with 60 top-level functions, used to exercise the per-file symbol cap overflow line."""
+
+
+def fn_00():
+    return 0
+
+
+def fn_01():
+    return 1
+
+
+def fn_02():
+    return 2
+
+
+def fn_03():
+    return 3
+
+
+def fn_04():
+    return 4
+
+
+def fn_05():
+    return 5
+
+
+def fn_06():
+    return 6
+
+
+def fn_07():
+    return 7
+
+
+def fn_08():
+    return 8
+
+
+def fn_09():
+    return 9
+
+
+def fn_10():
+    return 10
+
+
+def fn_11():
+    return 11
+
+
+def fn_12():
+    return 12
+
+
+def fn_13():
+    return 13
+
+
+def fn_14():
+    return 14
+
+
+def fn_15():
+    return 15
+
+
+def fn_16():
+    return 16
+
+
+def fn_17():
+    return 17
+
+
+def fn_18():
+    return 18
+
+
+def fn_19():
+    return 19
+
+
+def fn_20():
+    return 20
+
+
+def fn_21():
+    return 21
+
+
+def fn_22():
+    return 22
+
+
+def fn_23():
+    return 23
+
+
+def fn_24():
+    return 24
+
+
+def fn_25():
+    return 25
+
+
+def fn_26():
+    return 26
+
+
+def fn_27():
+    return 27
+
+
+def fn_28():
+    return 28
+
+
+def fn_29():
+    return 29
+
+
+def fn_30():
+    return 30
+
+
+def fn_31():
+    return 31
+
+
+def fn_32():
+    return 32
+
+
+def fn_33():
+    return 33
+
+
+def fn_34():
+    return 34
+
+
+def fn_35():
+    return 35
+
+
+def fn_36():
+    return 36
+
+
+def fn_37():
+    return 37
+
+
+def fn_38():
+    return 38
+
+
+def fn_39():
+    return 39
+
+
+def fn_40():
+    return 40
+
+
+def fn_41():
+    return 41
+
+
+def fn_42():
+    return 42
+
+
+def fn_43():
+    return 43
+
+
+def fn_44():
+    return 44
+
+
+def fn_45():
+    return 45
+
+
+def fn_46():
+    return 46
+
+
+def fn_47():
+    return 47
+
+
+def fn_48():
+    return 48
+
+
+def fn_49():
+    return 49
+
+
+def fn_50():
+    return 50
+
+
+def fn_51():
+    return 51
+
+
+def fn_52():
+    return 52
+
+
+def fn_53():
+    return 53
+
+
+def fn_54():
+    return 54
+
+
+def fn_55():
+    return 55
+
+
+def fn_56():
+    return 56
+
+
+def fn_57():
+    return 57
+
+
+def fn_58():
+    return 58
+
+
+def fn_59():
+    return 59

--- a/tests/fixtures/codemap_repo/pkg/sub/util.ts
+++ b/tests/fixtures/codemap_repo/pkg/sub/util.ts
@@ -1,0 +1,9 @@
+export function formatLabel(value: string): string {
+    return value.trim();
+}
+
+export class Formatter {
+    format(value: string): string {
+        return value;
+    }
+}

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -23,6 +23,15 @@ def test_bootstrap_commands_match_source_of_truth() -> None:
     )
 
 
+def test_codemap_argv_does_not_forward_to_search() -> None:
+    """Registration site 1 (commands.py KNOWN_COMMANDS): a miss here would silently misroute
+    `tg codemap` into a ripgrep search for the literal pattern "codemap" instead of the real
+    command -- `_normalize_search_invocation` returning non-None is exactly that misrouting."""
+    assert bootstrap._normalize_search_invocation(["codemap"]) is None
+    assert bootstrap._normalize_search_invocation(["codemap", "--json"]) is None
+    assert bootstrap._normalize_search_invocation(["codemap", "--check"]) is None
+
+
 def test_vendored_root_dir_names_match_source_of_truth() -> None:
     """Review finding L1 (PR #400): cli/bootstrap.py's front-door vendored-root mirror and
     cli/main.py's `_should_refuse_unbounded_vendored_root_scan` guard must trigger on

--- a/tests/unit/test_codemap.py
+++ b/tests/unit/test_codemap.py
@@ -1,0 +1,328 @@
+"""Tests for build_codemap -- the persisted, browsable folder->file->symbol code map (`tg
+codemap`). Fixture: tests/fixtures/codemap_repo/ (copied fresh into tmp_path per test so
+generated output never touches the checked-in fixture and mtimes are stable within a run).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import codemap as _codemap
+from tensor_grep.cli.codemap import build_codemap, build_codemap_json
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "codemap_repo"
+
+_FIXED_REVISION = {
+    "status": "present",
+    "commit_sha": "abc123def456abc123def456abc123def456ab",
+    "branch": "main",
+    "dirty": False,
+    "dirty_tree_sha256": "e" * 64,
+    "dirty_file_count": 0,
+}
+
+
+def _fixed_revision_identity(_root: Path) -> dict:
+    return dict(_FIXED_REVISION)
+
+
+def _fixed_now() -> datetime:
+    return datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _copy_fixture(dest_parent: Path) -> Path:
+    dest = dest_parent / "repo"
+    shutil.copytree(FIXTURE_ROOT, dest)
+    return dest
+
+
+def _build(repo: Path, **kwargs):
+    kwargs.setdefault("_revision_identity", _fixed_revision_identity)
+    kwargs.setdefault("_now", _fixed_now)
+    return build_codemap(repo, **kwargs)
+
+
+def _table_cells(line: str) -> list[str]:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+# ---------------------------------------------------------------------------
+# (1) index lists only folders w/ mapped files + every row's page exists
+# ---------------------------------------------------------------------------
+
+
+def test_index_lists_only_folders_with_mapped_files_and_pages_exist(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo)
+
+    index_text = Path(payload["index"]).read_text(encoding="utf-8")
+
+    # assets/ contains only an unmapped .bin extension -> must NOT appear as a folder row.
+    assert "`assets`" not in index_text
+    assert payload.get("folders_with_no_mapped_files", 0) >= 1
+
+    for folder_display, expected_slug in [
+        (".", "_root"),
+        ("pkg", "pkg"),
+        ("pkg/sub", "pkg_sub"),
+        ("native", "native"),
+    ]:
+        assert f"`{folder_display}`" in index_text, f"missing folder row for {folder_display!r}"
+        page_path = Path(payload["out"]) / f"{expected_slug}.md"
+        assert page_path.is_file(), f"page for {folder_display!r} was not written: {page_path}"
+
+
+# ---------------------------------------------------------------------------
+# (2) folder page has file purpose + signatures + docstrings + Class.method label
+# ---------------------------------------------------------------------------
+
+
+def test_folder_page_has_purpose_signature_docstring_and_class_method_label(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo)
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+
+    assert "### core.py" in pkg_page
+    assert "Purpose: Core module docstring sentence." in pkg_page
+    # the SECOND sentence of a docstring must never leak into the first-sentence excerpt.
+    assert "must drop" not in pkg_page
+    assert "must not appear" not in pkg_page
+
+    # Class.method attribution: the method must be qualified, never the bare unqualified form.
+    assert "`def render(self, size)`" not in pkg_page
+    assert "`def Widget.render(self, size)`" in pkg_page
+    assert "Render the widget at the given size." in pkg_page
+
+    assert "`class Widget`" in pkg_page
+    assert "`def bare_documented()`" in pkg_page
+    assert "A bare module-level function with a docstring." in pkg_page
+
+    # Folder blurb fallback chain: pkg/ has no README.md of its own -> falls back to
+    # __init__.py's module docstring first sentence.
+    assert "Package pkg: a small demo package for codemap tests." in pkg_page
+
+    root_page = (Path(payload["out"]) / "_root.md").read_text(encoding="utf-8")
+    # Root folder blurb: README.md exists at repo root -> its first prose sentence.
+    assert "tiny fixture repository" in root_page
+
+
+def test_typescript_and_rust_use_source_line_signature_fallback(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo)
+
+    sub_page = (Path(payload["out"]) / "pkg_sub.md").read_text(encoding="utf-8")
+    assert "### util.ts" in sub_page
+    assert "Language: TypeScript" in sub_page
+    assert "export function formatLabel(value: string): string {" in sub_page
+    assert "export class Formatter {" in sub_page
+
+    native_page = (Path(payload["out"]) / "native.md").read_text(encoding="utf-8")
+    assert "### lib.rs" in native_page
+    assert "Language: Rust" in native_page
+    assert "pub fn parse(input: &str) -> usize {" in native_page
+    assert "Parses the input and returns its length." in native_page
+
+
+# ---------------------------------------------------------------------------
+# (3) symbol cap emits overflow pointer
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_cap_emits_overflow_pointer(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo, max_symbols_per_file=10)
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    assert "... +50 more (run: tg defs <name> pkg/many_symbols.py)" in pkg_page
+
+
+def test_default_symbol_cap_does_not_overflow_a_small_file(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo)  # default max_symbols_per_file=50; many_symbols.py has 60 defs
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    assert "more (run: tg defs <name> pkg/many_symbols.py)" in pkg_page
+    assert "more (run: tg defs <name> pkg/core.py)" not in pkg_page  # only 4 symbols, no overflow
+
+
+# ---------------------------------------------------------------------------
+# (4) undocumented symbol -> EMPTY description (assert the _infer_from_name filler ABSENT)
+# ---------------------------------------------------------------------------
+
+
+def test_undocumented_symbol_has_empty_description_no_name_echo_filler(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo)
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    for line in pkg_page.splitlines():
+        if "bare_undocumented" in line and line.strip().startswith("|"):
+            cells = _table_cells(line)
+            assert cells[-1] == "", f"expected an EMPTY description cell, got: {line!r}"
+            break
+    else:
+        pytest.fail("bare_undocumented row not found in pkg.md")
+
+
+# ---------------------------------------------------------------------------
+# (5) --out/--index excluded from universe (2nd run identical)
+# ---------------------------------------------------------------------------
+
+
+def test_second_run_does_not_absorb_its_own_output(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    first = _build(repo)
+    second = _build(repo)
+
+    assert first["files_total"] == second["files_total"], (
+        "a second run must not pick up the first run's own generated pages as new source files"
+    )
+    assert first["folders_total"] == second["folders_total"]
+    assert first["tree_manifest_sha256"] == second["tree_manifest_sha256"]
+
+    index_text = Path(second["index"]).read_text(encoding="utf-8")
+    assert "`docs`" not in index_text  # the output tree itself must never become a folder row
+
+    # _coverage.json/index.md/*.md must never appear as a RENDERED FILE ENTRY (a `### name`
+    # heading) in any folder page -- the exclusions-section prose is allowed to name
+    # "_coverage.json" as documentation, so this checks the actual per-file headings instead of a
+    # blanket substring search over the whole index.
+    for written in second["written_files"]:
+        if not written.endswith(".md") or written == second["index"]:
+            continue
+        page_text = Path(written).read_text(encoding="utf-8")
+        assert "### _coverage.json" not in page_text
+        assert "### index.md" not in page_text
+
+
+def test_custom_index_filename_resolves_inside_out_and_is_excluded(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo, index="claude-index.md")
+
+    assert Path(payload["index"]).name == "claude-index.md"
+    assert Path(payload["index"]).parent == Path(payload["out"])
+    assert Path(payload["index"]).is_file()
+
+    # Re-running must still be stable (the custom index name is excluded too).
+    second = _build(repo, index="claude-index.md")
+    assert payload["files_total"] == second["files_total"]
+
+
+# ---------------------------------------------------------------------------
+# (6) deterministic (inject _revision_identity + _now -> byte-identical)
+# ---------------------------------------------------------------------------
+
+
+def test_byte_identical_output_across_two_runs_with_injected_clock_and_revision(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_fixture(tmp_path)
+
+    first = _build(repo)
+    index_text_1 = Path(first["index"]).read_text(encoding="utf-8")
+    pkg_text_1 = (Path(first["out"]) / "pkg.md").read_text(encoding="utf-8")
+
+    second = _build(repo)
+    index_text_2 = Path(second["index"]).read_text(encoding="utf-8")
+    pkg_text_2 = (Path(second["out"]) / "pkg.md").read_text(encoding="utf-8")
+
+    assert index_text_1 == index_text_2, "index.md must be byte-identical across two runs"
+    assert pkg_text_1 == pkg_text_2, "pkg.md must be byte-identical across two runs"
+    assert first["tree_manifest_sha256"] == second["tree_manifest_sha256"]
+
+
+# ---------------------------------------------------------------------------
+# (7) stamp line in index AND every page
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_line_present_in_index_and_every_folder_page(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = _build(repo)
+
+    stamp_fragment = "Verify: tg codemap --check"
+    index_text = Path(payload["index"]).read_text(encoding="utf-8")
+    assert stamp_fragment in index_text
+    assert "abc123def456" in index_text  # sha12 of the injected fixed commit
+    assert "(clean)" in index_text
+
+    page_count = 0
+    for written in payload["written_files"]:
+        if written.endswith(".md") and written != payload["index"]:
+            page_count += 1
+            page_text = Path(written).read_text(encoding="utf-8")
+            assert stamp_fragment in page_text, f"missing stamp line in {written}"
+    assert page_count >= 3  # pkg, pkg/sub, native (at least) all got a page
+
+
+# ---------------------------------------------------------------------------
+# (8) stdout ASCII (non-ASCII path/docstring fixture) -- the ASCII rule is about THIS module's
+# own truncation marker, never U+2026, even when formatting non-ASCII source content verbatim.
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_ascii_never_emits_the_unicode_ellipsis() -> None:
+    truncated = _codemap._truncate_ascii("x" * 300, 220)
+    assert truncated.endswith("...")
+    assert "…" not in truncated
+    assert truncated.isascii()
+
+
+def test_output_survives_non_ascii_docstring_and_stays_valid_utf8(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    weird_dir = repo / "weird"
+    weird_dir.mkdir()
+    (weird_dir / "mod.py").write_text(
+        '"""Café docstring with an em dash — and 中文 text."""\n\n\ndef f():\n    return 1\n',
+        encoding="utf-8",
+    )
+
+    payload = _build(repo)
+    weird_page = Path(payload["out"]) / "weird.md"
+    assert weird_page.is_file()
+    text = weird_page.read_text(encoding="utf-8")
+    # This module must never INJECT the U+2026 ellipsis itself (rule 6); it MAY legitimately
+    # carry verbatim non-ASCII source content (generated files are UTF-8, not ASCII-only).
+    assert "…" not in text
+    assert "Café" in text
+
+    coverage_path = Path(payload["out"]) / "_coverage.json"
+    json.loads(coverage_path.read_text(encoding="utf-8"))  # must round-trip as valid JSON
+
+
+# ---------------------------------------------------------------------------
+# JSON output path
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_is_parseable_and_matches_build_codemap(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    text = build_codemap_json(repo, _revision_identity=_fixed_revision_identity, _now=_fixed_now)
+    parsed = json.loads(text)
+    assert parsed["files_total"] > 0
+    assert "written_files" in parsed
+    assert parsed["revision"]["commit_sha"] == _FIXED_REVISION["commit_sha"]
+
+
+# ---------------------------------------------------------------------------
+# PATH contract: a file path must error, never silently scan the parent.
+# ---------------------------------------------------------------------------
+
+
+def test_file_path_raises_not_a_directory(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    a_file = repo / "README.md"
+
+    with pytest.raises(NotADirectoryError):
+        build_codemap(a_file)
+
+
+def test_missing_path_raises_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        build_codemap(tmp_path / "does-not-exist")

--- a/tests/unit/test_codemap_freshness.py
+++ b/tests/unit/test_codemap_freshness.py
@@ -1,0 +1,217 @@
+"""Bidirectional-oracle freshness tests for `tg codemap --check` (Section 4 of the build spec): a
+check that can only ever pass, or only ever fail, is not a check. Every "fresh" assertion here has
+a matching "this exact mutation flips it to stale" sibling.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli.codemap import build_codemap, check_codemap_freshness
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "codemap_repo"
+
+
+def _copy_fixture(dest_parent: Path) -> Path:
+    dest = dest_parent / "repo"
+    shutil.copytree(FIXTURE_ROOT, dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# (9) fresh map exits 0 (manifest, no git) / (10) edit/add/delete each flips to stale
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_map_check_passes_with_manifest_oracle_no_git(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    build_codemap(repo)  # tmp_path is not inside any git repo -> git oracle is "unavailable"
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is True, result["reason"]
+
+
+@pytest.mark.parametrize("mutation", ["edit", "add", "delete"])
+def test_any_tree_mutation_flips_check_to_stale(tmp_path: Path, mutation: str) -> None:
+    repo = _copy_fixture(tmp_path)
+    build_codemap(repo)
+
+    fresh_before = check_codemap_freshness(repo)
+    assert fresh_before["fresh"] is True, fresh_before["reason"]
+
+    target = repo / "pkg" / "core.py"
+    if mutation == "edit":
+        target.write_text(target.read_text(encoding="utf-8") + "\n# mutated\n", encoding="utf-8")
+    elif mutation == "add":
+        (repo / "pkg" / "new_module.py").write_text(
+            "def new_fn():\n    return 1\n", encoding="utf-8"
+        )
+    else:
+        target.unlink()
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is False, f"expected stale after {mutation!r}, got fresh"
+    assert result["reason"]
+
+
+def test_repeated_fresh_checks_are_stable(tmp_path: Path) -> None:
+    """A check that never mutates state must return the same verdict every time it is called."""
+    repo = _copy_fixture(tmp_path)
+    build_codemap(repo)
+
+    first = check_codemap_freshness(repo)
+    second = check_codemap_freshness(repo)
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# (11) missing/corrupt coverage exits 1
+# ---------------------------------------------------------------------------
+
+
+def test_missing_coverage_json_is_stale(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    # No build_codemap call -> _coverage.json never existed.
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is False
+    assert "missing" in result["reason"].lower()
+
+
+def test_corrupt_coverage_json_is_stale(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = build_codemap(repo)
+
+    coverage_path = Path(payload["out"]) / "_coverage.json"
+    coverage_path.write_text("{not valid json", encoding="utf-8")
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is False
+    assert "json" in result["reason"].lower()
+
+
+def test_non_object_coverage_json_is_stale(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = build_codemap(repo)
+
+    coverage_path = Path(payload["out"]) / "_coverage.json"
+    coverage_path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is False
+
+
+# ---------------------------------------------------------------------------
+# (12) git oracle commit+dirty transitions (tmp git repo)
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+@pytest.fixture
+def git_fixture_repo(tmp_path: Path) -> Path:
+    repo = _copy_fixture(tmp_path)
+    # The generated map's own output is untracked immediately after `build_codemap` writes it;
+    # `_repo_revision_identity`'s git-dirty signal is repo-wide (it has no --out-aware pathspec,
+    # and this test suite must not modify that shared, multi-consumer helper to add one -- see
+    # the "additive, read-only over shared infra" rule). Gitignoring the output directory keeps
+    # THIS test isolated to the git oracle itself instead of confounding it with "did you commit
+    # the regenerated pages" (a real, separate product question the final report calls out).
+    (repo / ".gitignore").write_text("docs/code-map/\n", encoding="utf-8")
+    _run_git(["init", "-b", "main", "."], cwd=repo)
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo)
+    _run_git(["config", "user.name", "Test User"], cwd=repo)
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-m", "initial commit"], cwd=repo)
+    return repo
+
+
+def test_git_oracle_fresh_on_clean_repo(git_fixture_repo: Path) -> None:
+    build_codemap(git_fixture_repo)
+    result = check_codemap_freshness(git_fixture_repo)
+    assert result["fresh"] is True, result["reason"]
+
+
+def test_git_oracle_detects_new_commit(git_fixture_repo: Path) -> None:
+    build_codemap(git_fixture_repo)
+
+    core_py = git_fixture_repo / "pkg" / "core.py"
+    core_py.write_text(core_py.read_text(encoding="utf-8") + "\n# more\n", encoding="utf-8")
+    _run_git(["add", "-A"], cwd=git_fixture_repo)
+    _run_git(["commit", "-m", "second commit"], cwd=git_fixture_repo)
+
+    result = check_codemap_freshness(git_fixture_repo)
+    assert result["fresh"] is False
+    assert "git" in result["reason"].lower()
+
+
+def test_git_oracle_detects_dirty_worktree(git_fixture_repo: Path) -> None:
+    build_codemap(git_fixture_repo)
+
+    core_py = git_fixture_repo / "pkg" / "core.py"
+    core_py.write_text(
+        core_py.read_text(encoding="utf-8") + "\n# dirty, uncommitted\n", encoding="utf-8"
+    )
+
+    result = check_codemap_freshness(git_fixture_repo)
+    assert result["fresh"] is False
+    assert "git" in result["reason"].lower()
+
+
+def test_git_oracle_recovers_fresh_after_committing_the_drift(git_fixture_repo: Path) -> None:
+    """Bidirectional: a dirty worktree reads stale, and regenerating + re-checking against that
+    SAME (now committed) state reads fresh again -- proves the oracle isn't just permanently
+    tripped, it tracks the CURRENT revision identity."""
+    core_py = git_fixture_repo / "pkg" / "core.py"
+    core_py.write_text(
+        core_py.read_text(encoding="utf-8") + "\n# now committed\n", encoding="utf-8"
+    )
+    _run_git(["add", "-A"], cwd=git_fixture_repo)
+    _run_git(["commit", "-m", "second commit"], cwd=git_fixture_repo)
+
+    build_codemap(git_fixture_repo)
+    result = check_codemap_freshness(git_fixture_repo)
+    assert result["fresh"] is True, result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# (13) truncated scan writes partial+exit-2-equivalent AND --check fails partial
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_scan_writes_partial_and_check_fails(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    payload = build_codemap(repo, max_repo_files=2)  # fixture has far more than 2 files
+
+    assert payload["partial"] is True
+    assert payload["partial_reason"] == "scan_limit"
+    assert payload["remediation"]
+
+    coverage = json.loads((Path(payload["out"]) / "_coverage.json").read_text(encoding="utf-8"))
+    assert coverage["partial"] is True
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is False
+    assert "partial" in result["reason"].lower()
+
+
+# ---------------------------------------------------------------------------
+# PATH contract on the check path too.
+# ---------------------------------------------------------------------------
+
+
+def test_check_on_file_path_raises_not_a_directory(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    with pytest.raises(NotADirectoryError):
+        check_codemap_freshness(repo / "README.md")
+
+
+def test_check_on_missing_path_raises_file_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        check_codemap_freshness(tmp_path / "does-not-exist")


### PR DESCRIPTION
## What
Native `tg codemap` — a browsable folder->file->symbol code map (a lean top-level index + per-folder drill-down pages), rendered from tensor-grep's **existing** `build_repo_map()` extraction. Companion to `tg orient` (ranked capsule) and `tg map` (raw JSON); `codemap` is the exhaustive, persisted, browsable inventory.

Origin: the CEO had an external AI generate a `claude-index.md` map for agent navigation; it re-implemented AST parsing that TG's engine already does. This makes it a first-class command that **reuses** the engine (`_cached_ast_parse` from #535, `_read_source_text_cached`, orient's `_file_centrality_scores`) instead of duplicating it.

## Design (Fable-designed -> verify-planned -> Sonnet-built)
- **No duplicated extraction.** Signatures/docstrings/Class.method are formatted off the already-cached AST; zero new `ast.parse`.
- **Freshness = correctness.** Dual oracle (git `_repo_revision_identity` + a tree-manifest sha256 over the walked files) stamped in `_coverage.json` and a one-line stamp in the index and every page. `--check` is read-only and **fails closed**: a partial map never passes; an unverifiable map reads stale.
- **Token-efficient (the moat).** Lean index (only folders with >=1 mapped file) + per-folder pages so an agent loads just the folder it needs; `--max-symbols-per-file` cap with a `... +N more (run: tg defs)` pointer; **empty descriptions, never name-echo filler**.
- **Exit codes:** 0 ok/fresh, 1 usage/path or --check-stale, 2 written-but-partial. All 4 registration sites wired (Python + Rust front doors, enforced by the routing-parity e2e test).

## Verification (real, not claimed)
Green in the pinned env: **30/30 codemap tests**, ruff check + `ruff format --check --preview` (0.15.20), mypy 1.19.1, `cargo check` compiles the Rust variant, **69/69 bootstrap + routing-parity** (both front doors expose `codemap`). The build agent additionally dogfooded the **real compiled `tg.exe`** across every exit path (generate / file-path-error / --check fresh->stale / --max-repo-files partial). Gate-free surface (repo_map/render path; consumes but does not modify `_index_lock`).

## Known follow-up (tracked, not a blocker)
`--check` currently keys on the repo-wide git-dirty signal, so a freshly-generated **untracked** `docs/code-map/` reads "stale" right after generation (workaround: gitignore or commit the output). The audit's tracked-only-universe (`git ls-files`) + an `--out`-aware freshness signal will fix this and make the map CI-governable — a coherent fast-follow (#138 code-map hardening). The committed-tree regeneration + retiring the CEO's untracked local generator scripts also wait for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
