### PR TITLE
fix(backends): fail closed with the documented ast-grep-dependency message when the native AstBackend gets an ast-grep-DSL pattern it cannot compile (#144)

### DIFF
--- a/src/tensor_grep/backends/ast_backend.py
+++ b/src/tensor_grep/backends/ast_backend.py
@@ -674,6 +674,25 @@ class AstBackend(ComputeBackend):
             # silent false negative (sibling of the SILENT-FALLBACK class). Raise per base.py's
             # contract so run_command's except-BackendExecutionError handler reports a real
             # "invalid pattern" error instead of "0 matches".
+            #
+            # #144 hotfix / #141 DSL divergence: a bare identifier (e.g. "calculateTotal") that
+            # already failed the node-type-index lookup above and then fails to compile as a
+            # tree-sitter QUERY is not a malformed query -- it is an ast-grep-DSL code pattern
+            # (tg run --pattern's native surface), which only AstGrepWrapperBackend speaks. The
+            # native tree-sitter backend and the ast-grep wrapper are two different pattern DSLs;
+            # when the wrapper is unavailable (e.g. CI without the ast-grep binary) routing falls
+            # through to this native backend, which cannot serve that pattern. Fail closed with
+            # the documented ast-grep-dependency message (matches agent_readiness.py's
+            # skip_error_patterns) instead of the generic "invalid pattern" message, so an
+            # environment gap is not misclassified as a real query bug. A non-simple pattern
+            # (e.g. a malformed "(...)" query) keeps the original message unchanged.
+            if self._is_simple_node_type_pattern(pattern):
+                raise BackendExecutionError(
+                    "Explicit AST search requires AST dependencies: the ast-grep wrapper "
+                    f"backend is required for pattern {pattern!r} (the native tree-sitter "
+                    "backend only serves structural node-type and (s-expression) queries, "
+                    "not ast-grep code patterns)."
+                ) from exc
             raise BackendExecutionError(
                 f"AST query compilation failed (invalid pattern for language {lang!r}?): {exc}"
             ) from exc

--- a/tests/unit/test_ast_backend.py
+++ b/tests/unit/test_ast_backend.py
@@ -226,6 +226,90 @@ class TestAstBackend:
                 str(file_path), "not a valid ast query", SearchConfig(ast=True, lang="python")
             )
 
