### PR TITLE
fix(gpu): WSL probe path-domain bridging + cuda-check CI anti-rot gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,46 @@ jobs:
         working-directory: rust_core
         run: cargo test --verbose --no-default-features
 
+  # #171 anti-bit-rot gate: today the `cuda` cargo feature (rust_core/Cargo.toml `[features]`)
+  # only compiles inside `build-release-native-assets`'s nvidia legs, which are themselves
+  # `if:`-skipped unless RELEASE_NATIVE_ASSET_PROFILE == 'native-frontdoor-gpu' (not the default)
+  # -- so it can rot silently with zero PR-time signal. This is a fast `cargo check` (not a full
+  # build/test, no CUDA toolkit required) that runs on every PR so a break is caught immediately.
+  cuda-feature-check:
+    name: cuda-feature-check (${{ matrix.os }})
+    needs: smoke
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python for PyO3 Linker
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Create venv for PyO3
+        shell: bash
+        run: |
+          python -m venv .venv
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            echo "$GITHUB_WORKSPACE\.venv\Scripts" >> "$GITHUB_PATH"
+          else
+            echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: cargo check --features cuda
+        working-directory: rust_core
+        run: cargo check --features cuda
+
   search-golden-parity:
     name: search-golden-parity (windows-latest)
     needs: smoke
@@ -883,7 +923,7 @@ jobs:
 
   release:
     name: Semantic Release
-    needs: [smoke, release-readiness, agent-readiness, windows-agent-readiness, package-manager-readiness, static-analysis, test-python, test-rust-core, search-golden-parity, native-build-smoke, test-gpu-linux, benchmark-regression]
+    needs: [smoke, release-readiness, agent-readiness, windows-agent-readiness, package-manager-readiness, static-analysis, test-python, test-rust-core, cuda-feature-check, search-golden-parity, native-build-smoke, test-gpu-linux, benchmark-regression]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !contains(github.event.head_commit.message, 'skip release')
     runs-on: ubuntu-latest
     outputs:

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Any
 
 from tensor_grep.cli import repo_map
-from tensor_grep.cli.runtime_paths import resolve_native_tg_binary
+from tensor_grep.cli.runtime_paths import (
+    gpu_probe_timeout_s,
+    is_cross_domain_native_binary,
+    resolve_native_tg_binary,
+    translate_path_for_windows_binary,
+)
 from tensor_grep.core.retrieval_lexical import split_terms
 
 _CAPSULE_LSP_CONFIDENCE_BOOST_ENV = "TG_CAPSULE_LSP_CONFIDENCE_BOOST"
@@ -1344,6 +1349,12 @@ def _agent_gpu_evidence(
             "reason": str(exc),
         }
 
+    # GPU-P0-1 (#171): the agent twin of the doctor's WSL path-domain bug -- tg_command can
+    # resolve to a Windows-target binary that cannot open a Linux TemporaryDirectory path. Share
+    # the same detection/translation/timeout helpers as the doctor probe (no divergent copy).
+    cross_domain = is_cross_domain_native_binary(tg_command)
+    effective_timeout_s = gpu_probe_timeout_s(cross_domain=cross_domain, default_s=timeout_s)
+
     device_arg = ",".join(str(device_id) for device_id in requested_device_ids)
     with tempfile.TemporaryDirectory(prefix="tg-agent-gpu-probe-") as probe_tmp:
         probe_dir = Path(probe_tmp)
@@ -1351,6 +1362,22 @@ def _agent_gpu_evidence(
             "tg agent gpu probe sentinel\n",
             encoding="utf-8",
         )
