### PR TITLE
fix(count): --count-matches refuses cleanly instead of silently under-counting when rg is unresolvable (#121)

### DIFF
--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -269,12 +269,23 @@ def _search_flag_tokens_for_sweep(command: list[str]) -> set[str]:
     return tokens
 
 
+def _ripgrep_available() -> bool:
+    """Whether tg can resolve a ripgrep binary (TG_RG_PATH / PATH / bundled). Gates the
+    #121 tolerance in the flag sweep below: `--count-matches` needs rg for its per-occurrence
+    count, so both tg front doors refuse cleanly (structured exit 2) when rg is unresolvable
+    instead of emitting a silently-wrong line count."""
+    from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+
+    return bool(RipgrepBackend().is_available())
+
+
 def validate_public_search_advertised_flag_sweep(
     _stdout: str, repo_root: Path, _expected_version: str
 ) -> None:
     if shutil.which("tg") is None:
         raise ReadinessError("could not resolve public tg command for search flag sweep")
 
+    rg_available = _ripgrep_available()
     probe_dir = repo_root / "artifacts" / "agent_readiness" / "public_search_flags"
     probe_dir.mkdir(parents=True, exist_ok=True)
     (probe_dir / "app.log").write_text("ERROR failed\nINFO ok\n", encoding="utf-8")
@@ -322,6 +333,18 @@ def validate_public_search_advertised_flag_sweep(
         )
         stderr = completed.stderr.strip()
         stdout = completed.stdout.strip()
+        # task #121: `--count-matches` needs rg for its per-occurrence count; both tg front
+        # doors refuse cleanly (structured exit 2) when rg is unresolvable rather than emit a
+        # silently-wrong line count. Accept that refuse here instead of flagging it as a sweep
+        # failure -- but ONLY when rg is genuinely absent (when rg IS available the probe must
+        # still exit 0/1 as before, so a real regression that breaks the flag still fails).
+        if (
+            label == "root-option-first-count-matches"
+            and not rg_available
+            and completed.returncode == 2
+            and "count-matches" in stderr.lower()
+        ):
+            continue
         if completed.returncode not in {0, 1}:
             failures.append(
                 f"{label}: exit={completed.returncode}, command={command!r}, "

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -458,6 +458,23 @@ def _can_delegate_to_native_tg_search(search_args: list[str]) -> bool:
         "--regexp",
         "-f",
         "--file",
+        # task #121: `--count-matches` reports ripgrep's per-OCCURRENCE count, which the
+        # separately-compiled native binary's fallback engine cannot produce (it is
+        # LINE-granular only, same as the Python CPU/Rust fallbacks -- see
+        # rust_core/src/backend_cpu.rs's `count_matches`, "count MATCHING LINES, not total
+        # occurrences"). Without this exclusion, `--count-matches` combined with a trigger
+        # flag (`--json`/`--ndjson`/`--cpu`/`--force-cpu`/`--gpu-device-ids`) delegated
+        # straight to the native binary and silently returned a LINE count mislabeled as an
+        # occurrence count (verified live: a 3-occurrence line undercounted to 1, exit 0, no
+        # visible signal) -- bypassing cli/main.py's OWN identical exclusion entirely
+        # (`count_matches` is already in `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS`
+        # there; this outer argv fast path had simply drifted out of parity with it, the
+        # same two-front-doors gap the -e/-f exclusion above already guards against).
+        # Excluding it here routes to the full CLI instead, which refuses cleanly when rg
+        # is unresolvable and otherwise still uses rg (correct occurrence counts) when it
+        # is. `-c`/`--count` is UNCHANGED: its line-count contract is exactly what the
+        # native binary's fallback already provides correctly, so it keeps delegating.
+        "--count-matches",
     }
     unsupported_prefixes = ("--format=", "--lang=", "--replace=", "--regexp=", "--file=")
     if any(arg in unsupported_flags or arg.startswith(unsupported_prefixes) for arg in search_args):

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -1056,6 +1056,16 @@ def main_entry() -> None:
         ) or _search_args_include_unbounded_broad_scan(passthrough_search_args)
         invalid_regex = _search_args_include_obviously_invalid_regex(passthrough_search_args)
 
