### PR TITLE
chore(test): suppress CodeQL py/redos on the intentional ReDoS fixture (#13)

### DIFF
--- a/tests/unit/test_cpu_backend.py
+++ b/tests/unit/test_cpu_backend.py
@@ -932,7 +932,7 @@ def test_max_count_zero_returns_no_matches_on_ltl_path(tmp_path):
 # must EITHER complete quickly via the linear-time Rust engine (the common case, Rust present)
 # OR raise `BackendExecutionError` (the fail-closed residual) -- and must NEVER hang. Each test
 # wall-clock-bounds the call; a hang manifests as a test timeout, not a silent pass.
-_HAZARD_PATTERN = r"(a+)+$"
+_HAZARD_PATTERN = r"(a+)+$"  # codeql[py/redos]: intentional ReDoS fixture, see comment above
 _HAZARD_BOUND_SECONDS = 2.0
 
 


### PR DESCRIPTION
## What

Resolves CodeQL code-scanning alert **#13** (`py/redos`, `test_cpu_backend.py:935`).

`_HAZARD_PATTERN = "(a+)+$"` is a **deliberate catastrophic-backtracking payload** — the Audit #6/#16 ReDoS-gate regression fixture. It is fed to tg's `cpu_backend` to **verify** the backend routes it through the linear-time Rust engine (or fails closed with `BackendExecutionError`) and **never hangs** — it is the malicious *input* the tests defend against, not a regex tg applies to untrusted data. CodeQL itself classified the instance as `["test"]`.

## Change

Add the inline `# codeql[py/redos]` suppression as a version-controlled source-of-truth (the existing 926-934 comment block documents the intent for humans). The live alert #13 was also dismissed via the API as **"used in tests"** with a matching audit comment — this PR makes that decision survive future re-scans at the source.

Test-only, no behavior change. ruff check + `ruff format --check --preview` clean. `chore(test)` → no release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>