### PR TITLE
fix(index): validate --index capability flags at both front doors, fail-closed (#138)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -6626,14 +6626,26 @@ fn run_index_query(
     }
 
     if args.count {
-        let unique_count = unique_line_matches(&matches).len();
-        println!("{unique_count}");
-        // fold-in (a): rg exit-parity. The native CPU (run_native_search_with_optional_rg_
-        // fallback) and multi-pattern (emit_multi_pattern_native_results) engines both already
-        // exit(1) on zero matches; run_index_query never did, so `--index --count` on a
-        // no-match query printed "0" but exited 0 -- indistinguishable from "found nothing but
-        // still succeeded" instead of rg's "no match" signal.
-        if unique_count == 0 {
+        // Audit fix #1 must-fix (Opus adversarial gate on PR #541): emit per-file `path:count`
+        // via the SAME emit_count_search_matches the sibling native aggregate path already uses
+        // (emit_multi_pattern_native_results below), NOT a bare aggregate total. The old
+        // `println!("{unique_count}")` printed a single number (e.g. `3`) while every other count
+        // emitter -- `rg -c`, the native CPU engine's append_count_output_bytes, and
+        // emit_count_search_matches -- prints per-file counts. Because `count` is (correctly) an
+        // Honor flag, the WARM auto-index path reaches here too, so a plain `tg search -c <pat>
+        // <dir>` silently changed output shape (per-file -> bare aggregate) the moment a `.tg_index`
+        // happened to exist -- exactly the silent-wrong-shape-with-exit-0 this validator exists to
+        // prevent. emit_count_search_matches omits zero-count files, byte-matching `rg -c` (the
+        // rg-compat target); the native CPU engine's separate grep-style zero-count emission is its
+        // own pre-existing divergence, deliberately not replicated on the index fast path.
+        emit_count_search_matches(request.primary_path(), &matches);
+        // fold-in (a): rg exit-parity. `rg -c` (and the native CPU / multi-pattern engines) exit 1
+        // on zero matches; run_index_query never did, so `--index --count` on a no-match query
+        // exited 0 -- indistinguishable from a successful search. `matches.is_empty()` is
+        // equivalent to the old `unique_count == 0` (unique_line_matches never empties a non-empty
+        // set), and emit_count_search_matches prints nothing for an empty set on a dir target,
+        // matching `rg -c`'s empty-stdout-plus-exit-1 no-match contract.
+        if matches.is_empty() {
             std::process::exit(1);
         }
         return Ok(());

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -4203,6 +4203,224 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(parse_early_positional_ripgrep_args(&replace).is_none());
     }
+
+    // -- Audit fix #1: --index capability validator (index_flag_violations) ------------------
+
+    fn index_violations_for(tokens: &[&str]) -> Vec<&'static str> {
+        let args = parse_search_args(tokens);
+        let request = resolve_search_request(&args).expect("expected request to resolve");
+        index_flag_violations(&args, &request)
+    }
+
+    /// Runtime backstop to the compile-time ratchet: `index_flag_violations` exhaustively
+    /// destructures `SearchArgs` (no `..`), so a NEW field already fails compilation until it's
+    /// added to that `match`/destructure. This test additionally guards the SEPARATE
+    /// `INDEX_FLAG_POLICY` documentation table (used only by the tests below) from drifting out
+    /// of sync with the real clap arg list -- e.g. someone satisfies the compiler by adding
+    /// `newfield: _` to the destructure but forgets to record its classification here.
+    #[test]
+    fn index_flag_policy_table_is_exhaustive_over_search_args_clap_ids() {
+        let command = <SearchArgs as clap::Args>::augment_args(clap::Command::new("t"));
+        let clap_ids: Vec<String> = command
+            .get_arguments()
+            .map(|arg| arg.get_id().as_str().to_string())
+            .filter(|id| id != "help")
+            .collect();
+        assert!(
+            !clap_ids.is_empty(),
+            "sanity: clap should report at least one SearchArgs argument"
+        );
+
+        let missing: Vec<&String> = clap_ids
+            .iter()
+            .filter(|id| {
+                !INDEX_FLAG_POLICY
+                    .iter()
+                    .any(|(name, _)| *name == id.as_str())
+            })
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "SearchArgs has clap arg(s) not classified in INDEX_FLAG_POLICY for the --index \
+             capability validator (index_flag_violations): {missing:?}"
+        );
+
+        let stale: Vec<&str> = INDEX_FLAG_POLICY
+            .iter()
+            .map(|(name, _)| *name)
+            .filter(|name| !clap_ids.iter().any(|id| id == name))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "INDEX_FLAG_POLICY has stale entries no longer present on SearchArgs: {stale:?}"
+        );
+
+        let mut seen: Vec<&str> = Vec::new();
+        for (name, _) in INDEX_FLAG_POLICY {
+            assert!(
+                !seen.contains(name),
+                "INDEX_FLAG_POLICY has a duplicate entry for {name:?}"
+            );
+            seen.push(name);
+        }
+    }
+
+    #[test]
+    fn index_flag_violations_catches_flags_outside_the_original_six() {
+        // None of these are in the original H1a 6-flag deny-list (invert_match/context/
+        // max_count/word_regexp/globs/multi-pattern); before audit fix #1 they were silently
+        // dropped by run_index_query the moment they reached it (combined with --json here so
+        // they reach index_flag_violations at all -- see its doc comment on reachability).
+        let cases: &[(&[&str], &str)] = &[
+            (&["--hidden"], "-./--hidden"),
+            (&["--max-depth", "2"], "-d/--max-depth"),
+            (&["-t", "py"], "-t/--type"),
+            (&["--sort", "path"], "--sort"),
+            (&["--sortr", "path"], "--sortr"),
+            (&["--sort-files"], "--sort-files"),
+            (&["-o"], "-o/--only-matching"),
+            (&["-r", "X"], "-r/--replace"),
+            (&["--max-filesize", "10K"], "--max-filesize"),
+            (&["--no-ignore-vcs"], "--no-ignore-vcs"),
+            (&["--require-git"], "--require-git"),
+            (&["-L"], "-L/--follow"),
+            (&["-a"], "-a/--text"),
+            (&["-l"], "-l/--files-with-matches"),
+            (&["--files-without-match"], "--files-without-match"),
+            (&["--column"], "--column"),
+            (&["--count-matches"], "--count-matches"),
+            (&["--vimgrep"], "--vimgrep"),
+            (&["--passthru"], "--passthru"),
+            (&["--null"], "-0/--null"),
+            (&["--null-data"], "--null-data"),
+            (&["-U"], "-U/--multiline"),
+            (&["--multiline-dotall"], "--multiline-dotall"),
+            (&["--path-separator", "/"], "--path-separator"),
+            (&["--no-ignore-dot"], "--no-ignore-dot"),
+            (&["--no-ignore-exclude"], "--no-ignore-exclude"),
+            (&["--no-ignore-files"], "--no-ignore-files"),
+            (&["--no-ignore-global"], "--no-ignore-global"),
+            (&["--no-ignore-parent"], "--no-ignore-parent"),
+            (&["--format", "text"], "--format"),
+        ];
+        for (extra, expected) in cases {
+            let mut tokens = vec!["tg", "search", "--index", "--json"];
+            tokens.extend_from_slice(extra);
+            tokens.push("foo");
+            tokens.push(".");
+            let violations = index_violations_for(&tokens);
+            assert!(
+                violations.contains(expected),
+                "flags {extra:?} should be refused (expected {expected:?}); got {violations:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn index_flag_violations_allows_passthrough_safe_bundle() {
+        let tokens = [
+            "tg",
+            "search",
+            "--index",
+            "--json",
+            "--no-fixed-strings",
+            "--no-invert-match",
+            "--ignore",
+            "--no-hidden",
+            "--no-column",
+            "--unicode",
+            "--pcre2-unicode",
+            "--messages",
+            "--no-config",
+            "--auto-hybrid-regex",
+            "--color",
+            "auto",
+            "foo",
+            ".",
+        ];
+        assert_eq!(
+            index_violations_for(&tokens),
+            Vec::<&str>::new(),
+            "PassthroughSafe flags must not be refused"
+        );
+    }
+
+    #[test]
+    fn index_flag_violations_color_never_and_auto_are_safe_but_always_is_refused() {
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "--color", "never", "foo", "."])
+                .is_empty()
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "--color", "auto", "foo", "."])
+                .is_empty()
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "--color", "always", "foo", "."])
+                .contains(&"--color"),
+            "explicit --color always asks for output the index path cannot produce"
+        );
+    }
+
+    #[test]
+    fn index_flag_violations_refuses_contradictory_engine_selection() {
+        // fold-in (c): --index combined with an explicit alternate engine is contradictory;
+        // route_search currently checks explicit_index before force_cpu/explicit_gpu_device_ids,
+        // so without this check the engine flag would be silently dropped, not honored.
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "--cpu", "foo", "."])
+                .contains(&"--cpu/--force-cpu")
+        );
+        assert!(index_violations_for(&[
+            "tg",
+            "search",
+            "--index",
+            "--gpu-device-ids",
+            "0",
+            "foo",
+            "."
+        ])
+        .contains(&"--gpu-device-ids"));
+    }
+
+    #[test]
+    fn index_flag_violations_honors_original_six_plus_no_line_number() {
+        // The pre-existing H1a 6 must still be classified Refuse after the rewrite.
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "-v", "foo", "."])
+                .contains(&"-v/--invert-match")
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "-C", "2", "foo", "."])
+                .contains(&"-C/-A/-B (context)")
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "-m", "1", "foo", "."])
+                .contains(&"-m/--max-count")
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "-w", "foo", "."])
+                .contains(&"-w/--word-regexp")
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "-g", "*.rs", "foo", "."])
+                .contains(&"-g/--glob")
+        );
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "-e", "foo", "-e", "bar", "."])
+                .contains(&"multiple patterns (-e)")
+        );
+
+        // Honor: -N/--no-line-number (and -n) must NOT be refused -- it's threaded into the
+        // emit call (fold-in b) instead of being rejected.
+        assert!(index_violations_for(&["tg", "search", "--index", "-N", "foo", "."]).is_empty());
+        assert!(index_violations_for(&["tg", "search", "--index", "-n", "foo", "."]).is_empty());
+        assert!(index_violations_for(&["tg", "search", "--index", "-S", "foo", "."]).is_empty());
+        assert!(
+            index_violations_for(&["tg", "search", "--index", "--no-ignore", "foo", "."])
+                .is_empty()
+        );
+    }
 }
 
 fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
