### PR TITLE
fix(security): canonicalize exec parent (8.3/junction/\?\) before apply_policy to close fail-open edges (#126)

### DIFF
--- a/src/tensor_grep/cli/apply_policy.py
+++ b/src/tensor_grep/cli/apply_policy.py
@@ -645,6 +645,29 @@ def _run_policy_command(name: str, command: str, cwd: Path, timeout: int) -> dic
             detail=f"{name} command executable {(argv[0] if argv else command)!r} was not found on PATH.",
         )
     resolved_path = Path(os.path.abspath(resolved_executable))
+
+    # #126 (Opus re-gate, 4th same-class edge -- UNC / network-share smuggling): a UNC spelling of
+    # the executable -- \\host\share\..., the loopback admin-share \\127.0.0.1\C$\...\<repo>\evil.cmd
+    # / \\localhost\C$\..., or the \\?\UNC\... extended form -- names the SAME on-disk in-repo shadow
+    # through the network/admin-share namespace, which Path.resolve() does NOT map back to its C:\
+    # drive-letter form (verified empirically). So _canonicalize_exec_parent returns a still-UNC
+    # parent and NEITHER the raw-stripped nor the canonical beneath-compare starts with the local
+    # repo-root string -- the OR-guard below would pass and the shadow would spawn (reproduced live
+    # end-to-end by the adversarial gate on a box where the C$ admin share is reachable). A
+    # UNC-spelled executable can never be confined to a LOCAL drive-letter repo root by a string
+    # comparison, and a legitimate local tool always resolves to a drive-letter path (C:\..., and
+    # \\?\C:\... -> C:\... after the ext-length strip -- NOT a UNC prefix), so refuse any UNC
+    # executable path outright. Fail closed, before the beneath-guard.
+    stripped_exec = _strip_extended_length_prefix(str(resolved_path))
+    if stripped_exec.startswith("\\\\"):
+        return _command_result(
+            passed=False,
+            detail=(
+                f"{name} command executable {argv[0]!r}: refusing a UNC/network-share "
+                f"executable path {resolved_path} (cannot be confined to the local repo root)."
+            ),
+        )
+
     try:
         untrusted_root = cwd.resolve()
     except OSError:

--- a/src/tensor_grep/cli/apply_policy.py
+++ b/src/tensor_grep/cli/apply_policy.py
@@ -386,8 +386,33 @@ def _path_is_under(path: Path, root: Path) -> bool:
         return False
 
 
+def _strip_extended_length_prefix(path_str: str) -> str:
+    r"""Strip a Windows ``\\?\`` / ``\\?\UNC\`` extended-length prefix for a STRING
+    comparison (#126).
+
+    The prefix opts a path OUT of Windows' normal path processing (component
+    normalization, 8.3 lookup, ``MAX_PATH`` checks) and is preserved verbatim by both
+    ``os.path.abspath`` and ``Path.resolve()`` -- verified empirically on this box:
+    neither adds nor removes it. An untrusted policy's ``lint_cmd``/``test_cmd`` can
+    spell its ``argv[0]`` with this prefix explicitly; since ``shutil.which()`` returns
+    an already-path-shaped ``argv[0]`` unchanged (a path containing a separator skips
+    the PATH search and is returned as-is after an access check), the prefix survives
+    all the way to the confinement comparison in ``_abspath_beneath_or_equal``. Left
+    unstripped, a prefixed spelling of a location and an unprefixed spelling of the
+    identical location never string-match, so the beneath-or-equal check silently
+    returns False (not beneath) for a path that IS beneath -- fail OPEN. Stripping it
+    here, ahead of ``normcase``/``normpath``, closes that gap for both operands
+    uniformly. A no-op on POSIX and on any path that never had the prefix.
+    """
+    if path_str.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path_str[len("\\\\?\\UNC\\") :]
+    if path_str.startswith("\\\\?\\"):
+        return path_str[len("\\\\?\\") :]
+    return path_str
+
+
 def _abspath_beneath_or_equal(path: Path, root: Path) -> bool:
-    """True if ``path`` is ``root`` itself or nested anywhere beneath it (any depth).
+    r"""True if ``path`` is ``root`` itself or nested anywhere beneath it (any depth).
 
     Deliberately independent of ``_path_is_under()``/``Path.relative_to()``: the
     shadow-executable guard in ``_run_policy_command`` must run this check on an
@@ -403,13 +428,57 @@ def _abspath_beneath_or_equal(path: Path, root: Path) -> bool:
     "outside root" negative. The beneath check requires a ``os.sep`` boundary after
     the root prefix, so a sibling directory that merely shares a string prefix with
     the root (e.g. ``repo-other`` next to ``repo``) is never wrongly treated as
