### PR TITLE
fix(repo-map): bound the AST parse cache by memory, not entry count

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import atexit
+import hashlib
 import json
 import math
 import os
@@ -327,6 +328,12 @@ _DEFAULT_REPO_CONTEXT_CACHE_MAX_ROOTS = 32
 # multi-MB bundled/generated files.  Override with env var.
 _MAX_PARSE_BYTES_ENV = "TENSOR_GREP_MAX_PARSE_BYTES"
 _DEFAULT_MAX_PARSE_BYTES = 2_000_000
+# Total-resident-bytes budget for the content-addressed AST parse cache (see
+# _cached_ast_parse below).  Bounds DAEMON MEMORY -- independent of _MAX_PARSE_BYTES_ENV
+# above, which only bounds a single file's eligibility to be parsed/cached at all.
+# Override with env var.
+_AST_CACHE_BYTES_ENV = "TENSOR_GREP_AST_CACHE_BYTES"
+_DEFAULT_AST_CACHE_BYTES = 64 * 1024 * 1024  # 64 MiB
 _RUST_TEST_FN_PATTERN = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\b"
 )
@@ -357,6 +364,11 @@ def _repo_context_cache_max_roots() -> int:
 def _max_parse_bytes() -> int:
     """Return the per-file byte cap for AST parsing (O2)."""
     return _configured_positive_int(_MAX_PARSE_BYTES_ENV, _DEFAULT_MAX_PARSE_BYTES)