@@ -4891,19 +5109,354 @@ fn resolve_search_request_with_stdin(
     })
 }
 
+/// Audit fix #1 (index capability validator, 2026-07-11): per-field classification of every
+/// `SearchArgs` flag against the trigram index engine (`run_index_query` / `TrigramIndex`).
+/// Three policy classes:
+///   - `Honor`: the index path already correctly implements this flag (or the flag is one of
+///     the query-defining fields -- `pattern`/`regexp`/`path` -- whose cardinality is enforced
+///     separately, via `request.patterns.len() != 1` below and the `request.paths.len() != 1`
+///     bail in `handle_index_search`).
+///   - `PassthroughSafe`: the flag is a semantic no-op on this path -- it only restates a
+///     default that already holds here (e.g. `--unicode`, `--no-hidden`, `--ignore`), or it only
+///     changes behavior once ripgrep itself is invoked (e.g. `--auto-hybrid-regex`), which the
+///     index path never does.
+///   - `Refuse`: the flag changes the result set or output shape in a way the index cannot (yet)
+///     reproduce. Silently dropping it would return wrong-but-plausible results with exit 0, so
+///     the explicit `--index` path must fail closed and warm auto-routing must reroute past the
+///     index instead (see the two call sites below and in `handle_index_search`).
+///
+/// Supersedes the original 6-flag ad-hoc deny-list (H1a, audit #79/#10/#14): that list was
+/// correct as far as it went, but `run_index_query` only ever consulted
+/// pattern/ignore_case/smart_case/fixed_strings/json/ndjson/count -- every OTHER flag (`--hidden`,
+/// `--sort`, `--max-depth`, `-t`, `-o`, `-r`, `--max-filesize`, the `--no-ignore-*` family, ...)
+/// was silently dropped once it reached this function instead of being honored or refused. (In
+/// practice most of those flags are only non-json/non-ndjson-reachable via
+/// `search_prefers_ripgrep_passthrough`'s early rg-passthrough branch in
+/// `handle_ripgrep_search`, which diverts them to `rg` before `route_search` ever runs; combined
+/// with `--json`/`--ndjson` that branch is skipped and they reach here directly -- see the H1e
+/// smart-case tests below for the same reachability shape.)
+///
+/// The destructure below names EVERY `SearchArgs` field with no `..` rest pattern: adding a new
+/// field to `SearchArgs` fails this function's compilation until it is explicitly classified
+/// here (the compile-time ratchet). `INDEX_FLAG_POLICY` (test-only, defined just below) is a
+/// second, independent listing used as a *runtime* backstop -- see
+/// `index_flag_policy_table_is_exhaustive_over_search_args_clap_ids` in the test module -- so an
+/// edit that adds a field here (satisfying the compiler) without ALSO updating that table still
+/// fails a test instead of silently drifting out of sync.
+fn index_flag_violations(args: &SearchArgs, request: &ResolvedSearchRequest) -> Vec<&'static str> {
+    let mut violations = Vec::new();
+
+    let SearchArgs {
+        ignore_case: _,      // Honor: threaded into TrigramIndex::search.
+        fixed_strings: _,    // Honor: threaded into TrigramIndex::search.
+        no_fixed_strings: _, // PassthroughSafe: restates the `fixed_strings` default (false).
+        invert_match,
+        no_invert_match: _, // PassthroughSafe: restates the `invert_match` default (false).
+        count: _,           // Honor: aggregate len(unique_line_matches).
+        count_matches,
+        line_number: _, // Honor: threaded as `line_number && !no_line_number` (fold-in b).
+        no_line_number: _, // Honor: see line_number.
+        column,
+        no_column: _, // PassthroughSafe: the index path never emits column offsets.
+        replace,
+        format,
+        sort,
+        sort_reverse,
+        sort_files,
+        null,
+        null_data,
+        multiline,
+        multiline_dotall,
+        context: _,        // Refuse: covered by search_has_context() below (existing H1a).
+        after_context: _,  // Refuse: see context.
+        before_context: _, // Refuse: see context.
+        max_count,
+        max_depth,
+        word_regexp,
+        smart_case: _, // Honor: H1e, resolved per-pattern inside run_index_query.
+        globs,
+        no_ignore: _, // Honor: threaded as build/staleness mode (H1d).
+        ignore: _,    // PassthroughSafe: restates the `no_ignore` default (respect ignore files).
+        no_ignore_dot,
+        no_ignore_exclude,
+        no_ignore_files,
+        no_ignore_global,
+        no_ignore_parent,
+        hidden,
+        no_hidden: _, // PassthroughSafe: the index build walker hardcodes hidden-file exclusion
+        // (`WalkBuilder::hidden(true)` in index.rs) regardless of query flags, so
+        // this restates what already happens.
+        follow,
+        text,
+        files_with_matches,
+        files_without_match,
+        file_type,
+        index: _, // Honor: the field that selects this engine; not a compat flag itself.
+        force_cpu,
+        gpu_device_ids,
+        color,
+        path_separator,
+        only_matching,
+        vimgrep,
+        passthru,
+        json: _,    // Honor.
+        ndjson: _,  // Honor.
+        verbose: _, // Honor: emit_verbose_metadata is called from run_index_query.
+        regexp: _,  // Honor: cardinality enforced via request.patterns.len() below.
+        pattern: _, // Honor: the query itself.
+        path: _,    // Honor: cardinality enforced by handle_index_search's paths.len()!=1 bail.
+        pcre2,
+        auto_hybrid_regex: _, // PassthroughSafe: only affects behavior once rg is actually invoked.
+        unicode: _,           // PassthroughSafe: restates the Unicode-mode default (on).
+        pcre2_unicode: _,     // PassthroughSafe: alias of `unicode`; same reasoning.
+        max_filesize,
+        no_ignore_vcs,
+        require_git,
+        messages: _, // PassthroughSafe: restates the default; index has no diagnostic-message mode.
+        no_config: _, // PassthroughSafe: the index path never reads an rg config file.
+        pcre2_version: _, // PassthroughSafe: early-exit flag (handle_ripgrep_search top), unreachable here.
+        type_list: _,     // PassthroughSafe: early-exit flag, unreachable here.
+        version: _,       // PassthroughSafe: early-exit flag, unreachable here.
+    } = args;
+
+    if *invert_match {
+        violations.push("-v/--invert-match");
+    }
+    if search_has_context(args) {
+        violations.push("-C/-A/-B (context)");
+    }
+    if max_count.is_some() {
+        violations.push("-m/--max-count");
+    }
+    if *word_regexp {
+        violations.push("-w/--word-regexp");
+    }
+    if !globs.is_empty() {
+        violations.push("-g/--glob");
+    }
+    if request.patterns.len() != 1 {
+        violations.push("multiple patterns (-e)");
+    }
+    if *count_matches {
+        violations.push("--count-matches");
+    }
+    if *column {
+        violations.push("--column");
+    }
+    if replace.is_some() {
+        violations.push("-r/--replace");
+    }
+    if format.is_some() {
+        violations.push("--format");
+    }
+    if sort.is_some() {
+        violations.push("--sort");
+    }
+    if sort_reverse.is_some() {
+        violations.push("--sortr");
+    }
+    if *sort_files {
+        violations.push("--sort-files");
+    }
+    if *null {
+        violations.push("-0/--null");
+    }
+    if *null_data {
+        violations.push("--null-data");
+    }
+    if *multiline {
+        violations.push("-U/--multiline");
+    }
+    if *multiline_dotall {
+        violations.push("--multiline-dotall");
+    }
+    if max_depth.is_some() {
+        violations.push("-d/--max-depth");
+    }
+    if *no_ignore_dot {
+        violations.push("--no-ignore-dot");
+    }
+    if *no_ignore_exclude {
+        violations.push("--no-ignore-exclude");
+    }
+    if *no_ignore_files {
+        violations.push("--no-ignore-files");
+    }
+    if *no_ignore_global {
+        violations.push("--no-ignore-global");
+    }
+    if *no_ignore_parent {
+        violations.push("--no-ignore-parent");
+    }
+    if *hidden {
+        violations.push("-./--hidden");
+    }
+    if *follow {
+        violations.push("-L/--follow");
+    }
+    if *text {
+        violations.push("-a/--text");
+    }
+    if *files_with_matches {
+        violations.push("-l/--files-with-matches");
+    }
+    if *files_without_match {
+        violations.push("--files-without-match");
+    }
+    if !file_type.is_empty() {
+        violations.push("-t/--type");
+    }
+    if *force_cpu {
+        // fold-in (c): --index and --cpu request contradictory engines; route_search currently
+        // checks explicit_index before force_cpu, so without this --cpu would be silently
+        // dropped rather than honored or refused.
+        violations.push("--cpu/--force-cpu");
+    }
+    if !gpu_device_ids.is_empty() {
+        // fold-in (c): same contradiction as force_cpu, for explicit --gpu-device-ids.
+        violations.push("--gpu-device-ids");
+    }
+    if let Some(mode) = color {
+        // `--color never`/`--color auto` restate a no-op default (the index's plain-text
+        // emitter never writes ANSI escapes either way); only an explicit `always` (or any other
+        // unrecognized value) asks for something this path cannot produce.
+        if mode.as_str() != "never" && mode.as_str() != "auto" {
+            violations.push("--color");
+        }
+    }
+    if path_separator.is_some() {
+        violations.push("--path-separator");
+    }
+    if *only_matching {
+        violations.push("-o/--only-matching");
+    }
+    if *vimgrep {
+        violations.push("--vimgrep");
+    }
+    if *passthru {
+        violations.push("--passthru");
+    }
+    if *pcre2 {
+        // fold-in (c): defense in depth only. route_search already sends --pcre2 to
+        // ripgrep_pcre2() ahead of explicit_index when rg is available, and
+        // handle_ripgrep_search's unconditional `require_ripgrep_or_exit(rg_available,
+        // "--pcre2")` guard already fails closed before either is reached when rg is NOT
+        // available -- so this arm should be unreachable in practice today. Kept so a future
+        // routing-order change fails closed instead of silently running PCRE2 syntax through
+        // the index's non-PCRE2 regex engine.
+        violations.push("-P/--pcre2");
+    }
+    if max_filesize.is_some() {
+        violations.push("--max-filesize");
+    }
+    if *no_ignore_vcs {
+        violations.push("--no-ignore-vcs");
+    }
+    if *require_git {
+        violations.push("--require-git");
+    }
+
+    violations
+}
+
+/// Test-only, independent-of-the-destructure classification table -- see
+/// `index_flag_violations`'s doc comment for why this exists alongside the compile-time
+/// exhaustive destructure. Keyed by clap arg id, which for a `#[derive(Args)]` struct field is
+/// the Rust field name itself (not the `long = "..."` CLI spelling).
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexFlagPolicy {
+    /// The index path already correctly implements this flag.
+    Honor,
+    /// The flag is a semantic no-op on the index path (restates a default, or only matters once
+    /// ripgrep itself runs). `color` is listed here even though `--color always` is refused at
+    /// runtime by value -- see `index_flag_violations`.
+    PassthroughSafe,
+    /// The flag changes the result set or output shape; `--index` must fail closed / reroute.
+    Refuse,
+}
+
+#[cfg(test)]
+const INDEX_FLAG_POLICY: &[(&str, IndexFlagPolicy)] = &[
+    ("ignore_case", IndexFlagPolicy::Honor),
+    ("fixed_strings", IndexFlagPolicy::Honor),
+    ("no_fixed_strings", IndexFlagPolicy::PassthroughSafe),
+    ("invert_match", IndexFlagPolicy::Refuse),
+    ("no_invert_match", IndexFlagPolicy::PassthroughSafe),
+    ("count", IndexFlagPolicy::Honor),
+    ("count_matches", IndexFlagPolicy::Refuse),
+    ("line_number", IndexFlagPolicy::Honor),
+    ("no_line_number", IndexFlagPolicy::Honor),
+    ("column", IndexFlagPolicy::Refuse),
+    ("no_column", IndexFlagPolicy::PassthroughSafe),
+    ("replace", IndexFlagPolicy::Refuse),
+    ("format", IndexFlagPolicy::Refuse),
+    ("sort", IndexFlagPolicy::Refuse),
+    ("sort_reverse", IndexFlagPolicy::Refuse),
+    ("sort_files", IndexFlagPolicy::Refuse),
+    ("null", IndexFlagPolicy::Refuse),
+    ("null_data", IndexFlagPolicy::Refuse),
+    ("multiline", IndexFlagPolicy::Refuse),
+    ("multiline_dotall", IndexFlagPolicy::Refuse),
+    ("context", IndexFlagPolicy::Refuse),
+    ("after_context", IndexFlagPolicy::Refuse),
+    ("before_context", IndexFlagPolicy::Refuse),
+    ("max_count", IndexFlagPolicy::Refuse),
+    ("max_depth", IndexFlagPolicy::Refuse),
+    ("word_regexp", IndexFlagPolicy::Refuse),
+    ("smart_case", IndexFlagPolicy::Honor),
+    ("globs", IndexFlagPolicy::Refuse),
+    ("no_ignore", IndexFlagPolicy::Honor),
+    ("ignore", IndexFlagPolicy::PassthroughSafe),
+    ("no_ignore_dot", IndexFlagPolicy::Refuse),
+    ("no_ignore_exclude", IndexFlagPolicy::Refuse),
+    ("no_ignore_files", IndexFlagPolicy::Refuse),
+    ("no_ignore_global", IndexFlagPolicy::Refuse),
+    ("no_ignore_parent", IndexFlagPolicy::Refuse),
+    ("hidden", IndexFlagPolicy::Refuse),
+    ("no_hidden", IndexFlagPolicy::PassthroughSafe),
+    ("follow", IndexFlagPolicy::Refuse),
+    ("text", IndexFlagPolicy::Refuse),
+    ("files_with_matches", IndexFlagPolicy::Refuse),
+    ("files_without_match", IndexFlagPolicy::Refuse),
+    ("file_type", IndexFlagPolicy::Refuse),
+    ("index", IndexFlagPolicy::Honor),
+    ("force_cpu", IndexFlagPolicy::Refuse),
+    ("gpu_device_ids", IndexFlagPolicy::Refuse),
+    ("color", IndexFlagPolicy::PassthroughSafe),
+    ("path_separator", IndexFlagPolicy::Refuse),
+    ("only_matching", IndexFlagPolicy::Refuse),
+    ("vimgrep", IndexFlagPolicy::Refuse),
+    ("passthru", IndexFlagPolicy::Refuse),
+    ("json", IndexFlagPolicy::Honor),
+    ("ndjson", IndexFlagPolicy::Honor),
+    ("verbose", IndexFlagPolicy::Honor),
+    ("regexp", IndexFlagPolicy::Honor),
+    ("pattern", IndexFlagPolicy::Honor),
+    ("path", IndexFlagPolicy::Honor),
+    ("pcre2", IndexFlagPolicy::Refuse),
+    ("auto_hybrid_regex", IndexFlagPolicy::PassthroughSafe),
+    ("unicode", IndexFlagPolicy::PassthroughSafe),
+    ("pcre2_unicode", IndexFlagPolicy::PassthroughSafe),
+    ("max_filesize", IndexFlagPolicy::Refuse),
+    ("no_ignore_vcs", IndexFlagPolicy::Refuse),
+    ("require_git", IndexFlagPolicy::Refuse),
+    ("messages", IndexFlagPolicy::PassthroughSafe),
+    ("no_config", IndexFlagPolicy::PassthroughSafe),
+    ("pcre2_version", IndexFlagPolicy::PassthroughSafe),
+    ("type_list", IndexFlagPolicy::PassthroughSafe),
+    ("version", IndexFlagPolicy::PassthroughSafe),
+];
+
 fn detect_warm_index_state(
     args: &SearchArgs,
     request: &ResolvedSearchRequest,
 ) -> IndexRoutingState {
     if args.index
         || request.paths.len() != 1
-        || args.invert_match
-        || search_has_context(args)
-        || args.max_count.is_some()
-        || args.word_regexp
-        || !args.globs.is_empty()
         || request.patterns.len() != 1
         || request.patterns[0].len() < 3
+        || !index_flag_violations(args, request).is_empty()
     {
         return IndexRoutingState::default();
     }
@@ -5901,36 +6454,20 @@ fn handle_index_search(
         anyhow::bail!("index search currently supports exactly one path root");
     }
 
-    // Backend Fail-Closed Contract (audit H1a): route_search() (routing.rs) selects
+    // Backend Fail-Closed Contract (audit H1a, superseded by audit fix #1 2026-07-11): H1a
+    // originally hand-listed the 6 flags below because route_search() (routing.rs) selects
     // TrigramIndex for --index before any compatibility checks run, and run_index_query()
-    // below only ever reads pattern/ignore_case/fixed_strings -- every other search flag
-    // was silently dropped instead of honored or refused (e.g. --index -v used to return
-    // the NON-inverted set with exit 0). Mirror the same compatibility subset
-    // detect_warm_index_state already enforces for warm-index auto-routing and fail
-    // closed instead of silently running the query without them. Deliberately excludes
-    // the pattern-length and non-ASCII-ignore-case checks detect_warm_index_state also
-    // has -- those (H1b/H1c) are handled as a transparent full-scan fallback inside
-    // TrigramIndex::search/fixed_string_candidate_selection instead of a refusal, since
-    // the index can still honor them correctly, just without the trigram prefilter.
-    let mut unsupported_with_index: Vec<&str> = Vec::new();
-    if args.invert_match {
-        unsupported_with_index.push("-v/--invert-match");
-    }
-    if search_has_context(args) {
-        unsupported_with_index.push("-C/-A/-B (context)");
-    }
-    if args.max_count.is_some() {
-        unsupported_with_index.push("-m/--max-count");
-    }
-    if args.word_regexp {
-        unsupported_with_index.push("-w/--word-regexp");
-    }
-    if !args.globs.is_empty() {
-        unsupported_with_index.push("-g/--glob");
-    }
-    if request.patterns.len() != 1 {
-        unsupported_with_index.push("multiple patterns (-e)");
-    }
+    // only ever reads a handful of fields -- every OTHER search flag was silently dropped
+    // instead of honored or refused (e.g. --index -v used to return the NON-inverted set with
+    // exit 0). `index_flag_violations` (above `detect_warm_index_state`) replaces the ad-hoc
+    // list with an exhaustive per-field classification covering every `SearchArgs` field, not
+    // just these 6, and is shared with `detect_warm_index_state`'s warm-auto-routing gate so
+    // the two can't drift apart again. Deliberately excludes the pattern-length and
+    // non-ASCII-ignore-case checks detect_warm_index_state also has -- those (H1b/H1c) are
+    // handled as a transparent full-scan fallback inside
+    // TrigramIndex::search/fixed_string_candidate_selection instead of a refusal, since the
+    // index can still honor them correctly, just without the trigram prefilter.
+    let unsupported_with_index = index_flag_violations(args, request);
     if !unsupported_with_index.is_empty() {
         anyhow::bail!(
             "--index does not support {} yet; rerun without --index (or without the \
@@ -6089,11 +6626,33 @@ fn run_index_query(
     }
 
     if args.count {
-        println!("{}", unique_line_matches(&matches).len());
+        let unique_count = unique_line_matches(&matches).len();
+        println!("{unique_count}");
+        // fold-in (a): rg exit-parity. The native CPU (run_native_search_with_optional_rg_
+        // fallback) and multi-pattern (emit_multi_pattern_native_results) engines both already
+        // exit(1) on zero matches; run_index_query never did, so `--index --count` on a
+        // no-match query printed "0" but exited 0 -- indistinguishable from "found nothing but
+        // still succeeded" instead of rg's "no match" signal.
+        if unique_count == 0 {
+            std::process::exit(1);
+        }
         return Ok(());
     }
 
-    emit_plain_search_matches(request.primary_path(), &matches);
+    // fold-in (b): thread `-N`/`--no-line-number` the same way the native/rg-passthrough
+    // configs already do (`args.line_number && !args.no_line_number`, see e.g.
+    // native_search_config_for_command) instead of emit_plain_search_matches's hardcoded
+    // `true`, which made `-N` a no-op on the index path.
+    emit_plain_search_matches_with_line_number(
+        request.primary_path(),
+        &matches,
+        args.line_number && !args.no_line_number,
+    );
+
+    // fold-in (a): see the --count arm above for why this matches native/GPU exit-parity.
+    if matches.is_empty() {
+        std::process::exit(1);
+    }
 
     Ok(())
 }
@@ -9669,6 +10228,12 @@ fn unique_line_matches(matches: &[SearchMatchJson]) -> Vec<SearchMatchJson> {
     unique
 }
 
+// Audit fix #1 (2026-07-11): `run_index_query`'s plain-output arm used to be this function's
+// only non-cuda caller, hardcoding `line_number: true` regardless of `-N`/`--no-line-number`
+// (fold-in b). It now calls `emit_plain_search_matches_with_line_number` directly with the same
+// `line_number && !no_line_number` expression the native/rg-passthrough configs already use, so
+// this wrapper's only remaining caller is the cuda-only `emit_gpu_native_plain_results` below.
+#[cfg(feature = "cuda")]
 fn emit_plain_search_matches(path: &str, matches: &[SearchMatchJson]) {
     emit_plain_search_matches_with_line_number(path, matches, true);
 }

--- a/rust_core/tests/test_index.rs
+++ b/rust_core/tests/test_index.rs
@@ -126,6 +126,39 @@ fn match_tuples(payload: &Value) -> Vec<(String, u64, String)> {
         .collect()
 }
 
+/// Audit fix #1 must-fix (Opus gate on PR #541): `tg search --index -c` (and warm-index `-c`)
+/// now emit per-file `path:count` output -- one `<path>:<count>` line per MATCHED file, matching
+/// `rg -c` and the native aggregate emitter (`emit_count_search_matches`) -- instead of the old
+/// bare aggregate total. This parses that shape into a basename->count map so the assertions are
+/// path-format-agnostic. Splits on the LAST `:` because a Windows path itself contains one
+/// (`C:/...`). Returns an empty map for empty stdout (the no-match / zero-file case).
+fn parse_per_file_counts(stdout: &[u8]) -> std::collections::BTreeMap<String, usize> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut counts = std::collections::BTreeMap::new();
+    for line in text.lines().filter(|line| !line.is_empty()) {
+        let (path, count) = line
+            .rsplit_once(':')
+            .unwrap_or_else(|| panic!("per-file count line must be `path:count`, got {line:?}"));
+        let base = Path::new(path)
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.to_string());
+        let count = count
+            .trim()
+            .parse::<usize>()
+            .unwrap_or_else(|_| panic!("count must be a number, got {count:?}"));
+        counts.insert(base, count);
+    }
+    counts
+}
+
+/// The per-file counts for the `hello` query over `write_corpus`: a.txt and b.txt each have one
+/// `hello` line; c.log has none (omitted, matching `rg -c`). Named so the many count tests share
+/// one source of truth for the expected shape.
+fn hello_per_file_counts() -> std::collections::BTreeMap<String, usize> {
+    std::collections::BTreeMap::from([("a.txt".to_string(), 1), ("b.txt".to_string(), 1)])
+}
+
 #[test]
 fn test_tg_search_index_builds_and_returns_results() {
     let dir = tempdir().unwrap();
@@ -170,11 +203,12 @@ fn test_tg_search_index_count_mode() {
         .unwrap();
 
     assert!(output.status.success());
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count, 2);
+    // Audit fix #1 must-fix (PR #541): `--index -c` now emits per-file `path:count` (matching
+    // `rg -c`), not the old bare aggregate `2`. hello matches one line each in a.txt and b.txt.
+    assert_eq!(
+        parse_per_file_counts(&output.stdout),
+        hello_per_file_counts()
+    );
 }
 
 #[test]
