### PR TITLE
fix(release): ruff-format cluster-124 doc code block + regenerate uv.lock (unblock v1.67.0)

### DIFF
--- a/docs/plans/backlog-100/cluster-124-evidence-signing.md
+++ b/docs/plans/backlog-100/cluster-124-evidence-signing.md
@@ -16,10 +16,11 @@ compact sorted (precedent audit_manifest.py:65 _canonical_json_bytes), NOT the i
 ```python
 def canonical_receipt_bytes(receipt: dict) -> bytes:
     canonical = dict(receipt)
-    canonical.pop("signature", None)        # excluded: added after signing
-    canonical.pop("receipt_sha256", None)   # excluded: digest of these very bytes
-    return json.dumps(canonical, sort_keys=True, separators=(",", ":"),
-                      ensure_ascii=True, allow_nan=False).encode("utf-8")
+    canonical.pop("signature", None)  # excluded: added after signing
+    canonical.pop("receipt_sha256", None)  # excluded: digest of these very bytes
+    return json.dumps(
+        canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False
+    ).encode("utf-8")
 ```
 Everything EXCEPT signature + receipt_sha256 is signed (incl the whole `signing` block -> algorithm claim authenticated -> blocks downgrade). Residual: float repr is Python-json-specific -> gotcontext must match number serializer; keep receipt floats simple (they are).
 

