### PR TITLE
fix(scan): apply the #154 marked-root workspace threshold to tg scan's broad-scan guard (#158)

### DIFF
--- a/src/tensor_grep/cli/scan_guardrails.py
+++ b/src/tensor_grep/cli/scan_guardrails.py
@@ -4,6 +4,12 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from tensor_grep.io.directory_scanner import (
+    BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
+    BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
+    BROAD_WORKSPACE_PROJECT_MARKERS,
+)
+
 _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "__pycache__",
     ".cache",
@@ -37,19 +43,9 @@ _BROAD_SYSTEM_SCAN_DIR_NAMES = {
     "windows",
 }
 
-_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
-_BROAD_WORKSPACE_PROJECT_MARKERS = {
-    ".git",
-    "Cargo.toml",
-    "build.gradle",
-    "composer.json",
-    "deno.json",
-    "go.mod",
-    "package.json",
-    "pom.xml",
-    "pyproject.toml",
-    "settings.gradle",
-}
+_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+_BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+_BROAD_WORKSPACE_PROJECT_MARKERS = BROAD_WORKSPACE_PROJECT_MARKERS
 
 
 @dataclass(frozen=True)
@@ -158,8 +154,20 @@ def _workspace_project_child_names(paths: list[str]) -> list[str]:
             continue
         path = _safe_resolve(Path(raw_path))
         try:
-            if not path.is_dir() or _path_has_project_marker(path):
+            if not path.is_dir():
                 continue
+            # Item #158 (`tg scan` sibling of #154 in main.py): a root carrying its OWN project
+            # marker is not skipped outright -- it can *also* be a workspace parent (a marked
+            # root with its own `package.json` that also holds many independently-marked sibling
+            # projects). A marked root uses the higher "marked-root" threshold, since an ordinary
+            # single project can legitimately carry a handful of marked children (a Cargo
+            # workspace member, a vendored submodule) without being a workspace parent; an
+            # unmarked root keeps the original (lower) threshold.
+            threshold = (
+                _BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+                if _path_has_project_marker(path)
+                else _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+            )
             child_project_names: list[str] = []
             for child in path.iterdir():
                 try:
@@ -167,7 +175,7 @@ def _workspace_project_child_names(paths: list[str]) -> list[str]:
                         child_project_names.append(child.name)
                 except OSError:
                     continue
-            if len(child_project_names) >= _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD:
+            if len(child_project_names) >= threshold:
                 found.update(child_project_names)
         except OSError:
             continue

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -33,6 +33,7 @@ from tensor_grep.cli.main import (
     _write_path_list,
     app,
 )
+from tensor_grep.cli.scan_guardrails import find_broad_scan_refusal
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.hardware.device_detect import DeviceInfo
 from tensor_grep.core.hardware.device_inventory import DeviceInventory
@@ -784,6 +785,46 @@ def test_workspace_root_guard_allows_marked_root_with_seven_marked_children(tmp_
 
     assert refused is False
     assert project_dirs == []
+
+
+def test_scan_guard_refuses_marked_workspace_root_with_many_marked_children(tmp_path: Path):
+    """Item #158 (`tg scan` sibling of #154): the broad-SCAN guard in scan_guardrails.py must
+    apply the same marked-root threshold as the search guard. A marked workspace parent (its
+    own top-level `pyproject.toml`) with 8 independently-marked children clears the higher
+    marked-root threshold, so `find_broad_scan_refusal` must refuse it. Previously the root's
+    own marker skipped it outright, so a whole-workspace `tg scan` slipped past unbounded."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text("", encoding="utf-8")
+    for index in range(8):
+        project = workspace / f"project-{index}"
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+
+    refusal = find_broad_scan_refusal([str(workspace)])
+
+    assert refusal is not None
+    assert refusal.kind == "workspace-root"
+    assert refusal.names == [f"project-{index}" for index in range(8)]
+
+
+def test_scan_guard_allows_marked_root_with_seven_marked_children(tmp_path: Path):
+    """Boundary pin for item #158's marked-root threshold (N=8) on the scan front door: a
+    marked root with exactly 7 marked children stays UNREFUSED -- one short of the higher bar
+    a marked root needs before it also counts as a workspace parent (an ordinary single
+    project can legitimately carry a handful of marked children without being a workspace
+    parent). Mirrors the search-side boundary pin above."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "pyproject.toml").write_text("", encoding="utf-8")
+    for index in range(7):
+        project = workspace / f"project-{index}"
+        project.mkdir()
+        (project / "pyproject.toml").write_text("", encoding="utf-8")
+
+    refusal = find_broad_scan_refusal([str(workspace)])
+
+    assert refusal is None
 
 
 def test_workspace_root_guard_refuses_glob_with_implicit_path(tmp_path: Path):


### PR DESCRIPTION
## #158 — `tg scan` broad-scan guard: marked-root workspace threshold (sibling of #154)

`scan_guardrails.py::_workspace_project_child_names` skipped any root carrying its own project marker **outright**, so `tg scan` over a marked monorepo / workspace-parent root never fast-refused — the exact gap #154 (v1.71.1) closed for `tg search`, still open on the scan front door.

### Fix (direct mirror of the #154 design, already Opus-gated)
- Drop the unconditional marker-skip; source the shared thresholds + marker set from `directory_scanner.py` (the constants #154 extracted).
- A **marked** root uses the higher marked-root child threshold (**8**); an **unmarked** root keeps the original threshold (**3**). The local vs shared marker sets were already identical, so the constant swap is behaviour-preserving for `_path_has_project_marker`.
- Scope is only `_workspace_project_child_names` — the generated-root / system-root skip sites correctly still skip marked roots.

### Tests (TDD)
- **RED reproduced**: a marked root + 8 marked children returned no refusal.
- Two scan-side unit tests co-located with #154's search-side tests (refuse-at-8, allow-at-7).
- **GREEN** + #154 search-guard tests + the scan-guardrail DoS suite all pass; `ruff format --check --preview` + `ruff check` clean.

MED consistency fix; `fix:` → patch bump.