### PR TITLE
fix(rerank): cap total rechunk on plain --rank to bound unbounded-rechunk DoS (#128)

### DIFF
--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 
 from tensor_grep.core.result import SearchResult
 from tensor_grep.core.retrieval_bm25 import Bm25Index
-from tensor_grep.core.retrieval_chunker import Chunk, chunk_file
+from tensor_grep.core.retrieval_chunker import MAX_CHUNKS, Chunk, chunk_file
 from tensor_grep.core.retrieval_dense import DenseIndex
 from tensor_grep.core.retrieval_fusion import DEFAULT_K, reciprocal_rank_fusion
 from tensor_grep.core.retrieval_late import LateReranker, LateRerankUnavailableError
@@ -51,6 +51,19 @@ _RERANK_BUDGET_MS_ENV: str = "TG_RERANK_BUDGET_MS"
 _DEFAULT_RERANK_POOL_K: int = 50
 _MAX_RERANK_POOL_K: int = 100
 _DEFAULT_RERANK_BUDGET_MS: int = 2000
+
+# #128d (backlog cluster-1 P0-CORRECTNESS, MED-1): retrieval_chunker.MAX_CHUNKS bounds a single
+# chunk_file() call (per FILE). A matched-file set of many small files can still blow past a sane
+# CORPUS-wide total even though no single file trips the per-file guard -- plain `tg search --rank`
+# (CLI cli/main.py:7222-7225, MCP cli/mcp_server.py:4258-4263, both funnel through the
+# `index is None` / `bm25_index is None` branches below) had NO total cap at all, unlike the
+# `--semantic` path's `_SEMANTIC_CORPUS_CHUNK_CAP` (cli/main.py, shipped by #527/A2). This mirrors
+# that cap at the shared reranker.py chokepoint instead, so CLI, MCP, and any future caller are
+# covered with ZERO call-site edits. Env-tunable (unlike the semantic path's plain constant)
+# because an operator may want to raise/lower it without a code change; the default equals
+# MAX_CHUNKS, the same threshold the per-file guard and the semantic cap already share, so there is
+# still exactly one number to tune in the common case.
+_RANK_CORPUS_CHUNK_CAP_ENV: str = "TG_RANK_CORPUS_CHUNK_CAP"
 
 
 def _int_env(name: str, default: int) -> int:
@@ -90,6 +103,61 @@ def _path_channel_ranking(chunks: list[Chunk], query: str) -> list[int]:
     return [chunk_index for chunk_index, _overlap in ranked]
 
 
+def _rank_corpus_chunk_cap() -> int:
+    """The corpus-wide chunk cap for the ``index is None`` / ``bm25_index is None`` build loops
+    below -- ``TG_RANK_CORPUS_CHUNK_CAP`` if set to a valid positive int, else :data:`MAX_CHUNKS`.
+    A non-positive or malformed override falls back to the default rather than pathologically
+    capping at (near) zero -- the same "a malformed override must degrade gracefully" spirit as
+    :func:`_int_env`."""
+    cap = _int_env(_RANK_CORPUS_CHUNK_CAP_ENV, MAX_CHUNKS)
+    return cap if cap > 0 else MAX_CHUNKS
+
+
+def _chunk_corpus_with_total_cap(
+    file_paths: list[str],
+    *,
+    chunk_size: int,
+    overlap: int,
+) -> tuple[list[Chunk], str | None]:
+    """Chunk every file in ``file_paths`` in order, STOPPING before the accumulated chunk count
+    would exceed :func:`_rank_corpus_chunk_cap` -- the chokepoint fix for #128d (MED-1): plain
+    `tg search --rank` previously chunked the ENTIRE matched-file set with no total bound (only a
+    per-FILE bound existed, ``retrieval_chunker.MAX_CHUNKS``), so a broad query on a large repo
+    could rechunk thousands of files before ranking even started -- unbounded CPU/memory, reachable
+    from both the CLI and the MCP ``rank``/``tg_search`` tool.
+
+    Returns ``(chunks, fallback_reason)``. ``fallback_reason`` is ``None`` when every file was
+    chunked (the common case -- byte-identical to the pre-cap behavior). When the cap trips it is a
+    human-readable string the caller MUST surface on the returned ``SearchResult`` (append, never
+    clobber -- the same convention every other rank/semantic degrade in this codebase follows, see
+    ``rerank_hybrid``'s late-rerank combination below and ``cli/main.py``'s semantic-cap degrade) --
+    silently truncating would be indistinguishable from "the corpus was simply small", exactly the
+    suppression-reads-as-absence failure the Backend Fail-Closed Contract forbids for a full engine
+    swap and this project's partial-results contract forbids for a soft per-item suppression.
+
+    Matches are NEVER dropped by this cap -- the rerank contract is order-only (see each caller's
+    docstring). Files left unchunked past the trip point simply have no scored chunk, so their
+    matches sink to the end via the existing zero-score path -- identical to how an unmatched file
+    behaves today.
+    """
+    cap = _rank_corpus_chunk_cap()
+    chunks: list[Chunk] = []
+    fallback_reason: str | None = None
+    chunked_file_count = 0
+    for path in file_paths:
+        chunks.extend(chunk_file(path, chunk_size=chunk_size, overlap=overlap))
+        chunked_file_count += 1
+        if len(chunks) > cap:
+            fallback_reason = (
+                f"bm25 rank corpus cap reached ({cap} chunks over {chunked_file_count} of "
+                f"{len(file_paths)} matched files); ranking covers the first "
+                f"{chunked_file_count} files, remaining matches keep grep order"
+            )
+            sys.stderr.write(f"tg: {fallback_reason}\n")
+            break
+    return chunks, fallback_reason
+
+
 def rerank_by_bm25(
     result: SearchResult,
     query: str,
@@ -99,14 +167,21 @@ def rerank_by_bm25(
     overlap: int = 5,
     index: Bm25Index | None = None,
 ) -> SearchResult:
-    """Return a copy of ``result`` with matches re-sorted by best BM25 chunk score (desc)."""
+    """Return a copy of ``result`` with matches re-sorted by best BM25 chunk score (desc).
+
+    When ``index`` is not supplied, the corpus built from ``file_paths`` is bounded by
+    :func:`_chunk_corpus_with_total_cap` (#128d) -- see its docstring for the chokepoint fix.
+    Passing a prebuilt ``index`` (e.g. a caller's own deliberately-capped corpus, as the
+    ``--semantic`` degrade path does) bypasses this bound entirely, same as before.
+    """
     if not result.matches:
         return dataclasses.replace(result, matches=list(result.matches))
 
+    corpus_cap_reason: str | None = None
     if index is None:
-        chunks: list[Chunk] = []
-        for path in file_paths:
-            chunks.extend(chunk_file(path, chunk_size=chunk_size, overlap=overlap))
+        chunks, corpus_cap_reason = _chunk_corpus_with_total_cap(
+            file_paths, chunk_size=chunk_size, overlap=overlap
+        )
         index = Bm25Index(chunks)
 
     # Best score per chunk index for this query.
@@ -126,6 +201,16 @@ def rerank_by_bm25(
 
     # Stable sort by descending score (Python's sort is stable -> ties keep grep order).
     reranked = sorted(result.matches, key=match_score, reverse=True)
+    if corpus_cap_reason is not None:
+        # Append rather than overwrite: a pre-existing reason on the input result (should a future
+        # caller ever pass one in) must survive alongside the corpus-cap reason -- mirrors
+        # rerank_hybrid's late-rerank combination below and cli/main.py's semantic-cap degrade.
+        combined_reason = (
+            f"{result.rank_fallback_reason}; {corpus_cap_reason}"
+            if result.rank_fallback_reason
+            else corpus_cap_reason
+        )
+        return dataclasses.replace(result, matches=reranked, rank_fallback_reason=combined_reason)
     return dataclasses.replace(result, matches=reranked)
 
 
@@ -178,10 +263,11 @@ def rerank_hybrid(
     if not result.matches:
         return dataclasses.replace(result, matches=list(result.matches))
 
+    corpus_cap_reason: str | None = None
     if bm25_index is None:
-        chunks: list[Chunk] = []
-        for path in file_paths:
-            chunks.extend(chunk_file(path, chunk_size=chunk_size, overlap=overlap))
+        chunks, corpus_cap_reason = _chunk_corpus_with_total_cap(
+            file_paths, chunk_size=chunk_size, overlap=overlap
+        )
         bm25_index = Bm25Index(chunks)
     chunks = bm25_index.chunks
 
@@ -286,15 +372,19 @@ def rerank_hybrid(
 
     # Stable sort by descending fused score (Python's sort is stable -> ties keep grep order).
     reranked = sorted(result.matches, key=match_score, reverse=True)
-    if late_rank_fallback_reason is not None:
-        # Append rather than overwrite: an earlier (e.g. dense-leg) fallback reason must survive
-        # alongside the late-stage one -- see T6's bidirectional invariant (exactly one of "order
-        # provably changed, reason untouched" / "reason non-None" holds; this is the "reason
-        # non-None" side for the late stage specifically).
-        combined_reason = (
-            f"{result.rank_fallback_reason}; {late_rank_fallback_reason}"
-            if result.rank_fallback_reason
-            else late_rank_fallback_reason
+    # Append rather than overwrite, folding in EVERY reason source in the order it was produced:
+    # the caller's own pre-existing reason (e.g. a dense-leg degrade set before this call), then
+    # the corpus-cap reason (#128d, set while building the BM25 index above), then the late-rerank
+    # reason (set last, during the late-interaction stage above) -- see T6's bidirectional
+    # invariant (exactly one of "order provably changed, reason untouched" / "reason non-None"
+    # holds; this is the "reason non-None" side, generalized from two sources to three).
+    combined_parts = [
+        part
+        for part in (result.rank_fallback_reason, corpus_cap_reason, late_rank_fallback_reason)
+        if part
+    ]
+    if combined_parts:
+        return dataclasses.replace(
+            result, matches=reranked, rank_fallback_reason="; ".join(combined_parts)
         )
-        return dataclasses.replace(result, matches=reranked, rank_fallback_reason=combined_reason)
     return dataclasses.replace(result, matches=reranked)

--- a/tests/integration/test_bm25_search_flag.py
+++ b/tests/integration/test_bm25_search_flag.py
@@ -39,3 +39,42 @@ def test_search_rank_reorders_by_bm25(tmp_path: Path) -> None:
     assert files_in_order[0] == str(dense)
     assert str(sparse) in files_in_order  # the sparse match is still present, just lower
     assert files_in_order.index(str(dense)) < files_in_order.index(str(sparse))
+
+
+def test_search_rank_corpus_cap_sets_fallback_reason_and_bounds_chunking(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#128d (backlog cluster-1 P0-CORRECTNESS, MED-1): plain `tg search --rank` -- unlike
+    `--semantic`, already capped via #527/A2 -- previously chunked the ENTIRE matched-file set
+    with NO total bound (only the per-FILE MAX_CHUNKS guard existed). This is the real end-to-end
+    CLI proof of the reranker.py chokepoint fix: TG_RANK_CORPUS_CHUNK_CAP set below the corpus's
+    chunk total must stop chunking early, surface `rank_fallback_reason` in the JSON envelope
+    (mirroring the semantic path's cap-fallback contract), and never drop a match."""
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "1")
+
+    from tensor_grep.core import retrieval_chunker
+
+    real_chunk_file = retrieval_chunker.chunk_file
+    calls: list[str] = []
+
+    def _counting_chunk_file(path: str, **kwargs: object):
+        calls.append(str(path))
+        return real_chunk_file(path, **kwargs)
+
+    # Patch reranker.py's bound name -- the same site plain --rank actually calls through.
+    monkeypatch.setattr("tensor_grep.core.reranker.chunk_file", _counting_chunk_file)
+
+    for i in range(3):
+        (tmp_path / f"f{i}.py").write_text(
+            f"def make_invoice_{i}(x):\n    return x\n", encoding="utf-8"
+        )
+
+    result = CliRunner().invoke(app, ["search", "--rank", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    matches = payload.get("matches", [])
+    assert len(matches) == 3, f"expected all 3 matches preserved, got: {payload}"
+    assert "corpus cap" in payload.get("rank_fallback_reason", "")
+    # Cap=1: file 1 chunked (1 chunk, 1<=1) then file 2 (2>1) trips -- file 3 never chunked.
+    assert len(calls) == 2, f"chunking did not stop after the cap tripped: {calls}"

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -963,6 +963,55 @@ def test_tg_search_rank_reranks_by_bm25(monkeypatch):
     assert payload["total_matches"] == 1
 
 
+def test_tg_search_rank_corpus_cap_sets_fallback_reason(tmp_path, monkeypatch):
+    """#128d (backlog cluster-1 P0-CORRECTNESS, MED-1): the MCP `rank=True` path funnels through
+    the SAME reranker.py chokepoint as the CLI --rank path (cli/main.py:7222-7225 /
+    cli/mcp_server.py:4258-4263 both call rerank_by_bm25 unmodified) -- a matched set exceeding
+    the total chunk cap must bound chunking AND surface rank_fallback_reason in the MCP JSON
+    envelope too. Unlike test_tg_search_rank_reranks_by_bm25 above, rerank_by_bm25 is NOT mocked
+    here -- it runs for real (against real tmp_path files) to prove the cap actually applies on
+    this call site, not just that the function gets called."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "1")
+    monkeypatch.chdir(tmp_path)  # an in-root path so _confine_mcp_path's confinement check passes
+
+    files = []
+    for i in range(3):
+        f = tmp_path / f"f{i}.py"
+        f.write_text(f"def make_invoice_{i}(x):\n    return x\n", encoding="utf-8")
+        files.append(str(f))
+
+    def _search_result_for(current_file, *_args, **_kwargs):
+        return SearchResult(
+            matches=[MatchLine(line_number=1, text="def make_invoice", file=current_file)],
+            matched_file_paths=[current_file],
+            total_files=1,
+            total_matches=1,
+        )
+
+    fake_backend = MagicMock()
+    fake_backend.search.side_effect = _search_result_for
+
+    with (
+        patch("tensor_grep.cli.mcp_server.Pipeline") as mock_pipeline,
+        patch("tensor_grep.cli.mcp_server.DirectoryScanner") as mock_scanner,
+    ):
+        pipeline = mock_pipeline.return_value
+        pipeline.get_backend.return_value = fake_backend
+        pipeline.selected_backend_name = "TorchBackend"
+        pipeline.selected_backend_reason = "gpu_native"
+        pipeline.selected_gpu_device_ids = []
+        pipeline.selected_gpu_chunk_plan_mb = []
+        mock_scanner.return_value.walk.return_value = files
+
+        out = mcp_server.tg_search("invoice", str(tmp_path), rank=True)
+
+    payload = json.loads(out)
+    assert payload["total_matches"] == 3, f"expected all 3 matches preserved, got: {payload}"
+    assert "corpus cap" in payload.get("rank_fallback_reason", "")
+
+
 def test_tg_search_semantic_applies_hybrid_rerank(monkeypatch):
     from tensor_grep.cli import mcp_server
 

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -309,3 +309,169 @@ def test_late_reranker_base_exception_user_abort_propagates_not_swallowed() -> N
             bm25_index=bm25_index,
             late_reranker=LateReranker(encode=_aborting_encode),
         )
+
+
+# --- #128d (backlog cluster-1 P0-CORRECTNESS, MED-1): the total corpus-chunk cap for plain
+# `tg search --rank` (rerank_by_bm25's `index is None` build loop). Unlike the `--semantic` path
+# (already capped via #527/A2, cli/main.py), plain --rank had NO total bound at all -- only the
+# per-FILE MAX_CHUNKS guard existed. These tests exercise the shared reranker.py chokepoint
+# directly, which is what BOTH the CLI (cli/main.py:7222-7225) and the MCP `rank` tool
+# (cli/mcp_server.py:4258-4263) call unmodified -- see test_bm25_search_flag.py /
+# test_mcp_server.py for the end-to-end CLI/MCP-level twins of this same fix.
+
+
+def _write_three_line_file(tmp_path: Path, name: str) -> Path:
+    """A 3-line file that produces exactly 3 chunks at chunk_size=1, overlap=0 (one chunk per
+    line) -- gives fully deterministic, hand-countable chunk totals for the cap tests below."""
+    path = tmp_path / name
+    path.write_text(f"{name}_line_a\n{name}_line_b\n{name}_line_c\n", encoding="utf-8")
+    return path
+
+
+def _patch_counting_chunk_file(monkeypatch):  # type: ignore[no-untyped-def]
+    """Wrap reranker.py's bound `chunk_file` name with a call-counting proxy, returning the list
+    of paths it was invoked with (in call order) -- mirrors the identical pattern in
+    test_semantic_search_flag.py's cap-fallback test."""
+    from tensor_grep.core import reranker as reranker_module
+    from tensor_grep.core.retrieval_chunker import chunk_file as real_chunk_file
+
+    calls: list[str] = []
+
+    def _counting_chunk_file(path: str, **kwargs: object):  # type: ignore[no-untyped-def]
+        calls.append(str(path))
+        return real_chunk_file(path, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(reranker_module, "chunk_file", _counting_chunk_file)
+    return calls
+
+
+def test_rerank_by_bm25_corpus_cap_bounds_chunking_and_sets_reason(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """RED->GREEN: a matched set whose total chunk count exceeds the cap must STOP chunking before
+    every file is processed, and must surface `rank_fallback_reason` -- never silently truncate.
+    Matches are NEVER dropped: the cap affects rank quality only."""
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "4")
+    calls = _patch_counting_chunk_file(monkeypatch)
+
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(3)]  # 3 chunks each -> 9
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=3,
+    )
+
+    out = rerank_by_bm25(result, "anything", [str(f) for f in files], chunk_size=1, overlap=0)
+
+    # Cap=4: file 1 (3 chunks, 3<=4) then file 2 (6>4) trips -- file 3 never chunked.
+    assert calls == [str(files[0]), str(files[1])], f"unexpected chunking calls: {calls}"
+    assert out.rank_fallback_reason is not None
+    assert "corpus cap" in out.rank_fallback_reason
+    assert "4 chunks" in out.rank_fallback_reason
+    # Never drop matches -- same file set, same count, only order may change.
+    assert len(out.matches) == len(result.matches) == 3
+    assert {m.file for m in out.matches} == {m.file for m in result.matches}
+
+
+def test_rerank_by_bm25_small_corpus_under_cap_leaves_reason_none(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """A matched set comfortably under the (default) cap chunks every file, unchanged from
+    pre-cap behavior: `rank_fallback_reason` stays None and every file is chunked."""
+    monkeypatch.delenv("TG_RANK_CORPUS_CHUNK_CAP", raising=False)
+    calls = _patch_counting_chunk_file(monkeypatch)
+
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(2)]
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=2,
+    )
+
+    out = rerank_by_bm25(result, "anything", [str(f) for f in files], chunk_size=1, overlap=0)
+
+    assert calls == [str(files[0]), str(files[1])]  # every file chunked, nothing capped
+    assert out.rank_fallback_reason is None
+    assert len(out.matches) == 2
+
+
+def test_rerank_by_bm25_corpus_cap_env_tunable(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The cap is env-tunable: the SAME corpus is uncapped by default (huge MAX_CHUNKS default)
+    but trips once TG_RANK_CORPUS_CHUNK_CAP is set below the corpus's chunk total -- proves the
+    override is actually read, not just that some hardcoded internal cap exists."""
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(2)]  # 3 chunks each -> 6
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=2,
+    )
+
+    monkeypatch.delenv("TG_RANK_CORPUS_CHUNK_CAP", raising=False)
+    default_out = rerank_by_bm25(
+        result, "anything", [str(f) for f in files], chunk_size=1, overlap=0
+    )
+    assert default_out.rank_fallback_reason is None  # default cap (100_000) never trips here
+
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "2")
+    calls = _patch_counting_chunk_file(monkeypatch)
+    capped_out = rerank_by_bm25(
+        result, "anything", [str(f) for f in files], chunk_size=1, overlap=0
+    )
+    assert capped_out.rank_fallback_reason is not None
+    assert "2 chunks" in capped_out.rank_fallback_reason
+    assert calls == [str(files[0])]  # trips after the very first file (3 chunks > cap 2)
+    assert len(capped_out.matches) == 2  # still never drops matches
+
+
+def test_rerank_by_bm25_corpus_cap_appends_to_existing_fallback_reason(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """Append, never clobber: a pre-existing `rank_fallback_reason` on the input result must
+    survive alongside the new corpus-cap reason (the same convention every other rank/semantic
+    degrade in this codebase follows)."""
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "1")
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(2)]
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=2,
+        rank_fallback_reason="pre-existing upstream reason",
+    )
+
+    out = rerank_by_bm25(result, "anything", [str(f) for f in files], chunk_size=1, overlap=0)
+
+    assert out.rank_fallback_reason is not None
+    assert "pre-existing upstream reason" in out.rank_fallback_reason
+    assert "corpus cap" in out.rank_fallback_reason
+
+
+def test_rerank_by_bm25_corpus_cap_trip_is_deterministic_across_calls(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """Determinism: matched_file_paths arrives sorted from the caller (main.py:7197); the cap
+    truncation point and resulting order must be stable across repeated calls on the same input."""
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "4")
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(3)]
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=3,
+    )
+    file_paths = [str(f) for f in files]
+
+    first = rerank_by_bm25(result, "anything", file_paths, chunk_size=1, overlap=0)
+    second = rerank_by_bm25(result, "anything", file_paths, chunk_size=1, overlap=0)
+
+    assert first.rank_fallback_reason == second.rank_fallback_reason
+    assert [m.file for m in first.matches] == [m.file for m in second.matches]
+
+
+def test_rank_corpus_chunk_cap_non_positive_or_malformed_env_falls_back_to_default(
+    monkeypatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """A malformed override must degrade gracefully (mirror `_int_env`'s own contract), and a
+    non-positive override must not pathologically cap ranking at (near) zero chunks."""
+    from tensor_grep.core.reranker import _rank_corpus_chunk_cap
+    from tensor_grep.core.retrieval_chunker import MAX_CHUNKS
+
+    for bad_value in ("0", "-5", "not-a-number", ""):
+        monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", bad_value)
+        assert _rank_corpus_chunk_cap() == MAX_CHUNKS, f"bad value {bad_value!r} was not rejected"
+
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "42")
+    assert _rank_corpus_chunk_cap() == 42

--- a/tests/unit/test_reranker_hybrid.py
+++ b/tests/unit/test_reranker_hybrid.py
@@ -8,6 +8,8 @@ being fetched.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 
 from tensor_grep.core.reranker import rerank_by_bm25, rerank_hybrid
@@ -184,3 +186,139 @@ def test_path_channel_no_filename_overlap_falls_back_to_bm25_dense_only(monkeypa
     )
 
     assert [m.file for m in hybrid_flag_on.matches] == [m.file for m in hybrid_flag_off.matches]
+
+
+# --- #128d (backlog cluster-1 P0-CORRECTNESS, MED-1): the hybrid twin of the total corpus-chunk
+# cap tests in test_reranker.py. `rerank_hybrid`'s `bm25_index is None` build loop is "currently
+# unreached from production after #527" (the semantic path always passes a prebuilt bm25_index --
+# see cli/main.py's `_apply_semantic_rerank`), but the fix covers it too per the audit's explicit
+# instruction: "any future caller re-opens the hole" otherwise.
+
+
+def _write_three_line_file(tmp_path: Path, name: str) -> Path:
+    """A 3-line file that produces exactly 3 chunks at chunk_size=1, overlap=0 (one chunk per
+    line) -- gives fully deterministic, hand-countable chunk totals for the cap tests below."""
+    path = tmp_path / name
+    path.write_text(f"{name}_line_a\n{name}_line_b\n{name}_line_c\n", encoding="utf-8")
+    return path
+
+
+def _patch_counting_chunk_file(monkeypatch):  # type: ignore[no-untyped-def]
+    """Wrap reranker.py's bound `chunk_file` name with a call-counting proxy, returning the list
+    of paths it was invoked with (in call order)."""
+    from tensor_grep.core import reranker as reranker_module
+    from tensor_grep.core.retrieval_chunker import chunk_file as real_chunk_file
+
+    calls: list[str] = []
+
+    def _counting_chunk_file(path: str, **kwargs: object):  # type: ignore[no-untyped-def]
+        calls.append(str(path))
+        return real_chunk_file(path, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(reranker_module, "chunk_file", _counting_chunk_file)
+    return calls
+
+
+def test_rerank_hybrid_corpus_cap_bounds_chunking_and_sets_reason(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """The `bm25_index is None` build loop is bounded by the same total cap as rerank_by_bm25's,
+    and never drops a match."""
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "4")
+    calls = _patch_counting_chunk_file(monkeypatch)
+
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(3)]  # 3 chunks each -> 9
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=3,
+    )
+
+    out = rerank_hybrid(result, "anything", [str(f) for f in files], chunk_size=1, overlap=0)
+
+    assert calls == [str(files[0]), str(files[1])], f"unexpected chunking calls: {calls}"
+    assert out.rank_fallback_reason is not None
+    assert "corpus cap" in out.rank_fallback_reason
+    assert len(out.matches) == len(result.matches) == 3
+    assert {m.file for m in out.matches} == {m.file for m in result.matches}
+
+
+def test_rerank_hybrid_small_corpus_under_cap_leaves_reason_none(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """A matched set comfortably under the (default) cap is unaffected: rank_fallback_reason stays
+    None and every file is chunked -- byte-identical to the pre-cap behavior."""
+    monkeypatch.delenv("TG_RANK_CORPUS_CHUNK_CAP", raising=False)
+    calls = _patch_counting_chunk_file(monkeypatch)
+
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(2)]
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=2,
+    )
+
+    out = rerank_hybrid(result, "anything", [str(f) for f in files], chunk_size=1, overlap=0)
+
+    assert calls == [str(files[0]), str(files[1])]
+    assert out.rank_fallback_reason is None
+    assert len(out.matches) == 2
+
+
+def test_rerank_hybrid_corpus_cap_env_tunable(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Same override-respected proof as rerank_by_bm25's twin: the default cap never trips this
+    small corpus, but TG_RANK_CORPUS_CHUNK_CAP set below the corpus total does."""
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(2)]  # 6 chunks total
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=2,
+    )
+
+    monkeypatch.delenv("TG_RANK_CORPUS_CHUNK_CAP", raising=False)
+    default_out = rerank_hybrid(
+        result, "anything", [str(f) for f in files], chunk_size=1, overlap=0
+    )
+    assert default_out.rank_fallback_reason is None
+
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "2")
+    capped_out = rerank_hybrid(result, "anything", [str(f) for f in files], chunk_size=1, overlap=0)
+    assert capped_out.rank_fallback_reason is not None
+    assert "2 chunks" in capped_out.rank_fallback_reason
+    assert len(capped_out.matches) == 2
+
+
+def test_rerank_hybrid_corpus_cap_appends_to_existing_and_late_rerank_reasons(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """The 3-way reason combination (pre-existing + corpus-cap + late-rerank) preserves every
+    source -- generalizing the existing 2-way late-rerank append test without regressing it."""
+    from tensor_grep.core.retrieval_late import LateReranker, LateRerankUnavailableError
+
+    monkeypatch.setenv("TG_RANK_CORPUS_CHUNK_CAP", "1")
+    files = [_write_three_line_file(tmp_path, f"f{i}.py") for i in range(2)]
+    result = SearchResult(
+        matches=[MatchLine(line_number=1, text="x", file=str(f)) for f in files],
+        total_matches=2,
+        rank_fallback_reason="pre-existing upstream reason",
+    )
+
+    def _raising_encode(text: str) -> np.ndarray:
+        raise LateRerankUnavailableError("late rerank unavailable: model not fetched")
+
+    # Query MUST match a real token in the corpus ("line", present in every _write_three_line_file
+    # chunk) so the BM25 leg's ranking -- and therefore the late-rerank pool `head` -- is non-empty.
+    # Bm25Index.query() excludes zero-score chunks, and LateReranker.rerank() short-circuits an
+    # EMPTY pool without ever invoking `encode` at all -- an unmatched query like "anything" would
+    # never reach `_raising_encode`, silently defeating this test's whole premise.
+    out = rerank_hybrid(
+        result,
+        "line",
+        [str(f) for f in files],
+        chunk_size=1,
+        overlap=0,
+        late_reranker=LateReranker(encode=_raising_encode),
+    )
+
+    assert out.rank_fallback_reason is not None
+    assert "pre-existing upstream reason" in out.rank_fallback_reason
+    assert "corpus cap" in out.rank_fallback_reason
+    assert "model not fetched" in out.rank_fallback_reason
+    assert len(out.matches) == 2  # matches still never dropped across all three degrade sources


### PR DESCRIPTION
Backlog-100 P0 #128d MED-1: plain `--rank` rechunked the ENTIRE matched set uncapped (MCP-reachable CPU/mem spike). Adds `_chunk_corpus_with_total_cap()` at the shared reranker chokepoint (both CLI + MCP funnel through, zero call-site edits) — env-tunable `TG_RANK_CORPUS_CHUNK_CAP` (default MAX_CHUNKS 100k); on trip sets `rank_fallback_reason` (visible, appended, stderr echo) and NEVER drops matches. Semantic path (#527) + per-file MAX_CHUNKS untouched. 8 bidirectionally-verified tests (CLI+MCP e2e). 4-gate green. Gate-free (reranker core).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>