### PR TITLE
fix(blast-radius): embed mermaid in JSON when --json --mermaid combined (#164)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -10572,7 +10572,14 @@ def blast_radius(
     # 2026-07-06) so the scan-vs-output-cap contract is defined exactly once.
     incomplete = _scan_incomplete(payload)
 
-    if mermaid_output:
+    if mermaid_output and json_output:
+        # task #164: `--json --mermaid` together used to let mermaid short-circuit json (an
+        # agent asking for both got only the human diagram and a `json.loads` on stdout raised).
+        # Embed, don't refuse: fold the rendered mermaid text into the JSON payload so one call
+        # returns both the machine graph and the diagram.
+        payload["mermaid"] = _render_blast_radius_mermaid(payload)
+        typer.echo(json.dumps(payload, indent=2))
+    elif mermaid_output:
         typer.echo(_render_blast_radius_mermaid(payload))
     elif json_output:
         typer.echo(json.dumps(payload, indent=2))

--- a/tests/unit/test_blast_radius_mermaid.py
+++ b/tests/unit/test_blast_radius_mermaid.py
@@ -6,6 +6,7 @@ the data already exists (blast-radius --json), so this is a faithful formatter o
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -97,3 +98,83 @@ def test_blast_radius_command_supports_mermaid_flag(
     assert result.exit_code == 0, result.stdout
     assert "graph TD" in result.stdout
     assert "-->" in result.stdout
+    # `--mermaid` alone must stay prose, never JSON.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)
+
+
+def test_blast_radius_json_alone_has_no_mermaid_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Preservation: `--json` alone must stay byte-identical to today -- no `mermaid` key
+    # unless `--mermaid` was ALSO requested.
+    monkeypatch.setattr(
+        repo_map,
+        "build_symbol_blast_radius",
+        lambda *a, **k: {
+            "symbol": "Sym",
+            "path": str(tmp_path),
+            "definitions": [],
+            "callers": [{"file": str(tmp_path / "c.py"), "line": 3}],
+            "files": [],
+            "tests": [],
+        },
+    )
+    result = runner.invoke(app, ["blast-radius", str(tmp_path), "Sym", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert "mermaid" not in payload
+
+
+def test_blast_radius_json_and_mermaid_combined_embeds_mermaid_in_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # task #164: `--json --mermaid` together must NOT silently drop the JSON (the pre-fix
+    # if/elif let `--mermaid` short-circuit `--json`, so an agent asking for both got only the
+    # human-readable diagram and a `json.loads` on stdout raised). Embed-don't-refuse: the
+    # rendered mermaid text is folded into the JSON payload under a `mermaid` key so one call
+    # returns both the machine graph and the diagram.
+    monkeypatch.setattr(
+        repo_map,
+        "build_symbol_blast_radius",
+        lambda *a, **k: {
+            "symbol": "Sym",
+            "path": str(tmp_path),
+            "definitions": [],
+            "callers": [{"file": str(tmp_path / "c.py"), "line": 3}],
+            "files": [],
+            "tests": [],
+        },
+    )
+    result = runner.invoke(app, ["blast-radius", str(tmp_path), "Sym", "--json", "--mermaid"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)  # must be valid JSON -- this is the core regression
+    assert payload.get("callers")  # the machine graph is still present
+    assert isinstance(payload.get("mermaid"), str) and payload["mermaid"]
+    assert payload["mermaid"].startswith("graph TD")
+    assert "-->" in payload["mermaid"]
+
+
+def test_blast_radius_json_and_mermaid_combined_still_honors_not_found_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The exit-2 (scan-incomplete) / exit-1 (not_found) contract sits AFTER the output block
+    # (main.py) and must still apply on the both-flags path -- the embed-both fix must not
+    # early-return before it.
+    monkeypatch.setattr(
+        repo_map,
+        "build_symbol_blast_radius",
+        lambda *a, **k: {
+            "symbol": "Ghost",
+            "path": str(tmp_path),
+            "definitions": [],
+            "callers": [],
+            "files": [],
+            "tests": [],
+        },
+    )
+    result = runner.invoke(app, ["blast-radius", str(tmp_path), "Ghost", "--json", "--mermaid"])
+    assert result.exit_code == 1, result.stdout  # not_found still exits 1, not swallowed
+    payload = json.loads(result.stdout)  # the JSON+mermaid embed still happened before the exit
+    assert payload["not_found"] is True
+    assert isinstance(payload.get("mermaid"), str) and payload["mermaid"]


### PR DESCRIPTION
## Summary

`tg blast-radius SYMBOL PATH --json --mermaid` let `--mermaid` short-circuit `--json` in the command's if/elif chain (main.py:10575, pre-fix) -- an agent asking for both outputs got only the human-readable Mermaid diagram on stdout, and a `json.loads` on that stdout raised (the machine-readable graph was silently dropped). This was task #164, the top item from the CEO's 1.74.0 dogfood pass.

**Fix (embed, don't refuse):** when both `--json` and `--mermaid` are set, fold the rendered Mermaid text into the JSON payload under a `mermaid` key and emit JSON, so one call returns both the machine graph and the diagram:

```python
if mermaid_output and json_output:
    payload["mermaid"] = _render_blast_radius_mermaid(payload)
    typer.echo(json.dumps(payload, indent=2))
elif mermaid_output:
    typer.echo(_render_blast_radius_mermaid(payload))
elif json_output:
    typer.echo(json.dumps(payload, indent=2))
else:
    ...
```

## Commands changed

Only **`blast-radius`** -- it is the only command with both a `--mermaid` and a `--json` option (verified via `grep -rn "mermaid" src/tensor_grep/cli/main.py`, only one flag-declaration site at main.py:10482-10485). `blast-radius-render` (~main.py:10597) has `--json` but **no** `--mermaid` flag at all, so it is unaffected and was left untouched. No other command in the CLI has a `--mermaid` option.

## Preservation (verified byte-identical)

- `--mermaid` alone -> still plain Mermaid text, not JSON (unchanged branch).
- `--json` alone -> still JSON with **no** `mermaid` key (unchanged branch; the key is only added when `--mermaid` is *also* requested).
- The exit-2 (scan-incomplete) / exit-1 (not_found) contract (main.py, after the output block) still applies on the both-flags path -- the new branch does not early-return before it; verified with a not_found symbol still exiting 1 while the JSON+mermaid embed still reaches stdout.

## Testing

- TDD: RED test added first (`test_blast_radius_json_and_mermaid_combined_embeds_mermaid_in_json`), confirmed failing against pre-fix code (`json.loads` raised `JSONDecodeError` because stdout was Mermaid text), then GREEN after the fix.
- `tests/unit/test_blast_radius_mermaid.py`: 9/9 passed (5 pre-existing + 4 new: combined-embed happy path, json-alone-no-mermaid-key preserve, mermaid-alone-not-json preserve assertion added to the existing test, not-found-exit-code-preserved-on-both-flags).
- Regression sweep: `test_blast_radius_mermaid.py` + `test_blast_radius_render_perf.py` + `test_main_cli_contracts.py` + `test_cli_deadline_flag.py` + `test_cap_fix_chokepoint.py` + `test_repo_map_graph.py` + `test_medlow2_repo_map.py` = 184/184 passed (first full run); 133/133 on the final re-run after a lint fix.
- Dogfooded against the REAL front door (not CliRunner) by invoking `tensor_grep.cli.bootstrap.main_entry()` directly (avoids the CliRunner-bypasses-bootstrap gap called out in AGENTS.md) against a real symbol (`_emit_symbol_command_result` in `main.py`) in this repo, for all three flag combinations (`--json --mermaid`, `--mermaid` alone, `--json` alone) -- confirmed valid JSON with both `callers` and a `mermaid` key starting with `graph TD` for the combined case, and byte-shape-preserving output for the two alone cases.
- `ruff format --preview` and `ruff check` clean on both changed files.

## Test plan

- [x] RED test written and confirmed failing pre-fix
- [x] GREEN after fix, full `test_blast_radius_mermaid.py` passes (9/9)
- [x] Regression sweep across blast-radius-adjacent test files passes (184/184, then 133/133)
- [x] Dogfooded against the real `bootstrap.main_entry()` front door, not just CliRunner
- [x] `ruff format --preview` + `ruff check` clean

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>