### PR TITLE
fix(ci): robustify the wedged-python help-probe timeout test + stop the nightly Rust leg from gating releases (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,13 @@ jobs:
     name: test-rust-core (${{ matrix.os }}, ${{ matrix.rust_channel }})
     needs: smoke
     runs-on: ${{ matrix.os }}
+    # #145: nightly Rust is unstable by design (a wall-clock-timing test on this leg has blocked
+    # the release gate 3x on wholly non-product flakes). Only the nightly leg is non-gating here --
+    # it still RUNS and stays VISIBLE (so a real nightly regression is seen and can be triaged), but
+    # a nightly-only failure no longer fails this job's conclusion, so `release`'s `needs: [...,
+    # test-rust-core, ...]` (below) is not blocked by it. The stable leg (every OS) is untouched and
+    # still hard-gates release on a real failure.
+    continue-on-error: ${{ matrix.rust_channel == 'nightly' }}
     permissions:
       contents: read
     strategy:

--- a/rust_core/tests/test_sidecar_ipc.rs
+++ b/rust_core/tests/test_sidecar_ipc.rs
@@ -533,6 +533,41 @@ fn write_wedged_python_script(dir: &Path) -> PathBuf {
 }
 
 #[cfg(not(feature = "cuda"))]
+// #145: `test_help_probe_timeout_env_override_falls_back_fast_with_wedged_python` (below) and
+// `test_help_probe_default_timeout_recovers_with_enriched_fallback_when_python_is_wedged` (further
+// below) both drive `tg --help` against the SAME wedged-Python mechanism and measure wall-clock --
+// the single most directly identifiable source of mutual contention for either test's timing
+// assertion if `cargo test`'s default thread-parallelism happens to schedule them at the same time.
+// This lock makes that specific pair mutually exclusive. It cannot (from a single test file) also
+// exclude the ~14 OTHER subprocess-spawning tests in this binary or unrelated CI-runner load; see
+// `HELP_PROBE_TRIALS` and the widened gap in the override-honored test below for how the timing
+// assertion itself stays robust to that residual noise.
+static HELP_PROBE_TIMING_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(not(feature = "cuda"))]
+fn lock_help_probe_timing() -> std::sync::MutexGuard<'static, ()> {
+    // Recover from poisoning instead of propagating it: if an EARLIER test panicked on its own
+    // assertion while holding this lock, unwrapping a PoisonError here would replace that test's
+    // real failure message with an unrelated "lock poisoned" panic in this one. The lock only
+    // provides mutual exclusion for timing purposes, not shared data integrity, so recovering is safe.
+    HELP_PROBE_TIMING_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(not(feature = "cuda"))]
+const HELP_PROBE_SHORT_OVERRIDE_MS: &str = "250";
+#[cfg(not(feature = "cuda"))]
+const HELP_PROBE_LONG_OVERRIDE_MS: &str = "6000";
+#[cfg(not(feature = "cuda"))]
+const HELP_PROBE_MIN_GAP: Duration = Duration::from_millis(2500);
+#[cfg(not(feature = "cuda"))]
+// Each variant is measured this many times and the FASTEST run is kept -- see the doc comment on
+// `min_wedged_help_probe` for why min-of-N is the right reducer for a noise source that only ever
+// adds latency.
+const HELP_PROBE_TRIALS: u32 = 2;
+
+#[cfg(not(feature = "cuda"))]
 fn run_wedged_help_probe(wedge_script: &Path, probe_timeout_ms: &str) -> Duration {
     // Run `tg --help` against a wedged (never-responding) Python with the given help-probe timeout
     // override; assert the native fallback still succeeds with enriched help; return wall-clock
@@ -547,8 +582,12 @@ fn run_wedged_help_probe(wedge_script: &Path, probe_timeout_ms: &str) -> Duratio
 
     let started = Instant::now();
     // Generous outer hang-guard: guards only against a truly-hung command, NOT the timing assertion
-    // (the short-vs-long comparison lives in the caller). 30s tolerates heavy CI runner starvation.
-    let output = run_with_timeout(tg, Duration::from_secs(30));
+    // (the short-vs-long comparison lives in the caller). #145: raised 30s->60s to keep a comparable
+    // safety margin above the widened long-side probe override (3000ms -> 6000ms); the wedged Python
+    // itself only ever sleeps ~20s (write_wedged_python_script), so in practice this ceiling is not
+    // expected to fire even under heavy contention -- it exists purely so a genuinely broken
+    // kill-on-timeout regression fails as a bounded panic instead of hanging the runner.
+    let output = run_with_timeout(tg, Duration::from_secs(60));
     let elapsed = started.elapsed();
 
     assert!(
@@ -565,6 +604,23 @@ fn run_wedged_help_probe(wedge_script: &Path, probe_timeout_ms: &str) -> Duratio
 }
 
 #[cfg(not(feature = "cuda"))]
+// #145: race `probe_timeout_ms` `trials` times against the wedged Python and keep the FASTEST
+// (minimum) elapsed. CI subprocess-spawn/scheduler contention only ever ADDS latency -- it never
+// makes a run finish faster than its true uncontended cost -- so the minimum across independent
+// trials is a statistically principled lower-bound estimate, and a single unlucky trial (one
+// thread-scheduling hiccup, one antivirus scan of a freshly-written EXE) no longer decides the
+// result the way a single-shot measurement does. This does NOT weaken the regression check: if
+// TG_HELP_PROBE_TIMEOUT_MS is genuinely ignored, EVERY trial of EVERY variant converges on the same
+// ~DEFAULT_HELP_PROBE_TIMEOUT_MS wait regardless of which is minimized, so the short-vs-long gap
+// still collapses to ~0 and the caller's assertion still fails.
+fn min_wedged_help_probe(wedge_script: &Path, probe_timeout_ms: &str, trials: u32) -> Duration {
+    (0..trials)
+        .map(|_| run_wedged_help_probe(wedge_script, probe_timeout_ms))
+        .min()
+        .expect("trials must be >= 1")
+}
+
+#[cfg(not(feature = "cuda"))]
 #[test]
 fn test_help_probe_timeout_env_override_falls_back_fast_with_wedged_python() {
     // audit #97 item 1: TG_HELP_PROBE_TIMEOUT_MS must override the (3000ms) default help-probe
@@ -572,23 +628,48 @@ fn test_help_probe_timeout_env_override_falls_back_fast_with_wedged_python() {
     // override must make the native --help fallback trigger fast against a Python that never responds.
     //
     // #136: this asserted an ABSOLUTE `elapsed < 3s`, which false-failed under extreme GitHub-runner
-    // starvation (spawn overhead alone exceeded the bound, blocking the v1.63.4 release). Instead RUN
-    // IT TWICE -- a 250ms override vs a 3000ms override -- on the same host and COMPARE: the wedged
-    // Python never responds, so each run waits its full probe timeout then falls back, and the short
-    // run must finish ~2750ms sooner. Both runs pay identical spawn/fallback overhead, so the
-    // DIFFERENCE is robust to CI contention (which inflates both equally); only the ~2750ms of
-    // probe-wait the short run skips is measured -- never an absolute wall-clock.
+    // starvation (spawn overhead alone exceeded the bound, blocking the v1.63.4 release). Fix: run the
+    // wedged probe TWICE -- a 250ms override vs a longer one -- on the same host and assert the short
+    // run finishes markedly sooner, since shared contention cancels in the DIFFERENCE rather than an
+    // absolute wall-clock. That held for a while but STILL false-failed a 3rd time on the
+    // windows-latest/nightly leg and blocked v1.65.2 (#145) -- a single-shot pair remains vulnerable
+    // to a contention spike landing on just the short run (which shrinks the gap), or to racing the
+    // sibling test below, which drives the exact same `tg --help`-against-wedged-Python code path.
+    //
+    // #145 hardening -- three independent, complementary changes, not another tolerance bump alone:
+    //   1. `HELP_PROBE_TIMING_LOCK` mutually excludes this test and its sibling below so they never
+    //      compete with EACH OTHER for process-creation resources (the single most directly
+    //      identifiable shared-mechanism contention source).
+    //   2. Each variant is measured `HELP_PROBE_TRIALS` times and the MINIMUM is kept (see
+    //      `min_wedged_help_probe`) so a single unlucky trial can no longer decide the result.
+    //   3. The long-side override is raised 3000ms -> 6000ms, doubling the nominal gap from ~2750ms
+    //      to ~5750ms, while the required minimum gap rises only 1500ms -> 2500ms -- i.e. the
+    //      required gap now needs to retain ~43% of the theoretical maximum instead of ~55%,
+    //      materially MORE tolerant of contention eroding the observed gap, while staying far above
+    //      the ~0ms gap a genuinely-ignored override would produce (both variants would then wait the
+    //      same real ~3000ms default, regardless of trials or minimum-taking).
     let dir = tempdir().unwrap();
     let wedge_script = write_wedged_python_script(dir.path());
+    let _guard = lock_help_probe_timing();
 
-    let elapsed_short = run_wedged_help_probe(&wedge_script, "250");
-    let elapsed_long = run_wedged_help_probe(&wedge_script, "3000");
+    let elapsed_short = min_wedged_help_probe(
+        &wedge_script,
+        HELP_PROBE_SHORT_OVERRIDE_MS,
+        HELP_PROBE_TRIALS,
+    );
+    let elapsed_long = min_wedged_help_probe(
+        &wedge_script,
+        HELP_PROBE_LONG_OVERRIDE_MS,
+        HELP_PROBE_TRIALS,
+    );
 
     assert!(
-        elapsed_short + Duration::from_millis(1500) < elapsed_long,
-        "TG_HELP_PROBE_TIMEOUT_MS=250 was not honored -- the 250ms-override run took {elapsed_short:?} \
-         but the 3000ms-override run took only {elapsed_long:?}; honoring 250ms should save ~2750ms of \
-         probe-wait (require >=1500ms of that gap to survive timing jitter)"
+        elapsed_short + HELP_PROBE_MIN_GAP < elapsed_long,
+        "TG_HELP_PROBE_TIMEOUT_MS override was not honored -- the best of {HELP_PROBE_TRIALS} \
+         run(s) at {HELP_PROBE_SHORT_OVERRIDE_MS}ms took {elapsed_short:?}, but the best of \
+         {HELP_PROBE_TRIALS} run(s) at {HELP_PROBE_LONG_OVERRIDE_MS}ms took only {elapsed_long:?}; \
+         honoring the short override should save several seconds of probe-wait (required >= \
+         {HELP_PROBE_MIN_GAP:?} of that gap to survive timing jitter)"
     );
 }
 
@@ -605,8 +686,13 @@ fn test_help_probe_default_timeout_recovers_with_enriched_fallback_when_python_i
     // lower bound: a sibling attempt at that showed parallel-test subprocess-spawn contention can
     // inflate elapsed time by ~1.5-2x, which would make a tight bound flaky. That the override is
     // honored is covered precisely, without timing ambiguity, by the sibling test above.
+    //
+    // #145: shares `HELP_PROBE_TIMING_LOCK` with the override-honored test above so the two
+    // `tg --help`-against-wedged-Python timing tests never race each other for process-creation
+    // resources; see the lock's doc comment for why.
     let dir = tempdir().unwrap();
     let wedge_script = write_wedged_python_script(dir.path());
+    let _guard = lock_help_probe_timing();
 
     let mut tg = Command::new(env!("CARGO_BIN_EXE_tg"));
     tg.current_dir(repo_root())


### PR DESCRIPTION
## Root cause

`test_help_probe_timeout_env_override_falls_back_fast_with_wedged_python`
(`rust_core/tests/test_sidecar_ipc.rs`) failed on the `test-rust-core (windows-latest,
nightly)` matrix leg during the v1.65.2 release run. Because `release` (name:
`Semantic Release`) `needs: [..., test-rust-core, ...]` with no `always()`/`failure()`
override, GitHub Actions implicitly also requires every listed job's *conclusion* to be
`success` -- so `test-rust-core` failing skipped `release`, which cascades to
`build-wheels-pypi` / `build-sdist-pypi` / `publish-pypi` (`needs: release, ...`) and
`publish-success-gate` / `release-tag-smoke` (`needs: [..., release, ...]`). The
version never published. This is the **3rd** time this exact test class has blocked a
release:

- **#129** de-flaked a same-named *Python* e2e test (`tests/e2e/test_routing_parity.py
  ::test_help_probe_timeout_env_override_is_honored`) via a delta comparison.
- **#136** converted *this Rust test's* own absolute `elapsed < 3s` bound into a
  single-shot short-vs-long delta comparison (`elapsed_short + 1500ms < elapsed_long`).
- **Now (#145)**: #136's fix held for a while but was still a *single-shot pair*,
  vulnerable to (a) a contention spike landing on just the short run, which shrinks the
  gap, or (b) racing its sibling test
  (`test_help_probe_default_timeout_recovers_with_enriched_fallback_when_python_is_wedged`),
  which drives the *identical* `tg --help`-against-wedged-Python code path and competes
  for the same OS process-creation resources.

## Fix A -- the test (`rust_core/tests/test_sidecar_ipc.rs`)

Three independent, complementary changes -- not another tolerance bump alone:

1. **`HELP_PROBE_TIMING_LOCK`** (a `static Mutex<()>`) mutually excludes the two
   `--help`-probe wedged-Python timing tests so they never compete with **each other**
   for process-creation resources -- the single most directly identifiable
   shared-mechanism contention source (both tests spawn `tg --help` against the same
   `write_wedged_python_script` mechanism).
2. **Min-of-N trials**: each variant (short/long override) is now measured
   `HELP_PROBE_TRIALS = 2` times and the **minimum** elapsed is kept
   (`min_wedged_help_probe`). CI subprocess-spawn/scheduler contention only ever *adds*
   latency -- it never makes a run finish faster than its true uncontended cost -- so
   the minimum across independent trials is a statistically principled lower-bound
   estimate. A single unlucky trial (one thread-scheduling hiccup, one antivirus scan
   of a freshly-written EXE) no longer decides the result.
3. **Materially widened gap + tolerance**: the long-side override is raised
   `3000ms -> 6000ms` (doubling the nominal gap from ~2750ms to ~5750ms) while the
   required minimum gap only rises `1500ms -> 2500ms` -- i.e. the required gap now
   needs to retain **~43%** of the theoretical maximum instead of **~55%**, materially
   *more* tolerant of contention eroding the observed gap, while staying far above the
   ~0ms gap a genuinely-ignored override would produce (both variants would then wait
   the same real ~3000ms default, regardless of trials or minimum-taking). The outer
   per-call hang-guard is raised `30s -> 60s` to keep a comparable safety margin (the
   wedged Python itself only ever sleeps ~20s, so this ceiling is not expected to fire
   in practice -- it exists purely so a genuinely broken kill-on-timeout regression
   fails as a bounded panic instead of hanging the runner).

**This is structurally different from #129/#136**, not a repeat: #129/#136 each
shipped a *single-shot* delta comparison (one short run vs one long run, compared
once). #145 adds cross-test mutual exclusion (a mechanism neither prior fix touched)
*and* a statistical min-of-N reducer (also new) *and* widens the gap/tolerance -- three
independent levers instead of re-tuning the one lever that already failed twice.

**Still catches a real regression**: verified locally by temporarily forcing both
variants to the same probe value (simulating "override ignored") and confirming the
assertion panics with the expected message (see Verification below), then reverted.

## Fix B -- CI config (`.github/workflows/ci.yml`)

`test-rust-core`'s matrix crosses `os: [ubuntu-latest, windows-latest, macos-latest]` x
`rust_channel: [stable, nightly]` (6 total legs, `fail-fast: false`). Added:

```yaml
continue-on-error: ${{ matrix.rust_channel == 'nightly' }}
```

scoped to **only** the nightly leg via the existing `matrix.rust_channel` value (no
`include:`/`experimental`-flag indirection needed -- the axis already exists as a
plain array, so referencing it directly in the expression is the minimal-diff form of
the same standard mechanism). Nightly still **runs** and stays **visible** (GitHub
shows a caution icon on a `continue-on-error`-masked failure) so a real nightly
regression is still seen and can be triaged, but a nightly-only failure no longer
flips `test-rust-core`'s overall conclusion to `failure`, so it no longer blocks jobs
that `needs: test-rust-core`. The **stable** leg (all 3 OSes) is untouched and still
hard-gates release on a real failure.

### Release-gate trace

Read directly from `ci.yml`:

- `release` (line ~877, `name: Semantic Release`):
  `needs: [smoke, release-readiness, agent-readiness, windows-agent-readiness, package-manager-readiness, static-analysis, test-python, test-rust-core, search-golden-parity, native-build-smoke, test-gpu-linux, benchmark-regression]`,
  `if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !contains(...)`
  (no `always()`/`failure()` override -> implicitly also requires every needed job to
  have `conclusion: success`).
- `build-wheels-pypi` / `build-sdist-pypi`: `needs: release`.
- `publish-pypi`: `needs: [release, build-wheels-pypi, build-sdist-pypi, validate-pypi-artifacts, publish-github-release-assets]`.
- `publish-success-gate`: `needs: [release, publish-pypi, publish-github-release-assets]`, `if: always()`.
- `release-tag-smoke`: `needs: [release, publish-success-gate]`.

With `continue-on-error` scoped to nightly, a nightly-only failure now yields
`conclusion: success` for `test-rust-core` (masking only that leg's raw failure, shown
with a caution icon), so `release` and everything chained below it can proceed even if
the nightly leg is red. A real **stable**-leg failure still flips the conclusion to
`failure` and still blocks `release` exactly as before.

I also confirmed no governance test asserts anything about `test-rust-core`'s matrix
structure or `continue-on-error` that this would conflict with (`grep`'d
`rust_channel|test-rust-core|nightly` across `tests/`; the only matches are the two
release-workflow-configuration test files below, which pin `needs: smoke` /
`release.needs` string content only -- both untouched by this change and still pass).

## Verification

- **Governance tests** pinning `ci.yml`/release structure --
  `tests/unit/test_release_workflow_configuration.py` +
  `tests/unit/test_release_assets_validation.py`: **171 passed**.
- `ci.yml` parses with PyYAML; `continue-on-error` and `release.needs` inspected
  programmatically and confirmed as expected (see commit message for the exact
  values read back).
- `cargo fmt -- --check`: clean.
- `cargo clippy -- -D warnings` (CI's *exact* `static-analysis` invocation, no extra
  flags): clean. (A pre-existing, unrelated `clippy::field_reassign_with_default`
  warning in `src/rg_passthrough.rs` only surfaces under `--tests --no-default-features`,
  a flag combination CI's clippy step does not use -- confirmed by running CI's exact
  command, which is clean. Not touched by this PR; out of scope, flagging for
  visibility only.)
- `cargo test --no-default-features --no-run`: succeeds across the **full workspace**
  (all 26 integration test binaries + lib/bin unit tests) -- no compile break.
- **Target test stability**: ran
  `cargo test --no-default-features --test test_sidecar_ipc test_help_probe_timeout_env_override_falls_back_fast_with_wedged_python -- --nocapture --exact`
  **5 times solo**: 5/5 passed (~15-17s each, consistent with the new min-of-2-trials
  design).
- **Full-suite stress test** (the *real* contention scenario -- all 16 tests in
  `test_sidecar_ipc.rs` under `cargo test`'s default thread parallelism, so the two
  wedged-Python timing tests run alongside ~14 other subprocess-spawning tests): ran
  **3 times**, **3/3 passed** (all 16 tests green each time, ~18-19s total), including
  both `test_help_probe_timeout_env_override_falls_back_fast_with_wedged_python` and
  `test_help_probe_default_timeout_recovers_with_enriched_fallback_when_python_is_wedged`.
- **Bidirectional oracle check**: temporarily edited the test to pass the same
  (long) probe value for both "short" and "long" measurements, simulating "override
  ignored". Re-ran -- the assertion correctly **panicked**:
  `TG_HELP_PROBE_TIMEOUT_MS override was not honored -- the best of 2 run(s) at 250ms
  took 6.4939138s, but the best of 2 run(s) at 6000ms took only 6.4730985s; ...`.
  Reverted immediately after confirming.
- **Total**: 8/8 real passing executions (5 solo + 3 full-suite) + 1/1 confirmed
  correct failure under the artificial regression, 0 flakes observed.

## Scope

Test file + CI config only, per the release-blocker mandate -- no production Rust
source touched (`git diff --stat` below).

```
.github/workflows/ci.yml            |   7 +++
rust_core/tests/test_sidecar_ipc.rs | 114 +++++++++++++++++++++++++++++++-----
2 files changed, 107 insertions(+), 14 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