@@ -322,11 +356,12 @@ fn test_tg_search_index_no_match_returns_zero() {
         .output()
         .unwrap();
 
-    // Audit fix #1 fold-in (a): rg exit-parity. --count still prints "0", but the process must
-    // now exit 1 (not 0) on zero matches, matching the native CPU/GPU engines
-    // (run_native_search_with_optional_rg_fallback / emit_multi_pattern_native_results), which
-    // already did this -- run_index_query previously always returned Ok(()) (exit 0) regardless
-    // of match count. See test_tg_search_index_count_no_match_exits_one_rg_parity and
+    // Audit fix #1 fold-in (a) + must-fix (PR #541): rg exit-parity AND rg output-shape parity.
+    // `rg -c` on a no-match dir search prints NOTHING and exits 1. run_index_query previously
+    // always returned Ok(()) (exit 0) and, once the count arm emitted a bare aggregate, printed
+    // "0"; it now routes through emit_count_search_matches (empty stdout for an empty match set on
+    // a dir target) AND exits 1, matching `rg -c` exactly. See
+    // test_tg_search_index_count_no_match_exits_one_rg_parity and
     // test_tg_search_index_plain_no_match_exits_one_rg_parity below for the dedicated coverage.
     assert_eq!(
         output.status.code(),
@@ -335,11 +370,11 @@ fn test_tg_search_index_no_match_returns_zero() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count, 0);
+    assert!(
+        output.stdout.is_empty(),
+        "no-match --index -c must print nothing (rg -c parity), got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
 }
 
 #[test]
@@ -358,11 +393,8 @@ fn test_tg_search_index_rebuilds_on_stale() {
         .output()
         .unwrap();
     assert!(out1.status.success());
-    let count1: usize = String::from_utf8_lossy(&out1.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count1, 2);
+    // Audit fix #1 must-fix (PR #541): per-file `path:count`, not a bare aggregate.
+    assert_eq!(parse_per_file_counts(&out1.stdout), hello_per_file_counts());
 
     // Modify corpus
     std::thread::sleep(std::time::Duration::from_millis(50));
@@ -380,11 +412,14 @@ fn test_tg_search_index_rebuilds_on_stale() {
         .output()
         .unwrap();
     assert!(out2.status.success());
-    let count2: usize = String::from_utf8_lossy(&out2.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count2, 3, "should find hello in the new file too");
+    // The rebuild must surface the new d.txt as an additional per-file count entry.
+    let mut expected = hello_per_file_counts();
+    expected.insert("d.txt".to_string(), 1);
+    assert_eq!(
+        parse_per_file_counts(&out2.stdout),
+        expected,
+        "should find hello in the new file too"
+    );
     let stderr = String::from_utf8_lossy(&out2.stderr);
     assert!(
         stderr.contains("stale") || stderr.contains("rebuilding"),
@@ -412,11 +447,11 @@ fn test_tg_search_index_handles_corrupt_index() {
         .unwrap();
 
     assert!(output.status.success(), "should recover from corrupt index");
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count, 2);
+    // Audit fix #1 must-fix (PR #541): per-file `path:count`, not a bare aggregate.
+    assert_eq!(
+        parse_per_file_counts(&output.stdout),
+        hello_per_file_counts()
+    );
 }
 
 #[test]
@@ -452,11 +487,14 @@ fn test_tg_search_auto_routes_to_warm_index() {
         stderr.contains("warm index found") || stderr.contains("TrigramIndex"),
         "should auto-route to index: stderr={stderr}"
     );
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count, 2);
+    // Audit fix #1 must-fix (PR #541): the whole point of the must-fix -- warm auto-routed `-c`
+    // (count is an Honor flag, so it still uses the index) must emit per-file `path:count`
+    // matching `rg -c`, NOT the old bare aggregate `2`. Before the fix, a plain `tg search -c`
+    // silently changed shape to a bare number the moment a `.tg_index` existed.
+    assert_eq!(
+        parse_per_file_counts(&output.stdout),
+        hello_per_file_counts()
+    );
 }
 
 #[test]
@@ -644,11 +682,11 @@ fn test_tg_search_index_old_format_triggers_rebuild() {
         .unwrap();
 
     assert!(output.status.success(), "should recover from old format");
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count, 2);
+    // Audit fix #1 must-fix (PR #541): per-file `path:count`, not a bare aggregate.
+    assert_eq!(
+        parse_per_file_counts(&output.stdout),
+        hello_per_file_counts()
+    );
 
     let rebuilt = fs::read(dir.path().join(".tg_index")).unwrap();
     assert_eq!(&rebuilt[0..4], b"TGI\x00");
@@ -683,11 +721,12 @@ fn test_tg_search_index_case_insensitive() {
         .unwrap();
 
     assert!(output.status.success());
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(count, 2);
+    // Audit fix #1 must-fix (PR #541): per-file `path:count`, not a bare aggregate. Case-insensitive
+    // `HELLO` matches the lowercase `hello` line in a.txt and b.txt (one each).
+    assert_eq!(
+        parse_per_file_counts(&output.stdout),
+        hello_per_file_counts()
+    );
 }
 
 #[test]
@@ -1056,12 +1095,12 @@ fn test_tg_search_explicit_index_no_ignore_flip_off_to_on_finds_newly_included_f
         .output()
         .unwrap();
     assert!(build.status.success());
-    let build_count: usize = String::from_utf8_lossy(&build.stdout)
-        .trim()
-        .parse()
-        .unwrap();
+    // Audit fix #1 must-fix (PR #541): `-c` is now per-file `path:count`. The invariant this test
+    // guards is the FILE SET (is secret.txt indexed?), captured order-independently by the count
+    // map's keys. Default build: only visible.txt (secret.txt gitignored).
     assert_eq!(
-        build_count, 1,
+        parse_per_file_counts(&build.stdout),
+        std::collections::BTreeMap::from([("visible.txt".to_string(), 1)]),
         "sanity: only visible.txt should be indexed by default"
     );
 
@@ -1087,12 +1126,12 @@ fn test_tg_search_explicit_index_no_ignore_flip_off_to_on_finds_newly_included_f
         "stderr={}",
         String::from_utf8_lossy(&requeried.stderr)
     );
