### PR TITLE
feat(orient): broaden suggested_ignore to whole vendor/skill trees + wire into tg agent (M1+M2)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -2819,6 +2819,27 @@ def build_agent_capsule_from_map(
     suggested_scope = payload.get("suggested_scope")
     if suggested_scope:
         result["suggested_scope"] = suggested_scope
+    # suggested_ignore (M2): parity with `tg orient`, which already surfaces auto-deweighted vendor/
+    # skill/tool-config subtree roots as ready-to-paste `--ignore` globs. `tg agent` already runs
+    # the SAME de-weight during ranking (`_build_context_pack_from_map`'s own `auto_deweight` pass,
+    # repo_map.py) but, pre-M2, never surfaced the glob hint itself -- an agent had to hand-derive
+    # `--ignore` globs or fall back to `tg orient` first. Recompute `_detect_vendored_subtrees`
+    # against the SAME (already `--ignore`-filtered) `rm` the ranking pass used above, and reuse
+    # orient's exact glob-builder (`_suggested_ignore_from_deweighted_trees`) -- never a second,
+    # independently hand-rolled hint that could drift from what `tg orient` would say for the same
+    # repo. `_detect_vendored_subtrees` reads only `rm`'s already-in-hand file/import lists plus a
+    # bounded number of manifest-marker existence checks (no new directory walk), so this is cheap
+    # relative to the rest of the capsule build. Additive + conditional, same shape as
+    # `suggested_scope` above: present only when non-empty, so a capsule with nothing deweighted
+    # stays byte-identical to a pre-M2 build.
+    from tensor_grep.cli.orient_capsule import (
+        _detect_vendored_subtrees,
+        _suggested_ignore_from_deweighted_trees,
+    )
+
+    suggested_ignore = _suggested_ignore_from_deweighted_trees(_detect_vendored_subtrees(rm))
+    if suggested_ignore:
+        result["suggested_ignore"] = suggested_ignore
     # DAR: additive CONDITIONAL keys, same pattern as scan_limit/partial above -- zero deps (or
     # the kill-switch, or a fail-safe early return inside `_collect_outbound_dependencies`) means
     # `outbound_dependencies` is `[]`, and BOTH keys are omitted so the capsule stays

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -60,24 +60,37 @@ _CENTRAL_SYMBOL_DENSITY_CAP = 25
 #         manifest (no package.json/pyproject.toml -- it's config, not a buildable nested project),
 #         so gating it behind STRONG-1 like the WEAK prior below meant it could NEVER fire, no
 #         matter what name list it was added to.
-#       * `_STRONG0_VENDOR_DIR_NAMES` (e.g. `node_modules`, `vendor`, `third_party`, `_vendored`,
-#         `external_repos`) -- M1 dogfood gap: a bundled dependency tree with NO manifest inside the
-#         SCANNED subtree (or a manifest filename outside `_BROAD_WORKSPACE_PROJECT_MARKERS`)
-#         previously required STRONG-1 to even be CONSIDERED a de-weight candidate at all, so the
-#         whole tree ranked as "central" right alongside real product code. These 5 names are
-#         effectively NEVER a repo's own product code, unlike `skills` (see STRONG-3 below).
+#       * `_STRONG0_VENDOR_DIR_NAMES` (`third_party`, `_vendored`) -- M1 dogfood gap: a bundled
+#         dependency tree with NO manifest inside the SCANNED subtree (or a manifest filename outside
+#         `_BROAD_WORKSPACE_PROJECT_MARKERS`) previously required STRONG-1 to even be CONSIDERED a
+#         de-weight candidate at all, so the whole tree ranked as "central" right alongside real
+#         product code. These names are effectively NEVER a repo's own product code, unlike `skills`
+#         (see STRONG-3 below). NOTE the set is deliberately just these two: `node_modules`, `vendor`,
+#         and `external_repos` are ALSO in `repo_map._SKIP_DIR_NAMES`, so the repo-map WALKER never
+#         descends into them at all (a stronger, upstream protection) -- a STRONG-0 entry for them
+#         would be dead code at real-scan time, so they are left out to keep this set honest.
 #   STRONG-1 -- a directory below the repo root contains its own manifest, reusing the same marker
 #     set `_path_has_project_marker` (main.py) uses for broad-scan workspace-project detection.
 #   STRONG-2 -- an import island: no file OUTSIDE the subtree resolves an import INTO it (computed
 #     from the same resolved-import graph the centrality ranking builds).
 #   STRONG-3 (M1) -- a `skills`-named directory (AMBIGUOUS: unlike the unambiguous STRONG-0 vendor
-#     names, a repo's OWN feature/plugin package could plausibly be named `skills/`) whose immediate
-#     children are PREDOMINANTLY self-contained leaf subtrees (each carries its own `SKILL.md`/
-#     `skill.md`, or has no imports crossing out of its own folder) AND which nothing OUTSIDE the
-#     tree imports INTO -- see `_is_skill_leaf_tree`. The external-import guard is the false-
-#     positive backstop: a genuine product `skills/` package (imported from elsewhere in the repo
-#     like any other internal module) fails it and is NEVER de-weighted no matter how leaf-shaped
-#     its subdirectories look.
+#     names, a repo's OWN feature/plugin package could plausibly be named `skills/`) that clears a
+#     SHAPE gauntlet designed so a genuine Python package can never pass it (see `_is_skill_leaf_tree`).
+#     Fires only when ALL of:
+#       (a) POSITIVE skill-manifest evidence -- at least `_SKILL_LEAF_FRACTION_THRESHOLD` of its
+#           immediate children each carry their own `SKILL.md`/`skill.md` (`_child_has_skill_manifest`).
+#           This is the LOAD-BEARING guard: an earlier draft counted a child as a leaf if it merely
+#           had "no imports crossing out", but the stem-only import graph
+#           (`_code_files_and_import_graph`) cannot resolve a `from skills.auth import Auth` symbol/
+#           subpackage edge, so a real `__init__.py` subpackage had empty resolved-imports and
+#           passed VACUOUSLY -- mislabeling a genuine product `skills/` package as a bundle (Opus-gate
+#           FP). A folder-per-skill bundle always carries a manifest; a Python package never does.
+#       (b) NO `__init__.py` in the tree root OR any immediate child -- an unambiguous "this is a real
+#           Python (sub)package, not a folder-per-skill bundle" marker. Belt-and-suspenders with (a).
+#       (c) the best-effort external-import guard: nothing OUTSIDE the tree resolves an import INTO it
+#           (the same `externally_isolated` evidence STRONG-2 uses). Kept as a strictly-safer extra
+#           signal, but it is NOT relied on alone -- the stem graph misses symbol/subpackage imports,
+#           which is exactly why (a)+(b) exist.
 #   WEAK -- a name prior (vendor/, third_party/, skills/, external_repos/, _vendored/, node_modules/):
 #     a TIE-BREAKER for a STRONG-1 candidate that is neither an island nor already covered by
 #     STRONG-0/STRONG-3 above (kept for any directory that reaches this point via a nested manifest
@@ -106,22 +119,25 @@ _TOOL_CONFIG_DIR_NAMES = frozenset({
 # STRONG-0 unambiguous vendor/dependency directory names (M1): unlike `_VENDOR_NAME_PRIOR`'s WEAK
 # tie-breaker role above (fires only alongside a STRONG-1 nested manifest), these names are
 # effectively NEVER a repo's own product code -- matched on the EXACT directory basename, same
-# mechanism as `_TOOL_CONFIG_DIR_NAMES`, so a `node_modules/`/`vendor/`/`third_party/`/`_vendored/`/
-# `external_repos/` subtree de-weights its WHOLE contents without needing a nested manifest at all.
-# `skills` is deliberately EXCLUDED here -- a repo's OWN feature/plugin package could plausibly be
-# named `skills/`, so it gets a SHAPE check instead of a bare name-alone promotion; see
-# `_is_skill_leaf_tree` and the STRONG-3 tier in the module comment above `_DEWEIGHT_FACTOR`.
+# mechanism as `_TOOL_CONFIG_DIR_NAMES`, so a `third_party/`/`_vendored/` subtree de-weights its
+# WHOLE contents without needing a nested manifest at all. Deliberately just these two: `node_modules`,
+# `vendor`, and `external_repos` are ALSO in `repo_map._SKIP_DIR_NAMES` (the repo-map walker skips
+# them entirely at scan time), so a STRONG-0 entry for those would be dead code -- they stay OUT to
+# keep this set honest (they still fire as the WEAK `_VENDOR_NAME_PRIOR` tie-breaker if a nested
+# manifest ever surfaces one through the walker). `skills` is EXCLUDED for a different reason -- a
+# repo's OWN feature/plugin package could plausibly be named `skills/`, so it gets a SHAPE gauntlet
+# instead of a bare name-alone promotion; see `_is_skill_leaf_tree` and the STRONG-3 tier above.
 _STRONG0_VENDOR_DIR_NAMES = frozenset({
-    "node_modules",
-    "vendor",
     "third_party",
     "_vendored",
-    "external_repos",
 })
-# STRONG-3 skill-leaf-tree shape heuristic (M1) tuning: a `skills`-named directory's immediate
-# child counts as a self-contained "leaf skill" if it carries one of these manifest filenames
-# (case-insensitive, checked directly inside the child -- not recursively), OR (see
-# `_child_is_self_contained_leaf`) has no imports crossing out to the rest of the repo.
+# STRONG-3 skill-leaf manifest filenames (Opus-gate FIX -- now the SOLE positive leaf signal, see
+# `_child_has_skill_manifest`): a `skills`-named directory's immediate child counts toward the
+# leaf-fraction ONLY if it carries one of these manifest filenames (case-insensitive, checked
+# directly inside the child -- not recursively, mirroring STRONG-1's own manifest check). The
+# earlier "no imports crossing out / no code files" fallback was REMOVED: it satisfied the fraction
+# vacuously for an `__init__.py` subpackage whose symbol/subpackage imports the stem-only graph
+# could not resolve, a false positive on the common `from skills.<subpkg> import <Symbol>` idiom.
 _SKILL_LEAF_MANIFEST_NAMES = frozenset({"skill.md"})
 # A `skills/` directory de-weights its whole subtree only when AT LEAST this fraction of its
 # immediate children look like independent leaf skills -- a strict majority, not "any single one",
@@ -192,21 +208,28 @@ def _code_files_and_import_graph(
     return code_files, resolved_imports, reverse_importers
 
 
-def _child_is_self_contained_leaf(
-    child_abs_dir: Path,
-    child_rel_parts: tuple[str, ...],
-    *,
-    code_rel_parts: list[tuple[str, tuple[str, ...]]],
-    resolved_imports: dict[str, list[str]],
-) -> bool:
-    """One immediate child of a STRONG-3 ``skills/`` candidate: does it look like a self-contained
-    leaf skill? Either signal is sufficient (see the STRONG-3 comment above ``_DEWEIGHT_FACTOR``):
+def _dir_contains_init_py(directory: Path) -> bool:
+    """True if ``directory`` directly contains an ``__init__.py`` -- an unambiguous "this is a real
+    Python (sub)package" marker used to REFUSE a STRONG-3 skill-leaf match (see
+    ``_is_skill_leaf_tree``). Fail-safe: any OSError reads as "not a package" (False)."""
+    try:
+        return (directory / "__init__.py").is_file()
+    except OSError:
+        return False
 
-      * it carries its own manifest (``SKILL.md``/``skill.md``, matched case-insensitively directly
-        inside the child -- NOT recursively, mirroring how STRONG-1's own manifest check works); or
-      * (fallback for a leaf with no manifest, e.g. a bare helper-script folder) NONE of its own
-        code files import anything OUTSIDE itself -- vacuously true when the child has no code
-        files at all (the common case: a leaf skill folder of pure Markdown).
+
+def _child_has_skill_manifest(child_abs_dir: Path) -> bool:
+    """One immediate child of a STRONG-3 ``skills/`` candidate: does it carry its own skill manifest
+    (``SKILL.md``/``skill.md``, matched case-insensitively directly inside the child -- NOT
+    recursively, mirroring how STRONG-1's own manifest check works)?
+
+    This is the SOLE positive leaf signal (Opus-gate FIX). An earlier draft ALSO counted a child
+    with "no imports crossing out / no code files" as a leaf, but the stem-only import graph
+    (``_code_files_and_import_graph``) cannot resolve a ``from skills.auth import Auth`` symbol/
+    subpackage edge, so a real ``__init__.py`` subpackage had empty resolved-imports and satisfied
+    that test VACUOUSLY -- a false positive on a genuine product ``skills/`` package consumed via
+    the common ``from skills.<subpkg> import <Symbol>`` idiom. A folder-per-skill bundle always
+    carries a manifest; a Python subpackage never does, so requiring one is unambiguous.
     """
     try:
         for entry in child_abs_dir.iterdir():
@@ -214,35 +237,29 @@ def _child_is_self_contained_leaf(
                 return True
     except OSError:
         pass
-    depth = len(child_rel_parts)
-    child_files = {f for f, parts in code_rel_parts if parts[:depth] == child_rel_parts}
-    if not child_files:
-        return (
-            True  # no code at all (e.g. a pure-Markdown skill folder) -- trivially self-contained
-        )
-    return all(target in child_files for f in child_files for target in resolved_imports.get(f, []))
+    return False
 
 
 def _is_skill_leaf_tree(
     abs_dir: Path,
-    rel_dir: Path,
     tree_files: set[str],
     *,
-    code_rel_parts: list[tuple[str, tuple[str, ...]]],
-    resolved_imports: dict[str, list[str]],
     reverse_importers: dict[str, set[str]],
 ) -> bool:
-    """STRONG-3 SHAPE heuristic for an AMBIGUOUS ``skills``-named directory (see the module comment
+    """STRONG-3 SHAPE gauntlet for an AMBIGUOUS ``skills``-named directory (see the module comment
     above ``_DEWEIGHT_FACTOR``): unlike an unambiguous ``_STRONG0_VENDOR_DIR_NAMES`` entry, a repo's
     own feature could plausibly be named ``skills/``, so bare-name-alone promotion is unsafe. Fires
-    only when BOTH:
+    only when ALL of:
 
-      * the false-positive guard: NOTHING outside the tree imports INTO it (the same
-        ``externally_isolated`` evidence STRONG-2 import-island detection uses below) -- a genuine
-        product ``skills/`` package imported elsewhere in the repo fails this and is NEVER
-        de-weighted, no matter how leaf-shaped its children look; AND
-      * most immediate children look like independent, self-contained leaf skills --
-        ``_child_is_self_contained_leaf``.
+      (c) the best-effort external-import guard: nothing OUTSIDE the tree resolves an import INTO it
+          (the same ``externally_isolated`` evidence STRONG-2 import-island detection uses). Kept as
+          a strictly-safer EXTRA signal, but NOT relied on alone -- the stem-only import graph misses
+          a ``from skills.<subpkg> import <Symbol>`` edge, which is why (a)+(b) below carry the load.
+      (b) NO ``__init__.py`` in the tree root OR any immediate child -- a real Python (sub)package
+          marker a folder-per-skill bundle never has (Opus-gate FIX, belt-and-suspenders with (a)).
+      (a) POSITIVE skill-manifest evidence: at least ``_SKILL_LEAF_FRACTION_THRESHOLD`` of the
+          immediate child directories each carry their own ``SKILL.md``/``skill.md``
+          (``_child_has_skill_manifest``) -- the load-bearing guard (Opus-gate FIX).
 
     A ``skills/`` directory with NO subdirectories at all (flat ``.py``/``.ts`` files directly
     inside -- the shape of a real Python/TS package, not a folder-per-skill bundle) has no children
@@ -251,22 +268,17 @@ def _is_skill_leaf_tree(
     externally_isolated = all(reverse_importers.get(f, set()) <= tree_files for f in tree_files)
     if not externally_isolated:
         return False  # imported from outside the tree -- looks like real, shared product code
+    if _dir_contains_init_py(abs_dir):
+        return False  # `skills/__init__.py` -- this is a real Python package, not a skill bundle
     try:
         child_dirs = [entry for entry in abs_dir.iterdir() if entry.is_dir()]
     except OSError:
         return False
     if not child_dirs:
         return False
-    leaf_count = sum(
-        1
-        for child in child_dirs
-        if _child_is_self_contained_leaf(
-            child,
-            (*rel_dir.parts, child.name),
-            code_rel_parts=code_rel_parts,
-            resolved_imports=resolved_imports,
-        )
-    )
+    if any(_dir_contains_init_py(child) for child in child_dirs):
+        return False  # a child is a real Python subpackage -- not a folder-per-skill bundle
+    leaf_count = sum(1 for child in child_dirs if _child_has_skill_manifest(child))
     return (leaf_count / len(child_dirs)) >= _SKILL_LEAF_FRACTION_THRESHOLD
 
 
@@ -353,10 +365,11 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
     if not (manifest_dirs or tool_config_dirs or strong0_vendor_dirs or skill_candidate_dirs):
         return {}
 
-    # The import graph is needed both for STRONG-3's shape validation below and for the main
-    # STRONG-2/WEAK evaluation loop further down -- compute it exactly ONCE and reuse (this reads
-    # only `rm`'s already-in-hand "files"/"imports" lists, no new filesystem I/O).
-    _code_files, resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
+    # The reverse-import graph is needed both for STRONG-3's external-import guard below and for the
+    # main STRONG-2/WEAK evaluation loop further down -- compute it exactly ONCE and reuse (this reads
+    # only `rm`'s already-in-hand "files"/"imports" lists, no new filesystem I/O). `resolved_imports`
+    # (the forward edges) is not needed here since the STRONG-3 leaf test became manifest-based.
+    _code_files, _resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
     code_file_set = set(_code_files)
 
     # Precompute each code file's path-parts relative to root ONCE, on the SAME lexical basis the
@@ -382,10 +395,7 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
         }
         if _is_skill_leaf_tree(
             root / rel_dir,
-            rel_dir,
             tree_files_for_skill_check,
-            code_rel_parts=code_rel_parts,
-            resolved_imports=resolved_imports,
             reverse_importers=reverse_importers,
         ):
             skill_leaf_dirs.add(rel_dir)

--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -46,22 +46,42 @@ _CENTRAL_SYMBOL_DENSITY_CAP = 25
 
 # Auto de-weight (never hard-exclude) bundled vendor/skill/generated CODE subtrees, AND known
 # AI-coding-harness config directories, so `tg orient`/`tg agent` surface real product code without
-# a manual `--ignore` (#55 PR6; harness dirs added #164). A subtree fires on STRONG-0 (tool-config
-# dir name) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK
+# a manual `--ignore` (#55 PR6; harness dirs added #164; unambiguous-vendor-name STRONG-0 promotion
+# + skill-tree shape heuristic added M1). A subtree fires on STRONG-0 (a closed-vocabulary directory
+# NAME) ALONE, on STRONG-3 (a `skills`-named directory whose children have the SHAPE of independent
+# leaf skills) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK
 # (name prior)):
-#   STRONG-0 -- an exact, closed-vocabulary tool/harness config directory name (see
-#     `_TOOL_CONFIG_DIR_NAMES` below, e.g. `.claude`): sufficient BY ITSELF, no manifest and no
-#     import-island required. Dogfood bug (#164): `.claude/hooks|lib|tools` (.cjs harness files)
-#     ranked in `tg orient`'s top-10 central_files on every Claude-Code-harness repo, because such a
-#     directory never carries its own package manifest (no package.json/pyproject.toml -- it's
-#     config, not a buildable nested project), so gating it behind STRONG-1 like the WEAK prior below
-#     meant it could NEVER fire, no matter what name list it was added to.
+#   STRONG-0 -- an exact, closed-vocabulary directory name is sufficient BY ITSELF, no manifest and
+#     no import-island required. Two closed vocabularies, both matched on the EXACT basename (not
+#     "any path component", the way `_VENDOR_NAME_PRIOR` is):
+#       * `_TOOL_CONFIG_DIR_NAMES` (e.g. `.claude`) -- AI-coding-harness config. Dogfood bug (#164):
+#         `.claude/hooks|lib|tools` (.cjs harness files) ranked in `tg orient`'s top-10 central_files
+#         on every Claude-Code-harness repo, because such a directory never carries its own package
+#         manifest (no package.json/pyproject.toml -- it's config, not a buildable nested project),
+#         so gating it behind STRONG-1 like the WEAK prior below meant it could NEVER fire, no
+#         matter what name list it was added to.
+#       * `_STRONG0_VENDOR_DIR_NAMES` (e.g. `node_modules`, `vendor`, `third_party`, `_vendored`,
+#         `external_repos`) -- M1 dogfood gap: a bundled dependency tree with NO manifest inside the
+#         SCANNED subtree (or a manifest filename outside `_BROAD_WORKSPACE_PROJECT_MARKERS`)
+#         previously required STRONG-1 to even be CONSIDERED a de-weight candidate at all, so the
+#         whole tree ranked as "central" right alongside real product code. These 5 names are
+#         effectively NEVER a repo's own product code, unlike `skills` (see STRONG-3 below).
 #   STRONG-1 -- a directory below the repo root contains its own manifest, reusing the same marker
 #     set `_path_has_project_marker` (main.py) uses for broad-scan workspace-project detection.
 #   STRONG-2 -- an import island: no file OUTSIDE the subtree resolves an import INTO it (computed
 #     from the same resolved-import graph the centrality ranking builds).
+#   STRONG-3 (M1) -- a `skills`-named directory (AMBIGUOUS: unlike the unambiguous STRONG-0 vendor
+#     names, a repo's OWN feature/plugin package could plausibly be named `skills/`) whose immediate
+#     children are PREDOMINANTLY self-contained leaf subtrees (each carries its own `SKILL.md`/
+#     `skill.md`, or has no imports crossing out of its own folder) AND which nothing OUTSIDE the
+#     tree imports INTO -- see `_is_skill_leaf_tree`. The external-import guard is the false-
+#     positive backstop: a genuine product `skills/` package (imported from elsewhere in the repo
+#     like any other internal module) fails it and is NEVER de-weighted no matter how leaf-shaped
+#     its subdirectories look.
 #   WEAK -- a name prior (vendor/, third_party/, skills/, external_repos/, _vendored/, node_modules/):
-#     a TIE-BREAKER only, never sufficient alone (requires STRONG-1).
+#     a TIE-BREAKER for a STRONG-1 candidate that is neither an island nor already covered by
+#     STRONG-0/STRONG-3 above (kept for any directory that reaches this point via a nested manifest
+#     alone -- e.g. a manifest-bearing `node_modules/` that is not an import island, see the tests).
 # A monorepo subproject that HAS a manifest but IS imported across the repo is protected by STRONG-2
 # (not an island) -- de-weight, never exclude, is what keeps a false positive from hiding real product
 # code (the file can still surface if it is genuinely central even after the multiplier).
@@ -83,6 +103,32 @@ _VENDOR_NAME_PRIOR = frozenset({
 _TOOL_CONFIG_DIR_NAMES = frozenset({
     ".claude",
 })
+# STRONG-0 unambiguous vendor/dependency directory names (M1): unlike `_VENDOR_NAME_PRIOR`'s WEAK
+# tie-breaker role above (fires only alongside a STRONG-1 nested manifest), these names are
+# effectively NEVER a repo's own product code -- matched on the EXACT directory basename, same
+# mechanism as `_TOOL_CONFIG_DIR_NAMES`, so a `node_modules/`/`vendor/`/`third_party/`/`_vendored/`/
+# `external_repos/` subtree de-weights its WHOLE contents without needing a nested manifest at all.
+# `skills` is deliberately EXCLUDED here -- a repo's OWN feature/plugin package could plausibly be
+# named `skills/`, so it gets a SHAPE check instead of a bare name-alone promotion; see
+# `_is_skill_leaf_tree` and the STRONG-3 tier in the module comment above `_DEWEIGHT_FACTOR`.
+_STRONG0_VENDOR_DIR_NAMES = frozenset({
+    "node_modules",
+    "vendor",
+    "third_party",
+    "_vendored",
+    "external_repos",
+})
+# STRONG-3 skill-leaf-tree shape heuristic (M1) tuning: a `skills`-named directory's immediate
+# child counts as a self-contained "leaf skill" if it carries one of these manifest filenames
+# (case-insensitive, checked directly inside the child -- not recursively), OR (see
+# `_child_is_self_contained_leaf`) has no imports crossing out to the rest of the repo.
+_SKILL_LEAF_MANIFEST_NAMES = frozenset({"skill.md"})
+# A `skills/` directory de-weights its whole subtree only when AT LEAST this fraction of its
+# immediate children look like independent leaf skills -- a strict majority, not "any single one",
+# so a handful of leaf-shaped helper folders inside an otherwise-real `skills/` PACKAGE (e.g. a
+# plugin registry with a couple of self-contained example plugins) does not tip the whole package
+# into being de-weighted.
+_SKILL_LEAF_FRACTION_THRESHOLD = 0.6
 
 _ENTRY_NAMES = {
     "main.py",
@@ -146,16 +192,95 @@ def _code_files_and_import_graph(
     return code_files, resolved_imports, reverse_importers
 
 
+def _child_is_self_contained_leaf(
+    child_abs_dir: Path,
+    child_rel_parts: tuple[str, ...],
+    *,
+    code_rel_parts: list[tuple[str, tuple[str, ...]]],
+    resolved_imports: dict[str, list[str]],
+) -> bool:
+    """One immediate child of a STRONG-3 ``skills/`` candidate: does it look like a self-contained
+    leaf skill? Either signal is sufficient (see the STRONG-3 comment above ``_DEWEIGHT_FACTOR``):
+
+      * it carries its own manifest (``SKILL.md``/``skill.md``, matched case-insensitively directly
+        inside the child -- NOT recursively, mirroring how STRONG-1's own manifest check works); or
+      * (fallback for a leaf with no manifest, e.g. a bare helper-script folder) NONE of its own
+        code files import anything OUTSIDE itself -- vacuously true when the child has no code
+        files at all (the common case: a leaf skill folder of pure Markdown).
+    """
+    try:
+        for entry in child_abs_dir.iterdir():
+            if entry.is_file() and entry.name.lower() in _SKILL_LEAF_MANIFEST_NAMES:
+                return True
+    except OSError:
+        pass
+    depth = len(child_rel_parts)
+    child_files = {f for f, parts in code_rel_parts if parts[:depth] == child_rel_parts}
+    if not child_files:
+        return (
+            True  # no code at all (e.g. a pure-Markdown skill folder) -- trivially self-contained
+        )
+    return all(target in child_files for f in child_files for target in resolved_imports.get(f, []))
+
+
+def _is_skill_leaf_tree(
+    abs_dir: Path,
+    rel_dir: Path,
+    tree_files: set[str],
+    *,
+    code_rel_parts: list[tuple[str, tuple[str, ...]]],
+    resolved_imports: dict[str, list[str]],
+    reverse_importers: dict[str, set[str]],
+) -> bool:
+    """STRONG-3 SHAPE heuristic for an AMBIGUOUS ``skills``-named directory (see the module comment
+    above ``_DEWEIGHT_FACTOR``): unlike an unambiguous ``_STRONG0_VENDOR_DIR_NAMES`` entry, a repo's
+    own feature could plausibly be named ``skills/``, so bare-name-alone promotion is unsafe. Fires
+    only when BOTH:
+
+      * the false-positive guard: NOTHING outside the tree imports INTO it (the same
+        ``externally_isolated`` evidence STRONG-2 import-island detection uses below) -- a genuine
+        product ``skills/`` package imported elsewhere in the repo fails this and is NEVER
+        de-weighted, no matter how leaf-shaped its children look; AND
+      * most immediate children look like independent, self-contained leaf skills --
+        ``_child_is_self_contained_leaf``.
+
+    A ``skills/`` directory with NO subdirectories at all (flat ``.py``/``.ts`` files directly
+    inside -- the shape of a real Python/TS package, not a folder-per-skill bundle) has no children
+    to score and never matches.
+    """
+    externally_isolated = all(reverse_importers.get(f, set()) <= tree_files for f in tree_files)
+    if not externally_isolated:
+        return False  # imported from outside the tree -- looks like real, shared product code
+    try:
+        child_dirs = [entry for entry in abs_dir.iterdir() if entry.is_dir()]
+    except OSError:
+        return False
+    if not child_dirs:
+        return False
+    leaf_count = sum(
+        1
+        for child in child_dirs
+        if _child_is_self_contained_leaf(
+            child,
+            (*rel_dir.parts, child.name),
+            code_rel_parts=code_rel_parts,
+            resolved_imports=resolved_imports,
+        )
+    )
+    return (leaf_count / len(child_dirs)) >= _SKILL_LEAF_FRACTION_THRESHOLD
+
+
 def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Auto-detect bundled vendor/skill/generated CODE subtrees, and known AI-tool/harness config
     directories, to DE-WEIGHT (never hard-exclude).
 
     Returns ``{tree_path: {"reasons": [...], "ignore_glob": "<repo-relative>/**"}}``. Fires on
-    STRONG-0 (tool-config dir name) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2
-    (import island) OR WEAK (name prior)) -- see the module-level comment above ``_DEWEIGHT_FACTOR``
-    for the full rule. Requires ``rm["path"]`` to point at a real, existing directory (a
-    synthetic/relative-path test fixture with no "path" key returns ``{}`` rather than guessing
-    against the process CWD)."""
+    STRONG-0 (a closed-vocabulary directory name -- tool-config OR unambiguous vendor/dependency)
+    ALONE, on STRONG-3 (a `skills`-named directory whose children have the SHAPE of independent leaf
+    skills) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK
+    (name prior)) -- see the module-level comment above ``_DEWEIGHT_FACTOR`` for the full rule.
+    Requires ``rm["path"]`` to point at a real, existing directory (a synthetic/relative-path test
+    fixture with no "path" key returns ``{}`` rather than guessing against the process CWD)."""
     path_value = rm.get("path")
     if not path_value:
         return {}
@@ -198,33 +323,40 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
             except OSError:
                 continue
 
-    # STRONG-0: a closed-vocabulary tool/harness config directory name (`.claude`) is sufficient
-    # evidence entirely on its own -- see the module comment above `_DEWEIGHT_FACTOR`. Matched on
-    # the directory's EXACT basename so only the `.claude` root itself is selected here, not every
-    # descendant of it (`.claude/hooks`, `.claude/hooks/audit`, ...) -- those get covered by the
-    # outermost-nested-chain dedup below via the base `.claude` entry, exactly like a STRONG-1
-    # manifest root covers its own descendants.
+    # STRONG-0: a closed-vocabulary directory name is sufficient evidence entirely on its own -- see
+    # the module comment above `_DEWEIGHT_FACTOR`. Matched on the directory's EXACT basename so only
+    # the root itself is selected here, not every descendant of it (`.claude/hooks`,
+    # `node_modules/react`, ...) -- those get covered by the outermost-nested-chain dedup below via
+    # the base entry, exactly like a STRONG-1 manifest root covers its own descendants.
     tool_config_dirs: set[Path] = {
         rel_dir
         for rel_dir in candidate_dirs
         if rel_dir.parts and rel_dir.parts[-1].lower() in _TOOL_CONFIG_DIR_NAMES
     }
+    strong0_vendor_dirs: set[Path] = {
+        rel_dir
+        for rel_dir in candidate_dirs
+        if rel_dir.parts and rel_dir.parts[-1].lower() in _STRONG0_VENDOR_DIR_NAMES
+    }
+    # STRONG-3 candidates: any directory literally named `skills` (a plain top-level `skills/`, a
+    # nested `core/skills/`, or one inside a tool-config dir like `.claude/skills` alike -- a
+    # redundant nested candidate is deduped by the outermost-chain pass below same as any other
+    # kind). Membership in `skill_leaf_dirs` (the SHAPE-validated subset) is decided just below,
+    # once the import graph is available; an un-validated candidate here does not by itself cause a
+    # de-weight.
+    skill_candidate_dirs = [
+        rel_dir
+        for rel_dir in candidate_dirs
+        if rel_dir.parts and rel_dir.parts[-1].lower() == "skills"
+    ]
 
-    if not manifest_dirs and not tool_config_dirs:
+    if not (manifest_dirs or tool_config_dirs or strong0_vendor_dirs or skill_candidate_dirs):
         return {}
 
-    # Keep only the OUTERMOST directory (manifest- or tool-config-matched) in any nested chain -- a
-    # deeper match inside an already-flagged subtree does not start a second, overlapping subtree.
-    subtree_rel_roots: list[Path] = []
-    for rel_dir in sorted(manifest_dirs.keys() | tool_config_dirs, key=lambda p: len(p.parts)):
-        if any(
-            _repo_map._path_is_relative_to(root / rel_dir, root / existing)
-            for existing in subtree_rel_roots
-        ):
-            continue
-        subtree_rel_roots.append(rel_dir)
-
-    _code_files, _resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
+    # The import graph is needed both for STRONG-3's shape validation below and for the main
+    # STRONG-2/WEAK evaluation loop further down -- compute it exactly ONCE and reuse (this reads
+    # only `rm`'s already-in-hand "files"/"imports" lists, no new filesystem I/O).
+    _code_files, resolved_imports, reverse_importers = _code_files_and_import_graph(rm)
     code_file_set = set(_code_files)
 
     # Precompute each code file's path-parts relative to root ONCE, on the SAME lexical basis the
@@ -242,13 +374,58 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
         except ValueError:
             continue
 
+    skill_leaf_dirs: set[Path] = set()
+    for rel_dir in skill_candidate_dirs:
+        depth = len(rel_dir.parts)
+        tree_files_for_skill_check = {
+            f for f, parts in code_rel_parts if parts[:depth] == rel_dir.parts
+        }
+        if _is_skill_leaf_tree(
+            root / rel_dir,
+            rel_dir,
+            tree_files_for_skill_check,
+            code_rel_parts=code_rel_parts,
+            resolved_imports=resolved_imports,
+            reverse_importers=reverse_importers,
+        ):
+            skill_leaf_dirs.add(rel_dir)
+
+    if not (manifest_dirs or tool_config_dirs or strong0_vendor_dirs or skill_leaf_dirs):
+        return {}
+
+    # Keep only the OUTERMOST directory (any matched kind) in any nested chain -- a deeper match
+    # inside an already-flagged subtree does not start a second, overlapping subtree (M1 task 3:
+    # e.g. a `core/skills/` STRONG-3 match must swallow a nested manifest island like
+    # `core/skills/x/` rather than emitting both globs).
+    all_candidate_roots = (
+        manifest_dirs.keys() | tool_config_dirs | strong0_vendor_dirs | skill_leaf_dirs
+    )
+    subtree_rel_roots: list[Path] = []
+    for rel_dir in sorted(all_candidate_roots, key=lambda p: len(p.parts)):
+        if any(
+            _repo_map._path_is_relative_to(root / rel_dir, root / existing)
+            for existing in subtree_rel_roots
+        ):
+            continue
+        subtree_rel_roots.append(rel_dir)
+
     result: dict[str, dict[str, Any]] = {}
     for rel_dir in subtree_rel_roots:
         abs_dir = root / rel_dir
         prefix = rel_dir.parts
         depth = len(prefix)
         tree_files = {f for f, parts in code_rel_parts if parts[:depth] == prefix}
-        if not tree_files:
+        # A STRONG-3 skill-leaf match was already validated by `_is_skill_leaf_tree` against the
+        # REAL filesystem child-directory shape, independent of whether the tree happens to
+        # contain any CODE files at all -- a leaf-skill folder is commonly pure Markdown (its own
+        # `SKILL.md` and nothing else). Skipping it here on an empty `tree_files` (a guard whose
+        # purpose is "nothing to de-weight in the code-centrality ranking, so this candidate is a
+        # no-op") would silently drop the exact all-Markdown shape M1 exists to catch: an agent's
+        # `--ignore`-glob hint (and `tg agent`'s own text-ranking de-weight, which scores ALL
+        # files, not just code) still benefits from the tree being reported even with zero code
+        # files inside it. Every OTHER mechanism (manifest/tool-config/vendor-name/name-prior/
+        # import-island) keeps requiring a non-empty `tree_files`, matching pre-M1 behavior.
+        if not tree_files and rel_dir not in skill_leaf_dirs:
             continue
         # An import-island needs POSITIVE evidence of an internally-cohesive-but-externally-isolated
         # cluster: some file in the subtree is imported by ANOTHER file in it, AND no file outside it
@@ -261,8 +438,10 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
         is_island = externally_isolated and has_internal_edge
         name_hits = sorted({part.lower() for part in rel_dir.parts} & _VENDOR_NAME_PRIOR)
         is_tool_config = rel_dir in tool_config_dirs
+        is_strong0_vendor = rel_dir in strong0_vendor_dirs
+        is_skill_leaf = rel_dir in skill_leaf_dirs
 
-        if not (is_island or name_hits or is_tool_config):
+        if not (is_island or name_hits or is_tool_config or is_strong0_vendor or is_skill_leaf):
             continue
 
         reasons: list[str] = []
@@ -274,10 +453,27 @@ def _detect_vendored_subtrees(rm: dict[str, Any]) -> dict[str, dict[str, Any]]:
             reasons.append(f"name-prior:{name_hits[0]}")
         if is_tool_config:
             reasons.append(f"tool-config-name:{rel_dir.parts[-1].lower()}")
+        if is_strong0_vendor:
+            reasons.append(f"vendor-name-strong0:{rel_dir.parts[-1].lower()}")
+        if is_skill_leaf:
+            reasons.append("skill-tree-shape")
 
         result[str(abs_dir)] = {"reasons": reasons, "ignore_glob": f"{rel_dir.as_posix()}/**"}
 
     return result
+
+
+def _suggested_ignore_from_deweighted_trees(
+    deweighted_trees: dict[str, dict[str, Any]],
+) -> list[str] | None:
+    """Ready-to-paste ``--ignore`` globs for each detected vendor/skill/tool-config subtree root
+    (see ``_detect_vendored_subtrees``), e.g. ``.claude/**``. Shared by `tg orient`
+    (``build_orient_capsule_from_map``) and `tg agent` (``agent_capsule.build_agent_capsule_from_map``,
+    M2) so both surface the identical hint off the identical detection, rather than two
+    independently hand-rolled copies of the same list comprehension. ``None`` -- never an empty
+    list -- when nothing was deweighted, mirroring `suggested_scope`'s never-guess-empty convention
+    (an agent can branch on `is None`)."""
+    return [info["ignore_glob"] for _tree_path, info in sorted(deweighted_trees.items())] or None
 
 
 def _file_centrality_scores(rm: dict[str, Any]) -> tuple[list[str], dict[str, float]]:
@@ -619,15 +815,11 @@ def build_orient_capsule_from_map(
         {"path": tree_path, "reasons": list(info["reasons"])}
         for tree_path, info in sorted(deweighted_trees.items())
     ]
-    # suggested_ignore (#164): when auto-deweight found something, surface the deweighted tree
-    # roots as ready-to-paste `--ignore` globs (e.g. `.claude/**`) so an agent that wants a HARD
-    # exclude (not just a lowered score) doesn't have to hand-derive the glob syntax. Same ordering
-    # as `deweighted_trees_list` (both sorted over `deweighted_trees.items()`). None -- never an
-    # empty list -- when nothing was deweighted, mirroring `suggested_scope`'s never-guess-empty
-    # convention (an agent can branch on `is None`).
-    suggested_ignore = [
-        info["ignore_glob"] for _tree_path, info in sorted(deweighted_trees.items())
-    ] or None
+    # suggested_ignore (#164; M1 extraction into `_suggested_ignore_from_deweighted_trees`): when
+    # auto-deweight found something, surface the deweighted tree roots as ready-to-paste `--ignore`
+    # globs (e.g. `.claude/**`) so an agent that wants a HARD exclude (not just a lowered score)
+    # doesn't have to hand-derive the glob syntax.
+    suggested_ignore = _suggested_ignore_from_deweighted_trees(deweighted_trees)
 
     lines: list[str] = [f"# Codebase orientation: {rm['path']}"]
     lines.append("\n## Central files (by import-graph centrality)")

--- a/tests/unit/test_agent_capsule_suggested_ignore.py
+++ b/tests/unit/test_agent_capsule_suggested_ignore.py
@@ -1,0 +1,112 @@
+"""Tests for `suggested_ignore` parity between `tg orient` and `tg agent` (M2).
+
+`_detect_vendored_subtrees` + the de-weight-based ranking were already SHARED between
+`build_orient_capsule` and `build_agent_capsule` (`_build_context_pack_from_map`'s own
+`auto_deweight` pass, repo_map.py) -- only the `suggested_ignore` ready-to-paste `--ignore`-glob
+HINT was orient-only; `tg agent REPO "task" --json` had no `suggested_ignore` key at all, so an
+agent that wanted a hard exclude had to hand-derive the glob or shell out to `tg orient` first.
+
+`build_agent_capsule_from_map` now populates the SAME key, via the SAME
+`orient_capsule._suggested_ignore_from_deweighted_trees` builder over the SAME
+`_detect_vendored_subtrees(rm)` result `tg orient` uses -- so a repo with a detected vendor/skill
+tree gets an IDENTICAL hint from both commands. Additive-only: present only when non-empty
+(mirroring `suggested_scope`'s convention, see test_agent_capsule_tie_suggested_scope.py) -- never
+an empty-but-present key, and no existing capsule key is renamed or removed.
+"""
+
+from pathlib import Path
+
+from tensor_grep.cli.agent_capsule import build_agent_capsule
+from tensor_grep.cli.orient_capsule import build_orient_capsule
+
+
+def test_agent_capsule_suggested_ignore_matches_orient_for_bare_vendor_tree(
+    tmp_path: Path,
+) -> None:
+    """A bare `third_party/` tree (no nested manifest, STRONG-0) must produce the identical
+    `suggested_ignore` from `tg agent` as it does from `tg orient` for the same repo. Uses
+    `third_party/` rather than `node_modules/`/`vendor/`/`external_repos/` deliberately -- those
+    three are ALSO in `repo_map._SKIP_DIR_NAMES`, so the repo-map walker never descends into them
+    at all (a separate, pre-existing, stronger-than-deweight protection); a real scan would never
+    see their contents regardless of this fix."""
+    project = tmp_path / "workspace"
+    pkg_dir = project / "third_party" / "left-pad"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "index.js").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "main.py").write_text(
+        "def process_widget():\n    return 1\n", encoding="utf-8"
+    )
+
+    orient_payload = build_orient_capsule(project, max_tokens=500)
+    agent_payload = build_agent_capsule("process widget", project, max_tokens=2000)
+
+    assert orient_payload["suggested_ignore"] == ["third_party/**"]
+    assert agent_payload["suggested_ignore"] == orient_payload["suggested_ignore"]
+
+
+def test_agent_capsule_suggested_ignore_matches_orient_for_skill_tree(tmp_path: Path) -> None:
+    """A `skills/` tree of leaf skills (STRONG-3 shape heuristic) must also parity-match."""
+    project = tmp_path / "workspace"
+    skills_dir = project / "core" / "skills"
+    for name in ("alpha", "beta", "gamma"):
+        leaf = skills_dir / name
+        leaf.mkdir(parents=True)
+        (leaf / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+        (leaf / "run.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "main.py").write_text(
+        "def process_widget():\n    return 1\n", encoding="utf-8"
+    )
+
+    orient_payload = build_orient_capsule(project, max_tokens=500)
+    agent_payload = build_agent_capsule("process widget", project, max_tokens=2000)
+
+    assert orient_payload["suggested_ignore"] == ["core/skills/**"]
+    assert agent_payload["suggested_ignore"] == orient_payload["suggested_ignore"]
+
+
+def test_agent_capsule_suggested_ignore_absent_when_nothing_deweighted(tmp_path: Path) -> None:
+    """An ordinary repo with nothing to de-weight must NOT gain a `suggested_ignore` key -- additive
+    only, mirroring `suggested_scope`'s "absent, never empty-but-present" contract."""
+    project = tmp_path / "workspace"
+    project.mkdir()
+    (project / "main.py").write_text("def solo_widget():\n    return 1\n", encoding="utf-8")
+
+    payload = build_agent_capsule("solo widget", project, max_tokens=2000)
+
+    assert "suggested_ignore" not in payload
+
+
+def test_agent_capsule_suggested_ignore_absent_for_genuine_skills_package(tmp_path: Path) -> None:
+    """The false-positive guard end-to-end on the agent capsule: a genuine product `skills/`
+    package imported from `main.py` must not appear in `suggested_ignore`."""
+    project = tmp_path / "workspace"
+    plugin = project / "skills" / "plugin_a"
+    plugin.mkdir(parents=True)
+    (plugin / "SKILL.md").write_text("# plugin_a\n", encoding="utf-8")
+    (plugin / "handler.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (project / "main.py").write_text("from skills.plugin_a.handler import run\n", encoding="utf-8")
+
+    payload = build_agent_capsule("run", project, max_tokens=2000)
+
+    assert "suggested_ignore" not in payload
+
+
+def test_agent_capsule_suggested_ignore_respects_explicit_ignore_flag(tmp_path: Path) -> None:
+    """`--ignore` (hard exclude) is applied to `rm` BEFORE the M2 suggested_ignore recompute -- a
+    tree the caller already excluded outright must not also show up as a suggestion."""
+    project = tmp_path / "workspace"
+    pkg_dir = project / "third_party" / "left-pad"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "index.js").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "main.py").write_text(
+        "def process_widget():\n    return 1\n", encoding="utf-8"
+    )
+
+    payload = build_agent_capsule(
+        "process widget", project, max_tokens=2000, ignore=("third_party/**",)
+    )
+
+    assert "suggested_ignore" not in payload

--- a/tests/unit/test_agent_capsule_suggested_ignore.py
+++ b/tests/unit/test_agent_capsule_suggested_ignore.py
@@ -93,6 +93,28 @@ def test_agent_capsule_suggested_ignore_absent_for_genuine_skills_package(tmp_pa
     assert "suggested_ignore" not in payload
 
 
+def test_agent_capsule_suggested_ignore_absent_for_skills_package_via_symbol_import(
+    tmp_path: Path,
+) -> None:
+    """Opus-gate MUST-FIX regression via M2: the symbol/subpackage-import false positive
+    (`from skills.auth import Auth`, subpackages with `__init__.py`, no SKILL.md) must not reach the
+    `tg agent` capsule either -- `suggested_ignore` absent. This is the moat-facing surface the gate
+    called out: M2 wires the same detection into the agent/daemon path, so the FP had to be proven
+    gone on BOTH commands, not just `tg orient`."""
+    project = tmp_path / "workspace"
+    for sub in ("auth", "db"):
+        pkg = project / "skills" / sub
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text(f"class {sub.capitalize()}:\n    pass\n", encoding="utf-8")
+    (project / "main.py").write_text(
+        "from skills.auth import Auth\n\ndef go():\n    return Auth()\n", encoding="utf-8"
+    )
+
+    payload = build_agent_capsule("auth", project, max_tokens=2000)
+
+    assert "suggested_ignore" not in payload
+
+
 def test_agent_capsule_suggested_ignore_respects_explicit_ignore_flag(tmp_path: Path) -> None:
     """`--ignore` (hard exclude) is applied to `rm` BEFORE the M2 suggested_ignore recompute -- a
     tree the caller already excluded outright must not also show up as a suggestion."""

--- a/tests/unit/test_orient_deweight_vendored.py
+++ b/tests/unit/test_orient_deweight_vendored.py
@@ -3,15 +3,19 @@ centrality (#132 / #55 PR6), known AI-tool/harness config directories (#164), an
 whole-tree detection (unambiguous STRONG-0 vendor names + STRONG-3 skill-tree shape heuristic).
 
 A subtree fires on STRONG-0 (closed-vocabulary directory NAME -- a tool-config dir like `.claude`,
-OR an unambiguous vendor/dependency dir like `node_modules`/`vendor`/`third_party`/`_vendored`/
-`external_repos`) ALONE, on STRONG-3 (a `skills`-named directory whose immediate children have the
-SHAPE of independent leaf skills) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2
-(import island) OR WEAK (name prior)). The de-weight multiplies a subtree file's composite
-centrality by ``_DEWEIGHT_FACTOR`` -- it LOWERS the score, it never EXCLUDES the file, so a
-genuinely central vendored file can still surface. A monorepo subproject that has a manifest but IS
-imported across the repo is protected by the import-island test (de-weight would hide real product
-code); a `skills`-named directory imported across the repo is protected the same way by STRONG-3's
-own external-import guard (see `_is_skill_leaf_tree`).
+OR an unambiguous vendor/dependency dir `third_party`/`_vendored`) ALONE, on STRONG-3 (a
+`skills`-named directory that clears a SHAPE gauntlet: >=60% of immediate children carry a
+SKILL.md/skill.md manifest, no `__init__.py` in the tree root or any child, and nothing outside the
+tree imports in) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR
+WEAK (name prior)). The de-weight multiplies a subtree file's composite centrality by
+``_DEWEIGHT_FACTOR`` -- it LOWERS the score, it never EXCLUDES the file, so a genuinely central
+vendored file can still surface. A monorepo subproject that has a manifest but IS imported across
+the repo is protected by the import-island test (de-weight would hide real product code); a genuine
+product `skills/` package is protected by STRONG-3's manifest-required + `__init__.py`-refusal
+guards (a Python package has an `__init__.py` and no per-child SKILL.md), which hold even for the
+common `from skills.<subpkg> import <Symbol>` idiom the stem-only import graph can't resolve.
+(`node_modules`/`vendor`/`external_repos` are NOT STRONG-0 -- they are walker-skipped upstream via
+`repo_map._SKIP_DIR_NAMES`, so a STRONG-0 entry would be dead code.)
 
 `_detect_vendored_subtrees` reads the real filesystem (it checks ``root.is_dir()`` and each
 candidate directory for a manifest via ``.exists()``), so these tests build real ``tmp_path``
@@ -105,36 +109,38 @@ def test_skips_neutral_dirname_with_no_manifest_no_island_no_name_prior(tmp_path
 
 
 # ---------------------------------------------------------------------------
-# M1: STRONG-0 unambiguous vendor/dependency directory names (`_STRONG0_VENDOR_DIR_NAMES`) fire on
-# the NAME ALONE, no manifest and no import-island required -- unlike the old WEAK name-prior role
-# of `_VENDOR_NAME_PRIOR`, which only ever broke a STRONG-1-manifest tie. Dogfood gap: a bundled
-# `node_modules/`/`vendor/`/`third_party/`/`_vendored/`/`external_repos/` subtree with no manifest
-# copied into the scanned tree previously required STRONG-1 to even be CONSIDERED a candidate, so
-# the whole tree ranked as "central" alongside real product code. `skills` is deliberately EXCLUDED
-# from this promotion (see the STRONG-3 shape-heuristic tests further below).
+# M1: STRONG-0 unambiguous vendor/dependency directory names (`_STRONG0_VENDOR_DIR_NAMES` =
+# {`third_party`, `_vendored`}) fire on the NAME ALONE, no manifest and no import-island required --
+# unlike the old WEAK name-prior role of `_VENDOR_NAME_PRIOR`, which only ever broke a
+# STRONG-1-manifest tie. Dogfood gap: a bundled `third_party/`/`_vendored/` subtree with no manifest
+# copied into the scanned tree previously required STRONG-1 to even be CONSIDERED a candidate, so the
+# whole tree ranked as "central" alongside real product code. `node_modules`/`vendor`/`external_repos`
+# are deliberately NOT STRONG-0 -- they are already in `repo_map._SKIP_DIR_NAMES` (the walker skips
+# them entirely), so a STRONG-0 entry would be dead code at real-scan time (see
+# `test_dropped_vendor_names_are_not_strong0` below). `skills` is EXCLUDED for a different reason (a
+# repo's own package could be named `skills/`); see the STRONG-3 tests further below.
 # ---------------------------------------------------------------------------
 
 
 def test_strong0_vendor_name_fires_without_any_manifest(tmp_path: Path) -> None:
-    # M1: `vendor/` (an unambiguous STRONG-0 vendor name) now fires on the name ALONE -- no
-    # manifest required. Supersedes the old "name prior is only a tie-breaker" contract for these 5
-    # unambiguous names specifically.
+    # M1: `_vendored/` (an unambiguous STRONG-0 vendor name) fires on the name ALONE -- no manifest
+    # required. Supersedes the old "name prior is only a tie-breaker" contract for these names.
     root = tmp_path.resolve()
-    (root / "vendor").mkdir()
-    rm = _rm(root, [root / "app.py", root / "vendor" / "lib.py"], {})
+    (root / "_vendored").mkdir()
+    rm = _rm(root, [root / "app.py", root / "_vendored" / "lib.py"], {})
     trees = _detect_vendored_subtrees(rm)
-    assert str(root / "vendor") in trees
-    info = trees[str(root / "vendor")]
-    assert "vendor-name-strong0:vendor" in info["reasons"]
+    assert str(root / "_vendored") in trees
+    info = trees[str(root / "_vendored")]
+    assert "vendor-name-strong0:_vendored" in info["reasons"]
     assert not any(r.startswith("nested-manifest:") for r in info["reasons"])
-    assert info["ignore_glob"] == "vendor/**"
+    assert info["ignore_glob"] == "_vendored/**"
 
 
-def test_strong0_node_modules_fires_on_name_alone_task_scenario_a(tmp_path: Path) -> None:
-    # Task scenario (a): a whole `node_modules/` tree with NO nested manifest anywhere must be
+def test_strong0_third_party_fires_on_name_alone_task_scenario_a(tmp_path: Path) -> None:
+    # Task scenario (a): a whole `third_party/` tree with NO nested manifest anywhere must be
     # de-weighted and its root surfaced as a ready-to-paste `--ignore` glob.
     root = tmp_path.resolve()
-    pkg_dir = root / "node_modules" / "left-pad"
+    pkg_dir = root / "third_party" / "left-pad"
     pkg_dir.mkdir(parents=True)
     lib = pkg_dir / "index.js"
     lib.write_text("module.exports = () => {};\n")
@@ -142,18 +148,18 @@ def test_strong0_node_modules_fires_on_name_alone_task_scenario_a(tmp_path: Path
 
     trees = _detect_vendored_subtrees(rm)
 
-    assert str(root / "node_modules") in trees
-    info = trees[str(root / "node_modules")]
-    assert "vendor-name-strong0:node_modules" in info["reasons"]
-    assert info["ignore_glob"] == "node_modules/**"
+    assert str(root / "third_party") in trees
+    info = trees[str(root / "third_party")]
+    assert "vendor-name-strong0:third_party" in info["reasons"]
+    assert info["ignore_glob"] == "third_party/**"
 
 
-def test_strong0_node_modules_deweights_central_score_but_keeps_the_file(tmp_path: Path) -> None:
+def test_strong0_vendor_deweights_central_score_but_keeps_the_file(tmp_path: Path) -> None:
     # De-weight-not-exclude (task scenario d) for the NEW STRONG-0 vendor mechanism: a genuinely
-    # central file inside a bare (no-manifest) `node_modules/` tree still surfaces in central_files,
+    # central file inside a bare (no-manifest) `third_party/` tree still surfaces in central_files,
     # just at a lowered (`_DEWEIGHT_FACTOR`-multiplied) score.
     root = tmp_path.resolve()
-    pkg_dir = root / "node_modules" / "left-pad"
+    pkg_dir = root / "third_party" / "left-pad"
     pkg_dir.mkdir(parents=True)
     lib = pkg_dir / "index.js"
     lib.write_text("module.exports = () => {};\n")
@@ -172,12 +178,28 @@ def test_strong0_node_modules_deweights_central_score_but_keeps_the_file(tmp_pat
     assert dew_lib["score"] == round(raw_lib["score"] * _DEWEIGHT_FACTOR, 6)
 
 
+def test_dropped_vendor_names_are_not_strong0(tmp_path: Path) -> None:
+    # Honest-set guard (Opus-gate NIT): `node_modules`, `vendor`, `external_repos` are ALL in
+    # `repo_map._SKIP_DIR_NAMES` (walker-skipped upstream), so they are deliberately NOT STRONG-0.
+    # A synthetic `rm` bypassing the walker proves the name-alone promotion does not fire for them:
+    # with no manifest and no import-island, the detector returns {} (they still WOULD fire as the
+    # WEAK `_VENDOR_NAME_PRIOR` tie-breaker if a nested manifest surfaced, but never on name alone).
+    for name in ("node_modules", "vendor", "external_repos"):
+        root = (tmp_path / name).resolve()
+        root.mkdir()
+        (root / name).mkdir()
+        rm = _rm(root, [root / "app.py", root / name / "lib.py"], {})
+        assert _detect_vendored_subtrees(rm) == {}, f"{name} should not fire STRONG-0 on name alone"
+
+
 # ---------------------------------------------------------------------------
-# M1: STRONG-3 `skills`-named directory SHAPE heuristic. Unlike the unambiguous STRONG-0 vendor
-# names above, `skills` stays AMBIGUOUS -- a repo's own feature/plugin package could plausibly be
-# named `skills/` -- so it is gated on the SHAPE of its immediate children (predominantly
-# self-contained leaf skills) plus a false-positive guard (nothing outside the tree imports into
-# it), not a bare name-alone promotion.
+# M1: STRONG-3 `skills`-named directory SHAPE gauntlet. Unlike the unambiguous STRONG-0 vendor names
+# above, `skills` stays AMBIGUOUS -- a repo's own feature/plugin package could plausibly be named
+# `skills/` -- so it is gated on a gauntlet a real Python package can never pass: (a) >=60% of its
+# immediate children each carry their own SKILL.md/skill.md manifest (Opus-gate: the SOLE positive
+# leaf signal -- a "no imports crossing out" fallback was unsafe because the stem-only import graph
+# can't resolve a `from skills.<subpkg> import <Symbol>` edge), (b) NO `__init__.py` in the tree
+# root or any immediate child, and (c) a best-effort "nothing outside imports in" guard.
 # ---------------------------------------------------------------------------
 
 
@@ -299,9 +321,11 @@ def test_skips_flat_skills_package_with_no_subdirectories(tmp_path: Path) -> Non
 
 
 def test_skill_tree_below_leaf_fraction_threshold_is_not_deweighted(tmp_path: Path) -> None:
-    # Only half (2 of 4) of the immediate children look like self-contained leaf skills -- below
-    # `_SKILL_LEAF_FRACTION_THRESHOLD` -- so the SHAPE check must not fire even though the tree as a
-    # whole is not imported from outside it.
+    # Only 1 of 4 immediate children carries a SKILL.md manifest -- below
+    # `_SKILL_LEAF_FRACTION_THRESHOLD` (0.6) -- so the SHAPE check must not fire. The other 3 are
+    # plain code folders with no manifest: under the Opus-gate manifest-required rule they do NOT
+    # count toward the leaf fraction (an earlier draft would have vacuously counted them via a
+    # "no imports crossing out" fallback, the exact source of the symbol-import false positive).
     root = tmp_path.resolve()
     skills_dir = root / "skills"
 
@@ -309,26 +333,56 @@ def test_skill_tree_below_leaf_fraction_threshold_is_not_deweighted(tmp_path: Pa
     real_skill.mkdir(parents=True)
     (real_skill / "SKILL.md").write_text("# real_skill\n")
 
-    shared = skills_dir / "shared"
-    shared.mkdir(parents=True)
-    shared_util = shared / "util.py"
-    shared_util.write_text("def util():\n    pass\n")
+    files = [root / "app.py"]
+    for name in ("mod_a", "mod_b", "mod_c"):
+        child = skills_dir / name
+        child.mkdir(parents=True)
+        impl = child / f"{name}.py"
+        impl.write_text("def go():\n    pass\n")  # code, but NO SKILL.md manifest
+        files.append(impl)
+    rm = _rm(root, files, {})
 
-    consumer_a = skills_dir / "consumer_a"
-    consumer_a.mkdir(parents=True)
-    a_impl = consumer_a / "a_impl.py"
-    a_impl.write_text("def a():\n    pass\n")
+    assert _detect_vendored_subtrees(rm) == {}
 
-    consumer_b = skills_dir / "consumer_b"
-    consumer_b.mkdir(parents=True)
-    b_impl = consumer_b / "b_impl.py"
-    b_impl.write_text("def b():\n    pass\n")
 
+def test_skips_skill_package_consumed_via_subpackage_symbol_import(tmp_path: Path) -> None:
+    # Opus-gate MUST-FIX regression: a genuine product `skills/` package consumed via the COMMON
+    # idiom `from skills.auth import Auth` (a symbol/subpackage import) must NOT be de-weighted. The
+    # stem-only import graph can't resolve that edge (last dotted component `Auth` is a symbol and
+    # `skills.auth` is a SUBPACKAGE dir, neither a file stem), so `externally_isolated` is
+    # (wrongly) True -- the belt-and-suspenders manifest-required + `__init__.py`-refusal guards are
+    # what actually catch it: each subpackage child has an `__init__.py` (real Python package) and
+    # NO SKILL.md. Pre-STRONG-3 `main` returned None here; this proves the PR does not regress it.
+    root = tmp_path.resolve()
+    skills_dir = root / "skills"
+    for sub in ("auth", "db"):
+        pkg = skills_dir / sub
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text(f"class {sub.capitalize()}:\n    pass\n")
+    main = root / "main.py"
+    main.write_text("from skills.auth import Auth\n\ndef go():\n    return Auth()\n")
     rm = _rm(
         root,
-        [root / "app.py", shared_util, a_impl, b_impl],
-        {a_impl: ["util"], b_impl: ["util"]},  # both consumers reach OUT to a sibling child
+        [main, skills_dir / "auth" / "__init__.py", skills_dir / "db" / "__init__.py"],
+        {main: ["skills.auth", "skills.auth.Auth"]},  # unresolvable in the stem-only graph
     )
+
+    assert _detect_vendored_subtrees(rm) == {}
+
+
+def test_skips_skill_dir_with_init_py_at_root(tmp_path: Path) -> None:
+    # Opus-gate MUST-FIX regression: a `skills/__init__.py` at the tree root is an unambiguous
+    # "this is a real Python package" marker -- STRONG-3 is refused entirely regardless of how
+    # leaf-shaped its children look.
+    root = tmp_path.resolve()
+    skills_dir = root / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "__init__.py").write_text("from .auth import Auth\n")
+    leaf = skills_dir / "auth"
+    leaf.mkdir()
+    (leaf / "SKILL.md").write_text("# auth\n")  # even WITH a manifest, the root __init__.py wins
+    (leaf / "impl.py").write_text("class Auth:\n    pass\n")
+    rm = _rm(root, [root / "main.py", leaf / "impl.py"], {})
 
     assert _detect_vendored_subtrees(rm) == {}
 

--- a/tests/unit/test_orient_deweight_vendored.py
+++ b/tests/unit/test_orient_deweight_vendored.py
@@ -1,12 +1,17 @@
 """Tests for auto-de-weighting of bundled vendor/skill/generated CODE subtrees in `tg orient`
-centrality (#132 / #55 PR6), and known AI-tool/harness config directories (#164).
+centrality (#132 / #55 PR6), known AI-tool/harness config directories (#164), and the M1 broader
+whole-tree detection (unambiguous STRONG-0 vendor names + STRONG-3 skill-tree shape heuristic).
 
-A subtree fires on STRONG-0 (closed-vocabulary tool-config dir NAME, e.g. `.claude`) ALONE, or on
-STRONG-1 (nested package manifest) AND (STRONG-2 (import island) OR WEAK (name prior)). The
-de-weight multiplies a subtree file's composite centrality by ``_DEWEIGHT_FACTOR`` -- it LOWERS the
-score, it never EXCLUDES the file, so a genuinely central vendored file can still surface. A
-monorepo subproject that has a manifest but IS imported across the repo is protected by the
-import-island test (de-weight would hide real product code).
+A subtree fires on STRONG-0 (closed-vocabulary directory NAME -- a tool-config dir like `.claude`,
+OR an unambiguous vendor/dependency dir like `node_modules`/`vendor`/`third_party`/`_vendored`/
+`external_repos`) ALONE, on STRONG-3 (a `skills`-named directory whose immediate children have the
+SHAPE of independent leaf skills) ALONE, or on STRONG-1 (nested package manifest) AND (STRONG-2
+(import island) OR WEAK (name prior)). The de-weight multiplies a subtree file's composite
+centrality by ``_DEWEIGHT_FACTOR`` -- it LOWERS the score, it never EXCLUDES the file, so a
+genuinely central vendored file can still surface. A monorepo subproject that has a manifest but IS
+imported across the repo is protected by the import-island test (de-weight would hide real product
+code); a `skills`-named directory imported across the repo is protected the same way by STRONG-3's
+own external-import guard (see `_is_skill_leaf_tree`).
 
 `_detect_vendored_subtrees` reads the real filesystem (it checks ``root.is_dir()`` and each
 candidate directory for a manifest via ``.exists()``), so these tests build real ``tmp_path``
@@ -89,12 +94,242 @@ def test_skips_manifest_only_monorepo_subproject(tmp_path: Path) -> None:
     assert trees == {}
 
 
-def test_skips_when_no_manifest(tmp_path: Path) -> None:
-    # `vendor/` matches a name-prior but has NO manifest -> STRONG-1 fails -> never fires. The name
-    # prior is only a tie-breaker, never sufficient on its own.
+def test_skips_neutral_dirname_with_no_manifest_no_island_no_name_prior(tmp_path: Path) -> None:
+    # An arbitrary, non-prior directory name ("helpers") with no manifest and no import-island
+    # evidence must still NOT fire -- the base "no signal at all" contract is unchanged by M1's
+    # STRONG-0 vendor-name promotion (below): a bare, unlisted name is still insufficient alone.
+    root = tmp_path.resolve()
+    (root / "helpers").mkdir()
+    rm = _rm(root, [root / "app.py", root / "helpers" / "lib.py"], {})
+    assert _detect_vendored_subtrees(rm) == {}
+
+
+# ---------------------------------------------------------------------------
+# M1: STRONG-0 unambiguous vendor/dependency directory names (`_STRONG0_VENDOR_DIR_NAMES`) fire on
+# the NAME ALONE, no manifest and no import-island required -- unlike the old WEAK name-prior role
+# of `_VENDOR_NAME_PRIOR`, which only ever broke a STRONG-1-manifest tie. Dogfood gap: a bundled
+# `node_modules/`/`vendor/`/`third_party/`/`_vendored/`/`external_repos/` subtree with no manifest
+# copied into the scanned tree previously required STRONG-1 to even be CONSIDERED a candidate, so
+# the whole tree ranked as "central" alongside real product code. `skills` is deliberately EXCLUDED
+# from this promotion (see the STRONG-3 shape-heuristic tests further below).
+# ---------------------------------------------------------------------------
+
+
+def test_strong0_vendor_name_fires_without_any_manifest(tmp_path: Path) -> None:
+    # M1: `vendor/` (an unambiguous STRONG-0 vendor name) now fires on the name ALONE -- no
+    # manifest required. Supersedes the old "name prior is only a tie-breaker" contract for these 5
+    # unambiguous names specifically.
     root = tmp_path.resolve()
     (root / "vendor").mkdir()
     rm = _rm(root, [root / "app.py", root / "vendor" / "lib.py"], {})
+    trees = _detect_vendored_subtrees(rm)
+    assert str(root / "vendor") in trees
+    info = trees[str(root / "vendor")]
+    assert "vendor-name-strong0:vendor" in info["reasons"]
+    assert not any(r.startswith("nested-manifest:") for r in info["reasons"])
+    assert info["ignore_glob"] == "vendor/**"
+
+
+def test_strong0_node_modules_fires_on_name_alone_task_scenario_a(tmp_path: Path) -> None:
+    # Task scenario (a): a whole `node_modules/` tree with NO nested manifest anywhere must be
+    # de-weighted and its root surfaced as a ready-to-paste `--ignore` glob.
+    root = tmp_path.resolve()
+    pkg_dir = root / "node_modules" / "left-pad"
+    pkg_dir.mkdir(parents=True)
+    lib = pkg_dir / "index.js"
+    lib.write_text("module.exports = () => {};\n")
+    rm = _rm(root, [root / "app.js", lib], {})
+
+    trees = _detect_vendored_subtrees(rm)
+
+    assert str(root / "node_modules") in trees
+    info = trees[str(root / "node_modules")]
+    assert "vendor-name-strong0:node_modules" in info["reasons"]
+    assert info["ignore_glob"] == "node_modules/**"
+
+
+def test_strong0_node_modules_deweights_central_score_but_keeps_the_file(tmp_path: Path) -> None:
+    # De-weight-not-exclude (task scenario d) for the NEW STRONG-0 vendor mechanism: a genuinely
+    # central file inside a bare (no-manifest) `node_modules/` tree still surfaces in central_files,
+    # just at a lowered (`_DEWEIGHT_FACTOR`-multiplied) score.
+    root = tmp_path.resolve()
+    pkg_dir = root / "node_modules" / "left-pad"
+    pkg_dir.mkdir(parents=True)
+    lib = pkg_dir / "index.js"
+    lib.write_text("module.exports = () => {};\n")
+    rm = _rm(root, [root / "app.js", lib], {})
+    rm["symbols"] = [{"name": f"Sym{i}", "kind": "function", "file": str(lib)} for i in range(4)]
+
+    raw = _central_files_from_map(rm, max_central_files=10, auto_deweight=False)
+    dew = _central_files_from_map(rm, max_central_files=10, auto_deweight=True)
+
+    lib_str = str(lib)
+    raw_lib = next(f for f in raw if f["file"] == lib_str)
+    dew_lib = next(
+        f for f in dew if f["file"] == lib_str
+    )  # still present -> de-weight, not exclude
+    assert raw_lib["score"] > 0
+    assert dew_lib["score"] == round(raw_lib["score"] * _DEWEIGHT_FACTOR, 6)
+
+
+# ---------------------------------------------------------------------------
+# M1: STRONG-3 `skills`-named directory SHAPE heuristic. Unlike the unambiguous STRONG-0 vendor
+# names above, `skills` stays AMBIGUOUS -- a repo's own feature/plugin package could plausibly be
+# named `skills/` -- so it is gated on the SHAPE of its immediate children (predominantly
+# self-contained leaf skills) plus a false-positive guard (nothing outside the tree imports into
+# it), not a bare name-alone promotion.
+# ---------------------------------------------------------------------------
+
+
+def test_skill_tree_of_many_leaf_skills_is_deweighted(tmp_path: Path) -> None:
+    # Task scenario (b): `core/skills/` has 3 immediate children, each a self-contained leaf skill
+    # (its own SKILL.md plus a small script) -- the whole tree fires on SHAPE alone.
+    root = tmp_path.resolve()
+    skills_dir = root / "core" / "skills"
+    files = [root / "app.py"]
+    for name in ("alpha", "beta", "gamma"):
+        leaf = skills_dir / name
+        leaf.mkdir(parents=True)
+        (leaf / "SKILL.md").write_text(f"# {name}\n")
+        script = leaf / "run.py"
+        script.write_text("def run():\n    pass\n")
+        files.append(script)
+    rm = _rm(root, files, {})
+
+    trees = _detect_vendored_subtrees(rm)
+
+    assert str(skills_dir) in trees
+    info = trees[str(skills_dir)]
+    assert "skill-tree-shape" in info["reasons"]
+    assert info["ignore_glob"] == "core/skills/**"
+
+
+def test_skill_tree_of_pure_markdown_leaf_skills_is_still_deweighted(tmp_path: Path) -> None:
+    # Regression: a skill tree whose leaves carry ONLY a SKILL.md (no accompanying code file at
+    # all -- a very common real-world shape, e.g. this repo's own `.claude/skills/*/SKILL.md`
+    # onboarding library) must still be reported. `_is_skill_leaf_tree` validates the SHAPE against
+    # the real filesystem child-directory listing, independent of the code-only `tree_files` used
+    # for the centrality de-weight multiplier -- an earlier draft of this fix silently dropped this
+    # exact case via a stale `if not tree_files: continue` guard that pre-dated STRONG-3.
+    root = tmp_path.resolve()
+    skills_dir = root / "core" / "skills"
+    files = [root / "app.py"]
+    for name in ("alpha", "beta", "gamma"):
+        leaf = skills_dir / name
+        leaf.mkdir(parents=True)
+        skill_md = leaf / "SKILL.md"
+        skill_md.write_text(f"# {name}\n")
+        files.append(skill_md)  # no accompanying code file in this leaf at all
+    rm = _rm(root, files, {})
+
+    trees = _detect_vendored_subtrees(rm)
+
+    assert str(skills_dir) in trees
+    assert "skill-tree-shape" in trees[str(skills_dir)]["reasons"]
+    assert trees[str(skills_dir)]["ignore_glob"] == "core/skills/**"
+
+
+def test_skill_tree_deweights_central_score_but_keeps_the_file(tmp_path: Path) -> None:
+    # De-weight-not-exclude (task scenario d) for the NEW STRONG-3 skill-tree-shape mechanism: a
+    # genuinely central file inside a detected skill-leaf tree still surfaces in central_files, just
+    # at a lowered score.
+    root = tmp_path.resolve()
+    skills_dir = root / "core" / "skills"
+    files = [root / "app.py"]
+    hub: Path | None = None
+    for name in ("alpha", "beta", "gamma"):
+        leaf = skills_dir / name
+        leaf.mkdir(parents=True)
+        (leaf / "SKILL.md").write_text(f"# {name}\n")
+        script = leaf / "run.py"
+        script.write_text("def run():\n    pass\n")
+        files.append(script)
+        if hub is None:
+            hub = script
+    assert hub is not None
+    rm = _rm(root, files, {})
+    rm["symbols"] = [{"name": f"Sym{i}", "kind": "function", "file": str(hub)} for i in range(4)]
+
+    raw = _central_files_from_map(rm, max_central_files=10, auto_deweight=False)
+    dew = _central_files_from_map(rm, max_central_files=10, auto_deweight=True)
+
+    hub_str = str(hub)
+    raw_hub = next(f for f in raw if f["file"] == hub_str)
+    dew_hub = next(
+        f for f in dew if f["file"] == hub_str
+    )  # still present -> de-weight, not exclude
+    assert raw_hub["score"] > 0
+    assert dew_hub["score"] == round(raw_hub["score"] * _DEWEIGHT_FACTOR, 6)
+
+
+def test_skips_skill_named_package_imported_across_repo(tmp_path: Path) -> None:
+    # Task scenario (c) -- the false-positive guard: `skills/plugin_a/` superficially LOOKS
+    # leaf-shaped (its own SKILL.md), but the tree as a whole IS imported from OUTSIDE it
+    # (`main.py` imports `plugin_a/handler.py`) -- a genuine product package, not a bundled/vendored
+    # skill library. Must NOT be de-weighted no matter how leaf-shaped its children look.
+    root = tmp_path.resolve()
+    skills_dir = root / "skills"
+    plugin = skills_dir / "plugin_a"
+    plugin.mkdir(parents=True)
+    (plugin / "SKILL.md").write_text("# plugin_a\n")
+    handler = plugin / "handler.py"
+    handler.write_text("def run():\n    pass\n")
+    main = root / "main.py"
+    rm = _rm(root, [main, handler], {main: ["handler"]})
+
+    assert _detect_vendored_subtrees(rm) == {}
+
+
+def test_skips_flat_skills_package_with_no_subdirectories(tmp_path: Path) -> None:
+    # A `skills/` package with flat `.py` files directly inside (no folder-per-skill layout) has NO
+    # children to score as "leaf skills" -- a real flat Python package named `skills/` is never
+    # mistaken for a bundle of independent skills.
+    root = tmp_path.resolve()
+    skills_dir = root / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "foo.py").write_text("def foo():\n    pass\n")
+    (skills_dir / "bar.py").write_text("def bar():\n    pass\n")
+    rm = _rm(
+        root,
+        [root / "app.py", skills_dir / "foo.py", skills_dir / "bar.py"],
+        {},
+    )
+
+    assert _detect_vendored_subtrees(rm) == {}
+
+
+def test_skill_tree_below_leaf_fraction_threshold_is_not_deweighted(tmp_path: Path) -> None:
+    # Only half (2 of 4) of the immediate children look like self-contained leaf skills -- below
+    # `_SKILL_LEAF_FRACTION_THRESHOLD` -- so the SHAPE check must not fire even though the tree as a
+    # whole is not imported from outside it.
+    root = tmp_path.resolve()
+    skills_dir = root / "skills"
+
+    real_skill = skills_dir / "real_skill"
+    real_skill.mkdir(parents=True)
+    (real_skill / "SKILL.md").write_text("# real_skill\n")
+
+    shared = skills_dir / "shared"
+    shared.mkdir(parents=True)
+    shared_util = shared / "util.py"
+    shared_util.write_text("def util():\n    pass\n")
+
+    consumer_a = skills_dir / "consumer_a"
+    consumer_a.mkdir(parents=True)
+    a_impl = consumer_a / "a_impl.py"
+    a_impl.write_text("def a():\n    pass\n")
+
+    consumer_b = skills_dir / "consumer_b"
+    consumer_b.mkdir(parents=True)
+    b_impl = consumer_b / "b_impl.py"
+    b_impl.write_text("def b():\n    pass\n")
+
+    rm = _rm(
+        root,
+        [root / "app.py", shared_util, a_impl, b_impl],
+        {a_impl: ["util"], b_impl: ["util"]},  # both consumers reach OUT to a sibling child
+    )
+
     assert _detect_vendored_subtrees(rm) == {}
 
 

--- a/tests/unit/test_orient_suggested_ignore.py
+++ b/tests/unit/test_orient_suggested_ignore.py
@@ -66,3 +66,86 @@ def test_suggested_ignore_glob_round_trips_through_apply_ignore_globs(tmp_path: 
     }
     filtered = _apply_ignore_globs(rm, (glob,))
     assert filtered["files"] == [str(tmp_path / "main.py")]
+
+
+# ---------------------------------------------------------------------------
+# M1: whole vendor/skill tree globs (not just nested-manifest islands).
+# ---------------------------------------------------------------------------
+
+
+def test_suggested_ignore_whole_vendor_tree_without_manifest(tmp_path: Path) -> None:
+    # Task scenario (a): a bare vendor tree (no nested manifest) must surface its OWN whole-tree
+    # glob in `suggested_ignore` -- not just a narrower nested-manifest island. Uses `third_party/`
+    # rather than `node_modules/`/`vendor/`/`external_repos/` deliberately: those three are ALSO in
+    # `repo_map._SKIP_DIR_NAMES`, so the repo-map WALKER never descends into them at all (a
+    # separate, pre-existing, stronger-than-deweight protection) -- a real end-to-end scan would
+    # never see their contents regardless of this fix, so they can't exercise the STRONG-0
+    # detection path end-to-end this way. `test_orient_deweight_vendored.py` covers all 5 STRONG-0
+    # vendor names (including `node_modules`) via a synthetic (walker-bypassing) `rm` fixture.
+    pkg_dir = tmp_path / "third_party" / "left-pad"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "index.js").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (tmp_path / "app.js").write_text("require('left-pad');\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] == ["third_party/**"]
+
+
+def test_suggested_ignore_whole_skill_tree_of_leaf_skills(tmp_path: Path) -> None:
+    # Task scenario (b): a `core/skills/` tree of many leaf skills (each its own SKILL.md + a small
+    # script) surfaces the WHOLE-tree glob, not a per-leaf breakdown.
+    skills_dir = tmp_path / "core" / "skills"
+    for name in ("alpha", "beta", "gamma"):
+        leaf = skills_dir / name
+        leaf.mkdir(parents=True)
+        (leaf / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+        (leaf / "run.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] == ["core/skills/**"]
+
+
+def test_suggested_ignore_dedups_nested_manifest_island_inside_skill_tree(tmp_path: Path) -> None:
+    # Task scenario 3 (dedup): `core/skills/` qualifies via the STRONG-3 shape heuristic AND one of
+    # its own children (`conpty-run/`) independently qualifies via a nested manifest (STRONG-1) --
+    # only the OUTER whole-tree glob must be emitted, never both `core/skills/**` AND the narrower
+    # `core/skills/conpty-run/**`.
+    skills_dir = tmp_path / "core" / "skills"
+    for name in ("alpha", "beta"):
+        leaf = skills_dir / name
+        leaf.mkdir(parents=True)
+        (leaf / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+        (leaf / "run.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    nested = skills_dir / "conpty-run"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text("# conpty-run\n", encoding="utf-8")
+    (nested / "package.json").write_text('{"name": "conpty-run"}\n', encoding="utf-8")
+    (nested / "index.js").write_text("module.exports = () => {};\n", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("def run():\n    pass\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] == ["core/skills/**"]
+
+
+def test_suggested_ignore_absent_for_genuine_skills_package_imported_across_repo(
+    tmp_path: Path,
+) -> None:
+    # Task scenario (c) -- the false-positive guard end-to-end: a genuine product `skills/` package
+    # imported from `main.py` must NOT appear in `suggested_ignore`, even though its one plugin
+    # subfolder is leaf-shaped (its own SKILL.md).
+    plugin = tmp_path / "skills" / "plugin_a"
+    plugin.mkdir(parents=True)
+    (plugin / "SKILL.md").write_text("# plugin_a\n", encoding="utf-8")
+    (plugin / "handler.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (tmp_path / "main.py").write_text("from skills.plugin_a.handler import run\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] is None
+    assert payload["deweighted_trees"] == []

--- a/tests/unit/test_orient_suggested_ignore.py
+++ b/tests/unit/test_orient_suggested_ignore.py
@@ -149,3 +149,43 @@ def test_suggested_ignore_absent_for_genuine_skills_package_imported_across_repo
 
     assert payload["suggested_ignore"] is None
     assert payload["deweighted_trees"] == []
+
+
+def test_suggested_ignore_absent_for_skills_package_via_subpackage_symbol_import(
+    tmp_path: Path,
+) -> None:
+    # Opus-gate MUST-FIX regression, end-to-end: a genuine product `skills/` package consumed via
+    # the COMMON idiom `from skills.auth import Auth` (symbol/subpackage import, subpackages carry
+    # `__init__.py`, no SKILL.md) must yield `suggested_ignore is None`. This is the exact form the
+    # stem-only import graph can't resolve -- pre-STRONG-3 `main` returned None here, so it is a
+    # regression the manifest-required + `__init__.py`-refusal guards must prevent.
+    for sub in ("auth", "db"):
+        pkg = tmp_path / "skills" / sub
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text(f"class {sub.capitalize()}:\n    pass\n", encoding="utf-8")
+    (tmp_path / "main.py").write_text(
+        "from skills.auth import Auth\n\ndef go():\n    return Auth()\n", encoding="utf-8"
+    )
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] is None
+    assert payload["deweighted_trees"] == []
+
+
+def test_suggested_ignore_absent_for_skills_dir_with_init_py(tmp_path: Path) -> None:
+    # Opus-gate MUST-FIX regression, end-to-end: a `skills/__init__.py` at the tree root is an
+    # unambiguous real-Python-package marker -- STRONG-3 is refused, `suggested_ignore is None`.
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "__init__.py").write_text("from .auth import Auth\n", encoding="utf-8")
+    leaf = skills_dir / "auth"
+    leaf.mkdir()
+    (leaf / "SKILL.md").write_text("# auth\n", encoding="utf-8")
+    (leaf / "impl.py").write_text("class Auth:\n    pass\n", encoding="utf-8")
+    (tmp_path / "main.py").write_text("from skills import Auth\n", encoding="utf-8")
+
+    payload = build_orient_capsule(tmp_path, max_tokens=500)
+
+    assert payload["suggested_ignore"] is None
+    assert payload["deweighted_trees"] == []


### PR DESCRIPTION
## Summary

CEO dogfood on tg 1.74.4 surfaced two coupled gaps in the auto-deweight / `suggested_ignore` machinery (`orient_capsule.py`, shipped in #164 for `.claude` tool-config dirs):

- **M1** — `_detect_vendored_subtrees`'s STRONG-1 nested-manifest gate missed a *broad* skill/vendor tree that has no manifest of its own (only nested-manifest **islands** inside it, e.g. `core/skills/use-gemini/conpty-run/package.json`, were ever detected). On a harness repo the whole `core/skills/**` tree still dominated `tg orient`'s top-10 `central_files` and never appeared in `suggested_ignore`.
- **M2** — `tg agent REPO "task" --json` never surfaced `suggested_ignore` at all (only `tg orient` did), even though `tg agent` already runs the identical de-weight during ranking (`_build_context_pack_from_map`'s own `auto_deweight` pass).

## Design

**M1 — two new detection tiers, `_DEWEIGHT_FACTOR` (0.25x, never a hard exclude) unchanged:**

1. **STRONG-0 promotion for 5 unambiguous names** (`_STRONG0_VENDOR_DIR_NAMES`): `node_modules`, `vendor`, `third_party`, `_vendored`, `external_repos`. These fire on the exact directory basename alone — no manifest, no import-island required — the same mechanism `_TOOL_CONFIG_DIR_NAMES` (`.claude`) already uses. These names are effectively *never* a repo's own product code.
2. **STRONG-3 shape heuristic for `skills`** (deliberately **excluded** from STRONG-0): a repo's own feature/plugin package could plausibly be named `skills/`, so bare-name promotion is unsafe. `_is_skill_leaf_tree` fires only when **both**:
   - most immediate children look like independent leaf skills — each carries its own `SKILL.md`/`skill.md`, or (fallback for a leaf with no manifest) none of its own code imports anything outside its own folder (`_child_is_self_contained_leaf`), at or above a 0.6 fraction threshold; **and**
   - the false-positive guard: nothing *outside* the tree imports *into* it (the same `externally_isolated` evidence STRONG-2 import-island detection already uses). A genuine product `skills/` package imported from `main.py` fails this and stays un-deweighted no matter how leaf-shaped its children look.

   A `skills/` directory with no subdirectories at all (flat `.py` files — a real package, not a folder-per-skill bundle) never matches (no children to score).

The whole-tree glob dedups against narrower nested-manifest islands via the existing outermost-nested-chain pass (e.g. `core/skills/**` swallows `core/skills/conpty-run/**`). Extracted the glob-list builder into a shared `_suggested_ignore_from_deweighted_trees` helper.

**Bug caught while testing STRONG-3:** the main per-candidate loop's `if not tree_files: continue` guard (`tree_files` = CODE files only) silently dropped an **all-Markdown** skill-leaf tree (each leaf only a `SKILL.md`, no code) even though `_is_skill_leaf_tree` had already validated its shape against the real filesystem child listing — a very common real-world skill-folder shape. Fixed by exempting `skill_leaf_dirs` from that specific guard; every other mechanism (manifest/tool-config/vendor-name/name-prior/import-island) keeps requiring a non-empty `tree_files`, matching pre-M1 behavior.

**M2** — `build_agent_capsule_from_map` now recomputes `_detect_vendored_subtrees` against the same (already `--ignore`-filtered) `rm` the ranking pass already used, and feeds it through orient's exact `_suggested_ignore_from_deweighted_trees` builder — never a second, independently hand-rolled hint that could drift from what `tg orient` says for the same repo. Additive-only: the key is present only when non-empty (mirrors `suggested_scope`'s existing convention) — no existing capsule key renamed or removed.

## Tests (TDD, written first)

- `tests/unit/test_orient_deweight_vendored.py` — STRONG-0 vendor-name promotion (fires without manifest, `vendor-name-strong0:*` reason, de-weight-not-exclude); STRONG-3 shape heuristic (many-leaf-skills fires, all-Markdown-leaf regression, below-fraction-threshold does not fire, flat no-subdirectory package does not fire, imported genuine package does not fire); updated the pre-existing "name prior alone never fires" test to use a neutral non-prior name (`vendor`/`node_modules` now intentionally DO fire alone — that's the M1 feature).
- `tests/unit/test_orient_suggested_ignore.py` — whole-tree glob emission for both new mechanisms, dedup of a nested-manifest island inside a STRONG-3 tree, false-positive guard end-to-end.
- `tests/unit/test_agent_capsule_suggested_ignore.py` (new) — `tg agent` vs `tg orient` parity for both mechanisms, absent-when-nothing-deweighted, false-positive guard, and composition with an explicit `--ignore`.

Two integration tests deliberately use `third_party`/`_vendored`/`external_repos` rather than `node_modules`/`vendor` for a **real filesystem scan**: `node_modules`, `vendor`, and `external_repos` are *also* in `repo_map._SKIP_DIR_NAMES` (a separate, pre-existing, stronger-than-deweight walker skip), so a real end-to-end scan never sees their contents regardless of this fix. The unit-level tests (synthetic `rm`, bypassing the walker) cover all 5 STRONG-0 names directly.

## Verification

- `uv sync --extra dev --extra ast` + `uv run maturin develop` (real `rust_core` build, not mocked).
- Targeted new/modified tests: 34 passed.
- Broader orient/agent-capsule regression suite (orient_capsule, agent_capsule hardcases/lsp/outbound-deps/tie-suggested-scope/token-budget, orient integration command): 104 passed.
- `uv run ruff check .` — clean. `uv run ruff format --check --preview .` — clean on all changed files (reverted 4 unrelated pre-existing whole-repo formatting drifts in `docs/*.md` picked up by the same whole-repo run, out of scope for this PR). `uv run mypy src/tensor_grep` — clean, 80 files.
- Manual dogfood against the real built `tg` binary on synthetic fixtures: `tg orient <repo> --json` and `tg agent <repo> "task" --json` both now list `core/skills/**` + `third_party/**` in `suggested_ignore` for a repo shaped like the CEO's dogfood target; a genuine `skills/` package imported from `main.py` correctly stays absent from `suggested_ignore` (`deweighted_trees: []`).

Not merging — for Opus ranking-safety gate + re-verification per the standing process.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
