### PR TITLE
feat(codemap): default --deadline 60s + --no-deadline opt-out (#153)

### DIFF
--- a/src/tensor_grep/cli/codemap.py
+++ b/src/tensor_grep/cli/codemap.py
@@ -49,6 +49,14 @@ from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, ru
 DEFAULT_MAX_REPO_FILES = 50_000
 DEFAULT_MAX_SYMBOLS_PER_FILE = 50
 
+# CLI-ONLY default (#153): a huge multi-root workspace can make `tg codemap` hang for ~90s because
+# the --deadline CLI option used to default to None (unbounded). This constant is read by main.py's
+# --deadline option (literal-mirrored there, like DEFAULT_MAX_REPO_FILES above, to keep the heavy
+# codemap import lazy) and pinned against it by a guard test. It intentionally does NOT change
+# build_codemap's own `deadline_seconds: float | None = None` signature default below -- a direct
+# library call stays unbounded by default; only the CLI front door is agent-loop-safe by default.
+DEFAULT_CLI_DEADLINE_SECONDS = 60.0
+
 _COVERAGE_SCHEMA_VERSION = 1
 _COVERAGE_FILENAME = "_coverage.json"
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7790,15 +7790,23 @@ def codemap(
         "repo-relative path and basename, e.g. --ignore 'benchmarks/**' --ignore '*.stub.py'. "
         "Excluded paths never reach the generated pages or index.",
     ),
-    deadline: float | None = typer.Option(
-        None,
+    deadline: float = typer.Option(
+        # Literal mirrors codemap.DEFAULT_CLI_DEADLINE_SECONDS (kept literal so the heavy codemap
+        # import stays lazy, matching max_repo_files' pattern above); a guard test pins them.
+        60.0,
         "--deadline",
         min=0.1,
         help=(
             "Stop the underlying repo scan after N seconds and return a partial map "
             "(partial=true, partial_reason='deadline') with whatever was found so far, instead "
-            "of running unbounded."
+            "of running unbounded. Defaults to 60s so a huge multi-root workspace can't hang an "
+            "agent loop; pass --no-deadline to disable the bound."
         ),
+    ),
+    no_deadline: bool = typer.Option(
+        False,
+        "--no-deadline",
+        help="Disable the default --deadline bound; let the scan run unbounded.",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
@@ -7824,6 +7832,7 @@ def codemap(
             raise typer.Exit(1)
         return
 
+    effective_deadline = None if no_deadline else deadline
     try:
         payload = build_codemap(
             path,
@@ -7832,7 +7841,7 @@ def codemap(
             max_repo_files=max_repo_files,
             max_symbols_per_file=max_symbols_per_file,
             ignore=tuple(ignore),
-            deadline_seconds=deadline,
+            deadline_seconds=effective_deadline,
         )
     except (FileNotFoundError, NotADirectoryError) as exc:
         typer.echo(str(exc), err=True)

--- a/tests/unit/test_codemap.py
+++ b/tests/unit/test_codemap.py
@@ -12,9 +12,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
 from tensor_grep.cli import codemap as _codemap
 from tensor_grep.cli.codemap import build_codemap, build_codemap_json
+from tensor_grep.cli.main import app
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "codemap_repo"
 
@@ -446,6 +448,97 @@ def test_generous_deadline_yields_partial_false(tmp_path: Path) -> None:
 
     assert payload["partial"] is False
     assert payload["partial_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# #153: the `tg codemap` CLI front door defaults --deadline to a bounded value (was None/unbounded,
+# which could hang ~90s on a huge multi-root workspace) -- build_codemap's own library default
+# stays None (see test_default_invocation_matches_explicit_noop_ignore_and_deadline above, which
+# must stay untouched). These are the first CliRunner-based tests in this file: they spy on
+# codemap.build_codemap (monkeypatched on the module, picked up by main.py's lazy
+# `from tensor_grep.cli.codemap import build_codemap` at call time -- the same pattern
+# tests/unit/test_cli_deadline_flag.py uses for repo_map.build_symbol_callers) so no real repo scan
+# runs.
+# ---------------------------------------------------------------------------
+
+
+def _stub_cli_codemap_payload(path: str | Path) -> dict:
+    out_dir = Path(path) / "docs" / "code-map"
+    return {
+        "path": str(path),
+        "out": str(out_dir),
+        "index": str(out_dir / "index.md"),
+        "folders_total": 0,
+        "files_total": 0,
+        "symbols_total": 0,
+        "partial": False,
+        "partial_reason": None,
+    }
+
+
+def test_codemap_cli_defaults_to_bounded_deadline(tmp_path: Path, monkeypatch) -> None:
+    recorded: dict = {}
+
+    def _spy(path, *, deadline_seconds=None, **_kwargs):
+        recorded["deadline_seconds"] = deadline_seconds
+        return _stub_cli_codemap_payload(path)
+
+    monkeypatch.setattr(_codemap, "build_codemap", _spy)
+    result = CliRunner().invoke(app, ["codemap", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert recorded.get("deadline_seconds") == 60.0
+
+
+def test_codemap_cli_no_deadline_flag_passes_none(tmp_path: Path, monkeypatch) -> None:
+    recorded: dict = {"deadline_seconds": "sentinel-untouched"}
+
+    def _spy(path, *, deadline_seconds=None, **_kwargs):
+        recorded["deadline_seconds"] = deadline_seconds
+        return _stub_cli_codemap_payload(path)
+
+    monkeypatch.setattr(_codemap, "build_codemap", _spy)
+    result = CliRunner().invoke(app, ["codemap", str(tmp_path), "--no-deadline"])
+
+    assert result.exit_code == 0, result.output
+    assert recorded.get("deadline_seconds") is None
+
+
+def test_codemap_cli_explicit_deadline_still_overrides_default(tmp_path: Path, monkeypatch) -> None:
+    recorded: dict = {}
+
+    def _spy(path, *, deadline_seconds=None, **_kwargs):
+        recorded["deadline_seconds"] = deadline_seconds
+        return _stub_cli_codemap_payload(path)
+
+    monkeypatch.setattr(_codemap, "build_codemap", _spy)
+    result = CliRunner().invoke(app, ["codemap", str(tmp_path), "--deadline", "30"])
+
+    assert result.exit_code == 0, result.output
+    assert recorded.get("deadline_seconds") == 30.0
+
+
+def test_default_cli_deadline_literal_pins_main_py_option(tmp_path: Path, monkeypatch) -> None:
+    """Guard test: main.py's --deadline typer.Option hardcodes a literal 60.0 (to keep the heavy
+    codemap import lazy -- the same pattern DEFAULT_MAX_REPO_FILES/50_000 uses). Nothing else pins
+    that literal against codemap.DEFAULT_CLI_DEADLINE_SECONDS, so the two could silently drift.
+    (A comment near main.py's max_repo_files option claims an analogous guard test already exists
+    for the 50_000 literal -- it doesn't; grepping the test suite confirms no such test. This is a
+    real guard, for the new constant.)"""
+    assert _codemap.DEFAULT_CLI_DEADLINE_SECONDS == 60.0
+
+    recorded: dict = {}
+
+    def _spy(path, *, deadline_seconds=None, **_kwargs):
+        recorded["deadline_seconds"] = deadline_seconds
+        return _stub_cli_codemap_payload(path)
+
+    monkeypatch.setattr(_codemap, "build_codemap", _spy)
+    CliRunner().invoke(app, ["codemap", str(tmp_path)])
+
+    # The CLI's actual (hardcoded-in-main.py) default must match the module constant -- not just
+    # two independently-hardcoded 60.0s that happen to agree today.
+    assert recorded.get("deadline_seconds") == _codemap.DEFAULT_CLI_DEADLINE_SECONDS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`tg codemap` on a huge multi-root workspace hung ~90s (CEO v1.69.3 dogfood: "not agent-loop-ready") because its `--deadline` CLI option defaulted to `None` (unbounded). The deadline machinery already existed (on expiry it sets `partial`+`partial_reason="deadline"`+a remediation message and raises exit-2) — only the default was missing.

## Fix (CLI layer only)

- `main.py`: codemap's `--deadline` typer default `None` → `60.0` (agent-loop-safe), + a new `--no-deadline` flag for a deliberate full map (`effective_deadline = None if no_deadline else deadline`).
- `codemap.py`: added `DEFAULT_CLI_DEADLINE_SECONDS = 60.0` (CLI-only constant). **Deliberately did NOT touch `build_codemap`'s own `deadline_seconds=None` library default** — that would break `test_codemap.py:457` and change semantics for every non-CLI caller.
- Rejected `--deadline 0`=unbounded (every `--deadline` in the CLI has `min=0.1`; overloading `0` on codemap only would be a cross-surface inconsistency).

## Verification

Built in an isolated worktree with a **real venv + native ext** (not mocked): `test_codemap.py` + `test_cli_deadline_flag.py` = **41 pass**; ruff check + `ruff format --check --preview` clean; the protected `test_codemap.py:457` untouched. Dogfooded the real binary: `tg codemap --help` shows `--deadline [default: 60.0; x>=0.1]` + `--no-deadline`; end-to-end runs exit 0. Design verified against code by an independent agent (found this exact trap).

Merge held until v1.70.2 (#571) publishes — one-per-publish. Closes #153.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>