### PR TITLE
fix(cli): clean error + exit 2 for explicit --gpu-device-ids without a GPU backend (#166)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7022,10 +7022,23 @@ def search_command(
     )
     config.input_total_bytes = _sum_total_bytes(candidate_files_ordered)
 
-    from tensor_grep.core.pipeline import Pipeline
+    from tensor_grep.core.pipeline import ConfigurationError, Pipeline
     from tensor_grep.core.result import SearchResult, merge_runtime_routing
 
-    pipeline = Pipeline(force_cpu=effective_force_cpu, config=config)
+    try:
+        pipeline = Pipeline(force_cpu=effective_force_cpu, config=config)
+    except ConfigurationError as exc:
+        # Task #166 finding A: Pipeline's explicit-routing guards (e.g. --gpu-device-ids with
+        # no GPU backend available, or --pcre2 with no PCRE2-capable rg) deliberately raise
+        # ConfigurationError as a fail-closed signal (core/pipeline.py), but this CLI boundary
+        # previously let it propagate as a raw, uncaught traceback instead of a clean error.
+        # Route it through the same `_exit_search_error` helper this function already uses for
+        # every other expected/clean CLI error (empty_pattern, unsupported_flag, path_not_found,
+        # invalid_regex) so the user gets a single-line `Error: ...` message and exit code 2
+        # instead of a Python stack trace. A genuinely unexpected exception is NOT caught here
+        # (only this specific, deliberate exception type), so a real bug still surfaces loudly.
+        _exit_search_error("configuration_error", str(exc), json_mode=json)
+        raise
     backend = pipeline.get_backend()
     selected_backend_name = getattr(pipeline, "selected_backend_name", backend.__class__.__name__)
     selected_backend_reason = getattr(pipeline, "selected_backend_reason", "unknown")

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -827,6 +827,59 @@ def test_main_entry_should_delegate_force_cpu_alias_to_native_tg(monkeypatch):
     assert seen == {"binary_name": "tg.exe", "search_args": ["ERROR", ".", "--force-cpu"]}
 
 