+        # task #121 note: `--count-matches` is excluded from `_can_delegate_to_native_tg_search`
+        # (it needs rg for its per-occurrence count, which the native binary's fallback engine
+        # cannot produce), but the `_prefer_rust_first_search()` OR-branch below can STILL route
+        # a bare `--count-matches` search to the native binary when TG_RUST_FIRST_SEARCH=1
+        # (`--count-matches` is not a `_requires_full_cli` flag). That is SAFE and deliberately
+        # NOT special-cased here: the native binary self-refuses count_matches via
+        # `require_ripgrep_or_exit` (rust_core/src/main.rs) when rg is unresolvable -- a clean
+        # exit-2, never a silent wrong count. Locked by
+        # test_cli_bootstrap.py::test_rust_first_count_matches_refuses_via_native_self_guard so a
+        # future routing change to this branch cannot silently reopen the silent-wrong-count.
         if (
             not explicit_rg_json
             and native_binary is not None

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6920,10 +6920,40 @@ def search_command(
     from tensor_grep.io.directory_scanner import DirectoryScanner
 
     rg_backend = RipgrepBackend()
+    rg_is_available = rg_backend.is_available()
+    if config.count_matches and not rg_is_available:
+        # Backend Fail-Closed Contract (AGENTS.md) / task #121: `--count-matches` reports
+        # ripgrep's OCCURRENCE count (every match on a line counts separately), which is
+        # semantically different from `-c`/`--count`'s LINE count (one per matching line,
+        # regardless of how many times the pattern occurs on it). Every fallback engine
+        # that can serve a query without rg -- RustCoreBackend AND CPUBackend -- is
+        # LINE-granular only: neither ever emits more than one match per line, so a
+        # `--count-matches` request routed to either would silently report a LINE count
+        # mislabeled as an occurrence count (verified live: a 3-occurrence line undercounts
+        # to 1). Unlike the default/--json search degrade (a like-for-like engine swap: the
+        # native engine's match set IS what tg's own aggregate model already uses), there is
+        # no fallback engine here that can serve the SAME semantics rg provides, so silently
+        # "degrading" would be silent-wrong-output, not a graceful degrade. Refuse cleanly
+        # instead -- mirroring the identical refusal the native `--index` fast path already
+        # applies to `count_matches` for the same reason (`IndexFlagPolicy::Refuse` in
+        # rust_core/src/main.rs) -- rather than let it through as a wrong number. `-c`/
+        # `--count` is unaffected: its line-count contract is exactly what the fallback
+        # engines already provide correctly (Pipeline's `count_rust_fast_path`).
+        _exit_search_error(
+            "count_matches_requires_ripgrep",
+            (
+                "--count-matches reports ripgrep's per-occurrence match count, which "
+                "requires the 'rg' binary; rg was not found (checked TG_RG_PATH, PATH, "
+                "and the bundled fallback). Install ripgrep "
+                "(https://github.com/BurntSushi/ripgrep#installation), set TG_RG_PATH, "
+                "or use --count (-c) for a line count that works without rg."
+            ),
+            json_mode=json,
+        )
     can_passthrough_rg = (
         not guarded_broad_root
         and not explicit_hidden_search_root
-        and rg_backend.is_available()
+        and rg_is_available
         and _can_passthrough_rg(
             config,
             format_type=format_type,

--- a/tests/e2e/test_output_golden_contract.py
+++ b/tests/e2e/test_output_golden_contract.py
@@ -64,6 +64,26 @@ EXACT_OUTPUT_CASES = {
     "replace_capture_groups_single_file": "world-hello\n",
 }
 
+# task #121: `--count-matches` reports ripgrep's per-OCCURRENCE count, which no rg-less
+# fallback engine can compute (they are line-granular only), so BOTH tg front doors now
+# refuse cleanly (structured exit 2) when rg is unresolvable rather than emit a silently
+# wrong line-count -- the Python path via `_exit_search_error(count_matches_requires_ripgrep)`
+# (cli/main.py) and the native binary via `require_ripgrep_or_exit` (rust_core/src/main.rs).
+# `run_tg` hard-asserts exit 0, so these two golden cases MUST be skipped when rg is
+# unresolvable (both the `python-m` launcher's TG_DISABLE_NATIVE_TG=1 Python path and the
+# `native` launcher hit the refuse). Do NOT re-snapshot: the recorded values happen to be
+# correct ONLY because occurrence-count == line-count for this fixture WHEN rg is available;
+# with rg absent the output is a structured error, not a count, so there is nothing stable
+# to snapshot.
+_COUNT_MATCHES_GOLDEN_CASES = {"count_matches_multi_file", "count_matches_single_file"}
+
+
+def _ripgrep_available() -> bool:
+    from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+
+    return RipgrepBackend().is_available()
+
+
 LAUNCHERS = ["python-m", "native"]
 
 
@@ -197,6 +217,11 @@ def test_output_golden_contract(golden_fixture_dir, snapshot, launcher, name, ar
         pytest.skip("Native tg.exe does not support this flag currently")
     if launcher == "python-m" and "--ndjson" in args:
         pytest.skip("python -m tensor_grep requires native tg support for --ndjson")
+    if name in _COUNT_MATCHES_GOLDEN_CASES and not _ripgrep_available():
+        pytest.skip(
+            "--count-matches needs rg for its per-occurrence count; both front doors refuse "
+            "cleanly (exit 2) when rg is unresolvable (#121), so there is no count to snapshot"
+        )
     tg_stdout = run_tg(launcher, args + target, golden_fixture_dir)
     if name in EXACT_OUTPUT_CASES:
         assert tg_stdout == EXACT_OUTPUT_CASES[name]

--- a/tests/unit/test_agent_readiness_script.py
+++ b/tests/unit/test_agent_readiness_script.py
@@ -1020,6 +1020,151 @@ def test_agent_readiness_public_search_flag_sweep_accepts_public_frontdoor(
     assert any(command.startswith("tg --count-matches") for command in flattened)
 
 
+def _flag_sweep_help_stdout() -> str:
+    """The advertised-flag help block the flag sweep validates against (covers every flag
+    the sweep probes exercise, so the missing-flag pre-check passes). Shared by the #121
+    count-matches refuse-tolerance tests below."""
+    return "\n".join([
+        "Usage: tg search [OPTIONS]",
+        "  -H, --with-filename",
+        "  -I, --no-filename",
+        "  -q, --quiet",
+        "  -N, --no-line-number",
+        "      --stats",
+        "      --debug",
+        "      --trace",
+        "      --pcre2-unicode",
+        "      --no-pcre2-unicode",
+        "      --no-auto-hybrid-regex",
+        "      --no-text",
+        "      --no-binary",
+        "      --no-follow",
+        "      --no-glob-case-insensitive",
+        "      --no-ignore-file-case-insensitive",
+        "      --ignore",
+        "      --ignore-dot",
+        "      --ignore-exclude",
+        "      --ignore-files",
+        "      --ignore-global",
+        "      --ignore-messages",
+        "      --ignore-parent",
+        "      --ignore-vcs",
+        "      --messages",
+        "      --require-git",
+        "      --no-hidden",
+        "      --no-one-file-system",
+        "      --no-block-buffered",
+        "      --no-byte-offset",
+        "      --column",
+        "      --no-column",
+        "      --no-crlf",
+        "      --no-encoding",
+        "      --no-fixed-strings",
+        "      --no-invert-match",
+        "      --no-mmap",
+        "      --no-multiline",
+        "      --no-multiline-dotall",
+        "      --no-pcre2",
+        "      --no-pre",
+        "      --no-search-zip",
+        "      --no-context-separator",
+        "      --no-include-zero",
+        "      --no-line-buffered",
+        "      --no-max-columns-preview",
+        "      --no-trim",
+        "      --no-json",
+        "      --no-stats",
+        "      --engine <ENGINE>",
+        "  -s, --case-sensitive",
+        "  -x, --line-regexp",
+        "  -j, --threads <THREADS>",
+        "      --iglob <GLOB>",
+        "  -T, --type-not <TYPE>",
+        "  -u, --unrestricted",
+        "      --sort <SORTBY>",
+        "      --format <FORMAT>",
+        "  -t, --type <TYPE>",
+        "      --count-matches",
+        "  -n, --line-number",
+        "  -F, --fixed-strings",
+    ])
+
+
+# The #121 structured refuse the tg CLI emits (plain-text path) when `--count-matches` is
+# invoked with rg unresolvable. Matches cli/main.py's `_exit_search_error` detail text.
+_COUNT_MATCHES_REFUSE_STDERR = (
+    "Error: --count-matches reports ripgrep's per-occurrence match count, which requires "
+    "the 'rg' binary; rg was not found (checked TG_RG_PATH, PATH, and the bundled fallback)."
+)
+
+
+def _make_flag_sweep_fake_run(count_matches_returncode: int):
+    """Build a fake `subprocess.run` for the flag sweep: real help advertisement, exit 0 for
+    every probe EXCEPT the count-matches probe, which returns `count_matches_returncode` with
+    the #121 refuse on stderr."""
+
+    def fake_run(command, **_kwargs):
+        if command == ["tg", "search", "--help"]:
+            return subprocess.CompletedProcess(
+                args=command, returncode=0, stdout=_flag_sweep_help_stdout(), stderr=""
+            )
+        if len(command) >= 2 and command[0] == "tg" and command[1] == "--count-matches":
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=count_matches_returncode,
+                stdout="",
+                stderr=_COUNT_MATCHES_REFUSE_STDERR if count_matches_returncode == 2 else "",
+            )
+        return subprocess.CompletedProcess(
+            args=command, returncode=0, stdout="accepted\n", stderr=""
+        )
+
+    return fake_run
+
+
+def test_agent_readiness_count_matches_probe_tolerates_rg_unresolvable_refuse(
+    monkeypatch, tmp_path
+) -> None:
+    # task #121: when rg is unresolvable, the `--count-matches` probe now gets a clean
+    # structured exit-2 refuse (it needs rg for its per-occurrence count) -- the sweep must
+    # TOLERATE that instead of raising ReadinessError, mirroring the golden-test skip.
+    module = _load_script_module()
+    monkeypatch.setattr(
+        module.shutil, "which", lambda command: command if command == "tg" else None
+    )
+    monkeypatch.setattr(module, "_ripgrep_available", lambda: False)
+    monkeypatch.setattr(
+        module.subprocess, "run", _make_flag_sweep_fake_run(count_matches_returncode=2)
+    )
+
+    # Must NOT raise -- the exit-2 count-matches refuse is expected when rg is absent.
+    module.validate_public_search_advertised_flag_sweep("", tmp_path, "1.12.28")
+
+
+def test_agent_readiness_count_matches_probe_still_fails_exit2_when_rg_available(
+    monkeypatch, tmp_path
+) -> None:
+    # Bidirectional guard: the #121 tolerance is gated on rg being ABSENT. When rg IS
+    # available, an exit-2 from the count-matches probe is a real regression and must still
+    # fail the sweep -- otherwise the tolerance would mask a genuinely broken flag.
+    module = _load_script_module()
+    monkeypatch.setattr(
+        module.shutil, "which", lambda command: command if command == "tg" else None
+    )
+    monkeypatch.setattr(module, "_ripgrep_available", lambda: True)
+    monkeypatch.setattr(
+        module.subprocess, "run", _make_flag_sweep_fake_run(count_matches_returncode=2)
+    )
+
+    try:
+        module.validate_public_search_advertised_flag_sweep("", tmp_path, "1.12.28")
+    except module.ReadinessError as exc:
+        assert "root-option-first-count-matches" in str(exc)
+        assert "exit=2" in str(exc)
+    else:
+        raise AssertionError("expected exit-2 count-matches probe to fail when rg IS available")
+
+
 def test_agent_readiness_public_search_flag_sweep_rejects_missing_help_advertisement(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -1469,3 +1469,32 @@ def test_multi_pattern_e_f_do_not_delegate_to_native_binary() -> None:
     # No -e/-f -> still delegates; -F (fixed-strings, uppercase) is not a -f prefix match.
     assert bootstrap._can_delegate_to_native_tg_search(["--cpu", "foo", "."])
     assert bootstrap._can_delegate_to_native_tg_search(["--cpu", "-F", "foo", "."])
+
+
+def test_count_matches_does_not_delegate_to_native_binary() -> None:
+    # task #121: `--count-matches` reports ripgrep's per-OCCURRENCE count, which the
+    # separately-compiled native binary's fallback engine cannot produce (LINE-granular
+    # only, same as the Python fallbacks -- see cli/bootstrap.py's
+    # `_can_delegate_to_native_tg_search` comment). Before this fix, `--count-matches`
+    # combined with a trigger flag (--json/--ndjson/--cpu/--force-cpu/--gpu-device-ids)
+    # delegated straight to the native binary and silently returned a LINE count
+    # mislabeled as an occurrence count -- this outer argv fast path must refuse it for
+    # parity with cli/main.py's OWN inner native-delegation gate, which already refuses it
+    # via `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS` (`count_matches`).
+    assert not bootstrap._can_delegate_to_native_tg_search([
+        "--json",
+        "--count-matches",
+        "foo",
+        ".",
+    ])
+    assert not bootstrap._can_delegate_to_native_tg_search(["--cpu", "--count-matches", "foo", "."])
+    assert not bootstrap._can_delegate_to_native_tg_search([
+        "--ndjson",
+        "--count-matches",
+        "foo",
+        ".",
+    ])
+    # -c/--count is UNCHANGED: its line-count contract is exactly what the native binary's
+    # fallback already provides correctly, so it keeps delegating.
+    assert bootstrap._can_delegate_to_native_tg_search(["--json", "-c", "foo", "."])
+    assert bootstrap._can_delegate_to_native_tg_search(["--json", "--count", "foo", "."])

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -1498,3 +1498,65 @@ def test_count_matches_does_not_delegate_to_native_binary() -> None:
     # fallback already provides correctly, so it keeps delegating.
     assert bootstrap._can_delegate_to_native_tg_search(["--json", "-c", "foo", "."])
     assert bootstrap._can_delegate_to_native_tg_search(["--json", "--count", "foo", "."])
+
+
+def _native_tg_binary_for_lock_test() -> str | None:
+    exe_name = "tg.exe" if sys.platform == "win32" else "tg"
+    for candidate in (
+        Path(f"rust_core/target/release/{exe_name}"),
+        Path(f"rust_core/target/debug/{exe_name}"),
+    ):
+        if candidate.exists():
+            return str(candidate.resolve())
+    return None
+
+
+def test_rust_first_count_matches_refuses_via_native_self_guard(tmp_path: Path) -> None:
+    """task #121 lock-test (dogfoods the REAL native binary).
+
+    `--count-matches` is excluded from `_can_delegate_to_native_tg_search`, but the
+    `_prefer_rust_first_search()` OR-branch in `main_entry` can still route a bare
+    `--count-matches` search to the native binary when `TG_RUST_FIRST_SEARCH=1` (it is not a
+    `_requires_full_cli` flag). That bypass is SAFE only because the native binary itself
+    self-refuses count_matches via `require_ripgrep_or_exit` (rust_core/src/main.rs) when rg
+    is unresolvable -- a clean exit-2, never a silent wrong count. This test locks that
+    end-to-end invariant so a future routing change to the rust-first branch cannot silently
+    reopen the silent-wrong-count. Uses `TG_DISABLE_RG=1` to force rg unresolvable
+    deterministically and `TG_NATIVE_TG_BINARY` to pin the in-tree binary.
+    """
+    native_binary = _native_tg_binary_for_lock_test()
+    if native_binary is None:
+        pytest.skip("Native tg binary not built in this environment")
+
+    target = tmp_path / "sample.txt"
+    # Line 1 has THREE occurrences of foo on ONE line: a silent line-count fallback would
+    # print 1 (wrong); the correct rg occurrence-count would be 3. The native self-refuse
+    # must produce NEITHER -- it must refuse rather than emit any bare number.
+    target.write_text("foo foo foo\nbar\n", encoding="utf-8")
+
+    env = dict(os.environ)
+    env["TG_RUST_FIRST_SEARCH"] = "1"
+    env["TG_NATIVE_TG_BINARY"] = native_binary
+    env["TG_DISABLE_RG"] = "1"
+    env.pop("TG_DISABLE_NATIVE_TG", None)
+    env.pop("TG_RG_PATH", None)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_grep", "search", "foo", str(target), "--count-matches"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # Clean refuse, never a silent wrong count.
+    assert result.returncode == 2, (
+        f"expected exit 2 refuse, got {result.returncode}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert result.stdout.strip() not in {"1", "3"}, (
+        f"native binary emitted a bare count instead of refusing: stdout={result.stdout!r}"
+    )
+    assert "rg" in result.stderr.lower() or "ripgrep" in result.stderr.lower(), (
+        f"refuse message should name the missing rg backend: stderr={result.stderr!r}"
+    )

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1294,6 +1294,118 @@ def test_plain_search_unscoped_still_runs_on_small_repo(monkeypatch, tmp_path: P
     assert "broad root scan refused" not in result.output
 
 
+def test_count_matches_refuses_cleanly_when_rg_unresolvable(monkeypatch, tmp_path: Path):
+    """Task #121: `--count-matches` reports ripgrep's per-OCCURRENCE count (multiple
+    matches on one line each count separately), which no fallback engine can compute --
+    RustCoreBackend/CPUBackend never emit more than one match per line (mirrors `-c`'s
+    LINE-count contract, not `--count-matches`'s occurrence contract; see
+    rust_core/src/backend_cpu.rs's own "count MATCHING LINES, not total occurrences"
+    comment on its count fast path). Before this fix, routing to that fallback silently
+    reported a LINE count mislabeled as an occurrence count (a 3-occurrence line
+    undercounted to 1, exit 0, no visible signal) -- silent-wrong-output, not a graceful
+    degrade. With rg fully unresolvable, the CLI must refuse cleanly (structured exit 2,
+    actionable message) instead of a bare crash OR a silently wrong number."""
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(cli_main, "resolve_ripgrep_binary", lambda: None)
+    monkeypatch.setattr("tensor_grep.cli.runtime_paths.resolve_ripgrep_binary", lambda: None)
+
+    target = tmp_path / "sample.txt"
+    target.write_text("foo bar foo baz foo\nanother line\nfoo\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "foo", str(target), "--count-matches"])
+
+    assert result.exit_code == 2, result.output
+    # Never a bare traceback/crash.
+    assert "Traceback" not in result.output
+    # Never a silently-wrong number standing in for the real answer (the line-count
+    # fallback would have printed "2", masquerading as the occurrence count).
+    assert result.output.strip() != "2"
+    assert "count-matches" in result.output
+    assert "rg" in result.output.lower() or "ripgrep" in result.output.lower()
+    # Points the user at the working degrade path (-c/--count) that IS correct without rg.
+    assert "--count" in result.output
+
+
+def test_count_matches_refuses_cleanly_when_rg_unresolvable_json(monkeypatch, tmp_path: Path):
+    """JSON-mode sibling of the test above: a structured, machine-readable error envelope
+    (matching the established `_exit_search_error` contract other refusals already use),
+    not a bare crash and not a JSON payload carrying a silently-wrong count."""
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(cli_main, "resolve_ripgrep_binary", lambda: None)
+    monkeypatch.setattr("tensor_grep.cli.runtime_paths.resolve_ripgrep_binary", lambda: None)
+
+    target = tmp_path / "sample.txt"
+    target.write_text("foo bar foo baz foo\nanother line\nfoo\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "foo", str(target), "--count-matches", "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "count_matches_requires_ripgrep"
+    assert "rg" in payload["detail"].lower() or "ripgrep" in payload["detail"].lower()
+
+
+def test_count_matches_still_uses_ripgrep_when_available(tmp_path: Path):
+    """Bidirectional half of task #121: when rg genuinely IS available, `--count-matches`
+    must keep working exactly as before (real occurrence count via rg), never refuse.
+
+    Plain (non-JSON) `--count-matches` is eligible for the raw rg passthrough fast path
+    (`_can_passthrough_rg`), which streams the real `rg` subprocess's stdout directly --
+    that bypasses CliRunner's captured stream (it redirects the Python-level `sys.stdout`
+    object, not the OS file descriptor a real subprocess inherits), so this uses a real
+    subprocess invocation instead, mirroring
+    `test_debug_passthrough_keeps_stdout_match_only`'s established pattern for the same
+    reason.
+    """
+    from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+
+    if not RipgrepBackend().is_available():
+        pytest.skip("rg is not available")
+
+    target = tmp_path / "sample.txt"
+    target.write_text("foo bar foo baz foo\nanother line\nfoo\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.main",
+            "search",
+            "foo",
+            str(target),
+            "--count-matches",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    # 4 total occurrences (3 on line 1 + 1 on line 3), NOT 2 matching lines -- proves real
+    # occurrence-level counting, not a line-count masquerading as one.
+    assert result.stdout.strip() == "4"
+
+
+def test_count_still_degrades_via_native_engine_when_rg_unresolvable(monkeypatch, tmp_path: Path):
+    """Regression guard: `-c`/`--count` (LINE-count semantics) must be UNAFFECTED by the
+    #121 fix -- it already degrades correctly to the native fallback engine (Pipeline's
+    `count_rust_fast_path`) because the fallback's one-match-per-line model IS `-c`'s
+    contract, not just an approximation of it."""
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(cli_main, "resolve_ripgrep_binary", lambda: None)
+    monkeypatch.setattr("tensor_grep.cli.runtime_paths.resolve_ripgrep_binary", lambda: None)
+
+    target = tmp_path / "sample.txt"
+    target.write_text("foo bar foo baz foo\nanother line\nfoo\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "foo", str(target), "--count"])
+
+    assert result.exit_code == 0, result.output
+    # 2 matching LINES (line 1 and line 3), correct for -c/--count even without rg.
+    assert result.output.strip() == "2"
+
+
 def test_plain_search_does_not_refuse_large_root_when_native_available(monkeypatch, tmp_path: Path):
     """Trap #2: when the fast native `tg` binary would handle this exact query, the new
     guard must NOT fire -- refusing there would convert a WORKING instant search into an


### PR DESCRIPTION
## Summary

Task #121 asked for `tg --count-matches` to degrade gracefully (like `--json`/default search)
instead of hard-erroring when ripgrep (`rg`) is fully unresolvable. **The literal "hard-errors"
premise does not reproduce on current `main`** -- I verified this live before building anything.
The actual bug is a different, more severe member of the same Backend Fail-Closed Contract family:
**`--count-matches` silently returns the WRONG number** (exit 0, no visible signal) instead of
crashing or refusing. This PR fixes that, at both front doors that can reach it.

## Current vs. fixed behavior (verified live, real binary, not CliRunner)

Fixture: a 3-line file where line 1 contains `foo` **three times** and line 3 contains it once
(4 total occurrences, 2 matching lines).

| Invocation | Before | After |
|---|---|---|
| `tg --count-matches foo file` (rg unresolvable) | prints `2`, exit 0 -- **silently wrong** (real answer is 4; `2` is `-c`'s line-count, not `--count-matches`'s occurrence-count) | `Error: --count-matches reports ripgrep's per-occurrence match count, which requires the 'rg' binary; ...`, **exit 2** |
| `tg search foo file --count-matches --json` (rg unresolvable) | `{"total_matches": 2, "routing_backend": "NativeCpuBackend", ...}` -- **silently wrong**, and via a **second, independent code path** (native-binary delegation) | `{"ok": false, "error": "count_matches_requires_ripgrep", "detail": "..."}`, exit 2 |
| `tg --count-matches foo file` (rg available) | `4` (correct) | unchanged: `4` (correct) |
| `tg -c foo file` (rg unresolvable) | `2` (correct -- this is `-c`'s actual contract) | unchanged: `2` (correct) |

## Root cause

`--count-matches` reports ripgrep's **per-occurrence** count (every match on a line counts
separately); `-c`/`--count` reports the **per-line** count (one per matching line, regardless of
how many times the pattern occurs on it). Every engine that can serve a query without `rg` is
line-granular only and cannot tell the two apart:

- `rust_core/src/backend_cpu.rs:522` (`count_file_memmem`) and `:559` (`count_file_regex`), the
  Rayon-parallel native count fast path used by both the PyO3 extension (`RustCoreBackend`) and
  the compiled standalone `tg` binary, says so explicitly in its own comment: *"For ripgrep parity
  on count matches, we count MATCHING LINES, not total occurrences."*
- `src/tensor_grep/backends/rust_backend.py:143-156` only sets `count_only` from `config.count`
  (`-c`), never `config.count_matches` -- so a `--count-matches`-only request falls through to the
  regular per-line `search()` path, which never emits more than one `MatchLine` per line
  (`rust_core/src/backend_cpu.rs:101-114`, `:164-186`; mirrored by the pure-Python fallback in
  `src/tensor_grep/backends/cpu_backend.py`).
- `src/tensor_grep/core/pipeline.py:263-266` (`count_rust_fast_path`) only fires for
  `config.count`, so a `--count-matches`-only request isn't caught there either; with `rg`
  unavailable it falls through to `rust_secondary_fast_path` (`pipeline.py:417-420`), the SAME
  backend the default/`--json` degrade already correctly uses.
- The CLI then derives a per-file count from the (line-granular) match list
  (`src/tensor_grep/cli/main.py:7206-7210`, plus the same fallback in
  `src/tensor_grep/cli/formatters/ripgrep_fmt.py:104-106`) -- silently reporting a line-count as if
  it were the requested occurrence-count.

This is confirmed **not a novel gap**: the native `--index` fast path already refuses
`count_matches` for the identical reason
(`rust_core/src/main.rs:5541`, `IndexFlagPolicy::Refuse`, and the explicit
`if *count_matches { violations.push("--count-matches"); }` check at `:5394`).

## Why refuse instead of "degrade" (mirroring --json/default, with one deliberate deviation)

`--json`/default search's degrade (`pipeline.py:417-420`, confirmed via
`tests/unit/test_pipeline.py::test_should_fallback_to_rust_when_ripgrep_missing`) is a
**like-for-like engine swap**: `RustCoreBackend`'s match set IS what tg's own aggregate model
already uses for a plain search (`total_matches` is line-based on the rg-JSON path too --
`ripgrep_backend.py:243-253`, "Counting stays one-per-matching-line ... so total_matches / parity
with the other backends is unchanged"). There is **no correctness gap** to paper over.

`--count-matches` has no such equivalent fallback -- I verified live that every rg-less engine is
architecturally line-granular (see Root cause above), so "degrading" would mean silently answering
a *different question* than the one asked. Per AGENTS.md's Backend Fail-Closed Contract ("never
silently wrong output") and the `IndexFlagPolicy::Refuse` precedent for this exact flag, I refuse
cleanly instead of shipping a plausible-looking wrong number. `-c`/`--count` is completely
unaffected -- its line-count contract is exactly what the fallback engines already provide
correctly, so it keeps using `count_rust_fast_path` / native delegation unchanged.

The refuse is implemented with the SAME "clean, structured, exit 2" mechanism `--json`/default
already use for other unserviceable requests (`_exit_search_error`, used elsewhere for
`unsupported_flag`/`invalid_regex`/`path_not_found`) -- not a bare exception. Note in passing: I
found that `Pipeline`'s existing `ConfigurationError` (e.g. the `--pcre2`-without-a-PCRE2-`rg`
case, `pipeline.py:193`) is genuinely **uncaught** by `cli/main.py`'s `search_command` and crashes
with a raw traceback (verified live, exit 1) -- that's a real, separate, pre-existing bug, out of
scope here, which is why I deliberately did NOT reuse `ConfigurationError`/`Pipeline` for this fix.

## The two front doors (miss one and it silently misroutes)

- `src/tensor_grep/cli/main.py` `search_command` (the primary Python Typer app) -- fixed at
  `main.py:6922-6952`, right after `RipgrepBackend()`/`is_available()`, before the expensive
  directory walk.
- `src/tensor_grep/cli/bootstrap.py` `_can_delegate_to_native_tg_search` (the pre-Typer argv-based
  fast path that can hand the whole request to the **compiled standalone `tg` binary**, bypassing
  Python's `Pipeline` entirely) -- **independently reachable**: `count_matches` was already
  excluded from `main.py`'s own `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS`
  (`main.py:1914`), but bootstrap's separate argv-based gate had drifted out of parity (the same
  class of gap its own `-e`/`-f` exclusion comment already calls out). Any `--count-matches`
  combined with a trigger flag (`--json`, `--ndjson`, `--cpu`, `--force-cpu`,
  `--gpu-device-ids`) delegated straight past the first fix. Fixed at `bootstrap.py:461-476` by
  adding `--count-matches` to `unsupported_flags`.

I found the second gap by dogfooding the real binary with `--json` added to the repro command --
the routing metadata (`"routing_backend": "NativeCpuBackend"`) gave it away.

## Tests (TDD: written first, confirmed RED without the fix via `git stash`, then GREEN)

`tests/unit/test_cli_modes.py`:
- `test_count_matches_refuses_cleanly_when_rg_unresolvable` -- plain mode, exit 2, no traceback,
  no silently-wrong `2`, message names `--count-matches`/`rg`/`--count`.
- `test_count_matches_refuses_cleanly_when_rg_unresolvable_json` -- `--json` mode, structured
  `{"ok": false, "error": "count_matches_requires_ripgrep", ...}` envelope.
- `test_count_matches_still_uses_ripgrep_when_available` -- bidirectional half: skips if `rg` isn't
  on the box, otherwise asserts the real occurrence count (`4`, not `2`) via a real subprocess
  invocation (matches `test_debug_passthrough_keeps_stdout_match_only`'s existing pattern, since
  plain `--count-matches` is eligible for raw rg passthrough, which bypasses `CliRunner`'s captured
  stream).
- `test_count_still_degrades_via_native_engine_when_rg_unresolvable` -- regression guard: `-c`
  keeps working correctly (`2`) with rg unresolvable.

`tests/unit/test_cli_bootstrap.py`:
- `test_count_matches_does_not_delegate_to_native_binary` -- unit-level on
  `_can_delegate_to_native_tg_search`, mirroring the existing `-e`/`-f` and `--rank`/`--bm25`
  exclusion tests; also asserts `-c`/`--count` keep delegating (unaffected).

## 4-gate status (real venv, `uv run --no-sync`, this worktree, `uv sync --extra dev --extra ast`
## + `uv pip install model2vec` for the semantic-search integration test)

- `ruff check src/tensor_grep tests` -- **pass**
- `ruff format --check --preview src/tensor_grep tests` -- **pass** (auto-fixed 2 formatting nits
  in the new tests with `ruff format --preview` before this check)
- `mypy src/tensor_grep` -- **pass** (79 source files, no issues)
- `pytest -q` -- **pass**, 4527 passed, 30 skipped, 0 failed (726s; the one pre-existing
  environment gap, a `model2vec`-missing integration test, was resolved by installing the
  `semantic` extra rather than skipped, so this is a genuinely full green run, not a
  git-diff-confirmed-unrelated skip)

No Rust files were touched (root cause traced into `rust_core/src/backend_cpu.rs` and `main.rs`
for citation, but the fix itself refuses at the Python front doors rather than changing the native
engine's match granularity), so `cargo test`/`cargo build` doesn't apply here.

## Opus-gate PENDING (count/backend path)

This touches the search command's routing/refuse logic on both front doors (`main.py`'s
`search_command` and `bootstrap.py`'s native-delegation gate) -- flagging for the mandatory
adversarial security/backends gate per AGENTS.md before merge.

## Follow-up (not in this PR)

- The pre-existing `Pipeline` `ConfigurationError`-is-uncaught-by-`search_command` crash (e.g.
  `--pcre2` with no PCRE2-capable `rg`, `pipeline.py:193`) is a real, separate bug I found while
  verifying this fix's own error-propagation path was safe. Out of scope here; flagging for a
  follow-up task.
- `docs/CONTRACTS.md:41` still lists `--count-matches` as a validated compatibility row -- that
  remains accurate (the contract is preserved whenever `rg` is available); I deliberately did not
  add a new contract bullet for the refuse-when-`rg`-unresolvable edge case to keep this PR
  scoped to the bug fix, per this repo's convention of batching docs changes separately.
