### PR TITLE
docs(agents): explain why ruff format's whole-repo '.' scope is load-bearing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,7 +370,7 @@ uv run mypy src/tensor_grep
 uv run pytest -q
 ```
 
-CI runs `ruff format --check --preview .`. Running only `uv run ruff check .` is not enough to prove formatter parity, and running `ruff format` WITHOUT `--preview` actively REVERTS preview-style formatting on disk — a "clean" bare `ruff format` will undo CI-mandated style and red the next `ruff format --check --preview` run even when local lint passes. Always pass `--preview` to `ruff format` locally; never pass it to `ruff check`.
+CI runs `ruff format --check --preview .`. Running only `uv run ruff check .` is not enough to prove formatter parity, and running `ruff format` WITHOUT `--preview` actively REVERTS preview-style formatting on disk — a "clean" bare `ruff format` will undo CI-mandated style and red the next `ruff format --check --preview` run even when local lint passes. Always pass `--preview` to `ruff format` locally; never pass it to `ruff check`. The trailing `.` (whole repo) is load-bearing too: under `--preview`, ruff formats Python code fences INSIDE Markdown, so a scoped run (`ruff format --check --preview src/tensor_grep tests`) passes locally yet MISSES an unformatted `docs/**/*.md` snippet — which reds CI's release-gating `static-analysis` job and blocked v1.67.0. Always run the whole-repo `.` form; never a `src`/`tests` subset.
 
 `uv run pytest -q` can take substantially longer than 70-90 seconds on this Windows machine when the full JS/TS and e2e surface is hot; use a timeout of at least 120 seconds for narrow suites and a much larger timeout for the full suite when running it through automation.
 


### PR DESCRIPTION
## What
One sentence added to AGENTS.md's **Required Local Validation** explaining why `ruff format --check --preview` must run against the whole repo (`.`), not a `src/tensor_grep tests` subset.

## Why
Under `--preview`, ruff (0.15.20) formats Python code fences INSIDE Markdown. A scoped `ruff format --check --preview src/tensor_grep tests` therefore passes locally but misses an unformatted `docs/**/*.md` snippet — which reds CI's **release-gating** `static-analysis` job. This empirically blocked **v1.67.0** (a design doc's `json.dumps(...)` fence) and failed the static-analysis on #555/#556/#557 (which merely inherited the bad doc from base main). The whole-repo `.` form was already prescribed, but agents kept scoping it down — this makes the *rationale* explicit.

## Verification
- Mechanism confirmed directly: `ruff format --preview` rewrote a `.md` python fence (`x= 1 ;y=2` -> `x = 1` / `y = 2`, "1 file reformatted").
- `ruff format --check --preview AGENTS.md` -> exit 0 (prose-only edit, no fence touched).

Prose-only; no code or config change; `docs:` (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
