### PR TITLE
feat(daemon): warm session daemon default-ON (opt-out) + version-skew guard (#94)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -81,7 +81,9 @@ signed consumable tg outputs.
   GPU code cleanup.
 
 ### P1 — moat / features
-- **#94** flip warm daemon to DEFAULT (20.9x proven, fail-open) — AFTER #498 merges (all blockers cleared).
+- **#94** flip warm daemon to DEFAULT (20.9x proven, fail-open) — PR-1 built on
+  `feat/warm-daemon-default` (opt-out flag flip + daemon/client package-version-skew guard +
+  conftest test-isolation fixture); pending the mandatory session_daemon Opus gate + PR/merge.
 - **#124** EvidenceReceipt **P2** (HMAC signing + `tg evidence verify`) → **P3** (MCP tool, gated). P1=#510
   in drain. Gaps: persist checkpoint undo_argv + manifest rollback field.
 - **#118** #93 **SUB-3** unscoped-refuse (hard-refuse vendored-top-level; fixes the dogfood 60s-hang) —

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -32,6 +32,7 @@ from tensor_grep.cli.formatters.base import OutputFormatter
 from tensor_grep.cli.runtime_paths import (
     _native_tg_version,
     _native_tg_version_matches,
+    env_flag_disabled,
     env_flag_enabled,
     iter_in_tree_native_tg_binaries,
     native_frontdoor_metadata_path,
@@ -211,7 +212,7 @@ persisted repeated-query acceleration, and optional GPU routing.
 - `TENSOR_GREP_LSP_OPERATION_BUDGET_SECONDS`: Total per-command budget for optional external LSP provider requests before native fallback.
 - `TENSOR_GREP_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES`, `TENSOR_GREP_STRING_INDEX_CACHE_MAX_ENTRIES`, `TENSOR_GREP_AST_QUERY_CACHE_MAX_ENTRIES`, `TENSOR_GREP_AST_NODE_INDEX_CACHE_MAX_ENTRIES`, `TENSOR_GREP_REPO_CONTEXT_CACHE_MAX_ROOTS`: Bound long-lived in-process search and repo-context caches.
 - `TENSOR_GREP_SESSION_RESPONSE_CACHE_MAX_BYTES`, `TENSOR_GREP_LSP_PROVIDER_CLIENT_CACHE_MAX_ENTRIES`, `TENSOR_GREP_LSP_PROVIDER_OPEN_DOCUMENT_MAX_ENTRIES`: Bound agent-loop response and LSP provider caches.
-- `TG_SESSION_DAEMON_AUTOSTART`: Set to `1` to opt `defs`/`impact`/`refs`/`callers`/`blast-radius` into a default warm-daemon fast path (probes a running `tg session daemon`; auto-spawns one non-blocking on a miss). Default off (today's cold-path behavior); always forced off when `CI` or `GITHUB_ACTIONS` is set. Querying N distinct repo roots with this on can leave up to N resident daemons; each self-shuts-down after `TG_SESSION_DAEMON_IDLE_SECONDS` (900s default) of inactivity.""",
+- `TG_SESSION_DAEMON_AUTOSTART`: Default-ON warm-daemon fast path for `defs`/`impact`/`refs`/`callers`/`blast-radius` (probes a running `tg session daemon`; auto-spawns one non-blocking on a miss, so only the first call per root pays the cold-start cost). Set to `0`/`false`/`no`/`off` to opt back out to the always-cold path; always forced off when `CI` or `GITHUB_ACTIONS` is set. Querying N distinct repo roots with this on can leave up to N resident daemons; each self-shuts-down after `TG_SESSION_DAEMON_IDLE_SECONDS` (900s default) of inactivity.""",
     no_args_is_help=True,
     add_completion=True,
     rich_markup_mode="markdown",
@@ -7854,12 +7855,16 @@ def _daemon_directory_path(path: str) -> str | None:
 
 
 def _session_daemon_autostart_enabled() -> bool:
-    """TG_SESSION_DAEMON_AUTOSTART opt-in for the default Tier-1 warm-daemon fast path.
+    """TG_SESSION_DAEMON_AUTOSTART opt-out for the default Tier-1 warm-daemon fast path.
 
-    Task #94 Part A, must-fix 4. DEFAULT OFF: unset (or any value other than 1/true/yes/on)
-    means today's behavior EXACTLY -- no daemon is probed, spawned, or routed to, for any of
-    the 5 symbol commands. Flipping this default ON is a separate, later, conscious decision
-    (per the design-gate verdict SHIP-WITH-CHANGES); this PR only wires the plumbing.
+    Task #94 PR-1 (the conscious default flip flagged by the original Part A comment; cleared
+    after #498 landed the daemon response-cache correctness fix docs/BACKLOG.md's #94 entry
+    gated the flip on). DEFAULT ON: unset -- or any value other than an explicit falsy token
+    (``0``/``false``/``no``/``off``, see ``env_flag_disabled`` in runtime_paths.py) -- routes
+    defs/impact/refs/callers/blast-radius through a running ``tg session daemon``, non-blocking
+    auto-spawning one on a miss. This is the ~20x warm-vs-cold latency win: the cold path pays a
+    6-33s repo-map build on every call. Set the flag to an explicit falsy token to opt back out
+    to the always-cold path, byte-for-byte unchanged from before this PR.
 
     Auto-forced OFF whenever CI or GITHUB_ACTIONS is set, regardless of the flag's own value,
     so a CI job can never leave a background session-daemon process (idle-lived up to
@@ -7867,7 +7872,7 @@ def _session_daemon_autostart_enabled() -> bool:
     """
     if env_flag_enabled("CI") or env_flag_enabled("GITHUB_ACTIONS"):
         return False
-    return env_flag_enabled("TG_SESSION_DAEMON_AUTOSTART")
+    return not env_flag_disabled("TG_SESSION_DAEMON_AUTOSTART")
 
 
 def _maybe_symbol_command_via_running_daemon(

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -15,6 +15,19 @@ def env_flag_enabled(name: str) -> bool:
     return value in {"1", "true", "yes", "on"}
 
 
+def env_flag_disabled(name: str) -> bool:
+    """Mirror of ``env_flag_enabled`` for a default-ON, opt-out env flag.
+
+    ``env_flag_enabled`` cannot express "on unless explicitly turned off" -- it treats unset as
+    falsy. This answers the opt-out question directly: true only when the variable is explicitly
+    set to a recognized falsy token (``0``/``false``/``no``/``off``, case-insensitive, trimmed).
+    An unset variable -- or any other value -- is NOT "disabled"; the caller applies its own
+    default-on behavior via ``not env_flag_disabled(...)``.
+    """
+    value = os.environ.get(name, "").strip().lower()
+    return value in {"0", "false", "no", "off"}
+
+
 def _current_python_bin_dirs() -> set[Path]:
     executable = Path(sys.executable)
     bin_dirs = {executable.parent}

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 from uuid import uuid4
 
 from tensor_grep.cli._index_lock import IndexLockTimeoutError, index_lock, replace_with_retry
+from tensor_grep.cli.runtime_paths import _expected_tg_version
 from tensor_grep.cli.session_store import (
     _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT,
     _DEFAULT_SESSION_EDIT_PLAN_REPO_MAP_LIMIT,
@@ -487,6 +488,16 @@ def _probe_daemon(root: Path) -> dict[str, Any] | None:
     except Exception:
         return None
     if not response.get("ok"):
+        return None
+    # Task #94 PR-1 safety addition: a daemon can survive a `tg upgrade` (daemons live up to
+    # TG_SESSION_DAEMON_MAX_UPTIME_SECONDS, 24h default) and keep serving stale-code responses
+    # to a freshly-upgraded client. Treat a package-version mismatch -- including a pre-PR-1
+    # daemon.json with no `package_version` field at all -- identically to "no daemon reachable":
+    # the caller's existing cold path + non-blocking respawn self-heals, since
+    # `_spawn_daemon_subprocess` unconditionally removes the stale daemon.json before launching a
+    # fresh one. The now-orphaned stale daemon process eventually shuts itself down via the
+    # existing idle/max-uptime lifecycle monitor.
+    if metadata.get("package_version") != _expected_tg_version():
         return None
     return metadata
 
@@ -1844,6 +1855,10 @@ def run_session_daemon_server(path: str = ".") -> None:
             root,
             {
                 "version": _SESSION_VERSION,
+                # Task #94 PR-1: the installed tensor-grep PACKAGE version (distinct from
+                # `version` above, which is the payload-schema version) -- see the matching
+                # `_probe_daemon` skew check for why this is needed.
+                "package_version": _expected_tg_version(),
                 "root": str(root),
                 "host": host,
                 "port": int(port),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,3 +64,19 @@ def cleanup_external_lsp_providers():
     manager = getattr(repo_map_module, "_EXTERNAL_LSP_PROVIDER_MANAGER", None)
     if manager is not None:
         manager.stop_all()
+
+
+@pytest.fixture(autouse=True)
+def _disable_session_daemon_autostart_by_default(monkeypatch):
+    """Task #94 PR-1 trap T3: TG_SESSION_DAEMON_AUTOSTART now defaults ON (opt-out, see
+    ``_session_daemon_autostart_enabled`` in ``src/tensor_grep/cli/main.py``). Without this,
+    hundreds of unrelated CliRunner tests across the suite that invoke defs/impact/refs/callers/
+    blast-radius would each try to autostart a REAL background session-daemon subprocess on a
+    dev box -- the CI/GITHUB_ACTIONS force-off baked into that function does not cover a local
+    ``pytest`` run. Force the flag off for the whole suite; individual daemon tests (see
+    ``tests/unit/test_symbol_daemon_autostart.py``) opt back in per-test via their own
+    ``monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")``, which overrides this fixture's
+    value for the remainder of that test only (pytest's ``monkeypatch`` restores in LIFO order,
+    so the per-test override never leaks to later tests).
+    """
+    monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "0")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def cleanup_external_lsp_providers():
 
 
 @pytest.fixture(autouse=True)
-def _disable_session_daemon_autostart_by_default(monkeypatch):
+def _disable_session_daemon_autostart_by_default():
     """Task #94 PR-1 trap T3: TG_SESSION_DAEMON_AUTOSTART now defaults ON (opt-out, see
     ``_session_daemon_autostart_enabled`` in ``src/tensor_grep/cli/main.py``). Without this,
     hundreds of unrelated CliRunner tests across the suite that invoke defs/impact/refs/callers/
@@ -75,8 +75,29 @@ def _disable_session_daemon_autostart_by_default(monkeypatch):
     dev box -- the CI/GITHUB_ACTIONS force-off baked into that function does not cover a local
     ``pytest`` run. Force the flag off for the whole suite; individual daemon tests (see
     ``tests/unit/test_symbol_daemon_autostart.py``) opt back in per-test via their own
-    ``monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")``, which overrides this fixture's
-    value for the remainder of that test only (pytest's ``monkeypatch`` restores in LIFO order,
-    so the per-test override never leaks to later tests).
+    ``monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")``, which overrides the value set
+    here for the remainder of that test only (restored below on teardown either way).
+
+    Deliberately does NOT take a ``monkeypatch`` fixture parameter -- taking one here would pull
+    ``monkeypatch`` into this autouse fixture's setup, which changes ITS position (and therefore
+    ``monkeypatch``'s own teardown position) in pytest's per-test fixture finalization stack
+    relative to every OTHER fixture that also depends on ``monkeypatch``, including a test's own
+    explicit ``monkeypatch`` parameter. That reordering was verified to break the existing
+    ``cleanup_external_lsp_providers`` fixture above: in
+    ``tests/unit/test_semantic_provider_navigation.py`` tests that
+    ``monkeypatch.setattr(repo_map, "_EXTERNAL_LSP_PROVIDER_MANAGER", _FakeManager())``, adding a
+    monkeypatch-dependent autouse fixture here made ``cleanup_external_lsp_providers``'s teardown
+    run BEFORE ``monkeypatch`` reverted that attribute, so it called ``.stop_all()`` on the test's
+    fake manager instead of on ``None`` -- ``AttributeError: '_FakeManager' object has no
+    attribute 'stop_all'``. Save/restore ``os.environ`` directly instead, which keeps this
+    fixture dependency-free and leaves the pre-existing fixture graph untouched.
     """
-    monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "0")
+    previous = os.environ.get("TG_SESSION_DAEMON_AUTOSTART")
+    os.environ["TG_SESSION_DAEMON_AUTOSTART"] = "0"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TG_SESSION_DAEMON_AUTOSTART", None)
+        else:
+            os.environ["TG_SESSION_DAEMON_AUTOSTART"] = previous

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -20,6 +20,25 @@ def clear_caches():
     resolve_ripgrep_binary.cache_clear()
 
 
+# Task #94 PR-1: env_flag_disabled is the mirror of env_flag_enabled for a default-ON, opt-out
+# flag (TG_SESSION_DAEMON_AUTOSTART) -- "explicitly turned off", not "is it on".
+def test_env_flag_disabled_recognizes_falsy_tokens(monkeypatch):
+    for token in ("0", "false", "no", "off", "FALSE", "No", "OFF", "  off  "):
+        monkeypatch.setenv("TG_TEST_FLAG_DISABLED_PROBE", token)
+        assert runtime_paths.env_flag_disabled("TG_TEST_FLAG_DISABLED_PROBE") is True, token
+
+
+def test_env_flag_disabled_false_when_unset_or_other_value(monkeypatch):
+    monkeypatch.delenv("TG_TEST_FLAG_DISABLED_PROBE", raising=False)
+    assert runtime_paths.env_flag_disabled("TG_TEST_FLAG_DISABLED_PROBE") is False
+    monkeypatch.setenv("TG_TEST_FLAG_DISABLED_PROBE", "1")
+    assert runtime_paths.env_flag_disabled("TG_TEST_FLAG_DISABLED_PROBE") is False
+    monkeypatch.setenv("TG_TEST_FLAG_DISABLED_PROBE", "true")
+    assert runtime_paths.env_flag_disabled("TG_TEST_FLAG_DISABLED_PROBE") is False
+    monkeypatch.setenv("TG_TEST_FLAG_DISABLED_PROBE", "banana")
+    assert runtime_paths.env_flag_disabled("TG_TEST_FLAG_DISABLED_PROBE") is False
+
+
 def test_resolve_native_tg_binary_env_override(tmp_path):
     binary_path = tmp_path / ("tg.exe" if sys.platform.startswith("win") else "tg")
     binary_path.touch()

--- a/tests/unit/test_session_daemon_version_skew.py
+++ b/tests/unit/test_session_daemon_version_skew.py
@@ -1,0 +1,140 @@
+"""TDD for task #94 PR-1 safety addition #2: close the daemon/client package-version skew gap.
+
+Before this PR, ``daemon.json`` recorded only the payload-schema ``version`` (an integer,
+``session_store._SESSION_VERSION``), and ``_probe_daemon`` did no version comparison at all -- it
+only pinged the daemon and checked ``response.get("ok")``. A daemon that survives a ``tg upgrade``
+(daemons live up to ``TG_SESSION_DAEMON_MAX_UPTIME_SECONDS``, 24h default) would keep serving
+stale-code responses to a freshly-upgraded client with no signal that anything was wrong.
+
+The fix: the daemon writes the installed tensor-grep PACKAGE version (``runtime_paths.
+_expected_tg_version()``, the same accessor already used to detect native-binary version skew)
+into ``daemon.json`` at startup, and ``_probe_daemon`` treats a mismatch -- including a
+``daemon.json`` from before this PR that has no ``package_version`` field at all -- as no-daemon
+(``None``), which routes the caller to the existing cold path + non-blocking respawn. That respawn
+(``_spawn_daemon_subprocess``) already unconditionally removes the stale ``daemon.json`` before
+launching, so the stale metadata self-heals; the orphaned old daemon process eventually shuts
+itself down via the existing idle/max-uptime lifecycle monitor.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli import session_daemon
+from tensor_grep.cli.runtime_paths import _expected_tg_version
+
+
+def _serve(server: session_daemon._ThreadedSessionDaemon) -> threading.Thread:
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+def _real_daemon(root: Path, token: str = "test-token") -> session_daemon._ThreadedSessionDaemon:
+    """Start a REAL (in-process, threaded, loopback) session daemon for `root`, mirroring the
+    helper in test_symbol_daemon_autostart.py."""
+    return session_daemon._ThreadedSessionDaemon(root, ("127.0.0.1", 0), token=token)
+
+
+def _publish_daemon_metadata(
+    server: session_daemon._ThreadedSessionDaemon,
+    root: Path,
+    token: str,
+    *,
+    package_version: str | None,
+) -> None:
+    """Hand-write daemon.json the way run_session_daemon_server does, with a controllable
+    package_version (including omitting the field entirely, to simulate a pre-PR-1 daemon)."""
+    host, port = server.server_address
+    payload: dict[str, Any] = {
+        "version": 1,
+        "root": str(root),
+        "host": str(host),
+        "port": int(port),
+        "pid": 0,
+        "started_at": "test",
+        "token": token,
+    }
+    if package_version is not None:
+        payload["package_version"] = package_version
+    session_daemon._write_daemon_metadata(root, payload)
+
+
+def test_probe_daemon_rejects_package_version_mismatch(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    server = _real_daemon(root)
+    _serve(server)
+    try:
+        _publish_daemon_metadata(server, root, "test-token", package_version="0.0.0-stale-fixture")
+        assert session_daemon._probe_daemon(root) is None
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_probe_daemon_rejects_missing_package_version_field(tmp_path: Path) -> None:
+    """A pre-PR-1 daemon.json (written before this field existed) must fail closed to the cold
+    path, not be trusted just because the ping still succeeds."""
+    root = tmp_path.resolve()
+    server = _real_daemon(root)
+    _serve(server)
+    try:
+        _publish_daemon_metadata(server, root, "test-token", package_version=None)
+        assert session_daemon._probe_daemon(root) is None
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_probe_daemon_serves_when_package_version_matches(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    server = _real_daemon(root)
+    _serve(server)
+    try:
+        _publish_daemon_metadata(server, root, "test-token", package_version=_expected_tg_version())
+        metadata = session_daemon._probe_daemon(root)
+        assert metadata is not None
+        assert metadata["package_version"] == _expected_tg_version()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_request_running_session_daemon_falls_through_on_version_mismatch(
+    tmp_path: Path,
+) -> None:
+    """One layer up: request_running_session_daemon (the function the autostart fast path
+    actually calls) must return None -- not raise, not serve a stale answer -- on a version
+    mismatch, exactly as it already does for "no daemon reachable"."""
+    root = tmp_path.resolve()
+    server = _real_daemon(root)
+    _serve(server)
+    try:
+        _publish_daemon_metadata(server, root, "test-token", package_version="0.0.0-stale-fixture")
+        result = session_daemon.request_running_session_daemon(
+            str(root), {"command": "defs", "path": str(root), "symbol": "helper"}
+        )
+        assert result is None
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_real_daemon_subprocess_writes_current_package_version(tmp_path: Path) -> None:
+    """Write-side proof against the REAL production path (run_session_daemon_server via a real
+    subprocess spawn, reusing start_session_daemon/stop_session_daemon) -- not just the
+    hand-written fixture above."""
+    root = tmp_path.resolve()
+    started = session_daemon.start_session_daemon(str(root))
+    try:
+        assert started["running"] is True
+        metadata = session_daemon._read_daemon_metadata(root)
+        assert metadata is not None
+        assert metadata.get("package_version") == _expected_tg_version()
+        # And the full _probe_daemon round-trip (real socket ping + the new version check)
+        # must accept the daemon it just spawned.
+        assert session_daemon._probe_daemon(root) is not None
+    finally:
+        session_daemon.stop_session_daemon(str(root))

--- a/tests/unit/test_symbol_daemon_autostart.py
+++ b/tests/unit/test_symbol_daemon_autostart.py
@@ -1,14 +1,16 @@
-"""TDD for task #94 Part A: the default-OFF warm-daemon Tier-1 fast path.
+"""TDD for task #94: the warm-daemon Tier-1 fast path.
 
-Scope: the 5 symbol commands (defs/impact/refs/callers/blast-radius) gain an OPTIONAL
-default routing path through a running ``tg session daemon``, gated end-to-end behind the
-net-new ``TG_SESSION_DAEMON_AUTOSTART`` env flag (default OFF -- today's cold-path behavior
-is byte-for-byte unchanged unless a caller opts in).
+Scope: the 5 symbol commands (defs/impact/refs/callers/blast-radius) gain a routing path
+through a running ``tg session daemon``, gated end-to-end behind the ``TG_SESSION_DAEMON_AUTOSTART``
+env flag. Part A (this file's original version) shipped the flag DEFAULT OFF (opt-in). Task #94
+PR-1 flips it to DEFAULT ON (opt-out): unset -- or any value other than an explicit falsy token
+(``0``/``false``/``no``/``off``) -- now enables the fast path; the cold-path behavior when
+disabled (explicitly or via the CI/GITHUB_ACTIONS force-off) is still byte-for-byte unchanged.
 
 Covers, in file order, one section per must-fix from the design-gate verdict (SHIP-WITH-CHANGES):
 
-- Must-fix 4: TG_SESSION_DAEMON_AUTOSTART default-OFF-is-a-no-op, plus the CI/GITHUB_ACTIONS
-  force-off.
+- Must-fix 4: TG_SESSION_DAEMON_AUTOSTART default-ON-unless-explicitly-disabled, plus the
+  CI/GITHUB_ACTIONS force-off.
 - Must-fix 1 (CORE SCOPE-FIX): ``_implicit_session_id_for_request`` (session_daemon.py)
   previously only recognized context_render/context_edit_plan; a symbol command sent to the
   daemon with no explicit session_id fell through to ``get_session("", path)`` ->
@@ -18,11 +20,14 @@ Covers, in file order, one section per must-fix from the design-gate verdict (SH
   contract (docs/CONTRACTS.md:109) via the daemon route.
 - Must-fix 3: the fire-and-forget non-blocking spawn primitive never blocks/polls waiting for
   warmup.
+- Trap T3 (task #94 PR-1): the autouse tests/conftest.py fixture that forces the now-default-ON
+  flag back off for the whole suite, so an ordinary CliRunner test never spawns a real daemon.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from pathlib import Path
@@ -89,26 +94,37 @@ def _autostart_env(monkeypatch, *, enabled: bool) -> None:
     if enabled:
         monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")
     else:
-        monkeypatch.delenv("TG_SESSION_DAEMON_AUTOSTART", raising=False)
+        # Default-ON (task #94 PR-1): unset no longer means disabled, so "disabled" must be
+        # spelled as an explicit falsy token, not a delenv.
+        monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "0")
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
 
 
 # ------------------------------------------------------------------------------------------
-# Must-fix 4: TG_SESSION_DAEMON_AUTOSTART -- default OFF, forced off in CI.
+# Must-fix 4: TG_SESSION_DAEMON_AUTOSTART -- default ON (opt-out), forced off in CI.
 # ------------------------------------------------------------------------------------------
 
 
-def test_autostart_disabled_when_unset(monkeypatch) -> None:
+def test_autostart_enabled_when_unset(monkeypatch) -> None:
+    """Task #94 PR-1: the conscious flip. Unset now means ENABLED, not disabled."""
     monkeypatch.delenv("TG_SESSION_DAEMON_AUTOSTART", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
-    assert _session_daemon_autostart_enabled() is False
+    assert _session_daemon_autostart_enabled() is True
 
 
 def test_autostart_enabled_when_flag_truthy(monkeypatch) -> None:
     _autostart_env(monkeypatch, enabled=True)
     assert _session_daemon_autostart_enabled() is True
+
+
+def test_autostart_disabled_when_explicit_falsy(monkeypatch) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    for token in ("0", "false", "no", "off", "FALSE", "Off"):
+        monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", token)
+        assert _session_daemon_autostart_enabled() is False, token
 
 
 def test_autostart_forced_off_in_ci(monkeypatch) -> None:
@@ -122,6 +138,16 @@ def test_autostart_forced_off_in_github_actions(monkeypatch) -> None:
     monkeypatch.setenv("TG_SESSION_DAEMON_AUTOSTART", "1")
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    assert _session_daemon_autostart_enabled() is False
+
+
+def test_autostart_forced_off_in_ci_even_when_unset(monkeypatch) -> None:
+    """The CI force-off must win over the new default-ON, not just over an explicit opt-in --
+    otherwise a CI job that never touches TG_SESSION_DAEMON_AUTOSTART would now autostart a
+    background daemon it never used to."""
+    monkeypatch.delenv("TG_SESSION_DAEMON_AUTOSTART", raising=False)
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
     assert _session_daemon_autostart_enabled() is False
 
 
@@ -653,3 +679,51 @@ def test_defs_cold_call_not_blocked_by_autostart(tmp_path: Path, monkeypatch) ->
     # noise band (well under half the blocking threshold) avoids flaking on a loaded CI box
     # while still failing hard if the fast path regresses to the blocking start_session_daemon.
     assert elapsed < 2.5, f"cold call took {elapsed:.2f}s -- must not block on daemon warmup"
+
+
+# ------------------------------------------------------------------------------------------
+# Trap T3 (task #94 PR-1): the autouse tests/conftest.py fixture, not a local monkeypatch,
+# must keep an ordinary CliRunner test daemon-free now that the flag defaults ON.
+# ------------------------------------------------------------------------------------------
+
+
+def test_conftest_autouse_fixture_forces_autostart_off_by_default() -> None:
+    """Direct proof the global fixture applied, independent of this file's own _autostart_env
+    helper (which this test deliberately never calls)."""
+    assert os.environ.get("TG_SESSION_DAEMON_AUTOSTART") == "0"
+    assert _session_daemon_autostart_enabled() is False
+
+
+def test_conftest_autouse_fixture_keeps_ordinary_cli_test_daemon_free(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """End-to-end proof via a plain CliRunner invocation that never calls _autostart_env.
+
+    Records touches to a list rather than raising inside the stub: `_maybe_symbol_command_via_
+    running_daemon` in main.py wraps its daemon calls in a broad `except Exception: return None`
+    fail-open (by design, see main.py ~:7935), which would silently swallow a raised
+    AssertionError and let the command still exit 0 with a correct (cold-path) answer -- masking
+    exactly the regression this test exists to catch. Asserting on the list AFTER `runner.invoke`
+    returns sidesteps that.
+    """
+    project = _project(tmp_path)
+    touched: list[str] = []
+
+    def _record_request(*args: object, **kwargs: object) -> dict[str, Any] | None:
+        touched.append("request_running_session_daemon")
+        return None
+
+    def _record_spawn(*args: object, **kwargs: object) -> bool:
+        touched.append("maybe_autostart_session_daemon_nonblocking")
+        return False
+
+    monkeypatch.setattr(session_daemon, "request_running_session_daemon", _record_request)
+    monkeypatch.setattr(session_daemon, "maybe_autostart_session_daemon_nonblocking", _record_spawn)
+
+    result = runner.invoke(app, ["defs", str(project), "helper", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert touched == [], (
+        "the autouse conftest fixture should have kept TG_SESSION_DAEMON_AUTOSTART off; the "
+        f"daemon module was touched anyway: {touched}"
+    )


### PR DESCRIPTION
Task #94 PR-1 (the ~20x latency moat): flip the warm session daemon from opt-in to DEFAULT-ON (opt-out), fail-open cold fallback (already built), + version-skew guard + test-env isolation.

**STATUS: WIP-SALVAGE.** The build agent wrote the full implementation (main.py flag inversion via new `env_flag_disabled`, session_daemon version-skew guard writing/checking the package version, conftest autouse `TG_SESSION_DAEMON_AUTOSTART=0` isolation fixture, + 3 test files) but was killed by an Anthropic session limit before committing/running its gate. Committed here to preserve + CI-validate. **NOT yet reviewed; the mandatory Opus session_daemon adversarial gate is PENDING** before this can merge. Draft until then.

`feat:` -> MINOR (v1.65.0) when it lands.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>