+    def test_bare_identifier_ast_grep_pattern_fails_closed_with_ast_dependency_message(
+        self, monkeypatch
+    ):
+        """#144 hotfix: release-tag-smoke's ast-run-smoke check runs
+        `tg run --pattern calculateTotal tests/fixtures/ast_smoke --lang js --json`, which is
+        ast-grep-DSL surface served by AstGrepWrapperBackend. When the ast-grep binary is absent
+        (CI, since #542 broadened AstBackend.is_available()), core/pipeline.py routing falls
+        through to this native tree-sitter AstBackend instead. "calculateTotal" satisfies
+        _is_simple_node_type_pattern (a bare identifier), so the node-type-index lookup runs
+        first, finds no such node TYPE (it is a user identifier, not a grammar node type),
+        returns 0 matches, and falls through to compiling the pattern as a tree-sitter QUERY --
+        which raises because "calculateTotal" is not a valid node type. Pre-fix, that surfaced
+        the generic "AST query compilation failed" error, which is not one of
+        agent_readiness.py's skip_error_patterns ("Explicit AST search requires AST
+        dependencies" / "no AST backend is available"), so CI failed instead of skipping. This
+        test drives the native AstBackend DIRECTLY (bypassing AstGrepWrapperBackend entirely)
+        against the real ast_smoke fixture and asserts the fail-closed message now names the
+        ast-grep dependency, so the smoke check recognizes it as an environment gap rather than
+        a real bug (#141 DSL divergence: native tree-sitter-query vs ast-grep-DSL)."""
+        pytest.importorskip("tree_sitter")
+        pytest.importorskip("tree_sitter_javascript")
+        monkeypatch.setenv("TENSOR_GREP_AST_CACHE", "0")  # hermetic: force the live query path
+        from tensor_grep.backends.ast_backend import AstBackend
+        from tensor_grep.backends.base import BackendExecutionError
+
+        backend = AstBackend()
+        assert backend.is_available() is True
+
+        fixture_path = Path(__file__).resolve().parents[1] / "fixtures" / "ast_smoke" / "app.js"
+        assert fixture_path.exists()
+
+        with pytest.raises(BackendExecutionError) as exc_info:
+            backend.search(str(fixture_path), "calculateTotal", SearchConfig(ast=True, lang="js"))
+
+        assert "Explicit AST search requires AST dependencies" in str(exc_info.value)
+
+    def test_malformed_non_simple_ast_query_still_raises_original_compilation_error(
+        self, tmp_path, mocker
+    ):
+        """Regression guard for #144: the new ast-grep-dependency branch must only fire for a
+        *simple* bare-identifier pattern (ast-grep-DSL-shaped). A malformed non-simple `(...)`
+        tree-sitter query is a genuinely invalid QUERY, not a plausible ast-grep pattern, and
+        must keep raising the ORIGINAL "AST query compilation failed" message -- proving the new
+        fail-closed branch was not over-broadened to swallow real invalid-query errors."""
+        from tensor_grep.backends.ast_backend import AstBackend
+        from tensor_grep.backends.base import BackendExecutionError
+
+        backend = AstBackend()
+        mocker.patch.object(backend, "is_available", return_value=True)
+
+        class FakeLanguage:
+            def query(self, _pattern):
+                raise Exception("invalid query")
+
+        class FakeTree:
+            class RootNode:
+                type = "module"
+                start_point = (0, 0)
+                children = ()
+
+            root_node = RootNode()
+
+        class FakeParser:
+            language = FakeLanguage()
+
+            def parse(self, _source):
+                return FakeTree()
+
+        mocker.patch.object(backend, "_get_parser", return_value=FakeParser())
+
+        file_path = tmp_path / "test.py"
+        file_path.write_text("def hello():\n    print('world')\n", encoding="utf-8")
+
+        with pytest.raises(BackendExecutionError) as exc_info:
+            backend.search(
+                str(file_path),
+                "(function_definition name",  # malformed s-expr, not a bare identifier
+                SearchConfig(ast=True, lang="python"),
+            )
+
+        message = str(exc_info.value)
+        assert "AST query compilation failed" in message
+        assert "Explicit AST search requires AST dependencies" not in message
+
     def test_should_support_dict_capture_shape(self, tmp_path, mocker):
         from tensor_grep.backends.ast_backend import AstBackend
 


### PR DESCRIPTION
## Root cause

The post-publish `release-tag-smoke` CI job (`.github/workflows/ci.yml`, gated on
`needs.release.outputs.released == 'true'`, runs on `ubuntu-latest`) has been failing since
v1.64.4. It runs `scripts/agent_readiness.py`'s `ast-run-smoke` check:

```
tg run --pattern calculateTotal tests/fixtures/ast_smoke --lang js --json
```

