### PR TITLE
fix(ast-grep): probe requires exit 0, not just the marker — doctor honesty (#90b)

### DIFF
--- a/src/tensor_grep/backends/ast_wrapper_backend.py
+++ b/src/tensor_grep/backends/ast_wrapper_backend.py
@@ -61,7 +61,13 @@ def _is_ast_grep_sg_binary(binary: str) -> bool:
     except (OSError, subprocess.TimeoutExpired):
         return False
     version_text = f"{result.stdout}\n{result.stderr}".lower()
-    return "ast-grep" in version_text
+    # #90(b): require a clean exit too, not just the "ast-grep" marker. A broken
+    # shim (e.g. a Windows `ast-grep.exe` invoked under WSL/Linux that exits 127)
+    # can print an error whose text still contains "ast-grep" -- the marker-only
+    # check would then mis-trust it, making is_available() (and `tg doctor`) report
+    # available:true for a binary that cannot actually run. A real `ast-grep
+    # --version` exits 0, so gate on that to stay honest and fail-closed.
+    return result.returncode == 0 and "ast-grep" in version_text
 
 
 def _ast_grep_command_timeout_seconds() -> float:

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -67,6 +67,7 @@ def test_ast_wrapper_backend_should_use_resolved_binary_path():
 def test_ast_wrapper_backend_should_ignore_linux_group_sg_binary():
     backend = AstGrepWrapperBackend()
     mock_result = MagicMock()
+    mock_result.returncode = 0  # exit 0 -> the rejection must come from the missing marker, not the exit code
     mock_result.stdout = "sg from util-linux 2.39\n"
     mock_result.stderr = ""
 

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -47,6 +47,7 @@ def test_ast_wrapper_backend_should_use_resolved_binary_path():
     this literal path) instead of exercising the mocked contract."""
     backend = AstGrepWrapperBackend()
     mock_result = MagicMock()
+    mock_result.returncode = 0  # a working `ast-grep --version` exits 0 (#90b probe gate)
     mock_result.stdout = "ast-grep 0.39.5\n"
     mock_result.stderr = ""
 
@@ -87,6 +88,7 @@ def test_ast_wrapper_backend_should_ignore_linux_group_sg_binary():
 def test_ast_wrapper_backend_should_accept_verified_sg_alias():
     backend = AstGrepWrapperBackend()
     mock_result = MagicMock()
+    mock_result.returncode = 0  # a working `sg --version` exits 0 (#90b probe gate)
     mock_result.stdout = "ast-grep 0.39.5\n"
     mock_result.stderr = ""
 
@@ -157,6 +159,33 @@ def test_ast_grep_backend_still_trusts_working_binary():
 
         assert backend.is_available() is True
         assert backend._get_binary_name() == "/real/path/ast-grep"
+
+
+def test_ast_grep_backend_rejects_shim_that_exits_nonzero_with_marker():
+    """#90(b): a broken shim that RUNS (no OSError) but exits NON-ZERO -- e.g. a
+    Windows `ast-grep.exe` invoked under WSL that exits 127 -- whose error output
+    still contains "ast-grep" must NOT be trusted. The probe requires exit 0, not
+    just the marker, so is_available() (and `tg doctor`) stays honest/fail-closed.
+    Without the returncode==0 gate this shim would falsely resolve as available."""
+    backend = AstGrepWrapperBackend()
+    mock_result = MagicMock()
+    mock_result.returncode = 127
+    mock_result.stdout = ""
+    mock_result.stderr = "ast-grep: command not found\n"
+
+    with (
+        patch("shutil.which") as which,
+        patch("tensor_grep.backends.ast_wrapper_backend.subprocess.run", return_value=mock_result),
+    ):
+        which.side_effect = lambda name: {
+            "ast-grep": "/broken/shim/ast-grep",
+            "ast-grep.exe": None,
+            "sg.exe": None,
+            "sg": None,
+        }.get(name)
+
+        assert backend.is_available() is False
+        assert backend._get_binary_name() == "ast-grep"
 
 
 def test_ast_grep_backend_memoizes_binary_probe():

--- a/tests/unit/test_ast_wrapper_backend.py
+++ b/tests/unit/test_ast_wrapper_backend.py
@@ -67,7 +67,7 @@ def test_ast_wrapper_backend_should_use_resolved_binary_path():
 def test_ast_wrapper_backend_should_ignore_linux_group_sg_binary():
     backend = AstGrepWrapperBackend()
     mock_result = MagicMock()
-    mock_result.returncode = 0  # exit 0 -> the rejection must come from the missing marker, not the exit code
+    mock_result.returncode = 0  # rejection must come from the missing marker, not the exit code
     mock_result.stdout = "sg from util-linux 2.39\n"
     mock_result.stderr = ""
 


### PR DESCRIPTION
## What

`_is_ast_grep_sg_binary` (the `#130b` probe-gate) trusted any `which()`-resolved candidate whose `--version` output **contained** `"ast-grep"` — even on a nonzero exit. A broken shim (e.g. a Windows `ast-grep.exe` invoked under WSL/Linux that exits **127**, the CEO's v1.69.3 dogfood case) whose error text still mentions "ast-grep" would be mis-trusted, making `is_available()` — and therefore `tg doctor` — report `available: true` for a binary that cannot run.

## Fix

Require `result.returncode == 0` too. A real `ast-grep --version` exits 0, so the probe stays honest and **fail-closed** (a broken shim → unavailable). Extends the `#130b` probe-gate; the in-git-repo and working-binary paths are unchanged.

## Tests

- New regression test: a shim that runs but exits 127 with `"ast-grep"` in stderr → `is_available()` False (fails without this fix).
- Made two existing working-binary mocks faithful (`returncode = 0`) — a working binary exits 0.
- Verified: `test_ast_wrapper_backend.py` 37 pass, broader ast + backend-contract suite 71 pass / 1 skip, ruff clean.

Addresses the doctor-honesty half of #90 (the `tg scan` ast-grep Linux portability half remains env-blocked — needs a Linux ast-grep). Directly responsive to the CEO's "should our doctor check + fix this" note.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>