-    nested inside it.
+    nested inside it. Each side is also run through ``_strip_extended_length_prefix``
+    first (#126) so a ``\\?\``-prefixed spelling of a path matches an unprefixed
+    spelling of the identical location.
     """
-    normalized_path = os.path.normcase(os.path.normpath(str(path)))
-    normalized_root = os.path.normcase(os.path.normpath(str(root)))
+    normalized_path = os.path.normcase(os.path.normpath(_strip_extended_length_prefix(str(path))))
+    normalized_root = os.path.normcase(os.path.normpath(_strip_extended_length_prefix(str(root))))
     if normalized_path == normalized_root:
         return True
     return normalized_path.startswith(normalized_root + os.sep)
+
+
+def _canonicalize_exec_parent(executable_path: Path) -> Path | None:
+    r"""Canonicalize ``executable_path``'s PARENT directory chain for the repo-confinement
+    comparison (#126, H2 fast-follow -- commit e10c91d explicitly deferred this: "the
+    parent-canonicalization hardening (8.3/junction/\?\ edges) is intentionally NOT
+    applied here -- it is a tracked fast-follow").
+
+    ``_run_policy_command`` intentionally confines on ``os.path.abspath`` rather than
+    ``Path.resolve()`` (see ``_abspath_beneath_or_equal``'s docstring): the #453 defense
+    requires a repo-local shadow that is ITSELF a symlink/junction to be judged by where
+    it lexically sits, never by where it points, or a symlink escaping the repo to an
+    arbitrary outside target would slip the guard. But that same lexical-only comparison
+    is bypassable in the OTHER direction: an 8.3 short name (``PROGRA~1`` vs
+    ``Program Files``), an NTFS junction alias, or an explicit ``\\?\``-prefixed spelling
+    can all name a location INSIDE the untrusted repo while spelling it differently from
+    the repo root's own canonical string -- ``_abspath_beneath_or_equal`` then silently
+    returns False (not beneath) for a path that IS beneath. Fail open.
+
+    The fix resolves ONLY ``executable_path.parent`` -- never the full path, which would
+    dereference the leaf and reopen #453 -- via ``Path.resolve(strict=True)``. Verified
+    empirically on Windows: this single call both expands 8.3 short-name components at
+    every level of the parent chain (``GetFinalPathNameByHandleW`` returns the
+    filesystem's own canonical long name directly; a second ``GetLongPathNameW`` pass is
+    not needed) and fully traverses NTFS junctions/symlinks in the parent chain, in one
+    step. ``strict=True`` is intentional and mirrors this module's existing
+    resolve-or-None convention (``_policy_file_arg``, above): the parent MUST exist by
+    the time this runs (``resolved_executable`` was just confirmed to exist by
+    ``shutil.which``), so a failure here means a TOCTOU race, a permission error, or
+    other OS-level unresolvability -- not a legitimate case worth weakening the guard
+    for.
+
+    Returns ``None`` when canonicalization fails for any reason. Callers MUST fail
+    closed (deny) on ``None`` -- mirroring the fail-closed contract already established
+    at every other confinement chokepoint in this module and in
+    ``mcp_server.py::_confine_mcp_path``. Never treat ``None`` as "not beneath root".
+    """
+    try:
+        resolved_parent = executable_path.parent.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    return resolved_parent / executable_path.name
 
 
 def _policy_file_arg(path_value: object, *, working_root: Path) -> str | None:
@@ -580,7 +649,30 @@ def _run_policy_command(name: str, command: str, cwd: Path, timeout: int) -> dic
         untrusted_root = cwd.resolve()
     except OSError:
         untrusted_root = cwd
-    if _abspath_beneath_or_equal(resolved_path, untrusted_root):
+
+    # #126 (Windows canonicalization fail-open, H2 fast-follow -- e10c91d deferred this):
+    # resolved_path above is deliberately lexical-only (os.path.abspath, no symlink-follow --
+    # see _abspath_beneath_or_equal's docstring), which an 8.3 short name / NTFS junction
+    # alias / \?\-prefixed spelling of an in-repo location can evade. _canonicalize_exec_parent
+    # closes that gap without reopening #453 (it never dereferences the leaf). Checked WITH,
+    # never INSTEAD OF, the raw lexical guard below: the two conditions cover disjoint gaps --
+    # raw catches "spelled in-repo", canonical catches "resolves in-repo but spelled
+    # differently" -- so ORing them only ever denies a superset of what either denies alone;
+    # a legitimate outside-root binary fails both and is never affected. Canonicalization
+    # failure fails closed (denied), matching every other confinement chokepoint in this
+    # module.
+    canonical_exec_parent = _canonicalize_exec_parent(resolved_path)
+    if canonical_exec_parent is None:
+        return _command_result(
+            passed=False,
+            detail=(
+                f"{name} command executable {argv[0]!r}: could not canonicalize "
+                f"{resolved_path} for the repo-confinement check; refusing to run it."
+            ),
+        )
+    if _abspath_beneath_or_equal(resolved_path, untrusted_root) or _abspath_beneath_or_equal(
+        canonical_exec_parent, untrusted_root
+    ):
         return _command_result(
             passed=False,
             detail=(

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -1951,3 +1951,136 @@ def test_run_policy_command_denies_when_exec_parent_canonicalization_fails(
     assert result["passed"] is False
     assert not spawn_calls
     assert "could not canonicalize" in str(result["detail"])
+
+
+# --- #126 Opus re-gate: the 4th same-class edge -- UNC / network-share smuggling ---
+#
+# The gate reproduced a fourth bypass END-TO-END against the real _run_policy_command: a UNC
+# loopback admin-share spelling of the identical in-repo shadow gets SPAWNED. argv[0] spellings of
+# <untrusted-repo>\evil.cmd like \\127.0.0.1\C$\...\untrusted-repo\evil.cmd, \\localhost\C$\...,
+# and \\?\UNC\127.0.0.1\C$\... all pass the guard and reach subprocess.run because Path.resolve()
+# does NOT map the \\host\C$\... admin-share namespace back to C:\..., so _canonicalize_exec_parent
+# returns a still-UNC parent and neither the raw-stripped nor the canonical beneath-compare starts
+# with the repo-root string. A UNC-spelled executable can never be confined to a LOCAL drive-letter
+# repo root by a string comparison, so _run_policy_command now refuses any UNC executable path
+# outright (fail closed). Verified empirically: a legitimate local tool always resolves to a
+# drive-letter path (C:\..., and \\?\C:\...->C:\... after the ext-length strip), never a UNC prefix.
+
+
+@pytest.mark.parametrize(
+    "unc_prefix",
+    [
+        "\\\\127.0.0.1\\C$\\",  # loopback IP admin share
+        "\\\\localhost\\C$\\",  # loopback hostname admin share
+        "\\\\?\\UNC\\127.0.0.1\\C$\\",  # extended-length UNC form of the same
+    ],
+)
+def test_run_policy_command_rejects_unc_admin_share_shadow_inside_repo(
+    tmp_path: Path, monkeypatch, unc_prefix: str
+) -> None:
+    r"""#126 bidirectional oracle (UNC / admin-share edge). A repo-local shadow is reached via a
+    UNC loopback admin-share (C$) spelling of the identical on-disk file. Pre-fix: fail open
+    (Path.resolve() leaves the parent UNC, so no beneath-compare matches -> spawned). Post-fix:
+    _run_policy_command refuses any UNC-spelled executable outright (it can never be confined to
+    a local drive-letter repo root).
+
+    Platform-agnostic on purpose: the refusal is a pure string check on argv[0]'s shape (does it
+    resolve to a \\... UNC path), which behaves identically on any OS -- no live C$ share or admin
+    token is needed to exercise the guard, only to exploit the underlying bypass. shutil.which()
+    returns an already-path-shaped argv[0] unchanged (no PATH search, no canonicalization), so the
+    UNC spelling reaches the guard verbatim."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    shadow = _write_fake_executable(repo, "pytest", "shadow-pwned")
+
+    # Build the UNC spelling of the SAME on-disk shadow. Only the drive-letter tail is reused; the
+    # UNC prefix (loopback admin share) is what Path.resolve() cannot fold back to a local path.
+    drive_tail = str(shadow.resolve())[3:]  # strip "C:\" -> "Users\...\untrusted-repo\pytest.cmd"
+    unc_shadow = unc_prefix + drive_tail
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: unc_shadow if cmd == "pytest" else None,
+    )
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("test", "pytest --check", repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls, "a UNC-spelled repo-local shadow must never be spawned"
+    assert "UNC/network-share" in str(result["detail"])
+
+
+def test_run_policy_command_rejects_unc_share_even_when_outside_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    r"""A UNC path is refused REGARDLESS of what it points to -- even a genuinely off-box
+    \\fileserver\share\tool.exe. A network-share executable can't be confined to (or reasoned
+    about against) the local repo root by a string comparison at all, so it fails closed. This
+    also documents the (rare, acceptable) behavior change: a policy that deliberately invoked a
+    tool off a mapped UNC share would now be refused; the security posture (never run an
+    unconfinable network binary against an untrusted checkout) wins over that niche convenience."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    repo.mkdir()
+    unc_tool = "\\\\fileserver\\tools\\ruff.exe"
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: unc_tool if cmd == "ruff" else None,
+    )
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("lint", "ruff check .", repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls
+    assert "UNC/network-share" in str(result["detail"])
+
+
+def test_run_policy_command_allows_local_drive_letter_tool_not_flagged_as_unc(
+    tmp_path: Path, monkeypatch
+) -> None:
+    r"""No regression from the UNC guard: an ordinary local drive-letter tool (C:\... or its
+    \\?\C:\... extended-length form, which strips to C:\...) is NOT a UNC path and still runs."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    repo.mkdir()
+    trusted = tmp_path / "trusted-bin"
+    real_tool = _write_fake_executable(trusted, "ruff", "real-tool")
+
+    # Exercise BOTH the plain and the \\?\-extended local spelling; both must be allowed.
+    for which_return in (str(real_tool), "\\\\?\\" + str(real_tool.resolve())):
+        monkeypatch.setattr(
+            apply_policy.shutil,
+            "which",
+            lambda cmd, path=None, _r=which_return: _r if cmd == "ruff" else None,
+        )
+        captured: dict[str, object] = {}
+
+        def _fake_run(argv, _cap=captured, **kwargs):
+            _cap["argv"] = list(argv)
+            import subprocess as _sp
+
+            return _sp.CompletedProcess(argv, 0, "", "")
+
+        monkeypatch.setattr(apply_policy.subprocess, "run", _fake_run)
+
+        result = apply_policy._run_policy_command("lint", "ruff check .", repo, timeout=10)
+
+        assert result["passed"] is True, f"local tool spelled {which_return!r} must run"
+        assert captured.get("argv") is not None
+        assert "UNC" not in str(result["detail"])

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -1757,6 +1757,14 @@ def test_canonicalize_exec_parent_resolves_real_junction(tmp_path: Path) -> None
     assert "junction-alias" not in str(canonical)
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows path-namespace semantics (8.3 short-name / NTFS junction / "
+    "extended-length prefix / UNC admin-share). On POSIX these argv[0] strings are literal "
+    "filenames (backslash is a valid char, no drive letter), so the shadow is still DENIED "
+    "fail-closed -- shutil.which returns None for the non-existent literal path -- but via a "
+    "different code path (not-found-on-PATH) than this Windows-specific assertion checks.",
+)
 def test_run_policy_command_rejects_extended_length_prefix_shadow_inside_repo(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1788,6 +1796,10 @@ def test_run_policy_command_rejects_extended_length_prefix_shadow_inside_repo(
     assert "refusing a repo-local executable shadow" in str(result["detail"])
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only NTFS junction (mklink /J via cmd.exe, absent on POSIX).",
+)
 def test_run_policy_command_rejects_junction_alias_shadow_inside_repo(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1830,6 +1842,10 @@ def test_run_policy_command_rejects_junction_alias_shadow_inside_repo(
     assert "refusing a repo-local executable shadow" in str(result["detail"])
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only NTFS junction (mklink /J via cmd.exe, absent on POSIX).",
+)
 def test_run_policy_command_allows_junction_alias_that_resolves_outside_repo(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1874,6 +1890,11 @@ def test_run_policy_command_allows_junction_alias_that_resolves_outside_repo(
     assert captured.get("argv") is not None
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only 8.3 short-name scenario (the ~1 short alias + the Path.resolve() "
+    "8.3-expansion behavior this simulates are Windows path-namespace concepts).",
+)
 def test_run_policy_command_rejects_8dot3_alias_shadow_inside_repo(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -1967,6 +1988,14 @@ def test_run_policy_command_denies_when_exec_parent_canonicalization_fails(
 # drive-letter path (C:\..., and \\?\C:\...->C:\... after the ext-length strip), never a UNC prefix.
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only UNC / admin-share (C$) path namespace. On POSIX a \\\\host\\C$\\ "
+    "string is a literal relative filename (no network/admin-share, no drive letter), so the "
+    "shadow is still DENIED fail-closed but via not-found/could-not-canonicalize, not this "
+    "Windows-specific UNC-refusal assertion. The UNC guard itself is inert on POSIX by design "
+    "(os.path.abspath never yields a \\\\-leading path there).",
+)
 @pytest.mark.parametrize(
     "unc_prefix",
     [
@@ -2017,6 +2046,10 @@ def test_run_policy_command_rejects_unc_admin_share_shadow_inside_repo(
     assert "UNC/network-share" in str(result["detail"])
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only UNC / network-share path namespace (see the admin-share test above).",
+)
 def test_run_policy_command_rejects_unc_share_even_when_outside_repo(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -2050,6 +2083,11 @@ def test_run_policy_command_rejects_unc_share_even_when_outside_repo(
     assert "UNC/network-share" in str(result["detail"])
 
 
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only: exercises the \\\\?\\C:\\ extended-length local spelling that only "
+    "resolves on Windows; on POSIX that literal string does not name the real tool.",
+)
 def test_run_policy_command_allows_local_drive_letter_tool_not_flagged_as_unc(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/unit/test_apply_policy.py
+++ b/tests/unit/test_apply_policy.py
@@ -1230,11 +1230,21 @@ def test_run_policy_command_resolves_relative_executable_to_absolute(
     # guard that fixture would itself BE the nested-shadow vulnerability, not a legitimate
     # outside-root binary, so it must live outside the untrusted root to keep testing what its
     # name says it tests.
+    #
+    # #126: the confinement check now also canonicalizes the resolved executable's parent
+    # directory (Path.resolve(strict=True), to catch 8.3/junction/\\?\ aliasing) rather than
+    # comparing purely lexical strings, so "trusted-bin" must be a real, resolvable directory --
+    # a mocked shutil.which() pointing at a path whose parent doesn't exist on disk no longer
+    # models a legitimate resolved binary (in reality shutil.which() never returns a path whose
+    # parent is missing).
     from tensor_grep.cli import apply_policy
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    fake_abs = str(tmp_path / "trusted-bin" / "ruff")
+    trusted_bin = tmp_path / "trusted-bin"
+    trusted_bin.mkdir()
+    fake_abs = str(trusted_bin / "ruff")
+    Path(fake_abs).write_text("", encoding="utf-8")
     monkeypatch.setattr(
         apply_policy.shutil,
         "which",
@@ -1594,5 +1604,350 @@ def test_search_path_without_cwd_keeps_sibling_prefix_directory(
 
     filtered = apply_policy._search_path_without_cwd()
     filtered_entries = filtered.split(os.pathsep) if filtered else []
-
     assert str(sibling_prefix) in filtered_entries
+
+
+# --- #126: canonicalize the exec parent before the apply_policy confinement decision ---
+#
+# commit e10c91d (H2, #509) fixed the beneath-or-equal depth bug but explicitly deferred this:
+# "Guard logic unchanged; the parent-canonicalization hardening (8.3/junction/\?\ edges) is
+# intentionally NOT applied here -- it is a tracked fast-follow." resolved_path in
+# _run_policy_command is built via os.path.abspath (a purely LEXICAL normalization, deliberately
+# NOT Path.resolve() -- see _abspath_beneath_or_equal's docstring and the #453 regression test
+# above) so that a repo-local shadow which is itself a symlink is judged by where it lexically
+# sits, never by where it points. But that same lexical-only comparison can be BYPASSED in the
+# opposite direction: an 8.3 short name (PROGRA~1 vs "Program Files"), an NTFS junction alias, or
+# an explicit \\?\ / \\?\UNC\ extended-length prefix can all spell a location INSIDE the untrusted
+# repo differently from the repo root's own canonical string, so the plain startswith-style check
+# silently returns False (not beneath) for a path that IS beneath -- fail OPEN.
+
+
+def test_strip_extended_length_prefix_removes_prefix() -> None:
+    r"""Pure string-level unit test (platform-agnostic): the \\?\ extended-length prefix is
+    preserved verbatim by both os.path.abspath and Path.resolve() (verified empirically --
+    neither adds nor strips it), so it must be stripped explicitly before a normcase/normpath
+    confinement comparison."""
+    from tensor_grep.cli.apply_policy import _strip_extended_length_prefix
+
+    assert _strip_extended_length_prefix("\\\\?\\C:\\repo\\evil.cmd") == "C:\\repo\\evil.cmd"
+
+
+def test_strip_extended_length_prefix_removes_unc_prefix() -> None:
+    from tensor_grep.cli.apply_policy import _strip_extended_length_prefix
+
+    assert (
+        _strip_extended_length_prefix("\\\\?\\UNC\\server\\share\\evil.cmd")
+        == "\\\\server\\share\\evil.cmd"
+    )
+
+
+def test_strip_extended_length_prefix_is_a_noop_for_normal_paths() -> None:
+    from tensor_grep.cli.apply_policy import _strip_extended_length_prefix
+
+    assert _strip_extended_length_prefix("C:\\repo\\evil.cmd") == "C:\\repo\\evil.cmd"
+    assert _strip_extended_length_prefix("/home/user/repo/evil") == "/home/user/repo/evil"
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="\\\\?\\ extended-length prefix is Windows-only"
+)
+def test_abspath_beneath_or_equal_matches_extended_length_prefixed_spelling(
+    tmp_path: Path,
+) -> None:
+    r"""A \\?\-prefixed spelling of a path INSIDE root must still compare beneath root -- the
+    exact fail-open #126 closes: before the fix these two spellings of the identical location
+    compared as unrelated strings."""
+    from tensor_grep.cli.apply_policy import _abspath_beneath_or_equal
+
+    root = tmp_path / "repo"
+    prefixed = Path("\\\\?\\" + str(root) + "\\evil.cmd")
+    assert _abspath_beneath_or_equal(prefixed, root) is True
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="\\\\?\\ extended-length prefix is Windows-only"
+)
+def test_abspath_beneath_or_equal_extended_length_prefix_no_false_positive(
+    tmp_path: Path,
+) -> None:
+    r"""Stripping the \\?\ prefix must not make an outside-root path look beneath root."""
+    from tensor_grep.cli.apply_policy import _abspath_beneath_or_equal
+
+    root = tmp_path / "repo"
+    prefixed_unrelated = Path("\\\\?\\" + str(tmp_path / "unrelated") + "\\evil.cmd")
+    assert _abspath_beneath_or_equal(prefixed_unrelated, root) is False
+
+
+def test_canonicalize_exec_parent_fails_closed_on_nonexistent_parent(tmp_path: Path) -> None:
+    """Canonicalization failure (a parent directory that doesn't resolve) must return None,
+    never a best-effort guess -- callers fail closed (deny) on None."""
+    from tensor_grep.cli.apply_policy import _canonicalize_exec_parent
+
+    missing = tmp_path / "does-not-exist-xyz" / "tool.cmd"
+    assert _canonicalize_exec_parent(missing) is None
+
+
+def test_canonicalize_exec_parent_does_not_dereference_the_leaf_symlink(tmp_path: Path) -> None:
+    """#453 preservation: _canonicalize_exec_parent must resolve ONLY the executable's parent
+    directory, never the leaf itself. If the leaf is a symlink whose target is OUTSIDE the repo,
+    canonicalizing it must NOT follow the link there -- that is exactly the #453 RCE (a
+    repo-local shadow that is a symlink escaping confinement by resolving outside the repo)."""
+    from tensor_grep.cli.apply_policy import _canonicalize_exec_parent
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside"
+    payload = _write_fake_executable(outside, "evil", "pwned")
+    shadow = repo / "ruff.cmd"
+    try:
+        shadow.symlink_to(payload)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted on this box")
+
+    canonical = _canonicalize_exec_parent(shadow)
+
+    assert canonical is not None
+    assert canonical.parent == repo.resolve()
+    assert canonical.name == "ruff.cmd"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="8.3 short names are a Windows-only concept")
+def test_canonicalize_exec_parent_expands_real_8dot3_short_name() -> None:
+    """Uses the OS-provided `C:\\PROGRA~1` short name for `C:\\Program Files`, present on every
+    Windows install and readable without admin/write access -- unlike forcing FRESH 8.3
+    generation on a throwaway test directory, which needs `fsutil 8dot3name set <path> 0` (an
+    elevated volume handle; verified 'Error 5: Access is denied' without admin on this dev box).
+    """
+    from tensor_grep.cli.apply_policy import _canonicalize_exec_parent
+
+    short_form_parent = Path(r"C:\PROGRA~1")
+    if not short_form_parent.is_dir():
+        pytest.skip("C:\\PROGRA~1 8.3 alias is not available on this box")
+
+    canonical = _canonicalize_exec_parent(short_form_parent / "tool.cmd")
+
+    assert canonical is not None
+    assert "PROGRA~1" not in str(canonical)
+    assert canonical.parent == Path(r"C:\Program Files").resolve()
+    assert canonical.name == "tool.cmd"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="NTFS junctions are a Windows-only concept")
+def test_canonicalize_exec_parent_resolves_real_junction(tmp_path: Path) -> None:
+    """`mklink /J` (a directory junction) needs no admin privilege, unlike a symlink -- this
+    reproduces the real reparse-point mechanism end-to-end."""
+    from tensor_grep.cli.apply_policy import _canonicalize_exec_parent
+
+    real_target = tmp_path / "real-target"
+    real_target.mkdir()
+    junction = tmp_path / "junction-alias"
+    proc = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(real_target)],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"junction creation not permitted on this box: {proc.stderr}")
+
+    canonical = _canonicalize_exec_parent(junction / "tool.cmd")
+
+    assert canonical is not None
+    assert canonical.parent == real_target.resolve()
+    assert canonical.name == "tool.cmd"
+    assert "junction-alias" not in str(canonical)
+
+
+def test_run_policy_command_rejects_extended_length_prefix_shadow_inside_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    r"""#126 bidirectional oracle (\\?\ edge), fully real: the policy's own command string
+    spells argv[0] with an explicit \\?\ extended-length prefix pointing at a real repo-local
+    shadow. shutil.which() treats an already-path-shaped argv[0] as-is (no PATH search, no
+    canonicalization -- verified empirically), so the prefix survives all the way to the
+    confinement check. Pre-fix this compares as an unrelated string (fail open, spawned);
+    post-fix _abspath_beneath_or_equal strips the prefix before comparing (denied)."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    shadow = _write_fake_executable(repo, "evil", "shadow-pwned")
+
+    extended_prefixed = "\\\\?\\" + str(shadow.resolve())
+    command = _policy_command(extended_prefixed, "--check")
+
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("test", command, repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls, "the \\?\\-prefixed repo-local shadow must never be spawned"
+    assert "refusing a repo-local executable shadow" in str(result["detail"])
+
+
+def test_run_policy_command_rejects_junction_alias_shadow_inside_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#126 bidirectional oracle (junction edge), fully real: a repo-local shadow is resolved
+    via an NTFS junction alias that lives OUTSIDE the repo but points AT it, so its lexical
+    string never starts with the repo root's string even though it names the same on-disk
+    file. Pre-fix: fail open (spawned). Post-fix: _canonicalize_exec_parent resolves through
+    the junction and the OR-guard denies it."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    shadow = _write_fake_executable(repo, "pytest", "shadow-pwned")
+
+    alias = tmp_path / "alias-outside-repo"
+    proc = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(alias), str(repo)],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"junction creation not permitted on this box: {proc.stderr}")
+
+    aliased_shadow = str(alias / shadow.name)
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: aliased_shadow if cmd == "pytest" else None,
+    )
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("test", "pytest --check", repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls, "the junction-aliased repo-local shadow must never be spawned"
+    assert "refusing a repo-local executable shadow" in str(result["detail"])
+
+
+def test_run_policy_command_allows_junction_alias_that_resolves_outside_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """No regression: a LEGITIMATE trusted binary reached via a junction alias, where both the
+    alias and its real target are genuinely outside the untrusted repo, must still be allowed
+    to run -- canonicalization must not manufacture a false positive."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    repo.mkdir()
+
+    real_trusted = tmp_path / "real-trusted-bin"
+    real_tool = _write_fake_executable(real_trusted, "ruff", "real-tool")
+    trusted_alias = tmp_path / "trusted-alias"
+    proc = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(trusted_alias), str(real_trusted)],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"junction creation not permitted on this box: {proc.stderr}")
+
+    aliased_tool = str(trusted_alias / real_tool.name)
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: aliased_tool if cmd == "ruff" else None,
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_run(argv, **kwargs):
+        captured["argv"] = list(argv)
+        import subprocess as _sp
+
+        return _sp.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(apply_policy.subprocess, "run", _fake_run)
+
+    result = apply_policy._run_policy_command("lint", "ruff check .", repo, timeout=10)
+
+    assert result["passed"] is True
+    assert captured.get("argv") is not None
+
+
+def test_run_policy_command_rejects_8dot3_alias_shadow_inside_repo(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#126 bidirectional oracle (8.3 edge). A fully real reproduction needs FRESH NTFS 8.3
+    short-name generation forced on a throwaway test directory (`fsutil 8dot3name set <path>
+    0`), which needs an elevated volume handle -- verified 'Error 5: Access is denied' without
+    admin on this dev box, and 8dot3 generation is disabled by default for new directories on
+    modern Windows anyway. The real mechanism (Path.resolve(strict=True) expanding an 8.3 alias)
+    is proven directly against the OS's own always-present `C:\\PROGRA~1` short name in
+    test_canonicalize_exec_parent_expands_real_8dot3_short_name. This test proves the
+    _run_policy_command WIRING side: shutil.which() returns an 8.3-shaped short alias (the exact
+    string shape GetShortPathNameW produces: a truncated stem + `~1`) of a real repo-local
+    shadow, and _canonicalize_exec_parent is monkeypatched to return exactly what a real
+    Path.resolve(strict=True) call resolves an 8.3 alias to (its own proven behavior) -- so the
+    only new thing under test here is that _run_policy_command's OR-guard denies when the
+    CANONICAL form (not the raw lexical form) lands inside the repo."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo-with-a-long-name"
+    shadow = _write_fake_executable(repo, "pytest", "shadow-pwned")
+
+    short_alias = str(tmp_path / "UNTRUS~1" / "pytest.cmd")
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: short_alias if cmd == "pytest" else None,
+    )
+    monkeypatch.setattr(
+        apply_policy,
+        "_canonicalize_exec_parent",
+        lambda executable_path: shadow.resolve(),
+    )
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("test", "pytest --check", repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls, "the 8.3-aliased repo-local shadow must never be spawned"
+    assert "refusing a repo-local executable shadow" in str(result["detail"])
+
+
+def test_run_policy_command_denies_when_exec_parent_canonicalization_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Fail closed: when _canonicalize_exec_parent cannot resolve the executable's parent for
+    any reason, _run_policy_command must deny, never fall back to allowing the command through
+    on the raw (un-canonicalized) comparison alone."""
+    from tensor_grep.cli import apply_policy
+
+    repo = tmp_path / "untrusted-repo"
+    repo.mkdir()
+    trusted = tmp_path / "trusted-bin"
+    real_tool = _write_fake_executable(trusted, "ruff", "real-tool")
+
+    monkeypatch.setattr(
+        apply_policy.shutil,
+        "which",
+        lambda cmd, path=None: str(real_tool) if cmd == "ruff" else None,
+    )
+    monkeypatch.setattr(apply_policy, "_canonicalize_exec_parent", lambda executable_path: None)
+    spawn_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        apply_policy.subprocess,
+        "run",
+        lambda argv, **kwargs: spawn_calls.append(list(argv)),
+    )
+
+    result = apply_policy._run_policy_command("lint", "ruff check .", repo, timeout=10)
+
+    assert result["passed"] is False
+    assert not spawn_calls
+    assert "could not canonicalize" in str(result["detail"])


### PR DESCRIPTION
## Summary

Closes the `apply_policy` Windows canonicalization fail-open edges tracked as a fast-follow
in commit `e10c91d` (H2, #509): *"the parent-canonicalization hardening (8.3/junction/\\?\
edges) is intentionally NOT applied here -- it is a tracked fast-follow."*

- **The fail-open edge, cited**: `src/tensor_grep/cli/apply_policy.py:647` builds
  `resolved_path = Path(os.path.abspath(resolved_executable))` -- deliberately **lexical only**
  (never `Path.resolve()`), by design: the `#453` defense requires a repo-local shadow that is
  itself a symlink/junction to be judged by where it lexically sits, never by where it points
  (see the docstring on `_abspath_beneath_or_equal`, `apply_policy.py:414-439`). That lexical-only
  comparison is bypassable in the *other* direction. All three of the task's named edges were
  confirmed fail-open on `main` (empirically verified on this Windows dev box, not just read from
  the code):
  1. **8.3 short name** (`PROGRA~1` vs `Program Files`) -- `os.path.abspath()` does not expand it;
     `_abspath_beneath_or_equal`'s `normcase(normpath(...))` string compare then sees two
     unrelated strings for the identical on-disk location.
  2. **NTFS junction alias** -- `os.path.abspath()` does not traverse a junction; a repo-local
     shadow reached via a junction alias that lives outside the lexical `repo\...` string escapes
     the check even though it is the same file.
  3. **`\\?\` / `\\?\UNC\` extended-length prefix** -- verified empirically that *neither*
     `os.path.abspath()` *nor* `Path.resolve()` strips this prefix; an untrusted policy's
     `lint_cmd`/`test_cmd` can spell `argv[0]` with the prefix explicitly (`shutil.which()`
     returns an already-path-shaped `argv[0]` unchanged, no PATH search, no canonicalization), so
     it survives all the way to the confinement comparison and never string-matches the
     unprefixed root.

## The fix

- `_canonicalize_exec_parent(executable_path)` (new, `apply_policy.py`) resolves **only**
  `executable_path.parent` via `Path.resolve(strict=True)` -- never the full path, which would
  dereference the leaf and reopen `#453`. Verified empirically on Windows: this single call both
  expands 8.3 short-name components at every level of the parent chain
  (`GetFinalPathNameByHandleW` returns the filesystem's own canonical long name directly -- a
  second `GetLongPathNameW` pass was not needed) and fully traverses NTFS junctions in the parent
  chain, in one step. Returns `None` on any resolution failure; callers must fail closed.
- `_abspath_beneath_or_equal()` now strips a `\\?\` / `\\?\UNC\` prefix (new
  `_strip_extended_length_prefix()` helper) from both operands before the `normcase`/`normpath`
  comparison.
- `_run_policy_command()` denies when **either** the raw lexical form **or** the canonicalized
  form lands beneath the untrusted root (an OR, not a replacement) -- the two conditions cover
  disjoint gaps (raw catches "spelled in-repo", canonical catches "resolves in-repo but spelled
  differently"), so this can only ever deny a *superset* of what either check denies alone; a
  legitimate outside-root binary fails both and is unaffected. Canonicalization failure
  (`_canonicalize_exec_parent` returns `None`) fails closed -- denied, never allowed through on
  the raw comparison alone.

## Per-edge tests (`tests/unit/test_apply_policy.py`)

All new tests proven **RED against pre-fix `main`** (via `git stash` on just the source file) and
**GREEN with the fix** -- see the bidirectional-oracle section added above
`test_strip_extended_length_prefix_removes_prefix`.

| Edge | Test(s) | How it's real |
|---|---|---|
| `\\?\` prefix | `test_run_policy_command_rejects_extended_length_prefix_shadow_inside_repo` | Fully real end-to-end: the policy's own command string embeds a `\\?\`-prefixed absolute path to a real repo-local shadow executable; no mocking of the resolution mechanism. |
| `\\?\` prefix (unit) | `test_strip_extended_length_prefix_*`, `test_abspath_beneath_or_equal_matches_extended_length_prefixed_spelling`, `..._no_false_positive` | Pure string / path-comparison unit tests. |
| NTFS junction | `test_run_policy_command_rejects_junction_alias_shadow_inside_repo` | Fully real: a real `mklink /J` junction (no admin needed) aliases the repo from outside it; `shutil.which` is mocked only to return the aliased path (simulating what a real PATH/cwd search could surface). |
| NTFS junction (unit) | `test_canonicalize_exec_parent_resolves_real_junction` | Direct unit test against a real junction. |
| 8.3 short name (unit, real) | `test_canonicalize_exec_parent_expands_real_8dot3_short_name` | Real mechanism proof against the OS's own always-present `C:\PROGRA~1` alias for `C:\Program Files` -- forcing **fresh** 8.3 generation on a throwaway test directory needs `fsutil 8dot3name set <path> 0`, which needs an elevated volume handle (verified `Error 5: Access is denied` without admin on this dev box), so a fully-real *end-to-end* repro isn't available unprivileged. |
| 8.3 short name (wiring) | `test_run_policy_command_rejects_8dot3_alias_shadow_inside_repo` | `_run_policy_command`'s OR-guard wiring, with `_canonicalize_exec_parent` monkeypatched to return exactly what the (separately, really proven) mechanism resolves an 8.3 alias to. |
| `#453` preserved | `test_canonicalize_exec_parent_does_not_dereference_the_leaf_symlink` + the existing `test_run_policy_command_rejects_symlink_shadow_resolving_outside_cwd` (unmodified, still green) | Proves the parent-only-resolve design never dereferences the leaf. |
| Fail-closed | `test_canonicalize_exec_parent_fails_closed_on_nonexistent_parent`, `test_run_policy_command_denies_when_exec_parent_canonicalization_fails` | Canonicalization failure denies, never falls back to allow. |
| No regression (legitimate cases) | `test_run_policy_command_resolves_relative_executable_to_absolute` (fixture updated), `test_run_policy_command_allows_junction_alias_that_resolves_outside_repo` | A real outside-root binary, and one reached via a *legitimate* outside-repo junction alias, both still run. |

One pre-existing test's fixture (`test_run_policy_command_resolves_relative_executable_to_absolute`)
needed a real (not merely mocked-path) trusted-bin directory, since the new canonicalization step
genuinely touches the filesystem (`Path.resolve(strict=True)`) where the old code was pure string
manipulation -- the mock previously pointed `shutil.which()` at a directory that never existed on
disk, which real `shutil.which()` never does.

## 4-gate status

All green on the touched files and the full tree:

- `ruff check src/tensor_grep tests` -- pass
- `ruff format --check --preview src/tensor_grep tests` -- pass (336 files already formatted)
- `mypy src/tensor_grep` -- pass
- `pytest -q` -- `tests/unit/test_apply_policy.py`: **66/66 passed**. `tests/unit/test_mcp_server.py`
  policy/apply/rewrite subset: **39/39 passed**. Full `tests/unit`: **4310 passed, 2 failed, 13
  skipped** in 630s -- the 2 failures are `test_retrieval_dense.py::TestRealFetchedModel` (real
  fetched-model dimensionality/ranking tests), confirmed pre-existing and unrelated via an empty
  `git diff --stat <branch-point> -- tests/unit/test_retrieval_dense.py
  src/tensor_grep/core/retrieval_dense.py`.

## Opus-gate PENDING

`apply_policy` is a mandatory-Opus-gate surface per `AGENTS.md` -- this PR is a draft pending that
adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
