### PR TITLE
fix(index): atomic + cross-process-locked .tg_index persistence + load-once (#138)

### DIFF
--- a/rust_core/src/index.rs
+++ b/rust_core/src/index.rs
@@ -11,6 +11,7 @@ use regex_syntax::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -848,13 +849,12 @@ impl TrigramIndex {
         &self.root
     }
 
+    /// Persists the bincode-serialized index atomically -- see [`atomic_write_bytes`]. Audit
+    /// #138 item #1: the previous `std::fs::write(path, ...)` here wrote the destination
+    /// in-place, so a crash mid-write left a truncated/corrupt `.tg_index` behind.
     pub fn save(&self, path: &Path) -> Result<()> {
         let data = bincode_serialize(self)?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(path, &data)
-            .with_context(|| format!("failed to write index to {}", path.display()))
+        atomic_write_bytes(path, &data)
     }
 
     pub fn load(path: &Path) -> Result<Self> {
@@ -863,14 +863,12 @@ impl TrigramIndex {
         bincode_deserialize(&data)
     }
 
+    /// Persists the legacy JSON index representation atomically -- see [`atomic_write_bytes`].
+    /// Same audit #138 item #1 rationale as [`Self::save`].
     pub fn save_json(&self, path: &Path) -> Result<()> {
         let data =
             serde_json::to_vec(&self.to_serializable()).context("failed to serialize index")?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(path, &data)
-            .with_context(|| format!("failed to write index to {}", path.display()))
+        atomic_write_bytes(path, &data)
     }
 
     pub fn load_json(path: &Path) -> Result<Self> {
@@ -892,6 +890,66 @@ impl TrigramIndex {
     pub fn total_postings(&self) -> usize {
         self.postings.values().map(|v| v.len()).sum()
     }
+}
+
+/// Writes `data` to `path` via write-temp-then-atomic-rename, mirroring
+/// `checkpoint_store.py::_write_json_atomic`: the temp file lives in the SAME directory as
+/// `path` (so the rename is same-filesystem and therefore atomic), is fsync'd before the rename
+/// so a crash between the write and the rename can never publish a truncated file (the rename
+/// simply never happens -- `path` itself is untouched until it atomically becomes the new
+/// complete content in one indivisible step), and the rename is retried via
+/// `index_lock::replace_with_retry` to absorb the transient Windows "destination momentarily
+/// held open by a reader/AV scanner" case. On `cfg(unix)` the parent directory is ALSO fsync'd
+/// after the rename, best-effort, for durability of the directory entry itself (skipped on
+/// Windows, where a directory handle cannot be fsync'd this way). Audit #138 item #1.
+fn atomic_write_bytes(path: &Path, data: &[u8]) -> Result<()> {
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create parent dir for {}", path.display()))?;
+
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("index");
+    let tmp_path = parent.join(format!(
+        ".{file_name}.{}.tmp",
+        crate::index_lock::random_token()
+    ));
+
+    let write_result = (|| -> io::Result<()> {
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(data)?;
+        // fsync the data before the rename so a crash can never publish a truncated index --
+        // the rename below is the ONLY step that makes the new content visible at `path`.
+        file.sync_all()
+    })();
+
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp_path); // best-effort cleanup; the original at `path` is untouched
+        return Err(e).with_context(|| format!("failed to write temp file {}", tmp_path.display()));
+    }
+
+    if let Err(e) = crate::index_lock::replace_with_retry(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| {
+            format!(
+                "failed to atomically rename {} -> {}",
+                tmp_path.display(),
+                path.display()
+            )
+        });
+    }
+
+    #[cfg(unix)]
+    {
+        // Best-effort durability of the rename's directory entry; a failure here does not
+        // invalidate the already-completed atomic rename above.
+        if let Ok(dir_file) = std::fs::File::open(parent) {
+            let _ = dir_file.sync_all();
+        }
+    }
+
+    Ok(())
 }
 
 fn collect_file_entries(root: &Path, no_ignore: bool) -> Vec<FileEntry> {
@@ -1319,6 +1377,80 @@ mod tests {
 
         let results = loaded.search("hello", false, true).unwrap();
         assert_eq!(results.len(), 1);
+    }
+
+    // -- Audit #138 item #1: atomic save -----------------------------------------------------
+
+    #[test]
+    fn test_save_leaves_no_temp_file_behind_after_success() {
+        let dir = tempdir().unwrap();
+        write_test_file(dir.path(), "a.txt", "hello world\n");
+        let index = TrigramIndex::build(dir.path()).unwrap();
+        let index_path = dir.path().join(".tg_index");
+        index.save(&index_path).unwrap();
+
+        assert!(index_path.exists());
+        let stray_tmp_files: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(
+            stray_tmp_files.is_empty(),
+            "a successful save must not leave a temp file behind: {stray_tmp_files:?}"
+        );
+    }
+
+    #[test]
+    fn test_save_overwrite_fully_replaces_previous_content_not_a_merge() {
+        let dir = tempdir().unwrap();
+        write_test_file(dir.path(), "a.txt", "hello world\n");
+        let index_path = dir.path().join(".tg_index");
+
+        let first = TrigramIndex::build(dir.path()).unwrap();
+        first.save(&index_path).unwrap();
+        assert_eq!(TrigramIndex::load(&index_path).unwrap().file_count(), 1);
+
+        write_test_file(dir.path(), "b.txt", "goodbye moon\n");
+        let second = TrigramIndex::build(dir.path()).unwrap();
+        second.save(&index_path).unwrap();
+
+        let reloaded = TrigramIndex::load(&index_path).unwrap();
+        assert_eq!(
+            reloaded.file_count(),
+            2,
+            "the second save must fully replace the destination's content"
+        );
+    }
+
+    #[test]
+    fn atomic_write_bytes_rename_failure_cleans_up_temp_and_returns_err() {
+        // Cross-platform deterministic failure injection: renaming a regular file onto a path
+        // that is an existing DIRECTORY fails on both POSIX (EISDIR) and Windows -- regardless
+        // of the temp file's randomly-generated name, so this does not need to predict it.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".tg_index");
+        fs::create_dir(&path).unwrap();
+
+        let result = atomic_write_bytes(&path, b"NEW_CONTENT_MUST_NOT_LAND");
+        assert!(
+            result.is_err(),
+            "rename onto an existing directory must fail"
+        );
+        assert!(
+            path.is_dir(),
+            "a failed atomic_write_bytes must not have disturbed the destination"
+        );
+
+        let stray_tmp_files: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(
+            stray_tmp_files.is_empty(),
+            "a failed atomic_write_bytes must clean up its own temp file: {stray_tmp_files:?}"
+        );
     }
 
     #[test]

--- a/rust_core/src/index_lock.rs
+++ b/rust_core/src/index_lock.rs
@@ -1,0 +1,624 @@
+//! Cross-process advisory locking for the persisted trigram index file, mirroring
+//! `src/tensor_grep/cli/_index_lock.py` (the Python checkpoint-store lock primitives) so the
+//! Rust-side `.tg_index` persistence gets the same fail-closed guarantees: an `O_CREAT | O_EXCL`
+//! lockfile records an owner (pid + random token), a lock older than [`DEFAULT_STALE_AFTER`] is
+//! reclaimed from a presumed-dead holder, and a live holder keeps its lock fresh via a heartbeat
+//! thread so a waiter never mistakes "slow" for "dead" mid-hold.
+//!
+//! Audit #138 item #2 (index.json write is non-atomic + unlocked -> crash-corrupts + concurrent
+//! writers lost-update). This module supplies ONLY the locking + retried-rename primitives (like
+//! `_index_lock.py`); the atomic-write-of-index-bytes sequence itself lives next to its caller in
+//! `index.rs::save`/`save_json`, and the decision of WHERE to acquire the lock (write sections
+//! only -- readers stay lock-free) lives in `main.rs`'s `save_index_locked`.
+
+use std::collections::hash_map::RandomState;
+use std::fmt;
+use std::fs::OpenOptions;
+use std::hash::{BuildHasher, Hasher};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+/// A lock older than this is presumed abandoned by a dead holder and is reclaimed by the next
+/// waiter. RMW-scaled (bounded by how long a save can plausibly take), NOT scaled to any
+/// daemon-launch or process-startup latency.
+pub const DEFAULT_STALE_AFTER: Duration = Duration::from_secs(10);
+
+/// H9 invariant (mirrors `_index_lock.py`'s `_TIMEOUT_S` comment verbatim): this MUST exceed
+/// [`DEFAULT_STALE_AFTER`]. A holder killed mid-write can leave a lock younger than
+/// `DEFAULT_STALE_AFTER` at the moment a waiter starts polling; if the waiter's own deadline
+/// could expire first (an old timeout < stale split), that fresh-but-dead lock would NEVER be
+/// reclaimed within the wait window -- every waiter would raise a timeout instead of
+/// self-healing. Keeping timeout > stale guarantees any lock already past (or about to pass) the
+/// staleness threshold is reclaimed before a waiter gives up. Enforced below at compile time, not
+/// just documented.
+pub const DEFAULT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(12);
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Bound on how long [`IndexLockGuard`]'s drop waits for the heartbeat thread to acknowledge a
+/// stop signal before giving up on it and releasing the lock anyway -- mirrors
+/// `_index_lock.py`'s `heartbeat.join(timeout=1.0)`: bounded, so a wedged heartbeat thread can
+/// never hang lock release (and therefore never hang the search it is guarding).
+const HEARTBEAT_JOIN_BOUND: Duration = Duration::from_millis(1000);
+
+const _H9_TIMEOUT_EXCEEDS_STALE: () = assert!(
+    DEFAULT_ACQUIRE_TIMEOUT.as_nanos() > DEFAULT_STALE_AFTER.as_nanos(),
+    "H9 invariant violated: DEFAULT_ACQUIRE_TIMEOUT must exceed DEFAULT_STALE_AFTER, else a \
+     fresh-but-dead lock can outlive every waiter's deadline and never self-heal"
+);
+
+/// Raised when a lock could not be acquired within the timeout. Per the Backend Fail-Closed
+/// Contract (AGENTS.md) this governs the on-disk CACHE, not search RESULTS: callers must treat
+/// this as "skip persisting this run, keep serving the freshly-built in-memory index," never as a
+/// reason to fail the search itself. A genuinely dead lock is reclaimed via mtime staleness
+/// before this fires, so in practice this only fires under sustained LIVE contention.
+#[derive(Debug)]
+pub struct IndexLockTimeoutError {
+    pub lock_path: PathBuf,
+    pub timeout: Duration,
+}
+
+impl fmt::Display for IndexLockTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "could not acquire index lock {} within {:?}",
+            self.lock_path.display(),
+            self.timeout
+        )
+    }
+}
+
+impl std::error::Error for IndexLockTimeoutError {}
+
+/// Dot-prefixed + `.lock` suffix, mirroring `_index_lock.py::_lock_path_for` -- never matched by
+/// any `.tg_index` / checkpoint / session discovery glob.
+fn lock_path_for(index_path: &Path) -> PathBuf {
+    let name = index_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("index");
+    index_path.with_file_name(format!(".{name}.lock"))
+}
+
+/// Process-local, non-cryptographic randomness for lock ownership tokens and temp-file name
+/// disambiguation -- collision-avoidance only (mutual exclusion itself comes from
+/// `O_CREAT | O_EXCL`, not from this being unguessable). Deliberately std-only (no new crate
+/// dependency): `RandomState::new()` mixes a per-thread call counter into an OS-random-seeded key
+/// on every construction, so hashing through a fresh instance yields a different digest each call
+/// within the same process (and a different seed across processes/threads).
+pub fn random_token() -> String {
+    let a = RandomState::new().build_hasher().finish();
+    let b = RandomState::new().build_hasher().finish();
+    format!("{a:016x}{b:016x}")
+}
+
+/// Reads back the ownership token written by [`IndexLockGuard::acquire_with`] (the second line of
+/// `{pid}\n{token}\n`). Returns `None` if the file is gone, unreadable, or lacks a token line
+/// (e.g. a partially-written or legacy lock) -- callers must treat `None` as "not mine," never as
+/// a match.
+fn token_for_lock(lock_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(lock_path).ok()?;
+    let mut lines = content.lines();
+    let _pid_line = lines.next()?;
+    let token_line = lines.next()?;
+    let token = token_line.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+/// Ownership-token-guarded release: unlink `lock_path` ONLY if it still carries `token` (i.e.
+/// this guard still owns it). If a waiter reclaimed the lock as stale while this holder was still
+/// slow-but-alive, the token on disk no longer matches -- leave that live lock alone instead of
+/// deleting it out from under the new owner (the lost-update / two-holders race). Tolerates the
+/// lock already being gone.
+fn release_lock(lock_path: &Path, token: &str) {
+    if token_for_lock(lock_path).as_deref() != Some(token) {
+        return;
+    }
+    let _ = std::fs::remove_file(lock_path);
+}
+
+/// Test-only observability hook (zero-cost/no-op unless `TG_INDEX_LOCK_DEBUG_LOG_DIR` is set):
+/// records a held-interval endpoint (`"start"` or `"end"`) as a nanosecond timestamp in its own
+/// per-acquisition file (`{pid}_{token}.{suffix}`). Each file is written exactly once by exactly
+/// one process, so -- unlike a single shared append log -- there is no cross-process write race
+/// to reason about. Lets a concurrency test assert mutual exclusion DIRECTLY (no two logged
+/// [start, end) intervals overlap) instead of only inferring it from absence-of-corruption.
+fn debug_log_event(token: &str, suffix: &str) {
+    let Ok(dir) = std::env::var("TG_INDEX_LOCK_DEBUG_LOG_DIR") else {
+        return;
+    };
+    let now_nanos = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let file_name = format!("{}_{token}.{suffix}", std::process::id());
+    let _ = std::fs::write(Path::new(&dir).join(file_name), now_nanos.to_string());
+}
+
+/// Sets the lock file's mtime to now, mirroring `_index_lock.py`'s `os.utime(lock_path, None)`
+/// heartbeat touch.
+fn touch(path: &Path) -> io::Result<()> {
+    let file = OpenOptions::new().write(true).open(path)?;
+    let times = std::fs::FileTimes::new().set_modified(SystemTime::now());
+    file.set_times(times)
+}
+
+/// Well under `stale_after` so a live-but-slow holder's mtime never crosses the staleness
+/// threshold between beats; floored at `poll_interval` so a tiny custom `stale_after` (tests)
+/// can't drive this to ~0 and busy-loop the heartbeat thread.
+fn default_heartbeat_interval(stale_after: Duration, poll_interval: Duration) -> Duration {
+    let third = stale_after / 3;
+    if third > poll_interval {
+        third
+    } else {
+        poll_interval
+    }
+}
+
+struct HeartbeatState {
+    stop: bool,
+    finished: bool,
+}
+
+struct HeartbeatControl {
+    state: Mutex<HeartbeatState>,
+    condvar: Condvar,
+}
+
+/// Spawns the heartbeat thread and returns the control handle used to signal + bounded-wait for
+/// its stop on release. The thread re-checks ownership (via [`token_for_lock`]) before every
+/// touch so a heartbeat that outlives its own lock (release already ran, or -- defensively --
+/// someone else reclaimed) never props up a DIFFERENT holder's lock.
+fn spawn_heartbeat(lock_path: PathBuf, token: String, interval: Duration) -> Arc<HeartbeatControl> {
+    let control = Arc::new(HeartbeatControl {
+        state: Mutex::new(HeartbeatState {
+            stop: false,
+            finished: false,
+        }),
+        condvar: Condvar::new(),
+    });
+    let thread_control = Arc::clone(&control);
+    thread::spawn(move || loop {
+        let guard = thread_control
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Check `stop` BEFORE waiting, not just after: if the guard's Drop already ran (set
+        // stop=true and notify_all()'d) before this thread reached its first wait_timeout --
+        // entirely possible for a short-held lock, since thread::spawn does not guarantee the
+        // new thread runs before the spawning thread continues -- that notification is
+        // otherwise MISSED (Condvar::notify_all only wakes threads already waiting at the
+        // moment it's called), and this thread would fall through to waiting out a full
+        // `interval` before ever re-checking `stop`. Checking here first closes that lost-
+        // wakeup race: whoever next acquires the mutex always observes the latest `stop`
+        // value regardless of notification timing.
+        if guard.stop {
+            let mut guard = guard;
+            guard.finished = true;
+            thread_control.condvar.notify_all();
+            return;
+        }
+        let (mut guard, timeout_result) = thread_control
+            .condvar
+            .wait_timeout(guard, interval)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard.stop {
+            guard.finished = true;
+            thread_control.condvar.notify_all();
+            return;
+        }
+        drop(guard);
+        if timeout_result.timed_out() {
+            if token_for_lock(&lock_path).as_deref() != Some(token.as_str()) {
+                let mut guard = thread_control
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                guard.finished = true;
+                thread_control.condvar.notify_all();
+                return;
+            }
+            let _ = touch(&lock_path); // transient failure (e.g. Windows delete-pending); next beat retries
+        }
+    });
+    control
+}
+
+/// RAII write-lock for the persisted index file. Acquire around the SAVE only -- never around a
+/// read/load -- per the fail-closed contract's "reads stay lock-free" invariant. Dropping the
+/// guard releases the lock (token-guarded) after signaling the heartbeat thread to stop and
+/// bounded-waiting (up to [`HEARTBEAT_JOIN_BOUND`]) for it to acknowledge.
+pub struct IndexLockGuard {
+    lock_path: PathBuf,
+    token: String,
+    heartbeat: Arc<HeartbeatControl>,
+}
+
+impl IndexLockGuard {
+    /// Acquires the write lock for `index_path` using the default production timing (12s
+    /// timeout, 10s stale threshold, 20ms poll -- the H9-verified values).
+    pub fn acquire(index_path: &Path) -> Result<Self, IndexLockTimeoutError> {
+        Self::acquire_with(
+            index_path,
+            DEFAULT_ACQUIRE_TIMEOUT,
+            DEFAULT_STALE_AFTER,
+            DEFAULT_POLL_INTERVAL,
+        )
+    }
+
+    /// Same as [`Self::acquire`] with caller-supplied timing, for tests that need a fast,
+    /// deterministic stale/timeout window instead of waiting out the real 10s/12s production
+    /// values. Production callers should use [`Self::acquire`].
+    pub fn acquire_with(
+        index_path: &Path,
+        timeout: Duration,
+        stale_after: Duration,
+        poll_interval: Duration,
+    ) -> Result<Self, IndexLockTimeoutError> {
+        let lock_path = lock_path_for(index_path);
+        if let Some(parent) = lock_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let deadline = Instant::now() + timeout;
+        loop {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true) // O_CREAT | O_EXCL
+                .open(&lock_path)
+            {
+                Ok(mut file) => {
+                    let token = random_token();
+                    use std::io::Write as _;
+                    // Best-effort content write, matching _index_lock.py: an OSError writing the
+                    // freshly-created lock file is exceptional (not a contention signal) and
+                    // isn't specially handled there either -- a missing/short token line just
+                    // makes token_for_lock() return None, which every guard (release/heartbeat)
+                    // already treats as "not mine, don't touch it": fails closed, not silently.
+                    let _ = writeln!(file, "{}", std::process::id());
+                    let _ = writeln!(file, "{token}");
+                    drop(file);
+                    debug_log_event(&token, "start");
+                    let hb_interval = default_heartbeat_interval(stale_after, poll_interval);
+                    let heartbeat = spawn_heartbeat(lock_path.clone(), token.clone(), hb_interval);
+                    return Ok(IndexLockGuard {
+                        lock_path,
+                        token,
+                        heartbeat,
+                    });
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    // Lock is held. Reclaim it if stale (dead holder), else fall through to wait.
+                    if let Ok(meta) = std::fs::metadata(&lock_path) {
+                        if let Ok(modified) = meta.modified() {
+                            if SystemTime::now()
+                                .duration_since(modified)
+                                .unwrap_or_default()
+                                > stale_after
+                            {
+                                // GUARDED: two racing reclaimers must not crash the loser.
+                                let _ = std::fs::remove_file(&lock_path);
+                                continue;
+                            }
+                        }
+                    }
+                }
+                Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+                    // Windows delete-pending race: a concurrent reclaimer just removed the lock,
+                    // so the name is in a "delete pending" state and create_new() raises
+                    // access-denied instead of POSIX's plain "already exists". Transient -- fall
+                    // through to wait/retry; a genuine permission error self-limits by continuing
+                    // to fail here and hitting the deadline below, never a raw leak.
+                }
+                Err(_) => {
+                    // Any other error (e.g. the parent directory itself is unwritable) is not a
+                    // contention signal; fall through to the same timeout/retry loop rather than
+                    // a distinct error type, matching _index_lock.py (which only special-cases
+                    // FileExistsError/PermissionError and otherwise retries to its own deadline).
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(IndexLockTimeoutError { lock_path, timeout });
+            }
+            thread::sleep(poll_interval);
+        }
+    }
+}
+
+impl Drop for IndexLockGuard {
+    fn drop(&mut self) {
+        {
+            // Mutate through the same MutexGuard handed to wait_timeout_while, so there is no
+            // window where another thread could observe stop=false after we set it here.
+            let mut guard = self
+                .heartbeat
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            guard.stop = true;
+            self.heartbeat.condvar.notify_all();
+            let _ = self
+                .heartbeat
+                .condvar
+                .wait_timeout_while(guard, HEARTBEAT_JOIN_BOUND, |s| !s.finished)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        debug_log_event(&self.token, "end");
+        release_lock(&self.lock_path, &self.token);
+    }
+}
+
+/// `std::fs::rename` retried on the Windows-only transient permission error that fires when the
+/// destination is momentarily held open by a concurrent reader / AV scanner / the search indexer.
+/// On POSIX, rename is atomic and essentially never raises this, so the retry loop is a no-op
+/// there. Fails CLOSED: the last error is returned after exhausting attempts, never silently
+/// leaving a stale/torn index in place. Mirrors `_index_lock.py::replace_with_retry`.
+pub fn replace_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
+    replace_with_retry_params(src, dst, 10, Duration::from_millis(20))
+}
+
+/// Same as [`replace_with_retry`] with caller-supplied attempt count/delay, for tests that need a
+/// fast, bounded retry window.
+pub fn replace_with_retry_params(
+    src: &Path,
+    dst: &Path,
+    attempts: u32,
+    delay: Duration,
+) -> io::Result<()> {
+    let attempts = attempts.max(1);
+    let mut last_err = None;
+    for attempt in 0..attempts {
+        match std::fs::rename(src, dst) {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+                last_err = Some(e);
+                if attempt + 1 == attempts {
+                    break;
+                }
+                thread::sleep(delay);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| io::Error::other("replace_with_retry: rename failed")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn tiny_timing() -> (Duration, Duration, Duration) {
+        // (timeout, stale_after, poll_interval) -- deterministic for tests, while preserving
+        // the H9 invariant (timeout > stale_after). Deliberately NOT as tiny as the name
+        // suggests: this races a live heartbeat thread against real OS scheduling, and a
+        // previous 300ms/120ms pairing was observed to flake under `cargo test`'s parallel
+        // load (the heartbeat thread got starved past stale_after, so the "held" lock looked
+        // abandoned and got reclaimed instead of timing out). 800ms stale_after tolerates far
+        // more scheduling jitter before that can happen again.
+        (
+            Duration::from_millis(1000),
+            Duration::from_millis(800),
+            Duration::from_millis(10),
+        )
+    }
+
+    #[test]
+    fn h9_invariant_holds_for_production_defaults() {
+        assert!(
+            DEFAULT_ACQUIRE_TIMEOUT > DEFAULT_STALE_AFTER,
+            "acquire timeout must exceed the stale threshold"
+        );
+    }
+
+    #[test]
+    fn acquire_then_release_leaves_no_lock_file_behind() {
+        let dir = tempdir().unwrap();
+        let index_path = dir.path().join(".tg_index");
+        let lock_path = lock_path_for(&index_path);
+
+        {
+            let _guard = IndexLockGuard::acquire_with(
+                &index_path,
+                Duration::from_secs(2),
+                Duration::from_secs(1),
+                Duration::from_millis(10),
+            )
+            .expect("uncontended acquire must succeed");
+            assert!(lock_path.exists(), "lock file should exist while held");
+            let content = std::fs::read_to_string(&lock_path).unwrap();
+            let mut lines = content.lines();
+            let pid_line: u32 = lines.next().unwrap().parse().unwrap();
+            assert_eq!(pid_line, std::process::id());
+            assert!(
+                !lines.next().unwrap().trim().is_empty(),
+                "token line must be non-empty"
+            );
+        }
+        assert!(
+            !lock_path.exists(),
+            "lock file must be removed after the guard drops"
+        );
+    }
+
+    #[test]
+    fn second_acquire_times_out_while_first_is_held() {
+        let dir = tempdir().unwrap();
+        let index_path = dir.path().join(".tg_index");
+        let (timeout, stale_after, poll) = tiny_timing();
+
+        let _holder = IndexLockGuard::acquire_with(&index_path, timeout, stale_after, poll)
+            .expect("first acquire must succeed");
+
+        let started = Instant::now();
+        let result = IndexLockGuard::acquire_with(&index_path, timeout, stale_after, poll);
+        let elapsed = started.elapsed();
+
+        assert!(
+            result.is_err(),
+            "second acquire must time out while the first guard is alive"
+        );
+        assert!(
+            elapsed >= timeout,
+            "must not return before the timeout elapsed: {elapsed:?} < {timeout:?}"
+        );
+        // Bounded upper check too, so a regression that busy-spins forever fails the test
+        // instead of hanging it (anti-hang-test-protocol).
+        assert!(
+            elapsed < timeout * 4,
+            "timed out far later than expected: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn stale_lock_is_reclaimed_without_waiting_out_the_full_timeout() {
+        let dir = tempdir().unwrap();
+        let index_path = dir.path().join(".tg_index");
+        let lock_path = lock_path_for(&index_path);
+
+        // Simulate an abandoned lock from a dead holder: write it directly (no heartbeat), then
+        // backdate its mtime past stale_after.
+        std::fs::write(&lock_path, b"999999\ndeadtoken\n").unwrap();
+        let stale_after = Duration::from_millis(50);
+        let backdated = SystemTime::now() - (stale_after + Duration::from_millis(200));
+        let file = OpenOptions::new().write(true).open(&lock_path).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(backdated))
+            .unwrap();
+
+        let timeout = Duration::from_secs(5); // generous; the assertion is on ELAPSED, not this
+        let started = Instant::now();
+        let guard = IndexLockGuard::acquire_with(
+            &index_path,
+            timeout,
+            stale_after,
+            Duration::from_millis(10),
+        )
+        .expect("a stale lock must be reclaimed, not waited out");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < timeout / 2,
+            "reclaim should be near-immediate, not close to the full timeout: {elapsed:?}"
+        );
+        drop(guard);
+    }
+
+    #[test]
+    fn heartbeat_keeps_a_slow_holder_alive_past_the_stale_threshold() {
+        let dir = tempdir().unwrap();
+        let index_path = dir.path().join(".tg_index");
+        // Deliberately WIDE margins: this test depends on the heartbeat thread actually getting
+        // scheduled promptly, which is not guaranteed under real OS contention (e.g. a
+        // `cargo test` run where 100 tests run in parallel across a handful of cores). A tight
+        // stale_after (previously 80ms, heartbeat interval ~27ms) was observed to flake under
+        // that exact load -- the heartbeat thread got starved past 80ms and its lock was
+        // (correctly, per the mechanism) reclaimed as stale, failing this test for a scheduling
+        // reason unrelated to the property it's checking. 1.2s stale_after (a ~400ms heartbeat
+        // interval) tolerates several missed/delayed beats before ever approaching staleness.
+        let stale_after = Duration::from_millis(1200);
+        let poll = Duration::from_millis(20);
+
+        let holder =
+            IndexLockGuard::acquire_with(&index_path, Duration::from_secs(10), stale_after, poll)
+                .unwrap();
+
+        // Outlive the stale threshold several times over while the ORIGINAL guard is still
+        // alive; the heartbeat thread must keep touching the lock's mtime so a waiter never
+        // reclaims a live holder's lock.
+        std::thread::sleep(stale_after * 3);
+
+        let started = Instant::now();
+        let result = IndexLockGuard::acquire_with(
+            &index_path,
+            Duration::from_millis(500),
+            stale_after,
+            poll,
+        );
+        assert!(
+            result.is_err(),
+            "a live, heartbeating holder's lock must never be stolen"
+        );
+        assert!(started.elapsed() < Duration::from_secs(2), "must not hang");
+        drop(holder);
+    }
+
+    #[test]
+    fn replace_with_retry_succeeds_on_a_plain_rename() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.tmp");
+        let dst = dir.path().join("dst");
+        std::fs::write(&src, b"payload").unwrap();
+        replace_with_retry(&src, &dst).unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), b"payload");
+        assert!(!src.exists());
+    }
+
+    #[test]
+    fn replace_with_retry_overwrites_an_existing_destination() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src.tmp");
+        let dst = dir.path().join("dst");
+        std::fs::write(&dst, b"old").unwrap();
+        std::fs::write(&src, b"new").unwrap();
+        replace_with_retry(&src, &dst).unwrap();
+        assert_eq!(std::fs::read(&dst).unwrap(), b"new");
+    }
+
+    #[test]
+    fn random_token_is_not_constant_across_calls() {
+        let tokens: std::collections::HashSet<String> = (0..32).map(|_| random_token()).collect();
+        assert!(
+            tokens.len() > 1,
+            "random_token() must vary across calls (got {} unique of 32)",
+            tokens.len()
+        );
+    }
+
+    #[test]
+    fn two_threads_never_observe_the_lock_simultaneously() {
+        // In-process complement to the cross-process hammer test (rust_core/tests/): proves
+        // mutual exclusion at the thread level using a shared counter that must never exceed 1.
+        let dir = tempdir().unwrap();
+        let index_path = Arc::new(dir.path().join(".tg_index"));
+        let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let max_observed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let index_path = Arc::clone(&index_path);
+            let active = Arc::clone(&active);
+            let max_observed = Arc::clone(&max_observed);
+            handles.push(thread::spawn(move || {
+                for _ in 0..20 {
+                    let guard = IndexLockGuard::acquire_with(
+                        &index_path,
+                        Duration::from_secs(5),
+                        Duration::from_millis(500),
+                        Duration::from_millis(2),
+                    )
+                    .expect("acquire must eventually succeed for every thread");
+                    let now = active.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                    max_observed.fetch_max(now, std::sync::atomic::Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_micros(200));
+                    active.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                    drop(guard);
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_eq!(
+            max_observed.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "at most one thread must hold the lock at any instant"
+        );
+    }
+}

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod editor_plane;
 #[cfg(feature = "cuda")]
 pub mod gpu_native;
 pub mod index;
+pub mod index_lock;
 pub mod mmap_arrow;
 pub mod native_search;
 pub mod python_sidecar;

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -5448,39 +5448,60 @@ const INDEX_FLAG_POLICY: &[(&str, IndexFlagPolicy)] = &[
     ("version", IndexFlagPolicy::PassthroughSafe),
 ];
 
+/// Detects warm-index routing state, loading the persisted index AT MOST ONCE (audit #138 item
+/// #3): the previous version only returned `IndexRoutingState`, so the immediate warm-routing
+/// caller (below) and `handle_index_search` each independently re-loaded + re-deserialized the
+/// SAME `.tg_index` file for a single search invocation. Returning the loaded index lets the
+/// caller reuse it directly instead of reading the file a second time. This is a pure READ -- it
+/// never acquires the write lock (`IndexLockGuard` is only taken around a `save()`, never here);
+/// see `save_index_locked` for where persistence is actually gated.
+///
+/// The returned `Option<TrigramIndex>` is `Some` only when a load actually succeeded; it is
+/// always `None` when the guard clauses short-circuit (no `.tg_index` yet, explicit `--index`,
+/// or an incompatible flag combination) or when the load itself failed (a corrupt/legacy index),
+/// mirroring the `IndexRoutingState` this replaces field-for-field.
 fn detect_warm_index_state(
     args: &SearchArgs,
     request: &ResolvedSearchRequest,
-) -> IndexRoutingState {
+) -> (IndexRoutingState, Option<TrigramIndex>) {
     if args.index
         || request.paths.len() != 1
         || request.patterns.len() != 1
         || request.patterns[0].len() < 3
         || !index_flag_violations(args, request).is_empty()
     {
-        return IndexRoutingState::default();
+        return (IndexRoutingState::default(), None);
     }
 
     let index_path = resolve_index_path(request.primary_path());
     if !index_path.exists() {
-        return IndexRoutingState::default();
+        return (IndexRoutingState::default(), None);
     }
 
     match TrigramIndex::load(&index_path) {
-        Ok(index) => IndexRoutingState {
-            exists: true,
+        Ok(index) => {
             // H1d (audit): a query's --no-ignore mode that disagrees with the mode this
             // index was built under must be treated as stale so auto-routing does not
             // silently serve gitignored content the query didn't ask for (or silently
             // omit gitignored content a --no-ignore query did ask for).
-            is_stale: index.is_stale(args.no_ignore),
-            pattern_compatible: true,
-        },
-        Err(_) => IndexRoutingState {
-            exists: true,
-            is_stale: true,
-            pattern_compatible: true,
-        },
+            let is_stale = index.is_stale(args.no_ignore);
+            (
+                IndexRoutingState {
+                    exists: true,
+                    is_stale,
+                    pattern_compatible: true,
+                },
+                Some(index),
+            )
+        }
+        Err(_) => (
+            IndexRoutingState {
+                exists: true,
+                is_stale: true,
+                pattern_compatible: true,
+            },
+            None,
+        ),
     }
 }
 
@@ -5838,7 +5859,7 @@ fn search_prefers_ripgrep_passthrough(
         || args.index
         || args.force_cpu
         || !args.gpu_device_ids.is_empty()
-        || detect_warm_index_state(args, request).exists
+        || detect_warm_index_state(args, request).0.exists
     {
         return false;
     }
@@ -6244,7 +6265,7 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
     #[cfg(not(feature = "cuda"))]
     let (corpus_bytes, corpus_bytes_known) = (0u64, false);
 
-    let index_state = detect_warm_index_state(&args, &request);
+    let (index_state, warm_loaded_index) = detect_warm_index_state(&args, &request);
 
     #[cfg(feature = "cuda")]
     let gpu_auto_supported = request.paths.len() == 1
@@ -6308,7 +6329,9 @@ fn handle_ripgrep_search(args: SearchArgs) -> anyhow::Result<()> {
     );
 
     match decision.selection {
-        BackendSelection::TrigramIndex => handle_index_search(&args, &request, &query),
+        BackendSelection::TrigramIndex => {
+            handle_index_search(&args, &request, &query, warm_loaded_index)
+        }
         BackendSelection::NativeGpu => {
             let gpu_device_ids = if args.gpu_device_ids.is_empty() {
                 &auto_gpu_ids
@@ -6445,10 +6468,38 @@ fn resolve_index_path(search_path: &str) -> PathBuf {
     }
 }
 
+/// Persists `index` to `index_path` under the write-serializing index lock -- the ONLY place in
+/// the search path that acquires it. Readers (`TrigramIndex::load`, `detect_warm_index_state`)
+/// never take this lock; a wrong lock on the read path would deadlock (or at minimum
+/// unnecessarily serialize) EVERY `tg` invocation against a warm index (audit #138 item #2
+/// critical trap). Per the Backend Fail-Closed Contract (AGENTS.md), a failed PERSIST must never
+/// fail the SEARCH: on a lock-acquire timeout (another writer holding it past the 12s budget) or
+/// an actual write/rename failure, this warns to stderr and returns without persisting -- the
+/// caller's in-memory `index` (already fully built) is unaffected and is what actually answers
+/// the search.
+fn save_index_locked(index: &TrigramIndex, index_path: &Path, verbose: bool) {
+    match tensor_grep_rs::index_lock::IndexLockGuard::acquire(index_path) {
+        Ok(_guard) => {
+            if let Err(e) = index.save(index_path) {
+                eprintln!("[index] warning: failed to persist index: {e}");
+            } else if verbose {
+                eprintln!("[index] persisted index to {}", index_path.display());
+            }
+        }
+        Err(timeout) => {
+            eprintln!(
+                "[index] warning: {timeout}; skipping persistence for this run (search \
+                 results are unaffected -- a later invocation will retry)"
+            );
+        }
+    }
+}
+
 fn handle_index_search(
     args: &SearchArgs,
     request: &ResolvedSearchRequest,
     query: &str,
+    preloaded_index: Option<TrigramIndex>,
 ) -> anyhow::Result<()> {
     if request.paths.len() != 1 {
         anyhow::bail!("index search currently supports exactly one path root");
@@ -6486,7 +6537,20 @@ fn handle_index_search(
 
     let index_path = resolve_index_path(request.primary_path());
 
-    let index = if index_path.exists() {
+    let index = if let Some(loaded) = preloaded_index {
+        // audit #138 item #3 (load-once): `detect_warm_index_state` already loaded this index
+        // (and, by construction, only ever hands one to us via the `should_route_to_index()` /
+        // warm_index() routing arm, which requires `!is_stale`) -- reuse it instead of reading
+        // and re-deserializing the same `.tg_index` file a second time.
+        if args.verbose {
+            eprintln!(
+                "[index] loaded cached index: {} files, {} trigrams",
+                loaded.file_count(),
+                loaded.trigram_count()
+            );
+        }
+        loaded
+    } else if index_path.exists() {
         let loaded = match TrigramIndex::load(&index_path) {
             Ok(idx) => idx,
             Err(e) => {
@@ -6496,7 +6560,7 @@ fn handle_index_search(
                     Path::new(request.primary_path()),
                     args.no_ignore,
                 )?;
-                fresh.save(&index_path)?;
+                save_index_locked(&fresh, &index_path, args.verbose);
                 if args.verbose {
                     eprintln!(
                         "[index] full rebuild complete in {:?}: {} files, {} trigrams, {} postings",
@@ -6518,7 +6582,7 @@ fn handle_index_search(
                 Path::new(request.primary_path()),
                 args.no_ignore,
             )?;
-            update.index.save(&index_path)?;
+            save_index_locked(&update.index, &index_path, args.verbose);
             if args.verbose {
                 eprintln!(
                     "[index] incremental update complete in {:?}: reused {} unchanged files, added {}, modified {}, deleted {}; {} files, {} trigrams, {} postings",
@@ -6553,7 +6617,7 @@ fn handle_index_search(
         let started = Instant::now();
         let fresh =
             TrigramIndex::build_with_options(Path::new(request.primary_path()), args.no_ignore)?;
-        fresh.save(&index_path)?;
+        save_index_locked(&fresh, &index_path, args.verbose);
         if args.verbose {
             eprintln!(
                 "[index] full rebuild complete in {:?}: {} files, {} trigrams, {} postings",

--- a/rust_core/tests/test_index_lock_concurrency.rs
+++ b/rust_core/tests/test_index_lock_concurrency.rs
@@ -1,0 +1,458 @@
+//! Cross-process concurrency + crash-safety coverage for audit #138 item #2 (index.json write
+//! is non-atomic + unlocked -> crash-corrupts + concurrent writers lost-update).
+//!
+//! `tg index` as a bare subcommand does not exist in this codebase (verified: no `Commands::Index`
+//! clap variant, no bootstrap/typer routing) -- the real, and only, mechanism that persists the
+//! `.tg_index` trigram index is `tg search --index <pattern> <path>`. Every test below dogfoods
+//! the real compiled `tg` binary (`env!("CARGO_BIN_EXE_tg")`), never `CliRunner`-equivalent
+//! in-process calls, per this repo's "dogfood the real binary" house rule.
+//!
+//! Anti-hang-test-protocol: every subprocess wait in this file is bounded via
+//! `process_control`'s `controlled_with_output().time_limit(..).terminate_for_timeout()`, which
+//! drains stdout/stderr WHILE timing out (a hand-rolled `spawn` + `wait_timeout` deadlocks if the
+//! child fills the OS pipe buffer -- see the identical rationale in `main.rs`'s validation-command
+//! runner). A hang-class regression in the lock therefore fails these tests fast (a clear
+//! `panic!` naming the bound that was exceeded), not by hanging the test run itself.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+use process_control::{ChildExt, Control, Output};
+use serde_json::Value;
+use tempfile::tempdir;
+use tensor_grep_rs::index::TrigramIndex;
+
+fn tg() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_tg"))
+}
+
+/// Bounded wait draining stdout/stderr while timing out -- see the module doc for why a plain
+/// `wait_timeout` is unsafe here. Panics (rather than returning a sentinel) on a real timeout, so
+/// a hang-class regression shows up as an unmissable, immediately-diagnosable test failure.
+fn run_bounded(mut cmd: Command, timeout: Duration) -> Output {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = cmd.spawn().expect("failed to spawn tg");
+    match child
+        .controlled_with_output()
+        .time_limit(timeout)
+        .terminate_for_timeout()
+        .wait()
+    {
+        Ok(Some(output)) => output,
+        Ok(None) => panic!(
+            "tg process exceeded the {timeout:?} bound and was terminated -- this is the exact \
+             hang class audit #138 item #2 must prevent (a lock must never block a search forever)"
+        ),
+        Err(e) => panic!("failed waiting for tg process: {e}"),
+    }
+}
+
+fn write_corpus(dir: &Path) {
+    fs::write(
+        dir.join("a.txt"),
+        "hello world\nfoo bar baz\ngoodbye world\n",
+    )
+    .unwrap();
+    fs::write(dir.join("b.txt"), "nothing here\nhello again friend\nend\n").unwrap();
+}
+
+fn write_wide_corpus(dir: &Path, file_count: usize) {
+    for i in 0..file_count {
+        let mut content = String::new();
+        for line in 0..40 {
+            content.push_str(&format!(
+                "needle0 filler line {i}-{line} filler filler filler filler filler\n"
+            ));
+        }
+        fs::write(dir.join(format!("f{i:04}.txt")), content).unwrap();
+    }
+}
+
+/// Mirrors the private `lock_path_for` in `rust_core/src/index_lock.rs` (dot-prefixed original
+/// name + `.lock` suffix). Duplicated here deliberately -- an integration test only sees the
+/// crate's public API, and if this drifts from the real implementation the tests that use it fail
+/// loudly (lock file never found) rather than silently passing for the wrong reason.
+fn lock_path_for(index_path: &Path) -> PathBuf {
+    let name = index_path.file_name().unwrap().to_str().unwrap();
+    index_path.with_file_name(format!(".{name}.lock"))
+}
+
+fn set_mtime(path: &Path, when: SystemTime) {
+    let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(when))
+        .unwrap();
+}
+
+// -- Hammer: N concurrent writers -----------------------------------------------------------
+
+/// TDD spec: "cross-process HAMMER 15-20 concurrent tg search --index on one root -> exactly 1
+/// writer wins, no corruption, NO invocation hangs." Reads per-acquisition interval files that
+/// `index_lock.rs` writes ONLY when `TG_INDEX_LOCK_DEBUG_LOG_DIR` is set (each file written
+/// exactly once by exactly one process -- no cross-process append race to reason about) for a
+/// DIRECT mutual-exclusion proof, on top of the hard correctness assertions (no hangs, every
+/// process returns the correct match count, the final index is loadable, no lock survives).
+#[test]
+fn hammer_concurrent_tg_search_index_one_writer_at_a_time_no_corruption_no_hangs() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+    let root = dir.path().to_path_buf();
+    let index_path = dir.path().join(".tg_index");
+    let lock_path = lock_path_for(&index_path);
+
+    let debug_dir = tempdir().unwrap();
+    let debug_dir_path = debug_dir.path().to_path_buf();
+
+    const N: usize = 20;
+    // Generous: a cold, unoptimized debug build under CI/hammer load must never be mistaken
+    // for a hang. The lock's own production budget (12s acquire timeout) is a small fraction
+    // of this.
+    let per_process_timeout = Duration::from_secs(90);
+
+    let handles: Vec<_> = (0..N)
+        .map(|_| {
+            let root = root.clone();
+            let debug_dir_path = debug_dir_path.clone();
+            thread::spawn(move || {
+                let mut cmd = tg();
+                cmd.arg("search")
+                    .arg("--index")
+                    .arg("--fixed-strings")
+                    .arg("--json")
+                    .arg("hello")
+                    .arg(&root)
+                    .env("TG_INDEX_LOCK_DEBUG_LOG_DIR", &debug_dir_path);
+                run_bounded(cmd, per_process_timeout)
+            })
+        })
+        .collect();
+
+    let outputs: Vec<Output> = handles
+        .into_iter()
+        .map(|h| h.join().expect("hammer worker thread panicked"))
+        .collect();
+
+    for (i, output) in outputs.iter().enumerate() {
+        assert!(
+            output.status.success(),
+            "process {i} failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("process {i}: non-JSON stdout ({e}): {stdout}"));
+        assert_eq!(
+            json["total_matches"], 2,
+            "process {i} returned the wrong match count (a lost-update or a torn read of the \
+             index would show up here as a wrong/short result set): {stdout}"
+        );
+    }
+
+    assert!(index_path.exists(), "the index must exist after the hammer");
+    TrigramIndex::load(&index_path)
+        .expect("final index must be loadable -- concurrent writers must never corrupt it");
+
+    assert!(
+        !lock_path.exists(),
+        "no lock file should survive after every writer released it"
+    );
+
+    let intervals = read_lock_activity_intervals(&debug_dir_path);
+    assert!(
+        !intervals.is_empty(),
+        "expected at least one of the {N} processes to actually acquire the write lock (the \
+         index did not exist before this test ran)"
+    );
+    assert_no_overlapping_intervals(&intervals);
+}
+
+fn read_lock_activity_intervals(dir: &Path) -> Vec<(u128, u128)> {
+    let mut starts: std::collections::HashMap<String, u128> = std::collections::HashMap::new();
+    let mut ends: std::collections::HashMap<String, u128> = std::collections::HashMap::new();
+    for entry in fs::read_dir(dir).unwrap().filter_map(|e| e.ok()) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let Some((key, suffix)) = name.rsplit_once('.') else {
+            continue;
+        };
+        let value: u128 = fs::read_to_string(entry.path())
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0);
+        match suffix {
+            "start" => {
+                starts.insert(key.to_string(), value);
+            }
+            "end" => {
+                ends.insert(key.to_string(), value);
+            }
+            _ => {}
+        }
+    }
+    let mut intervals: Vec<(u128, u128)> = starts
+        .into_iter()
+        .filter_map(|(key, start)| ends.get(&key).map(|end| (start, *end)))
+        .collect();
+    intervals.sort_unstable();
+    intervals
+}
+
+fn assert_no_overlapping_intervals(intervals: &[(u128, u128)]) {
+    for window in intervals.windows(2) {
+        let (_, end_a) = window[0];
+        let (start_b, _) = window[1];
+        assert!(
+            end_a <= start_b,
+            "overlapping lock-held intervals detected: {:?} then {:?} -- mutual exclusion \
+             violated (two writers held the lock at the same instant)",
+            window[0],
+            window[1]
+        );
+    }
+}
+
+// -- Atomic-crash: a kill mid-write must never leave a torn index ---------------------------
+
+/// TDD spec: "Atomic-crash: a partial write never leaves a corrupt index." Repeatedly starts a
+/// rebuild (by mutating the corpus each iteration so a save is always due) and terminates the
+/// process after a short, jittered delay to sample different points in its lifetime, including
+/// during the write. This is necessarily probabilistic (a black-box CLI test cannot pin the exact
+/// instant of a kill to "mid-rename"), but the guarantee it is checking is NOT probabilistic:
+/// because the destination is only ever touched by one atomic `rename`, `.tg_index` is
+/// structurally guaranteed to be either its pre-attempt content or the fully-written new content
+/// after ANY kill, never a hybrid -- this test samples across many timings to build confidence in
+/// that guarantee empirically, on the real binary.
+#[test]
+fn atomic_crash_kill_mid_rebuild_never_leaves_a_torn_index_file() {
+    let dir = tempdir().unwrap();
+    write_wide_corpus(dir.path(), 300);
+    let index_path = dir.path().join(".tg_index");
+
+    let baseline = run_bounded(
+        {
+            let mut cmd = tg();
+            cmd.arg("search")
+                .arg("--index")
+                .arg("--fixed-strings")
+                .arg("--count")
+                .arg("needle0")
+                .arg(dir.path());
+            cmd
+        },
+        Duration::from_secs(60),
+    );
+    assert!(
+        baseline.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&baseline.stderr)
+    );
+    assert!(index_path.exists());
+    TrigramIndex::load(&index_path).expect("baseline index must be valid");
+
+    for attempt in 0..8u64 {
+        fs::write(
+            dir.path().join(format!("mutate_{attempt}.txt")),
+            "needle0 fresh addition\n",
+        )
+        .unwrap();
+
+        let mut cmd = tg();
+        cmd.arg("search")
+            .arg("--index")
+            .arg("--fixed-strings")
+            .arg("--count")
+            .arg("needle0")
+            .arg(dir.path());
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = cmd.spawn().expect("failed to spawn tg");
+
+        // A short, jittered time limit: process_control terminates the child once this
+        // elapses, sampling a different point in the process's lifetime each iteration
+        // (including, on some iterations, mid-write) without a separate manual kill()+reap.
+        let short_bound = Duration::from_millis(3 + attempt * 6);
+        match child
+            .controlled_with_output()
+            .time_limit(short_bound)
+            .terminate_for_timeout()
+            .wait()
+        {
+            Ok(_) => {}
+            Err(e) => panic!("attempt {attempt}: failed to reap the terminated child: {e}"),
+        }
+
+        if index_path.exists() {
+            TrigramIndex::load(&index_path).unwrap_or_else(|e| {
+                panic!(
+                    "attempt {attempt}: .tg_index exists but failed to load after a kill \
+                     mid-run -- this is a torn/corrupt write, exactly what atomic save must \
+                     prevent: {e}"
+                )
+            });
+        }
+    }
+
+    // Sanity: a final, uninterrupted run must still succeed and see every mutation (proves the
+    // repeated kills above never wedged the corpus/index into an unrecoverable state).
+    let final_run = run_bounded(
+        {
+            let mut cmd = tg();
+            cmd.arg("search")
+                .arg("--index")
+                .arg("--fixed-strings")
+                .arg("--verbose")
+                .arg("--count")
+                .arg("needle0")
+                .arg(dir.path());
+            cmd
+        },
+        Duration::from_secs(60),
+    );
+    assert!(
+        final_run.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&final_run.stderr)
+    );
+}
+
+// -- Lock-timeout: a held (heartbeating) lock must never fail the search --------------------
+
+/// TDD spec: "Lock-timeout: a held lock -> 2nd writer builds-in-memory+warns+returns CORRECT
+/// results (no hang/error)." Simulates a concurrent external writer by creating the lock file
+/// ourselves and heartbeating its mtime for the whole window, so the competing `tg` process must
+/// genuinely exhaust its production 12s acquire timeout rather than stale-reclaim early --
+/// distinguishing THIS test from the stale-reclaim test below.
+#[test]
+fn lock_held_and_heartbeating_causes_tg_to_skip_persistence_but_still_return_correct_results() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+    let index_path = dir.path().join(".tg_index");
+    let lock_path = lock_path_for(&index_path);
+
+    fs::write(
+        &lock_path,
+        format!("{}\nsimulated-external-holder\n", std::process::id()),
+    )
+    .unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let hb_lock_path = lock_path.clone();
+    let hb_stop = Arc::clone(&stop);
+    let heartbeat = thread::spawn(move || {
+        while !hb_stop.load(Ordering::SeqCst) {
+            set_mtime(&hb_lock_path, SystemTime::now());
+            thread::sleep(Duration::from_millis(400));
+        }
+    });
+
+    let mut cmd = tg();
+    cmd.arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("--verbose")
+        .arg("hello")
+        .arg(dir.path());
+
+    let started = Instant::now();
+    // Bounded generously past the ~12s production timeout: a genuine timeout is a normal,
+    // fast-ish completion here, not a hang -- 45s only guards against an ACTUAL regression.
+    let output = run_bounded(cmd, Duration::from_secs(45));
+    let elapsed = started.elapsed();
+
+    stop.store(true, Ordering::SeqCst);
+    heartbeat.join().unwrap();
+    let _ = fs::remove_file(&lock_path);
+
+    assert!(
+        output.status.success(),
+        "search must still succeed even though persistence was skipped; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello world") && stdout.contains("hello again"),
+        "a lock-acquire timeout must still return CORRECT results from the in-memory index, \
+         not an error or empty output: stdout={stdout}"
+    );
+
+    // Proves this genuinely exercised the TIMEOUT path (H9: timeout=12s > stale=10s), not an
+    // early stale-reclaim -- our heartbeat kept the lock's mtime fresh the whole time.
+    assert!(
+        elapsed >= Duration::from_secs(10),
+        "expected tg to wait out close to the full ~12s acquire timeout, got {elapsed:?} \
+         (looks like it stale-reclaimed our heartbeating lock instead)"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(
+        stderr.contains("lock") || stderr.contains("skip"),
+        "expected a persistence-skip warning naming the lock contention: stderr={stderr}"
+    );
+
+    assert!(
+        !index_path.exists(),
+        "a lock-acquire timeout must SKIP persistence, not write anyway (our simulated holder \
+         still 'owned' the file for the entire window)"
+    );
+}
+
+// -- Stale-reclaim: an abandoned lock must not be waited out --------------------------------
+
+/// TDD spec: "Stale-reclaim: an abandoned lock (age>10s) reclaimed." A lock with no heartbeat,
+/// backdated well past the 10s production stale threshold, must be reclaimed promptly by the
+/// next writer -- proven by wall-clock: reclaim must be far faster than the 12s acquire timeout
+/// (the exact H9 property: a fresh-but-dead lock is always reclaimed before any waiter's deadline
+/// can expire, so this never degrades into the lock-timeout test above).
+#[test]
+fn tg_search_index_reclaims_an_abandoned_stale_lock_without_waiting_out_the_full_timeout() {
+    let dir = tempdir().unwrap();
+    write_corpus(dir.path());
+    let index_path = dir.path().join(".tg_index");
+    let lock_path = lock_path_for(&index_path);
+
+    fs::write(&lock_path, "999999\ndeadtoken-no-heartbeat\n").unwrap();
+    set_mtime(&lock_path, SystemTime::now() - Duration::from_secs(30));
+
+    let mut cmd = tg();
+    cmd.arg("search")
+        .arg("--index")
+        .arg("--fixed-strings")
+        .arg("hello")
+        .arg(dir.path());
+
+    let started = Instant::now();
+    let output = run_bounded(cmd, Duration::from_secs(30));
+    let elapsed = started.elapsed();
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("hello world") && stdout.contains("hello again"),
+        "stdout={stdout}"
+    );
+
+    assert!(
+        elapsed < Duration::from_secs(8),
+        "expected a near-immediate stale-lock reclaim (well under the 12s timeout), took \
+         {elapsed:?} -- looks like it waited out the full timeout instead of reclaiming"
+    );
+
+    assert!(
+        index_path.exists(),
+        "the reclaiming writer must have persisted the index"
+    );
+    assert!(
+        !lock_path.exists(),
+        "the reclaiming writer's own lock must be released after it completes"
+    );
+}


### PR DESCRIPTION
External-audit #138 item #2 (re-fired after the session-limit death). Non-atomic + unlocked index.json -> crash-corrupts + concurrent-writer lost-update. New rust_core/src/index_lock.rs (624L, mirrors _index_lock.py: O_EXCL, pid+token, stale>10s reclaim, acquire-timeout 12s>stale=H9 compile-assert, heartbeat); atomic save via temp->fsync->rename+Windows-retry (index.rs); WRITE-only lock, readers lock-free (grep-verified: guard only in save_index_locked, never in detect_warm_index_state/load); on timeout -> build-in-memory+warn+skip-persist (Fail-Closed governs results not cache); load-once (detect_warm_index_state -> Option<TrigramIndex>). HAMMER: 20 concurrent --index, mutual-exclusion DIRECTLY proven (non-overlapping interval logs), no corruption/hang/surviving-lock. cargo check(+cuda)/fmt/clippy/test all green (80+42+81+100+4 new). TDD caught a real condvar lost-wakeup race pre-ship. Opus index_lock gate pending.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>