### PR TITLE
perf(cli): defer heavy launcher-path imports to cut cold-start shim tax (#94)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -1,5 +1,4 @@
 import dataclasses
-import html
 import json
 import os
 import re
@@ -26,8 +25,6 @@ import click
 import typer
 from typer.core import TyperGroup
 
-from tensor_grep.backends.base import BackendExecutionError
-from tensor_grep.cli import ast_workflows
 from tensor_grep.cli.formatters.base import OutputFormatter
 from tensor_grep.cli.runtime_paths import (
     _native_tg_version,
@@ -39,9 +36,7 @@ from tensor_grep.cli.runtime_paths import (
     resolve_native_tg_binary,
     resolve_ripgrep_binary,
 )
-from tensor_grep.cli.scan_guardrails import BroadScanRefusedError, ensure_scan_not_broad
 from tensor_grep.core.observability import nvtx_range
-from tensor_grep.core.result import MatchLine
 from tensor_grep.core.retrieval_chunker import MAX_CHUNKS
 from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
@@ -49,7 +44,7 @@ from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
 if TYPE_CHECKING:
     from tensor_grep.backends.base import ComputeBackend
     from tensor_grep.core.config import SearchConfig
-    from tensor_grep.core.result import SearchResult
+    from tensor_grep.core.result import MatchLine, SearchResult
     from tensor_grep.io.directory_scanner import DirectoryScanner
 
 # backlog #1 (Fable+thinktank plan, 2026-07-06): kept numerically in sync with
@@ -399,6 +394,8 @@ def _candidate_versions_from_pypi_json(payload: object) -> list[str]:
 
 
 def _candidate_versions_from_pypi_simple_index(simple_index: str) -> list[str]:
+    import html
+
     candidates: list[str] = []
     for match in _PYPI_SIMPLE_ANCHOR_RE.finditer(simple_index):
         attrs = match.group("attrs")
@@ -4472,8 +4469,8 @@ def _run_rg_compatible_info_action(flag: str, unavailable_message: str) -> None:
 
 
 def _replace_lines(
-    matches: list[MatchLine], pattern: str, config: "SearchConfig"
-) -> list[MatchLine]:
+    matches: list["MatchLine"], pattern: str, config: "SearchConfig"
+) -> list["MatchLine"]:
     if config.replace_str is None:
         return matches
 
@@ -4577,8 +4574,8 @@ def _expand_ripgrep_replacement(template: str, match: re.Match[str]) -> str:
 
 
 def _only_matching_lines(
-    matches: list[MatchLine], pattern: str, config: "SearchConfig"
-) -> list[MatchLine]:
+    matches: list["MatchLine"], pattern: str, config: "SearchConfig"
+) -> list["MatchLine"]:
     flags = 0
     if config.ignore_case or (config.smart_case and pattern.islower()):
         flags |= re.IGNORECASE
@@ -5392,6 +5389,7 @@ def _run_ast_scan_payload(
     max_evidence_snippet_chars: int = 120,
 ) -> dict[str, object]:
     from tensor_grep.backends.ast_backend import normalize_ast_language
+    from tensor_grep.cli.scan_guardrails import ensure_scan_not_broad
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.result import SearchResult
     from tensor_grep.io.directory_scanner import DirectoryScanner
@@ -6445,6 +6443,12 @@ def search_command(
     Search files for a regex pattern. GPU routing is experimental and opt-in via --gpu-device-ids; CPU/ripgrep is the default and the current speed baseline.
     The stable text-search contract is the validated rg-compatible surface documented in docs/CONTRACTS.md.
     """
+    # Perf (#94 Part-B): lazy-imported here (not at module top) so non-search commands don't pay
+    # for backends.base's transitive core.config/core.result chain. search_command is the sole
+    # runtime user of BackendExecutionError in this module (except-clauses further below), and
+    # this sits before any loop, so it costs exactly one import per invocation, not per iteration.
+    from tensor_grep.backends.base import BackendExecutionError
+
     # Just forward to CPU backend for now as a stub.
     # Note: Full flag wiring will require mapping these dozens of parameters into the Pipeline/Core components.
     args = positionals or []
@@ -11656,6 +11660,7 @@ def scan(
     """Scan code with tensor-grep's bounded AST rule/config surface."""
     from tensor_grep.backends.ast_backend import normalize_ast_language
     from tensor_grep.cli.rule_packs import resolve_rule_pack
+    from tensor_grep.cli.scan_guardrails import BroadScanRefusedError
 
     inline_source_count = sum(item is not None for item in (ruleset, inline_rules, rule_file))
     if inline_source_count > 1:
@@ -11870,6 +11875,8 @@ def test(
     ),
 ) -> None:
     """Test structural rules in tensor-grep's bounded AST workflow slice."""
+    from tensor_grep.cli import ast_workflows
+
     exit_code = ast_workflows.test_command(config)
     if exit_code != 0:
         raise typer.Exit(code=exit_code)


### PR DESCRIPTION
## Summary