-    let requeried_count: usize = String::from_utf8_lossy(&requeried.stdout)
-        .trim()
-        .parse()
-        .unwrap();
     assert_eq!(
-        requeried_count, 2,
+        parse_per_file_counts(&requeried.stdout),
+        std::collections::BTreeMap::from([
+            ("secret.txt".to_string(), 1),
+            ("visible.txt".to_string(), 1),
+        ]),
         "--no-ignore query must rebuild the index and include the gitignored file"
     );
 }
@@ -1119,12 +1158,13 @@ fn test_tg_search_explicit_index_no_ignore_flip_on_to_off_does_not_leak_gitignor
         .output()
         .unwrap();
     assert!(build.status.success());
-    let build_count: usize = String::from_utf8_lossy(&build.stdout)
-        .trim()
-        .parse()
-        .unwrap();
+    // Audit fix #1 must-fix (PR #541): per-file count map; the FILE SET is the invariant.
     assert_eq!(
-        build_count, 2,
+        parse_per_file_counts(&build.stdout),
+        std::collections::BTreeMap::from([
+            ("secret.txt".to_string(), 1),
+            ("visible.txt".to_string(), 1),
+        ]),
         "sanity: --no-ignore build should index both visible.txt and secret.txt"
     );
 
@@ -1147,12 +1187,9 @@ fn test_tg_search_explicit_index_no_ignore_flip_on_to_off_does_not_leak_gitignor
         "stderr={}",
         String::from_utf8_lossy(&requeried.stderr)
     );
