### PR TITLE
fix(backends): repair AstBackend query API (tree-sitter 0.26) + delete dead LSP tensor/GNN + wrapper-preferred routing (#138)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -518,8 +518,8 @@ dependencies = [
 # or CUDA-mismatched torch. The SUPPORTED GPU runtime path is the managed installer
 # (scripts/install.sh / install.ps1), which deliberately installs pinned CUDA 12.8 wheels.
 # `pip install tensor-grep[gpu]` is best-effort experimental, not the supported managed GPU path.
-gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "torch_geometric>=2.5.0"]
-gpu-win = ["torch>=2.0", "torch_geometric>=2.5.0"]
+gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0"]
+gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
 ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "pygls>=1.3.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):

--- a/src/tensor_grep/backends/ast_backend.py
+++ b/src/tensor_grep/backends/ast_backend.py
@@ -569,7 +569,18 @@ class AstBackend(ComputeBackend):
             self._queries[cache_key] = query
             return query
 
-        query = parser.language.query(f"({pattern}) @match")
+        query_source = f"({pattern}) @match"
+        language = parser.language
+        if hasattr(language, "query"):
+            # tree-sitter < 0.25 (and test fakes): Language.query() builds the query.
+            query = language.query(query_source)
+        else:
+            # tree-sitter >= 0.25 (0.26 is pinned): Language.query was REMOVED; the
+            # tree_sitter.Query(language, source) constructor builds it, and a
+            # QueryCursor executes it (mirrored at the capture site in search()).
+            import tree_sitter
+
+            query = tree_sitter.Query(language, query_source)
         self._queries.pop(cache_key, None)
         self._queries[cache_key] = query
         while len(self._queries) > self._query_cache_max_entries():

--- a/src/tensor_grep/backends/ast_backend.py
+++ b/src/tensor_grep/backends/ast_backend.py
@@ -1,15 +1,11 @@
-from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, ClassVar
-
-if TYPE_CHECKING:
-    import torch
-
 import hashlib
 import json
 import logging
 import os
 import re
+from collections import OrderedDict
 from pathlib import Path
+from typing import Any, ClassVar
 
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.core.config import SearchConfig
@@ -136,9 +132,10 @@ def get_supported_languages() -> list[str]:
 
 class AstBackend(ComputeBackend):
     """
-    A Graph Neural Network (GNN) backend that parses source code into an Abstract Syntax Tree (AST)
-    using tree-sitter, converts the AST into a geometric graph tensor, and then performs parallel
-    subgraph isomorphism matching directly in GPU VRAM using PyTorch Geometric.
+    A native, in-process structural-search backend: parses source code into an Abstract Syntax
+    Tree (AST) using tree-sitter and matches tree-sitter queries directly against the parsed
+    tree (or a cached node-type index for simple single-node-type patterns). Pure CPU, no
+    torch/GPU dependency -- see ``is_available()``.
     """
 
     _shared_parsers: ClassVar[dict[str, Any]] = {}
@@ -506,18 +503,18 @@ class AstBackend(ComputeBackend):
         )
 
     def is_available(self) -> bool:
-        """Check if torch-geometric and tree-sitter are installed."""
+        """Check if tree-sitter is installed.
+
+        AstBackend.search() is pure tree-sitter query matching -- it never touches torch,
+        CUDA, or any graph-learning library (the dead GNN/tensor-graph path, `_ast_to_graph`,
+        was audited as unreachable and removed). GPU/torch are therefore not part of this
+        backend's availability contract; gating a fully-functional CPU backend behind an
+        unrelated GPU dependency was itself the bug.
+        """
         try:
             import importlib.util
 
-            if not importlib.util.find_spec("torch_geometric") or not importlib.util.find_spec(
-                "tree_sitter"
-            ):
-                return False
-
-            import torch
-
-            return bool(torch.cuda.is_available())
+            return importlib.util.find_spec("tree_sitter") is not None
         except ImportError:
             return False
 
@@ -609,65 +606,13 @@ class AstBackend(ComputeBackend):
             return cached[1]
         return None
 
-    def _ast_to_graph(
-        self, root_node: Any, source_bytes: bytes
-    ) -> tuple["torch.Tensor", "torch.Tensor", list[int]]:
-        """
-        Converts a tree-sitter AST into a PyTorch Geometric Graph (edge_index, node_features).
-        Returns:
-            edge_index: [2, num_edges] long tensor.
-            node_features: [num_nodes, feature_dim] float tensor.
-            line_numbers: A mapping from node index back to the source code line number.
-        """
-        edges = []
-        features: list[list[float]] = []
-        line_numbers = []
-
-        # In a real model, this would be a loaded embedding dictionary
-        node_type_map: dict[str, float] = {}
-
-        # audit B3: convert recursive DFS to explicit stack to avoid RecursionError on
-        # deeply-nested ASTs.  Stack entries are (node, parent_idx).
-        stack: list[tuple[Any, int]] = [(root_node, -1)]
-        while stack:
-            node, parent_idx = stack.pop()
-            current_idx = len(features)
-
-            # Simple feature representation: Hash the node type string to a pseudo-embedding
-            # A true production model uses Word2Vec or CodeBERT embeddings here
-            node_type = node.type
-            if node_type not in node_type_map:
-                node_type_map[node_type] = float(hash(node_type) % 1000) / 1000.0
-
-            features.append([node_type_map[node_type]])
-            line_numbers.append(node.start_point[0] + 1)
-
-            if parent_idx != -1:
-                edges.append([parent_idx, current_idx])
-                edges.append([current_idx, parent_idx])  # Bidirectional for GNNs
-
-            # Push children in reverse order so leftmost child is processed first.
-            for child in reversed(node.children):
-                stack.append((child, current_idx))
-
-        import torch
-
-        edge_index = (
-            torch.tensor(edges, dtype=torch.long).t().contiguous()
-            if edges
-            else torch.empty((2, 0), dtype=torch.long)
-        )
-        x = torch.tensor(features, dtype=torch.float)
-
-        return edge_index, x, line_numbers
-
     def search(
         self, file_path: str, pattern: str, config: SearchConfig | None = None
     ) -> SearchResult:
         if not self.is_available():
-            raise RuntimeError(
-                "AstBackend requires torch-geometric and tree-sitter to be installed."
-            )
+            # Backend Fail-Closed Contract (base.py): a real failure must raise
+            # BackendExecutionError, never fall through to a silent-empty result.
+            raise BackendExecutionError("AstBackend requires tree-sitter to be installed.")
 
         lang = "python"
         if config and hasattr(config, "lang") and config.lang:

