### PR TITLE
fix(search): fast-refuse unscoped scan of a marked workspace-parent root with many marked children (#154)

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -15,7 +15,12 @@ from tensor_grep.cli.runtime_paths import (
     resolve_ripgrep_binary,
 )
 from tensor_grep.cli.subprocess_policy import run_subprocess as run_subprocess
-from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+from tensor_grep.io.directory_scanner import (
+    BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
+    BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
+    BROAD_WORKSPACE_PROJECT_MARKERS,
+    UNBOUNDED_VENDORED_ROOT_DIR_NAMES,
+)
 
 # Saved at import time so _streaming_passthrough_returncode can detect when
 # run_subprocess has been monkey-patched by a test (old mock pattern).
@@ -140,19 +145,11 @@ _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "target",
     "venv",
 }
-_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
-_BROAD_WORKSPACE_PROJECT_MARKERS = {
-    ".git",
-    "Cargo.toml",
-    "build.gradle",
-    "composer.json",
-    "deno.json",
-    "go.mod",
-    "package.json",
-    "pom.xml",
-    "pyproject.toml",
-    "settings.gradle",
-}
+# Single source of truth: `io/directory_scanner.py` (item #154) -- keeps this file and
+# `cli/main.py`'s equivalent guard from drifting out of sync.
+_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+_BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+_BROAD_WORKSPACE_PROJECT_MARKERS = BROAD_WORKSPACE_PROJECT_MARKERS
 _SEARCH_PATTERN_FLAGS = {"-e", "--regexp"}
 _SEARCH_LITERAL_FLAGS = {"-F", "--fixed-strings"}
 _SEARCH_PCRE2_FLAGS = {"-P", "--pcre2"}
@@ -614,8 +611,17 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
             continue
         path = Path(raw_path)
         try:
-            if not path.is_dir() or _path_has_project_marker(path):
+            if not path.is_dir():
                 continue
+            # Item #154: mirrors cli/main.py's `_workspace_project_child_names` -- a root
+            # carrying its own project marker is not skipped outright, it just needs more
+            # marked children (the higher "marked-root" threshold) before it counts as a
+            # workspace parent too.
+            threshold = (
+                _BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+                if _path_has_project_marker(path)
+                else _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+            )
             project_children = 0
             for child in path.iterdir():
                 try:
@@ -623,7 +629,7 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
                         project_children += 1
                 except OSError:
                     continue
-                if project_children >= _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD:
+                if project_children >= threshold:
                     return True
         except OSError:
             continue
@@ -631,10 +637,12 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
 
 
 # Critical unscoped-search-hang fix C: heavy vendored dirs that can sit at the TOP LEVEL of
-# a single project root -- `_search_paths_include_workspace_root` above SKIPS any root that
-# is itself a project (has its own marker like package.json/.git) and only fires when it
-# finds >= 3 sibling project dirs, so a single huge vendored repo (its own project, one
-# giant `node_modules`/`external_repos`/etc. at the top) always slipped past it. This check
+# a single project root -- `_search_paths_include_workspace_root` above only fires on
+# independently-MARKED children (a `.git`/`package.json`/etc. of their own; item #154 raised
+# the marked-root threshold from a flat skip to >= 8 marked children), and a single huge
+# vendored repo's own `node_modules`/`external_repos`/etc. is not itself marked that way, so a
+# single huge vendored repo (one giant vendored dir at the top, however few or many marked
+# siblings) always slipped past it. This check
 # MUST live here (not just in cli/main.py's equivalent guard) because `main_entry` below
 # decides whether to delegate straight to the native `tg` binary or to `rg` passthrough --
 # both of which bypass cli/main.py's Python guards entirely. Without this, an unscoped

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -38,7 +38,12 @@ from tensor_grep.cli.runtime_paths import (
 )
 from tensor_grep.core.observability import nvtx_range
 from tensor_grep.core.retrieval_chunker import MAX_CHUNKS