-    let requeried_count: usize = String::from_utf8_lossy(&requeried.stdout)
-        .trim()
-        .parse()
-        .unwrap();
     assert_eq!(
-        requeried_count, 1,
+        parse_per_file_counts(&requeried.stdout),
+        std::collections::BTreeMap::from([("visible.txt".to_string(), 1)]),
         "default query must rebuild the index and exclude the gitignored file, not leak it"
     );
 }
@@ -1657,16 +1694,16 @@ fn test_tg_search_index_count_no_match_exits_one_rg_parity() {
         .output()
         .unwrap();
 
-    // fold-in (a): native CPU/GPU already exit(1) on zero matches; run_index_query previously
-    // always returned Ok(()) (exit 0) regardless of match count.
+    // fold-in (a) + must-fix (PR #541): native CPU/GPU already exit(1) on zero matches;
+    // run_index_query previously always returned Ok(()) (exit 0). And with the count arm now
+    // routed through emit_count_search_matches, a no-match dir search prints NOTHING (an empty
+    // match set yields no per-file lines), byte-matching `rg -c`'s empty-stdout + exit-1 contract
+    // -- not the old bare `0`.
     assert_eq!(output.status.code(), Some(1));
-    let count: usize = String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse()
-        .unwrap();
-    assert_eq!(
-        count, 0,
-        "the count itself is unaffected, only the exit code"
+    assert!(
+        output.stdout.is_empty(),
+        "no-match --index -c must print nothing (rg -c parity), got {:?}",
+        String::from_utf8_lossy(&output.stdout)
     );
 }
 
@@ -1707,6 +1744,192 @@ fn test_tg_search_index_plain_match_still_exits_zero() {
         "a real match must still exit 0; stderr={}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+// -- Audit fix #1 MUST-FIX (Opus gate on PR #541): --index/warm `-c` per-file output shape -------
+//
+// The index count arm used to emit a bare aggregate total (`println!("{unique_count}")`, e.g.
+// `3`) while `rg -c`, the native CPU engine, and the sibling native aggregate emitter all print
+// per-file `path:count`. Because `count` is an Honor flag (correctly -- the index HAS the matches,
+// so refusing would needlessly disable a fast count), the WARM auto-index path reaches the same
+// arm; so a plain `tg search -c <pat> <dir>` silently changed output shape the moment a `.tg_index`
+// existed -- the silent-wrong-shape-with-exit-0 this validator exists to prevent. Fixed by routing
+// the arm through emit_count_search_matches (rg-compatible per-file counts, zero-count files
+// omitted). These tests pin the fixed shape end to end through the real binary.
+
+#[test]
+fn test_tg_search_explicit_index_count_emits_per_file_not_bare_aggregate() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-c")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        indexed.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+
+    // Deterministic (the index count path is rg-independent): one `path:count` line per MATCHED
+    // file, zero-count c.log omitted -- exactly `rg -c`'s shape.
+    assert_eq!(
+        parse_per_file_counts(&indexed.stdout),
+        hello_per_file_counts()
+    );
+
+    // Regression guard against the old bare-aggregate emitter: the output must NOT be a single
+    // parseable number (it printed `2` before the fix). Two per-file lines can't parse as one usize.
+    let stdout = String::from_utf8_lossy(&indexed.stdout);
+    assert!(
+        stdout.trim().parse::<usize>().is_err(),
+        "--index -c must be per-file `path:count`, not a bare aggregate number: {stdout:?}"
+    );
+    assert_eq!(
+        stdout.lines().count(),
+        2,
+        "one line per matched file: {stdout:?}"
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_count_matches_rg_oracle_per_file_when_rg_present() {
+    // The coordinator's requested parity: `tg search --index -c` must match `tg search -c`
+    // (no --index). Compared by per-file COUNT MAP, not raw bytes: `rg -c` emits files in
+    // nondeterministic parallel-walk order (observed b,a in one run and a,b in another), whereas
+    // the index path's emit_count_search_matches is BTreeMap-sorted -- so a raw byte-match against
+    // rg is inherently flaky (the "golden-test rg-backend sensitivity" trap this repo has hit
+    // before). The order-independent count map is the meaningful, deterministic invariant. When rg
+    // is ABSENT the oracle falls to the native CPU engine, which additionally emits grep-style
+    // `<file>:0` zero-count lines (a pre-existing native-vs-rg divergence out of scope here) -- so
+    // the oracle comparison is asserted ONLY when the oracle used rg, detected by the absence of
+    // any `:0` line (which rg never emits). The deterministic index-side shape is asserted
+    // unconditionally.
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let oracle = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("-c")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        oracle.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&oracle.stderr)
+    );
+    let oracle_used_rg = !String::from_utf8_lossy(&oracle.stdout)
+        .lines()
+        .any(|line| line.ends_with(":0"));
+
+    let indexed = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-c")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(indexed.status.success());
+
+    // Always-true deterministic invariant: rg-compatible per-file counts (zero-count c.log omitted).
+    assert_eq!(
+        parse_per_file_counts(&indexed.stdout),
+        hello_per_file_counts()
+    );
+
+    if oracle_used_rg {
+        assert_eq!(
+            parse_per_file_counts(&indexed.stdout),
+            parse_per_file_counts(&oracle.stdout),
+            "--index -c must match the `rg -c` oracle's per-file counts. indexed={:?} oracle={:?}",
+            String::from_utf8_lossy(&indexed.stdout),
+            String::from_utf8_lossy(&oracle.stdout)
+        );
+    }
+}
+
+#[test]
+fn test_tg_search_warm_index_count_shape_does_not_depend_on_hidden_index_file() {
+    // The coordinator's CORE correctness concern: a plain `tg search -c <pat> <dir>` must NOT
+    // silently change output SHAPE when a `.tg_index` appears on disk. Capture the cold oracle
+    // BEFORE the index exists, build the index, then re-run the SAME plain `-c` (now warm
+    // auto-routed to the index) and require the same per-file counts. Compared by count MAP, not
+    // raw bytes, for the same rg-nondeterministic-order reason as the sibling test above.
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+    assert!(!dir.path().join(".tg_index").exists());
+
+    let cold = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("-c")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(cold.status.success());
+    let cold_used_rg = !String::from_utf8_lossy(&cold.stdout)
+        .lines()
+        .any(|line| line.ends_with(":0"));
+
+    // Build the warm index (this run ALSO now emits per-file, which is fine).
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-c")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+    assert!(dir.path().join(".tg_index").exists());
+
+    // Same plain `-c` again -- now warm auto-routes to the index (count is an Honor flag).
+    let warm = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--verbose")
+        .arg("-c")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        warm.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    // Confirm it actually used the index (else the "shape unchanged" assertion would be vacuous).
+    assert!(
+        String::from_utf8_lossy(&warm.stderr).contains("TrigramIndex"),
+        "warm `-c` should auto-route to the trigram index: stderr={}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    // Deterministic: warm `-c` emits per-file counts, NOT the old bare aggregate `3`.
+    assert_eq!(parse_per_file_counts(&warm.stdout), hello_per_file_counts());
+    // The whole point: per-file counts must not depend on whether a hidden `.tg_index` exists.
+    if cold_used_rg {
+        assert_eq!(
+            parse_per_file_counts(&warm.stdout),
+            parse_per_file_counts(&cold.stdout),
+            "warm-index `-c` must match the pre-index (rg) `-c` per-file counts; a hidden \
+             `.tg_index` must not change output shape. warm={:?} cold={:?}",
+            String::from_utf8_lossy(&warm.stdout),
+            String::from_utf8_lossy(&cold.stdout)
+        );
+    }
 }
 
 // NOTE on -N/--no-line-number specifically: `-N`/`--no-line-number` cannot be exercised via the

--- a/rust_core/tests/test_index.rs
+++ b/rust_core/tests/test_index.rs
@@ -322,7 +322,19 @@ fn test_tg_search_index_no_match_returns_zero() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    // Audit fix #1 fold-in (a): rg exit-parity. --count still prints "0", but the process must
+    // now exit 1 (not 0) on zero matches, matching the native CPU/GPU engines
+    // (run_native_search_with_optional_rg_fallback / emit_multi_pattern_native_results), which
+    // already did this -- run_index_query previously always returned Ok(()) (exit 0) regardless
+    // of match count. See test_tg_search_index_count_no_match_exits_one_rg_parity and
+    // test_tg_search_index_plain_no_match_exits_one_rg_parity below for the dedicated coverage.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     let count: usize = String::from_utf8_lossy(&output.stdout)
         .trim()
         .parse()
@@ -1331,4 +1343,480 @@ fn test_tg_search_warm_auto_index_smart_case_lowercase_pattern_matches_native() 
         "warm auto-routed -S (all-lowercase) must honor smart-case like native"
     );
     assert_eq!(match_tuples(&warm_json), match_tuples(&native_json));
+}
+
+// -- Audit fix #1 (2026-07-11): exhaustive --index capability validator -------------------
+//
+// H1a (above) hand-listed 6 refused flags; `index_flag_violations` (rust_core/src/main.rs)
+// replaces that ad-hoc list with an exhaustive per-field classification (Honor / PassthroughSafe
+// / Refuse) covering every `SearchArgs` field, shared by both the explicit `--index` gate
+// (`handle_index_search`) and the warm auto-routing gate (`detect_warm_index_state`). The
+// runtime-backstop exhaustiveness test (`index_flag_policy_table_is_exhaustive_over_search_args_
+// clap_ids`) plus several fast direct-call unit tests for `index_flag_violations` itself live in
+// rust_core/src/main.rs's own `#[cfg(test)] mod tests`, NOT here -- `SearchArgs` and
+// `index_flag_violations` are private to that binary crate, so an external integration test file
+// cannot call them directly (house rule: dogfood the real binary; these tests below do that for
+// the observable CLI contract).
+
+#[test]
+fn test_tg_search_explicit_index_refuses_flags_outside_the_original_six() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    // Build the index first so a missing/stale index cannot itself explain a non-zero exit.
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+
+    // --json guarantees reaching handle_index_search for every case: route_search checks
+    // explicit_index (set by --index) ahead of everything except `--pcre2 && rg_available`, and
+    // none of these cases pass --pcre2. (Several of these flags -- hidden, max_depth, file_type,
+    // sort*, column, vimgrep, null, count_matches, replace, only_matching, path_separator,
+    // no_ignore_vcs -- are ALSO in search_requires_ripgrep_passthrough's non-json OR-list, so a
+    // *plain* (non-json) invocation would instead be intercepted by handle_ripgrep_search's early
+    // rg-passthrough branch before route_search ever runs -- see index_flag_violations's doc
+    // comment for the same reachability shape as the pre-existing H1e smart-case tests above.)
+    //
+    // Deliberately EXCLUDES require_git, passthru, null_data, multiline(+dotall), and the
+    // no_ignore_dot/exclude/files/global/parent family: these are all separately intercepted
+    // even earlier, by `search_format_python_passthrough_args`'s SEARCH_PYTHON_PASSTHROUGH_FLAGS
+    // allowlist (require_git, unconditionally) or its `--json`-gated third/fourth checks
+    // (passthru/no_ignore_dot/.../no_config; -U/multiline/multiline-dotall/null-data) -- BEFORE
+    // `--index` is even parsed by clap. In an environment with a working Python sidecar on PATH,
+    // that pre-existing, unrelated dispatcher forwards the raw args to Python, which has no
+    // `--index` concept at all and errors out ("No such option '--index'") rather than reaching
+    // this binary's own routing. That is a real, separate gap in
+    // `search_format_python_passthrough_args` (main.rs) worth its own audit item; it is NOT
+    // something `index_flag_violations` can address (it never runs). These 9 flags' Refuse
+    // classification is still covered by the direct-call unit tests in main.rs's `mod tests`
+    // (`index_flag_violations_catches_flags_outside_the_original_six`), which call the function
+    // directly and are unaffected by CLI/Python dispatch.
+    let cases: &[(&[&str], &str)] = &[
+        (&["--hidden"], "hidden"),
+        (&["--max-depth", "2"], "max-depth"),
+        (&["-t", "py"], "type"),
+        (&["--sort", "path"], "sort"),
+        (&["--sortr", "path"], "sortr"),
+        (&["--sort-files"], "sort-files"),
+        (&["-o"], "only-matching"),
+        (&["-r", "X"], "replace"),
+        (&["--max-filesize", "10K"], "max-filesize"),
+        (&["--no-ignore-vcs"], "no-ignore-vcs"),
+        (&["-L"], "follow"),
+        (&["-a"], "text"),
+        (&["-l"], "files-with-matches"),
+        (&["--files-without-match"], "files-without-match"),
+        (&["--column"], "column"),
+        (&["--count-matches"], "count-matches"),
+        (&["--vimgrep"], "vimgrep"),
+        (&["--null"], "null"),
+        (&["--path-separator", "/"], "path-separator"),
+    ];
+
+    for (extra, needle) in cases {
+        let mut cmd = tg();
+        cmd.arg("search").arg("--index").arg("--json");
+        for arg in *extra {
+            cmd.arg(arg);
+        }
+        let output = cmd.arg("hello").arg(dir.path()).output().unwrap();
+        assert!(
+            !output.status.success(),
+            "expected --index {extra:?} to fail closed; stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        assert!(
+            stderr.contains(needle),
+            "error for {extra:?} should name the incompatible flag (expected {needle:?}): stderr={stderr}"
+        );
+    }
+}
+
+#[test]
+fn test_tg_search_explicit_index_refuses_contradictory_engine_flags() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    // fold-in (c): --index combined with an explicit alternate engine is contradictory.
+    // route_search checks explicit_index ahead of force_cpu/explicit_gpu_device_ids, so without
+    // this check the engine flag would be silently dropped (the index would just be used)
+    // instead of honored or refused.
+    let cpu = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--cpu")
+        .arg("--fixed-strings")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !cpu.status.success(),
+        "--index --cpu requests contradictory engines and must fail closed; stdout={} stderr={}",
+        String::from_utf8_lossy(&cpu.stdout),
+        String::from_utf8_lossy(&cpu.stderr)
+    );
+
+    let gpu = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--gpu-device-ids")
+        .arg("0")
+        .arg("--fixed-strings")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !gpu.status.success(),
+        "--index --gpu-device-ids requests contradictory engines and must fail closed; stdout={} stderr={}",
+        String::from_utf8_lossy(&gpu.stdout),
+        String::from_utf8_lossy(&gpu.stderr)
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_allows_passthrough_safe_flags_and_matches_baseline() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let baseline = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--json")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(baseline.status.success());
+    let baseline_json: Value = serde_json::from_slice(&baseline.stdout).unwrap();
+
+    // Deliberately excludes no_fixed_strings/no_invert_match/ignore/no_hidden/pcre2_unicode/
+    // messages/no_config/auto_hybrid_regex from this black-box bundle: those PassthroughSafe
+    // flags are ALSO in search_format_python_passthrough_args's SEARCH_PYTHON_PASSTHROUGH_FLAGS
+    // allowlist (unconditionally, or via its --json-gated third check for no_config/
+    // auto_hybrid_regex) -- an earlier, unrelated dispatcher that forwards to the Python sidecar
+    // before `--index` is even parsed by clap (see the comment on
+    // test_tg_search_explicit_index_refuses_flags_outside_the_original_six above for the same
+    // gap). Their PassthroughSafe classification is covered by the direct-call unit test
+    // `index_flag_violations_allows_passthrough_safe_bundle` in main.rs's `mod tests` instead.
+    let passthrough_safe = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--json")
+        .arg("--no-column")
+        .arg("--unicode")
+        .arg("--color")
+        .arg("auto")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        passthrough_safe.status.success(),
+        "PassthroughSafe flags must not be refused; stderr={}",
+        String::from_utf8_lossy(&passthrough_safe.stderr)
+    );
+    let passthrough_json: Value = serde_json::from_slice(&passthrough_safe.stdout).unwrap();
+    assert_eq!(
+        match_tuples(&passthrough_json),
+        match_tuples(&baseline_json),
+        "PassthroughSafe flags must not change the result set"
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_color_always_is_refused_but_never_and_auto_are_not() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    for mode in ["never", "auto"] {
+        let output = tg()
+            .arg("search")
+            .arg("--index")
+            .arg("--fixed-strings")
+            .arg("--count")
+            .arg("--color")
+            .arg(mode)
+            .arg("hello")
+            .arg(dir.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "--color {mode} must not be refused; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let always = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("--color")
+        .arg("always")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !always.status.success(),
+        "--color always asks for output the index path cannot produce and must be refused"
+    );
+}
+
+#[test]
+fn test_tg_search_warm_auto_index_reroutes_instead_of_dropping_hidden_files() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+    fs::write(dir.path().join(".hidden_secret.txt"), "hello hidden\n").unwrap();
+
+    // Build a warm index. The trigram build walker hardcodes hidden-file exclusion
+    // (`WalkBuilder::hidden(true)` in index.rs), so .hidden_secret.txt is never indexed
+    // regardless of this build's own flags.
+    let build = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(build.status.success());
+    assert!(dir.path().join(".tg_index").exists());
+
+    // NO --index: --hidden combined with --json reaches detect_warm_index_state's gate the same
+    // way the pre-existing H1e smart-case tests above reach handle_index_search's (a plain/non-
+    // json --hidden invocation is instead intercepted earlier by search_prefers_ripgrep_
+    // passthrough's rg-passthrough branch in handle_ripgrep_search). --json also makes the
+    // eventual reroute destination deterministic regardless of whether `rg` happens to be on
+    // PATH: once detect_warm_index_state denies warm-index eligibility, route_search's
+    // `structured_output` branch sends it to native_cpu_json unconditionally.
+    //
+    // Before audit fix #1, detect_warm_index_state's 6-flag gate didn't cover --hidden, so this
+    // query would have silently auto-routed to the (hidden-file-blind) warm index and missed
+    // .hidden_secret.txt.
+    let output = tg()
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("--json")
+        .arg("--verbose")
+        .arg("--hidden")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("routing_backend=TrigramIndex"),
+        "--hidden must reroute past the warm index (which cannot see hidden files), not use it: stderr={stderr}"
+    );
+
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let files = match_tuples(&payload)
+        .into_iter()
+        .map(|(file, _, _)| file)
+        .collect::<Vec<_>>();
+    assert!(
+        files.iter().any(|f| f.contains(".hidden_secret.txt")),
+        "warm auto-routing must reroute to an engine that honors --hidden, not silently drop it: matches={files:?}"
+    );
+}
+
+#[test]
+fn test_tg_search_index_count_no_match_exits_one_rg_parity() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--count")
+        .arg("zzzzzznotfound")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // fold-in (a): native CPU/GPU already exit(1) on zero matches; run_index_query previously
+    // always returned Ok(()) (exit 0) regardless of match count.
+    assert_eq!(output.status.code(), Some(1));
+    let count: usize = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        count, 0,
+        "the count itself is unaffected, only the exit code"
+    );
+}
+
+#[test]
+fn test_tg_search_index_plain_no_match_exits_one_rg_parity() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("zzzzzznotfound")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stdout).is_empty());
+}
+
+#[test]
+fn test_tg_search_index_plain_match_still_exits_zero() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    let output = tg()
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("hello")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "a real match must still exit 0; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// NOTE on -N/--no-line-number specifically: `-N`/`--no-line-number` cannot be exercised via the
+// top-level `tg search --index -N ...` CLI in an environment with a working Python sidecar on
+// PATH. `-N` is unconditionally in `SEARCH_PYTHON_PASSTHROUGH_FLAGS` (main.rs), so
+// `search_format_python_passthrough_args` forwards the ENTIRE invocation to the Python sidecar
+// before `--index` is even parsed by this binary's own clap `SearchArgs` -- and Python has no
+// `--index` concept, so it errors ("No such option '--index'") instead of ever reaching
+// `run_index_query`. That is a real, separate, pre-existing gap in the Rust/Python dispatch
+// layer (confirmed present on main before this fix too), not something `index_flag_violations`
+// or the fold-in (b) line-number threading can address -- fixing it would mean touching
+// `search_format_python_passthrough_args`'s allowlist or the Python CLI itself, well outside
+// this audit item's scope. `-N`'s Honor classification (not refused) is covered by the
+// direct-call unit test `index_flag_violations_honors_original_six_plus_no_line_number` in
+// main.rs's `mod tests`, which calls `index_flag_violations` directly and is unaffected by CLI
+// dispatch. The test below instead exercises the SAME `line_number && !no_line_number`
+// expression's "numbers shown" branch via `-n` (which is NOT in any Python-dispatch allowlist),
+// proving the threading fold-in (b) added end to end -- through the real shipped binary.
+#[test]
+fn test_tg_search_explicit_index_line_number_shown_via_n_matches_native() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    // Single-match query ("goodbye" appears exactly once, in a.txt only) so the comparison
+    // isn't confounded by the trigram-index engine and the native-CPU engine returning
+    // multi-file matches in different (each internally consistent, but mutually different)
+    // orders -- an orthogonal, pre-existing characteristic unrelated to line-number rendering
+    // (TrigramIndex::search's postings order vs native's explicit sort_search_matches).
+    //
+    // TG_DISABLE_RG=1 pins the no-index baseline to the native CPU engine deterministically --
+    // without it, route_search sends a plain (non-json) query to rg passthrough whenever `rg`
+    // happens to be on PATH, which would make this comparison's baseline engine (and thus its
+    // exact byte format) depend on the test machine (the "golden test rg-backend sensitivity"
+    // trap this repo has hit before).
+    let native = tg()
+        .env("TG_DISABLE_RG", "1")
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("-n")
+        .arg("goodbye")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(native.status.success());
+    assert!(
+        String::from_utf8_lossy(&native.stdout).contains(":3:"),
+        "sanity: 'goodbye world' is line 3 of a.txt; stdout={}",
+        String::from_utf8_lossy(&native.stdout)
+    );
+
+    let indexed = tg()
+        .env("TG_DISABLE_RG", "1")
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("-n")
+        .arg("goodbye")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        indexed.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+
+    assert_eq!(
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&native.stdout),
+        "-n output via --index must byte-match the no-index route"
+    );
+}
+
+#[test]
+fn test_tg_search_explicit_index_default_line_number_behavior_matches_native() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+
+    // No -n/-N: the index path's default must now byte-match the no-index route's default,
+    // since both compute the same `line_number && !no_line_number` expression (fold-in b)
+    // instead of the index path's old hardcoded `true`. Single-match query + TG_DISABLE_RG=1:
+    // see the ordering/rg-sensitivity notes above.
+    let native = tg()
+        .env("TG_DISABLE_RG", "1")
+        .arg("search")
+        .arg("--fixed-strings")
+        .arg("goodbye")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(native.status.success());
+
+    let indexed = tg()
+        .env("TG_DISABLE_RG", "1")
+        .arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("goodbye")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        indexed.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&indexed.stderr)
+    );
+
+    assert_eq!(
+        String::from_utf8_lossy(&indexed.stdout),
+        String::from_utf8_lossy(&native.stdout),
+        "default (no -n/-N) output via --index must byte-match the no-index route"
+    );
 }


