### PR TITLE
fix(gpu): doctor probe failure taxonomy + honest device-id validation

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -2503,6 +2503,52 @@ mod tests {
         assert_eq!(gpu_native_fallback_reason(&params), None);
     }
 
+    // GPU-P0-3 (#171): `validate_requested_cuda_device_ids` (gpu_native.rs) raises "invalid CUDA
+    // device id {id}; available CUDA devices: {..}" for an out-of-range --gpu-device-ids request.
+    // Before this fix, `classify_gpu_route_failure`'s catch-all arm relabeled that message as
+    // "CUDA initialization failed: ..." -- true-sounding but wrong: nothing failed to initialize,
+    // the id was simply invalid. These tests pin the classifier's OWN reason, verbatim, distinct
+    // from the genuine-initialization-failure arms below.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn classify_gpu_route_failure_reports_invalid_device_id_as_its_own_fatal_reason() {
+        let failure =
+            classify_gpu_route_failure("invalid CUDA device id 99; available CUDA devices: 0, 1");
+
+        assert_eq!(failure.kind, GpuRouteFailureKind::Fatal);
+        assert_eq!(
+            failure.message,
+            "invalid CUDA device id 99; available CUDA devices: 0, 1"
+        );
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn classify_gpu_route_failure_does_not_relabel_invalid_device_id_as_init_failure() {
+        let failure =
+            classify_gpu_route_failure("invalid CUDA device id 3; available CUDA devices: 0, 1, 2");
+
+        assert!(
+            !failure.message.starts_with("CUDA initialization failed"),
+            "message={}",
+            failure.message
+        );
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn classify_gpu_route_failure_still_labels_genuine_init_failures_as_such() {
+        // Baseline: the pre-existing "CUDA initialization failed:" arm must keep working --
+        // the new invalid-device-id arm must not swallow unrelated Fatal messages.
+        let failure = classify_gpu_route_failure("CUDA initialization failed: driver too old");
+
+        assert_eq!(failure.kind, GpuRouteFailureKind::Fatal);
+        assert_eq!(
+            failure.message,
+            "CUDA initialization failed: driver too old"
+        );
+    }
+
     #[test]
     fn gpu_cpu_fallback_unhonorable_flag_detects_each_of_the_three() {
         let patterns = vec!["needle".to_string()];
@@ -10355,6 +10401,17 @@ fn classify_gpu_route_failure(raw_message: &str) -> GpuRouteFailure {
     if raw_message.starts_with("CUDA is unavailable:") {
         return GpuRouteFailure {
             kind: GpuRouteFailureKind::Unavailable,
+            message: raw_message.to_string(),
+        };
+    }
+    // GPU-P0-3 (#171): `validate_requested_cuda_device_ids` raises this exact prefix for an
+    // out-of-range --gpu-device-ids request. It is a Fatal (user-input) reason in its own right
+    // -- catching it here, before the generic "CUDA initialization failed:" arm and the
+    // lowercase-substring fallback below, keeps the catch-all from relabeling it as a driver/
+    // hardware initialization problem it never was.
+    if raw_message.starts_with("invalid CUDA device id") {
+        return GpuRouteFailure {
+            kind: GpuRouteFailureKind::Fatal,
             message: raw_message.to_string(),
         };
     }

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4779,6 +4779,42 @@ def _parse_gpu_device_ids_cli(raw: str | None) -> list[int] | None:
     return parsed
 
 
+def _warn_unavailable_gpu_device_ids(gpu_device_ids: list[int] | None) -> None:
+    """P0-3 (#171): WARN (never hard-fail) when a requested --gpu-device-ids id is absent from
+    the local DeviceDetector inventory, so id 99 no longer silently CPU-falls-back
+    indistinguishably from id 0.
+
+    This is deliberately advisory only. A CPU-only native `tg` build cannot enumerate CUDA
+    devices at all -- DeviceDetector fails closed to an empty inventory in that case -- and an
+    empty inventory means "cannot verify", not "every id is invalid", so this stays silent
+    rather than warn on every single invocation on a machine with no local NVML/torch signal.
+    The native Rust classifier (classify_gpu_route_failure's "invalid CUDA device id" arm) owns
+    the authoritative rejection on an actual CUDA-enabled build; this is the best-effort,
+    fail-open Python-side signal for everyone else.
+    """
+    if not gpu_device_ids:
+        return
+    try:
+        from tensor_grep.core.hardware.device_detect import DeviceDetector
+
+        available_ids = DeviceDetector().enumerate_device_ids()
+    except Exception:
+        return
+    if not available_ids:
+        return
+    missing_ids = [device_id for device_id in gpu_device_ids if device_id not in available_ids]
+    if not missing_ids:
+        return
+    missing_text = ", ".join(str(device_id) for device_id in missing_ids)
+    available_text = ", ".join(str(device_id) for device_id in available_ids)
+    typer.echo(
+        f"warning: --gpu-device-ids requested {missing_text} not present in the local GPU "
+        f"device inventory (available: {available_text}); the search will still run and may "
+        "silently fall back to CPU for the missing id(s)",
+        err=True,
+    )
+
+
 def _selected_gpu_execution_defaults(
     gpu_device_ids: list[int], gpu_chunk_plan_mb: list[tuple[int, int]]
 ) -> tuple[bool, int]:
@@ -6704,6 +6740,7 @@ def search_command(
     from tensor_grep.core.config import SearchConfig
 
     parsed_gpu_device_ids = _parse_gpu_device_ids_cli(gpu_device_ids)
+    _warn_unavailable_gpu_device_ids(parsed_gpu_device_ids)
 
     effective_force_cpu = cpu or env_flag_enabled("TG_FORCE_CPU")
     implicit_with_filename = (
@@ -8727,6 +8764,7 @@ def agent(
             command_name="agent",
         )
         parsed_gpu_device_ids = _parse_gpu_device_ids_cli(gpu_device_ids)
+        _warn_unavailable_gpu_device_ids(parsed_gpu_device_ids)
         # CLI consistency fix (CEO v1.71.3 dogfood): `--deadline` used to be undefined on
         # `tg agent` (Click "No such option" exit-2).
         effective_deadline = None if no_deadline else deadline

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -32,6 +32,7 @@ from tensor_grep.cli.runtime_paths import (
     env_flag_disabled,
     env_flag_enabled,
     gpu_probe_timeout_s,
+    inspect_native_tg_binary,
     is_cross_domain_native_binary,
     iter_in_tree_native_tg_binaries,
     native_frontdoor_metadata_path,
@@ -2657,6 +2658,52 @@ def _doctor_gpu_status() -> dict[str, Any]:
     return status
 
 
+# P0-2 (#171 taxonomy): the native tg binary, run with --json by the probe below, prints a
+# single structured error object to stdout before exiting non-zero (see
+# exit_structured_search_error_if_needed in rust_core/src/main.rs) with an "error" field naming
+# the failure kind. Map each KNOWN kind to a distinct doctor status instead of collapsing every
+# rc!=0 outcome to one opaque "failed" -- an agent reading tg doctor --json can then tell "the
+# probe's own temp/translated path went missing" (failed_path_bridging) apart from "the sentinel
+# search input was rejected" (failed_input) apart from "the GPU route itself hit a real CUDA
+# fault" (failed_gpu_unavailable). Any kind this table has never seen -- or stdout that is not
+# the expected structured JSON at all (a raw panic, empty output, etc.) -- fails closed to
+# failed_other rather than guessing.
+_DOCTOR_GPU_PROBE_FAILURE_STATUS_BY_NATIVE_ERROR_KIND: dict[str, str] = {
+    "path_not_found": "failed_path_bridging",
+    "empty_pattern": "failed_input",
+    "invalid_regex": "failed_input",
+    "gpu_fatal": "failed_gpu_unavailable",
+}
+_DOCTOR_GPU_PROBE_DEFAULT_FAILURE_STATUS = "failed_other"
+
+
+def _doctor_gpu_probe_native_error_kind(stdout: str | None) -> str | None:
+    """Parse the native binary's structured --json error kind from a failed probe's stdout.
+
+    Returns None when stdout is empty, not JSON, not an object, or has no string "error" field
+    -- any of which means there is nothing trustworthy to classify, so the caller must fail
+    closed to the generic failed_other status rather than inventing a kind.
+    """
+    if not stdout:
+        return None
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error_kind = payload.get("error")
+    return error_kind if isinstance(error_kind, str) and error_kind else None
+
+
+def _doctor_gpu_probe_failure_status(native_error_kind: str | None) -> str:
+    if native_error_kind is None:
+        return _DOCTOR_GPU_PROBE_DEFAULT_FAILURE_STATUS
+    return _DOCTOR_GPU_PROBE_FAILURE_STATUS_BY_NATIVE_ERROR_KIND.get(
+        native_error_kind, _DOCTOR_GPU_PROBE_DEFAULT_FAILURE_STATUS
+    )
+
+
 def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str, Any]:
     requested_gpu_device_ids = [0]
     base: dict[str, Any] = {
@@ -2668,6 +2715,7 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
         "routing_reason": None,
         "sidecar_used": None,
         "routing_gpu_device_ids": [],
+        "native_error_kind": None,
         "error": None,
     }
     if native_tg_binary is None:
@@ -2733,7 +2781,9 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
 
     base["exit_code"] = result.returncode
     if result.returncode != 0:
-        base["status"] = "failed"
+        native_error_kind = _doctor_gpu_probe_native_error_kind(result.stdout)
+        base["native_error_kind"] = native_error_kind
+        base["status"] = _doctor_gpu_probe_failure_status(native_error_kind)
         base["error"] = (result.stderr or "").strip() or "GPU runtime probe failed"
         return base
 
@@ -2852,6 +2902,27 @@ def _doctor_shell_escaping_guidance() -> dict[str, Any]:
     }
 
 
+def _doctor_native_frontdoor_flavor_mismatch_note(
+    *, installed_flavor: str | None, requested_flavor: str | None
+) -> str | None:
+    """Honest note when the installed native-frontdoor asset flavor differs from what was
+    requested (TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR) at install/upgrade time -- for example the
+    caller asked for `nvidia` but the installer fell back to `cpu` because no NVIDIA asset was
+    published for this platform at that release. None when either side is unknown (no metadata
+    file -- an in-tree dev build never writes one) or the two already agree.
+    """
+    if installed_flavor is None or requested_flavor is None:
+        return None
+    if installed_flavor == requested_flavor:
+        return None
+    return (
+        f"installed native-frontdoor flavor '{installed_flavor}' does not match the requested "
+        f"flavor '{requested_flavor}' ({_NATIVE_FRONTDOOR_FLAVOR_ENV}) -- the requested flavor "
+        "may not have been published for this platform at install time; rerun `tg upgrade` or "
+        "unset the flavor override to accept the installed build."
+    )
+
+
 def _build_doctor_payload(
     path: str, config: str | None = None, *, with_lsp: bool
 ) -> dict[str, Any]:
@@ -2876,6 +2947,22 @@ def _build_doctor_payload(
         _DOCTOR_LSP_PROBE_TIMEOUT_ENV,
     ]
     installed_version = _doctor_installed_version()
+    # P0-2 (#171): surface the native-frontdoor flavor metadata that inspect_native_tg_binary
+    # already computes (merging installed-vs-requested asset flavor) -- until now this was only
+    # consumed by benchmarks/run_benchmarks.py and benchmarks/run_gpu_native_benchmarks.py, so
+    # `tg doctor` had no way to tell a caller "you asked for nvidia but got cpu" without them
+    # reaching for a benchmark script. Empty dict (no keys) for no binary / no metadata file (an
+    # in-tree dev build never writes tg-native-metadata.json), so every lookup below is a safe
+    # `.get(...)` returning None.
+    native_frontdoor_inspection = (
+        inspect_native_tg_binary(native_tg_binary, expected_version=installed_version)
+        if native_tg_binary is not None
+        else {}
+    )
+    native_frontdoor_flavor = native_frontdoor_inspection.get("native_frontdoor_flavor")
+    native_frontdoor_requested_flavor = native_frontdoor_inspection.get(
+        "native_frontdoor_requested_flavor"
+    )
     rust_binary_version = _doctor_rust_binary_version(native_tg_binary)
     native_tg_binary_kind = _doctor_native_tg_binary_kind(native_tg_binary)
     rust_binary_version_matches = _doctor_rust_binary_version_matches(
@@ -3022,6 +3109,18 @@ def _build_doctor_payload(
         "native_tg_binary": str(native_tg_binary) if native_tg_binary is not None else None,
         "native_tg_binary_exists": native_tg_binary is not None,
         "native_tg_binary_kind": native_tg_binary_kind,
+        "native_frontdoor_flavor": native_frontdoor_flavor,
+        "native_frontdoor_requested_flavor": native_frontdoor_requested_flavor,
+        "native_frontdoor_asset_name": native_frontdoor_inspection.get(
+            "native_frontdoor_asset_name"
+        ),
+        "native_frontdoor_metadata_status": native_frontdoor_inspection.get(
+            "native_frontdoor_metadata_status"
+        ),
+        "native_frontdoor_flavor_mismatch_note": _doctor_native_frontdoor_flavor_mismatch_note(
+            installed_flavor=native_frontdoor_flavor,
+            requested_flavor=native_frontdoor_requested_flavor,
+        ),
         "rust_core_extension_available": rust_core_extension_available,
         "search_acceleration_backend": (
             "standalone-native-tg"
@@ -3156,6 +3255,14 @@ def _render_doctor_payload(payload: dict[str, Any]) -> str:
     native_tg_binary = payload.get("native_tg_binary")
     lines.append(f"native_tg_binary: {native_tg_binary or 'missing'}")
     lines.append(f"native_tg_binary_kind: {payload.get('native_tg_binary_kind', 'unknown')}")
+    if native_frontdoor_flavor := payload.get("native_frontdoor_flavor"):
+        lines.append(
+            "native_frontdoor_flavor: "
+            f"{native_frontdoor_flavor} "
+            f"requested={payload.get('native_frontdoor_requested_flavor') or 'unknown'}"
+        )
+    if flavor_mismatch_note := payload.get("native_frontdoor_flavor_mismatch_note"):
+        lines.append(f"native_frontdoor_flavor_mismatch_note: {flavor_mismatch_note}")
     lines.append(
         f"search_acceleration_backend: {payload.get('search_acceleration_backend', 'unknown')}"
     )

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2306,6 +2306,192 @@ def test_doctor_gpu_runtime_probe_timeout_env_override_honored(monkeypatch, tmp_
     assert captured_kwargs["timeout"] == pytest.approx(17.5)
 
 
+def test_doctor_gpu_runtime_probe_native_error_kind_is_none_on_success(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        payload = {
+            "routing_backend": "NativeGpuBackend",
+            "routing_reason": "gpu-device-ids-explicit",
+            "sidecar_used": False,
+            "routing_gpu_device_ids": [0],
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "supported"
+    assert probe["native_error_kind"] is None
+
+
+# GPU-P0-2 (#171 taxonomy): rc!=0 must no longer collapse every native probe failure to one
+# opaque "failed" status. The native binary (run with --json) prints a structured
+# {"error": "<kind>", "detail": ...} object to stdout before exiting non-zero; these pin the
+# doctor's mapping from each known kind to a distinct, honest status.
+def test_doctor_gpu_runtime_probe_maps_path_not_found_to_failed_path_bridging(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "path_not_found",
+            "detail": "search path does not exist: <doctor-gpu-probe-file>",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_path_bridging"
+    assert probe["native_error_kind"] == "path_not_found"
+    assert probe["exit_code"] == 2
+
+
+def test_doctor_gpu_runtime_probe_maps_empty_pattern_to_failed_input(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "empty_pattern",
+            "detail": "PATTERN must not be empty.",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_input"
+    assert probe["native_error_kind"] == "empty_pattern"
+
+
+def test_doctor_gpu_runtime_probe_maps_invalid_regex_to_failed_input(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "invalid_regex",
+            "detail": "invalid regex pattern: unterminated group",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_input"
+    assert probe["native_error_kind"] == "invalid_regex"
+
+
+def test_doctor_gpu_runtime_probe_maps_gpu_fatal_to_failed_gpu_unavailable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "gpu_fatal",
+            "detail": "invalid CUDA device id 0; available CUDA devices: (none)",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_gpu_unavailable"
+    assert probe["native_error_kind"] == "gpu_fatal"
+
+
+def test_doctor_gpu_runtime_probe_maps_unrecognized_error_kind_to_failed_other(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "some_future_error_kind",
+            "detail": "an error the doctor has never seen before",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_other"
+    assert probe["native_error_kind"] == "some_future_error_kind"
+
+
+def test_doctor_gpu_runtime_probe_maps_non_json_stdout_to_failed_other(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """rc!=0 with no structured JSON on stdout at all (e.g. a raw panic) must still fail
+    closed to a bucketed status instead of raising -- native_error_kind stays None so the
+    caller can tell 'could not classify' apart from 'the native binary named a kind'."""
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 101, "", "thread panicked at ...")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_other"
+    assert probe["native_error_kind"] is None
+    assert probe["error"] == "thread panicked at ..."
+
+
+def test_doctor_gpu_runtime_probe_native_error_kind_absent_for_path_domain_mismatch(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The P0-1 WSL path_domain_mismatch short-circuit never execs the native binary at all,
+    so there is no native stdout to classify; native_error_kind must stay None, not invent a
+    kind, and the pre-existing status must survive untouched."""
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fail_run(*_args, **_kwargs):
+        raise AssertionError("must not shell out when translation is unavailable")
+
+    monkeypatch.setattr("tensor_grep.cli.main.is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr("tensor_grep.cli.main.translate_path_for_windows_binary", lambda _p: None)
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fail_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "path_domain_mismatch"
+    assert probe["native_error_kind"] is None
+
+
 def test_doctor_json_reports_native_version_mismatch(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.8.1")
     monkeypatch.setattr(
@@ -3222,6 +3408,155 @@ def test_doctor_json_explains_rust_core_extension_when_standalone_binary_missing
     assert payload["native_tg_binary_exists"] is False
     assert payload["rust_core_extension_available"] is True
     assert payload["search_acceleration_backend"] == "rust-core-extension"
+
+
+def test_doctor_native_frontdoor_flavor_mismatch_note_helper() -> None:
+    assert (
+        cli_main._doctor_native_frontdoor_flavor_mismatch_note(
+            installed_flavor=None, requested_flavor=None
+        )
+        is None
+    )
+    assert (
+        cli_main._doctor_native_frontdoor_flavor_mismatch_note(
+            installed_flavor="cpu", requested_flavor="cpu"
+        )
+        is None
+    )
+    assert (
+        cli_main._doctor_native_frontdoor_flavor_mismatch_note(
+            installed_flavor="cpu", requested_flavor=None
+        )
+        is None
+    )
+    note = cli_main._doctor_native_frontdoor_flavor_mismatch_note(
+        installed_flavor="cpu", requested_flavor="nvidia"
+    )
+    assert note is not None
+    assert "cpu" in note
+    assert "nvidia" in note
+
+
+# GPU-P0-2 (#171): `tg doctor` never surfaced inspect_native_tg_binary's flavor metadata --
+# only benchmarks/run_benchmarks.py and benchmarks/run_gpu_native_benchmarks.py read it. These
+# pin the new top-level doctor JSON fields.
+def test_doctor_json_includes_native_frontdoor_flavor_fields_when_metadata_present(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    native_tg.parent.mkdir(parents=True, exist_ok=True)
+    native_tg.write_text("native", encoding="utf-8")
+    metadata_path = native_tg.with_name("tg-native-metadata.json")
+    metadata_path.write_text(
+        json.dumps({
+            "artifact": "tensor_grep_native_frontdoor_metadata",
+            "asset_flavor": "cpu",
+            "requested_asset_flavor": "nvidia",
+            "asset_name": "tg-windows-amd64-cpu.exe",
+            "version": "9.9.9",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_gpu_search_runtime_probe",
+        lambda binary: {"status": "not_run"},
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["native_frontdoor_flavor"] == "cpu"
+    assert payload["native_frontdoor_requested_flavor"] == "nvidia"
+    assert payload["native_frontdoor_asset_name"] == "tg-windows-amd64-cpu.exe"
+    assert payload["native_frontdoor_metadata_status"] == "present"
+    note = payload["native_frontdoor_flavor_mismatch_note"]
+    assert note is not None
+    assert "cpu" in note
+    assert "nvidia" in note
+
+
+def test_doctor_json_native_frontdoor_flavor_fields_absent_without_metadata_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_gpu_search_runtime_probe",
+        lambda binary: {"status": "not_run"},
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["native_frontdoor_flavor"] is None
+    assert payload["native_frontdoor_requested_flavor"] is None
+    assert payload["native_frontdoor_metadata_status"] is None
+    assert payload["native_frontdoor_flavor_mismatch_note"] is None
+
+
+def test_doctor_json_native_frontdoor_flavor_fields_none_when_binary_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["native_frontdoor_flavor"] is None
+    assert payload["native_frontdoor_flavor_mismatch_note"] is None
+
+
+def test_doctor_text_reports_native_frontdoor_flavor_mismatch(monkeypatch, tmp_path: Path) -> None:
+    native_tg = tmp_path / ".tensor-grep" / "bin" / "tg.exe"
+    native_tg.parent.mkdir(parents=True, exist_ok=True)
+    native_tg.write_text("native", encoding="utf-8")
+    metadata_path = native_tg.with_name("tg-native-metadata.json")
+    metadata_path.write_text(
+        json.dumps({
+            "artifact": "tensor_grep_native_frontdoor_metadata",
+            "asset_flavor": "cpu",
+            "requested_asset_flavor": "nvidia",
+            "asset_name": "tg-windows-amd64-cpu.exe",
+            "version": "9.9.9",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_gpu_search_runtime_probe",
+        lambda binary: {"status": "not_run"},
+    )
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--no-lsp"])
+
+    assert result.exit_code == 0
+    assert "native_frontdoor_flavor: cpu requested=nvidia" in result.stdout
+    assert "native_frontdoor_flavor_mismatch_note:" in result.stdout
 
 
 def test_cli_should_parse_gpu_device_ids_into_search_config(monkeypatch):

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -3601,6 +3601,108 @@ def test_cli_should_fail_fast_on_invalid_gpu_device_ids(monkeypatch):
     assert "Invalid GPU device id 'foo'" in result.output
 
 
+# GPU-P0-3 (#171): honest out-of-range --gpu-device-ids. Today id 99 silently CPU-falls-back
+# indistinguishably from id 0 -- these pin the new Python-side pre-flight WARN (never a hard
+# failure) against a mocked DeviceDetector inventory.
+def test_warn_unavailable_gpu_device_ids_silent_when_all_ids_in_inventory(monkeypatch) -> None:
+    import tensor_grep.core.hardware.device_detect as device_detect_mod
+
+    monkeypatch.setattr(
+        device_detect_mod.DeviceDetector, "enumerate_device_ids", lambda self: [0, 1]
+    )
+    captured: list[str] = []
+    monkeypatch.setattr(
+        cli_main.typer, "echo", lambda message="", **kwargs: captured.append(str(message))
+    )
+
+    cli_main._warn_unavailable_gpu_device_ids([0, 1])
+
+    assert captured == []
+
+
+def test_warn_unavailable_gpu_device_ids_warns_naming_available_ids_when_out_of_range(
+    monkeypatch,
+) -> None:
+    import tensor_grep.core.hardware.device_detect as device_detect_mod
+
+    monkeypatch.setattr(
+        device_detect_mod.DeviceDetector, "enumerate_device_ids", lambda self: [0, 1]
+    )
+    captured: list[str] = []
+    monkeypatch.setattr(
+        cli_main.typer, "echo", lambda message="", **kwargs: captured.append(str(message))
+    )
+
+    cli_main._warn_unavailable_gpu_device_ids([0, 5])
+
+    assert len(captured) == 1
+    assert "5" in captured[0]
+    assert "0, 1" in captured[0]
+
+
+def test_warn_unavailable_gpu_device_ids_silent_when_inventory_cannot_be_enumerated(
+    monkeypatch,
+) -> None:
+    """A CPU-only environment can't enumerate CUDA devices at all (empty inventory) -- warning
+    here would be a FALSE claim that id X is invalid. Silence is the honest move; the native
+    Rust classifier owns the authoritative rejection on an actual CUDA build."""
+    import tensor_grep.core.hardware.device_detect as device_detect_mod
+
+    monkeypatch.setattr(device_detect_mod.DeviceDetector, "enumerate_device_ids", lambda self: [])
+    captured: list[str] = []
+    monkeypatch.setattr(
+        cli_main.typer, "echo", lambda message="", **kwargs: captured.append(str(message))
+    )
+
+    cli_main._warn_unavailable_gpu_device_ids([0, 99])
+
+    assert captured == []
+
+
+def test_warn_unavailable_gpu_device_ids_noop_for_empty_request(monkeypatch) -> None:
+    import tensor_grep.core.hardware.device_detect as device_detect_mod
+
+    def _fail(_self):
+        raise AssertionError("must not probe hardware when no ids were requested")
+
+    monkeypatch.setattr(device_detect_mod.DeviceDetector, "enumerate_device_ids", _fail)
+
+    cli_main._warn_unavailable_gpu_device_ids(None)
+    cli_main._warn_unavailable_gpu_device_ids([])
+
+
+def test_warn_unavailable_gpu_device_ids_never_hard_fails_on_detector_error(monkeypatch) -> None:
+    import tensor_grep.core.hardware.device_detect as device_detect_mod
+
+    def _raise(_self):
+        raise RuntimeError("simulated NVML failure")
+
+    monkeypatch.setattr(device_detect_mod.DeviceDetector, "enumerate_device_ids", _raise)
+
+    # Must not raise -- NEVER hard-fail is the explicit contract.
+    cli_main._warn_unavailable_gpu_device_ids([0])
+
+
+def test_cli_search_warns_when_gpu_device_id_out_of_local_inventory(monkeypatch) -> None:
+    global _FAKE_WALK, _FAKE_BACKEND
+    _FAKE_WALK = {".": ["a.log"]}
+    _FAKE_BACKEND = _FakeBackend(results_by_file={})
+    _patch_cli_dependencies(monkeypatch)
+
+    import tensor_grep.core.hardware.device_detect as device_detect_mod
+
+    monkeypatch.setattr(
+        device_detect_mod.DeviceDetector, "enumerate_device_ids", lambda self: [0, 1]
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["search", "ERROR", ".", "--gpu-device-ids", "5"])
+
+    assert result.exit_code == 0
+    assert "5" in result.output
+    assert "0, 1" in result.output
+
+
 def test_cli_should_delegate_force_cpu_search_to_native_binary(monkeypatch):
     seen: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

GPU Phase-0 batch 2 (audit #171), two items:

**P0-2 — Doctor probe failure taxonomy + native-frontdoor flavor surfacing**
- `_doctor_gpu_search_runtime_probe` (`src/tensor_grep/cli/main.py`) no longer collapses every
  `rc!=0` native-probe outcome to one opaque `status="failed"`. It now parses the structured
  `{"error": "<kind>", ...}` object the native binary prints to stdout in `--json` mode
  (`exit_structured_search_error_if_needed`, `rust_core/src/main.rs`) and maps known kinds to
  distinct statuses: `path_not_found` -> `failed_path_bridging`, `empty_pattern`/`invalid_regex`
  -> `failed_input`, `gpu_fatal` -> `failed_gpu_unavailable`; anything unrecognized or non-JSON
  fails closed to `failed_other`. A new `native_error_kind` field carries the raw kind. The P0-1
  `path_domain_mismatch` short-circuit is untouched (it never execs the binary).
- `tg doctor` now surfaces `inspect_native_tg_binary`'s native-frontdoor flavor metadata
  (`native_frontdoor_flavor`, `native_frontdoor_requested_flavor`, `native_frontdoor_asset_name`,
  `native_frontdoor_metadata_status`, and a derived `native_frontdoor_flavor_mismatch_note`) --
  previously only `benchmarks/run_benchmarks.py` / `benchmarks/run_gpu_native_benchmarks.py` read
  it, so there was no way to see "you asked for nvidia but got cpu" without a benchmark script.
  Both the JSON payload and the text renderer (`_render_doctor_payload`) carry the new fields.

**P0-3 — Honest out-of-range `--gpu-device-ids`**
- New `_warn_unavailable_gpu_device_ids` (`src/tensor_grep/cli/main.py`), wired into both
  `tg search` and `tg agent` right after `_parse_gpu_device_ids_cli`. Prints a stderr WARN
  (never a hard failure) naming any requested id absent from the local `DeviceDetector`
  inventory plus the available ids. Silent when the inventory is empty (a CPU-only environment
  cannot enumerate CUDA devices at all, so warning there would be a false claim) and never
  raises on a detector failure.
- `classify_gpu_route_failure` (`rust_core/src/main.rs`) gets an explicit `"invalid CUDA device
  id"` arm so an out-of-range id on an actual CUDA-enabled build classifies as its own `Fatal`
  reason with the verbatim message, instead of the catch-all relabeling it as
  `"CUDA initialization failed: ..."` (true-sounding but wrong -- nothing failed to initialize).

Neither change touches `_DOCTOR_SCHEMA_VERSION` (stays at 2) -- purely additive fields/status
values, matching how the P0-1 `path_domain_mismatch` addition was shipped without a bump.

## Test plan

- [x] Rust: 3 new `#[cfg(feature = "cuda")]` unit tests in `rust_core/src/main.rs` pin
      `classify_gpu_route_failure`'s new arm (verbatim message, `Fatal` kind, no relabeling) and
      guard the pre-existing "CUDA initialization failed:" arm still works.
      `cargo test --bin tg --features cuda` (98 passed), `cargo test --lib --features cuda`
      (114 passed, unaffected), `cargo test --no-default-features` (full CI-parity suite, all
      green), `cargo fmt --check`, `cargo clippy -- -D warnings` (default),
      `cargo clippy --features cuda -- -D warnings`, `cargo check --features cuda` all clean.
- [x] Python: 7 new tests pin the P0-2(a) status taxonomy (path_not_found/empty_pattern/
      invalid_regex/gpu_fatal/unrecognized-kind/non-JSON-stdout/path_domain_mismatch-unaffected),
      5 new tests pin the P0-2(b) flavor fields + mismatch-note helper (present/absent/
      binary-missing/text-renderer), 6 new tests pin the P0-3(a) warn helper (in-inventory
      silent / out-of-range warns naming available ids / empty-inventory silent / no-op on empty
      request / never-hard-fails / CLI-wired end-to-end).
      `pytest tests/unit/test_cli_modes.py` (510 passed), `test_gpu_observability.py` +
      `test_runtime_paths.py` + `test_agent_capsule_gpu_probe.py` (84 passed, 1 skipped),
      `test_benchmark_scripts.py` + `test_run_benchmarks_launcher_modes.py` (277 passed,
      confirms `inspect_native_tg_binary`'s existing benchmark callers are unaffected),
      `test_mcp_server.py -k doctor` (7 passed).
- [x] `ruff check` clean, `ruff format --preview` clean on touched files (whole-repo check shows
      4 pre-existing unrelated `docs/*.md` code-fence drifts, not touched by this PR).
      `mypy src/tensor_grep/cli/main.py` clean.
- [x] Each P0 item verified independently self-consistent (staged/committed separately, tests
      re-run against each intermediate state before combining).

Draft only -- this touches doctor + GPU routing/backends, so a mandatory adversarial Opus gate
and re-verification happens before merge, per repo change-control policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
