### PR TITLE
fix(importers): honest signal when FILE is outside the scanned ROOT

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -15112,10 +15112,28 @@ def build_file_importers_from_map(
     if not resolved_file.exists():
         raise FileNotFoundError(f"File not found: {resolved_file}")
     target_file = str(resolved_file)
+    # Honesty fix (dogfood, published v1.69.2 wheel): a purely lexical containment check --
+    # both paths are already `.resolve()`d above, so this touches no filesystem state beyond
+    # what the code above already did. A relative FILE (the daemon/session convention, joined
+    # onto repo_root by the `if not resolved_file.is_absolute()` branch above) stays a
+    # descendant of repo_root for the normal in-repo convention, so it does not trip this; a
+    # net-escaping `..` relative path (e.g. `../other/mod.py`) correctly DOES. The usual
+    # outside-root case is an already-absolute FILE (the CLI cold-tier caller, pre-resolved
+    # against cwd by `build_file_importers` before this function ever sees it). `relative_to` raises ValueError both for a genuinely
+    # unrelated path and for a different Windows drive -- both mean "outside root" here. Without
+    # this signal, an outside-root FILE silently reported `importer_count: 0`, indistinguishable
+    # from a genuine "unimported inside ROOT" answer, when the real problem was ROOT defaulting
+    # to the wrong scan boundary (e.g. CWD instead of the repo that actually contains FILE).
+    try:
+        resolved_file.relative_to(repo_root)
+        file_outside_root = False
+    except ValueError:
+        file_outside_root = True
 
     payload = _envelope(repo_root)
     payload["routing_reason"] = "file-importers"
     payload["file"] = target_file
+    payload["file_outside_root"] = file_outside_root
 
     all_files = [str(current) for current in repo_map.get("files", [])]
     imports_by_file = {
@@ -15180,6 +15198,21 @@ def build_file_importers_from_map(
             "importer_candidates_scanned": scanned_count,
             "importer_candidates_total": len(bounded_candidates),
         }
+    # Stamped LAST (after _copy_scan_limit and the ceiling/deadline blocks above), only when no
+    # more specific remediation already claimed the slot: _copy_scan_limit unconditionally copies
+    # the repo-map's own `scan_remediation` (often `None` on a complete ROOT scan) whenever the
+    # repo-map carried a `scan_limit` dict, and the ceiling-hit branch above stamps its own
+    # narrower message first via `_mark_result_incomplete` -- either would silently clobber this
+    # one if it ran earlier (backlog #57 taught the same lesson for the ceiling-hit remediation
+    # above). `file_outside_root` is additive-only: it never flips `result_incomplete`/`partial`
+    # or changes exit code, since a truly outside-root FILE always finds zero prefiltered
+    # candidates (never ceiling- or deadline-bound).
+    if file_outside_root and not payload.get("scan_remediation"):
+        payload["scan_remediation"] = (
+            f"FILE {resolved_file} is outside the scanned ROOT {repo_root}; the importers scan "
+            "only covers ROOT, so 0 importers here does NOT mean the file is unused. Pass the "
+            "repo containing FILE as ROOT (tg importers FILE <its-repo>) or run from inside it."
+        )
     payload["resolution_gaps"] = list(repo_map.get("resolution_gaps", []))
     return payload
 

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -756,6 +756,92 @@ def test_build_file_importers_outside_root_file_returns_no_importers_not_a_crash
     assert payload["file"] == str(outside_file.resolve())
     assert payload["importer_count"] == 0
     assert payload["importer_files"] == []
+    # Dogfood honesty fix (published v1.69.2 wheel): a valid FILE outside the scanned ROOT must
+    # be flagged so `importer_count: 0` here is never confused with a genuine unimported-in-ROOT
+    # answer -- an agent shelling out from the wrong CWD needs to see this, not a look-alike zero.
+    assert payload["file_outside_root"] is True
+    remediation = payload["scan_remediation"]
+    assert isinstance(remediation, str) and remediation
+    assert "ROOT" in remediation
+
+
+def test_build_file_importers_from_map_outside_root_stamps_honest_signal(
+    tmp_path: Path,
+) -> None:
+    """Direct `build_file_importers_from_map` unit coverage of the same honesty fix: a repo_map
+    scoped to dirA, queried for a FILE that genuinely exists in a separate dirB, must stamp
+    `file_outside_root: True` plus a non-empty `scan_remediation` naming the mismatch -- instead
+    of a bare `importer_count: 0` that is indistinguishable from a real no-importers answer."""
+    dir_a = tmp_path / "dirA"
+    dir_a.mkdir()
+    (dir_a / "util.py").write_text("VALUE = 1\n", encoding="utf-8")
+    dir_b = tmp_path / "dirB"
+    dir_b.mkdir()
+    outside_file = dir_b / "other.py"
+    outside_file.write_text("VALUE = 2\n", encoding="utf-8")
+
+    repo_map_payload = repo_map.build_repo_map(dir_a)
+    payload = repo_map.build_file_importers_from_map(repo_map_payload, str(outside_file))
+
+    assert payload["importer_count"] == 0
+    assert payload["file_outside_root"] is True
+    remediation = payload["scan_remediation"]
+    assert isinstance(remediation, str) and remediation
+    assert "ROOT" in remediation
+    assert str(dir_a.resolve()) in remediation
+
+
+def test_build_file_importers_from_map_inside_root_unimported_is_not_flagged_outside(
+    tmp_path: Path,
+) -> None:
+    """Regression guard: a FILE genuinely inside ROOT but unimported is a LEGIT empty result --
+    must not be mistaken for (or ever stamped with) the outside-root signal."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    lonely = repo_dir / "lonely.py"
+    lonely.write_text("VALUE = 1\n", encoding="utf-8")
+
+    repo_map_payload = repo_map.build_repo_map(repo_dir)
+    payload = repo_map.build_file_importers_from_map(repo_map_payload, str(lonely))
+
+    assert payload["importer_count"] == 0
+    assert payload["file_outside_root"] is False
+    # `scan_remediation` is only ever populated (as a dict-copy sibling of `scan_limit`) when the
+    # repo-map scan itself was max-repo-files-capped; a plain `build_repo_map(repo_dir)` call
+    # (no cap) never sets the key at all -- `.get()` tolerates that, `is None` would KeyError.
+    assert not payload.get("scan_remediation")
+
+
+def test_build_file_importers_from_map_inside_root_with_importers_is_not_flagged_outside(
+    tmp_path: Path,
+) -> None:
+    """Regression guard: a FILE inside ROOT WITH real importers must report them normally and
+    never carry the outside-root signal."""
+    repo_dir, target, importer = _make_js_importer_fixture(tmp_path)
+
+    repo_map_payload = repo_map.build_repo_map(repo_dir)
+    payload = repo_map.build_file_importers_from_map(repo_map_payload, str(target))
+
+    assert payload["file_outside_root"] is False
+    assert payload["importer_count"] == 1
+    assert str(importer.resolve()) in set(payload["importer_files"])
+
+
+def test_build_file_importers_from_map_relative_file_stays_in_root_daemon_convention(
+    tmp_path: Path,
+) -> None:
+    """Safety constraint: the daemon/session convention passes a FILE relative to the repo_map's
+    OWN root (session_file_importers / the raw daemon-socket `file_importers` command both do
+    this). That join (`repo_root / resolved_file`) always lands under repo_root, so the new
+    containment check must never fire a false positive for this calling convention."""
+    repo_dir, target, _importer = _make_js_importer_fixture(tmp_path)
+
+    repo_map_payload = repo_map.build_repo_map(repo_dir)
+    payload = repo_map.build_file_importers_from_map(repo_map_payload, "src/util.js")
+
+    assert payload["file_outside_root"] is False
+    assert payload["file"] == str(target.resolve())
+    assert payload["importer_count"] == 1
 
 
 def test_importers_cli_relative_file_and_root_from_parent_cwd_no_doubling(
@@ -799,6 +885,11 @@ def test_importers_cli_outside_root_file_exits_1_not_found(
     assert payload["not_found"] is True
     assert payload["importer_count"] == 0
     assert payload["file"] == str(outside_file.resolve())
+    # Dogfood honesty fix: the CLI-level payload must carry the same outside-root signal as the
+    # underlying builder -- an agent reading `not_found: true` + `importer_count: 0` alone cannot
+    # tell "wrong ROOT" from "really unimported"; this is additive only (exit code unchanged).
+    assert payload["file_outside_root"] is True
+    assert isinstance(payload["scan_remediation"], str) and payload["scan_remediation"]
 
 
 def test_imports_relative_file_from_parent_cwd_already_resolves_correctly(


### PR DESCRIPTION
## What

`tg importers FILE [ROOT]` (ROOT defaults to CWD) returned an empty `importer_count: 0` with **no signal** distinguishing "FILE is outside the scanned ROOT" (wrong root / usage error) from "FILE is genuinely unimported inside ROOT." An agent shelling out `tg importers /other/repo/file.py` from a different CWD got a **silently-wrong empty answer** identical to a real no-importers result.

**Dogfound** by running the published v1.69.2 wheel against a real external repo (Flask): from CWD=tensor-grep, `tg importers <flask-file>` scanned 891 tensor-grep files (ROOT defaulted to CWD), returned `importer_count: 0` + exit 1; from CWD=flask it correctly found 6 importers. This is the reverse #74 file-dependency primitive — a moat feature — so a silent-wrong empty is a real correctness gap.

## The fix (additive-only)

In `build_file_importers_from_map` (`repo_map.py`): a purely lexical `resolved_file.relative_to(repo_root)` containment check computes `file_outside_root` (always stamped on the payload), and — stamped last, only when no more-specific remediation already claimed the slot — a `scan_remediation` message when FILE is outside ROOT. No change to exit code, `importer_count`, `result_incomplete`, `partial`, or the "importers within ROOT" contract. Safe for the daemon/session relative-file path (always joined onto root, never fires).

## Verification

- **TDD** 6 tests (real dirA/dirB separation, bidirectional): outside-root -> flagged; in-root-unimported -> not flagged; in-root-with-importers -> not flagged; daemon relative convention -> not flagged; CLI cold-tier + CLI exit-code. Genuine red->green (KeyError before, pass after).
- **Real-venv re-verified** 6/6 green (worktree source, not the editable install).
- **Mandatory adversarial Opus gate: SHIP** — broke against 7 axes (containment correctness incl. Windows case-fold/drive/symlink; daemon-caller safety across all 3 callers; MCP output-shape contract; additive-only; remediation clobber ordering; info disclosure; test quality) and found no correctness or security defect. MCP confinement (`_confine_read_path`) already refuses out-of-anchor files, so the new signal never leaks a path outside the permitted scope.

FastAPI (a 2nd real repo) dogfood battery: all commands exit 0, no new defects.