--- a/uv.lock
+++ b/uv.lock
@@ -623,8 +623,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pywin32", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/75/0814c3ca505d5fb1986e381b4967cc1d0d62c6d5f52d271546f51cd4991c/cuda_bindings-12.9.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b65cbe73aa657daf8cc0137da2223e1858e4057056aad727aae5f839f35a724c", size = 12515235, upload-time = "2025-08-18T15:47:27.748Z" },
@@ -649,8 +649,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -678,7 +678,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/a5/e9d37c10f6c27c9c65d53c6cd6d9763e1df99c004780585fc2ad9041fbe3/cuda_bindings-12.9.6-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2662f59db67d9aeaf8959c593c91f600792c2970cf02cae2814387fc687b115a", size = 7090971, upload-time = "2026-03-11T14:47:29.526Z" },
@@ -697,7 +697,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/62/ed3039d866879872099fc855f8ad8b5e2ae9010b5e30d702fde3d66f23df/cuda_core-0.6.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07df8dd46494bd53943759232051facd4372104f2997732e0d39c5bc12a616d5", size = 21790662, upload-time = "2026-02-23T18:59:27.064Z" },
@@ -726,8 +726,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/83/03139c7d9c0425ec4824d6269cfd9e1ac8ae1cc88f12540578a405113083/cuda_core-0.7.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69946d1d5e2d96fc65b7bb36164d26c328cca75d9482b74ee7d61b2c1e1d33a7", size = 30374690, upload-time = "2026-04-08T17:03:08.962Z" },
@@ -790,7 +790,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/3c/4475aebeaab9651f2e61000fbe76f91a476d371dbfbf0a1cf46e689af253/cuda_python-12.9.0-py3-none-any.whl", hash = "sha256:926acba49b2c0a0374c61b7c98f337c085199cf51cdfe4d6423c4129c20547a7", size = 7532, upload-time = "2025-05-06T19:14:07.771Z" },
@@ -807,7 +807,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
@@ -824,7 +824,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/69/4a79126959ad6f1653504122ee1eb22d089dd6272d3fa37694dcdeb78ba5/cuda_python-12.9.6-py3-none-any.whl", hash = "sha256:ed5cf30e1129729eecf4605dff6e8bce84f2d30c17b17c7e5ac4b76448de35d2", size = 7596, upload-time = "2026-03-11T15:35:17.282Z" },
@@ -846,19 +846,19 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -877,16 +877,16 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -900,24 +900,24 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"] },
-    { name = "numpy" },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pynvjitlink-cu12" },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cachetools", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pandas", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pynvjitlink-cu12", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rich", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/d3/1686e1a2d6187bf8cc248b7d0a8efbea6eb20784a707176dfdd881529149/cudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:888641383ee908b820a7acafec028e8bd9851b8884009c61281d19b312c15ca9", size = 2630152, upload-time = "2025-08-07T12:23:36.002Z" },
@@ -943,25 +943,25 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
     { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "numba-cuda", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
-    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version < '3.14' or platform_machine != 'x86_64'" },
-    { name = "numpy" },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pandas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pyarrow", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rich", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/36/5caed16456ce318abb32ce66717231d5ce7b9713047ac4ae315d3f9b179e/cudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:43cbc0175e5016fa94ae96de83355c578dc149b644961301b47c6e28d5f61f49", size = 2715406, upload-time = "2026-04-09T09:42:26.382Z" },
@@ -993,7 +993,7 @@ name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
@@ -1532,7 +1532,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5", size = 54320, upload-time = "2024-08-20T17:11:42.348Z" }
 wheels = [
@@ -1555,7 +1555,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1630,12 +1630,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "zarr" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "zarr", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/b7/fbc1968592c92396efd3dc68f330d0e3da98a1150bfae414029bea9f9fe1/kvikio_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51094df8e0793485ae5021174b65bcd2bc584853cd832c142e6b463380bf4109", size = 672337, upload-time = "2025-08-07T13:50:13.422Z" },
@@ -1661,10 +1661,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/24/95abc4335e8db5b8e140dbe7bdaa9bd7c8620cc087b33ccf748f474c43b0/kvikio_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72cf92d7786b9cb34c60d616a25ef1c802ee465ebc20dd4b5ca2a365b409be16", size = 587150, upload-time = "2026-04-09T11:38:07.743Z" },
@@ -1742,9 +1742,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/69/529bd3a5b6d8edac3e530a0b71c3a8f620a544248c9e22d509852be269a7/libcudf_cu12-25.8.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2ae790b881a67511b414451821ec894f014e4c49d3c62e8f230c45b56cfce0cb", size = 521220643, upload-time = "2025-08-07T11:49:07.039Z" },
@@ -1766,10 +1766,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-libnvcomp-cu12" },
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-libnvcomp-cu12", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/26/f0ae0915b0efac09de00229a205912e25691163e3a6cb51d5327b75d2119/libcudf_cu12-26.4.0-py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2448f34ec63ef9bca6ec47b2089fb331826a834e5e256ae9e0f21a5a7e56df", size = 674674052, upload-time = "2026-04-20T17:52:44.693Z" },
@@ -1821,7 +1821,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fe/35789d6aed0df9336ca07fcb57e756f0f91df4136c5c3087ffa97f912f4e/librmm_cu12-25.8.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18381166e7d855d1ee9ab4684d2ab8af67a115e2015753f1ce91b8ef1ad06013", size = 3539813, upload-time = "2025-08-07T11:22:46.099Z" },
@@ -1843,7 +1843,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/dc/04009da12d0ebccee9c7319929194839d1b3c0f306877c32e85ae1778fb3/librmm_cu12-26.4.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7fa86af3cf2fdd956c5906f8bd9c2a139ddcbb1a5e4c9c4aa33f391623be6c3", size = 3969220, upload-time = "2026-04-09T12:45:21.77Z" },
@@ -2363,7 +2363,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "numba" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/94/63e54c690f093869c5ed3e811ff440554e87085e4301ba9fe37953a6dd80/numba_cuda-0.14.1.tar.gz", hash = "sha256:2e23bc9f5946e850f21f42cb2dcd24a2cb8ea84b60ad020b6e3b357830a9a697", size = 491974, upload-time = "2025-08-22T16:40:43.58Z" }
 wheels = [
@@ -2372,11 +2372,11 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 
 [[package]]
@@ -2387,10 +2387,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "numba", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/51/8935ff9ae5150e1ffed945bf1b95002a6a5e1f9256aeb1143e1c159b68c5/numba_cuda-0.24.0.tar.gz", hash = "sha256:f15a11a8d224e160e9cb2345049c5fa0bbd49eb255b2e8f661086746a7feb378", size = 1347749, upload-time = "2026-01-12T22:38:08.289Z" }
 wheels = [
@@ -2404,9 +2404,9 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"] },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2423,11 +2423,11 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numba", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/aa/78ba931a3ddce12d0948302ae46b6fd7a5fe9009cf0e0add84d8f7ad9197/numba_cuda-0.28.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:733ca2823c208baab10d5d67107c267c248bca11ad94eee14c5a90cb57041b33", size = 1838625, upload-time = "2026-03-03T18:17:37.461Z" },
@@ -2446,12 +2446,12 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 
 [[package]]
@@ -2459,8 +2459,8 @@ name = "numcodecs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
 wheels = [
@@ -2691,7 +2691,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2702,7 +2702,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2729,9 +2729,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2742,7 +2742,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3441,12 +3441,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/12/023332074131122d839be397fe78195eb51eae131a82004438933e9ffbbc/pylibcudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18d7032242d2b8a136f226b7ae4fd8e631e526cbc886186cb7571eb1c25fbcef", size = 28162734, upload-time = "2025-08-07T11:45:56.918Z" },
@@ -3473,10 +3473,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ad/d2a1961ae8b194ce33a9d8269dd046629fb556147aca74223cabc632a07b/pylibcudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0b191096b574cff4d709bb0880d2f0a346120493090cc8103098de9abead71", size = 8009026, upload-time = "2026-04-09T13:28:51.019Z" },
@@ -3949,9 +3949,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/2c/3363bbf6f5ee3699e28f5a3c525a165bedfa496b5a2a426777648a0297d6/rmm_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:856c38c22e8e1ea8a7216ff9c55d902a9a59b0a18a7affd426338743781f6725", size = 1139163, upload-time = "2025-08-07T11:18:37.215Z" },
@@ -3978,9 +3978,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c1/6c3a3c0e14ccd1f92e43dd90d1137bd3d0592794c02e871bbcc6cdbf2888/rmm_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be5e54e32bfac027803a658e1ee41d0c0c4fd89849a77c5ed148c3edcdc0269d", size = 1197307, upload-time = "2026-04-09T14:23:55.527Z" },
@@ -4348,6 +4348,7 @@ name = "tensor-grep"
 version = "1.66.1"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "importlib-metadata", version = "8.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
@@ -4430,6 +4431,7 @@ semantic = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "cudf-cu12", marker = "extra == 'gpu'" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = "<8.5.0" },
@@ -5036,12 +5038,12 @@ name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "google-crc32c", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [


### PR DESCRIPTION
**Unblocks the v1.67.0 release** — #553 merged with 2 failing release-gating checks.

## Root cause
1. **Formatting & Linting** (`static-analysis`, a `release` gate): `ruff format --check --preview .` reformats the embedded Python code fence in `docs/plans/backlog-100/cluster-124-evidence-signing.md` (ruff formats Markdown code blocks under `--preview`). #553's build agent left the snippet unformatted. Local scoped gates (`src/tensor_grep tests`) never see it — CI runs the whole repo.
2. **Dependency & License Audit**: `uv.lock` was stale — #553 added `cryptography>=48.0.1` to `[project].dependencies` without regenerating the lock.

## Fix
- `ruff format --preview` the doc's code block (9 lines).
- `uv lock` regenerated.

## Verification (CI-equivalent clean checkout, autocrlf=false)
- `ruff format --check --preview` → 548 files already formatted ✓
- `ruff check` → All checks passed ✓
- `uv lock --locked` → current ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)