+
+
+def _ast_cache_byte_budget() -> int:
+    """Return the total-resident-bytes budget for the AST parse cache."""
+    return _configured_positive_int(_AST_CACHE_BYTES_ENV, _DEFAULT_AST_CACHE_BYTES)
 
 
 def _remember_repo_context(
@@ -1661,21 +1673,129 @@ def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
     return entries
 
 
-@lru_cache(maxsize=2048)
+# ---------------------------------------------------------------------------
+# Content-addressed, memory-bounded AST parse cache backing _cached_ast_parse below.
+#
+# Was `@lru_cache(maxsize=2048)` -- an ENTRY-COUNT bound, not a memory bound. 2048 cached ASTs
+# of large files is unbounded resident-memory growth in the long-lived warm daemon (external-
+# audit finding: an OOM/DoS vector). Replaced with a hand-rolled LRU bounded by TOTAL CACHED
+# SOURCE BYTES (`_ast_cache_byte_budget()`, env-configurable, default 64 MiB), evicting
+# least-recently-used entries on insert -- same eviction shape as
+# `_remember_repo_context`/`_get_repo_context_cache_entry` above, just keyed by cumulative bytes
+# instead of entry count.
+# ---------------------------------------------------------------------------
+
+
+class _AstCacheInfo(NamedTuple):
+    """Observability snapshot for `_cached_ast_parse`'s cache. `hits`/`misses` match
+    `functools.lru_cache.cache_info()`'s field names (this was a plain lru_cache before);
+    `evictions`/`current_bytes`/`current_entries` are new for the byte-budgeted design."""
+
+    hits: int
+    misses: int
+    evictions: int
+    current_bytes: int
+    current_entries: int
+
+
+_ast_cache: OrderedDict[str, tuple[ast.Module, int]] = OrderedDict()
+_ast_cache_lock = threading.Lock()
+_ast_cache_stats: dict[str, int] = {"hits": 0, "misses": 0, "evictions": 0, "current_bytes": 0}
+
+
 def _cached_ast_parse(source: str) -> ast.Module:
     """Content-addressed AST parse cache. `build_agent_capsule` parses each Python file 2-3x
     across phases -- once in the map-build imports/symbols pass and again in the caller/blast-radius
     consumer scan (and the `tg imports`/`importers` extractors) -- all on the SAME source read the
     same way (`path.read_text(encoding="utf-8")`). Profiling `tg agent` on an 872-file repo (2026-
     07-11) showed ~40% of the wall in `ast.parse` + `ast.walk` over those duplicate parses (1512
-    parses for ~783 files). Keying on the source TEXT (not the path) is staleness-free: an edited
-    file has different content -> a fresh key -> a fresh parse, so this stays correct even under the
-    reused session-daemon process (no mtime races). Callers only ever READ the tree (`tree.body` /
-    `ast.walk` + `isinstance`, no mutation -- audited), so sharing one parsed tree is safe. Raises
-    on invalid syntax exactly like `ast.parse` (lru_cache does not cache the exception, so a
-    syntax-error file simply re-raises + re-parses each time -- the caller's try/except is
-    unchanged). Bounded at 2048 entries to cap resident memory in the long-lived daemon."""
-    return ast.parse(source)
+    parses for ~783 files).
+
+    Bounded by TOTAL CACHED SOURCE BYTES (`_ast_cache_byte_budget()`, default 64 MiB), not entry
+    count -- see the module comment above. A source larger than `_max_parse_bytes()` (or larger
+    than the byte budget itself) BYPASSES the cache: it is still fully parsed and a real
+    `ast.Module` is returned, it is just never stored. Bypass must never degrade into a skip --
+    several of this function's ~9 call sites have no size guard of their own and would silently
+    lose symbols/imports/callers if this returned anything less than a fully parsed tree.
+
+    Keying on the source TEXT (not the path) is staleness-free: an edited file has different
+    content -> a fresh sha256 key -> a fresh parse, so this stays correct even under the reused
+    session-daemon process (no mtime races, and no path-keyed staleness risk -- see the #535
+    daemon-staleness regression this design must never reintroduce). Callers only ever READ the
+    tree (`tree.body` / `ast.walk` + `isinstance`, no mutation -- audited), so sharing one parsed
+    tree across callers is safe. Raises on invalid syntax exactly like `ast.parse` (a syntax-error
+    source is never cached -- it simply re-raises + re-parses each time; callers' try/except is
+    unchanged).
+
+    Thread safety: the daemon calls this concurrently. The lock is held ONLY around the
+    dict/counter mutations, never around `ast.parse()` itself -- holding it there would serialize
+    all parsing across every concurrent caller. Two threads racing on the same brand-new source
+    may both parse outside the lock; the loser's redundant tree is discarded under the lock and
+    counted as a hit (a benign, tolerated double-parse race)."""
+    key = hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+    with _ast_cache_lock:
+        cached = _ast_cache.get(key)
+        if cached is not None:
+            _ast_cache.move_to_end(key)
+            _ast_cache_stats["hits"] += 1
+            return cached[0]
+
+    # Miss: parse OUTSIDE the lock (see docstring -- never serialize concurrent parsing).
+    tree = ast.parse(source)
+    size = len(source.encode("utf-8"))
+    budget = _ast_cache_byte_budget()
+
+    if size > _max_parse_bytes() or size > budget:
+        # Per-entry ceiling: too large to cache (or larger than the whole budget). Bypass means
+        # "parse, don't store" -- the caller still gets a real, correct ast.Module.
+        with _ast_cache_lock:
+            _ast_cache_stats["misses"] += 1
+        return tree
+
+    with _ast_cache_lock:
+        raced = _ast_cache.get(key)
+        if raced is not None:
+            # Another thread inserted this exact key while we were parsing above.
+            _ast_cache.move_to_end(key)
+            _ast_cache_stats["hits"] += 1
+            return raced[0]
+
+        _ast_cache_stats["misses"] += 1
+        while _ast_cache and _ast_cache_stats["current_bytes"] + size > budget:
+            _, (_, evicted_size) = _ast_cache.popitem(last=False)
+            _ast_cache_stats["current_bytes"] -= evicted_size
+            _ast_cache_stats["evictions"] += 1
+        _ast_cache[key] = (tree, size)
+        _ast_cache_stats["current_bytes"] += size
+
+    return tree
+
+
+def _ast_cache_info() -> _AstCacheInfo:
+    """Return a snapshot of the AST parse cache's counters (see `_AstCacheInfo`)."""
+    with _ast_cache_lock:
+        return _AstCacheInfo(
+            hits=_ast_cache_stats["hits"],
+            misses=_ast_cache_stats["misses"],
+            evictions=_ast_cache_stats["evictions"],
+            current_bytes=_ast_cache_stats["current_bytes"],
+            current_entries=len(_ast_cache),
+        )
+
+
+def _ast_cache_clear() -> None:
+    """Clear the AST parse cache and reset its counters (mirrors `lru_cache.cache_clear()`)."""
+    with _ast_cache_lock:
+        _ast_cache.clear()
+        _ast_cache_stats["hits"] = 0
+        _ast_cache_stats["misses"] = 0
+        _ast_cache_stats["evictions"] = 0
+        _ast_cache_stats["current_bytes"] = 0
+
+
+_cached_ast_parse.cache_info = _ast_cache_info  # type: ignore[attr-defined]
+_cached_ast_parse.cache_clear = _ast_cache_clear  # type: ignore[attr-defined]
 
 
 def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:

--- a/tests/unit/test_ast_parse_cache.py
+++ b/tests/unit/test_ast_parse_cache.py
@@ -3,10 +3,21 @@ file parses `build_agent_capsule` does across phases -- the map-build imports/sy
 caller/blast-radius consumer scan both `ast.parse` the SAME source. Profile 2026-07-11: ~40% of
 `tg agent` wall was `ast.parse` + `ast.walk` over those duplicate parses (1512 parses / ~783 files).
 Keying on source TEXT (not path) keeps it staleness-free under the reused session-daemon process.
