### PR TITLE
fix(codemap): harden --check freshness oracle against output-dir + untracked false positives (#138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,19 @@ jobs:
           grep -F "tests/golden/fixture_data/readme.txt:ERROR: do not delete" smoke.out
           grep -F "tests/golden/fixture_data/server_0.log:ERROR database timeout" smoke.out
 
+      # Regenerate-then-check in the SAME clean checkout: a real end-to-end proof (real git, real
+      # working tree) that generating the code map never makes `--check` read the repo as stale
+      # against its own freshly-written output (the git-dirty-oracle false positive this exercises
+      # -- see evidence_receipt._repo_revision_identity's exclude_prefixes and
+      # codemap._revision_exclude_prefixes). Complements the unit tests, which mock/construct git
+      # state directly; this runs the real binary against the real repo's real git history.
+      - name: Codemap freshness smoke (regenerate must not read as stale)
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run python -m tensor_grep codemap
+          uv run python -m tensor_grep codemap --check
+
   release-readiness:
     name: release-readiness
     needs: smoke

--- a/src/tensor_grep/cli/codemap.py
+++ b/src/tensor_grep/cli/codemap.py
@@ -27,6 +27,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -38,6 +39,7 @@ from tensor_grep.cli import lang_registry
 from tensor_grep.cli import orient_capsule as _orient_capsule
 from tensor_grep.cli import repo_map as _repo_map
 from tensor_grep.cli._index_lock import replace_with_retry
+from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
 
 # Mirrors inventory's/docs-coverage's 50000 default (NOT map's 512 or agent's 2000 -- codemap is
 # an exhaustive inventory, not an agent-context budget). Kept as a real module constant (unlike
@@ -134,6 +136,16 @@ def _repo_relative_posix(file_path: str, root: Path) -> str:
         return Path(file_path).resolve().relative_to(root).as_posix()
     except (OSError, ValueError):
         return Path(file_path).as_posix()
+
+
+def _revision_exclude_prefixes(out_dir: Path, root: Path) -> list[str]:
+    """The single repo-relative POSIX exclude-prefix for `_repo_revision_identity`'s git-dirty
+    oracle: the map's own `--out` directory, so regenerating a persisted, committed map never
+    reads as a dirty change against itself (the `tg codemap --check` false-positive). Computed
+    fresh from the SAME `out_dir` input at BOTH the stamp site (`build_codemap`) and the `--check`
+    site (`check_codemap_freshness`) -- symmetric by construction, never hardcoded to the
+    `docs/code-map` default (a custom `--out` is excluded too)."""
+    return [_repo_relative_posix(str(out_dir), root)]
 
 
 def _is_under_dir(path: Path, directory: Path) -> bool:
@@ -441,6 +453,61 @@ def _exclude_output_paths(rm: dict[str, Any], *, out_dir: Path, index_path: Path
     filtered["imports"] = [
         i for i in rm.get("imports", []) if not _excluded(str(i.get("file", "")))
     ]
+    return filtered
+
+
+def _tracked_file_set(root: Path) -> set[str] | None:
+    """Resolved absolute paths of every git-tracked file under `root` (`git ls-files -z`), or
+    `None` when git is unavailable/errors (not a repo, git missing, timeout). `None` is a distinct
+    sentinel from "empty set": callers must degrade to "no intersection possible" (keep
+    everything) on `None`, never mistake it for "this repo genuinely tracks zero files"."""
+    try:
+        result = run_subprocess(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            timeout_seconds=configured_git_timeout_seconds(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    tracked: set[str] = set()
+    for rel_posix in result.stdout.split("\0"):
+        if not rel_posix:
+            continue
+        try:
+            tracked.add(str((root / rel_posix).resolve()))
+        except OSError:
+            continue
+    return tracked
+
+
+def _exclude_untracked_paths(rm: dict[str, Any], *, root: Path) -> dict[str, Any]:
+    """Post-filter the repo_map payload to drop every file `git ls-files` does not track --
+    mirrors `_exclude_output_paths`'s exact shape. An untracked/gitignored file (scratch script,
+    build artifact, local-only note) is filesystem-real but not part of the project's committed
+    surface, and its volatile mtime/existence must never leak into the persisted, browsable
+    inventory. Degrades to a no-op (returns `rm` unchanged) when the tracked-file set is
+    unavailable (non-git dir, git missing, timeout) -- never crashes, never guesses."""
+    tracked = _tracked_file_set(root)
+    if tracked is None:
+        return rm
+
+    def _is_tracked(file_str: str) -> bool:
+        if not file_str:
+            return False
+        try:
+            return str(Path(file_str).resolve()) in tracked
+        except OSError:
+            return False
+
+    filtered = dict(rm)
+    filtered["files"] = [f for f in rm.get("files", []) if _is_tracked(str(f))]
+    filtered["tests"] = [f for f in rm.get("tests", []) if _is_tracked(str(f))]
+    filtered["symbols"] = [s for s in rm.get("symbols", []) if _is_tracked(str(s.get("file", "")))]
+    filtered["imports"] = [i for i in rm.get("imports", []) if _is_tracked(str(i.get("file", "")))]
     return filtered
 
 
@@ -782,14 +849,19 @@ def build_codemap(
     out_dir = Path(out).expanduser().resolve() if out is not None else (root / "docs" / "code-map")
     index_path = _resolve_index_path(out_dir, index).resolve()
 
-    revision_fn = _revision_identity or _evidence_receipt._repo_revision_identity
-    revision = revision_fn(root)
+    if _revision_identity is not None:
+        revision = _revision_identity(root)
+    else:
+        revision = _evidence_receipt._repo_revision_identity(
+            root, exclude_prefixes=_revision_exclude_prefixes(out_dir, root)
+        )
     now = _now() if _now is not None else datetime.now(UTC)
     now_iso = _format_utc_iso(now)
     stamp_line = _format_stamp_line(revision, now_iso)
 
     rm = _repo_map.build_repo_map(root, max_repo_files=max_repo_files)
     rm = _exclude_output_paths(rm, out_dir=out_dir, index_path=index_path)
+    rm = _exclude_untracked_paths(rm, root=root)
 
     universe = sorted(set(rm.get("files", [])) | set(rm.get("tests", [])))
 
@@ -942,8 +1014,12 @@ def check_codemap_freshness(
 
     stamped_revision = coverage.get("revision")
     if isinstance(stamped_revision, dict) and stamped_revision.get("status") == "present":
-        revision_fn = _revision_identity or _evidence_receipt._repo_revision_identity
-        live_revision = revision_fn(root)
+        if _revision_identity is not None:
+            live_revision = _revision_identity(root)
+        else:
+            live_revision = _evidence_receipt._repo_revision_identity(
+                root, exclude_prefixes=_revision_exclude_prefixes(out_dir, root)
+            )
         if live_revision.get("status") == "present":
             if (
                 live_revision.get("commit_sha") == stamped_revision.get("commit_sha")

--- a/src/tensor_grep/cli/evidence_receipt.py
+++ b/src/tensor_grep/cli/evidence_receipt.py
@@ -26,6 +26,7 @@ import json
 import os
 import shlex
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -135,13 +136,25 @@ def _parse_branch_header(header_text: str) -> str | None:
     return local or None
 
 
-def _repo_revision_identity(root: Path) -> dict[str, Any]:
+def _repo_revision_identity(
+    root: Path, exclude_prefixes: Sequence[str] | None = None
+) -> dict[str, Any]:
     """`git rev-parse HEAD` + `git status --porcelain=v1 -b` -> commit/branch/dirty identity.
 
     Exactly 2 git subprocess calls (the CEO's performance mandate): the porcelain `-b` flag folds
     the branch name into the SAME `git status` call that reports dirty entries, so a second
     `rev-parse --abbrev-ref HEAD` call is unnecessary. Fails closed to `status: "unavailable"` on
     any git error (not a repo, git missing, timeout) -- never raises, never fabricates a value.
+
+    `exclude_prefixes` (opt-in, default None): repo-root-relative POSIX path prefixes whose
+    porcelain entries never count toward `dirty`/`dirty_tree_sha256` -- e.g. a generator's own
+    `--out` directory, so regenerating a persisted, committed artifact doesn't make the repo read
+    as dirty against its own prior output (the `tg codemap --check` false-positive this param was
+    added for). This module is signing-adjacent (P2 will sign receipts built from this identity),
+    so the DEFAULT (None) branch below is left byte-for-byte IDENTICAL to the pre-exclusion
+    implementation -- every existing caller that never passes `exclude_prefixes` is provably
+    unaffected; see `_repo_revision_identity_excluding` for the separate opt-in branch, which is
+    still exactly 1 status call (2 total with the `rev-parse` above).
     """
     timeout_seconds = configured_git_timeout_seconds()
 
@@ -160,6 +173,14 @@ def _repo_revision_identity(root: Path) -> dict[str, Any]:
     commit_sha = commit_result.stdout.strip()
     if not commit_sha:
         return {"status": "unavailable", "reason": "git rev-parse HEAD returned no output"}
+
+    if exclude_prefixes:
+        return _repo_revision_identity_excluding(
+            root,
+            commit_sha=commit_sha,
+            timeout_seconds=timeout_seconds,
+            exclude_prefixes=exclude_prefixes,
+        )
 
     try:
         status_result = run_subprocess(
@@ -181,6 +202,104 @@ def _repo_revision_identity(root: Path) -> dict[str, Any]:
             branch = _parse_branch_header(line[3:])
         elif line.strip():
             dirty_lines.append(line)
+
+    dirty_tree_sha256 = hashlib.sha256("\n".join(sorted(dirty_lines)).encode("utf-8")).hexdigest()
+    return {
+        "status": "present",
+        "commit_sha": commit_sha,
+        "branch": branch,
+        "dirty": bool(dirty_lines),
+        "dirty_tree_sha256": dirty_tree_sha256,
+        "dirty_file_count": len(dirty_lines),
+    }
+
+
+def _parse_porcelain_z(raw: str) -> tuple[str | None, list[tuple[str, str]]]:
+    """Parse `git status --porcelain=v1 -b -z` stdout into `(branch, [(XY, path), ...])`.
+
+    `-z` NUL-terminates every record instead of LF and never quotes special characters, so paths
+    are read verbatim -- no `" -> "` string-splitting and no core.quotePath unescaping needed. Per
+    git-status(1), a rename/copy record's field order is reversed under `-z` ("`from -> to`
+    becomes `to from`"), so the FIRST path field is always the destination path; a second,
+    NUL-terminated ORIG_PATH field follows only when the status contains R or C, and is consumed
+    here without being mistaken for its own record.
+    """
+    tokens = raw.split("\0")
+    if tokens and tokens[-1] == "":
+        tokens.pop()
+    branch: str | None = None
+    entries: list[tuple[str, str]] = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        i += 1
+        if not token:
+            continue
+        if token.startswith("## "):
+            branch = _parse_branch_header(token[3:])
+            continue
+        if len(token) < 3:
+            continue  # malformed/short record -- skip defensively, never crash
+        # Fixed-width fields (2-char XY status + 1 separator space + path), NOT a
+        # `.partition(" ")`/whole-token `startswith` split: X or Y can itself be a literal space
+        # (e.g. " M" = modified-in-worktree-only), which a naive first-space split would misparse.
+        status, path = token[:2], token[3:]
+        entries.append((status, path))
+        if "R" in status or "C" in status:
+            i += 1  # skip the NUL-terminated ORIG_PATH field for a rename/copy record
+    return branch, entries
+
+
+def _path_excluded(path: str, exclude_prefixes: Sequence[str]) -> bool:
+    """True if `path` should be dropped from the dirty set: `path` is nested under (or equal to)
+    an excluded prefix, OR an excluded prefix is nested under (or equal to) `path`. The second
+    direction matters because git collapses an entirely-untracked directory to its own path (e.g.
+    a brand-new `docs/` shows as a single `?? docs/` entry even though the excluded prefix is the
+    deeper `docs/code-map`) -- a one-directional `startswith` would miss that collapsed case.
+    Path-segment-boundary-safe: `docs-extra` is never treated as nested under `docs`.
+    """
+    normalized_path = path.strip("/")
+    for prefix in exclude_prefixes:
+        normalized_prefix = prefix.strip("/")
+        if not normalized_prefix:
+            continue
+        if normalized_path == normalized_prefix:
+            return True
+        if normalized_path.startswith(normalized_prefix + "/"):
+            return True
+        if normalized_prefix.startswith(normalized_path + "/"):
+            return True
+    return False
+
+
+def _repo_revision_identity_excluding(
+    root: Path,
+    *,
+    commit_sha: str,
+    timeout_seconds: float,
+    exclude_prefixes: Sequence[str],
+) -> dict[str, Any]:
+    """The `exclude_prefixes`-aware sibling of `_repo_revision_identity`'s status half: a SEPARATE
+    `-z` status call (never mixed into the default LF-parsed branch above, so that default branch
+    stays byte-for-byte unchanged). Still exactly 1 status call (2 total with the already-issued
+    `rev-parse`)."""
+    try:
+        status_result = run_subprocess(
+            ["git", "-C", str(root), "status", "--porcelain=v1", "-b", "-z"],
+            timeout_seconds=timeout_seconds,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"status": "unavailable", "reason": f"git status could not run: {exc}"}
+    if status_result.returncode != 0:
+        return {"status": "unavailable", "reason": _last_stderr_line(status_result.stderr)}
+
+    branch, entries = _parse_porcelain_z(status_result.stdout)
+    dirty_lines = [
+        f"{status} {path}" for status, path in entries if not _path_excluded(path, exclude_prefixes)
+    ]
 
     dirty_tree_sha256 = hashlib.sha256("\n".join(sorted(dirty_lines)).encode("utf-8")).hexdigest()
     return {

--- a/tests/unit/test_codemap.py
+++ b/tests/unit/test_codemap.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -39,6 +40,18 @@ def _copy_fixture(dest_parent: Path) -> Path:
     dest = dest_parent / "repo"
     shutil.copytree(FIXTURE_ROOT, dest)
     return dest
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def _init_git_repo(repo: Path) -> None:
+    _run_git(["init", "-b", "main", "."], cwd=repo)
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo)
+    _run_git(["config", "user.name", "Test User"], cwd=repo)
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-m", "initial commit"], cwd=repo)
 
 
 def _build(repo: Path, **kwargs):
@@ -308,6 +321,66 @@ def test_json_output_is_parseable_and_matches_build_codemap(tmp_path: Path) -> N
     assert parsed["files_total"] > 0
     assert "written_files" in parsed
     assert parsed["revision"]["commit_sha"] == _FIXED_REVISION["commit_sha"]
+
+
+# ---------------------------------------------------------------------------
+# (14) tracked-only map universe: untracked/gitignored files never enter the payload
+# ---------------------------------------------------------------------------
+
+
+def test_untracked_source_file_is_excluded_from_map_payload(tmp_path: Path) -> None:
+    """A stray untracked .py file (never `git add`ed) must not appear as a mapped file -- its
+    volatile existence/mtime must never leak into the persisted, browsable inventory."""
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+
+    (repo / "pkg" / "untracked_scratch.py").write_text(
+        "def scratch():\n    return 1\n", encoding="utf-8"
+    )
+
+    payload = _build(repo)
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    assert "### untracked_scratch.py" not in pkg_page
+
+
+def test_gitignored_source_file_is_excluded_from_map_payload(tmp_path: Path) -> None:
+    repo = _copy_fixture(tmp_path)
+    (repo / ".gitignore").write_text("pkg/ignored_scratch.py\n", encoding="utf-8")
+    _init_git_repo(repo)
+
+    (repo / "pkg" / "ignored_scratch.py").write_text(
+        "def ignored():\n    return 1\n", encoding="utf-8"
+    )
+
+    payload = _build(repo)
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    assert "### ignored_scratch.py" not in pkg_page
+
+
+def test_tracked_files_still_appear_in_map_payload_in_a_git_repo(tmp_path: Path) -> None:
+    """The tracked-only filter must not become an accidental deny-all: every file that IS tracked
+    keeps appearing exactly as before."""
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+
+    payload = _build(repo)
+
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    assert "### core.py" in pkg_page
+
+
+def test_non_git_repo_map_payload_degrades_gracefully_keeps_all_files(tmp_path: Path) -> None:
+    """Outside a git repo, the tracked-only filter must degrade to a no-op (keep everything), not
+    crash and not silently produce an empty map."""
+    repo = _copy_fixture(tmp_path)  # never git-init'd
+
+    payload = _build(repo)
+
+    assert payload["files_total"] > 0
+    pkg_page = (Path(payload["out"]) / "pkg.md").read_text(encoding="utf-8")
+    assert "### core.py" in pkg_page
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_codemap_freshness.py
+++ b/tests/unit/test_codemap_freshness.py
@@ -202,6 +202,94 @@ def test_truncated_scan_writes_partial_and_check_fails(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# (14) exclude_prefixes end-to-end: regenerating a COMMITTED map must not flip --check to stale
+# (the reported false positive) -- proven WITHOUT the .gitignore workaround `git_fixture_repo`
+# above needs (its own comment names this exact gap as a "real, separate product question").
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def git_fixture_repo_output_tracked(tmp_path: Path) -> Path:
+    """Same setup as `git_fixture_repo` but does NOT gitignore the output dir -- proves the
+    exclude_prefixes fix makes the git-dirty oracle output-dir-aware on its own, without needing
+    the .gitignore workaround."""
+    repo = _copy_fixture(tmp_path)
+    _run_git(["init", "-b", "main", "."], cwd=repo)
+    _run_git(["config", "user.email", "test@example.com"], cwd=repo)
+    _run_git(["config", "user.name", "Test User"], cwd=repo)
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-m", "initial commit"], cwd=repo)
+    return repo
+
+
+def test_regenerating_a_committed_map_does_not_flip_check_to_stale(
+    git_fixture_repo_output_tracked: Path,
+) -> None:
+    """The exact false positive this PR fixes: `docs/code-map/` is committed, and a second
+    `build_codemap` run rewrites its own pages (a new `generated_at` timestamp at minimum) --
+    without output-dir exclusion this reads as a dirty worktree and --check falsely fails."""
+    repo = git_fixture_repo_output_tracked
+    build_codemap(repo)
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-m", "commit first codemap output"], cwd=repo)
+
+    build_codemap(repo)  # regenerate -- rewrites every page's stamp line + generated_at
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is True, result["reason"]
+
+
+def test_first_ever_generation_leaves_an_uncommitted_map_reading_fresh(
+    git_fixture_repo_output_tracked: Path,
+) -> None:
+    """First-ever generation: `docs/code-map/` has never been committed, so git collapses it to a
+    single untracked `docs/` entry -- the exclusion must still catch this (ancestor direction)."""
+    repo = git_fixture_repo_output_tracked
+    build_codemap(repo)  # docs/code-map/ now exists on disk, entirely untracked, never committed
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is True, result["reason"]
+
+
+def test_custom_out_dir_is_also_excluded_from_the_git_dirty_oracle(
+    git_fixture_repo_output_tracked: Path,
+) -> None:
+    """Symmetry: a non-default --out directory must be excluded too, computed dynamically at BOTH
+    the stamp site and the --check site -- not hardcoded to `docs/code-map`."""
+    repo = git_fixture_repo_output_tracked
+    custom_out = repo / "generated-map"
+
+    build_codemap(repo, out=custom_out)
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-m", "commit custom-out codemap"], cwd=repo)
+
+    build_codemap(repo, out=custom_out)  # regenerate under the custom out dir
+
+    result = check_codemap_freshness(repo, out=custom_out)
+    assert result["fresh"] is True, result["reason"]
+
+
+def test_unrelated_dirty_file_still_flips_check_to_stale_with_exclusions_active(
+    git_fixture_repo_output_tracked: Path,
+) -> None:
+    """The exclusion must be scoped to the output dir only -- a genuine, unrelated dirty file must
+    still flip the check to stale (bidirectional oracle: this can't just always read fresh now)."""
+    repo = git_fixture_repo_output_tracked
+    build_codemap(repo)
+    _run_git(["add", "-A"], cwd=repo)
+    _run_git(["commit", "-m", "commit first codemap output"], cwd=repo)
+
+    (repo / "pkg" / "core.py").write_text(
+        (repo / "pkg" / "core.py").read_text(encoding="utf-8") + "\n# unrelated edit\n",
+        encoding="utf-8",
+    )
+
+    result = check_codemap_freshness(repo)
+    assert result["fresh"] is False
+    assert result["reason"]
+
+
+# ---------------------------------------------------------------------------
 # PATH contract on the check path too.
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_evidence_receipt.py
+++ b/tests/unit/test_evidence_receipt.py
@@ -304,6 +304,188 @@ def test_repo_revision_identity_makes_at_most_two_git_subprocess_calls(
     assert call_count <= 2
 
 
+# ---------------------------------------------------------------------------
+# exclude_prefixes: opt-in output-dir exclusion for the git-dirty oracle (the `tg codemap --check`
+# false-positive: regenerating a persisted artifact's own committed output must not make the repo
+# read as dirty against itself). Default None is characterization-tested to stay byte-for-byte
+# identical -- this helper is signing-adjacent (P2 will sign receipts built from this identity).
+# ---------------------------------------------------------------------------
+
+
+def test_repo_revision_identity_default_exclude_prefixes_is_byte_identical_baseline(
+    git_repo: Path,
+) -> None:
+    """Characterization test: omitting exclude_prefixes, passing it as None, and passing an empty
+    list must all reproduce the EXACT pre-existing (unfiltered) dirty computation -- the opt-in
+    param must never move the default path even one bit."""
+    (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
+    (git_repo / "docs").mkdir()
+    (git_repo / "docs" / "generated.md").write_text("stuff\n", encoding="utf-8")
+
+    omitted = evidence_receipt._repo_revision_identity(git_repo)
+    explicit_none = evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=None)
+    explicit_empty = evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=[])
+
+    assert omitted == explicit_none == explicit_empty
+    # sanity: both new paths are genuinely still counted dirty by the unfiltered default
+    assert omitted["dirty_file_count"] == 2
+
+
+def test_repo_revision_identity_exclude_prefixes_ignores_matching_dirty_path(
+    git_repo: Path,
+) -> None:
+    (git_repo / "docs" / "code-map").mkdir(parents=True)
+    (git_repo / "docs" / "code-map" / "index.md").write_text("generated\n", encoding="utf-8")
+    (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
+
+    filtered = evidence_receipt._repo_revision_identity(
+        git_repo, exclude_prefixes=["docs/code-map"]
+    )
+
+    assert filtered["status"] == "present"
+    assert filtered["dirty"] is True  # scratch.tmp is still genuinely dirty
+    assert filtered["dirty_file_count"] == 1
+
+
+def test_repo_revision_identity_exclude_prefixes_regenerated_tracked_output_reads_clean(
+    git_repo: Path,
+) -> None:
+    """The exact reported bug, descendant direction: the output dir was already committed, then a
+    file inside it is regenerated (edited in place) -- git reports the specific nested path (`M
+    docs/code-map/index.md`), which must be recognized as a descendant of the excluded prefix."""
+    (git_repo / "docs" / "code-map").mkdir(parents=True)
+    (git_repo / "docs" / "code-map" / "index.md").write_text("v1\n", encoding="utf-8")
+    _run_git(["add", "-A"], cwd=git_repo)
+    _run_git(["commit", "-m", "commit codemap output"], cwd=git_repo)
+
+    (git_repo / "docs" / "code-map" / "index.md").write_text("v2 regenerated\n", encoding="utf-8")
+
+    filtered = evidence_receipt._repo_revision_identity(
+        git_repo, exclude_prefixes=["docs/code-map"]
+    )
+
+    assert filtered["dirty"] is False, filtered
+    assert filtered["dirty_tree_sha256"] == _EMPTY_SHA256
+
+
+def test_repo_revision_identity_exclude_prefixes_first_ever_generation_reads_clean(
+    git_repo: Path,
+) -> None:
+    """Ancestor direction: the output dir has NEVER been committed, so git collapses the whole new
+    subtree to a single `?? docs/` entry -- an ANCESTOR of the excluded prefix `docs/code-map`, not
+    a descendant of it. A one-directional `path.startswith(prefix)` filter would miss this."""
+    (git_repo / "docs" / "code-map").mkdir(parents=True)
+    (git_repo / "docs" / "code-map" / "index.md").write_text(
+        "freshly generated\n", encoding="utf-8"
+    )
+
+    filtered = evidence_receipt._repo_revision_identity(
+        git_repo, exclude_prefixes=["docs/code-map"]
+    )
+
+    assert filtered["dirty"] is False, filtered
+
+
+def test_repo_revision_identity_exclude_prefixes_respects_path_segment_boundaries(
+    git_repo: Path,
+) -> None:
+    """`docs-extra/file.py` must NOT be excluded by exclude_prefixes=["docs"] -- prefix matching
+    must respect path-segment ("/") boundaries, never a bare substring/startswith(prefix)."""
+    (git_repo / "docs-extra").mkdir()
+    (git_repo / "docs-extra" / "file.py").write_text("content\n", encoding="utf-8")
+
+    filtered = evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=["docs"])
+
+    assert filtered["dirty"] is True, filtered
+    assert filtered["dirty_file_count"] == 1
+
+
+def test_repo_revision_identity_exclude_prefixes_handles_rename_into_excluded_dir(
+    git_repo: Path,
+) -> None:
+    """A rename INTO the excluded dir is excluded by its DESTINATION path (-z reverses field order
+    to put the new path first) -- a naive parse that grabbed the ORIG_PATH instead would wrongly
+    keep this dirty."""
+    (git_repo / "scratch.py").write_text("content\n", encoding="utf-8")
+    _run_git(["add", "-A"], cwd=git_repo)
+    _run_git(["commit", "-m", "add scratch.py"], cwd=git_repo)
+
+    (git_repo / "docs").mkdir()
+    _run_git(["mv", "scratch.py", "docs/scratch.py"], cwd=git_repo)
+
+    filtered = evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=["docs"])
+
+    assert filtered["dirty"] is False, filtered
+
+
+def test_repo_revision_identity_exclude_prefixes_handles_rename_out_of_excluded_dir(
+    git_repo: Path,
+) -> None:
+    """A rename FROM the excluded dir elsewhere must NOT be excluded -- only the destination path
+    decides, matching git's own `-z` "to, from" field order."""
+    (git_repo / "docs").mkdir()
+    (git_repo / "docs" / "scratch.py").write_text("content\n", encoding="utf-8")
+    _run_git(["add", "-A"], cwd=git_repo)
+    _run_git(["commit", "-m", "add docs/scratch.py"], cwd=git_repo)
+
+    _run_git(["mv", "docs/scratch.py", "scratch.py"], cwd=git_repo)
+
+    filtered = evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=["docs"])
+
+    assert filtered["dirty"] is True, filtered
+
+
+def test_repo_revision_identity_exclude_prefixes_still_makes_at_most_two_git_calls(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    call_count = 0
+    real_run_subprocess = evidence_receipt.run_subprocess
+
+    def _counting_run_subprocess(*args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_receipt, "run_subprocess", _counting_run_subprocess)
+
+    evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=["docs/code-map"])
+
+    assert call_count <= 2
+
+
+# ---------------------------------------------------------------------------
+# _parse_porcelain_z: the `-z` record parser in isolation (pure function, no subprocess).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_porcelain_z_handles_leading_space_status_and_simple_entries() -> None:
+    raw = "## main\x00 M sub/core.py\x00?? new_file.py\x00"
+    branch, entries = evidence_receipt._parse_porcelain_z(raw)
+    assert branch == "main"
+    assert entries == [(" M", "sub/core.py"), ("??", "new_file.py")]
+
+
+def test_parse_porcelain_z_rename_takes_destination_path_and_consumes_orig_path() -> None:
+    raw = "## main\x00R  new_name.py\x00old_name.py\x00"
+    branch, entries = evidence_receipt._parse_porcelain_z(raw)
+    assert branch == "main"
+    # exactly one entry: ORIG_PATH is consumed, never surfaced as its own record
+    assert entries == [("R ", "new_name.py")]
+
+
+def test_parse_porcelain_z_path_field_never_includes_the_status_prefix() -> None:
+    raw = "## main\x00?? docs_lookalike.py\x00"
+    _branch, entries = evidence_receipt._parse_porcelain_z(raw)
+    assert entries == [("??", "docs_lookalike.py")]
+
+
+def test_parse_porcelain_z_no_branch_header_still_parses_entries() -> None:
+    raw = " M sub/core.py\x00"
+    branch, entries = evidence_receipt._parse_porcelain_z(raw)
+    assert branch is None
+    assert entries == [(" M", "sub/core.py")]
+
+
 def test_receipt_revision_block_reflects_dirty_worktree_end_to_end(git_repo: Path) -> None:
     (git_repo / "scratch.tmp").write_text("uncommitted\n", encoding="utf-8")
 


### PR DESCRIPTION
## What / why
External-audit remediation campaign #138, item #7. Two false-positive sources in `tg codemap` freshness:
1. The git-dirty oracle counted the map's **own output dir** as a repo change, so `tg codemap --check` false-fails right after a regeneration.
2. The map universe included **untracked/gitignored** files (scratch scripts, build artifacts) whose volatile mtime/existence leaked into the persisted inventory.

## Fix
- `evidence_receipt._repo_revision_identity(root, exclude_prefixes=None)` — **opt-in** param, default `None` leaves the branch **byte-for-byte identical** (signing-adjacent; characterization-tested). When set, a separate `_repo_revision_identity_excluding` issues `git status --porcelain=v1 -b -z` and drops entries under the excluded prefixes. `-z` parsing (`_parse_porcelain_z`) reads fixed-width `XY`+path (handles a literal space in the status, e.g. `" M"`) and skips the rename/copy `ORIG_PATH` field.
- `_path_excluded` matches **bidirectionally** (path-under-prefix AND prefix-under-path) so git's collapsed `?? docs/` form of an entirely-untracked new dir is caught; path-segment-boundary-safe (`docs-extra` never matches `docs`).
- `codemap.py` passes the exclude prefix (the map's `--out` dir) **symmetrically** at both the stamp site (`build_codemap`) and `--check` site, without touching the `_tree_manifest_sha256` oracle or `--check` control-flow. A `git ls-files -z` **tracked-only** post-filter (`_exclude_untracked_paths`, mirroring `_exclude_output_paths`) intersects the payload; degrades to a no-op outside a git repo.
- CI `codemap-freshness` smoke step: runs `tg codemap` then `tg codemap --check` back-to-back — a live regression guard.

## Tests / gate (real venv, ruff 0.15.20 / mypy 1.19.1 pinned)
+20 new TDD tests (12 evidence_receipt incl. default-None characterization + porcelain rename/status-char parsing; 8 codemap/freshness incl. regen-then-check + untracked-exclusion), all RED-first. `ruff check` + `ruff format --check --preview` + `mypy` (79 files) + `pytest` (89 passed) all PASS. Opus diff-review confirmed the default signing path is untouched and the bidirectional exclusion can't produce a false-negative.

Drains one-per-publish after v1.64.0 clears PyPI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>