### PR TITLE
fix(lsp): fail closed with an actionable message when the optional 'ast' extra is missing (#159)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -12442,8 +12442,6 @@ def lsp(
     """
     import os
 
-    from tensor_grep.cli.lsp_server import run_lsp
-
     normalized_provider = provider.strip().lower()
     if normalized_provider not in {"native", "lsp", "hybrid"}:
         typer.echo(
@@ -12464,6 +12462,19 @@ def lsp(
         if status.get("health_status") != "ready":
             raise typer.Exit(code=1)
         return
+    # The LSP server needs the optional `ast` extra (pygls/lsprotocol). Import it lazily and
+    # fail closed with an actionable message rather than leaking a ModuleNotFoundError traceback
+    # (item #159). Provider validation and --debug-trace above deliberately run first: they must
+    # work on a bare `pip install tensor-grep` without the extra.
+    try:
+        from tensor_grep.cli.lsp_server import run_lsp
+    except ImportError as exc:
+        typer.echo(
+            "tg lsp requires the optional 'ast' extra (language-server support). "
+            'Install it with: pip install "tensor-grep[ast]"',
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
     os.environ["TG_LSP_PROVIDER"] = normalized_provider
     run_lsp()
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -1798,6 +1798,44 @@ def test_lsp_rejects_unknown_provider_mode() -> None:
     assert "native, lsp, hybrid" in combined_output
 
 
+def test_lsp_reports_clean_error_when_ast_extra_missing(monkeypatch) -> None:
+    """Item #159: `tg lsp` with a VALID provider must emit a clean, actionable error (name the
+    `ast` extra + the install command) instead of a raw `ModuleNotFoundError` traceback when the
+    optional `ast` extra (pygls/lsprotocol) is not installed. Simulate the missing extra by
+    poisoning the lazy `lsp_server` import so it raises ImportError, exactly as a bare install
+    would. Env-robust: this passes whether or not the extra is installed in the test venv."""
+    monkeypatch.setitem(sys.modules, "tensor_grep.cli.lsp_server", None)
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["lsp", "--provider", "native"])
+
+    assert result.exit_code != 0
+    combined_output = _strip_ansi(result.stdout + result.stderr)
+    assert "ast" in combined_output.lower()
+    assert "pip install" in combined_output.lower()
+    # The whole point: a clean message, NOT a leaked traceback / exception.
+    assert "Traceback" not in combined_output
+    assert "ModuleNotFoundError" not in combined_output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_lsp_rejects_unknown_provider_without_needing_ast_extra(monkeypatch) -> None:
+    """Item #159: validating `--provider` must not require the optional `ast` extra -- an invalid
+    provider yields the clean "Unsupported LSP provider mode" error even when `lsp_server`
+    (pygls/lsprotocol) is unavailable, because provider validation now precedes the lazy import.
+    This is the env-robust twin of `test_lsp_rejects_unknown_provider_mode` (which relies on the
+    extra being present in the CI venv)."""
+    monkeypatch.setitem(sys.modules, "tensor_grep.cli.lsp_server", None)
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["lsp", "--provider", "remote"])
+
+    assert result.exit_code == 2
+    combined_output = _strip_ansi(result.stdout + result.stderr)
+    assert "Unsupported LSP provider mode" in combined_output
+    assert "Traceback" not in combined_output
+
+
 def test_lsp_debug_trace_emits_json_probe_payload(monkeypatch, tmp_path) -> None:
     from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager
 


### PR DESCRIPTION
## #159 — `tg lsp` raw traceback when the optional `ast` extra is absent

`tg lsp` imported `run_lsp` from `lsp_server` at the **top** of the command — before validating `--provider`. On a bare `pip install tensor-grep` (no `ast` extra, which supplies pygls/lsprotocol), that import raised a raw `ModuleNotFoundError: No module named 'lsprotocol'` **traceback** for *any* invocation, including an invalid `--provider` that should simply be rejected. (Found while dogfooding #158.)

### Fix
- Move `--provider` validation (and `--debug-trace`, which uses only `lsp_external_provider`, not lsprotocol) **ahead** of the lazy import — these must work on a bare install.
- Guard the `run_lsp` import with `try/except ImportError` → a clean, actionable message ("tg lsp requires the optional 'ast' extra … pip install tensor-grep[ast]") + exit 1.

Fail-Closed-Contract UX: a missing optional dependency must yield an actionable error, never a leaked traceback.

### Tests (TDD)
- Two **env-robust** tests (poison `sys.modules['tensor_grep.cli.lsp_server']`, so they pass with OR without the extra in the venv): a valid provider yields the clean extra-missing message (no traceback); an invalid provider is rejected without needing the extra.
- All 19 `lsp` tests pass; `ruff format --check --preview` + `ruff check` clean.
- Bonus: un-breaks `test_lsp_rejects_unknown_provider_mode` on venvs lacking the `ast` extra (previously crashed on the top-level import before reaching validation).

MED fail-closed UX gap; `fix:` → patch bump.