-from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+from tensor_grep.io.directory_scanner import (
+    BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
+    BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
+    BROAD_WORKSPACE_PROJECT_MARKERS,
+    UNBOUNDED_VENDORED_ROOT_DIR_NAMES,
+)
 from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
 
 if TYPE_CHECKING:
@@ -93,19 +98,11 @@ _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "target",
     "venv",
 }
-_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
-_BROAD_WORKSPACE_PROJECT_MARKERS = {
-    ".git",
-    "Cargo.toml",
-    "build.gradle",
-    "composer.json",
-    "deno.json",
-    "go.mod",
-    "package.json",
-    "pom.xml",
-    "pyproject.toml",
-    "settings.gradle",
-}
+# Single source of truth: `io/directory_scanner.py` (item #154) -- keeps this file and
+# `cli/bootstrap.py`'s front-door mirror from drifting out of sync.
+_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+_BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+_BROAD_WORKSPACE_PROJECT_MARKERS = BROAD_WORKSPACE_PROJECT_MARKERS
 _GUARDED_BROAD_ROOT_RG_GLOBS = (
     "!context/**",
     "!**/context/**",
@@ -4045,8 +4042,20 @@ def _workspace_project_child_names(paths: list[str]) -> list[str]:
             continue
         path = Path(raw_path)
         try:
-            if not path.is_dir() or _path_has_project_marker(path):
+            if not path.is_dir():
                 continue
+            # Item #154: a root carrying its OWN project marker (e.g. a top-level
+            # `package.json`) is not skipped outright -- it can *also* be a workspace parent
+            # (a real repro: a workspace dir with its own `package.json` that also contains
+            # dozens of independently-marked sibling projects). A marked root uses the higher
+            # "marked-root" threshold, since an ordinary single project can legitimately carry
+            # a handful of marked children without being a workspace parent; an unmarked root
+            # keeps the original (lower) threshold.
+            threshold = (
+                _BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+                if _path_has_project_marker(path)
+                else _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+            )
             child_project_names: list[str] = []
             for child in path.iterdir():
                 try:
@@ -4054,7 +4063,7 @@ def _workspace_project_child_names(paths: list[str]) -> list[str]:
                         child_project_names.append(child.name)
                 except OSError:
                     continue
-            if len(child_project_names) >= _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD:
+            if len(child_project_names) >= threshold:
                 found.update(child_project_names)
         except OSError:
             continue
@@ -4076,10 +4085,11 @@ def _should_refuse_unbounded_workspace_root_scan(
 
 # Critical unscoped-search-hang fix C: heavy vendored/index directories that can sit at the
 # TOP LEVEL of a single project root -- a root `_workspace_project_child_names` never flags
-# because the guard above SKIPS any root that is itself a project (has its own marker like
-# pyproject.toml/.git) and only fires when it finds >= 3 sibling project dirs. A single huge
-# vendored repo (its own project, one giant `node_modules`/`external_repos`/etc. at the top)
-# always slips past that guard.
+# on their account because that guard only fires on independently-MARKED children (a
+# `.git`/`pyproject.toml`/etc. of their own), and a single huge vendored repo's own
+# `node_modules`/`external_repos`/etc. is not itself marked that way (item #154 raised the
+# marked-root threshold from a flat skip to >= 8 marked children, but a bare vendored dir still
+# never counts as one). That single huge vendored repo always slips past that guard.
 #
 # Deliberately EXCLUDES tg's own index/reference dirs (`.tensor-grep`, `_tg_refs`,
 # `.tg_semantic_index`): those are already (a) skipped by repo_map's walk (Fix A), (b)

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -45,6 +45,37 @@ _ALL_HEAVY_ROOT_DIR_NAMES = frozenset({
 })
 UNBOUNDED_VENDORED_ROOT_DIR_NAMES = frozenset(_ALL_HEAVY_ROOT_DIR_NAMES - _GENERATED_DIR_NAMES)
 
+# Project-marker names that flag a directory as an independent project root, plus the
+# child-count thresholds that decide when a root "looks like" a multi-project workspace
+# parent (item #154). Single source of truth: both `cli/main.py`'s
+# `_should_refuse_unbounded_workspace_root_scan` and `cli/bootstrap.py`'s front-door mirror
+# `_search_paths_include_workspace_root` import `BROAD_WORKSPACE_PROJECT_MARKERS` and the two
+# thresholds below from here rather than each hardcoding their own copy, so the two guards can
+# never drift out of sync.
+BROAD_WORKSPACE_PROJECT_MARKERS = frozenset({
+    ".git",
+    "Cargo.toml",
+    "build.gradle",
+    "composer.json",
+    "deno.json",
+    "go.mod",
+    "package.json",
+    "pom.xml",
+    "pyproject.toml",
+    "settings.gradle",
+})
+# An UNMARKED root (no project marker of its own -- e.g. a plain folder of unrelated repos) is
+# flagged as a workspace parent once it has this many independently-marked children.
+BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
+# A MARKED root (carries its own project marker, e.g. a top-level `package.json`) is NOT
+# skipped outright (item #154, reported repro: an unscoped search from a workspace parent that
+# itself has a top-level `package.json` timed out instead of fast-refusing): such a root can
+# *also* be a workspace parent once it has enough independently-marked children. It uses a
+# HIGHER threshold than an unmarked root, since one ordinary project can legitimately carry a
+# handful of marked children (a Cargo workspace member, a vendored submodule) without itself
+# being a workspace parent.
+BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = 8
+
 # The Rust PyO3 directory scanner (`RustDirectoryScanner`) is NOT exported by the `rust_core`
 # extension (only `RustBackend` + functions are), so the old `from rust_core import
 # RustDirectoryScanner` always raised and this flag was permanently False — the Python walk below was

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -199,6 +199,45 @@ def test_main_entry_should_not_passthrough_unbounded_workspace_root_search(
     assert called["full_cli"] is True
 
 
+def test_main_entry_should_not_passthrough_marked_workspace_root_with_many_marked_children(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Item #154: reported repro is an unscoped `tg search "def main" <root> --json` from a
+    multi-root workspace parent that ALSO carries its own top-level project marker (a real
+    example: a workspace dir with a top-level `package.json`, like `C:/dev/projects`) --
+    `_search_paths_include_workspace_root` used to skip any root with its own marker
+    unconditionally, so this exact shape always fell through to an unbounded native/rg walk
+    (the reported 60s timeout) instead of refusing fast. A marked root must still refuse once
+    it has enough independently-marked children (the higher marked-root threshold)."""
+    called = {"full_cli": False}
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "package.json").write_text("{}", encoding="utf-8")
+    for index in range(8):
+        child = root / f"project-{index}"
+        child.mkdir()
+        (child / "package.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "def main", str(root), "--json"])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_native_tg_search",
+        lambda *_args, **_kwargs: pytest.fail("native passthrough should not run"),
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda *_args, **_kwargs: pytest.fail("rg passthrough should not run"),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
+
+    bootstrap.main_entry()
+
+    assert called["full_cli"] is True
+
+
 def test_main_entry_should_not_passthrough_single_project_root_with_top_level_vendored_dir(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -736,6 +736,56 @@ def test_workspace_root_guard_allows_real_repo_root(tmp_path: Path):
     assert project_dirs == []
 
 
+def test_workspace_root_guard_refuses_marked_root_with_many_marked_children(tmp_path: Path):
+    """Item #154: a root carrying its OWN project marker (e.g. a real-world multi-project
+    workspace parent with a top-level `pyproject.toml`/`package.json`) must NOT be skipped
+    outright -- it can *also* be a workspace parent when it has many independently-marked
+    children. 8 marked children clears the higher marked-root threshold, so the guard must
+    still refuse (the reported bug: this case previously always slipped past unbounded)."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text("", encoding="utf-8")
+    for index in range(8):
+        project = workspace / f"project-{index}"
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+
+    refused, project_dirs = _should_refuse_unbounded_workspace_root_scan(
+        [str(workspace)],
+        SearchConfig(),
+        allow_broad_generated_scan=False,
+        paths_defaulted=False,
+    )
+
+    assert refused is True
+    assert project_dirs == [f"project-{index}" for index in range(8)]
+
+
+def test_workspace_root_guard_allows_marked_root_with_seven_marked_children(tmp_path: Path):
+    """Boundary pin for item #154's marked-root threshold (N=8): a marked root with exactly
+    7 marked children must stay UNREFUSED -- one short of the higher bar a marked root needs
+    before it counts as a workspace parent too (an ordinary single project can legitimately
+    carry a handful of marked children, e.g. Cargo workspace members or vendored submodules,
+    without itself being a workspace parent)."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text("", encoding="utf-8")
+    for index in range(7):
+        project = workspace / f"project-{index}"
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+
+    refused, project_dirs = _should_refuse_unbounded_workspace_root_scan(
+        [str(workspace)],
+        SearchConfig(),
+        allow_broad_generated_scan=False,
+        paths_defaulted=False,
+    )
+
+    assert refused is False
+    assert project_dirs == []
+
+
 def test_workspace_root_guard_refuses_glob_with_implicit_path(tmp_path: Path):
     """Bug #88 (dogfood v1.54.0): `--glob` narrows WHICH files match, it does not bound how
     much of the tree must be walked to find them. When PATH was left to default (no explicit


### PR DESCRIPTION
## What

An unscoped `tg search "def main" C:/dev/projects --json` on a multi-root workspace TIMED OUT at 60s (exit 124) instead of fast-refusing (CEO v1.69.3 dogfood; reproduced). Root cause: `_workspace_project_child_names` (main.py:4041) **unconditionally skipped** any root that has its own project marker (line 4048). `C:\dev\projects` has a top-level `package.json`, so the workspace-refuse guard never fired and the walk ran all 75+ children to the deadline.

## Fix

Replace the unconditional marker-skip with a **threshold**: a marked root still needs a *higher* bar (`BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = 8`) of independently-marked children to be flagged as a workspace parent, vs the weak `3` for an unmarked root. A normal single project / small monorepo (≤7 top-level marked children) is unaffected.

**Landed in BOTH front doors** (verified necessary — bootstrap.py's copy gates whether main.py's enforcement ever runs; fixing only main.py leaves the repro broken): `main.py:4041` + `bootstrap.py:611`. Constants de-duplicated into `io/directory_scanner.py` as the single source of truth (same pattern as the vendored-root guard) — verified the two modules share the literal same object.

Rejected npm/pnpm workspace-config detection: `C:\dev\projects\package.json` has no `workspaces` key, so a manifest-field detector would miss the exact repro.

## Verification

Full real venv (native ext compiled), **553 passed / 1 skipped**. **TDD proof**: stashing the fix made the new `bootstrap.main_entry` test fail showing the native-passthrough-instead-of-refuse bug, then pass on restore. ruff check + `ruff format --preview` + mypy clean on all 5 files. Existing guard tests (`test_workspace_root_guard_allows_real_repo_root` 3-children, `test_main_entry_still_uses_native_fast_path...`) still green. Non-fatal refuse (exit 2 + suggested_scope + `--allow-broad-generated-scan` escape all unchanged).

Sibling finding (not fixed here, out of scope): `scan_guardrails.py:161` (feeding `tg scan --ruleset`) has the same marked-root skip — filed as a follow-up.

Adversarial Opus gate running before merge (front-door contract change). Merge held until v1.70.3 (one-per-publish). Closes #154.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>