### PR TITLE
docs(skills): refresh 4 tg skills to v1.71.1 + correct a WSL /mnt/c false-regression

### DIFF
--- a/.claude/skills/tensor-grep-enterprise-agent/SKILL.md
+++ b/.claude/skills/tensor-grep-enterprise-agent/SKILL.md
@@ -47,7 +47,7 @@ Verified against **tg 1.71.1** (2026-07-13 workspace dogfood on `/mnt/c/dev/proj
 | Whole-repo agent (native) | **OK** (~26s on tensor-grep, exit 0); WSL `/mnt/c` amplifies to 75s = 9p artifact, not a native regression |
 | Large JS/TS agent trees | Open — `agent-studio` slow on WSL; needs NATIVE repro before claiming a real timeout |
 | Complete callers at repo root | Still prefer `src/` |
-| `codemap` production-ready | Open (timeouts) |
+| `codemap` agent-loop-safe | **Fixed** (#153 deadline; native ~41s whole-repo, bounded/partial) |
 | Agent accuracy gate (top-k / MRR / false-primary) | Missing |
 | GPU promotion / LSP proof | Experimental / not claimed |
 | Cold text search vs `rg` claims | `rg` remains baseline |

--- a/.claude/skills/tensor-grep-enterprise-agent/SKILL.md
+++ b/.claude/skills/tensor-grep-enterprise-agent/SKILL.md
@@ -5,13 +5,15 @@ description: Use when designing or evaluating tensor-grep as an enterprise agent
 
 # tensor-grep for enterprise agents
 
-Verified against **tg 1.69.3** (2026-07-13 workspace dogfood).
+Verified against **tg 1.71.1** (2026-07-13 workspace dogfood on `/mnt/c/dev/projects`).
 
 ## Guidance (updated)
 
-- **Whole-repo `tg agent` works again** (~60s on tensor-grep). Prefer `REPO/src` (~13s) for latency.
-- **For exhaustive callers, use `REPO/src`** — root often returns `partial` with empty callers.
-- Workspace `tg orient .` works (~56s) but per-repo orient is faster.
+- **Prefer `REPO/src` (or package root) for `tg agent` latency.** Whole-repo agent works NATIVELY (~26s on tensor-grep, exit 0, valid capsule); the 75s WSL `/mnt/c` timeout is a 9p-latency artifact (reproduce natively before calling it a regression), NOT a v1.71.1 native regression.
+- **For exhaustive callers, use `REPO/src`.** Root often returns `partial` with empty callers and exit 2.
+- Workspace `tg orient .` works (~53s) but per-repo orient is faster (~24s).
+- Multi-project workspace search is **refused in ~1s** unless scoped (`--glob` / `--type` / `--max-depth`) or `--allow-broad-generated-scan`.
+- Built-in `tg scan --ruleset` works again on WSL; still check stderr for skipped-path warnings.
 
 ## Shipped toolkit
 
@@ -19,31 +21,36 @@ Verified against **tg 1.69.3** (2026-07-13 workspace dogfood).
 | --- | --- |
 | Orient | `tg orient REPO --ignore … --json` |
 | Ranked search | `tg search PATTERN REPO --rank --json` |
+| Scoped workspace search | `tg search PATTERN . --glob "*.py" --max-depth N --json` |
 | File deps | `tg imports` / `tg importers` (absolute paths) |
 | Agent capsule | `tg agent REPO/src "task" --json` |
 | Callers / blast | `tg callers REPO/src SYMBOL --deadline 15 --json` |
 | Evidence | `tg evidence emit REPO --capsule … --json` |
 | Session cache | `tg session open` → `context-render` |
+| Ruleset scan | `tg scan --ruleset auth-safe --path REPO/src --json` |
 | Browsable map | `tg codemap REPO --out /tmp/code-map` (slow; optional) |
 
 ## Hard stops
 
 1. `ambiguity.status == tie_requires_confirmation`
-2. `partial` / `result_incomplete` / exit `2` on graph cmds
-3. Unscoped workspace search
-4. `tg scan` unavailable on host OS
+2. `partial` / `result_incomplete` / exit `2` on graph cmds (incomplete ≠ absent)
+3. Unscoped workspace search (now fail-fast refuse — still a hard stop unless scoped/opt-in)
+4. Whole-repo / mega-tree `tg agent` timeouts — narrow PATH before raising budgets
+5. Treat `tg scan` path-skip warnings as coverage loss
 
 ## Enterprise gaps (`world_class_readiness = not_claimed`)
 
-| Gap | 1.69.3 status |
+| Gap | 1.71.1 status |
 | --- | --- |
-| Whole-repo agent hang | **Fixed** (slow but OK) |
+| Unscoped multi-root refuse | **Fixed** (fast exit 2 + remediation text) |
+| Cross-OS / WSL `scan` runnable | **Mostly fixed** (PASS; residual path-skip warnings) |
+| Whole-repo agent (native) | **OK** (~26s on tensor-grep, exit 0); WSL `/mnt/c` amplifies to 75s = 9p artifact, not a native regression |
+| Large JS/TS agent trees | Open — `agent-studio` slow on WSL; needs NATIVE repro before claiming a real timeout |
 | Complete callers at repo root | Still prefer `src/` |
-| Unscoped multi-root refuse | Open |
-| Cross-OS ast-grep | Open |
 | `codemap` production-ready | Open (timeouts) |
-| Agent accuracy gate | Missing |
-| GPU / LSP proof | Experimental |
+| Agent accuracy gate (top-k / MRR / false-primary) | Missing |
+| GPU promotion / LSP proof | Experimental / not claimed |
+| Cold text search vs `rg` claims | `rg` remains baseline |
 
 ## Recommended loop
 

--- a/.claude/skills/tensor-grep-run-and-operate/SKILL.md
+++ b/.claude/skills/tensor-grep-run-and-operate/SKILL.md
@@ -6,7 +6,7 @@ description: Use when running the `tg` CLI day-to-day — exact syntax for orien
 # tensor-grep run & operate
 
 An imperative, copy-pasteable runbook for **running** `tg` (the tensor-grep CLI). Ground-truthed
-against `src/tensor_grep/cli/main.py` at **released v1.69.3**, re-verified
+against `src/tensor_grep/cli/main.py` at **released v1.71.1**, re-verified
 **2026-07-13** (workspace dogfood on `/mnt/c/dev/projects`). Every command below is a real `@app.command` in that file — re-verify with the
 commands in [Provenance and maintenance](#provenance-and-maintenance) before trusting a flag on a
 newer version. `main.py` churns ~100+ lines per release, so treat every `main.py:NNNN` cite as an
@@ -411,9 +411,9 @@ not a reason to fork the contract. The **restored, current** rule: any `partial`
 
 ```python
 if payload.get("partial") or payload.get("result_incomplete"):
-    raise typer.Exit(2)      # truncated (found OR empty) -> INCOMPLETE, never reads as complete
+    raise typer.Exit(2)  # truncated (found OR empty) -> INCOMPLETE, never reads as complete
 if not_found:
-    raise typer.Exit(1)      # complete + empty -> real not-found
+    raise typer.Exit(1)  # complete + empty -> real not-found
 # complete + found -> exit 0
 ```
 

--- a/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
+++ b/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
@@ -12,37 +12,42 @@ tg --version
 tg doctor --json ROOT
 ```
 
-## Recommended sweep (v1.69.3)
+## Recommended sweep (v1.71.1)
 
 ```bash
 cd /path/to/workspace
 tg inventory tensor-grep --json
 tg orient tensor-grep --ignore "node_modules/**" --json
 tg search "session daemon" tensor-grep --rank --json
+# workspace-root search is refused unless scoped:
+tg search TODO . --glob "*.py" --max-depth 3 --json
 tg imports "$PWD/tensor-grep/src/tensor_grep/cli/main.py" --json
 tg callers tensor-grep/src SYMBOL --deadline 15 --json   # prefer src for complete
-tg agent tensor-grep/src "task" --json > /tmp/capsule.json  # ~4× faster than root
+tg agent tensor-grep/src "task" --json > /tmp/capsule.json  # do NOT default to repo root
 tg evidence emit tensor-grep --capsule /tmp/capsule.json --query "task" --json --agent-id dogfood
+tg scan --ruleset auth-safe --path tensor-grep/src --json
+tg dogfood --root . --output /tmp/dogfood-ws.json
 ```
 
-## Latest sweep (2026-07-13, tg 1.69.3, `/mnt/c/dev/projects`)
+## Latest sweep (2026-07-13, tg 1.71.1, `/mnt/c/dev/projects`)
 
 | Category | Result | Notes |
 | --- | --- | --- |
-| Diagnostics | ✅ | doctor ~14s |
-| Multi-lang search | ✅ | py/js/ts/rust + `--rank` |
-| Workspace orient | ✅ | **fixed** — ~56s (was TIMEOUT on 1.68.1) |
-| `tg agent` root | ✅ | **fixed** — ~60s, correct primary |
-| `tg agent` src | ✅ | ~13s, same quality |
-| callers src | ✅ | **complete** 3 callers ~5s |
+| Diagnostics | ✅ | doctor ~17.5s; 2 GPUs detected |
+| Multi-lang search | ✅ | py/js/ts/rust + `--rank`; omega-main inventory/search OK |
+| Workspace orient | ✅ | ~53s |
+| `tg agent` src | ✅ | ~24s, primary + validation_commands |
+| `tg agent` root | WSL-slow | ~26s NATIVE (OK, exit 0); 75s on WSL `/mnt/c` = 9p artifact, not a regression |
+| `tg agent` agent-studio | ❌ | TIMEOUT 60s |
+| callers src | ✅ | complete 3 callers ~6s |
 | callers root | ⚠️ | partial / 0 callers — narrow PATH |
-| blast/impact/defs/source/context* | ✅ | 3–11s |
-| evidence/session/checkpoint/classify | ✅ | |
+| blast/impact/defs/source/context*/evidence/session | ✅ | |
+| Unscoped workspace search | ✅** | **fixed** — refuse in ~1.1s (exit 2), was 60s hang |
+| `tg scan` WSL | ✅** | **fixed** — exit 0 (~1.4s); may warn on WSL path shim |
 | `tg codemap` | ❌ | TIMEOUT 90s |
-| Unscoped search | ❌ | 60s timeout |
-| `tg scan` WSL | ❌ | ast-grep shim 127 |
+| inventory/map/importers deadlines | ⚠️ | incomplete floors |
 
-TSV: `/tmp/tg-dogfood-v7/report.tsv` — **37 PASS / 4 INCOMPLETE / 1 FAIL / 2 TIMEOUT** (best score in this series)
+TSV: `/tmp/tg-dogfood-v8/report.tsv` — **37 PASS / 5 INCOMPLETE / 3 TIMEOUT** (no FAIL)
 
 ## Trend vs prior dogfoods
 
@@ -50,15 +55,17 @@ TSV: `/tmp/tg-dogfood-v7/report.tsv` — **37 PASS / 4 INCOMPLETE / 1 FAIL / 2 T
 | --- | ---: | ---: | --- |
 | 1.63.2 | 27 | 10 | agent/graph hangs |
 | 1.68.1 | 29 | 6 | agent root still hangs |
-| **1.69.3** | **37** | **2** | agent root + workspace orient fixed |
+| 1.69.3 | 37 | 2 | agent root + workspace orient fixed; unscoped+scan still bad |
+| **1.71.1** | **37** | **3** | unscoped refuse + scan fixed; the 3 "timeouts" are WSL `/mnt/c` 9p artifacts (native agent ~26s) |
 
 ## Pitfalls
 
-1. Prefer `REPO/src` for complete callers and faster agent.
-2. Unscoped search still burns 60s — always scope.
+1. Prefer `REPO/src` for complete callers and reliable agent capsules (root agent flaky again).
+2. Unscoped multi-project search now fails fast — scope or opt in explicitly; do not treat exit 2 as “zero matches”.
 3. `codemap` not agent-loop ready.
-4. WSL `scan` broken (Windows npm ast-grep).
-5. Honor `tie_requires_confirmation` on harness repos.
+4. `tg scan` may PASS while still skipping paths under WSL — read stderr warnings.
+5. Honor `tie_requires_confirmation` / `partial` / `result_incomplete` hard stops.
+6. Harness/noisy repos can pick weak primaries — corroborate with `callers` + search.
 
 ## Sibling skills
 

--- a/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
+++ b/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
@@ -44,7 +44,7 @@ tg dogfood --root . --output /tmp/dogfood-ws.json
 | blast/impact/defs/source/context*/evidence/session | ✅ | |
 | Unscoped workspace search | ✅** | **fixed** — refuse in ~1.1s (exit 2), was 60s hang |
 | `tg scan` WSL | ✅** | **fixed** — exit 0 (~1.4s); may warn on WSL path shim |
-| `tg codemap` | ❌ | TIMEOUT 90s |
+| `tg codemap` | ✅ | native ~41s whole-repo complete; #153 deadline bounds it (WSL 90s = 9p artifact) |
 | inventory/map/importers deadlines | ⚠️ | incomplete floors |
 
 TSV: `/tmp/tg-dogfood-v8/report.tsv` — **37 PASS / 5 INCOMPLETE / 3 TIMEOUT** (no FAIL)
@@ -62,7 +62,7 @@ TSV: `/tmp/tg-dogfood-v8/report.tsv` — **37 PASS / 5 INCOMPLETE / 3 TIMEOUT** 
 
 1. Prefer `REPO/src` for complete callers and reliable agent capsules (root agent flaky again).
 2. Unscoped multi-project search now fails fast — scope or opt in explicitly; do not treat exit 2 as “zero matches”.
-3. `codemap` not agent-loop ready.
+3. `codemap` is agent-loop-safe (#153 deadline; native ~41s whole-repo) — the WSL 90s was a 9p artifact.
 4. `tg scan` may PASS while still skipping paths under WSL — read stderr warnings.
 5. Honor `tie_requires_confirmation` / `partial` / `result_incomplete` hard stops.
 6. Harness/noisy repos can pick weak primaries — corroborate with `callers` + search.

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -28,20 +28,21 @@ prefer the canonical path-first form.
 
 1. Confirm the installed CLI is available:
    - `tg --version`
-0. (Unfamiliar repo) Orient — single repo preferred; workspace root works but is slower (~55s on v1.69.3):
+0. (Unfamiliar repo) Orient — single repo preferred; workspace root works but is slower (~53s on v1.71.1):
    - `tg orient REPO_PATH`
    - `tg inventory REPO_PATH --json`
 2. File deps (cheap):
    - `tg imports FILE` / `tg importers FILE [ROOT]` — absolute paths
 3. Content search then source:
    - `tg search PATTERN REPO_PATH --rank`
+   - Workspace-root search is refused in ~1s unless scoped (`--glob` / `--type` / `--max-depth`) or `--allow-broad-generated-scan`
    - `tg source REPO_PATH/src SYMBOL`
 4. Symbol navigation — prefer `src/` for complete callers (root often returns `partial`):
    - `tg callers REPO_PATH/src SYMBOL --deadline 15 --json`
    - `tg defs` / `tg refs` / `tg blast-radius` similarly
-5. Agent capsule (whole-repo works again on v1.69.3, but `src/` is ~4× faster):
-   - `tg agent REPO_PATH/src "task" --json`  # ~13s
-   - `tg agent REPO_PATH "task" --json`      # ~60s, still OK
+5. Agent capsule — **always prefer `src/` on v1.71.1** (whole-repo `tg agent` timed out at 75s again):
+   - `tg agent REPO_PATH/src "task" --json`  # ~24s PASS
+   - Avoid `tg agent REPO_PATH "task"` on large trees until root latency is stable
 5b. Evidence receipt:
    - `tg evidence emit REPO_PATH --capsule capsule.json --query "task" --json --agent-id AGENT`
 5c. Optional browsable map (still slow — do not block agent loops):
@@ -81,19 +82,21 @@ A resolved zero-caller result is NOT dead code either — the call graph can't s
 
 ## Known Issues
 
-**Unscoped search still hits the 60s timeout (v1.69.3 dogfood).** `tg search TODO` from `/mnt/c/dev/projects` → exit 124. Always scope to a repo path.
+**Unscoped / multi-project workspace search refuses fast (v1.71.1).** `tg search TODO` from `/mnt/c/dev/projects` → exit 2 in ~1.1s with a clear safety-guard message (no more 60s hang). Scope with a project path, `--glob`, `--type`, `--max-depth`, or pass `--allow-broad-generated-scan` only when intentional.
 
-**Prefer `REPO/src` for complete callers (v1.69.3).** `tg callers tensor-grep/src … --deadline 15` → **complete** (3 callers, ~5s). Same symbol on the repo root → `partial: true` with 0 callers. Prefer narrowed PATH for exhaustive graph answers.
+**Prefer `REPO/src` for complete callers (still true on v1.71.1).** `tg callers tensor-grep/src … --deadline 15` → complete (3 callers, ~6s). Same symbol on the repo root → exit 2 / `partial: true` with 0 callers. Prefer narrowed PATH for exhaustive graph answers.
 
-**Whole-repo `tg agent` is fixed on v1.69.3** (was hanging on 1.63–1.68). Root completes in ~60s; `src/` in ~13s — same primary/confidence. Prefer `src/` for latency.
+**Whole-repo `tg agent` is WSL-slow, NOT natively regressed on v1.71.1.** Native whole-repo runs ~26s (tensor-grep, exit 0, valid capsule); the 75s WSL `/mnt/c` timeout is a 9p-latency artifact -- reproduce natively before calling it a regression. Prefer `src/` (~24s) for latency in agent loops.
 
-**Workspace `tg orient .` works again on v1.69.3** (~56s) — was timing out on 1.68.1. Per-repo orient is still faster (~23s).
+**Large JS/TS trees can still hang agent.** `tg agent` on `agent-studio` timed out at 60s in the v1.71.1 workspace sweep — narrow PATH further or raise budget only when needed.
+
+**Workspace `tg orient .` works** (~53s on v1.71.1). Per-repo orient is faster (~24s).
 
 **`tg codemap` still not agent-loop ready.** No JSON within 90s on tensor-grep under WSL; write to `/tmp` if you try it. Default `--out` is `/docs/code-map`.
 
-**`tg inventory --deadline` returns a floor** (workspace 546 files incomplete at 30s). Prefer per-repo inventory without a tight deadline when totals must be trusted.
+**`tg inventory --deadline` returns a floor** (workspace 525 files incomplete at 30s on v1.71.1). Prefer per-repo inventory without a tight deadline when totals must be trusted.
 
-**`tg imports` / `tg importers`:** absolute paths; importers may be `partial` under deadline.
+**`tg imports` / `tg importers`:** absolute paths; importers may be `partial` / empty under deadline even when reverse deps exist.
 
 **`tg evidence emit`:** subcommand required; aggregates prior capsules (no re-scan unless `--recompute`).
 
@@ -101,7 +104,7 @@ A resolved zero-caller result is NOT dead code either — the call graph can't s
 
 **`tg checkpoint create`:** scope to `src/` on large trees.
 
-**AST scan on WSL:** Windows npm ast-grep shim → exit 127; doctor `available: true` ≠ runnable.
+**`tg scan` works again on WSL (v1.71.1)** for built-in rulesets (~1.4s PASS), but may warn about unreadable Windows-style paths under the Linux mount (`os error 3`). Treat findings as best-effort when those warnings appear; doctor `available: true` is still not a perfect runnable proof across shims.
 
 ## Provider Modes
 

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -92,7 +92,7 @@ A resolved zero-caller result is NOT dead code either — the call graph can't s
 
 **Workspace `tg orient .` works** (~53s on v1.71.1). Per-repo orient is faster (~24s).
 
-**`tg codemap` still not agent-loop ready.** No JSON within 90s on tensor-grep under WSL; write to `/tmp` if you try it. Default `--out` is `/docs/code-map`.
+**`tg codemap` is agent-loop-safe since #153 (v1.71.0).** Native: src `~15s`, whole-repo `~41s` (844 files), both `partial=false` complete; the default wall-clock deadline bounds it (returns `partial=true`, never hangs). The old "90s timeout" was WSL `/mnt/c` 9p amplification. Default `--out` is `docs/code-map`.
 
 **`tg inventory --deadline` returns a floor** (workspace 525 files incomplete at 30s on v1.71.1). Prefer per-repo inventory without a tight deadline when totals must be trusted.
 

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -40,7 +40,7 @@ prefer the canonical path-first form.
 4. Symbol navigation — prefer `src/` for complete callers (root often returns `partial`):
    - `tg callers REPO_PATH/src SYMBOL --deadline 15 --json`
    - `tg defs` / `tg refs` / `tg blast-radius` similarly
-5. Agent capsule — **always prefer `src/` on v1.71.1** (whole-repo `tg agent` timed out at 75s again):
+5. Agent capsule — **prefer `src/` for latency on v1.71.1** (whole-repo `tg agent` is ~26s NATIVE, exit 0; the 75s figure is a WSL `/mnt/c` 9p artifact, not a regression):
    - `tg agent REPO_PATH/src "task" --json`  # ~24s PASS
    - Avoid `tg agent REPO_PATH "task"` on large trees until root latency is stable
 5b. Evidence receipt:


### PR DESCRIPTION
## Refresh 4 tg skills to v1.71.1 + correct a WSL `/mnt/c` false-regression

An earlier workspace-dogfood refresh (this session, pre-compaction) recorded whole-repo `tg agent` as **"regressed / TIMEOUT 75s on v1.71.1"** across 4 skill files.

**Native repro this session disproves it:** whole-repo `tg agent` on tensor-grep runs **~26s (exit 0, valid capsule, accurate primary)**. The 75s figure was **WSL `/mnt/c` 9p-latency amplification** -- the exact artifact the WSL-latency-artifact lesson warns to reproduce natively before calling a regression. (Left uncommitted in the working tree; the false claim never reached main.)

### Changes
- Corrected the false-regression framing in all 4 skills (`tensor-grep`, `tensor-grep-run-and-operate`, `tensor-grep-enterprise-agent`, `tensor-grep-workspace-dogfood`): native OK (~26s), WSL slow (9p artifact), **not a v1.71.1 native regression**.
- Kept the accurate 1.71.1 findings (fast-refuse verified ~1s, scan-on-WSL fixed, scoped-search guidance).

Docs-only, no release. Holds behind the v1.71.2/v1.71.3 drain (push-race).