### PR TITLE
feat(classify): add tg classify --stdin / --text literal mode for log-streaming agents (#92)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -863,8 +863,16 @@ pub struct ClassifyArgs {
     #[arg(long = "max-lines", default_value_t = 500)]
     pub max_lines: usize,
 
-    /// The log file to classify
-    pub file_path: String,
+    /// Read the text to classify from stdin instead of a file (mutually exclusive with --text)
+    #[arg(long = "stdin")]
+    pub stdin_flag: bool,
+
+    /// Classify a literal string instead of a file or stdin (mutually exclusive with --stdin)
+    #[arg(long = "text", value_name = "TEXT")]
+    pub text: Option<String>,
+
+    /// The log file to classify (omit when using --stdin or --text)
+    pub file_path: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -4431,24 +4439,7 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         Commands::AuditVerify(args) => handle_audit_verify_command(args),
         Commands::Audit { args } => handle_python_passthrough("audit", args),
         Commands::Mcp => handle_python_passthrough("mcp", vec![]),
-        Commands::Classify(args) => {
-            if !Path::new(&args.file_path).exists() {
-                anyhow::bail!(
-                    "classify expects a file path; --text/stdin literal classification is not supported yet. Received: {}",
-                    args.file_path
-                );
-            }
-            handle_sidecar_command(
-                "classify",
-                vec![
-                    "--format".to_string(),
-                    args.format,
-                    "--max-lines".to_string(),
-                    args.max_lines.to_string(),
-                    args.file_path,
-                ],
-            )
-        }
+        Commands::Classify(args) => handle_classify_command(args),
         Commands::Run(args) => handle_ast_run(args),
         Commands::Scan { args } => {
             if ast_scan_requires_python_passthrough(&args) {
@@ -10127,8 +10118,64 @@ fn classify_gpu_sidecar_unavailable(stderr: &str, message: &str) -> Option<Strin
     }
 }
 
-fn handle_sidecar_command(command: &str, args: Vec<String>) -> anyhow::Result<()> {
-    match execute_sidecar_command(command, args, None) {
+// #92: classify's --stdin/--text share the sidecar's pre-existing `payload["content"]` path
+// (sidecar.py:_classify_payload already prefers payload content over the positional file
+// argument) -- no new IPC protocol, just wiring these two flags into the existing Optional
+// payload parameter that execute_sidecar_command has always accepted.
+fn handle_classify_command(args: ClassifyArgs) -> anyhow::Result<()> {
+    if args.stdin_flag && args.text.is_some() {
+        anyhow::bail!("tg classify --stdin cannot be combined with --text");
+    }
+    if args.stdin_flag && args.file_path.is_some() {
+        anyhow::bail!("tg classify --stdin cannot be combined with a file path argument");
+    }
+    if args.text.is_some() && args.file_path.is_some() {
+        anyhow::bail!("tg classify --text cannot be combined with a file path argument");
+    }
+
+    let sidecar_args = vec![
+        "--format".to_string(),
+        args.format,
+        "--max-lines".to_string(),
+        args.max_lines.to_string(),
+    ];
+
+    if args.stdin_flag {
+        // Read to EOF; an empty/closed pipe yields an empty string rather than hanging, and
+        // the sidecar's existing empty-content branch degrades cleanly (exit 1 with a message
+        // instead of a silent hang or crash) -- see sidecar.py's `if not lines:` branch.
+        let mut stdin_bytes = Vec::new();
+        io::stdin().read_to_end(&mut stdin_bytes)?;
+        let content = String::from_utf8_lossy(&stdin_bytes).into_owned();
+        let payload = serde_json::json!({ "content": content });
+        return handle_sidecar_command("classify", sidecar_args, Some(payload));
+    }
+
+    if let Some(text) = args.text {
+        let payload = serde_json::json!({ "content": text });
+        return handle_sidecar_command("classify", sidecar_args, Some(payload));
+    }
+
+    let file_path = args.file_path.ok_or_else(|| {
+        anyhow::anyhow!("classify requires a file path, or --stdin, or --text <literal>")
+    })?;
+    if !Path::new(&file_path).exists() {
+        anyhow::bail!(
+            "classify expects a file path; use --text for a literal string or --stdin to read from stdin. Received: {}",
+            file_path
+        );
+    }
+    let mut full_args = sidecar_args;
+    full_args.push(file_path);
+    handle_sidecar_command("classify", full_args, None)
+}
+
+fn handle_sidecar_command(
+    command: &str,
+    args: Vec<String>,
+    payload: Option<serde_json::Value>,
+) -> anyhow::Result<()> {
+    match execute_sidecar_command(command, args, payload) {
         Ok(result) => {
             let _ = result.sidecar_pid;
             if !result.stdout.is_empty() {

--- a/rust_core/tests/test_public_native_cli_parity.rs
+++ b/rust_core/tests/test_public_native_cli_parity.rs
@@ -1852,6 +1852,8 @@ fn test_classify_help_describes_local_default_provider_contract() {
 
 #[test]
 fn test_classify_reports_clear_error_for_literal_input_on_public_native_frontdoor() {
+    // #92: a bare positional that isn't a real file path must still fail -- literal
+    // classification is only supported via the explicit --text flag now, not by accident.
     let output = tg()
         .current_dir(repo_root())
         .args([
@@ -1865,13 +1867,89 @@ fn test_classify_reports_clear_error_for_literal_input_on_public_native_frontdoo
 
     assert!(
         !output.status.success(),
-        "literal classify input should fail until literal/stdin mode exists"
+        "a non-existent positional path should still fail without --text/--stdin"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("classify expects a file path")
-            && stderr.contains("--text/stdin literal classification is not supported yet"),
-        "classify literal error should be actionable: {stderr}"
+            && stderr.contains("use --text for a literal string or --stdin to read from stdin"),
+        "classify literal error should point at the new --text/--stdin flags: {stderr}"
+    );
+}
+
+#[test]
+fn test_classify_help_lists_stdin_and_text_flags_on_public_native_frontdoor() {
+    let output = tg()
+        .current_dir(repo_root())
+        .args(["classify", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--stdin"),
+        "classify --help missing --stdin: {stdout}"
+    );
+    assert!(
+        stdout.contains("--text"),
+        "classify --help missing --text: {stdout}"
+    );
+}
+
+#[test]
+fn test_classify_stdin_and_text_together_is_a_clean_error_on_public_native_frontdoor() {
+    // Validation must happen BEFORE any stdin read, so this can never hang even though we
+    // pass an empty (immediately-closed) stdin pipe as a hang-safety belt-and-suspenders.
+    let mut command = tg();
+    command.current_dir(repo_root()).args([
+        "classify",
+        "--stdin",
+        "--text",
+        "2026-05-26 ERROR payment retry failed",
+    ]);
+    let output = run_command_with_stdin(command, b"");
+
+    assert!(
+        !output.status.success(),
+        "tg classify --stdin --text should be a clean, immediate error"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--stdin") && stderr.contains("--text"),
+        "mutual-exclusion error should name both flags: {stderr}"
+    );
+}
+
+#[test]
+fn test_classify_text_and_file_path_together_is_a_clean_error_on_public_native_frontdoor() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("sample.log");
+    fs::write(&file, "INFO ok\n").unwrap();
+
+    let mut command = tg();
+    command
+        .current_dir(repo_root())
+        .arg("classify")
+        .arg("--text")
+        .arg("literal input")
+        .arg(&file);
+    let output = run_command_with_stdin(command, b"");
+
+    assert!(
+        !output.status.success(),
+        "tg classify --text PATH should be a clean, immediate error"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--text") && stderr.contains("file path"),
+        "mutual-exclusion error should name the conflicting flag and file path: {stderr}"
     );
 }
 

--- a/rust_core/tests/test_sidecar_ipc.rs
+++ b/rust_core/tests/test_sidecar_ipc.rs
@@ -206,6 +206,113 @@ fn test_tg_classify_stdout_matches_python_module() {
 }
 
 #[test]
+fn test_tg_classify_text_flag_stdout_matches_python_module() {
+    // #92: --text classifies a literal string through the SAME sidecar payload["content"]
+    // path a file classify already used -- verify both front doors agree byte-for-byte.
+    if !repo_python_has_module("typer") {
+        return;
+    }
+
+    let literal = "2026-05-26 ERROR payment retry failed";
+
+    let mut tg = Command::new(env!("CARGO_BIN_EXE_tg"));
+    tg.current_dir(repo_root())
+        .arg("classify")
+        .arg("--text")
+        .arg(literal);
+    configure_classify_env(&mut tg);
+    let tg_output = run_with_timeout(tg, Duration::from_secs(40));
+
+    let mut py = Command::new(repo_python());
+    py.current_dir(repo_root())
+        .arg("-m")
+        .arg("tensor_grep")
+        .arg("classify")
+        .arg("--text")
+        .arg(literal);
+    configure_classify_env(&mut py);
+    let py_output = run_with_timeout(py, Duration::from_secs(40));
+
+    assert_eq!(tg_output.status.code(), py_output.status.code());
+    assert_eq!(tg_output.stdout, py_output.stdout);
+    assert_eq!(tg_output.stderr, py_output.stderr);
+
+    assert!(
+        tg_output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        tg_output.status.code(),
+        String::from_utf8_lossy(&tg_output.stdout),
+        String::from_utf8_lossy(&tg_output.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&tg_output.stdout).unwrap();
+    let classifications = payload["classifications"].as_array().unwrap();
+    assert_eq!(classifications.len(), 1);
+    assert_eq!(classifications[0]["label"], "error");
+    assert!(classifications[0]["file"].is_null());
+}
+
+#[test]
+fn test_tg_classify_stdin_flag_stdout_matches_python_module() {
+    // #92: --stdin reads to EOF and classifies via the same content payload; compare against
+    // `python -m tensor_grep classify --stdin` fed identical bytes.
+    if !repo_python_has_module("typer") {
+        return;
+    }
+
+    let content = b"INFO ok\nERROR database failed\nWARN retrying\n".to_vec();
+
+    let mut tg = Command::new(env!("CARGO_BIN_EXE_tg"));
+    tg.current_dir(repo_root()).arg("classify").arg("--stdin");
+    configure_classify_env(&mut tg);
+    let tg_output = run_with_stdin_timeout(tg, content.clone(), Duration::from_secs(40));
+
+    let mut py = Command::new(repo_python());
+    py.current_dir(repo_root())
+        .arg("-m")
+        .arg("tensor_grep")
+        .arg("classify")
+        .arg("--stdin");
+    configure_classify_env(&mut py);
+    let py_output = run_with_stdin_timeout(py, content, Duration::from_secs(40));
+
+    assert_eq!(tg_output.status.code(), py_output.status.code());
+    assert_eq!(tg_output.stdout, py_output.stdout);
+    assert_eq!(tg_output.stderr, py_output.stderr);
+
+    assert!(
+        tg_output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        tg_output.status.code(),
+        String::from_utf8_lossy(&tg_output.stdout),
+        String::from_utf8_lossy(&tg_output.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&tg_output.stdout).unwrap();
+    let classifications = payload["classifications"].as_array().unwrap();
+    assert_eq!(classifications.len(), 3);
+    assert_eq!(classifications[1]["label"], "error");
+}
+
+#[test]
+fn test_tg_classify_stdin_empty_input_degrades_cleanly_without_hanging() {
+    // TRAP coverage: a closed/empty stdin pipe must exit cleanly (bounded by
+    // run_with_stdin_timeout's own hard timeout), not hang and not crash.
+    let mut tg = Command::new(env!("CARGO_BIN_EXE_tg"));
+    tg.current_dir(repo_root()).arg("classify").arg("--stdin");
+    configure_classify_env(&mut tg);
+    let output = run_with_stdin_timeout(tg, Vec::new(), sidecar_test_timeout());
+
+    assert!(
+        !output.status.success(),
+        "empty stdin should exit non-zero rather than fabricate an empty success"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no content to classify"),
+        "expected a clean diagnostic, got: {stderr}"
+    );
+}
+
+#[test]
 fn test_sidecar_protocol_handles_large_payload_and_large_stdout() {
     let payload = json!({
         "content": large_classify_payload(2 * 1024 * 1024),

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -11446,12 +11446,26 @@ def checkpoint_undo(
 
 @app.command()
 def classify(
-    file_path: str,
+    file_path: str | None = typer.Argument(
+        None, help="The log file to classify (omit when using --stdin or --text)."
+    ),
     format_type: str = typer.Option("json", "--format", help="Output format"),
     max_lines: int = typer.Option(
         DEFAULT_CLASSIFY_MAX_LINES,
         "--max-lines",
         help="Maximum input lines to emit in JSON output (0 disables the cap).",
+    ),
+    stdin_flag: bool = typer.Option(
+        False,
+        "--stdin",
+        help="Read the text to classify from stdin instead of a file "
+        "(mutually exclusive with --text).",
+    ),
+    text: str | None = typer.Option(
+        None,
+        "--text",
+        help="Classify a literal string instead of a file or stdin "
+        "(mutually exclusive with --stdin).",
     ),
 ) -> None:
     """Run log classification with local heuristics or an explicit cyBERT provider."""
@@ -11464,19 +11478,61 @@ def classify(
         _enrich_classifications,
     )
 
-    classify_path = Path(file_path).expanduser()
-    if not classify_path.exists():
+    if stdin_flag and text is not None:
+        typer.echo("Error: tg classify --stdin cannot be combined with --text", err=True)
+        raise typer.Exit(1)
+    if stdin_flag and file_path is not None:
         typer.echo(
-            "Error: classify expects a file path; --text/stdin literal classification "
-            f"is not supported yet. Received: {file_path}",
-            err=True,
+            "Error: tg classify --stdin cannot be combined with a file path argument", err=True
+        )
+        raise typer.Exit(1)
+    if text is not None and file_path is not None:
+        typer.echo(
+            "Error: tg classify --text cannot be combined with a file path argument", err=True
         )
         raise typer.Exit(1)
 
-    reader = FallbackReader()
-    lines = list(reader.read_lines(file_path))
-    if not lines:
-        sys.exit(1)
+    # Mirrors sidecar.py's _classify_payload: content supplied directly (stdin/--text) skips
+    # the file-read branch entirely, and empty content degrades cleanly instead of hanging or
+    # crashing (audit MED's fix for the sidecar's own empty-content branch, mirrored here for
+    # front-door parity).
+    source_path: str | None = None
+    if stdin_flag:
+        content = sys.stdin.read()
+        lines = content.splitlines(keepends=True)
+        if content and not lines:
+            lines = [content]
+        if not lines:
+            typer.echo("no content to classify (input is empty)", err=True)
+            raise typer.Exit(1)
+    elif text is not None:
+        lines = text.splitlines(keepends=True)
+        if text and not lines:
+            lines = [text]
+        if not lines:
+            typer.echo("no content to classify (input is empty)", err=True)
+            raise typer.Exit(1)
+    else:
+        if file_path is None:
+            typer.echo(
+                "Error: classify requires a file path, or --stdin, or --text <literal>",
+                err=True,
+            )
+            raise typer.Exit(1)
+        classify_path = Path(file_path).expanduser()
+        if not classify_path.exists():
+            typer.echo(
+                "Error: classify expects a file path; use --text for a literal string or "
+                f"--stdin to read from stdin. Received: {file_path}",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+        source_path = file_path
+        reader = FallbackReader()
+        lines = list(reader.read_lines(file_path))
+        if not lines:
+            sys.exit(1)
 
     budgeted_lines, line_budget = _apply_classify_line_budget(lines, max_lines)
     results, classification_backend = _classify_lines_with_metadata(budgeted_lines)
@@ -11490,7 +11546,7 @@ def classify(
             "classifications": _enrich_classifications(
                 results,
                 budgeted_lines,
-                source_path=file_path,
+                source_path=source_path,
             ),
         }
         print(json.dumps(data))

--- a/tests/unit/test_sidecar_classify.py
+++ b/tests/unit/test_sidecar_classify.py
@@ -192,7 +192,78 @@ def test_python_cli_classify_reports_clear_error_for_literal_input():
 
     assert result.exit_code == 1
     assert "classify expects a file path" in result.stderr
-    assert "--text/stdin literal classification is not supported yet" in result.stderr
+    assert "use --text for a literal string or --stdin to read from stdin" in result.stderr
+
+
+def test_python_cli_classify_text_flag_classifies_literal(monkeypatch):
+    """#92: --text classifies a literal string via the pure-Python front door."""
+    from tensor_grep.cli.main import app
+
+    monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
+
+    result = CliRunner().invoke(
+        app,
+        ["classify", "--format", "json", "--text", "2026-05-26 ERROR payment retry failed"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["classifications"]) == 1
+    assert payload["classifications"][0]["label"] == "error"
+    assert payload["classifications"][0]["file"] is None
+    assert payload["classifications"][0]["path"] is None
+
+
+def test_python_cli_classify_stdin_flag_classifies_piped_content(monkeypatch):
+    """#92: --stdin classifies piped content via the pure-Python front door."""
+    from tensor_grep.cli.main import app
+
+    monkeypatch.delenv("TENSOR_GREP_CLASSIFY_PROVIDER", raising=False)
+
+    result = CliRunner().invoke(
+        app,
+        ["classify", "--format", "json", "--stdin"],
+        input="INFO ok\nERROR database failed\nWARN retrying\n",
+    )
+
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["classifications"]) == 3
+    assert payload["classifications"][1]["label"] == "error"
+    assert payload["classifications"][1]["file"] is None
+
+
+def test_python_cli_classify_stdin_empty_input_degrades_cleanly():
+    """TRAP coverage: empty stdin must exit cleanly, not hang and not crash."""
+    from tensor_grep.cli.main import app
+
+    result = CliRunner().invoke(app, ["classify", "--stdin"], input="")
+
+    assert result.exit_code == 1
+    assert "no content to classify" in result.stderr
+
+
+def test_python_cli_classify_stdin_and_text_together_is_a_clean_error():
+    from tensor_grep.cli.main import app
+
+    result = CliRunner().invoke(app, ["classify", "--stdin", "--text", "literal"])
+
+    assert result.exit_code == 1
+    assert "--stdin" in result.stderr
+    assert "--text" in result.stderr
+
+
+def test_python_cli_classify_text_and_file_path_together_is_a_clean_error(tmp_path):
+    from tensor_grep.cli.main import app
+
+    log_path = tmp_path / "app.log"
+    log_path.write_text("INFO ok\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["classify", "--text", "literal", str(log_path)])
+
+    assert result.exit_code == 1
+    assert "--text" in result.stderr
+    assert "file path" in result.stderr
 
 
 def test_sidecar_classify_accepts_explicit_max_lines(monkeypatch):


### PR DESCRIPTION
Backlog-100 #92: adds `tg classify --stdin` + `--text <literal>` on both front doors, reusing the existing sidecar payload['content'] path (zero protocol change). Mutually-exclusive validation before any stdin read (can't hang); empty input degrades cleanly (exit 1, not a hang); bare file-path mode unchanged. Replaces the old 'not supported yet' bail. Dual-front-door byte-identical parity verified. cargo+Python 4-gate green (native 80/80, parity 42/42, classify 65/65). Gate-free (sidecar IPC, no gated surface).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>