### PR DESCRIPTION
## What / why
External-audit remediation #138 item #1 (the flagship correctness blocker). Explicit `--index` silently dropped unsupported flags (`--hidden`/`--max-depth`/`-l`/`-o`/`--replace`/`--sort`/context/`-w`/`-x`/...) and returned **wrong results with exit 0**; the warm auto-index route had the same gap.

## Fix
`index_flag_violations(args, request)` — exhaustive `let SearchArgs { .. }` destructure with **no `..` rest** (a new field fails compilation until classified). 3 classes: **Honor** (14), **PassthroughSafe** (14), **Refuse** (40). Wired to **REFUSE** on the explicit `--index` door and **REROUTE-to-rg** on the warm auto-index door (subsumes 5 of 9 old ad-hoc checks). Folds in: `exit(1)` on zero matches (was exit 0); `-N` un-numbering via `emit_plain_search_matches_with_line_number`; `--cpu`/`--gpu` contradiction Refuse; `--pcre2`-without-rg stays fail-closed. `color` is value-conditional (never/auto honored, always refused).

## Verification (agent, real rust toolchain 1.96.0)
`cargo check` (default + cuda) clean 0 warnings; `cargo fmt --check` clean; `cargo test --bin tg` 80/80; `test_index` 39/39; routing/search/golden 97/97; native/parity/schema/replace 100/102 (2 pre-existing ignored). Manual dogfood against built `tg.exe` confirms refuse/honor/exit-1/contradiction behavior.

## Gate status
**Opus adversarial gate IN PROGRESS** (index surface) — verifying that every Honor/PassthroughSafe flag is actually honored by the trigram index (not silently wrong). A separate front-door gap (Python-passthrough intercepts `--index`+flags before clap) is tracked as a follow-up task, out of scope here. Drains after v1.64.0 on PyPI + gate clears.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>