### PR TITLE
test: de-flake incremental-vs-full repo_map perf assertion (#156)

### DIFF
--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -508,8 +508,18 @@ def test_incremental_repo_map_is_faster_than_full_rebuild_for_small_changes(
 
     original = repo_map._imports_and_symbols_for_path
 
+    # The per-file parse cost must DOMINATE the fixed graph/PageRank/assembly
+    # overhead that BOTH paths share (the ``all_files`` loop in
+    # build_repo_map_incremental + build_repo_map). With a small sleep that
+    # shared overhead was ~equal to the sleep-savings, pinning the ratio at
+    # ~0.5 and flaking on CI (assert 0.2126 < 0.2113, missed by 0.0013s). A
+    # larger per-file sleep makes the timing reflect the real file-count
+    # savings (incremental reparses 1 of 80 files, ratio -> ~0.13), so the
+    # threshold below has ~14x headroom against overhead noise.
+    per_file_parse_cost = 0.02
+
     def slow_parser(path: Path) -> tuple[list[str], list[dict[str, object]]]:
-        time.sleep(0.005)
+        time.sleep(per_file_parse_cost)
         return original(path)
 
     monkeypatch.setattr(repo_map, "_imports_and_symbols_for_path", slow_parser)
@@ -525,4 +535,7 @@ def test_incremental_repo_map_is_faster_than_full_rebuild_for_small_changes(
     repo_map.build_repo_map(project)
     full_duration = time.perf_counter() - start
 
-    assert incremental_duration < (full_duration * 0.5)
+    # Incremental reparses 1 file; full reparses all 80. The real ratio is
+    # ~0.13; 0.65 catches the regression class (incremental accidentally
+    # reparsing every file -> ratio -> ~1.0) while tolerating CI overhead noise.
+    assert incremental_duration < (full_duration * 0.65)


### PR DESCRIPTION
## What

De-flakes `test_incremental_repo_map_is_faster_than_full_rebuild_for_small_changes`, which blocked the **v1.69.4** release run (carrying the #152 `sys.path.insert` HIGH fix) on `test-python (ubuntu-latest, py3.12)`:

```
assert 0.21262048099998765 < (0.4226320120000082 * 0.5)
```

Incremental was **50.3%** of full-rebuild time; the test demanded `<50%`. Missed by **0.0013s** (0.3%).

## Root cause (verified against `repo_map.py`)

Both `build_repo_map` and `build_repo_map_incremental` share a fixed graph/PageRank/assembly overhead (the `all_files` loop). With a 0.005s per-file sleep, that shared overhead was ~equal to the sleep-savings, pinning the incremental/full ratio at ~0.5 -> inherent boundary flake. The incremental path correctly reparses only the 1 changed file (loop at `repo_map.py:6323`), so this is a timing-assertion fragility, **not** a #152 regression (the test monkeypatches `_imports_and_symbols_for_path`, bypassing #152's resolution changes entirely in the timed section).

## Fix

- Raise the per-file parse cost (0.005 -> 0.02s) so the timing reflects the real 1-of-80 file-count savings (ratio -> ~0.13).
- Relax the threshold 0.5 -> 0.65 for ~14x overhead-noise headroom. Still catches the regression class (incremental accidentally reparsing every file -> ratio -> ~1.0).

Test-only; no production change. Verified 3/3 local passes (~2.6-3.3s each).

Closes #156.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>