### PR TITLE
fix(orient): deweight .claude tool-config trees + populate suggested_ignore (#164)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -44,15 +44,24 @@ _CENTRAL_NON_CODE_SUFFIXES = _CENTRAL_DOC_SUFFIXES | _CENTRAL_CONFIG_DATA_SUFFIX
 _CENTRAL_FAN_IN_CAP = 12
 _CENTRAL_SYMBOL_DENSITY_CAP = 25
 
-# Auto de-weight (never hard-exclude) bundled vendor/skill/generated CODE subtrees so `tg orient`/
-# `tg agent` surface real product code without a manual `--ignore` (#55 PR6). A subtree fires ONLY on
-# STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK (name prior)):
+# Auto de-weight (never hard-exclude) bundled vendor/skill/generated CODE subtrees, AND known
+# AI-coding-harness config directories, so `tg orient`/`tg agent` surface real product code without
+# a manual `--ignore` (#55 PR6; harness dirs added #164). A subtree fires on STRONG-0 (tool-config
+# dir name) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK
+# (name prior)):
+#   STRONG-0 -- an exact, closed-vocabulary tool/harness config directory name (see
+#     `_TOOL_CONFIG_DIR_NAMES` below, e.g. `.claude`): sufficient BY ITSELF, no manifest and no
+#     import-island required. Dogfood bug (#164): `.claude/hooks|lib|tools` (.cjs harness files)
+#     ranked in `tg orient`'s top-10 central_files on every Claude-Code-harness repo, because such a
+#     directory never carries its own package manifest (no package.json/pyproject.toml -- it's
+#     config, not a buildable nested project), so gating it behind STRONG-1 like the WEAK prior below
+#     meant it could NEVER fire, no matter what name list it was added to.
 #   STRONG-1 -- a directory below the repo root contains its own manifest, reusing the same marker
 #     set `_path_has_project_marker` (main.py) uses for broad-scan workspace-project detection.
 #   STRONG-2 -- an import island: no file OUTSIDE the subtree resolves an import INTO it (computed
 #     from the same resolved-import graph the centrality ranking builds).
 #   WEAK -- a name prior (vendor/, third_party/, skills/, external_repos/, _vendored/, node_modules/):
-#     a TIE-BREAKER only, never sufficient alone.
+#     a TIE-BREAKER only, never sufficient alone (requires STRONG-1).
 # A monorepo subproject that HAS a manifest but IS imported across the repo is protected by STRONG-2
 # (not an island) -- de-weight, never exclude, is what keeps a false positive from hiding real product
 # code (the file can still surface if it is genuinely central even after the multiplier).
@@ -64,6 +73,15 @@ _VENDOR_NAME_PRIOR = frozenset({
     "external_repos",
     "_vendored",
     "node_modules",
+})
+# STRONG-0 tool/harness config directory names (see the comment above `_DEWEIGHT_FACTOR`): matched
+# on the EXACT directory basename (not "any path component", the way `_VENDOR_NAME_PRIOR` is), so
+# only the `.claude` root itself is flagged, not every subdirectory beneath it. Deliberately
+# CONSERVATIVE -- only a name validated by a real-corpus before/after (agent-studio, #164) is
+# listed. `.github`/`.vscode` are plausible future candidates but are NOT included without their
+# own validation pass (over-deweighting a real source directory is worse than missing one).
+_TOOL_CONFIG_DIR_NAMES = frozenset({
+    ".claude",
 })
 
 _ENTRY_NAMES = {
@@ -129,13 +147,15 @@ def _code_files_and_import_graph(
 
 
 def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    """Auto-detect bundled vendor/skill/generated CODE subtrees to DE-WEIGHT (never hard-exclude).
+    """Auto-detect bundled vendor/skill/generated CODE subtrees, and known AI-tool/harness config
+    directories, to DE-WEIGHT (never hard-exclude).
 
-    Returns ``{tree_path: {"reasons": [...]}}``. Fires ONLY on STRONG-1 (nested package manifest)
-    AND (STRONG-2 (import island) OR WEAK (name prior)) -- see the module-level comment above
-    ``_DEWEIGHT_FACTOR`` for the full rule. Requires ``rm["path"]`` to point at a real, existing
-    directory (a synthetic/relative-path test fixture with no "path" key returns ``{}`` rather than
-    guessing against the process CWD)."""
+    Returns ``{tree_path: {"reasons": [...], "ignore_glob": "<repo-relative>/**"}}``. Fires on
+    STRONG-0 (tool-config dir name) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2
+    (import island) OR WEAK (name prior)) -- see the module-level comment above ``_DEWEIGHT_FACTOR``
+    for the full rule. Requires ``rm["path"]`` to point at a real, existing directory (a
+    synthetic/relative-path test fixture with no "path" key returns ``{}`` rather than guessing
+    against the process CWD)."""
     path_value = rm.get("path")
     if not path_value:
         return {}
@@ -177,13 +197,26 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
                     break
             except OSError:
                 continue
-    if not manifest_dirs:
+
+    # STRONG-0: a closed-vocabulary tool/harness config directory name (`.claude`) is sufficient
+    # evidence entirely on its own -- see the module comment above `_DEWEIGHT_FACTOR`. Matched on
+    # the directory's EXACT basename so only the `.claude` root itself is selected here, not every
+    # descendant of it (`.claude/hooks`, `.claude/hooks/audit`, ...) -- those get covered by the
+    # outermost-nested-chain dedup below via the base `.claude` entry, exactly like a STRONG-1
+    # manifest root covers its own descendants.
+    tool_config_dirs: set[Path] = {
+        rel_dir
+        for rel_dir in candidate_dirs
+        if rel_dir.parts and rel_dir.parts[-1].lower() in _TOOL_CONFIG_DIR_NAMES
+    }
+
+    if not manifest_dirs and not tool_config_dirs:
         return {}
 
-    # Keep only the OUTERMOST manifest directory in any nested chain -- a deeper manifest inside an
-    # already-flagged subtree does not start a second, overlapping subtree.
+    # Keep only the OUTERMOST directory (manifest- or tool-config-matched) in any nested chain -- a
+    # deeper match inside an already-flagged subtree does not start a second, overlapping subtree.
     subtree_rel_roots: list[Path] = []
-    for rel_dir in sorted(manifest_dirs, key=lambda p: len(p.parts)):
+    for rel_dir in sorted(manifest_dirs.keys() | tool_config_dirs, key=lambda p: len(p.parts)):
         if any(
             _repo_map._path_is_relative_to(root / rel_dir, root / existing)
             for existing in subtree_rel_roots
@@ -227,17 +260,22 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
         has_internal_edge = any(reverse_importers.get(f, set()) & tree_files for f in tree_files)
         is_island = externally_isolated and has_internal_edge
         name_hits = sorted({part.lower() for part in rel_dir.parts} & _VENDOR_NAME_PRIOR)
+        is_tool_config = rel_dir in tool_config_dirs
 
-        if not (is_island or name_hits):
+        if not (is_island or name_hits or is_tool_config):
             continue
 
-        reasons = [f"nested-manifest:{manifest_dirs[rel_dir]}"]
+        reasons: list[str] = []
+        if rel_dir in manifest_dirs:
+            reasons.append(f"nested-manifest:{manifest_dirs[rel_dir]}")
         if is_island:
             reasons.append("import-island")
         if name_hits:
             reasons.append(f"name-prior:{name_hits[0]}")
+        if is_tool_config:
+            reasons.append(f"tool-config-name:{rel_dir.parts[-1].lower()}")
 
-        result[str(abs_dir)] = {"reasons": reasons}
+        result[str(abs_dir)] = {"reasons": reasons, "ignore_glob": f"{rel_dir.as_posix()}/**"}
 
     return result
 
@@ -581,6 +619,15 @@ def build_orient_capsule_from_map(
         {"path": tree_path, "reasons": list(info["reasons"])}
         for tree_path, info in sorted(deweighted_trees.items())
     ]
+    # suggested_ignore (#164): when auto-deweight found something, surface the deweighted tree
+    # roots as ready-to-paste `--ignore` globs (e.g. `.claude/**`) so an agent that wants a HARD
+    # exclude (not just a lowered score) doesn't have to hand-derive the glob syntax. Same ordering
+    # as `deweighted_trees_list` (both sorted over `deweighted_trees.items()`). None -- never an
+    # empty list -- when nothing was deweighted, mirroring `suggested_scope`'s never-guess-empty
+    # convention (an agent can branch on `is None`).
+    suggested_ignore = [
+        info["ignore_glob"] for _tree_path, info in sorted(deweighted_trees.items())
+    ] or None
 
     lines: list[str] = [f"# Codebase orientation: {rm['path']}"]
     lines.append("\n## Central files (by import-graph centrality)")
@@ -620,6 +667,7 @@ def build_orient_capsule_from_map(
         "truncated": truncated,
         "scan_limit": effective_max_repo_files,
         "suggested_scope": suggested_scope,
+        "suggested_ignore": suggested_ignore,
         "routing_reason": "orient",
         "deweighted_trees": deweighted_trees_list,
         "auto_deweight": auto_deweight,

--- a/tests/unit/test_orient_deweight_vendored.py
+++ b/tests/unit/test_orient_deweight_vendored.py
@@ -1,11 +1,12 @@
 """Tests for auto-de-weighting of bundled vendor/skill/generated CODE subtrees in `tg orient`
-centrality (#132 / #55 PR6).
+centrality (#132 / #55 PR6), and known AI-tool/harness config directories (#164).
 
-A subtree fires ONLY on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK
-(name prior)). The de-weight multiplies a subtree file's composite centrality by
-``_DEWEIGHT_FACTOR`` -- it LOWERS the score, it never EXCLUDES the file, so a genuinely central
-vendored file can still surface. A monorepo subproject that has a manifest but IS imported across
-the repo is protected by the import-island test (de-weight would hide real product code).
+A subtree fires on STRONG-0 (closed-vocabulary tool-config dir NAME, e.g. `.claude`) ALONE, or on
+STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK (name prior)). The
+de-weight multiplies a subtree file's composite centrality by ``_DEWEIGHT_FACTOR`` -- it LOWERS the
+score, it never EXCLUDES the file, so a genuinely central vendored file can still surface. A
+monorepo subproject that has a manifest but IS imported across the repo is protected by the
+import-island test (de-weight would hide real product code).
 
 `_detect_vendored_subtrees` reads the real filesystem (it checks ``root.is_dir()`` and each
 candidate directory for a manifest via ``.exists()``), so these tests build real ``tmp_path``
@@ -183,3 +184,77 @@ def test_deeply_nested_subtree_file_counts_as_a_member(tmp_path: Path) -> None:
     trees = _detect_vendored_subtrees(rm)
     assert str(root / "bundled") in trees
     assert "import-island" in trees[str(root / "bundled")]["reasons"]
+
+
+# ---------------------------------------------------------------------------
+# STRONG-0: tool/harness config directory names (#164 dogfood -- `.claude/hooks|lib|tools`
+# ranked as top-10 orient central_files on every Claude-Code-harness repo, because such a
+# directory carries NO manifest of its own, so the old STRONG-1-gated detector could never flag
+# it no matter what name list it was added to).
+# ---------------------------------------------------------------------------
+
+
+def test_fires_on_tool_config_dir_name_without_any_manifest(tmp_path: Path) -> None:
+    # `.claude/hooks/` has NO manifest anywhere in the tree (real agent-studio shape: no
+    # package.json/pyproject.toml directly inside .claude, .claude/hooks, etc.) -- the manifest-
+    # gated STRONG-1 path would never even consider it a candidate. STRONG-0 (exact dir-name
+    # match) must fire on the name alone.
+    root = tmp_path.resolve()
+    (root / ".claude" / "hooks").mkdir(parents=True)
+    rm = _rm(
+        root,
+        [root / "app.py", root / ".claude" / "hooks" / "run-hook.cjs"],
+        {},
+    )
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / ".claude") in trees
+    info = trees[str(root / ".claude")]
+    assert info["reasons"] == ["tool-config-name:.claude"]
+    assert not any(r.startswith("nested-manifest:") for r in info["reasons"])
+    assert info["ignore_glob"] == ".claude/**"
+
+
+def test_tool_config_dir_deeply_nested_file_counts_as_a_member(tmp_path: Path) -> None:
+    # A file several levels inside `.claude/` (e.g. `.claude/hooks/audit/check.cjs`) must still be
+    # attributed to the `.claude` subtree -- same tuple-prefix membership test as the manifest path.
+    root = tmp_path.resolve()
+    (root / ".claude" / "hooks" / "audit").mkdir(parents=True)
+    rm = _rm(
+        root,
+        [root / "app.py", root / ".claude" / "hooks" / "audit" / "check.cjs"],
+        {},
+    )
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / ".claude") in trees
+
+
+def test_does_not_fire_on_dirname_without_leading_dot(tmp_path: Path) -> None:
+    # "claude" (no leading dot, not the closed STRONG-0 vocabulary) with no manifest and no vendor
+    # name-prior hit must NOT fire -- guards against an over-broad substring/prefix match.
+    root = tmp_path.resolve()
+    (root / "claude").mkdir()
+    rm = _rm(root, [root / "app.py", root / "claude" / "lib.py"], {})
+    assert _detect_vendored_subtrees(rm) == {}
+
+
+def test_tool_config_dir_deweights_central_files_score_but_keeps_the_file(tmp_path: Path) -> None:
+    # End-to-end through _central_files_from_map (mirrors test_central_files_deweights_but_keeps_
+    # the_file for the manifest path): the composite score of a file under `.claude/` is multiplied
+    # by _DEWEIGHT_FACTOR when auto_deweight is on -- de-weight, never exclude, so the file is still
+    # present in central_files either way.
+    root = tmp_path.resolve()
+    (root / ".claude" / "hooks").mkdir(parents=True)
+    hook = root / ".claude" / "hooks" / "run-hook.cjs"
+    rm = _rm(root, [root / "app.py", hook], {})
+    rm["symbols"] = [{"name": f"Sym{i}", "kind": "function", "file": str(hook)} for i in range(4)]
+
+    raw = _central_files_from_map(rm, max_central_files=10, auto_deweight=False)
+    dew = _central_files_from_map(rm, max_central_files=10, auto_deweight=True)
+
+    hook_str = str(hook)
+    raw_hook = next(f for f in raw if f["file"] == hook_str)
+    dew_hook = next(
+        f for f in dew if f["file"] == hook_str
+    )  # still present -> de-weight, not exclude
+    assert raw_hook["score"] > 0
+    assert dew_hook["score"] == round(raw_hook["score"] * _DEWEIGHT_FACTOR, 6)

--- a/tests/unit/test_orient_suggested_ignore.py
+++ b/tests/unit/test_orient_suggested_ignore.py
@@ -1,0 +1,68 @@
+"""Tests for build_orient_capsule's `suggested_ignore` hint (#164).
+
+When auto-deweight (`_detect_vendored_subtrees`) finds a vendor/skill/tool-config subtree to
+de-weight, `suggested_ignore` surfaces the deweighted tree roots as ready-to-paste `--ignore` globs
+(e.g. `.claude/**`) so an agent that wants a HARD exclude (not just a lowered centrality score)
+doesn't have to hand-derive the glob syntax. `None` -- never an empty list -- when nothing was
+deweighted, mirroring `suggested_scope`'s never-guess-empty convention (audit #93 SUB-2 sibling)."""
+
+from pathlib import Path
+
+from tensor_grep.cli.orient_capsule import _apply_ignore_globs, build_orient_capsule
+
+
+def test_suggested_ignore_none_when_nothing_deweighted(tmp_path: Path) -> None:
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (tmp_path / "helper.py").write_text("def helper():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] is None
+    assert payload["deweighted_trees"] == []
+
+
+def test_suggested_ignore_populated_for_claude_tool_config_dir(tmp_path: Path) -> None:
+    hooks_dir = tmp_path / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "run-hook.cjs").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] == [".claude/**"]
+    assert payload["deweighted_trees"]
+    assert payload["deweighted_trees"][0]["path"] == str((tmp_path / ".claude").resolve())
+
+
+def test_suggested_ignore_absent_when_auto_deweight_disabled(tmp_path: Path) -> None:
+    hooks_dir = tmp_path / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "run-hook.cjs").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500, auto_deweight=False)
+
+    assert payload["suggested_ignore"] is None
+    assert payload["deweighted_trees"] == []
+
+
+def test_suggested_ignore_glob_round_trips_through_apply_ignore_globs(tmp_path: Path) -> None:
+    # The glob suggested_ignore emits must actually be consumable by `--ignore`: feed it back
+    # through the same `_apply_ignore_globs` the CLI uses and confirm the .claude file is dropped.
+    hooks_dir = tmp_path / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "run-hook.cjs").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (tmp_path / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+    glob = payload["suggested_ignore"][0]
+
+    rm = {
+        "path": str(tmp_path),
+        "files": [str(hooks_dir / "run-hook.cjs"), str(tmp_path / "main.py")],
+        "symbols": [],
+        "imports": [],
+    }
+    filtered = _apply_ignore_globs(rm, (glob,))
+    assert filtered["files"] == [str(tmp_path / "main.py")]


### PR DESCRIPTION
## Summary
- `tg orient <harness-repo> --json` was ranking Claude-Code harness tooling (`.claude/hooks|lib|tools`) in the top-10 `central_files`, drowning out real project code -- confirmed on `agent-studio` (10/10 top-10 hits were `.claude/...`).
- Root cause: `_detect_vendored_subtrees` required STRONG-1 (a nested package manifest) as a mandatory AND-gate before the WEAK name-prior list was even consulted. `.claude/` never carries its own `package.json`/`pyproject.toml` (verified: none exist under `agent-studio/.claude` to depth 3), so simply adding `.claude` to the existing `_VENDOR_NAME_PRIOR` set would have been a no-op -- the function would still `return {}` before ever reaching the name check.
- Fix (two parts):
  1. New **STRONG-0** signal: `_TOOL_CONFIG_DIR_NAMES = {".claude"}` -- an exact, closed-vocabulary directory-basename match that deweights on the name ALONE, no manifest and no import-island required. Deliberately conservative: only `.claude` is included (`.github`/`.vscode` explicitly deferred, not validated).
  2. `suggested_ignore` (previously always `None`) is now populated: when auto-deweight finds a subtree, its root is emitted as a ready-to-paste `--ignore` glob (e.g. `.claude/**`).
- Deweight, never hard-exclude: `.claude` files still *appear* in `central_files`, just ranked lower (`_DEWEIGHT_FACTOR` = 0.25), consistent with the existing vendor/skill-subtree contract.

## Real-corpus validation (the DocPrism-trap gate)
Ran the built `tg orient --json` cold path (session-daemon fast path explicitly bypassed via `TG_SESSION_DAEMON_AUTOSTART=0` -- a stale daemon otherwise keeps serving a pre-fix in-memory response even after the file on disk changes, which is exactly what happened on my first validation pass before I caught it).

**agent-studio (must improve) -- BEFORE:**
```
1-10. score=25.0  .claude\hooks\...  /  .claude\lib\...   (10/10 .claude files)
deweighted_trees: []
suggested_ignore: None
```
**agent-studio -- AFTER:**
```
 1. score=25.0  scripts\channels\daemon\memory.cjs
 2. score=24.0  scripts\channels\daemon\executor.cjs
 3. score=18.0  scripts\channels\daemon\dispatcher.cjs
 4. score=15.0  scripts\channels\daemon\claude-cli.cjs
 5. score=14.0  scripts\channels\daemon\task-pool.cjs
 6. score=14.0  scripts\validation\validate-all-references.mjs
 7. score=13.0  scripts\channels\daemon\renderer.cjs
 8. score=13.0  scripts\codegen\generate-claude-index.py
 9. score=12.0  scripts\channels\telegram-ctl.cjs
10. score=12.0  scripts\generation\generate-rule-index.mjs
deweighted_trees: [{"path": "...\agent-studio\.claude", "reasons": ["import-island", "tool-config-name:.claude"]}]
suggested_ignore: ['.claude/**']
```
0/10 `.claude` files in the top-10 (was 10/10); real project code now dominates.

**tensor-grep (must not regress) -- BEFORE and AFTER are byte-identical** on `central_files` (`src/tensor_grep/cli/main.py` still #1 at score 82.0, same top-10 in the same order). `deweighted_trees` now additionally flags tensor-grep's own small `.claude` dir (`tool-config-name:.claude` only, not an import-island) with `suggested_ignore: ['.claude/**']` -- harmless since real code scores (33-82) far exceed it either way.

Also verified end-to-end with default settings (session daemon enabled): both the cold-path call (probe miss) and a follow-up warm-daemon call return the identical fixed result -- cold/warm parity holds (both share `build_orient_capsule_from_map`).

## Known follow-up (not fixed here, flagged for visibility)
`suggested_scope` (a *different*, pre-existing heuristic, audit #93 SUB-2) still suggests `.claude` on agent-studio, both before and after this fix. It deliberately reads `_file_centrality_scores`' RAW un-deweighted score by design (see the comment on `_central_files_from_map`), so it is unaffected by the STRONG-0 deweight. This is the same underlying pollution class but is outside the two-part fix this PR was scoped to (`central_files` ranking + `suggested_ignore`) and touches a documented, tested invariant (`test_file_centrality_scores_are_raw_not_deweighted`) that would need its own deliberate design decision. Filing as a candidate follow-up rather than silently changing it here.

## Test plan
- [x] RED->GREEN TDD: confirmed the new tests fail against the pre-fix `HEAD` version of `orient_capsule.py` (`.claude` tree returns `{}`), then pass against the fix.
- [x] `tests/unit/test_orient_deweight_vendored.py` -- 4 new tests for the STRONG-0 path (fires on name alone with no manifest, deep-nesting membership, does-not-fire on `claude` without the leading dot, central_files score deweight-but-keep).
- [x] `tests/unit/test_orient_suggested_ignore.py` (new file) -- 4 tests (`None` when nothing deweighted, populated for a `.claude` tree, absent when `--no-auto-deweight`, glob round-trips through `_apply_ignore_globs`).
- [x] Full existing orient/agent/daemon test surface (71 tests: `test_orient_deweight_vendored`, `test_orient_suggested_ignore`, `test_orient_suggested_scope`, `test_orient_capsule`, `test_orient_central_excludes_docs`, `test_orient_agent_daemon`, `test_orient_command`) -- all green, including cold/warm daemon-parity tests.
- [x] Broader consumer sweep (`-k "context or agent_capsule or repo_map or vendor or deweight"`, 542 tests) -- all green, since `tg context`/`tg agent` share the same `_detect_vendored_subtrees` via `repo_map.py`.
- [x] Full `tests/unit` + `tests/integration` suite, `-k "not upgrade"` (the `test_cli_modes.py::test_upgrade_*` family fails on a pre-existing, unrelated mock-desync bug -- verified it fails standalone in isolation against this same fix, in ~1s, touching only `tg upgrade`'s PyPI-version mocking; nothing this PR touches).
- [x] `ruff format --preview` + `ruff check` clean on all 3 touched files.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>