+def test_main_entry_explicit_gpu_device_ids_without_gpu_backend_exits_cleanly(
+    monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Task #166 finding A (dogfood-caught on the v1.74.1 wheel): `tg PATTERN PATH
+    --gpu-device-ids 0` on a machine with no GPU backend available (no CuDF/Torch) must exit
+    with a clean, single-line `Error: ...` message and exit code 2 -- never a raw Python
+    traceback. `Pipeline.__init__` deliberately raises `ConfigurationError` as its fail-closed
+    explicit-GPU-routing contract (core/pipeline.py's
+    `_raise_explicit_gpu_configuration_error`), but nothing at the CLI boundary
+    (`search_command` in cli/main.py) caught it, so it propagated straight through Typer's
+    `app()` call in `main_entry` as an unhandled exception -- confirmed live via the real
+    console script before this fix: exit code 1 and a raw
+    `tensor_grep.core.pipeline.ConfigurationError` traceback on stderr.
+
+    Explicitly forces the "chunk plan found, but neither CuDF nor Torch is available" branch
+    (the exact shape from the dogfood report) so this test is deterministic regardless of
+    whether the host machine happens to have real GPU hardware/drivers.
+    """
+    target = tmp_path / "f.txt"
+    target.write_text("hello world\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys, "argv", ["tg", "search", "hello", str(target), "--gpu-device-ids", "0"]
+    )
+    # Two independent native-delegation gates exist -- bootstrap.py's fast argv-based
+    # pre-check AND cli/main.py's OWN second check inside search_command (cli/main.py:6905,
+    # imported separately at cli/main.py:36) -- so both must be forced off, or a real in-tree
+    # `rust_core/target/{debug,release}/tg[.exe]` (e.g. left over from a local `maturin
+    # develop`/`cargo build`) lets the second gate silently delegate to the native binary and
+    # this test would exercise the Rust CLI's own GPU-fallback behavior instead of the Python
+    # ConfigurationError path this fix targets.
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(
+        "tensor_grep.core.hardware.memory_manager.MemoryManager.get_device_chunk_plan_mb",
+        lambda self, preferred_ids=None: [(0, 512)],
+    )
+    monkeypatch.setattr("tensor_grep.core.pipeline.CuDFBackend.is_available", lambda self: False)
+    monkeypatch.setattr(
+        "tensor_grep.backends.torch_backend.TorchBackend.is_available", lambda self: False
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2, (captured.out, captured.err)
+    assert "Traceback" not in captured.err, captured.err
+    assert "Traceback" not in captured.out, captured.out
+    assert "error" in captured.err.lower(), captured.err
+    assert "GPU" in captured.err, captured.err
+
+
 def test_main_entry_should_delegate_force_cpu_env_to_native_tg(monkeypatch):
     seen: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

- `tg <pattern> <path> --gpu-device-ids 0` (or `tg search ...`) on a machine with no GPU backend
  (no CuDF/Torch) dumped a raw, uncaught Python traceback to stderr and exited 1. The underlying
  `ConfigurationError` (`core/pipeline.py:20`) is a deliberate fail-closed signal from
  `Pipeline.__init__`'s explicit-GPU-routing guard — the bug was that nothing caught it at the CLI
  boundary (`search_command` in `cli/main.py`), so it propagated straight through Typer's `app()`
  call in `main_entry`.
- Fix: wrap the `Pipeline(force_cpu=..., config=config)` construction in `search_command`
  (`cli/main.py:7028` pre-fix) in a `try/except ConfigurationError`, routing the exception through
  the **existing** `_exit_search_error` helper this same function already uses for every other
  expected/clean CLI error (`empty_pattern`, `unsupported_flag`, `path_not_found`, `invalid_regex`).
  Only this specific, deliberate exception type is caught — a genuinely unexpected exception still
  surfaces with a full traceback.
- As a side effect this also closes the same raw-traceback gap for `--pcre2` requested on a
  ripgrep build without PCRE2 support (`ConfigurationError` from the same `Pipeline.__init__`,
  `core/pipeline.py:193`), since it goes through the identical, now-guarded construction call.

## Where it was caught

- `src/tensor_grep/core/pipeline.py:20` — `class ConfigurationError(RuntimeError)`, the deliberate
  fail-closed signal.
- `src/tensor_grep/core/pipeline.py:346` (`_raise_explicit_gpu_configuration_error`) — where the
  specific "CuDF and Torch GPU backends were unavailable" message is raised for this bug.
- `src/tensor_grep/cli/main.py:7028` (pre-fix line) — `search_command`'s `Pipeline(...)`
  construction, the CLI boundary that previously let it propagate uncaught.
- No existing generic boundary handler catches `ConfigurationError` (`main_entry`/`_run_full_cli`
  call `app()`/`full_main_entry()` directly, no try/except). The established local pattern for
  "expected/clean CLI error + exit 2" **inside `search_command`** is the `_exit_search_error`
  helper (used 8x in this function already, e.g. for `empty_pattern`/`path_not_found`), so this fix
  routes through it rather than adding a new, differently-styled catch-all at the outer boundary.

## Verified live against the real built console script

```
$ tg hello gpu_repro.txt --gpu-device-ids 0
```

**Before:**
```
Traceback (most recent call last):
  ...
  File "...\src\tensor_grep\cli\main.py", line 7028, in search_command
    pipeline = Pipeline(force_cpu=effective_force_cpu, config=config)
  File "...\src\tensor_grep\core\pipeline.py", line 346, in __init__
    self._raise_explicit_gpu_configuration_error(
  File "...\src\tensor_grep\core\pipeline.py", line 39, in _raise_explicit_gpu_configuration_error
    raise ConfigurationError(message)
tensor_grep.core.pipeline.ConfigurationError: GPU acceleration is experimental. Explicit GPU device selection [0] could not initialize a GPU backend: CuDF and Torch GPU backends were unavailable
EXIT_CODE=1
```

**After:**
```
Error: GPU acceleration is experimental. Explicit GPU device selection [0] could not initialize a GPU backend: CuDF and Torch GPU backends were unavailable
EXIT_CODE=2
```

`--json` mode emits a structured envelope instead: `{"version": 1, "schema_version": 1, "ok": false, "error": "configuration_error", "detail": "GPU acceleration is experimental. ..."}`, exit code 2.

## Test plan

- [x] RED: new test `test_main_entry_explicit_gpu_device_ids_without_gpu_backend_exits_cleanly` in
      `tests/unit/test_cli_bootstrap.py`, invoking the real `bootstrap.main_entry()` entry point
      (not `CliRunner`, which can bypass the bootstrap front door) — confirmed failing against the
      unfixed code (raw `ConfigurationError` propagates out of the test instead of a clean
      `SystemExit(2)`).
- [x] GREEN after the fix; asserts exit code 2, no `"Traceback"` in stdout/stderr, a clean
      `Error: ...` message present.
- [x] Dogfooded the actual built console script (`uv pip install -e ".[dev,ast]"` +
      `.venv/Scripts/tg.exe`), both the bare-pattern and `search` subcommand forms, plus `--json`
      mode — all show the clean message and exit 2, confirmed above.
- [x] Full local suite: `uv run pytest -q` — 4015 passed, 29 skipped, 0 failed related to this
      change (2 pre-existing, environment-only failures in `test_retrieval_dense.py` /
      `test_semantic_search_flag.py` — both require the `semantic` extra's `model2vec` package,
      which is not installed in this venv; unrelated to this change, confirmed on both full runs).
- [x] `ruff check` / `ruff format --preview --check` / `mypy src/tensor_grep/cli/main.py` all clean
      on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)