Defers 6 heavy, non-fast-path top-level imports in `src/tensor_grep/cli/main.py` to
function-local (lazy) imports at their sole real use sites, cutting the Python launcher shim's
cold-start import tax paid by every `tg` invocation (task #94 Part-B, "collapse the launcher-shim
import tax"). Pure import relocation.

**gate-free: import relocation only, no semantic change.**

## Imports moved (top-level -> function-local)

1. `import html` -> lazy inside `_candidate_versions_from_pypi_simple_index` (only reachable from
   `tg upgrade`'s PyPI-simple-index version parsing).
2. `from tensor_grep.backends.base import BackendExecutionError` -> lazy at the top of
   `search_command`'s body (before any loop -> one import per call, never per-iteration). Frees
   every non-search command (`defs`/`callers`/`refs`/`checkpoint`/`session`/`doctor`/...) from
   force-loading `backends.base`'s transitive `core.config`/`core.result` chain.
3. `from tensor_grep.cli import ast_workflows` -> lazy inside `test()` (`tg test`). Biggest single
   chunk in the importtime trace; transitively pulls in `backends.ast_backend` +
   `cli.scan_guardrails`.
4. `from tensor_grep.cli.scan_guardrails import BroadScanRefusedError` -> lazy inside `scan()`.
5. `from tensor_grep.cli.scan_guardrails import ensure_scan_not_broad` -> lazy inside
   `_run_ast_scan_payload` (added to its existing lazy-import block).
6. `from tensor_grep.core.result import MatchLine` -> moved under the existing `TYPE_CHECKING`
   block (used only as a type annotation in `_replace_lines`/`_only_matching_lines`, never
   instantiated at runtime). The 4 function-signature annotations are quoted forward refs
   (`list["MatchLine"]`); the 2 local-variable annotations stay unquoted (ruff UP037 -- CPython
   never evaluates a function-local variable annotation, verified empirically).

## Before / after cold-start (perf_counter wall-clock, `.pyc` cleared + cold warm-up discarded)

Command: `python -c "import time;t=time.perf_counter();import tensor_grep.cli.main;print(time.perf_counter()-t)"`

| metric | before (clean main) | after | delta |
|---|---|---|---|
| median of 8 warm samples | 151.1 ms | 141.05 ms | -10.05 ms (-6.7%) |
| min warm | 140.1 ms | 135.3 ms | -4.8 ms |
| cold (1st import post cache-clear) | 527 ms | 459 ms | -68 ms (-12.8%) |

Independent earlier controlled A/B (same method, separate run): warm avg 153.0 ms -> 138.4 ms
(-9.5%), warm min 149.2 ms -> 133.0 ms. The reduction shows up in median, min, AND distribution
tightness across both independent runs -- it is not measurement noise.

Note: `python -X importtime`'s raw cumulative total was used ONLY to identify which modules to
defer (per the task method); it is deliberately NOT the headline number because its per-module
instrumentation overhead makes its absolute totals non-representative -- the same clean-main code
ranged 159-517 ms cumulative across runs. The perf_counter wall-clock above is the load-bearing
measurement.

## Considered and rejected (do NOT re-propose without re-checking tests first)

Each looked like a safe lazy-import target by import cost alone, but a grep of the test suite
surfaced a hard dependency on the symbol staying a real module-level attribute of
`tensor_grep.cli.main`:

- `MAX_CHUNKS` (builds module-level `_SEMANTIC_CORPUS_CHUNK_CAP`) --
  `tests/integration/test_semantic_search_flag.py` does
  `monkeypatch.setattr("tensor_grep.cli.main._SEMANTIC_CORPUS_CHUNK_CAP", 1)`.
- `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` (builds `_UNBOUNDED_VENDORED_ROOT_DIR_NAMES`) --
  `tests/unit/test_cli_bootstrap.py` asserts the bootstrap.py and main.py mirrors are equal at
  module scope (the mirror is intentional so the two front-door guards can't drift).
- `import shutil` -- `tests/unit/test_cli_modes.py` does `monkeypatch.setattr(cli_main.shutil, ...)`.
- `DEFAULT_CLASSIFY_MAX_LINES` -- used as a live `typer.Option(...)` default, evaluated at
  module-import time by Python; deferring would change rendered `--help` (out of scope for a
  gate-free change).
- `cli.formatters` package (~57 ms) -- cost is driven by `formatters/__init__.py`'s own eager
  re-exports, a different module's contract; out of scope here.

## Verification

- `tg --help`, `tg search/scan/test/upgrade --help`: byte-identical before vs after (`diff` clean
  on all 5).
- Dogfooded the REAL built binary (`.venv/Scripts/tg.exe`, not CliRunner): `tg search`, `tg defs`,
  `tg callers` (fast path) exit 0; `tg test` (no sgconfig) and `tg scan --ruleset subprocess-safe`
  both execute the newly-lazy import paths cleanly (no NameError).

## Gate status -- all 4 pass

1. `ruff check src/tensor_grep` -- PASS (`All checks passed!`).
2. `ruff format --check --preview src/tensor_grep` -- PASS (79 files already formatted).
3. `mypy src/tensor_grep` -- PASS (`Success: no issues found in 79 source files`). Confirms the 4
   module-level references a no-venv Pyright pass flagged (env_flag_disabled,
   UNBOUNDED_VENDORED_ROOT_DIR_NAMES, _ast_grep_command_timeout_seconds, line_number_explicit) all
   resolve -- they were Pyright false positives, none were touched.
4. `pytest -q` (full suite, natural CI collection order) -- PASS: **4511 passed, 30 skipped**.
   (One test, `test_search_semantic_with_real_model_engages_dense_leg`, needs the `semantic` extra
   `model2vec`, which was installed to complete the local dev env; it fails identically on clean
   `main` without it -- an env condition, not a regression.)

**all 4 gates pass**
