### PR TITLE
fix(lang): iterative Go AST walk (stop RecursionError command crash) + annotation ref-kind + registry governance (#63)

### DIFF
--- a/src/tensor_grep/cli/lang_go.py
+++ b/src/tensor_grep/cli/lang_go.py
@@ -222,81 +222,87 @@ def go_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]
     imports: list[str] = []
     symbols: list[dict[str, Any]] = []
 
-    def _walk(node: Any) -> None:
-        node_type = node.type
-        if node_type == "import_spec":
-            path_field = node.child_by_field_name("path")
-            import_path_text = _go_import_spec_path_text(path_field, source_bytes)
-            if import_path_text is not None:
-                imports.append(import_path_text)
-        elif node_type == "function_declaration":
-            name_node = node.child_by_field_name("name")
-            if name_node is not None:
-                name = _node_text(name_node)
-                if _is_clean_symbol_name(name):
-                    symbols.append(
-                        _symbol_record(
+    def _walk(root: Any) -> None:
+        # F26 fix (audit #63): explicit-stack DFS instead of recursion, so a pathologically
+        # deep AST can never raise RecursionError (matches the ast_backend.py B3 precedent:
+        # `AstBackend._build_node_type_index`). Children are pushed in reverse so the leftmost
+        # child is popped (and thus visited) first, preserving the original pre-order traversal.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "import_spec":
+                path_field = node.child_by_field_name("path")
+                import_path_text = _go_import_spec_path_text(path_field, source_bytes)
+                if import_path_text is not None:
+                    imports.append(import_path_text)
+            elif node_type == "function_declaration":
+                name_node = node.child_by_field_name("name")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type == "method_declaration":
+                name_node = node.child_by_field_name("name")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        record = _symbol_record(
                             name=name,
-                            kind="function",
+                            kind="method",
                             file=path,
                             start_line=node.start_point[0] + 1,
                             end_line=node.end_point[0] + 1,
                         )
-                    )
-        elif node_type == "method_declaration":
-            name_node = node.child_by_field_name("name")
-            if name_node is not None:
-                name = _node_text(name_node)
-                if _is_clean_symbol_name(name):
-                    record = _symbol_record(
-                        name=name,
-                        kind="method",
-                        file=path,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
-                    )
-                    receiver_type = _go_receiver_type_name(node, source_bytes)
-                    if receiver_type:
-                        record["receiver_type"] = receiver_type
-                    symbols.append(record)
-        elif node_type == "type_spec":
-            name_node = node.child_by_field_name("name")
-            type_node = node.child_by_field_name("type")
-            if name_node is not None:
-                name = _node_text(name_node)
-                if _is_clean_symbol_name(name):
-                    kind = _GO_TYPE_SPEC_KIND_BY_TYPE_FIELD.get(
-                        type_node.type if type_node is not None else "", "type"
-                    )
-                    symbols.append(
-                        _symbol_record(
-                            name=name,
-                            kind=kind,
-                            file=path,
-                            start_line=node.start_point[0] + 1,
-                            end_line=node.end_point[0] + 1,
+                        receiver_type = _go_receiver_type_name(node, source_bytes)
+                        if receiver_type:
+                            record["receiver_type"] = receiver_type
+                        symbols.append(record)
+            elif node_type == "type_spec":
+                name_node = node.child_by_field_name("name")
+                type_node = node.child_by_field_name("type")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        kind = _GO_TYPE_SPEC_KIND_BY_TYPE_FIELD.get(
+                            type_node.type if type_node is not None else "", "type"
                         )
-                    )
-        elif node_type in {"const_spec", "var_spec"} and not _node_has_ancestor_type(
-            node, {"block"}
-        ):
-            kind = "const" if node_type == "const_spec" else "var"
-            for name_node in node.children_by_field_name("name"):
-                if name_node.type != "identifier":
-                    continue
-                name = _node_text(name_node)
-                if _is_clean_symbol_name(name):
-                    symbols.append(
-                        _symbol_record(
-                            name=name,
-                            kind=kind,
-                            file=path,
-                            start_line=node.start_point[0] + 1,
-                            end_line=node.end_point[0] + 1,
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind=kind,
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
                         )
-                    )
-        for child in node.children:
-            _walk(child)
+            elif node_type in {"const_spec", "var_spec"} and not _node_has_ancestor_type(
+                node, {"block"}
+            ):
+                kind = "const" if node_type == "const_spec" else "var"
+                for name_node in node.children_by_field_name("name"):
+                    if name_node.type != "identifier":
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind=kind,
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            stack.extend(reversed(node.children))
 
     _walk(tree.root_node)
     imports = sorted(dict.fromkeys(imports))
@@ -326,36 +332,40 @@ def go_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
     def _node_text(node: Any) -> str:
         return _tree_sitter_node_text(source_bytes, node)
 
-    def _walk(node: Any) -> None:
-        node_type = node.type
-        name_node: Any | None = None
-        kind: str | None = None
-        if node_type == "function_declaration":
-            name_node = node.child_by_field_name("name")
-            kind = "function"
-        elif node_type == "method_declaration":
-            name_node = node.child_by_field_name("name")
-            kind = "method"
-        elif node_type == "type_spec":
-            name_node = node.child_by_field_name("name")
-            type_node = node.child_by_field_name("type")
-            kind = _GO_TYPE_SPEC_KIND_BY_TYPE_FIELD.get(
-                type_node.type if type_node is not None else "", "type"
-            )
-        if name_node is not None and kind is not None and _node_text(name_node) == symbol:
-            block = _node_text(node)
-            if block and not block.endswith("\n"):
-                block = f"{block}\n"
-            sources.append({
-                "name": symbol,
-                "kind": kind,
-                "file": str(path),
-                "start_line": node.start_point[0] + 1,
-                "end_line": node.end_point[0] + 1,
-                "source": block,
-            })
-        for child in node.children:
-            _walk(child)
+    def _walk(root: Any) -> None:
+        # F26 fix (audit #63): explicit-stack DFS instead of recursion -- see the identical
+        # comment on go_imports_and_symbols's `_walk` above for the rationale/precedent.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            name_node: Any | None = None
+            kind: str | None = None
+            if node_type == "function_declaration":
+                name_node = node.child_by_field_name("name")
+                kind = "function"
+            elif node_type == "method_declaration":
+                name_node = node.child_by_field_name("name")
+                kind = "method"
+            elif node_type == "type_spec":
+                name_node = node.child_by_field_name("name")
+                type_node = node.child_by_field_name("type")
+                kind = _GO_TYPE_SPEC_KIND_BY_TYPE_FIELD.get(
+                    type_node.type if type_node is not None else "", "type"
+                )
+            if name_node is not None and kind is not None and _node_text(name_node) == symbol:
+                block = _node_text(node)
+                if block and not block.endswith("\n"):
+                    block = f"{block}\n"
+                sources.append({
+                    "name": symbol,
+                    "kind": kind,
+                    "file": str(path),
+                    "start_line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                    "source": block,
+                })
+            stack.extend(reversed(node.children))
 
     _walk(tree.root_node)
     sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
@@ -510,30 +520,38 @@ def _go_import_bindings(source_bytes: bytes, tree: Any) -> list[dict[str, Any]]:
     """Every ``import_spec`` in *tree*: ``{"path", "alias", "dot", "blank"}``."""
     bindings: list[dict[str, Any]] = []
 
-    def _walk(node: Any) -> None:
-        if node.type == "import_spec":
-            path_field = node.child_by_field_name("path")
-            name_field = node.child_by_field_name("name")
-            import_path_text = _go_import_spec_path_text(path_field, source_bytes)
-            if import_path_text is not None:
-                alias: str | None = None
-                dot = False
-                blank = False
-                if name_field is not None:
-                    if name_field.type == "package_identifier":
-                        alias = _tree_sitter_node_text(source_bytes, name_field)
-                    elif name_field.type == "dot":
-                        dot = True
-                    elif name_field.type == "blank_identifier":
-                        blank = True
-                bindings.append({
-                    "path": import_path_text,
-                    "alias": alias,
-                    "dot": dot,
-                    "blank": blank,
-                })
-        for child in node.children:
-            _walk(child)
+    def _walk(root: Any) -> None:
+        # F26 fix (audit #63): explicit-stack DFS instead of recursion -- see the identical
+        # comment on go_imports_and_symbols's `_walk` (above, this module) for the rationale/
+        # precedent. Order preservation matters MORE here than in the other three walkers: unlike
+        # them, `bindings` is never re-sorted by its caller (`_go_alias_to_import_path` folds it
+        # into a dict in traversal order) -- pushing children in reverse and popping from the end
+        # keeps this an exact pre-order DFS, byte-identical visiting order to the old recursion.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == "import_spec":
+                path_field = node.child_by_field_name("path")
+                name_field = node.child_by_field_name("name")
+                import_path_text = _go_import_spec_path_text(path_field, source_bytes)
+                if import_path_text is not None:
+                    alias: str | None = None
+                    dot = False
+                    blank = False
+                    if name_field is not None:
+                        if name_field.type == "package_identifier":
+                            alias = _tree_sitter_node_text(source_bytes, name_field)
+                        elif name_field.type == "dot":
+                            dot = True
+                        elif name_field.type == "blank_identifier":
+                            blank = True
+                    bindings.append({
+                        "path": import_path_text,
+                        "alias": alias,
+                        "dot": dot,
+                        "blank": blank,
+                    })
+            stack.extend(reversed(node.children))
 
     _walk(tree.root_node)
     return bindings
@@ -694,7 +712,14 @@ def go_references_and_calls(
 
     source_bytes = source.encode("utf-8")
     tree = parser.parse(source_bytes)
-    lines = source.splitlines()
+    # F26 fix (audit #63): tree-sitter's row counting (`node.start_point[0]`) advances only on
+    # "\n", but `str.splitlines()` ALSO splits on "\r", "\v"/"\x0b", "\f"/"\x0c", "\x1c"-"\x1e",
+    # "\x85", U+2028 and U+2029 -- a single stray form-feed (or any of those other separators)
+    # anywhere in the source injects an EXTRA entry into a splitlines()-based array, shifting
+    # every row-indexed `text` lookup below it out of alignment with tree-sitter's own rows.
+    # Split strictly on "\n" (matching tree-sitter's row semantics) and strip a trailing "\r"
+    # per line so CRLF-terminated files still read cleanly.
+    lines = [line.rstrip("\r") for line in source.split("\n")]
     references: list[dict[str, Any]] = []
     calls: list[dict[str, Any]] = []
 
@@ -764,79 +789,87 @@ def go_references_and_calls(
             entry["resolution_confidence"] = float(resolution.get("confidence", 0.95))
         bucket.append(entry)
 
-    def _walk(node: Any) -> None:
-        node_type = node.type
-        node_text = (
-            _node_text(node)
-            if node_type in {"identifier", "type_identifier", "field_identifier"}
-            else ""
-        )
-        if (
-            node_type == "identifier"
-            and node_text == symbol
-            and not _is_definition_identifier(node)
-        ):
-            parent = node.parent
+    def _walk(root: Any) -> None:
+        # F26 fix (audit #63): explicit-stack DFS instead of recursion -- see the
+        # identical comment on go_imports_and_symbols's `_walk` (above, this module) for
+        # the rationale/precedent. This is the walker invoked BARE at repo_map.py:14613
+        # (build_symbol_refs) and :15339 (build_symbol_callers) -- the highest-priority
+        # crash site the audit finding names.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            node_text = (
+                _node_text(node)
+                if node_type in {"identifier", "type_identifier", "field_identifier"}
+                else ""
+            )
             if (
-                parent is not None
-                and parent.type == "call_expression"
-                and parent.child_by_field_name("function") == node
+                node_type == "identifier"
+                and node_text == symbol
+                and not _is_definition_identifier(node)
             ):
-                _emit(references, node, kind="reference", ref_kind="call", resolution=None)
-                _emit(calls, node, kind="call", ref_kind="call", resolution=None)
-            else:
-                _emit(references, node, kind="reference", ref_kind="value", resolution=None)
-        elif (
-            node_type == "type_identifier"
-            and node_text == symbol
-            and not _is_definition_identifier(node)
-        ):
-            _emit(references, node, kind="reference", ref_kind="type", resolution=None)
-        elif (
-            node_type == "field_identifier"
-            and node_text == symbol
-            and not _is_definition_identifier(node)
-        ):
-            parent = node.parent
-            if parent is not None and parent.type == "selector_expression":
-                field_node = parent.child_by_field_name("field")
-                if field_node is not None and field_node == node:
-                    operand_node = parent.child_by_field_name("operand")
-                    operand_name = (
-                        _node_text(operand_node)
-                        if operand_node is not None and operand_node.type == "identifier"
-                        else None
-                    )
-                    package_resolution = _resolution_for_package(operand_name)
-                    grandparent = getattr(parent, "parent", None)
-                    is_call = (
-                        grandparent is not None
-                        and grandparent.type == "call_expression"
-                        and grandparent.child_by_field_name("function") == parent
-                    )
-                    if is_call:
-                        resolution = _confident_call_resolution(package_resolution)
-                        _emit(
-                            references,
-                            node,
-                            kind="reference",
-                            ref_kind="call",
-                            resolution=resolution,
+                parent = node.parent
+                if (
+                    parent is not None
+                    and parent.type == "call_expression"
+                    and parent.child_by_field_name("function") == node
+                ):
+                    _emit(references, node, kind="reference", ref_kind="call", resolution=None)
+                    _emit(calls, node, kind="call", ref_kind="call", resolution=None)
+                else:
+                    _emit(references, node, kind="reference", ref_kind="value", resolution=None)
+            elif (
+                node_type == "type_identifier"
+                and node_text == symbol
+                and not _is_definition_identifier(node)
+            ):
+                _emit(references, node, kind="reference", ref_kind="type", resolution=None)
+            elif (
+                node_type == "field_identifier"
+                and node_text == symbol
+                and not _is_definition_identifier(node)
+            ):
+                parent = node.parent
+                if parent is not None and parent.type == "selector_expression":
+                    field_node = parent.child_by_field_name("field")
+                    if field_node is not None and field_node == node:
+                        operand_node = parent.child_by_field_name("operand")
+                        operand_name = (
+                            _node_text(operand_node)
+                            if operand_node is not None and operand_node.type == "identifier"
+                            else None
                         )
-                        _emit(calls, node, kind="call", ref_kind="call", resolution=resolution)
-                    else:
-                        # F9 fix: a package-qualified non-call selector (`config.DefaultTimeout`)
-                        # is a VALUE read (const/var), not a struct FIELD access -- only a
-                        # genuinely unresolved operand (a real struct field access) stays "field".
-                        _emit(
-                            references,
-                            node,
-                            kind="reference",
-                            ref_kind="value" if package_resolution is not None else "field",
-                            resolution=package_resolution,
+                        package_resolution = _resolution_for_package(operand_name)
+                        grandparent = getattr(parent, "parent", None)
+                        is_call = (
+                            grandparent is not None
+                            and grandparent.type == "call_expression"
+                            and grandparent.child_by_field_name("function") == parent
                         )
-        for child in node.children:
-            _walk(child)
+                        if is_call:
+                            resolution = _confident_call_resolution(package_resolution)
+                            _emit(
+                                references,
+                                node,
+                                kind="reference",
+                                ref_kind="call",
+                                resolution=resolution,
+                            )
+                            _emit(calls, node, kind="call", ref_kind="call", resolution=resolution)
+                        else:
+                            # F9 fix: a package-qualified non-call selector
+                            # (`config.DefaultTimeout`) is a VALUE read (const/var), not a struct
+                            # FIELD access -- only a genuinely unresolved operand (a real struct
+                            # field access) stays "field".
+                            _emit(
+                                references,
+                                node,
+                                kind="reference",
+                                ref_kind="value" if package_resolution is not None else "field",
+                                resolution=package_resolution,
+                            )
+            stack.extend(reversed(node.children))
 
     _walk(tree.root_node)
     references.sort(key=lambda item: (item["file"], item["line"], item["text"]))

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4381,7 +4381,15 @@ def _python_references_and_calls(
                 })
 
         for field_name, value in ast.iter_fields(node):
-            child_in_annotation = in_annotation or field_name in ("annotation", "returns")
+            if isinstance(node, ast.Call) and field_name in ("args", "keywords"):
+                # F19 fix (audit #63): a Call's arguments are runtime VALUES, not type syntax,
+                # even when the call itself sits inside a type-annotation subtree (e.g.
+                # `Annotated[int, validate(LIMIT)]`) -- only the callee should keep the
+                # enclosing annotation context, and that's moot anyway since the parent-is-Call
+                # precedence above always wins for the callee regardless of in_annotation.
+                child_in_annotation = False
+            else:
+                child_in_annotation = in_annotation or field_name in ("annotation", "returns")
             if isinstance(value, list):
                 for item in value:
                     if isinstance(item, ast.AST):

--- a/tests/unit/test_lang_go.py
+++ b/tests/unit/test_lang_go.py
@@ -26,6 +26,7 @@ used to verify:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -675,3 +676,125 @@ def test_nested_go_mod_boundary_stops_import_resolution(tmp_path: Path) -> None:
     # Before the F24 fix this greedily resolved to <root>/toolsmod/sub via the ROOT module's own
     # prefix, silently treating a separate nested module's directory as part of the parent.
     assert target_dir is None
+
+
+# ---------------------------------------------------------------------------
+# F26: splitlines() vs tree-sitter row semantics -- a stray form-feed shifts every `text` below.
+# ---------------------------------------------------------------------------
+
+
+def test_go_reference_text_survives_form_feed_in_a_comment(tmp_path: Path) -> None:
+    """F26 (audit #63): `_line_text`'s row-indexed lookup (lang_go.py:697/:707-709) used
+    ``source.splitlines()`` for the row-indexed `text` array, but tree-sitter's OWN row
+    counting (``node.start_point[0]``) only advances on ``\\n``. ``str.splitlines()`` ALSO
+    splits on ``\\r``, ``\\v``/``\\x0b``, ``\\f``/``\\x0c``, ``\\x1c``-``\\x1e``, ``\\x85``,
+    U+2028 and U+2029 -- so a single stray form-feed inside a comment injects one EXTRA entry
+    into the splitlines()-based array, shifting the row-indexed `text` lookup for every node
+    below it by one line out of alignment with tree-sitter's own row count.
+    """
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text("module example.com/ffmod\n\ngo 1.21\n", encoding="utf-8")
+    ff_go = tmp_path / "ff.go"
+    ff_go.write_text(
+        "package main\n"
+        "\n"
+        "// leading\x0ccomment\n"
+        "func Target() int {\n"
+        "\treturn 1\n"
+        "}\n"
+        "\n"
+        "func caller() int {\n"
+        "\treturn Target()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    refs, calls = lang_go.go_references_and_calls(ff_go, "Target")
+
+    assert len(refs) == 1
+    # Before the F26 fix this read "func caller() int {" -- the WRONG line, shifted by exactly
+    # the one extra split the \f comment injected above it.
+    assert refs[0]["line"] == 9
+    assert refs[0]["text"] == "\treturn Target()"
+    assert refs[0]["kind"] == "reference"
+
+    assert len(calls) == 1
+    assert calls[0]["line"] == 9
+    assert calls[0]["text"] == "\treturn Target()"
+    assert calls[0]["kind"] == "call"
+
+
+# ---------------------------------------------------------------------------
+# F26: unbounded recursive `_walk` -- a pathologically deep AST must not raise RecursionError.
+# ---------------------------------------------------------------------------
+
+
+def _deep_nested_go_source(depth: int) -> str:
+    """Syntactically valid Go whose parse tree is *depth* levels deep: redundant parens around
+    a literal (tree-sitter accepts arbitrarily nested ``parenthesized_expression`` the same way
+    the Go compiler does), inside an exported function body."""
+    return (
+        "package main\n\nfunc Target() int {\n\treturn "
+        + ("(" * depth)
+        + "1"
+        + (")" * depth)
+        + "\n}\n"
+    )
+
+
+def test_go_walkers_survive_pathologically_deep_ast_without_recursion_error(
+    tmp_path: Path,
+) -> None:
+    """F26 (audit #63, CRASH -- highest priority): all four of lang_go.py's `_walk` functions
+    (``go_imports_and_symbols`` :225, ``go_parser_symbol_sources`` :329, ``_go_import_bindings``
+    :513, ``go_references_and_calls`` :767) recursed one Python stack frame per AST node depth
+    with no bound -- a deeply-nested but syntactically VALID Go file raised an uncaught
+    ``RecursionError``. ``go_references_and_calls`` is invoked BARE (no try/except) at
+    repo_map.py:14613 (``build_symbol_refs``) and :15339 (``build_symbol_callers``), so this used
+    to crash the WHOLE ``tg refs``/``tg callers`` command instead of a graceful degrade.
+
+    Depth matches the established ``ast_backend.py`` B3 precedent
+    (``sys.getrecursionlimit() + 500``, `tests/unit/test_backend_bug_fixes.py`) -- deep enough to
+    exceed the default 1000-frame limit, bounded enough to stay fast (anti-hang protocol: no
+    unbounded loop/subprocess, a fixed small fixture, single-process, no timeout wrapper needed
+    since a RecursionError raises in well under a second, verified empirically before writing
+    this test).
+    """
+    depth = sys.getrecursionlimit() + 500
+    go_mod = tmp_path / "go.mod"
+    go_mod.write_text("module example.com/deepmod\n\ngo 1.21\n", encoding="utf-8")
+    deep_go = tmp_path / "deep.go"
+    deep_go.write_text(_deep_nested_go_source(depth), encoding="utf-8")
+
+    # go_imports_and_symbols (lang_go.py:225).
+    imports, symbols = lang_go.go_imports_and_symbols(deep_go)
+    assert imports == []
+    assert any(s["name"] == "Target" and s["kind"] == "function" for s in symbols)
+
+    # go_parser_symbol_sources (lang_go.py:329).
+    sources = lang_go.go_parser_symbol_sources(deep_go, "Target")
+    assert len(sources) == 1
+    assert sources[0]["kind"] == "function"
+
+    # _go_import_bindings (lang_go.py:513) -- private helper, exercised directly like the
+    # existing F11 tests above already do for its sibling helpers.
+    parser = lang_go._go_parser()
+    assert parser is not None
+    source_bytes = deep_go.read_text(encoding="utf-8").encode("utf-8")
+    tree = parser.parse(source_bytes)
+    bindings = lang_go._go_import_bindings(source_bytes, tree)
+    assert bindings == []
+
+    # go_references_and_calls (lang_go.py:767) -- the function invoked BARE at
+    # repo_map.py:14613/:15339.
+    refs, calls = lang_go.go_references_and_calls(deep_go, "Target")
+    assert refs == []
+    assert calls == []
+
+    # And the actual repo_map.py entry points that call it bare -- confirms the fix closes the
+    # crash at the REAL call sites the audit finding names, not just the lower-level function.
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    assert not refs_payload.get("no_match")
+    assert refs_payload["references"] == []
+    callers_payload = repo_map.build_symbol_callers("Target", tmp_path)
+    assert callers_payload["callers"] == []

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -84,6 +84,40 @@ def test_language_registry_has_exactly_the_stage1_languages() -> None:
     }
 
 
+def test_target_and_provider_language_agree_with_registry() -> None:
+    """F22 (audit #63 LOW tail): `_target_language_for_path` (repo_map.py:6475-6494) and
+    `_provider_language_for_path` (repo_map.py:13018+) each still carry their OWN hardcoded
+    suffix dispatch instead of routing through `lang_registry` -- the "MOST-FORGOTTEN seam"
+    the code comments itself warn about (repo_map.py:6489-6493: miss the teach on either
+    function and the agent capsule's query-language-vs-target-language 0.55 confidence cap
+    silently misfires on the new language). `test_graph_suffixes_matches_the_historical_
+    hardcoded_union` above pins only the suffix UNION; it says nothing about whether each
+    suffix maps to the SAME language id in all three places.
+
+    Parametrize DYNAMICALLY over `lang_registry.LANGUAGE_REGISTRY` (never a hardcoded suffix
+    list, which would itself be exactly the kind of thing that drifts) so this is a ratchet
+    against the NEXT language expansion (the #62 CEO fork), not just a snapshot of today's
+    five languages: it fails loudly the moment a new `LanguageSpec` is registered without
+    teaching both dispatch functions, instead of the new language silently reading as "no
+    target language" / "no provider language".
+    """
+    assert lang_registry.LANGUAGE_REGISTRY, (
+        "registry must be non-empty for this test to mean anything"
+    )
+    for spec in lang_registry.LANGUAGE_REGISTRY.values():
+        assert spec.suffixes, f"{spec.language_id!r} has no suffixes to check"
+        for suffix in spec.suffixes:
+            path = f"example{suffix}"
+            assert repo_map._target_language_for_path(path) == spec.language_id, (
+                f"_target_language_for_path disagrees with lang_registry for suffix {suffix!r}: "
+                f"registry says {spec.language_id!r}"
+            )
+            assert repo_map._provider_language_for_path(path) == spec.language_id, (
+                f"_provider_language_for_path disagrees with lang_registry for suffix {suffix!r}: "
+                f"registry says {spec.language_id!r}"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Provenance labeling (parsed vs missing-grammar)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_typed_ref_kinds.py
+++ b/tests/unit/test_typed_ref_kinds.py
@@ -418,6 +418,82 @@ def test_rust_classifier_exception_defaults_to_value_without_dropping_rows(
 
 
 # ---------------------------------------------------------------------------
+# F19: a Call's arguments inside a type annotation are VALUES, not type syntax.
+# ---------------------------------------------------------------------------
+
+
+def test_python_call_argument_inside_annotation_is_not_mislabeled_type(tmp_path: Path) -> None:
+    """F19 (audit #63): `_walk` propagates `in_annotation` into every child field, including an
+    `ast.Call`'s `args`/`keywords` (repo_map.py:4383-4390) -- so a runtime-value argument passed
+    to a call INSIDE a type annotation (e.g. ``Annotated[Head, validate(Symbol)]``) mislabeled
+    the argument ref_kind "type" (it is a plain VALUE read, not type syntax) purely because the
+    call happens to sit inside an annotation subtree. The callee (``validate``) and the
+    annotation's own head (``AnnotationHead``) are both unaffected -- the parent-Call precedence
+    (repo_map.py:4320-4321) already wins for the callee regardless of in_annotation, and the fix
+    only resets in_annotation for a Call's OWN args/keywords fields, not Annotated's slice.
+    """
+    mod_path = tmp_path / "mod.py"
+    mod_path.write_text(
+        "class Symbol:\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "class AnnotationHead:\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "def validate(value):\n"
+        "    return value\n",
+        encoding="utf-8",
+    )
+    use_path = tmp_path / "use.py"
+    use_path.write_text(
+        "from typing import Annotated\n"
+        "\n"
+        "from mod import AnnotationHead, Symbol, validate\n"
+        "\n"
+        "\n"
+        "def plain_annotation(y: Symbol) -> None:\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "def f(x: Annotated[AnnotationHead, validate(Symbol)]) -> None:\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    symbol_payload = repo_map.build_symbol_refs("Symbol", tmp_path)
+    symbol_refs = {
+        row["line"]: row
+        for row in symbol_payload["references"]
+        if row["file"] == str(use_path.resolve())
+    }
+    # Row-count invariant (the #422 zero-count-change rule governing this whole tail PR): the
+    # fix only relabels ref_kind, it must never add/remove a reference row.
+    assert len(symbol_refs) == 2
+    assert symbol_refs[6]["ref_kind"] == "type"  # def plain_annotation(y: Symbol) -> None:
+    # Before the F19 fix this was "type" -- Symbol here is a call ARGUMENT, not type syntax,
+    # even though `validate(Symbol)` sits inside `Annotated[...]`'s type-annotation subtree.
+    assert symbol_refs[10]["ref_kind"] == "value"  # ...Annotated[AnnotationHead, validate(Symbol)]
+
+    validate_payload = repo_map.build_symbol_refs("validate", tmp_path)
+    validate_refs = [
+        row for row in validate_payload["references"] if row["file"] == str(use_path.resolve())
+    ]
+    assert len(validate_refs) == 1
+    assert validate_refs[0]["ref_kind"] == "call"  # the callee keeps "call" -- untouched by F19.
+
+    head_payload = repo_map.build_symbol_refs("AnnotationHead", tmp_path)
+    head_refs = [
+        row for row in head_payload["references"] if row["file"] == str(use_path.resolve())
+    ]
+    assert len(head_refs) == 1
+    # Annotated's own first arg (the actual annotation head) stays "type" -- only a Call's
+    # args/keywords reset in_annotation, not Annotated's subscript slice itself.
+    assert head_refs[0]["ref_kind"] == "type"
+
+
+# ---------------------------------------------------------------------------
 # F21: `_reference_kind_counts` must count non-dict rows too (sum == len invariant).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Backlog-100 #63 F19/F22/F26. **F26 (crash):** the 4 unbounded recursive Go `_walk`s (invoked bare at repo_map.py:14613/:15339) -> RecursionError crashed the whole `tg refs`/`callers` command on deep ASTs; converted to iterative DFS (ast_backend precedent) + fixed the splitlines-vs-tree-sitter-row mismatch. Repro: before=exit1 empty-stdout+traceback, after=exit0 correct JSON. **F19:** in_annotation resets in ast.Call args -> correct ref_kind. **F22:** governance test pinning _target/_provider_language_for_path <-> registry agreement. 4-gate green (199 tests). Gate-free.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>