+
+The cache is bounded by TOTAL CACHED SOURCE BYTES (a byte budget), not entry count -- an
+entry-count cap (the original `@lru_cache(maxsize=2048)`) does not bound resident memory, since
+2048 large-file ASTs is unbounded growth in a long-lived daemon (external-audit finding: an
+OOM/DoS vector). The tests below the first block cover that memory-bounded redesign: content-key
+dedup across distinct paths, staleness-safety on a same-path edit, LRU eviction once the budget is
+exceeded, the per-entry-ceiling bypass (parse-but-don't-store, never a skip), and thread safety
+under concurrent daemon-style access.
 """
 
 import ast
+import threading
 from pathlib import Path
+
+import pytest
 
 from tensor_grep.cli.repo_map import _cached_ast_parse, _python_imports_and_symbols
 
@@ -46,3 +57,139 @@ def test_reparsing_the_same_unchanged_file_hits_the_cache(tmp_path: Path) -> Non
     info = _cached_ast_parse.cache_info()
     assert info.misses == misses_after_first  # NOT re-parsed
     assert info.hits >= 1
+
+
+# ---------------------------------------------------------------------------
+# Memory-bounded (byte-budget) cache redesign -- content-key dedup, staleness-safety,
+# byte-budget eviction, per-entry-ceiling bypass, and concurrency.
+# ---------------------------------------------------------------------------
+
+
+def test_two_paths_identical_source_dedupe_to_one_entry(tmp_path: Path) -> None:
+    """Content-key dedup: two DIFFERENT paths with identical source content collapse to a
+    single cache entry / a single parse -- the cache key is the source text, never the path."""
+    _cached_ast_parse.cache_clear()
+    src = "import os\n\n\ndef shared():\n    return os\n"
+    path_a = tmp_path / "a.py"
+    path_b = tmp_path / "b.py"
+    path_a.write_text(src, encoding="utf-8")
+    path_b.write_text(src, encoding="utf-8")
+
+    _python_imports_and_symbols(path_a)
+    misses_after_a = _cached_ast_parse.cache_info().misses
+    _python_imports_and_symbols(path_b)
+    info = _cached_ast_parse.cache_info()
+
+    assert info.misses == misses_after_a, "identical content from a second path was re-parsed"
+    assert info.hits >= 1
+    assert info.current_entries == 1
+
+
+def test_same_path_changed_source_is_not_stale(tmp_path: Path) -> None:
+    """Staleness-safety: the SAME path, edited to different content, must re-parse -- content
+    (not path) is the key, so an edit always produces a different key. This is the #535
+    daemon-staleness regression this cache exists to never reintroduce."""
+    _cached_ast_parse.cache_clear()
+    p = tmp_path / "evolving.py"
+    p.write_text("def alpha():\n    pass\n", encoding="utf-8")
+    _, symbols_v1 = _python_imports_and_symbols(p)
+    assert any(s["name"] == "alpha" for s in symbols_v1)
+
+    p.write_text("def beta():\n    pass\n", encoding="utf-8")
+    _, symbols_v2 = _python_imports_and_symbols(p)
+
+    assert any(s["name"] == "beta" for s in symbols_v2)
+    assert not any(s["name"] == "alpha" for s in symbols_v2), (
+        "stale AST served after a same-path content edit"
+    )
+    info = _cached_ast_parse.cache_info()
+    assert info.misses == 2  # two distinct contents -> two distinct parses
+    assert info.current_entries == 2
+
+
+def test_byte_budget_evicts_oldest_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Byte-budget eviction: once the configured budget is exceeded, the least-recently-used
+    entry is evicted first, and total resident bytes never exceed the budget."""
+    _cached_ast_parse.cache_clear()
+    sources = [f"x_{i} = {i}\n" * 3 for i in range(6)]
+    entry_size = len(sources[0].encode("utf-8"))
+    budget = entry_size * 3  # fits about half of the 6 sources -> forces eviction
+    monkeypatch.setenv("TENSOR_GREP_AST_CACHE_BYTES", str(budget))
+
+    for src in sources:
+        _cached_ast_parse(src)
+
+    info = _cached_ast_parse.cache_info()
+    assert info.current_bytes <= budget
+    assert info.evictions > 0
+
+    # The oldest (first-inserted) source was never touched again -> evicted -> fresh MISS.
+    misses_before = _cached_ast_parse.cache_info().misses
+    _cached_ast_parse(sources[0])
+    assert _cached_ast_parse.cache_info().misses == misses_before + 1
+
+    # The most-recently-inserted source is still resident -> HIT, no new miss.
+    misses_before = _cached_ast_parse.cache_info().misses
+    hits_before = _cached_ast_parse.cache_info().hits
+    _cached_ast_parse(sources[-1])
+    info_after = _cached_ast_parse.cache_info()
+    assert info_after.misses == misses_before
+    assert info_after.hits == hits_before + 1
+
+
+def test_oversized_source_bypasses_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-entry ceiling: a source over the configured cap must BYPASS the cache (never stored)
+    but still return a real, correctly-parsed ast.Module -- bypass must never degrade into a
+    skip, since several call sites have no size guard of their own and would silently lose
+    symbols/imports/callers if this returned anything less than a fully parsed tree."""
+    _cached_ast_parse.cache_clear()
+    monkeypatch.setenv("TENSOR_GREP_MAX_PARSE_BYTES", "10")  # tiny cap -> everything is "huge"
+
+    src = "def f():\n    return 42\n"
+    tree = _cached_ast_parse(src)
+
+    assert isinstance(tree, ast.Module)
+    assert ast.dump(tree) == ast.dump(ast.parse(src))
+    assert _cached_ast_parse.cache_info().current_entries == 0  # never stored
+
+    # Calling again re-parses (a second MISS, not a HIT) -- proof it truly bypassed storage.
+    misses_before = _cached_ast_parse.cache_info().misses
+    _cached_ast_parse(src)
+    assert _cached_ast_parse.cache_info().misses == misses_before + 1
+
+
+def test_concurrent_parses_are_thread_safe() -> None:
+    """Concurrency smoke: many threads hammering the cache with a mix of shared and per-thread
+    unique sources must not crash or corrupt state, and every call must land as exactly one hit
+    or one miss (no double-counting from the tolerated benign double-parse race)."""
+    _cached_ast_parse.cache_clear()
+    shared_sources = [f"def shared_{i}():\n    return {i}\n" for i in range(4)]
+    calls_per_thread = 20
+    thread_count = 16
+    errors: list[Exception] = []
+
+    def worker(thread_id: int) -> None:
+        try:
+            for i in range(calls_per_thread):
+                # Alternate a small shared pool (drives hits after warmup) with a thread-unique
+                # source (drives misses), exercising both cache paths concurrently.
+                if i % 2 == 0:
+                    src = shared_sources[i % len(shared_sources)]
+                else:
+                    src = f"def unique_{thread_id}_{i}():\n    return {thread_id}\n"
+                tree = _cached_ast_parse(src)
+                assert isinstance(tree, ast.Module)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(thread_count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not any(t.is_alive() for t in threads), "a worker thread hung"
+    assert not errors, f"worker thread(s) raised: {errors}"
+
+    info = _cached_ast_parse.cache_info()
+    assert info.hits + info.misses == thread_count * calls_per_thread
+    assert info.evictions == 0  # tiny sources, default 64 MiB budget -> nothing evicted


### PR DESCRIPTION
## What / why
External-audit remediation campaign #138, item #3. The warm-daemon AST parse cache (`_cached_ast_parse`, added in #535) was bounded by **entry count** (`@lru_cache(maxsize=2048)`), so 2048 large-file ASTs is unbounded *memory* growth in the long-lived daemon (an OOM / resource-DoS vector).

## Fix
Hand-rolled `OrderedDict` LRU bounded by **total cached source bytes**, not entry count:
- `TENSOR_GREP_AST_CACHE_BYTES` (default 64 MiB); evicts oldest until `total_bytes + new <= budget`.
- Keyed on **`sha256(source)`** (content-addressed, never path) — preserves the #535 daemon-staleness fix (edited file -> new content -> fresh parse).
- **Per-entry-ceiling bypass**: a source larger than the ceiling (reuses `_max_parse_bytes()` / `TENSOR_GREP_MAX_PARSE_BYTES`) or the budget is still fully `ast.parse`d and a real `ast.Module` returned -- just never stored. Bypass != skip, so none of the ~9 call sites can silently lose symbols/imports/callers.
- Lock protects only the dict/counter mutation; `ast.parse()` runs **outside** the lock (miss -> parse -> re-check-and-insert), tolerating a benign double-parse race rather than serializing concurrent daemon parsing.
- `cache_info()` / `cache_clear()` preserved on the function -> zero call-site changes.

## Tests / gate (real venv, ruff 0.15.20 / mypy 1.19.1 pinned)
5 new TDD tests (content-key dedup, staleness-safety, byte-budget eviction, per-entry-ceiling bypass, 16-thread concurrency) + 4 pre-existing + 89 regression (codemap / agent-capsule consumers) all green. `ruff check` + `ruff format --check --preview` + `mypy` (79 files) + `pytest` all PASS.

Gate-free surface (repo_map.py). Drains one-per-publish after v1.64.0 clears PyPI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>