--- a/src/tensor_grep/cli/ast_workflows.py
+++ b/src/tensor_grep/cli/ast_workflows.py
@@ -710,7 +710,7 @@ def run_command(
 
         if backend_name not in {"AstBackend", "AstGrepWrapperBackend"}:
             print(
-                "Warning: AstBackend not available (requires torch_geometric/tree_sitter). "
+                "Warning: AstBackend not available (requires tree-sitter or ast-grep). "
                 "Falling back to CPU regex.",
                 file=sys.stderr,
             )

--- a/src/tensor_grep/cli/ast_workflows.py
+++ b/src/tensor_grep/cli/ast_workflows.py
@@ -974,11 +974,19 @@ def _select_ast_backend_for_pattern(
 
     backend: Any
     if Pipeline.__module__ == "tensor_grep.core.pipeline":
-        # Optimization: Prefer native AST backend if available, as it is much faster
-        if pattern_kind == "native" and _check_backend_available("AstBackend"):
-            backend = _get_cached_backend("AstBackend")
-        elif _check_backend_available("AstGrepWrapperBackend"):
+        # Prefer the ast-grep wrapper whenever it is available -- it is the stable,
+        # results-defining backend for BOTH native-shaped and wrapper-shaped patterns.
+        # The native tree-sitter AstBackend uses a DIFFERENT query DSL and returns
+        # DIFFERENT results for the same pattern (e.g. `identifier`: native matches every
+        # identifier node, the wrapper's code-pattern matches none), so it must NOT be
+        # silently preferred here -- that would change `tg run`/`tg scan` results for every
+        # box that has ast-grep + tree-sitter but no CUDA. Making native the CPU-perf default
+        # (and reconciling the two DSLs) is tracked separately (task #141). Native is reached
+        # ONLY as the ast-grep-absent fallback for native-shaped patterns.
+        if _check_backend_available("AstGrepWrapperBackend"):
             backend = _get_cached_backend("AstGrepWrapperBackend")
+        elif pattern_kind == "native" and _check_backend_available("AstBackend"):
+            backend = _get_cached_backend("AstBackend")
         elif pattern_kind == "wrapper":
             from tensor_grep.core.pipeline import ConfigurationError
 

--- a/src/tensor_grep/cli/lsp_server.py
+++ b/src/tensor_grep/cli/lsp_server.py
@@ -26,8 +26,6 @@ from lsprotocol.types import (
     DocumentSymbol,
     DocumentSymbolParams,
     Location,
-    LogMessageParams,
-    MessageType,
     OptionalVersionedTextDocumentIdentifier,
     Position,
     PrepareRenameParams,
@@ -50,18 +48,15 @@ from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LS
 # audit I3: max entries per LRU cache dict.
 _DOCUMENTS_CACHE_MAX = 512
 _REPO_MAP_CACHE_MAX = 64
-_TENSOR_CACHE_MAX = 128
 
 
 class TensorGrepLSPServer(LanguageServer):  # type: ignore
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # audit I3: use OrderedDict-backed LRU caches so that open documents,
-        # repo maps, and GPU tensors cannot grow without bound.  Eviction is
-        # LRU (move_to_end on access, popitem(last=False) when over limit).
+        # audit I3: use OrderedDict-backed LRU caches so that open documents and
+        # repo maps cannot grow without bound.  Eviction is LRU (move_to_end on
+        # access, popitem(last=False) when over limit).
         self.documents_cache: OrderedDict[str, str] = OrderedDict()
-        # In a real enterprise version, we would keep the AST graph warm in VRAM here.
-        self.tensor_cache: OrderedDict[str, Any] = OrderedDict()
         self.repo_map_cache: OrderedDict[str, dict[str, Any]] = OrderedDict()
         self.provider_mode = "native"
         self.external_providers = ExternalLSPProviderManager()
@@ -793,19 +788,15 @@ def did_open(ls: TensorGrepLSPServer, params: DidOpenTextDocumentParams) -> None
         _DOCUMENTS_CACHE_MAX,
     )
     _invalidate_repo_map_cache(ls, params.text_document.uri)
-    _update_ast_tensor(ls, params.text_document.uri, params.text_document.text)
     if ls.provider_mode != "native":
         _external_client_for_uri(ls, params.text_document.uri)
 
 
 @server.feature(TEXT_DOCUMENT_DID_CLOSE)  # type: ignore
 def did_close(ls: TensorGrepLSPServer, params: DidCloseTextDocumentParams) -> None:
-    """Document closed — evict from all caches and release GPU tensors (audit I3)."""
+    """Document closed — evict from all caches (audit I3)."""
     uri = params.text_document.uri
     ls.documents_cache.pop(uri, None)
-    # Drop tensor cache entry; if it contains GPU tensors the reference count
-    # falls to zero and VRAM is released at the next GC cycle.
-    ls.tensor_cache.pop(uri, None)
     # repo_map_cache is keyed by repo root, not URI, so we invalidate via the
     # normal helper which resolves the root from the URI.
     _invalidate_repo_map_cache(ls, uri)
@@ -849,10 +840,9 @@ def did_change(ls: TensorGrepLSPServer, params: DidChangeTextDocumentParams) -> 
 @server.feature(TEXT_DOCUMENT_DID_SAVE)  # type: ignore
 def did_save(ls: TensorGrepLSPServer, params: DidSaveTextDocumentParams) -> None:
     """Document saved."""
-    # audit I3: use LRU-promoting get.
-    text = cast(str, _lru_get(ls.documents_cache, params.text_document.uri) or "")
+    # audit I3: promote to MRU so a just-saved document isn't first to be evicted.
+    _lru_get(ls.documents_cache, params.text_document.uri)
     _invalidate_repo_map_cache(ls, params.text_document.uri)
-    _update_ast_tensor(ls, params.text_document.uri, text)
     if ls.provider_mode != "native":
         client = _external_client_for_uri(ls, params.text_document.uri)
         if client is not None:
@@ -925,49 +915,6 @@ def _negotiate_position_encoding(
         ls._position_encoding = "utf-32"
     else:
         ls._position_encoding = "utf-16"
-
-
-def _update_ast_tensor(ls: TensorGrepLSPServer, uri: str, text: str) -> None:
-    try:
-        from tensor_grep.backends.ast_backend import AstBackend
-
-        backend = AstBackend()
-        if not backend.is_available():
-            return
-
-        lang = _infer_language(uri)
-        parser_language = "javascript" if lang == "javascript" else lang
-        parser = backend._get_parser(parser_language)
-        source_bytes = text.encode("utf-8")
-        tree = parser.parse(source_bytes)
-
-        edge_index, x, line_numbers = backend._ast_to_graph(tree.root_node, source_bytes)
-
-        import torch
-
-        device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-        # audit I3: use LRU eviction; evicted entries drop GPU tensor references,
-        # allowing VRAM to be reclaimed at the next GC cycle.
-        _lru_put(
-            ls.tensor_cache,
-            uri,
-            {
-                "edge_index": edge_index.to(device),
-                "x": x.to(device),
-                "line_numbers": line_numbers,
-                "text": text,
-                "language": lang,
-            },
-            _TENSOR_CACHE_MAX,
-        )
-    except Exception as e:
-        ls.window_log_message(
-            LogMessageParams(
-                type=MessageType.Error,
-                message=f"Failed to update AST Tensor for {uri}: {e}",
-            )
-        )
 
 
 def run_lsp() -> None:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6410,7 +6410,7 @@ def search_command(
     ast: bool = typer.Option(
         False,
         "--ast",
-        help="Parse files into ASTs and search structurally using PyTorch Geometric.",
+        help="Parse files into ASTs and search structurally using tree-sitter.",
     ),
     lang: str | None = typer.Option(
         None,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -5897,23 +5897,26 @@ def _select_ast_backend_for_pattern(
 
             ast_backend = AstBackend()
             ast_wrapper = AstGrepWrapperBackend()
-            if pattern_kind == "native":
+            # Prefer the ast-grep wrapper whenever it is available: it is the stable,
+            # results-defining backend for BOTH pattern kinds. The native tree-sitter
+            # AstBackend uses a DIFFERENT DSL and returns DIFFERENT results, so it must not
+            # be silently preferred (that would change tg run/tg scan results on every
+            # ast-grep+tree-sitter box without CUDA). Native-as-CPU-default is task #141.
+            # Native is reached ONLY as the ast-grep-absent fallback for native patterns.
+            if ast_wrapper.is_available():
+                backend = ast_wrapper
+            elif pattern_kind == "native":
                 if ast_backend.is_available():
                     backend = ast_backend
-                elif ast_wrapper.is_available():
-                    backend = ast_wrapper
                 else:
                     backend = Pipeline(
                         config=replace(base_config, query_pattern=pattern)
                     ).get_backend()
             else:
-                if ast_wrapper.is_available():
-                    backend = ast_wrapper
-                else:
-                    raise ConfigurationError(
-                        "Explicit AST search requires AST dependencies: ast-grep wrapper backend "
-                        "is required for this pattern but is not available"
-                    )
+                raise ConfigurationError(
+                    "Explicit AST search requires AST dependencies: ast-grep wrapper backend "
+                    "is required for this pattern but is not available"
+                )
         except ImportError:
             backend = Pipeline(config=replace(base_config, query_pattern=pattern)).get_backend()
     else:

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -4513,7 +4513,7 @@ def tg_ast_search(
                 },
                 indent=2,
             )
-        return "Error: AstBackend is not available on this system. Requires torch_geometric and tree_sitter."
+        return "Error: AstBackend is not available on this system. Requires ast-grep/tree-sitter."
 
     all_results = SearchResult(matches=[], total_files=0, total_matches=0)
     all_results.routing_backend = getattr(

--- a/tests/unit/test_ast_backend.py
+++ b/tests/unit/test_ast_backend.py
@@ -91,9 +91,37 @@ class TestAstBackend:
         # Act & Assert
         assert backend.is_available() is False
 
+    def test_is_available_is_true_on_tree_sitter_alone_even_without_torch_geometric(self, mocker):
+        """Parity/characterization test (delete-dead-lsp-tensor-gnn): AstBackend.search() is
+        pure tree-sitter query matching -- the dead GNN/_ast_to_graph path (which was the only
+        thing that ever touched torch/torch_geometric/CUDA) has been deleted. is_available()
+        must therefore report availability from tree-sitter alone: a fully-functional CPU
+        backend must not be gated behind an unrelated, no-longer-relevant GPU dependency.
+        Simulates the common non-GPU box: `tree_sitter` importable, `torch_geometric` is not.
+        """
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def fake_find_spec(name, *args, **kwargs):
+            if name == "torch_geometric":
+                return None  # simulate: torch_geometric is NOT installed
+            if name == "tree_sitter":
+                return object()  # simulate: tree_sitter IS installed (any non-None spec)
+            return real_find_spec(name, *args, **kwargs)
+
+        mocker.patch("importlib.util.find_spec", side_effect=fake_find_spec)
+        from tensor_grep.backends.ast_backend import AstBackend
+
+        backend = AstBackend()
+
+        # Act & Assert
+        assert backend.is_available() is True
+
     @pytest.mark.gpu
     def test_should_parse_python_ast(self, tmp_path):
-        # Note: This test requires tree-sitter, tree-sitter-python, and torch_geometric to be installed.
+        # Note: this test only requires tree-sitter + tree-sitter-python to be installed
+        # (AstBackend is a pure tree-sitter structural matcher; it has no torch/GPU dependency).
         from tensor_grep.backends.ast_backend import AstBackend
 
         backend = AstBackend()
@@ -107,8 +135,7 @@ class TestAstBackend:
         config = SearchConfig(ast=True, lang="python")
 
         # Act
-        # In this simplistic simulated graph match, we're passing a pattern that doesn't actually match the GNN directly,
-        # but verifies the graph extraction pipeline doesn't crash.
+        # Verifies the tree-sitter query-matching pipeline doesn't crash on a real pattern.
         result = backend.search(str(file_path), "def", config)
 
         # Assert

--- a/tests/unit/test_ast_backend.py
+++ b/tests/unit/test_ast_backend.py
@@ -118,29 +118,74 @@ class TestAstBackend:
         # Act & Assert
         assert backend.is_available() is True
 
-    @pytest.mark.gpu
-    def test_should_parse_python_ast(self, tmp_path):
-        # Note: this test only requires tree-sitter + tree-sitter-python to be installed
-        # (AstBackend is a pure tree-sitter structural matcher; it has no torch/GPU dependency).
+    def test_should_parse_python_ast(self, tmp_path, monkeypatch):
+        # CPU test (was @pytest.mark.gpu): AstBackend is a pure tree-sitter structural
+        # matcher with no torch/GPU dependency, so it must run in ordinary non-GPU CI.
+        pytest.importorskip("tree_sitter")
+        pytest.importorskip("tree_sitter_python")
+        monkeypatch.setenv("TENSOR_GREP_AST_CACHE", "0")  # hermetic: no persistent disk cache
         from tensor_grep.backends.ast_backend import AstBackend
 
         backend = AstBackend()
-
-        if not backend.is_available():
-            pytest.skip("AstBackend dependencies not installed")
+        assert backend.is_available() is True  # tree-sitter present -> available (no CUDA needed)
 
         # Arrange
         file_path = tmp_path / "test.py"
-        file_path.write_text("def hello():\n    print('world')\n")
+        file_path.write_text("def hello():\n    print('world')\n", encoding="utf-8")
         config = SearchConfig(ast=True, lang="python")
 
-        # Act
-        # Verifies the tree-sitter query-matching pipeline doesn't crash on a real pattern.
-        result = backend.search(str(file_path), "def", config)
+        # Act: a simple node-type pattern routes through the node-type index path.
+        result = backend.search(str(file_path), "function_definition", config)
 
-        # Assert
-        assert result is not None
-        assert isinstance(result.total_matches, int)
+        # Assert: real native match on CPU.
+        assert result.routing_backend == "AstBackend"
+        assert result.total_matches == 1
+
+    def test_should_match_sexpr_query_via_query_cursor_on_real_tree_sitter(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for the tree-sitter >=0.25 `_get_query` migration (found by the Opus gate):
+        a non-simple ``(...)`` S-expr pattern routes through ``_get_query`` -> the
+        ``tree_sitter.Query(language, source)`` constructor + ``QueryCursor`` (mirroring the
+        capture site in ``search()``). tree-sitter 0.26 REMOVED ``Language.query``, so on the
+        pre-fix code this raised ``BackendExecutionError: 'tree_sitter.Language' object has no
+        attribute 'query'`` -- this test fails on the broken API and passes with the fix. Uses
+        REAL tree-sitter (no ``FakeLanguage.query`` mock, which would mask the API mismatch).
+        """
+        pytest.importorskip("tree_sitter")
+        pytest.importorskip("tree_sitter_python")
+        monkeypatch.setenv("TENSOR_GREP_AST_CACHE", "0")  # hermetic: force the live query path
+        from tensor_grep.backends.ast_backend import AstBackend
+
+        backend = AstBackend()
+        assert backend.is_available() is True
+
+        file_path = tmp_path / "svc.py"
+        file_path.write_text(
+            "def alpha():\n    return 1\n\n\ndef beta():\n    return 2\n", encoding="utf-8"
+        )
+        config = SearchConfig(ast=True, lang="python")
+
+        # Act: exercises _get_query on the real tree-sitter >=0.25 API.
+        result = backend.search(str(file_path), "(function_definition) @fn", config)
+
+        # Assert: both function definitions matched via the QueryCursor path (not the index).
+        assert result.routing_backend == "AstBackend"
+        assert result.routing_reason == "ast_structural_match"
+        assert result.total_matches == 2
+
+    def test_search_raises_backend_execution_error_when_tree_sitter_missing(self, mocker):
+        """Backend Fail-Closed Contract: when tree-sitter is unavailable, search() must raise
+        BackendExecutionError (never silent-empty), so run_command reports a real error."""
+        mocker.patch.dict("sys.modules", {"tree_sitter": None})
+        from tensor_grep.backends.ast_backend import AstBackend
+        from tensor_grep.backends.base import BackendExecutionError
+
+        backend = AstBackend()
+        with pytest.raises(BackendExecutionError):
+            backend.search(
+                "whatever.py", "function_definition", SearchConfig(ast=True, lang="python")
+            )
 
     def test_should_raise_on_invalid_ast_query(self, tmp_path, mocker):
         """Audit MED: a broad `except Exception` around tree-sitter query compilation

--- a/tests/unit/test_ast_workflows.py
+++ b/tests/unit/test_ast_workflows.py
@@ -506,6 +506,94 @@ def test_select_ast_backend_should_reject_wrapper_pattern_when_wrapper_is_unavai
         )
 
 
+def test_select_ast_backend_prefers_wrapper_when_ast_grep_available(monkeypatch):
+    """Invariant C (delete-dead-lsp-tensor-gnn): with ast-grep AVAILABLE, tg run/tg scan MUST
+    select the wrapper even for a native-shaped pattern with ast_prefer_native=True. This is the
+    exact production scenario the Opus gate flagged: tree-sitter present (native is_available now
+    True) + ast-grep present. The native tree-sitter AstBackend uses a different query DSL and
+    returns different results, so it must NOT be silently preferred -- that would change results
+    for every ast-grep + tree-sitter box without CUDA. (Native-as-CPU-default is task #141.)
+    """
+    from tensor_grep.cli.ast_workflows import _select_ast_backend_for_pattern
+
+    monkeypatch.setattr("tensor_grep.backends.ast_backend.AstBackend", _AvailableAstBackend)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend", AstGrepWrapperBackend
+    )
+
+    backend = _select_ast_backend_for_pattern(
+        SearchConfig(ast=True, ast_prefer_native=True, lang="python", query_pattern="identifier"),
+        "identifier",
+        {},
+    )
+
+    # Wrapper wins despite native being available AND ast_prefer_native=True + native pattern.
+    assert isinstance(backend, AstGrepWrapperBackend)
+    assert not isinstance(backend, _AvailableAstBackend)
+
+
+def test_select_ast_backend_falls_back_to_native_only_when_ast_grep_absent(monkeypatch):
+    """The ONLY place the native tree-sitter backend is now reachable: ast-grep ABSENT plus a
+    native-shaped pattern. (There the _get_query >=0.25 fix makes it actually run on CPU.)"""
+    from tensor_grep.cli.ast_workflows import _select_ast_backend_for_pattern
+
+    monkeypatch.setattr("tensor_grep.backends.ast_backend.AstBackend", _AvailableAstBackend)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend",
+        _UnavailableAstGrepWrapperBackend,
+    )
+
+    backend = _select_ast_backend_for_pattern(
+        SearchConfig(ast=True, ast_prefer_native=True, lang="python", query_pattern="identifier"),
+        "identifier",
+        {},
+    )
+
+    assert isinstance(backend, _AvailableAstBackend)
+
+
+def test_main_select_ast_backend_prefers_wrapper_when_ast_grep_available(monkeypatch):
+    """Invariant C, the main.py twin of _select_ast_backend_for_pattern (used by tg scan's
+    rule loop): wrapper preferred when ast-grep is available, regardless of native availability."""
+    from tensor_grep.cli.main import _select_ast_backend_for_pattern as main_select
+
+    monkeypatch.setattr("tensor_grep.backends.ast_backend.AstBackend", _AvailableAstBackend)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend", AstGrepWrapperBackend
+    )
+
+    backend = main_select(
+        SearchConfig(ast=True, ast_prefer_native=True, lang="python", query_pattern="identifier"),
+        "identifier",
+        {},
+    )
+
+    assert isinstance(backend, AstGrepWrapperBackend)
+    assert not isinstance(backend, _AvailableAstBackend)
+
+
+def test_run_command_picks_wrapper_when_ast_grep_available(monkeypatch, tmp_path, capsys):
+    """Command-level proof of invariant C: `tg run` selects the ast-grep wrapper (whose
+    search_many runs), NOT the native backend, when ast-grep is available -- even for a
+    native-shaped pattern. If the router wrongly picked native (_AvailableAstBackend has no
+    search()/search_many()) this would raise AttributeError, so a regression fails loudly."""
+    from tensor_grep.cli.ast_workflows import run_command
+
+    monkeypatch.setattr("tensor_grep.backends.ast_backend.AstBackend", _AvailableAstBackend)
+    monkeypatch.setattr(
+        "tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend", AstGrepWrapperBackend
+    )
+    AstGrepWrapperBackend.search_many_calls = 0
+    (tmp_path / "a.py").write_text("def hello():\n    return 1\n", encoding="utf-8")
+
+    exit_code = run_command(pattern="identifier", path=str(tmp_path), lang="python")
+
+    captured = capsys.readouterr()
+    assert "ast-grep structural matching" in captured.out
+    assert AstGrepWrapperBackend.search_many_calls == 1
+    assert exit_code == 0
+
+
 def test_run_command_interactive_apply_should_return_error_when_apply_fails(
     monkeypatch, tmp_path, capsys
 ):

--- a/tests/unit/test_backend_bug_fixes.py
+++ b/tests/unit/test_backend_bug_fixes.py
@@ -77,27 +77,37 @@ def test_build_node_type_index_correct_line_mapping() -> None:
     assert index["grandchild"] == [4]
 
 
-def test_ast_to_graph_deep_tree_does_not_raise_recursion_error() -> None:
-    """_ast_to_graph must also survive deeply-nested trees (it has its own walker)."""
-    # _ast_to_graph imports torch — skip if not present.
-    try:
-        import torch  # noqa: F401
-    except ImportError:
-        import pytest
+# ---------------------------------------------------------------------------
+# delete-dead-lsp-tensor-gnn: the GNN/tensor path (_ast_to_graph, torch_geometric,
+# the LSP tensor cache) was audited as dead -- _ast_to_graph's only caller was the
+# LSP's tensor-cache updater, whose output nothing ever read back. Both were
+# deleted in the same change that made AstBackend.is_available() tree-sitter-only
+# (see test_ast_backend.py). These hygiene assertions pin the deletion so the
+# dead path cannot silently grow back.
+# ---------------------------------------------------------------------------
 
-        pytest.skip("torch not installed")
 
+def test_ast_to_graph_and_torch_geometric_are_fully_removed() -> None:
+    """_ast_to_graph (the dead GNN/tensor-graph conversion helper) must be gone from
+    AstBackend, and neither ast_backend.py nor lsp_server.py may import torch_geometric
+    anymore -- AstBackend.search() is pure tree-sitter query matching and never touches it.
+    """
+    from pathlib import Path
+
+    import tensor_grep.backends.ast_backend as ast_backend_module
     from tensor_grep.backends.ast_backend import AstBackend
 
-    backend = AstBackend()
-    depth = sys.getrecursionlimit() + 200
-    root = _build_chain(depth)
+    assert not hasattr(AstBackend, "_ast_to_graph"), "_ast_to_graph must be deleted (dead GNN path)"
 
-    # Must not raise RecursionError
-    _edge_index, x, line_numbers = backend._ast_to_graph(root, b"")
+    ast_backend_source = Path(ast_backend_module.__file__).read_text(encoding="utf-8")
+    assert "torch_geometric" not in ast_backend_source
 
-    assert x.shape[0] == depth + 1  # one node per level
-    assert len(line_numbers) == depth + 1
+    import tensor_grep.cli.lsp_server as lsp_server_module
+
+    lsp_server_source = Path(lsp_server_module.__file__).read_text(encoding="utf-8")
+    assert "torch_geometric" not in lsp_server_source
+    assert "tensor_cache" not in lsp_server_source, "the dead LSP tensor cache must be removed"
+    assert "_update_ast_tensor" not in lsp_server_source
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -14224,13 +14224,18 @@ def test_test_command_should_reuse_wrapper_backend_selection_for_multiple_ast_gr
 
 
 def test_ast_selection_should_skip_pipeline_for_native_backend(monkeypatch):
+    # delete-dead-lsp-tensor-gnn: native is now reachable ONLY when ast-grep is ABSENT
+    # (the wrapper is preferred whenever available, since the two backends use different
+    # query DSLs and are not results-interchangeable). This test's real purpose is that a
+    # DIRECT native selection skips Pipeline construction, so it now models the ast-grep-absent
+    # fallback: wrapper unavailable + native available + native-shaped pattern -> native.
     monkeypatch.setattr(
         "tensor_grep.backends.ast_backend.AstBackend",
         _FakeDirectNativeAstBackend,
     )
     monkeypatch.setattr(
         "tensor_grep.backends.ast_wrapper_backend.AstGrepWrapperBackend",
-        _FakeDirectWrapperAstBackend,
+        _FakeUnavailableAstBackend,
     )
     monkeypatch.setattr(
         "tensor_grep.core.pipeline.Pipeline.__init__",

--- a/tests/unit/test_lsp_hygiene.py
+++ b/tests/unit/test_lsp_hygiene.py
@@ -159,11 +159,11 @@ pytest.importorskip("pygls.lsp.server")
 
 from tensor_grep.cli.lsp_server import (  # noqa: E402
     _DOCUMENTS_CACHE_MAX,
-    _TENSOR_CACHE_MAX,
     TensorGrepLSPServer,
     _lru_get,
     _lru_put,
     did_close,
+    did_open,
 )
 
 
@@ -194,11 +194,13 @@ class TestLruHelpers:
 
 
 # ---------------------------------------------------------------------------
-# I3: didClose handler evicts from documents_cache, tensor_cache, repo_map_cache
+# I3: didClose handler evicts from documents_cache, repo_map_cache
 # ---------------------------------------------------------------------------
 from lsprotocol.types import (  # noqa: E402
     DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
     TextDocumentIdentifier,
+    TextDocumentItem,
 )
 
 
@@ -211,8 +213,6 @@ class TestDidCloseHandler:
         server = _make_server()
         uri = (tmp_path / "file.py").as_uri()
         server.documents_cache[uri] = "print('hello')"
-        # Seed tensor and repo map caches too.
-        server.tensor_cache[uri] = {"dummy": True}
         server.repo_map_cache[str(tmp_path)] = {"symbols": []}
 
         did_close(
@@ -221,7 +221,6 @@ class TestDidCloseHandler:
         )
 
         assert uri not in server.documents_cache
-        assert uri not in server.tensor_cache
 
     def test_did_close_unknown_uri_is_safe(self, tmp_path: Path) -> None:
         server = _make_server()
@@ -239,11 +238,44 @@ class TestDidCloseHandler:
             _lru_put(server.documents_cache, f"file://{i}.py", f"content {i}", _DOCUMENTS_CACHE_MAX)
         assert len(server.documents_cache) <= _DOCUMENTS_CACHE_MAX
 
-    def test_tensor_cache_bounded_by_max(self) -> None:
+
+# ---------------------------------------------------------------------------
+# delete-dead-lsp-tensor-gnn: the LSP server has no tensor_cache anymore -- prove
+# it still constructs cleanly and still serves its real (documents_cache /
+# repo_map_cache) path through didOpen/didClose after the field + use-site removal.
+# ---------------------------------------------------------------------------
+class TestLspServerServesRealPathWithoutTensorCache:
+    def test_server_construction_has_no_tensor_cache_attribute(self) -> None:
         server = _make_server()
-        for i in range(_TENSOR_CACHE_MAX + 10):
-            _lru_put(server.tensor_cache, f"file://{i}.py", {"tensor": i}, _TENSOR_CACHE_MAX)
-        assert len(server.tensor_cache) <= _TENSOR_CACHE_MAX
+        assert not hasattr(server, "tensor_cache")
+
+    def test_did_open_then_did_close_serves_real_path(self, tmp_path: Path) -> None:
+        server = _make_server()
+        file_path = tmp_path / "file.py"
+        file_path.write_text("print('hello')\n", encoding="utf-8")
+        uri = file_path.as_uri()
+
+        # Must not raise: didOpen no longer touches a tensor cache, only the real
+        # documents_cache / repo_map_cache invalidation path.
+        did_open(
+            server,
+            DidOpenTextDocumentParams(
+                text_document=TextDocumentItem(
+                    uri=uri,
+                    language_id="python",
+                    version=1,
+                    text=file_path.read_text(encoding="utf-8"),
+                )
+            ),
+        )
+        assert server.documents_cache[uri] == "print('hello')\n"
+
+        # Must not raise: didClose evicts documents_cache/repo_map_cache only.
+        did_close(
+            server,
+            DidCloseTextDocumentParams(text_document=TextDocumentIdentifier(uri=uri)),
+        )
+        assert uri not in server.documents_cache
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -623,8 +623,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pywin32", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/75/0814c3ca505d5fb1986e381b4967cc1d0d62c6d5f52d271546f51cd4991c/cuda_bindings-12.9.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b65cbe73aa657daf8cc0137da2223e1858e4057056aad727aae5f839f35a724c", size = 12515235, upload-time = "2025-08-18T15:47:27.748Z" },
@@ -649,8 +649,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -678,7 +678,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/a5/e9d37c10f6c27c9c65d53c6cd6d9763e1df99c004780585fc2ad9041fbe3/cuda_bindings-12.9.6-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2662f59db67d9aeaf8959c593c91f600792c2970cf02cae2814387fc687b115a", size = 7090971, upload-time = "2026-03-11T14:47:29.526Z" },
@@ -697,7 +697,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/62/ed3039d866879872099fc855f8ad8b5e2ae9010b5e30d702fde3d66f23df/cuda_core-0.6.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07df8dd46494bd53943759232051facd4372104f2997732e0d39c5bc12a616d5", size = 21790662, upload-time = "2026-02-23T18:59:27.064Z" },
@@ -726,8 +726,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/83/03139c7d9c0425ec4824d6269cfd9e1ac8ae1cc88f12540578a405113083/cuda_core-0.7.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69946d1d5e2d96fc65b7bb36164d26c328cca75d9482b74ee7d61b2c1e1d33a7", size = 30374690, upload-time = "2026-04-08T17:03:08.962Z" },
@@ -790,7 +790,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/3c/4475aebeaab9651f2e61000fbe76f91a476d371dbfbf0a1cf46e689af253/cuda_python-12.9.0-py3-none-any.whl", hash = "sha256:926acba49b2c0a0374c61b7c98f337c085199cf51cdfe4d6423c4129c20547a7", size = 7532, upload-time = "2025-05-06T19:14:07.771Z" },
@@ -807,7 +807,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
@@ -824,7 +824,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/69/4a79126959ad6f1653504122ee1eb22d089dd6272d3fa37694dcdeb78ba5/cuda_python-12.9.6-py3-none-any.whl", hash = "sha256:ed5cf30e1129729eecf4605dff6e8bce84f2d30c17b17c7e5ac4b76448de35d2", size = 7596, upload-time = "2026-03-11T15:35:17.282Z" },
@@ -846,19 +846,19 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -877,16 +877,16 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -900,24 +900,24 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"] },
-    { name = "numpy" },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pynvjitlink-cu12" },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cachetools", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pandas", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pynvjitlink-cu12", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rich", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/d3/1686e1a2d6187bf8cc248b7d0a8efbea6eb20784a707176dfdd881529149/cudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:888641383ee908b820a7acafec028e8bd9851b8884009c61281d19b312c15ca9", size = 2630152, upload-time = "2025-08-07T12:23:36.002Z" },
@@ -943,25 +943,25 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
     { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "numba-cuda", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
-    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version < '3.14' or platform_machine != 'x86_64'" },
-    { name = "numpy" },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pandas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pyarrow", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rich", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/36/5caed16456ce318abb32ce66717231d5ce7b9713047ac4ae315d3f9b179e/cudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:43cbc0175e5016fa94ae96de83355c578dc149b644961301b47c6e28d5f61f49", size = 2715406, upload-time = "2026-04-09T09:42:26.382Z" },
@@ -993,7 +993,7 @@ name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
@@ -1532,7 +1532,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5", size = 54320, upload-time = "2024-08-20T17:11:42.348Z" }
 wheels = [
@@ -1555,7 +1555,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1630,12 +1630,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "zarr" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "zarr", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/b7/fbc1968592c92396efd3dc68f330d0e3da98a1150bfae414029bea9f9fe1/kvikio_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51094df8e0793485ae5021174b65bcd2bc584853cd832c142e6b463380bf4109", size = 672337, upload-time = "2025-08-07T13:50:13.422Z" },
@@ -1661,10 +1661,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/24/95abc4335e8db5b8e140dbe7bdaa9bd7c8620cc087b33ccf748f474c43b0/kvikio_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72cf92d7786b9cb34c60d616a25ef1c802ee465ebc20dd4b5ca2a365b409be16", size = 587150, upload-time = "2026-04-09T11:38:07.743Z" },
@@ -1742,9 +1742,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/69/529bd3a5b6d8edac3e530a0b71c3a8f620a544248c9e22d509852be269a7/libcudf_cu12-25.8.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2ae790b881a67511b414451821ec894f014e4c49d3c62e8f230c45b56cfce0cb", size = 521220643, upload-time = "2025-08-07T11:49:07.039Z" },
@@ -1766,10 +1766,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-libnvcomp-cu12" },
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-libnvcomp-cu12", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/26/f0ae0915b0efac09de00229a205912e25691163e3a6cb51d5327b75d2119/libcudf_cu12-26.4.0-py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2448f34ec63ef9bca6ec47b2089fb331826a834e5e256ae9e0f21a5a7e56df", size = 674674052, upload-time = "2026-04-20T17:52:44.693Z" },
@@ -1821,7 +1821,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fe/35789d6aed0df9336ca07fcb57e756f0f91df4136c5c3087ffa97f912f4e/librmm_cu12-25.8.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18381166e7d855d1ee9ab4684d2ab8af67a115e2015753f1ce91b8ef1ad06013", size = 3539813, upload-time = "2025-08-07T11:22:46.099Z" },
@@ -1843,7 +1843,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/dc/04009da12d0ebccee9c7319929194839d1b3c0f306877c32e85ae1778fb3/librmm_cu12-26.4.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7fa86af3cf2fdd956c5906f8bd9c2a139ddcbb1a5e4c9c4aa33f391623be6c3", size = 3969220, upload-time = "2026-04-09T12:45:21.77Z" },
@@ -2363,7 +2363,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "numba" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/94/63e54c690f093869c5ed3e811ff440554e87085e4301ba9fe37953a6dd80/numba_cuda-0.14.1.tar.gz", hash = "sha256:2e23bc9f5946e850f21f42cb2dcd24a2cb8ea84b60ad020b6e3b357830a9a697", size = 491974, upload-time = "2025-08-22T16:40:43.58Z" }
 wheels = [
@@ -2372,11 +2372,11 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 
 [[package]]
@@ -2387,10 +2387,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "numba", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/51/8935ff9ae5150e1ffed945bf1b95002a6a5e1f9256aeb1143e1c159b68c5/numba_cuda-0.24.0.tar.gz", hash = "sha256:f15a11a8d224e160e9cb2345049c5fa0bbd49eb255b2e8f661086746a7feb378", size = 1347749, upload-time = "2026-01-12T22:38:08.289Z" }
 wheels = [
@@ -2404,9 +2404,9 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"] },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2423,11 +2423,11 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numba", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/aa/78ba931a3ddce12d0948302ae46b6fd7a5fe9009cf0e0add84d8f7ad9197/numba_cuda-0.28.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:733ca2823c208baab10d5d67107c267c248bca11ad94eee14c5a90cb57041b33", size = 1838625, upload-time = "2026-03-03T18:17:37.461Z" },
@@ -2446,12 +2446,12 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 
 [[package]]
@@ -2459,8 +2459,8 @@ name = "numcodecs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
 wheels = [
@@ -2691,7 +2691,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2702,7 +2702,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2729,9 +2729,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2742,7 +2742,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3441,12 +3441,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/12/023332074131122d839be397fe78195eb51eae131a82004438933e9ffbbc/pylibcudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18d7032242d2b8a136f226b7ae4fd8e631e526cbc886186cb7571eb1c25fbcef", size = 28162734, upload-time = "2025-08-07T11:45:56.918Z" },
@@ -3473,10 +3473,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ad/d2a1961ae8b194ce33a9d8269dd046629fb556147aca74223cabc632a07b/pylibcudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0b191096b574cff4d709bb0880d2f0a346120493090cc8103098de9abead71", size = 8009026, upload-time = "2026-04-09T13:28:51.019Z" },
@@ -3494,15 +3494,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/c1/8ca003a16c2391ba8542c9f51ceae1124d3be3f824b7605c8af9d62c300a/pynvjitlink_cu12-0.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e6b9aec00ad37647692b030ee545fdb3b701b0a91579a5b9075fbe314c0f9bb", size = 46934247, upload-time = "2025-06-25T14:38:20.18Z" },
     { url = "https://files.pythonhosted.org/packages/bc/17/81bcaebdf678a47c084629cde924cf27acc69500a9da625d163b408b4a2c/pynvjitlink_cu12-0.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc9b904531dfc416a74a30ad81bb0a851857c3d34bf6335ffa75bc6a1db228c7", size = 45929897, upload-time = "2025-06-25T14:38:23.034Z" },
     { url = "https://files.pythonhosted.org/packages/02/89/08a2b8b5cd91c2ed080ecc8a144f6984bd2579915857fa68016c5e775906/pynvjitlink_cu12-0.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff2627f9fa15514a0af47dfe5fba4689a52dca79878d457f8a204fa418c0a4f", size = 46934163, upload-time = "2025-06-25T14:38:25.593Z" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -3958,9 +3949,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/2c/3363bbf6f5ee3699e28f5a3c525a165bedfa496b5a2a426777648a0297d6/rmm_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:856c38c22e8e1ea8a7216ff9c55d902a9a59b0a18a7affd426338743781f6725", size = 1139163, upload-time = "2025-08-07T11:18:37.215Z" },
@@ -3987,9 +3978,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c1/6c3a3c0e14ccd1f92e43dd90d1137bd3d0592794c02e871bbcc6cdbf2888/rmm_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be5e54e32bfac027803a658e1ee41d0c0c4fd89849a77c5ed148c3edcdc0269d", size = 1197307, upload-time = "2026-04-09T14:23:55.527Z" },
@@ -4418,11 +4409,9 @@ gpu = [
     { name = "kvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
     { name = "kvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "torch" },
-    { name = "torch-geometric" },
 ]
 gpu-win = [
     { name = "torch" },
-    { name = "torch-geometric" },
 ]
 nlp = [
     { name = "transformers" },
@@ -4476,8 +4465,6 @@ requires-dist = [
     { name = "torch", marker = "extra == 'bench'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'gpu'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'gpu-win'", specifier = ">=2.0" },
-    { name = "torch-geometric", marker = "extra == 'gpu'", specifier = ">=2.5.0" },
-    { name = "torch-geometric", marker = "extra == 'gpu-win'", specifier = ">=2.5.0" },
     { name = "transformers", marker = "extra == 'nlp'", specifier = ">=5.3.0" },
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'bench'", specifier = ">=0.22" },
@@ -4664,26 +4651,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
     { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
     { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
-]
-
-[[package]]
-name = "torch-geometric"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "numpy" },
-    { name = "psutil" },
-    { name = "pyparsing" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/75/63/b210152635902da7fe79fcdd16517fae108f457a0ed22c737e702a9afbae/torch_geometric-2.7.0.tar.gz", hash = "sha256:f9099e4aece1a9f618c84dbaac33a77f43139736698c7e8bddf3301ef1f2e8d4", size = 876725, upload-time = "2025-10-15T20:48:03.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/4dffd7300500465e0b4a2ae917dcb2ce771de0b9a772670365799a27c024/torch_geometric-2.7.0-py3-none-any.whl", hash = "sha256:6e0cd3ad824d484651ef5d308fc66c687bfcf5ba040d56d1e0fe0f81f365e292", size = 1275346, upload-time = "2025-10-15T20:48:01.949Z" },
 ]
 
 [[package]]
@@ -4955,109 +4922,6 @@ wheels = [
 ]
 
 [[package]]
-name = "xxhash"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", size = 32844, upload-time = "2025-10-02T14:34:14.037Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/ec/1cc11cd13e26ea8bc3cb4af4eaadd8d46d5014aebb67be3f71fb0b68802a/xxhash-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa", size = 30809, upload-time = "2025-10-02T14:34:15.484Z" },
-    { url = "https://files.pythonhosted.org/packages/04/5f/19fe357ea348d98ca22f456f75a30ac0916b51c753e1f8b2e0e6fb884cce/xxhash-3.6.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248", size = 194665, upload-time = "2025-10-02T14:34:16.541Z" },
-    { url = "https://files.pythonhosted.org/packages/90/3b/d1f1a8f5442a5fd8beedae110c5af7604dc37349a8e16519c13c19a9a2de/xxhash-3.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62", size = 213550, upload-time = "2025-10-02T14:34:17.878Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ef/3a9b05eb527457d5db13a135a2ae1a26c80fecd624d20f3e8dcc4cb170f3/xxhash-3.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f", size = 212384, upload-time = "2025-10-02T14:34:19.182Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/18/ccc194ee698c6c623acbf0f8c2969811a8a4b6185af5e824cd27b9e4fd3e/xxhash-3.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e", size = 445749, upload-time = "2025-10-02T14:34:20.659Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/86/cf2c0321dc3940a7aa73076f4fd677a0fb3e405cb297ead7d864fd90847e/xxhash-3.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8", size = 193880, upload-time = "2025-10-02T14:34:22.431Z" },
-    { url = "https://files.pythonhosted.org/packages/82/fb/96213c8560e6f948a1ecc9a7613f8032b19ee45f747f4fca4eb31bb6d6ed/xxhash-3.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0", size = 210912, upload-time = "2025-10-02T14:34:23.937Z" },
-    { url = "https://files.pythonhosted.org/packages/40/aa/4395e669b0606a096d6788f40dbdf2b819d6773aa290c19e6e83cbfc312f/xxhash-3.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77", size = 198654, upload-time = "2025-10-02T14:34:25.644Z" },
-    { url = "https://files.pythonhosted.org/packages/67/74/b044fcd6b3d89e9b1b665924d85d3f400636c23590226feb1eb09e1176ce/xxhash-3.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c", size = 210867, upload-time = "2025-10-02T14:34:27.203Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fd/3ce73bf753b08cb19daee1eb14aa0d7fe331f8da9c02dd95316ddfe5275e/xxhash-3.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b", size = 414012, upload-time = "2025-10-02T14:34:28.409Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/b3/5a4241309217c5c876f156b10778f3ab3af7ba7e3259e6d5f5c7d0129eb2/xxhash-3.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3", size = 191409, upload-time = "2025-10-02T14:34:29.696Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/01/99bfbc15fb9abb9a72b088c1d95219fc4782b7d01fc835bd5744d66dd0b8/xxhash-3.6.0-cp311-cp311-win32.whl", hash = "sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd", size = 30574, upload-time = "2025-10-02T14:34:31.028Z" },
-    { url = "https://files.pythonhosted.org/packages/65/79/9d24d7f53819fe301b231044ea362ce64e86c74f6e8c8e51320de248b3e5/xxhash-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef", size = 31481, upload-time = "2025-10-02T14:34:32.062Z" },
-    { url = "https://files.pythonhosted.org/packages/30/4e/15cd0e3e8772071344eab2961ce83f6e485111fed8beb491a3f1ce100270/xxhash-3.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7", size = 27861, upload-time = "2025-10-02T14:34:33.555Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/07/d9412f3d7d462347e4511181dea65e47e0d0e16e26fbee2ea86a2aefb657/xxhash-3.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c", size = 32744, upload-time = "2025-10-02T14:34:34.622Z" },
-    { url = "https://files.pythonhosted.org/packages/79/35/0429ee11d035fc33abe32dca1b2b69e8c18d236547b9a9b72c1929189b9a/xxhash-3.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204", size = 30816, upload-time = "2025-10-02T14:34:36.043Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f2/57eb99aa0f7d98624c0932c5b9a170e1806406cdbcdb510546634a1359e0/xxhash-3.6.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490", size = 194035, upload-time = "2025-10-02T14:34:37.354Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ed/6224ba353690d73af7a3f1c7cdb1fc1b002e38f783cb991ae338e1eb3d79/xxhash-3.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2", size = 212914, upload-time = "2025-10-02T14:34:38.6Z" },
-    { url = "https://files.pythonhosted.org/packages/38/86/fb6b6130d8dd6b8942cc17ab4d90e223653a89aa32ad2776f8af7064ed13/xxhash-3.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa", size = 212163, upload-time = "2025-10-02T14:34:39.872Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/dc/e84875682b0593e884ad73b2d40767b5790d417bde603cceb6878901d647/xxhash-3.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0", size = 445411, upload-time = "2025-10-02T14:34:41.569Z" },
-    { url = "https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2", size = 193883, upload-time = "2025-10-02T14:34:43.249Z" },
-    { url = "https://files.pythonhosted.org/packages/53/5a/ddbb83eee8e28b778eacfc5a85c969673e4023cdeedcfcef61f36731610b/xxhash-3.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9", size = 210392, upload-time = "2025-10-02T14:34:45.042Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c2/ff69efd07c8c074ccdf0a4f36fcdd3d27363665bcdf4ba399abebe643465/xxhash-3.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e", size = 197898, upload-time = "2025-10-02T14:34:46.302Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ca/faa05ac19b3b622c7c9317ac3e23954187516298a091eb02c976d0d3dd45/xxhash-3.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374", size = 210655, upload-time = "2025-10-02T14:34:47.571Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/7a/06aa7482345480cc0cb597f5c875b11a82c3953f534394f620b0be2f700c/xxhash-3.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d", size = 414001, upload-time = "2025-10-02T14:34:49.273Z" },
-    { url = "https://files.pythonhosted.org/packages/23/07/63ffb386cd47029aa2916b3d2f454e6cc5b9f5c5ada3790377d5430084e7/xxhash-3.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae", size = 191431, upload-time = "2025-10-02T14:34:50.798Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/93/14fde614cadb4ddf5e7cebf8918b7e8fac5ae7861c1875964f17e678205c/xxhash-3.6.0-cp312-cp312-win32.whl", hash = "sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb", size = 30617, upload-time = "2025-10-02T14:34:51.954Z" },
-    { url = "https://files.pythonhosted.org/packages/13/5d/0d125536cbe7565a83d06e43783389ecae0c0f2ed037b48ede185de477c0/xxhash-3.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c", size = 31534, upload-time = "2025-10-02T14:34:53.276Z" },
-    { url = "https://files.pythonhosted.org/packages/54/85/6ec269b0952ec7e36ba019125982cf11d91256a778c7c3f98a4c5043d283/xxhash-3.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829", size = 27876, upload-time = "2025-10-02T14:34:54.371Z" },
-    { url = "https://files.pythonhosted.org/packages/33/76/35d05267ac82f53ae9b0e554da7c5e281ee61f3cad44c743f0fcd354f211/xxhash-3.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec", size = 32738, upload-time = "2025-10-02T14:34:55.839Z" },
-    { url = "https://files.pythonhosted.org/packages/31/a8/3fbce1cd96534a95e35d5120637bf29b0d7f5d8fa2f6374e31b4156dd419/xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1", size = 30821, upload-time = "2025-10-02T14:34:57.219Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ea/d387530ca7ecfa183cb358027f1833297c6ac6098223fd14f9782cd0015c/xxhash-3.6.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6", size = 194127, upload-time = "2025-10-02T14:34:59.21Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/0c/71435dcb99874b09a43b8d7c54071e600a7481e42b3e3ce1eb5226a5711a/xxhash-3.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263", size = 212975, upload-time = "2025-10-02T14:35:00.816Z" },
-    { url = "https://files.pythonhosted.org/packages/84/7a/c2b3d071e4bb4a90b7057228a99b10d51744878f4a8a6dd643c8bd897620/xxhash-3.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546", size = 212241, upload-time = "2025-10-02T14:35:02.207Z" },
-    { url = "https://files.pythonhosted.org/packages/81/5f/640b6eac0128e215f177df99eadcd0f1b7c42c274ab6a394a05059694c5a/xxhash-3.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89", size = 445471, upload-time = "2025-10-02T14:35:03.61Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/1e/3c3d3ef071b051cc3abbe3721ffb8365033a172613c04af2da89d5548a87/xxhash-3.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d", size = 193936, upload-time = "2025-10-02T14:35:05.013Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/bd/4a5f68381939219abfe1c22a9e3a5854a4f6f6f3c4983a87d255f21f2e5d/xxhash-3.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7", size = 210440, upload-time = "2025-10-02T14:35:06.239Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/37/b80fe3d5cfb9faff01a02121a0f4d565eb7237e9e5fc66e73017e74dcd36/xxhash-3.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db", size = 197990, upload-time = "2025-10-02T14:35:07.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/fd/2c0a00c97b9e18f72e1f240ad4e8f8a90fd9d408289ba9c7c495ed7dc05c/xxhash-3.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42", size = 210689, upload-time = "2025-10-02T14:35:09.438Z" },
-    { url = "https://files.pythonhosted.org/packages/93/86/5dd8076a926b9a95db3206aba20d89a7fc14dd5aac16e5c4de4b56033140/xxhash-3.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11", size = 414068, upload-time = "2025-10-02T14:35:11.162Z" },
-    { url = "https://files.pythonhosted.org/packages/af/3c/0bb129170ee8f3650f08e993baee550a09593462a5cddd8e44d0011102b1/xxhash-3.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd", size = 191495, upload-time = "2025-10-02T14:35:12.971Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/3a/6797e0114c21d1725e2577508e24006fd7ff1d8c0c502d3b52e45c1771d8/xxhash-3.6.0-cp313-cp313-win32.whl", hash = "sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799", size = 30620, upload-time = "2025-10-02T14:35:14.129Z" },
-    { url = "https://files.pythonhosted.org/packages/86/15/9bc32671e9a38b413a76d24722a2bf8784a132c043063a8f5152d390b0f9/xxhash-3.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392", size = 31542, upload-time = "2025-10-02T14:35:15.21Z" },
-    { url = "https://files.pythonhosted.org/packages/39/c5/cc01e4f6188656e56112d6a8e0dfe298a16934b8c47a247236549a3f7695/xxhash-3.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6", size = 27880, upload-time = "2025-10-02T14:35:16.315Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/30/25e5321c8732759e930c555176d37e24ab84365482d257c3b16362235212/xxhash-3.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702", size = 32956, upload-time = "2025-10-02T14:35:17.413Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3c/0573299560d7d9f8ab1838f1efc021a280b5ae5ae2e849034ef3dee18810/xxhash-3.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db", size = 31072, upload-time = "2025-10-02T14:35:18.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1c/52d83a06e417cd9d4137722693424885cc9878249beb3a7c829e74bf7ce9/xxhash-3.6.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54", size = 196409, upload-time = "2025-10-02T14:35:20.31Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/8e/c6d158d12a79bbd0b878f8355432075fc82759e356ab5a111463422a239b/xxhash-3.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f", size = 215736, upload-time = "2025-10-02T14:35:21.616Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/68/c4c80614716345d55071a396cf03d06e34b5f4917a467faf43083c995155/xxhash-3.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5", size = 214833, upload-time = "2025-10-02T14:35:23.32Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e9/ae27c8ffec8b953efa84c7c4a6c6802c263d587b9fc0d6e7cea64e08c3af/xxhash-3.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1", size = 448348, upload-time = "2025-10-02T14:35:25.111Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/6b/33e21afb1b5b3f46b74b6bd1913639066af218d704cc0941404ca717fc57/xxhash-3.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee", size = 196070, upload-time = "2025-10-02T14:35:26.586Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b6/fcabd337bc5fa624e7203aa0fa7d0c49eed22f72e93229431752bddc83d9/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd", size = 212907, upload-time = "2025-10-02T14:35:28.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d3/9ee6160e644d660fcf176c5825e61411c7f62648728f69c79ba237250143/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729", size = 200839, upload-time = "2025-10-02T14:35:29.857Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/98/e8de5baa5109394baf5118f5e72ab21a86387c4f89b0e77ef3e2f6b0327b/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292", size = 213304, upload-time = "2025-10-02T14:35:31.222Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/1d/71056535dec5c3177eeb53e38e3d367dd1d16e024e63b1cee208d572a033/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf", size = 416930, upload-time = "2025-10-02T14:35:32.517Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/6c/5cbde9de2cd967c322e651c65c543700b19e7ae3e0aae8ece3469bf9683d/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033", size = 193787, upload-time = "2025-10-02T14:35:33.827Z" },
-    { url = "https://files.pythonhosted.org/packages/19/fa/0172e350361d61febcea941b0cc541d6e6c8d65d153e85f850a7b256ff8a/xxhash-3.6.0-cp313-cp313t-win32.whl", hash = "sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec", size = 30916, upload-time = "2025-10-02T14:35:35.107Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/e6/e8cf858a2b19d6d45820f072eff1bea413910592ff17157cabc5f1227a16/xxhash-3.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8", size = 31799, upload-time = "2025-10-02T14:35:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/56/15/064b197e855bfb7b343210e82490ae672f8bc7cdf3ddb02e92f64304ee8a/xxhash-3.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746", size = 28044, upload-time = "2025-10-02T14:35:37.195Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/5e/0138bc4484ea9b897864d59fce9be9086030825bc778b76cb5a33a906d37/xxhash-3.6.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e", size = 32754, upload-time = "2025-10-02T14:35:38.245Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d7/5dac2eb2ec75fd771957a13e5dda560efb2176d5203f39502a5fc571f899/xxhash-3.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405", size = 30846, upload-time = "2025-10-02T14:35:39.6Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/71/8bc5be2bb00deb5682e92e8da955ebe5fa982da13a69da5a40a4c8db12fb/xxhash-3.6.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3", size = 194343, upload-time = "2025-10-02T14:35:40.69Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3b/52badfb2aecec2c377ddf1ae75f55db3ba2d321c5e164f14461c90837ef3/xxhash-3.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6", size = 213074, upload-time = "2025-10-02T14:35:42.29Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/2b/ae46b4e9b92e537fa30d03dbc19cdae57ed407e9c26d163895e968e3de85/xxhash-3.6.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063", size = 212388, upload-time = "2025-10-02T14:35:43.929Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/80/49f88d3afc724b4ac7fbd664c8452d6db51b49915be48c6982659e0e7942/xxhash-3.6.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7", size = 445614, upload-time = "2025-10-02T14:35:45.216Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ba/603ce3961e339413543d8cd44f21f2c80e2a7c5cfe692a7b1f2cccf58f3c/xxhash-3.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b", size = 194024, upload-time = "2025-10-02T14:35:46.959Z" },
-    { url = "https://files.pythonhosted.org/packages/78/d1/8e225ff7113bf81545cfdcd79eef124a7b7064a0bba53605ff39590b95c2/xxhash-3.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd", size = 210541, upload-time = "2025-10-02T14:35:48.301Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/58/0f89d149f0bad89def1a8dd38feb50ccdeb643d9797ec84707091d4cb494/xxhash-3.6.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0", size = 198305, upload-time = "2025-10-02T14:35:49.584Z" },
-    { url = "https://files.pythonhosted.org/packages/11/38/5eab81580703c4df93feb5f32ff8fa7fe1e2c51c1f183ee4e48d4bb9d3d7/xxhash-3.6.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152", size = 210848, upload-time = "2025-10-02T14:35:50.877Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/6b/953dc4b05c3ce678abca756416e4c130d2382f877a9c30a20d08ee6a77c0/xxhash-3.6.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11", size = 414142, upload-time = "2025-10-02T14:35:52.15Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a9/238ec0d4e81a10eb5026d4a6972677cbc898ba6c8b9dbaec12ae001b1b35/xxhash-3.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5", size = 191547, upload-time = "2025-10-02T14:35:53.547Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ee/3cf8589e06c2164ac77c3bf0aa127012801128f1feebf2a079272da5737c/xxhash-3.6.0-cp314-cp314-win32.whl", hash = "sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f", size = 31214, upload-time = "2025-10-02T14:35:54.746Z" },
-    { url = "https://files.pythonhosted.org/packages/02/5d/a19552fbc6ad4cb54ff953c3908bbc095f4a921bc569433d791f755186f1/xxhash-3.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad", size = 32290, upload-time = "2025-10-02T14:35:55.791Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/11/dafa0643bc30442c887b55baf8e73353a344ee89c1901b5a5c54a6c17d39/xxhash-3.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679", size = 28795, upload-time = "2025-10-02T14:35:57.162Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/db/0e99732ed7f64182aef4a6fb145e1a295558deec2a746265dcdec12d191e/xxhash-3.6.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4", size = 32955, upload-time = "2025-10-02T14:35:58.267Z" },
-    { url = "https://files.pythonhosted.org/packages/55/f4/2a7c3c68e564a099becfa44bb3d398810cc0ff6749b0d3cb8ccb93f23c14/xxhash-3.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67", size = 31072, upload-time = "2025-10-02T14:35:59.382Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d9/72a29cddc7250e8a5819dad5d466facb5dc4c802ce120645630149127e73/xxhash-3.6.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad", size = 196579, upload-time = "2025-10-02T14:36:00.838Z" },
-    { url = "https://files.pythonhosted.org/packages/63/93/b21590e1e381040e2ca305a884d89e1c345b347404f7780f07f2cdd47ef4/xxhash-3.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b", size = 215854, upload-time = "2025-10-02T14:36:02.207Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b8/edab8a7d4fa14e924b29be877d54155dcbd8b80be85ea00d2be3413a9ed4/xxhash-3.6.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b", size = 214965, upload-time = "2025-10-02T14:36:03.507Z" },
-    { url = "https://files.pythonhosted.org/packages/27/67/dfa980ac7f0d509d54ea0d5a486d2bb4b80c3f1bb22b66e6a05d3efaf6c0/xxhash-3.6.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca", size = 448484, upload-time = "2025-10-02T14:36:04.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/63/8ffc2cc97e811c0ca5d00ab36604b3ea6f4254f20b7bc658ca825ce6c954/xxhash-3.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a", size = 196162, upload-time = "2025-10-02T14:36:06.182Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/77/07f0e7a3edd11a6097e990f6e5b815b6592459cb16dae990d967693e6ea9/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99", size = 213007, upload-time = "2025-10-02T14:36:07.733Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/d8/bc5fa0d152837117eb0bef6f83f956c509332ce133c91c63ce07ee7c4873/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3", size = 200956, upload-time = "2025-10-02T14:36:09.106Z" },
-    { url = "https://files.pythonhosted.org/packages/26/a5/d749334130de9411783873e9b98ecc46688dad5db64ca6e04b02acc8b473/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6", size = 213401, upload-time = "2025-10-02T14:36:10.585Z" },
-    { url = "https://files.pythonhosted.org/packages/89/72/abed959c956a4bfc72b58c0384bb7940663c678127538634d896b1195c10/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93", size = 417083, upload-time = "2025-10-02T14:36:12.276Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b3/62fd2b586283b7d7d665fb98e266decadf31f058f1cf6c478741f68af0cb/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518", size = 193913, upload-time = "2025-10-02T14:36:14.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
-    { url = "https://files.pythonhosted.org/packages/93/1e/8aec23647a34a249f62e2398c42955acd9b4c6ed5cf08cbea94dc46f78d2/xxhash-3.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0", size = 30662, upload-time = "2025-10-02T14:37:01.743Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/0b/b14510b38ba91caf43006209db846a696ceea6a847a0c9ba0a5b1adc53d6/xxhash-3.6.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296", size = 41056, upload-time = "2025-10-02T14:37:02.879Z" },
-    { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", size = 36251, upload-time = "2025-10-02T14:37:04.44Z" },
-    { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", size = 32481, upload-time = "2025-10-02T14:37:05.869Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", size = 31565, upload-time = "2025-10-02T14:37:06.966Z" },
-]
-
-[[package]]
 name = "yarl"
 version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5172,12 +5036,12 @@ name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "google-crc32c", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [


### PR DESCRIPTION
## What / why
External-audit remediation #138 item #5. Removes a dead LSP "tensor cache" + GNN path (`_ast_to_graph`, `_update_ast_tensor`, `tensor_cache` — all write-only / unreachable, grep-evidenced) and corrects `AstBackend.is_available()` from CUDA-gated to **tree-sitter-only**, since `AstBackend.search()` is pure tree-sitter query matching with no torch/CUDA. Drops the now-unused `torch_geometric` from the gpu extras.

## Routing change (the flagged trap)
`is_available()` old: `torch_geometric AND tree_sitter AND torch.cuda.is_available()`. New: `tree_sitter present`. `pipeline.py`/`main.py` call it to choose native `AstBackend` vs the `AstGrepWrapperBackend` sidecar — the old gate meant `AstBackend` was **never** selected on non-GPU boxes despite needing no GPU. New **parity test** asserts available-on-tree-sitter-alone; the fail-closed side (tree-sitter absent → False) is unchanged. `search()`'s unavailable guard now raises `BackendExecutionError` (was a bare `RuntimeError`) per the Backend Fail-Closed Contract.

## Verification (agent, real venv)
4 gates green (ruff / format --preview / mypy 79 / pytest 75+4skip) + heavy regression: `test_cli_modes` 477, mcp suite 361, routing/contract 293 — zero regressions.

## Gate status
**Opus parity gate IN PROGRESS** (backends surface: the is_available routing flip + BackendExecutionError change). Drains after v1.64.0 on PyPI + gate clears. Doc residuals (2 skill files, uv.lock torch_geometric) flagged for a follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>