+        probe_target = str(probe_dir)
+        if cross_domain:
+            translated = translate_path_for_windows_binary(probe_dir)
+            if translated is None:
+                return {
+                    "status": "path_domain_mismatch",
+                    "requested_device_ids": requested_device_ids,
+                    "used_for_evidence": False,
+                    "promotion_claim": False,
+                    "reason": (
+                        "resolved native tg binary targets Windows but this WSL host could not "
+                        "translate the probe path via wslpath (path-domain mismatch, not a GPU "
+                        "capability gap)"
+                    ),
+                }
+            probe_target = translated
         probe_command: list[object] = [
             tg_command,
             "search",
@@ -1359,9 +1386,9 @@ def _agent_gpu_evidence(
             "--json",
             "-F",
             "tg agent gpu probe sentinel",
-            str(probe_dir),
+            probe_target,
         ]
-        probe = _run_agent_gpu_json_command(probe_command, timeout_s=timeout_s)
+        probe = _run_agent_gpu_json_command(probe_command, timeout_s=effective_timeout_s)
 
     if probe["status"] != "ok":
         return {
@@ -1412,7 +1439,7 @@ def _agent_gpu_evidence(
     evidence_command.append(path)
     evidence = _run_agent_gpu_json_command(
         evidence_command,
-        timeout_s=timeout_s,
+        timeout_s=effective_timeout_s,
         valid_return_codes=(0, 1),
     )
     if evidence["status"] != "ok":

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -31,10 +31,13 @@ from tensor_grep.cli.runtime_paths import (
     _native_tg_version_matches,
     env_flag_disabled,
     env_flag_enabled,
+    gpu_probe_timeout_s,
+    is_cross_domain_native_binary,
     iter_in_tree_native_tg_binaries,
     native_frontdoor_metadata_path,
     resolve_native_tg_binary,
     resolve_ripgrep_binary,
+    translate_path_for_windows_binary,
 )
 from tensor_grep.core.observability import nvtx_range
 from tensor_grep.core.retrieval_chunker import MAX_CHUNKS
@@ -2674,10 +2677,29 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
         base["error"] = f"native tg binary does not exist: {native_tg_binary}"
         return base
 
+    # GPU-P0-1 (#171): on WSL, native_tg_binary can be a Windows-target binary that cannot
+    # resolve a Linux TemporaryDirectory path. Detect that cross-domain mismatch and bridge the
+    # sentinel path via wslpath before it becomes argv; the shared helper also raises the probe
+    # timeout floor since a WSL -> Windows exec can legitimately take longer.
+    cross_domain = is_cross_domain_native_binary(native_tg_binary)
+    probe_timeout_s = gpu_probe_timeout_s(cross_domain=cross_domain)
+
     sentinel = "tg doctor gpu runtime probe"
     with TemporaryDirectory(prefix="tg-doctor-gpu-probe-") as temp_dir:
         probe_file = Path(temp_dir) / "probe.log"
         probe_file.write_text(f"{sentinel}\n", encoding="utf-8")
+        probe_target = str(probe_file)
+        if cross_domain:
+            translated = translate_path_for_windows_binary(probe_file)
+            if translated is None:
+                base["status"] = "path_domain_mismatch"
+                base["error"] = (
+                    "resolved native tg binary targets Windows but this WSL host could not "
+                    "translate the probe path via wslpath (path-domain mismatch, not a GPU "
+                    "capability gap)"
+                )
+                return base
+            probe_target = translated
         command = [
             str(native_tg_binary),
             "search",
@@ -2687,7 +2709,7 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
             "--no-ignore",
             "-F",
             sentinel,
-            str(probe_file),
+            probe_target,
         ]
         base["command"] = " ".join([*command[:-1], "<doctor-gpu-probe-file>"])
         try:
@@ -2698,11 +2720,11 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
                 text=True,
                 encoding="utf-8",
                 errors="replace",
-                timeout=2.0,
+                timeout=probe_timeout_s,
             )
         except subprocess.TimeoutExpired:
             base["status"] = "failed"
-            base["error"] = "GPU runtime probe timed out after 2.0 seconds"
+            base["error"] = f"GPU runtime probe timed out after {probe_timeout_s:g} seconds"
             return base
         except OSError as exc:
             base["status"] = "failed"

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -286,6 +286,141 @@ def resolve_native_tg_binary() -> Path | None:
     return None
 
 
+# --- GPU-P0-1 (#171): WSL native-binary path-domain bridging ----------------------------------
+#
+# On WSL, resolve_native_tg_binary() can return a Windows-target binary (an explicit
+# TG_NATIVE_TG_BINARY override pointing at a `.exe` under `/mnt/<drive>/...`, or an in-tree build
+# produced by a Windows-side `cargo build` against a repo checkout shared over the same mount).
+# The GPU doctor/agent probes write a sentinel file under a Linux TemporaryDirectory (a
+# `/tmp/...`-style path) and pass it as argv to that binary. A Windows PE cannot resolve a
+# `/tmp/...` path -- a different filesystem namespace -- so the probe fails with a structured
+# `path_not_found` from the native binary, which reads as "no GPU support" even when the GPU route
+# itself may be fine. These helpers detect that mismatch and bridge it via `wslpath`, so the
+# doctor probe (cli/main.py) and the agent probe (cli/agent_capsule.py) share ONE implementation
+# instead of two divergent copies.
+
+#: Base GPU probe timeout (seconds) when host and resolved binary share a filesystem domain.
+DEFAULT_GPU_PROBE_TIMEOUT_S = 2.0
+
+#: Floor applied when the resolved native binary is cross-domain (WSL host, Windows binary) -- a
+#: WSL -> Windows exec crosses an interop boundary that can legitimately exceed the same-domain
+#: default.
+CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S = 6.0
+
+_WSLPATH_TRANSLATE_TIMEOUT_S = 2.0
+
+_WINDOWS_DRVFS_MOUNT_RE = re.compile(r"^/mnt/[a-zA-Z](?:/|$)")
+
+
+def is_wsl_host() -> bool:
+    """True when this process is running inside a WSL (1 or 2) Linux environment.
+
+    This is a NARROWER check than "any Linux box" -- it only adds the "genuinely WSL" signal on
+    top of the `sys.platform.startswith("linux")` gate already applied by callers, so a
+    `.exe`-suffixed path used by an unrelated fixture on a bare Linux CI runner (no WSL) is never
+    misread as a real WSL path-domain mismatch. `WSL_DISTRO_NAME`/`WSL_INTEROP` are set by WSL
+    itself in every real WSL session and are the standard, filesystem-read-free way to detect it;
+    `/run/WSL` (also used by `core.hardware.device_detect`) is the fallback for a stripped
+    subprocess environment that dropped those variables.
+    """
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    return os.path.exists("/run/WSL")
+
+
+def native_binary_targets_windows(binary: Path | str) -> bool:
+    """True when `binary`'s path shape looks like a Windows-target executable.
+
+    Either signal alone is sufficient: a `.exe` suffix cannot be a native Linux ELF or macOS
+    Mach-O binary regardless of where it lives on disk, and a path rooted at `/mnt/<drive>/` is
+    the WSL2 drvfs mount of a Windows drive -- nothing genuinely native to the WSL Linux
+    filesystem lives there.
+    """
+    text = str(binary).replace("\\", "/")
+    if text.lower().endswith(".exe"):
+        return True
+    return _WINDOWS_DRVFS_MOUNT_RE.match(text) is not None
+
+
+def is_cross_domain_native_binary(binary: Path | str | None) -> bool:
+    """True when the host is Linux/WSL but the resolved native `tg` binary targets Windows.
+
+    Requires ALL THREE: a Linux host (`sys.platform`), a genuine WSL signal (`is_wsl_host()`),
+    and a Windows-shaped binary path (`native_binary_targets_windows()`). Dropping the WSL-signal
+    check would false-positive on any bare Linux CI runner whose test fixtures happen to use a
+    `.exe`-suffixed name for unrelated reasons; dropping the platform check would be redundant but
+    harmless. The downstream `wslpath` lookup also fails closed (returns None) when unavailable,
+    so even a false positive here degrades to the honest `path_domain_mismatch` status rather than
+    a silently wrong argv.
+    """
+    if binary is None:
+        return False
+    if not sys.platform.startswith("linux"):
+        return False
+    if not is_wsl_host():
+        return False
+    return native_binary_targets_windows(binary)
+
+
+def translate_path_for_windows_binary(
+    path: Path | str, *, timeout_s: float = _WSLPATH_TRANSLATE_TIMEOUT_S
+) -> str | None:
+    """Translate a Linux-side path to a form a Windows binary can open, via `wslpath -w`.
+
+    Works both for a path under a drive mount (translates to the Windows drive-letter form) and a
+    path purely inside the WSL VM filesystem such as `/tmp/...` (translates to a UNC path served
+    over the WSL network redirector, which Windows can read while the distro is running). Returns
+    None -- never raises -- when `wslpath` is not on PATH, times out, or exits non-zero, so the
+    caller can report a distinct `path_domain_mismatch` status instead of silently handing the
+    Windows binary a Linux path it cannot open.
+    """
+    wslpath_bin = shutil.which("wslpath")
+    if wslpath_bin is None:
+        return None
+    try:
+        result = subprocess.run(
+            [wslpath_bin, "-w", str(path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_s,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    translated = result.stdout.strip()
+    return translated or None
+
+
+def gpu_probe_timeout_s(
+    *, cross_domain: bool = False, default_s: float = DEFAULT_GPU_PROBE_TIMEOUT_S
+) -> float:
+    """Resolve the GPU probe subprocess timeout (seconds).
+
+    `TENSOR_GREP_GPU_PROBE_TIMEOUT_S` always wins when set to a valid positive float -- one
+    operator-level knob shared by the doctor probe and the agent probe (no divergent copy).
+    Absent an override, `default_s` applies unless `cross_domain` is set, in which case the floor
+    is raised to at least `CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S` (a WSL -> Windows exec can
+    legitimately exceed the same-domain default; #171 GPU-P0-1). Passing the caller's own existing
+    default as `default_s` (e.g. the agent capsule's `--gpu-timeout-s`) means an explicit,
+    already-generous caller value is never lowered by the cross-domain floor -- only ever raised
+    when it would otherwise be too tight.
+    """
+    raw = os.environ.get("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", "").strip()
+    if raw:
+        try:
+            override = float(raw)
+        except ValueError:
+            override = 0.0
+        if override > 0:
+            return override
+    if cross_domain:
+        return max(default_s, CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S)
+    return default_s
+
+
 @lru_cache(maxsize=1)
 def resolve_ripgrep_binary() -> Path | None:
     binary_name = "rg.exe" if sys.platform.startswith("win") else "rg"

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -288,16 +288,24 @@ def resolve_native_tg_binary() -> Path | None:
 
 # --- GPU-P0-1 (#171): WSL native-binary path-domain bridging ----------------------------------
 #
-# On WSL, resolve_native_tg_binary() can return a Windows-target binary (an explicit
-# TG_NATIVE_TG_BINARY override pointing at a `.exe` under `/mnt/<drive>/...`, or an in-tree build
-# produced by a Windows-side `cargo build` against a repo checkout shared over the same mount).
-# The GPU doctor/agent probes write a sentinel file under a Linux TemporaryDirectory (a
-# `/tmp/...`-style path) and pass it as argv to that binary. A Windows PE cannot resolve a
-# `/tmp/...` path -- a different filesystem namespace -- so the probe fails with a structured
-# `path_not_found` from the native binary, which reads as "no GPU support" even when the GPU route
-# itself may be fine. These helpers detect that mismatch and bridge it via `wslpath`, so the
-# doctor probe (cli/main.py) and the agent probe (cli/agent_capsule.py) share ONE implementation
-# instead of two divergent copies.
+# On WSL, resolve_native_tg_binary() can return a Windows-target binary: an explicit
+# TG_NATIVE_TG_BINARY override pointing at a `.exe`, or an in-tree `tg.exe` produced by a
+# Windows-side `cargo build` against a repo checkout shared over a `/mnt/<drive>/...` mount. In
+# EVERY such case the binary carries the `.exe` suffix -- a Windows PE is not executable via the
+# Win32 loader or the WSL binfmt interop handler without it. The GPU doctor/agent probes write a
+# sentinel file under a Linux TemporaryDirectory (a `/tmp/...`-style path) and pass it as argv to
+# that binary. A Windows PE cannot resolve a `/tmp/...` path -- a different filesystem namespace --
+# so the probe fails with a structured `path_not_found` from the native binary, which reads as "no
+# GPU support" even when the GPU route itself may be fine. These helpers detect that mismatch and
+# bridge it via `wslpath`, so the doctor probe (cli/main.py) and the agent probe
+# (cli/agent_capsule.py) share ONE implementation instead of two divergent copies.
+#
+# The detection keys on the `.exe` suffix ALONE, deliberately NOT on a `/mnt/<drive>/` location:
+# a WSL user who checks the repo out on a Windows drive and runs the LINUX `maturin develop` /
+# `cargo build` there gets a genuine Linux ELF at `/mnt/c/.../rust_core/target/release/tg` (no
+# `.exe`), which the default resolver returns (it looks for `tg`, not `tg.exe`, on Linux). That
+# ELF is same-domain -- it opens the `/tmp` sentinel fine -- so translating its path would BREAK a
+# working config. The `.exe` suffix is both necessary and sufficient for a real Windows target.
 
 #: Base GPU probe timeout (seconds) when host and resolved binary share a filesystem domain.
 DEFAULT_GPU_PROBE_TIMEOUT_S = 2.0
@@ -308,8 +316,6 @@ DEFAULT_GPU_PROBE_TIMEOUT_S = 2.0
 CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S = 6.0
 
 _WSLPATH_TRANSLATE_TIMEOUT_S = 2.0
-
-_WINDOWS_DRVFS_MOUNT_RE = re.compile(r"^/mnt/[a-zA-Z](?:/|$)")
 
 
 def is_wsl_host() -> bool:
@@ -329,17 +335,16 @@ def is_wsl_host() -> bool:
 
 
 def native_binary_targets_windows(binary: Path | str) -> bool:
-    """True when `binary`'s path shape looks like a Windows-target executable.
+    """True when `binary` is a Windows-target executable, keyed on the `.exe` suffix ALONE.
 
-    Either signal alone is sufficient: a `.exe` suffix cannot be a native Linux ELF or macOS
-    Mach-O binary regardless of where it lives on disk, and a path rooted at `/mnt/<drive>/` is
-    the WSL2 drvfs mount of a Windows drive -- nothing genuinely native to the WSL Linux
-    filesystem lives there.
+    The `.exe` suffix is both necessary and sufficient: a Windows PE cannot be exec'd via the
+    Win32 loader or the WSL binfmt interop handler without it, and nothing native to a Linux/macOS
+    filesystem carries it. A `/mnt/<drive>/` location is deliberately NOT treated as a Windows
+    signal -- a Linux ELF built in-place on a Windows-drive checkout (the default resolver returns
+    `/mnt/c/.../tg`, no `.exe`) lives there too and is same-domain, so flagging it would break a
+    working WSL config (Opus MF-1).
     """
-    text = str(binary).replace("\\", "/")
-    if text.lower().endswith(".exe"):
-        return True
-    return _WINDOWS_DRVFS_MOUNT_RE.match(text) is not None
+    return str(binary).lower().endswith(".exe")
 
 
 def is_cross_domain_native_binary(binary: Path | str | None) -> bool:

--- a/tests/unit/test_agent_capsule_gpu_probe.py
+++ b/tests/unit/test_agent_capsule_gpu_probe.py
@@ -1,0 +1,190 @@
+"""GPU-P0-1 (#171): the agent capsule's GPU evidence probe is the twin of the doctor's WSL
+path-domain bridging bug -- `_agent_gpu_tg_command()` can resolve to a Windows-target binary that
+cannot open a Linux TemporaryDirectory path. These tests exercise the AGENT-SIDE wiring by
+monkeypatching the shared runtime_paths collaborators directly; the collaborators' own detection/
+translation/timeout logic is unit-tested exhaustively in tests/unit/test_runtime_paths.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tensor_grep.cli import agent_capsule
+from tensor_grep.cli.runtime_paths import CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S
+
+
+def _fake_native_gpu_payload() -> dict[str, Any]:
+    return {
+        "routing_backend": "NativeGpuBackend",
+        "routing_reason": "gpu-device-ids-explicit",
+        "sidecar_used": False,
+        "routing_gpu_device_ids": [0],
+        "matches": [],
+        "total_matches": 0,
+    }
+
+
+def test_agent_gpu_evidence_cross_domain_translates_probe_path(monkeypatch, tmp_path):
+    translated_path = "C:\\Users\\x\\AppData\\Local\\Temp\\tg-agent-gpu-probe-abc"
+
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(
+        agent_capsule, "translate_path_for_windows_binary", lambda _path: translated_path
+    )
+
+    captured_calls: list[list[str]] = []
+
+    def _fake_run(command, **_kwargs):
+        captured_calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    result = agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert captured_calls, "expected the probe to shell out at least once"
+    # The LAST argv element of the probe call is the sentinel path -- it must be the TRANSLATED
+    # Windows path, not the raw Linux TemporaryDirectory path the sentinel was written under.
+    assert captured_calls[0][-1] == translated_path
+    assert result["status"] != "path_domain_mismatch"
+    assert result["status"] != "failed"
+
+
+def test_agent_gpu_evidence_path_domain_mismatch_when_translation_unavailable(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(agent_capsule, "translate_path_for_windows_binary", lambda _path: None)
+
+    def _fake_run(command, **_kwargs):
+        raise AssertionError(
+            "must not shell out to the native binary when wslpath translation is unavailable -- "
+            "the path would be unresolvable and misreport as a generic GPU failure"
+        )
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    result = agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert result["status"] == "path_domain_mismatch"
+    assert result["used_for_evidence"] is False
+    assert result["promotion_claim"] is False
+    assert "wslpath" in result["reason"]
+
+
+def test_agent_gpu_evidence_same_domain_is_unaffected(monkeypatch, tmp_path):
+    """Cross-domain detection false (the common case) leaves argv/behavior exactly as before."""
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/usr/local/bin/tg")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: False)
+
+    def _fail_translate(_path):
+        raise AssertionError("must not be called when cross_domain is False")
+
+    monkeypatch.setattr(agent_capsule, "translate_path_for_windows_binary", _fail_translate)
+
+    captured_calls: list[list[str]] = []
+
+    def _fake_run(command, **_kwargs):
+        captured_calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    result = agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert result["status"] != "path_domain_mismatch"
+    assert "tg-agent-gpu-probe-" in captured_calls[0][-1]
+
+
+def test_agent_gpu_evidence_cross_domain_raises_timeout_floor(monkeypatch, tmp_path):
+    monkeypatch.delenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", raising=False)
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(
+        agent_capsule, "translate_path_for_windows_binary", lambda _path: "C:\\translated"
+    )
+
+    captured_kwargs: list[dict[str, Any]] = []
+
+    def _fake_run(command, **kwargs):
+        captured_kwargs.append(kwargs)
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    # The CLI's own --gpu-timeout-s default (5.0) is smaller than the cross-domain floor -- the
+    # shared helper must raise it, not silently time out on a WSL -> Windows interop exec.
+    agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert captured_kwargs[0]["timeout"] == pytest.approx(CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S)
+
+
+def test_agent_gpu_evidence_cross_domain_keeps_larger_explicit_timeout(monkeypatch, tmp_path):
+    monkeypatch.delenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", raising=False)
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(
+        agent_capsule, "translate_path_for_windows_binary", lambda _path: "C:\\translated"
+    )
+
+    captured_kwargs: list[dict[str, Any]] = []
+
+    def _fake_run(command, **kwargs):
+        captured_kwargs.append(kwargs)
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    # An explicit --gpu-timeout-s already above the cross-domain floor must never be LOWERED.
+    agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=30.0
+    )
+
+    assert captured_kwargs[0]["timeout"] == pytest.approx(30.0)
+
+
+def test_agent_gpu_evidence_timeout_env_override_honored(monkeypatch, tmp_path):
+    monkeypatch.setenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", "12.5")
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/usr/local/bin/tg")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: False)
+
+    captured_kwargs: list[dict[str, Any]] = []
+
+    def _fake_run(command, **kwargs):
+        captured_kwargs.append(kwargs)
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert captured_kwargs[0]["timeout"] == pytest.approx(12.5)

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2184,6 +2184,128 @@ def test_doctor_gpu_runtime_probe_redacts_temp_probe_path(monkeypatch, tmp_path:
     assert "<doctor-gpu-probe-file>" in probe["command"]
 
 
+# GPU-P0-1 (#171): WSL path-domain bridging for the doctor's GPU runtime probe. These monkeypatch
+# the collaborator functions directly (rather than simulating a real WSL host) so they exercise
+# ONLY the doctor-probe wiring; the cross-domain detection/translation logic itself is unit-tested
+# exhaustively in tests/unit/test_runtime_paths.py.
+def test_doctor_gpu_runtime_probe_cross_domain_translates_probe_path(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+    translated_path = "C:\\Users\\x\\AppData\\Local\\Temp\\tg-doctor-gpu-probe-abc\\probe.log"
+
+    monkeypatch.setattr("tensor_grep.cli.main.is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main.translate_path_for_windows_binary",
+        lambda _path: translated_path,
+    )
+
+    captured_command: list[str] = []
+
+    def _fake_run(command, **_kwargs):
+        captured_command.extend(command)
+        payload = {
+            "routing_backend": "NativeGpuBackend",
+            "routing_reason": "gpu-device-ids-explicit",
+            "sidecar_used": False,
+            "routing_gpu_device_ids": [0],
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "supported"
+    # The LAST argv element is the sentinel path -- it must be the TRANSLATED Windows path, not
+    # the raw Linux TemporaryDirectory path the sentinel file was actually written under.
+    assert captured_command[-1] == translated_path
+
+
+def test_doctor_gpu_runtime_probe_path_domain_mismatch_when_translation_unavailable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    monkeypatch.setattr("tensor_grep.cli.main.is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main.translate_path_for_windows_binary", lambda _path: None
+    )
+
+    def _fake_run(command, **_kwargs):
+        raise AssertionError(
+            "must not shell out to the native binary when wslpath translation "
+            "is unavailable -- the path would be unresolvable and misreport as a GPU failure"
+        )
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "path_domain_mismatch"
+    assert probe["error"]
+    assert "wslpath" in probe["error"]
+
+
+def test_doctor_gpu_runtime_probe_same_domain_is_unaffected(monkeypatch, tmp_path: Path) -> None:
+    """Cross-domain detection false (the common case) leaves argv/behavior exactly as before."""
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    monkeypatch.setattr("tensor_grep.cli.main.is_cross_domain_native_binary", lambda _binary: False)
+
+    def _fail_translate(_path):
+        raise AssertionError("must not be called when cross_domain is False")
+
+    monkeypatch.setattr("tensor_grep.cli.main.translate_path_for_windows_binary", _fail_translate)
+
+    captured_command: list[str] = []
+
+    def _fake_run(command, **_kwargs):
+        captured_command.extend(command)
+        payload = {
+            "routing_backend": "NativeGpuBackend",
+            "routing_reason": "gpu-device-ids-explicit",
+            "sidecar_used": False,
+            "routing_gpu_device_ids": [0],
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "supported"
+    assert "tg-doctor-gpu-probe-" in captured_command[-1]
+
+
+def test_doctor_gpu_runtime_probe_timeout_env_override_honored(monkeypatch, tmp_path: Path) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+    monkeypatch.setenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", "17.5")
+
+    captured_kwargs: dict = {}
+
+    def _fake_run(command, **kwargs):
+        captured_kwargs.update(kwargs)
+        payload = {
+            "routing_backend": "NativeGpuBackend",
+            "routing_reason": "gpu-device-ids-explicit",
+            "sidecar_used": False,
+            "routing_gpu_device_ids": [0],
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "supported"
+    assert captured_kwargs["timeout"] == pytest.approx(17.5)
+
+
 def test_doctor_json_reports_native_version_mismatch(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.8.1")
     monkeypatch.setattr(

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -1,6 +1,8 @@
 import importlib.metadata
 import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -522,3 +524,214 @@ def test_mcp_sidecar_env_propagation():
         assert "env" in kwargs
         assert "TG_SIDECAR_PYTHON" in kwargs["env"]
         assert kwargs["env"]["TG_SIDECAR_PYTHON"] == sys.executable
+
+
+# ---------------------------------------------------------------------------
+# GPU-P0-1 (#171): WSL native-binary path-domain bridging
+# ---------------------------------------------------------------------------
+
+
+class TestNativeBinaryTargetsWindows:
+    def test_exe_suffix_is_windows_target(self):
+        assert runtime_paths.native_binary_targets_windows("/mnt/c/Users/x/tg.exe") is True
+        assert runtime_paths.native_binary_targets_windows(Path("/some/path/tg.exe")) is True
+        assert runtime_paths.native_binary_targets_windows("/some/path/TG.EXE") is True
+
+    def test_mnt_drive_mount_is_windows_target(self):
+        assert runtime_paths.native_binary_targets_windows("/mnt/c/tg") is True
+        assert runtime_paths.native_binary_targets_windows("/mnt/d/tools/tg") is True
+
+    def test_plain_linux_path_is_not_windows_target(self):
+        assert runtime_paths.native_binary_targets_windows("/usr/local/bin/tg") is False
+        assert (
+            runtime_paths.native_binary_targets_windows(
+                "/home/user/repo/rust_core/target/release/tg"
+            )
+            is False
+        )
+
+    def test_lookalike_path_without_mnt_prefix_is_not_windows_target(self):
+        # "/mount/c/tg" and "/mnt2/c/tg" must not false-positive on a loose substring match.
+        assert runtime_paths.native_binary_targets_windows("/mount/c/tg") is False
+        assert runtime_paths.native_binary_targets_windows("/mnt2/c/tg") is False
+
+
+class TestIsWslHost:
+    def test_true_when_wsl_distro_name_set(self, monkeypatch):
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        assert runtime_paths.is_wsl_host() is True
+
+    def test_true_when_wsl_interop_set(self, monkeypatch):
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.setenv("WSL_INTEROP", "/run/WSL/1_interop")
+        assert runtime_paths.is_wsl_host() is True
+
+    def test_true_when_run_wsl_exists_without_env_signal(self, monkeypatch):
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.delenv("WSL_INTEROP", raising=False)
+        original_exists = os.path.exists
+        monkeypatch.setattr(
+            runtime_paths.os.path,
+            "exists",
+            lambda p: True if p == "/run/WSL" else original_exists(p),
+        )
+        assert runtime_paths.is_wsl_host() is True
+
+    def test_false_on_plain_linux_without_any_wsl_signal(self, monkeypatch):
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.delenv("WSL_INTEROP", raising=False)
+        original_exists = os.path.exists
+        monkeypatch.setattr(
+            runtime_paths.os.path,
+            "exists",
+            lambda p: False if p == "/run/WSL" else original_exists(p),
+        )
+        assert runtime_paths.is_wsl_host() is False
+
+
+class TestIsCrossDomainNativeBinary:
+    def test_false_when_binary_is_none(self):
+        assert runtime_paths.is_cross_domain_native_binary(None) is False
+
+    def test_false_on_non_linux_host_even_with_windows_shaped_path(self, monkeypatch):
+        monkeypatch.setattr(runtime_paths.sys, "platform", "win32")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        assert runtime_paths.is_cross_domain_native_binary("/mnt/c/tg.exe") is False
+
+    def test_false_on_bare_linux_ci_runner_without_wsl_signal(self, monkeypatch, tmp_path):
+        """Regression guard: a Linux CI fixture that happens to name a binary `tg.exe` must NOT
+        be misread as a WSL cross-domain binary just because of the host platform -- only a
+        genuine WSL signal (env var or /run/WSL) may trigger cross-domain handling."""
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.delenv("WSL_INTEROP", raising=False)
+        original_exists = os.path.exists
+        monkeypatch.setattr(
+            runtime_paths.os.path,
+            "exists",
+            lambda p: False if p == "/run/WSL" else original_exists(p),
+        )
+        native_tg = tmp_path / "tg.exe"
+        assert runtime_paths.is_cross_domain_native_binary(native_tg) is False
+
+    def test_true_on_wsl_host_with_windows_target_binary(self, monkeypatch):
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        binary = Path("/mnt/c/Users/x/.tensor-grep/bin/tg.exe")
+        assert runtime_paths.is_cross_domain_native_binary(binary) is True
+
+    def test_false_on_wsl_host_with_native_linux_binary(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        native_tg = tmp_path / "rust_core" / "target" / "release" / "tg"
+        assert runtime_paths.is_cross_domain_native_binary(native_tg) is False
+
+
+class TestTranslatePathForWindowsBinary:
+    def test_returns_translated_path_when_wslpath_succeeds(self, monkeypatch, tmp_path):
+        probe_file = tmp_path / "probe.log"
+        probe_file.write_text("sentinel\n", encoding="utf-8")
+        monkeypatch.setattr(
+            runtime_paths.shutil,
+            "which",
+            lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
+        )
+
+        def fake_run(command, **_kwargs):
+            assert command[0] == "/usr/bin/wslpath"
+            assert command[1] == "-w"
+            return subprocess.CompletedProcess(
+                command, 0, "C:\\Users\\x\\AppData\\Local\\Temp\\probe.log\r\n", ""
+            )
+
+        monkeypatch.setattr(runtime_paths.subprocess, "run", fake_run)
+
+        translated = runtime_paths.translate_path_for_windows_binary(probe_file)
+        assert translated == "C:\\Users\\x\\AppData\\Local\\Temp\\probe.log"
+
+    def test_returns_none_when_wslpath_absent(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(runtime_paths.shutil, "which", lambda _name: None)
+        assert runtime_paths.translate_path_for_windows_binary(tmp_path / "probe.log") is None
+
+    def test_returns_none_on_nonzero_exit(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            runtime_paths.shutil,
+            "which",
+            lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
+        )
+        monkeypatch.setattr(
+            runtime_paths.subprocess,
+            "run",
+            lambda command, **_kwargs: subprocess.CompletedProcess(command, 1, "", "no such path"),
+        )
+        assert runtime_paths.translate_path_for_windows_binary(tmp_path / "probe.log") is None
+
+    def test_returns_none_on_timeout(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            runtime_paths.shutil,
+            "which",
+            lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
+        )
+
+        def raise_timeout(command, **_kwargs):
+            raise subprocess.TimeoutExpired(cmd=command, timeout=2.0)
+
+        monkeypatch.setattr(runtime_paths.subprocess, "run", raise_timeout)
+        assert runtime_paths.translate_path_for_windows_binary(tmp_path / "probe.log") is None
+
+    def test_returns_none_on_os_error(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            runtime_paths.shutil,
+            "which",
+            lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
+        )
+
+        def raise_os_error(command, **_kwargs):
+            raise OSError("exec format error")
+
+        monkeypatch.setattr(runtime_paths.subprocess, "run", raise_os_error)
+        assert runtime_paths.translate_path_for_windows_binary(tmp_path / "probe.log") is None
+
+
+class TestGpuProbeTimeoutS:
+    def test_default_when_not_cross_domain_and_no_override(self, monkeypatch):
+        monkeypatch.delenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", raising=False)
+        assert runtime_paths.gpu_probe_timeout_s(cross_domain=False) == pytest.approx(2.0)
+
+    def test_cross_domain_raises_floor_above_small_default(self, monkeypatch):
+        monkeypatch.delenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", raising=False)
+        assert runtime_paths.gpu_probe_timeout_s(cross_domain=True) == pytest.approx(
+            runtime_paths.CROSS_DOMAIN_GPU_PROBE_TIMEOUT_S
+        )
+
+    def test_cross_domain_keeps_a_larger_explicit_default(self, monkeypatch):
+        monkeypatch.delenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", raising=False)
+        assert runtime_paths.gpu_probe_timeout_s(
+            cross_domain=True, default_s=30.0
+        ) == pytest.approx(30.0)
+
+    def test_env_override_honored_regardless_of_cross_domain(self, monkeypatch):
+        monkeypatch.setenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", "9.5")
+        assert runtime_paths.gpu_probe_timeout_s(cross_domain=False) == pytest.approx(9.5)
+        assert runtime_paths.gpu_probe_timeout_s(cross_domain=True) == pytest.approx(9.5)
+
+    def test_env_override_invalid_value_falls_back_to_default_logic(self, monkeypatch):
+        monkeypatch.setenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", "banana")
+        assert runtime_paths.gpu_probe_timeout_s(cross_domain=False) == pytest.approx(2.0)
+
+    def test_env_override_non_positive_value_falls_back_to_default_logic(self, monkeypatch):
+        monkeypatch.setenv("TENSOR_GREP_GPU_PROBE_TIMEOUT_S", "0")
+        assert runtime_paths.gpu_probe_timeout_s(cross_domain=False) == pytest.approx(2.0)
+
+
+@pytest.mark.skipif(
+    shutil.which("wslpath") is None, reason="requires a real WSL host with wslpath on PATH"
+)
+def test_translate_path_for_windows_binary_real_wslpath_smoke(tmp_path):
+    """Integration smoke test against the REAL wslpath binary -- only runs on an actual WSL
+    host; every other test above is fully monkeypatched and platform-independent."""
+    probe_file = tmp_path / "probe.log"
+    probe_file.write_text("sentinel\n", encoding="utf-8")
+    translated = runtime_paths.translate_path_for_windows_binary(probe_file)
+    assert translated is not None
+    assert translated.strip() != ""

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -537,9 +537,18 @@ class TestNativeBinaryTargetsWindows:
         assert runtime_paths.native_binary_targets_windows(Path("/some/path/tg.exe")) is True
         assert runtime_paths.native_binary_targets_windows("/some/path/TG.EXE") is True
 
-    def test_mnt_drive_mount_is_windows_target(self):
-        assert runtime_paths.native_binary_targets_windows("/mnt/c/tg") is True
-        assert runtime_paths.native_binary_targets_windows("/mnt/d/tools/tg") is True
+    def test_mnt_drive_mount_without_exe_is_not_windows_target(self):
+        # Opus MF-1: a `/mnt/<drive>/` location is NOT itself a Windows signal. A Linux ELF built
+        # in-place on a Windows-drive checkout lives here (the default resolver returns `tg`, not
+        # `tg.exe`, on Linux) and is same-domain -- flagging it would break a working WSL config.
+        assert runtime_paths.native_binary_targets_windows("/mnt/c/tg") is False
+        assert runtime_paths.native_binary_targets_windows("/mnt/d/tools/tg") is False
+        assert (
+            runtime_paths.native_binary_targets_windows(
+                "/mnt/c/dev/tensor-grep/rust_core/target/release/tg"
+            )
+            is False
+        )
 
     def test_plain_linux_path_is_not_windows_target(self):
         assert runtime_paths.native_binary_targets_windows("/usr/local/bin/tg") is False
@@ -549,11 +558,6 @@ class TestNativeBinaryTargetsWindows:
             )
             is False
         )
-
-    def test_lookalike_path_without_mnt_prefix_is_not_windows_target(self):
-        # "/mount/c/tg" and "/mnt2/c/tg" must not false-positive on a loose substring match.
-        assert runtime_paths.native_binary_targets_windows("/mount/c/tg") is False
-        assert runtime_paths.native_binary_targets_windows("/mnt2/c/tg") is False
 
 
 class TestIsWslHost:
@@ -625,6 +629,19 @@ class TestIsCrossDomainNativeBinary:
         monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
         native_tg = tmp_path / "rust_core" / "target" / "release" / "tg"
         assert runtime_paths.is_cross_domain_native_binary(native_tg) is False
+
+    def test_false_on_wsl_host_with_linux_elf_on_windows_drive_mount(self, monkeypatch):
+        """Opus MF-1 regression: the DEFAULT resolver on WSL looks for `tg` (not `tg.exe`), so a
+        repo checked out + built in-place on a Windows drive yields a genuine Linux ELF at
+        `/mnt/c/.../rust_core/target/release/tg`. That binary is same-domain -- it opens a `/tmp`
+        sentinel fine -- so it must NOT be flagged cross-domain (which would translate its `/tmp`
+        path to a UNC path the Linux ELF cannot open, breaking a config that worked pre-PR). CI
+        was green without this test; the earlier `/mnt`-disjunct implementation returned True
+        here."""
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        linux_elf_on_mount = Path("/mnt/c/dev/tensor-grep/rust_core/target/release/tg")
+        assert runtime_paths.is_cross_domain_native_binary(linux_elf_on_mount) is False
 
 
 class TestTranslatePathForWindowsBinary:


### PR DESCRIPTION
## Summary

Two independently-reviewable changes from the GPU Phase-0 audit (#171):

**Part A -- `fix(gpu):`** WSL path-domain bridging for the GPU probes
- On WSL, `resolve_native_tg_binary()` can return a Windows-target binary (an explicit `TG_NATIVE_TG_BINARY` override, or an in-tree build reachable over `/mnt/<drive>/...`). Both the doctor probe (`_doctor_gpu_search_runtime_probe`, `src/tensor_grep/cli/main.py`) and the agent probe (`_agent_gpu_evidence`, `src/tensor_grep/cli/agent_capsule.py`) write a GPU-route sentinel under a Linux `TemporaryDirectory` and pass that `/tmp/...` path as argv to the resolved binary. A Windows PE cannot resolve a Linux path -- a different filesystem namespace -- so the probe fails with a structured `path_not_found` (`rust_core/src/main.rs:5568`) and reads as "no GPU support" when the real cause is a path-domain mismatch.
- New shared helpers in `src/tensor_grep/cli/runtime_paths.py` (one implementation, reused by both probes, no divergent copy):
  - `is_cross_domain_native_binary()` -- true only when the host is genuinely WSL (`WSL_DISTRO_NAME`/`WSL_INTEROP` or `/run/WSL`) AND the resolved binary is Windows-shaped (`.exe` suffix or `/mnt/<drive>/` mount). Gating on a real WSL signal (not just `sys.platform == "linux"`) prevents false positives on bare Linux CI runners whose test fixtures happen to use a `tg.exe` name.
  - `translate_path_for_windows_binary()` -- translates the sentinel path via `wslpath -w`, failing closed to `None` (never raises) when `wslpath` is absent, times out, or exits non-zero.
  - `gpu_probe_timeout_s()` -- resolves the probe timeout, honoring `TENSOR_GREP_GPU_PROBE_TIMEOUT_S` and raising the floor on cross-domain (a WSL -> Windows exec can legitimately exceed the same-domain 2.0s default).
- Both probes now detect cross-domain, translate the sentinel path before it becomes argv, report a distinct `path_domain_mismatch` status when translation is unavailable (instead of a generic `failed`, or silently passing an unresolvable path), and share the timeout helper. Behavior is unchanged when not cross-domain (the common case).
- The probe still routes directly through the resolved native binary (never through the Python entrypoint), preserving its purpose of proving the native route.

**Part B -- `ci:`** cuda-feature-check anti-bit-rot gate
- The `cuda` cargo feature (`rust_core/Cargo.toml` `[features]`) today only compiles inside `build-release-native-assets`'s nvidia legs, which are themselves `if:`-skipped unless `RELEASE_NATIVE_ASSET_PROFILE == 'native-frontdoor-gpu'` (not the default) -- so it can rot invisibly with zero PR-time signal.
- Added `cuda-feature-check` job (`.github/workflows/ci.yml`): a fast `cargo check --features cuda` on `ubuntu-latest` + `windows-latest`, no CUDA toolkit required, modeled on the existing `test-rust-core`/`native-build-smoke` jobs' Rust+PyO3 setup. Wired into the `release` job's `needs` so a broken cuda feature actually blocks release. Publishes nothing.

## Test plan

- [x] `uv sync` && `uv run --no-sync maturin develop` -- clean build
- [x] `uv run --no-sync pytest tests/unit/test_runtime_paths.py -q` -- 47 passed, 1 skipped (real-wslpath smoke, skipped off-WSL)
- [x] `uv run --no-sync pytest tests/unit/test_cli_modes.py -q` -- 491 passed (full file, no regressions)
- [x] `uv run --no-sync pytest tests/unit/test_agent_capsule_gpu_probe.py -q` -- 6 passed (new file)
- [x] `uv run --no-sync pytest tests/unit/test_gpu_observability.py tests/unit/test_orient_agent_daemon.py tests/integration/test_multi_gpu_distribution.py tests/integration/test_cross_backend.py -q` -- all passed, no regressions
- [x] `uv run --no-sync ruff check .` -- clean
- [x] `uv run --no-sync ruff format --preview .` -- applied (whole-repo)
- [x] `uv run --no-sync mypy src/tensor_grep` -- clean, 80 source files
- [x] `cargo check --features cuda` (rust_core/) -- compiles clean in ~37s with no CUDA toolkit
- [x] `.github/workflows/ci.yml` YAML validated with `yaml.safe_load`

Not merging -- this touches the native probe + resolver (routing/backends-adjacent), so a mandatory adversarial review + re-verify in the real venv happens before merge per repo change-control rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)