### PR TITLE
fix(gpu): calibrate remediation message + loud nvidia->cpu installer downgrade

### DIFF
--- a/rust_core/src/crossover.rs
+++ b/rust_core/src/crossover.rs
@@ -476,6 +476,36 @@ fn user_crossover_config_path() -> Option<PathBuf> {
     })
 }
 
+// P0-4 (GPU Phase-0 honesty): a bare "requires a CUDA-enabled build" / "device unavailable"
+// error leaves a caller with no idea how to fix it. Point at the exact remediation -- the
+// TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR override + `tg upgrade` -- and name the platform's
+// NVIDIA release asset via compile-time cfg. HONESTY: never claim an asset "isn't published
+// yet" (that phrasing goes false the moment the asset profile is flipped on); phrase the
+// linux/windows case conditionally ("if published ... falls back to CPU when it is not") and
+// state the macOS case as the structural fact it is (Apple platforms are not a CUDA target).
+fn crossover_gpu_remediation_hint() -> String {
+    let platform_clause = if cfg!(target_os = "linux") {
+        "on linux this fetches the tg-linux-amd64-nvidia asset, if an NVIDIA asset is \
+         published for this platform on the release page; the installer falls back to CPU \
+         when it is not"
+            .to_string()
+    } else if cfg!(target_os = "windows") {
+        "on windows this fetches the tg-windows-amd64-nvidia.exe asset, if an NVIDIA asset is \
+         published for this platform on the release page; the installer falls back to CPU \
+         when it is not"
+            .to_string()
+    } else {
+        "no NVIDIA asset is published for this platform (Apple platforms are not a CUDA \
+         target); the installer stays on CPU here"
+            .to_string()
+    };
+    format!(
+        "To enable, set env TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia then run `tg upgrade` \
+         ({platform_clause}). Run `tg doctor` to check the requested-vs-installed native \
+         flavor."
+    )
+}
+
 fn detect_device_name(device_id: i32) -> Result<String> {
     #[cfg(feature = "cuda")]
     {
@@ -487,17 +517,64 @@ fn detect_device_name(device_id: i32) -> Result<String> {
         {
             return Ok(device.name);
         }
-        bail!("CUDA device {device_id} is unavailable for crossover calibration");
+        bail!(
+            "CUDA device {device_id} is unavailable for crossover calibration.\n{}",
+            crossover_gpu_remediation_hint()
+        );
     }
 
     #[cfg(not(feature = "cuda"))]
     {
         let _ = device_id;
-        bail!("crossover calibration requires a CUDA-enabled build")
+        bail!(
+            "crossover calibration requires a CUDA-enabled build.\n{}",
+            crossover_gpu_remediation_hint()
+        )
     }
 }
 
 enum SearchMode {
     Cpu,
     Gpu(i32),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // P0-4 RED test: detect_device_name is always-compiled (no `cuda` feature required), so
+    // this runs in the default `test-rust-core` CI matrix (ubuntu/windows/macos x stable/
+    // nightly, `cargo test --no-default-features`). The `#[cfg(feature = "cuda")]` arm's own
+    // edit (crossover.rs:520-523) is only compile-checked by the separate `cuda-feature-check`
+    // job (`cargo check --features cuda`, ubuntu+windows only) -- never test-executed here,
+    // which is an accepted gap (council nit).
+    #[cfg(not(feature = "cuda"))]
+    #[test]
+    fn detect_device_name_without_cuda_feature_names_remediation() {
+        let err = detect_device_name(0).expect_err("a non-cuda build must fail closed");
+        let message = err.to_string();
+        assert!(
+            message.contains("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR"),
+            "message should point at the native-frontdoor flavor override env var: {message}"
+        );
+        assert!(
+            message.contains("tg upgrade"),
+            "message should tell the user how to fetch an NVIDIA-enabled binary: {message}"
+        );
+        #[cfg(target_os = "linux")]
+        assert!(
+            message.contains("tg-linux-amd64-nvidia"),
+            "message should name the linux NVIDIA asset: {message}"
+        );
+        #[cfg(target_os = "windows")]
+        assert!(
+            message.contains("tg-windows-amd64-nvidia.exe"),
+            "message should name the windows NVIDIA asset: {message}"
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            message.contains("no NVIDIA asset"),
+            "message should honestly state macOS has no NVIDIA asset: {message}"
+        );
+    }
 }

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -322,6 +322,10 @@ class _NativeFrontdoorInstallResult:
     url: str
     flavor: str
     asset_name: str
+    # P0-5 (GPU Phase-0 honesty): defaulted so the single construction site below and any
+    # future caller stay valid without threading these through everywhere.
+    requested_flavor: str = "cpu"
+    downgrade_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -713,6 +717,40 @@ def _native_frontdoor_checksum_error(
     return None
 
 
+def _native_frontdoor_download_error_for_flavor(
+    download_errors: list[str], flavor: str
+) -> str | None:
+    """First download_errors entry attributable to `flavor` (each entry is formatted as
+    "<flavor> asset ...", see _install_release_native_frontdoor), or None if no candidate of
+    that flavor was ever attempted. SF-1: a platform with no NVIDIA asset at all never
+    appends an nvidia candidate to the download loop, so download_errors has no
+    nvidia-flavored entry -- callers must not index into it blindly in that case.
+    """
+    prefix = f"{flavor} asset"
+    for error in download_errors:
+        if error.startswith(prefix):
+            return error
+    return None
+
+
+def _native_frontdoor_downgrade_reason(
+    *, requested_flavor: str, installed_flavor: str, download_errors: list[str]
+) -> str | None:
+    """Honest reason the installed native-frontdoor flavor differs from what was requested
+    (TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR), or None when they already agree -- including the
+    default cpu-request path, which must stay silent (requested cpu always installs cpu).
+    """
+    if installed_flavor == requested_flavor:
+        return None
+    reason = _native_frontdoor_download_error_for_flavor(download_errors, requested_flavor)
+    if reason is not None:
+        return reason
+    # SF-1: no candidate of the requested flavor was ever attempted for this platform (e.g.
+    # darwin/non-amd64, where _native_frontdoor_asset_candidates never appends an nvidia
+    # entry) -- state that honestly rather than fabricating a reason nothing recorded.
+    return f"no {requested_flavor.upper()} asset is published for this platform"
+
+
 def _write_native_frontdoor_metadata(
     destination: Path,
     *,
@@ -793,10 +831,33 @@ def _install_release_native_frontdoor(
                 version=version,
                 candidate=candidate,
             )
+            # P0-5 (GPU Phase-0 honesty): a requested nvidia flavor that silently
+            # lands cpu (nvidia unavailable, or no nvidia asset exists for this platform at
+            # all) used to be indistinguishable from an ordinary cpu install. Warn loudly on
+            # stderr so a caller sees the downgrade instead of only discovering it later via
+            # `tg doctor`. Silent on the default cpu-request path (requested cpu always
+            # installs cpu, so this never fires there) and never pollutes any --json stream
+            # (stderr only; `tg upgrade` has no --json output).
+            requested_flavor = _requested_native_frontdoor_flavor()
+            downgrade_reason = _native_frontdoor_downgrade_reason(
+                requested_flavor=requested_flavor,
+                installed_flavor=candidate.flavor,
+                download_errors=download_errors,
+            )
+            if downgrade_reason is not None:
+                print(
+                    f"WARNING: requested native tg front-door flavor '{requested_flavor}' "
+                    f"was not installed ({downgrade_reason}); installed '{candidate.flavor}' "
+                    "instead. Run 'tg doctor' to check the requested-vs-installed native "
+                    "flavor.",
+                    file=sys.stderr,
+                )
             return _NativeFrontdoorInstallResult(
                 url=url,
                 flavor=candidate.flavor,
                 asset_name=candidate.asset_name,
+                requested_flavor=requested_flavor,
+                downgrade_reason=downgrade_reason,
             )
         finally:
             temp_path.unlink(missing_ok=True)
@@ -7625,7 +7686,20 @@ def calibrate() -> None:
         # audit L10: calibrate is unsupported without the native binary (and on CPU-only
         # boxes the native binary itself exits non-zero when CUDA is unavailable). tg's
         # convention is exit 1 for runtime/unsupported errors, not exit 2 (usage errors).
-        typer.echo("Error: native tg binary not found for calibrate command.", err=True)
+        # P0-4 (GPU Phase-0 honesty): don't leave the caller with a dead end -- name the
+        # remediation. This wrapper uses inherited stdio for the real `calibrate` subprocess
+        # below and must NOT capture its stderr (that would break streaming), so only THIS
+        # wrapper-owned missing-binary message gets the pointer; the native binary's own
+        # calibrate-failure remediation text is Rust-owned (crossover.rs).
+        typer.echo(
+            "Error: native tg binary not found for calibrate command.\n"
+            "To enable GPU crossover calibration, set env "
+            "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia then run 'tg upgrade' to fetch an "
+            "NVIDIA-enabled native binary, if one is published for this platform on the "
+            "release page; the installer falls back to CPU when it is not. Run 'tg doctor' "
+            "to check the requested-vs-installed native flavor.",
+            err=True,
+        )
         raise typer.Exit(1)
 
     completed = subprocess.run([str(native_tg_binary), "calibrate"], check=False)

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -266,3 +266,9 @@ def test_l10_calibrate_exits_one_when_unsupported(monkeypatch) -> None:
     # On a box without the native binary / CUDA, calibrate is a runtime/unsupported
     # error: tg's convention is exit 1, not the usage-error exit 2.
     assert result.exit_code == 1, result.stdout
+    # P0-4 (GPU Phase-0 honesty): the missing-binary message must carry an actionable
+    # remediation pointer -- not just "not found" with no next step -- naming the flavor
+    # override env var, the `tg upgrade` command, and the `tg doctor` diagnostic.
+    assert "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR" in result.output
+    assert "tg upgrade" in result.output
+    assert "tg doctor" in result.output

--- a/tests/unit/test_native_frontdoor_checksum.py
+++ b/tests/unit/test_native_frontdoor_checksum.py
@@ -3,9 +3,15 @@ native tg front-door binary, but unlike the installers (install.sh / install.ps1
 npm/install.js, hardened in audit S4) it never verified the download against the
 published CHECKSUMS.txt manifest — only a forgeable `--version` smoke test stood in
 the way. These tests pin the fail-closed checksum gate.
+
+P0-5 (GPU Phase-0 honesty, 2026-07-14): when a caller requests the nvidia native
+front-door flavor but only the cpu asset installs (nvidia unavailable, or no nvidia
+asset exists for this platform at all), `_install_release_native_frontdoor` used to
+install cpu silently. These tests pin the loud stderr downgrade warning.
 """
 
 import hashlib
+import json
 from pathlib import Path
 
 import pytest
@@ -13,8 +19,8 @@ import pytest
 from tensor_grep.cli import main as cli_main
 
 
-def _candidate(asset_name: str = "tg-test-asset"):
-    return cli_main._NativeFrontdoorAssetCandidate(flavor="cpu", asset_name=asset_name)
+def _candidate(asset_name: str = "tg-test-asset", flavor: str = "cpu"):
+    return cli_main._NativeFrontdoorAssetCandidate(flavor=flavor, asset_name=asset_name)
 
 
 def test_expected_asset_sha256_parses_checksums_manifest():
@@ -108,3 +114,175 @@ def test_install_release_native_frontdoor_refuses_when_checksums_unavailable(tmp
     message = str(exc.value).lower()
     assert "checksums" in message or "unverified" in message
     assert not dest.exists()
+
+
+def _stub_checksum_and_version_gates(monkeypatch, *, digest: str, asset_name: str) -> None:
+    """Make the checksum + --version smoke-test gates pass so the ONLY thing under test in
+    the P0-5 tests below is the nvidia->cpu downgrade warning, matching the existing
+    tampered/verified-asset tests' pattern of isolating one gate at a time."""
+    monkeypatch.setattr(
+        cli_main,
+        "_fetch_native_frontdoor_checksums",
+        lambda version: f"{digest}  {asset_name}\n",
+    )
+    monkeypatch.setattr(cli_main, "_native_tg_version", lambda path: "1.2.3")
+    monkeypatch.setattr(cli_main, "_native_tg_version_matches", lambda *a, **k: True)
+
+
+def test_install_release_native_frontdoor_warns_on_nvidia_to_cpu_downgrade(
+    tmp_path, monkeypatch, capsys
+):
+    # (a) requested=nvidia, nvidia download fails, cpu succeeds -> stderr carries the
+    # downgrade warning + the nvidia failure reason; metadata records requested=nvidia,
+    # installed asset=cpu.
+    monkeypatch.setenv("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR", "nvidia")
+    monkeypatch.delenv("TG_NATIVE_FRONTDOOR_REQUESTED_FLAVOR", raising=False)
+
+    nvidia_cand = _candidate("tg-linux-amd64-nvidia", flavor="nvidia")
+    cpu_cand = _candidate("tg-linux-amd64-cpu", flavor="cpu")
+    monkeypatch.setattr(
+        cli_main,
+        "_native_frontdoor_download_candidates",
+        lambda version: [
+            (nvidia_cand, "https://example.invalid/tg-linux-amd64-nvidia"),
+            (cpu_cand, "https://example.invalid/tg-linux-amd64-cpu"),
+        ],
+    )
+
+    asset_bytes = b"LEGIT-CPU-BINARY"
+
+    def _fake_download(url: str, dest) -> None:
+        if "nvidia" in url:
+            raise RuntimeError("404 Not Found: no nvidia asset for this release")
+        Path(dest).write_bytes(asset_bytes)
+
+    monkeypatch.setattr(cli_main, "_download_native_frontdoor_asset", _fake_download)
+    _stub_checksum_and_version_gates(
+        monkeypatch,
+        digest=hashlib.sha256(asset_bytes).hexdigest(),
+        asset_name="tg-linux-amd64-cpu",
+    )
+
+    dest = tmp_path / "tg.exe"
+    result = cli_main._install_release_native_frontdoor("1.2.3", dest)
+
+    assert result.flavor == "cpu"
+    warning = capsys.readouterr().err
+    assert "nvidia" in warning.lower()
+    assert "404 not found" in warning.lower()
+    assert "cpu" in warning.lower()
+    assert "tg doctor" in warning.lower()
+
+    metadata = json.loads(cli_main.native_frontdoor_metadata_path(dest).read_text(encoding="utf-8"))
+    assert metadata["requested_asset_flavor"] == "nvidia"
+    assert metadata["asset_flavor"] == "cpu"
+
+
+def test_install_release_native_frontdoor_silent_on_default_cpu_request(
+    tmp_path, monkeypatch, capsys
+):
+    # (b) requested=cpu (the default) -> installing cpu matches the request -> NO warning.
+    monkeypatch.delenv("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR", raising=False)
+    monkeypatch.delenv("TG_NATIVE_FRONTDOOR_REQUESTED_FLAVOR", raising=False)
+
+    cpu_cand = _candidate("tg-linux-amd64-cpu", flavor="cpu")
+    monkeypatch.setattr(
+        cli_main,
+        "_native_frontdoor_download_candidates",
+        lambda version: [(cpu_cand, "https://example.invalid/tg-linux-amd64-cpu")],
+    )
+    asset_bytes = b"LEGIT-CPU-BINARY"
+    monkeypatch.setattr(
+        cli_main,
+        "_download_native_frontdoor_asset",
+        lambda url, dest: Path(dest).write_bytes(asset_bytes),
+    )
+    _stub_checksum_and_version_gates(
+        monkeypatch,
+        digest=hashlib.sha256(asset_bytes).hexdigest(),
+        asset_name="tg-linux-amd64-cpu",
+    )
+    monkeypatch.setattr(cli_main, "_write_native_frontdoor_metadata", lambda *a, **k: None)
+
+    dest = tmp_path / "tg.exe"
+    result = cli_main._install_release_native_frontdoor("1.2.3", dest)
+
+    assert result.flavor == "cpu"
+    assert capsys.readouterr().err == ""
+
+
+def test_install_release_native_frontdoor_silent_when_nvidia_succeeds(
+    tmp_path, monkeypatch, capsys
+):
+    # (c) requested=nvidia, nvidia succeeds on the first try -> installed flavor matches the
+    # request -> NO warning.
+    monkeypatch.setenv("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR", "nvidia")
+    monkeypatch.delenv("TG_NATIVE_FRONTDOOR_REQUESTED_FLAVOR", raising=False)
+
+    nvidia_cand = _candidate("tg-linux-amd64-nvidia", flavor="nvidia")
+    cpu_cand = _candidate("tg-linux-amd64-cpu", flavor="cpu")
+    monkeypatch.setattr(
+        cli_main,
+        "_native_frontdoor_download_candidates",
+        lambda version: [
+            (nvidia_cand, "https://example.invalid/tg-linux-amd64-nvidia"),
+            (cpu_cand, "https://example.invalid/tg-linux-amd64-cpu"),
+        ],
+    )
+    asset_bytes = b"LEGIT-NVIDIA-BINARY"
+    monkeypatch.setattr(
+        cli_main,
+        "_download_native_frontdoor_asset",
+        lambda url, dest: Path(dest).write_bytes(asset_bytes),
+    )
+    _stub_checksum_and_version_gates(
+        monkeypatch,
+        digest=hashlib.sha256(asset_bytes).hexdigest(),
+        asset_name="tg-linux-amd64-nvidia",
+    )
+    monkeypatch.setattr(cli_main, "_write_native_frontdoor_metadata", lambda *a, **k: None)
+
+    dest = tmp_path / "tg.exe"
+    result = cli_main._install_release_native_frontdoor("1.2.3", dest)
+
+    assert result.flavor == "nvidia"
+    assert capsys.readouterr().err == ""
+
+
+def test_install_release_native_frontdoor_warns_honestly_when_no_nvidia_candidate(
+    tmp_path, monkeypatch, capsys
+):
+    # (d) SF-1: requested=nvidia but NO nvidia candidate exists at all for this platform
+    # (simulating darwin / a non-amd64 arch, where _native_frontdoor_asset_candidates never
+    # appends an nvidia entry) -> download_errors has NO nvidia-flavored entry to report, so
+    # the warning must fall back to the honest "no NVIDIA asset is published for this
+    # platform" text instead of indexing blindly into an empty/mismatched reason.
+    monkeypatch.setenv("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR", "nvidia")
+    monkeypatch.delenv("TG_NATIVE_FRONTDOOR_REQUESTED_FLAVOR", raising=False)
+
+    cpu_cand = _candidate("tg-macos-amd64-cpu", flavor="cpu")
+    monkeypatch.setattr(
+        cli_main,
+        "_native_frontdoor_download_candidates",
+        lambda version: [(cpu_cand, "https://example.invalid/tg-macos-amd64-cpu")],
+    )
+    asset_bytes = b"LEGIT-CPU-BINARY"
+    monkeypatch.setattr(
+        cli_main,
+        "_download_native_frontdoor_asset",
+        lambda url, dest: Path(dest).write_bytes(asset_bytes),
+    )
+    _stub_checksum_and_version_gates(
+        monkeypatch,
+        digest=hashlib.sha256(asset_bytes).hexdigest(),
+        asset_name="tg-macos-amd64-cpu",
+    )
+    monkeypatch.setattr(cli_main, "_write_native_frontdoor_metadata", lambda *a, **k: None)
+
+    dest = tmp_path / "tg.exe"
+    result = cli_main._install_release_native_frontdoor("1.2.3", dest)
+
+    assert result.flavor == "cpu"
+    warning = capsys.readouterr().err
+    assert "no nvidia asset is published for this platform" in warning.lower()
+    assert "tg doctor" in warning.lower()


### PR DESCRIPTION
## Summary

Two GPU Phase-0 honesty fixes, batched per the council-reviewed plan (must-fixes MF-1/SF-1 baked in).

**P0-4 — calibrate remediation message.** `tg calibrate` on a non-GPU / non-nvidia build used to fail with a bare "requires a CUDA-enabled build" (or "CUDA device unavailable") message and no next step.
- Rust (`rust_core/src/crossover.rs::detect_device_name`): both `bail!` arms now append an ASCII remediation block via a new `crossover_gpu_remediation_hint()` helper — set `TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia` then run `tg upgrade`, naming the platform's release asset via compile-time `cfg` (`tg-linux-amd64-nvidia`, `tg-windows-amd64-nvidia.exe`; macOS honestly states no NVIDIA asset exists there), plus a `tg doctor` pointer. Phrased conditionally ("if published ... falls back to CPU when it is not") so it never goes false if the release asset profile is later flipped on.
- Python (`cli/main.py::calibrate`): the wrapper extends only its OWN missing-binary message with the same pointer. It does not capture the native subprocess's stderr (would break streaming) — the native binary's own calibrate-failure text stays Rust-owned.

**P0-5 — loud nvidia-to-cpu installer downgrade.** `_install_release_native_frontdoor` used to silently install the cpu asset when nvidia was requested but unavailable — indistinguishable from an ordinary cpu install until a later `tg doctor` check.
- It now prints one ASCII warning to stderr at the success chokepoint when the installed flavor differs from the requested flavor, including the first nvidia-flavored download failure reason.
- New `_native_frontdoor_downgrade_reason()` + `_native_frontdoor_download_error_for_flavor()` helpers implement the **SF-1 guard**: when no candidate of the requested flavor was ever attempted at all (e.g. darwin/non-amd64, where `_native_frontdoor_asset_candidates` never appends an nvidia entry), it states the honest "no NVIDIA asset is published for this platform" reason instead of indexing blindly into `download_errors`.
- Silent on the default cpu-request path and when the requested flavor installs successfully. Never pollutes any `--json` stream (stderr only; `tg upgrade` has no `--json` output).
- `_NativeFrontdoorInstallResult` gains `requested_flavor` / `downgrade_reason` fields, defaulted so the single construction site stays valid.

**Bounded gap (not chased here):** the detached Windows refresh helper (`_schedule_windows_native_frontdoor_refresh`, `Popen` with `DEVNULL` stdio) cannot warn interactively — its log file remains the only surface there.

## Tests added (RED verified before the fix)
- `rust_core/src/crossover.rs`: `crossover::tests::detect_device_name_without_cuda_feature_names_remediation` (crossover.rs had no prior `#[cfg(test)]` module — this is the first one)
- `tests/unit/test_medlow_main_cli.py::test_l10_calibrate_exits_one_when_unsupported` (extended with remediation-token assertions; exit-1 contract preserved)
- `tests/unit/test_native_frontdoor_checksum.py`: 4 new tests — (a) nvidia-fails/cpu-succeeds warns with the nvidia reason + metadata check, (b) cpu-requested stays silent, (c) nvidia-succeeds stays silent, (d) SF-1 no-nvidia-candidate-at-all warns honestly with no index error

`tests/unit/test_cli_modes.py::test_calibrate_command_delegates_to_native_tg` (argv pin) verified untouched-green.

## Test plan
- [x] `cargo test` (rust_core) — all green, including the new crossover test
- [x] `cargo clippy -- -D warnings` (default features, no `--tests`) — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --features cuda` — clean (matches the separate `cuda-feature-check` CI job; the cuda-arm edit is only compile-checked there, never test-executed, per the council nit)
- [x] `ruff format --preview .` + `ruff check .` (whole repo) — clean
- [x] `mypy` on the touched module — clean
- [x] Targeted pytest across the 3 affected files — 529 passed
- [x] Full local `pytest -q` — 4823 passed, 34 skipped, 3 pre-existing failures unrelated to this change (an optional `semantic` extra not installed in this fresh worktree venv, combined with a leftover real model directory from a prior session on this machine — confirmed by reading the affected tests' own skip-guard code, which gates on model-directory presence rather than the package import)

Council must-fixes MF-1/SF-1 baked in per the pre-approved plan; **Opus gate pending before merge** (draft, not marked ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)