On a dev box with the ast-grep binary installed, that command routes to
`AstGrepWrapperBackend` and returns 2 matches. On the CI runner the ast-grep binary is
absent, so `core/pipeline.py` routing falls through to the native `AstBackend`
(`is_available()` only requires `tree-sitter`, which CI's `uv pip install -e ".[dev]"` does
install -- the wrapper-preferred-routing fix landed in #542).

`AstBackend.search()` then:
1. `_is_simple_node_type_pattern("calculateTotal")` returns `True` (bare identifier regex).
2. The node-type-index lookup finds no node TYPE named `calculateTotal` (it's a user
   identifier, not a grammar node type) -> 0 matches -> falls through.
3. `_get_query()` compiles `(calculateTotal) @match` as a tree-sitter QUERY -> raises
   `Invalid node type at row 0, column 1: calculateTotal`.
4. The `except Exception` wrapper raised the generic `"AST query compilation failed
   (invalid pattern for language 'js'?): ..."` message.

That message is not one of `agent_readiness.py`'s `skip_error_patterns`
(`"Explicit AST search requires AST dependencies"` / `"no AST backend is available"`), so
the check FAILED instead of SKIPPING. Root cause: `tg run --pattern` is ast-grep-DSL
surface; the native `AstBackend` speaks the tree-sitter-query DSL. Only
`AstGrepWrapperBackend` can serve a bare code-pattern like `calculateTotal` (the #141 DSL
divergence -- deferred design work this hotfix does not touch).

**Confirmed against a real CI failure**, not just theory. Pulled the actual job log for
`release-tag-smoke` on run
[29183762070](https://github.com/oimiragieo/tensor-grep/actions/runs/29183762070) (main,
2026-07-12T07:09Z): the `ast-run-smoke` check record shows `"status": "failed"`,
`"returncode": 2`, `"message": "exit 2; stderr=<empty>"`, and `stdout_tail` containing:

```json
{"version": 1, "schema_version": 1, "mode": "search", "total_matches": 0, "ok": false,
 "error": "backend_error",
 "detail": "AST query compilation failed (invalid pattern for language 'js'?): Invalid node
 type at row 0, column 1: calculateTotal",
 "routing_backend": "AstBackend", "routing_reason": "ast",
 "query": "calculateTotal", "path": "tests/fixtures/ast_smoke"}
```

This is byte-for-byte the message this PR changes, produced by the exact `AstBackend` /
`ast_workflows.py` code path this PR patches (`routing_reason: "ast"` is
`ast_workflows.py`'s label for the plain-search JSON envelope -- distinct from
`routing_reason: "ast-native"`, a hardcoded literal that only exists in
`rust_core/src/backend_ast.rs`/`routing.rs`, see the dev-box caveat below). Same pattern
recurs on runs
[29182236842](https://github.com/oimiragieo/tensor-grep/actions/runs/29182236842) and
[29180751660](https://github.com/oimiragieo/tensor-grep/actions/runs/29180751660) -- this is
a persistent, currently-red failure, not a one-off.

## The fix (one site)

In `src/tensor_grep/backends/ast_backend.py`, inside the `except Exception as exc:` block
wrapping `_get_query(...)`: before raising the generic "AST query compilation failed"
error, check `self._is_simple_node_type_pattern(pattern)`. A bare identifier that already
failed the node-type-index lookup and then fails to compile as a tree-sitter query is an
ast-grep-DSL pattern the native backend cannot serve -- raise a fail-closed
`BackendExecutionError` naming the ast-grep-wrapper dependency (matches
`agent_readiness.py`'s skip pattern). A non-simple pattern (e.g. a malformed `(...)` query)
keeps the ORIGINAL message unchanged.

Before:
```python
        try:
            query = self._get_query(parser, lang, pattern)
        except Exception as exc:
            # Audit MED: a broad `except Exception` here converted a malformed/misspelled AST
            # node-type pattern into a look-alike 0-match result with zero logging -- a
            # silent false negative (sibling of the SILENT-FALLBACK class). Raise per base.py's
            # contract so run_command's except-BackendExecutionError handler reports a real
            # "invalid pattern" error instead of "0 matches".
            raise BackendExecutionError(
                f"AST query compilation failed (invalid pattern for language {lang!r}?): {exc}"
            ) from exc
```

After:
```python
        try:
            query = self._get_query(parser, lang, pattern)
        except Exception as exc:
            # Audit MED: a broad `except Exception` here converted a malformed/misspelled AST
            # node-type pattern into a look-alike 0-match result with zero logging -- a
            # silent false negative (sibling of the SILENT-FALLBACK class). Raise per base.py's
            # contract so run_command's except-BackendExecutionError handler reports a real
            # "invalid pattern" error instead of "0 matches".
            #
            # #144 hotfix / #141 DSL divergence: a bare identifier (e.g. "calculateTotal") that
            # already failed the node-type-index lookup above and then fails to compile as a
            # tree-sitter QUERY is not a malformed query -- it is an ast-grep-DSL code pattern
            # (tg run --pattern's native surface), which only AstGrepWrapperBackend speaks. The
            # native tree-sitter backend and the ast-grep wrapper are two different pattern DSLs;
            # when the wrapper is unavailable (e.g. CI without the ast-grep binary) routing falls
            # through to this native backend, which cannot serve that pattern. Fail closed with
            # the documented ast-grep-dependency message (matches agent_readiness.py's
            # skip_error_patterns) instead of the generic "invalid pattern" message, so an
            # environment gap is not misclassified as a real query bug. A non-simple pattern
            # (e.g. a malformed "(...)" query) keeps the original message unchanged.
            if self._is_simple_node_type_pattern(pattern):
                raise BackendExecutionError(
                    "Explicit AST search requires AST dependencies: the ast-grep wrapper "
                    f"backend is required for pattern {pattern!r} (the native tree-sitter "
                    "backend only serves structural node-type and (s-expression) queries, "
                    "not ast-grep code patterns)."
                ) from exc
            raise BackendExecutionError(
                f"AST query compilation failed (invalid pattern for language {lang!r}?): {exc}"
            ) from exc
```

No changes to `core/pipeline.py` routing, `_supports_native_ast_pattern`, `is_available()`,
the ast-grep wrapper, or the node-type-index path -- all deferred to #141.

## Tests (TDD, `tests/unit/test_ast_backend.py`)

1. **`test_bare_identifier_ast_grep_pattern_fails_closed_with_ast_dependency_message`** --
   drives the native `AstBackend` directly (bypassing the wrapper) against the real
   `tests/fixtures/ast_smoke/app.js` fixture with pattern `calculateTotal`, lang `js`;
   asserts `BackendExecutionError` whose message contains `"Explicit AST search requires AST
   dependencies"`. Confirmed RED pre-fix (reproduced the exact predicted message: `"AST
   query compilation failed (invalid pattern for language 'js'?): Invalid node type at row
   0, column 1: calculateTotal"`, via `git stash` of just the implementation file) and GREEN
   post-fix.
2. **`test_malformed_non_simple_ast_query_still_raises_original_compilation_error`** --
   regression guard proving the new branch is not over-broadened: a malformed non-simple
   `(...)`-shaped pattern (mocked `_get_query` failure, mirroring the existing
   `test_should_raise_on_invalid_ast_query` pattern) still raises the ORIGINAL "AST query
   compilation failed" message and does not contain the new ast-grep-dependency text. Passes
   both before and after the fix by design (it targets the untouched branch).

## Verification (real venv, `uv run --no-sync`, `.[dev,ast,semantic]`)

- New tests: RED before the fix (implementation stashed), GREEN after (both confirmed
  individually, `-x` override via `--maxfail=0`).
- `tests/unit/test_ast_backend.py`: 35/35 passed (33 pre-existing + 2 new), no regressions.
- 4-step gate, all PASS:
  - `ruff check src/tensor_grep tests` -- All checks passed!
  - `ruff format --check --preview src/tensor_grep tests` -- 336 files already formatted
  - `mypy src/tensor_grep` -- Success: no issues found in 79 source files
  - `pytest -q` (full suite) -- all green (one unrelated pre-existing local-environment gap
    hit on the first pass and closed, see note below; no failures after)
- `PYTHONPATH=src python -m tensor_grep.core.registration_check .tg-registration.toml`:
  2/2 groups complete (no command/flag surface touched, as expected for this fix).
- Full suite final tally: **4513 passed, 30 skipped, 0 failed in 628.67s**. Also separately
  ran the full `tests/unit/` tree standalone: **4291 passed, 11 skipped** (495.90s), plus
  targeted re-runs of every file adjacent to this change -- `test_ast_backend.py` (35/35,
  33 pre-existing + 2 new), `test_ast_workflows.py` (30/30), `test_agent_readiness_script.py`
  (39/39, including the existing static assertion that `"Explicit AST search requires AST
  dependencies"` is in `ast-run-smoke`'s `skip_error_patterns`), `test_ast_wrapper_backend.py`
  + `test_backend_error_handling.py` (40/40), `test_pipeline.py` (38/38, confirms routing is
  untouched), `test_backend_contracts.py` (1 passed, 1 skipped) -- all green.
- `git diff --check`: clean. Both changed files confirmed LF (`git ls-files --eol`).
- Traced the CI mechanism end-to-end, not just the unit test: `cli/ast_workflows.py`'s
  `run_command` catches `BackendExecutionError` and for `--json` mode embeds `str(exc)` in
  the JSON `"detail"` field with exit code 2; `agent_readiness.py::run_check` scans the
  combined stdout+stderr of a non-zero exit against `skip_error_patterns` and marks the
  check "skipped" on a substring match -- confirmed the new message's exact substring
  (`"Explicit AST search requires AST dependencies"`) will trip that skip path in CI. This
  is not hypothetical: the real CI failure log quoted above shows exactly this code path
  (`routing_reason: "ast"`) producing exactly this message.
- **Dev-box caveat (important, do not misread as "unverified end-to-end"):** on this
  specific dev box, `tg run --pattern calculateTotal tests/fixtures/ast_smoke --lang js
  --json` currently resolves to neither `AstGrepWrapperBackend` nor the patched Python
  `AstBackend` -- `tg doctor --json` shows `native_tg_binary_kind: "in-tree-debug"`
  (`rust_core/target/debug/tg.exe`, a side effect of this worktree's `uv pip install -e
  ".[dev,ast]"`, since `cli/bootstrap.py`'s `main_entry` delegates a plain `tg run --pattern
  ... --lang ... --json` -- no `--selector/--strictness/--stdin/--globs` -- straight to any
  resolvable native binary before Python ever runs). That binary embeds its own,
  independent AST/ast-grep-pattern implementation (`rust_core/src/backend_ast.rs`,
  `routing_reason: "ast-native"`, a Rust-only literal, distinct from this PR's Python code),
  which happens to handle `calculateTotal` correctly and returns 2 real matches -- so it
  masks the bug locally rather than reproducing the wrapper-preferred path the original
  diagnosis assumed. This is a local build-artifact quirk of this worktree, not something
  present in `release-tag-smoke`'s fresh CI checkout (confirmed by the real failure log
  above, which shows `routing_backend: "AstBackend"`, `routing_reason: "ast"` -- the plain
  Python path, exactly what this PR patches). Net effect: the **unit test is the primary,
  and now doubly-grounded, proof** (RED/GREEN cycle + byte-for-byte match against a real CI
  failure); the local e2e command was not usable as a second confirmation on this box for a
  reason now fully understood, not a gap glossed over.
- Note: the first full-suite run hit one unrelated failure,
  `tests/integration/test_semantic_search_flag.py::test_search_semantic_with_real_model_engages_dense_leg`,
  caused by this fresh worktree venv having a stale machine-wide model cache
  (`~/.tensor-grep/models/potion-code-16M`, per-machine, not per-worktree) without the
  `model2vec` package (only `.[dev,ast]` was installed initially). This is a local-only
  environment mismatch unrelated to this change -- CI's `test-python` job installs `.[dev]`
  only and runs on a fresh runner with no pre-existing model directory, so the test skips
  there via its own `pytest.skip(...)` guard. Installed `.[semantic]` locally to close the
  gap and confirmed a subsequent full run was clean.

## Status

Opus-gate pending (backends surface).
