### PR TITLE
fix(gpu): doctor probe precision + native error-kind taxonomy gate-nits (#172)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -2509,7 +2509,13 @@ mod tests {
     // "CUDA initialization failed: ..." -- true-sounding but wrong: nothing failed to initialize,
     // the id was simply invalid. These tests pin the classifier's OWN reason, verbatim, distinct
     // from the genuine-initialization-failure arms below.
-    #[cfg(feature = "cuda")]
+    //
+    // GPU Phase-0 gate-nit #172 NIT-4 / MF-1: these 3 tests used to ALSO carry their own
+    // `#[cfg(feature = "cuda")]`, so a default `cargo test` (no --features cuda) never compiled
+    // or ran them at all -- silently, since `mod tests` itself is only `#[cfg(test)]`-gated, so
+    // nothing signaled the gap. `classify_gpu_route_failure` and its types are now gated
+    // `any(feature = "cuda", test)` (see the definitions above), which is present under plain
+    // `cargo test`, so the redundant per-test cuda gate is dropped here and these run by default.
     #[test]
     fn classify_gpu_route_failure_reports_invalid_device_id_as_its_own_fatal_reason() {
         let failure =
@@ -2522,7 +2528,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "cuda")]
     #[test]
     fn classify_gpu_route_failure_does_not_relabel_invalid_device_id_as_init_failure() {
         let failure =
@@ -2535,7 +2540,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "cuda")]
     #[test]
     fn classify_gpu_route_failure_still_labels_genuine_init_failures_as_such() {
         // Baseline: the pre-existing "CUDA initialization failed:" arm must keep working --
@@ -2546,6 +2550,23 @@ mod tests {
         assert_eq!(
             failure.message,
             "CUDA initialization failed: driver too old"
+        );
+    }
+
+    // NIT-3 (#172): `gpu_fatal_native_error_kind` is the thin, pure, directly-testable string
+    // check the two `exit_structured_search_error_if_needed` emission sites now call instead of
+    // hardcoding "gpu_fatal" -- these pin its two branches directly, independent of the enum
+    // `kind` (both messages below classify as `GpuRouteFailureKind::Fatal`; only the WIRE error
+    // string differs).
+    #[test]
+    fn gpu_fatal_native_error_kind_distinguishes_invalid_device_id() {
+        assert_eq!(
+            gpu_fatal_native_error_kind("invalid CUDA device id 99; available CUDA devices: 0, 1"),
+            "gpu_invalid_device_id"
+        );
+        assert_eq!(
+            gpu_fatal_native_error_kind("CUDA initialization failed: driver too old"),
+            "gpu_fatal"
         );
     }
 
@@ -10221,14 +10242,26 @@ fn explicit_gpu_sidecar_is_available() -> bool {
         .is_some_and(|path| path.exists())
 }
 
-#[cfg(feature = "cuda")]
+// GPU Phase-0 gate-nit #172 NIT-4 / MF-1: `GpuRouteFailureKind`, `GpuRouteFailure`,
+// `sanitize_cuda_detail`, and `classify_gpu_route_failure` below are gated `any(feature = "cuda",
+// test)` rather than plain `feature = "cuda"` so `cargo test` (default features, no cuda) can
+// compile and RUN the 3 `classify_gpu_route_failure_*` tests in `mod tests` above -- previously
+// those tests were ALSO `#[cfg(feature = "cuda")]`-gated, so a default `cargo test` silently
+// never executed them at all. A bare un-gate of just the tests would not compile (the classifier
+// and its types would still be absent by default); a bare un-gate of the classifier alone would
+// leave it with zero callers in the default build (its production callers stay cuda-gated) and
+// fail `cargo clippy -- -D warnings` on `dead_code`. Gating the definitions themselves on
+// `any(feature = "cuda", test)` solves both: present whenever cuda is enabled (unchanged
+// production behavior) OR whenever `cfg(test)` is set (so the tests below have something to call
+// and are not themselves dead code), absent in the default clippy/release build (no dead_code).
+#[cfg(any(feature = "cuda", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GpuRouteFailureKind {
     Unavailable,
     Fatal,
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", test))]
 struct GpuRouteFailure {
     kind: GpuRouteFailureKind,
     message: String,
@@ -10377,7 +10410,7 @@ fn simulated_gpu_route_failure() -> Option<GpuRouteFailure> {
     None
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", test))]
 fn sanitize_cuda_detail(raw: &str) -> String {
     let compact = raw.replace(['\r', '\n'], " ");
     let lower = compact.to_ascii_lowercase();
@@ -10396,7 +10429,7 @@ fn sanitize_cuda_detail(raw: &str) -> String {
         .to_string()
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", test))]
 fn classify_gpu_route_failure(raw_message: &str) -> GpuRouteFailure {
     if raw_message.starts_with("CUDA is unavailable:") {
         return GpuRouteFailure {
@@ -10469,6 +10502,26 @@ fn classify_gpu_route_failure(raw_message: &str) -> GpuRouteFailure {
             "CUDA initialization failed: {}",
             sanitize_cuda_detail(raw_message)
         ),
+    }
+}
+
+// GPU-P0 gate-nit #172 NIT-3: `classify_gpu_route_failure`'s `Fatal` kind is deliberately coarse
+// (kind + human message only) -- both emission sites below used to collapse EVERY Fatal straight
+// to one native error kind ("gpu_fatal"), including the out-of-range --gpu-device-ids arm above
+// (already given its own message-level branch in `classify_gpu_route_failure` so it is never
+// relabeled as an init failure). The doctor/agent-capsule Python layer maps native error kinds to
+// a status; "gpu_fatal" reads as "GPU unavailable", so a typo'd device id misreported as a
+// capability gap instead of a user-input error. This is a thin, pure, directly-testable string
+// check on the ALREADY-CLASSIFIED Fatal message -- deliberately NOT a 3rd `GpuRouteFailureKind`
+// variant, which would force every `match failure.kind` call site's Fatal arm to add a case for a
+// distinction only the WIRE error-kind string needs to make; the two enum variants remain the
+// coarse "should we CPU-fallback or hard-fail" signal.
+#[cfg(any(feature = "cuda", test))]
+fn gpu_fatal_native_error_kind(message: &str) -> &'static str {
+    if message.starts_with("invalid CUDA device id") {
+        "gpu_invalid_device_id"
+    } else {
+        "gpu_fatal"
     }
 }
 
@@ -10668,7 +10721,7 @@ fn handle_auto_gpu_search(
                     exit_structured_search_error_if_needed(
                         params.json,
                         params.ndjson,
-                        "gpu_fatal",
+                        gpu_fatal_native_error_kind(&failure.message),
                         failure.message,
                     );
                 }
@@ -10838,7 +10891,7 @@ fn handle_gpu_native_search(params: GpuSearchParams<'_>) -> anyhow::Result<()> {
                     exit_structured_search_error_if_needed(
                         params.json,
                         params.ndjson,
-                        "gpu_fatal",
+                        gpu_fatal_native_error_kind(&failure.message),
                         failure.message,
                     );
                 }

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -1426,6 +1426,30 @@ def _agent_gpu_evidence(
             **route_fields,
         }
 
+    # GPU-P0 gate-nit B (#172): the probe command above already translates its (self-generated)
+    # sentinel path when cross_domain, but this evidence command used to append the RAW user
+    # `path` unconditionally -- a Windows-target binary can no more resolve a raw WSL/Linux
+    # search root here than it could the probe's temp dir. Mirror the probe's translate-or-fail-
+    # closed handling instead of silently handing the native binary an unresolvable path (which
+    # would misreport as a generic evidence-command failure rather than the honest
+    # path_domain_mismatch status).
+    evidence_path = path
+    if cross_domain:
+        translated_evidence_path = translate_path_for_windows_binary(path)
+        if translated_evidence_path is None:
+            return {
+                "status": "path_domain_mismatch",
+                "requested_device_ids": requested_device_ids,
+                "used_for_evidence": False,
+                "promotion_claim": False,
+                "reason": (
+                    "resolved native tg binary targets Windows but this WSL host could not "
+                    "translate the evidence path via wslpath (path-domain mismatch, not a GPU "
+                    "capability gap)"
+                ),
+            }
+        evidence_path = translated_evidence_path
+
     evidence_command: list[object] = [
         tg_command,
         "search",
@@ -1436,7 +1460,7 @@ def _agent_gpu_evidence(
     ]
     for term in query_terms:
         evidence_command.extend(["-e", term])
-    evidence_command.append(path)
+    evidence_command.append(evidence_path)
     evidence = _run_agent_gpu_json_command(
         evidence_command,
         timeout_s=effective_timeout_s,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -845,12 +845,14 @@ def _install_release_native_frontdoor(
                 download_errors=download_errors,
             )
             if downgrade_reason is not None:
-                print(
+                # Gate-nit C (#172): the house idiom is typer.echo(..., err=True), not a raw
+                # print(..., file=sys.stderr) -- functionally equivalent, ASCII-safe.
+                typer.echo(
                     f"WARNING: requested native tg front-door flavor '{requested_flavor}' "
                     f"was not installed ({downgrade_reason}); installed '{candidate.flavor}' "
                     "instead. Run 'tg doctor' to check the requested-vs-installed native "
                     "flavor.",
-                    file=sys.stderr,
+                    err=True,
                 )
             return _NativeFrontdoorInstallResult(
                 url=url,
@@ -2724,18 +2726,30 @@ def _doctor_gpu_status() -> dict[str, Any]:
 # exit_structured_search_error_if_needed in rust_core/src/main.rs) with an "error" field naming
 # the failure kind. Map each KNOWN kind to a distinct doctor status instead of collapsing every
 # rc!=0 outcome to one opaque "failed" -- an agent reading tg doctor --json can then tell "the
-# probe's own temp/translated path went missing" (failed_path_bridging) apart from "the sentinel
-# search input was rejected" (failed_input) apart from "the GPU route itself hit a real CUDA
-# fault" (failed_gpu_unavailable). Any kind this table has never seen -- or stdout that is not
-# the expected structured JSON at all (a raw panic, empty output, etc.) -- fails closed to
-# failed_other rather than guessing.
+# probe's own temp/translated path went missing" (failed_path_bridging / failed_probe_path,
+# see _doctor_gpu_probe_failure_status) apart from "the sentinel search input was rejected"
+# (failed_input) apart from "the GPU route itself hit a real CUDA fault" (failed_gpu_unavailable).
+# Any kind this table has never seen -- or stdout that is not the expected structured JSON at all
+# (a raw panic, empty output, etc.) -- fails closed to failed_other rather than guessing.
+#
+# "path_not_found" is intentionally absent from this static table -- NIT-2 (#172):
+# _doctor_gpu_probe_failure_status conditions it on is_cross_domain_native_binary(...) instead,
+# because "failed_path_bridging" bakes in a WSL cross-domain assumption a same-domain host has no
+# grounds to make (a vanished probe dir there is a neutral failed_probe_path, not a bridging
+# failure). CONTRACTS.md does not enumerate doctor GPU-probe failure statuses, so both are
+# additive diagnostics, not a breaking contract change.
 _DOCTOR_GPU_PROBE_FAILURE_STATUS_BY_NATIVE_ERROR_KIND: dict[str, str] = {
-    "path_not_found": "failed_path_bridging",
     "empty_pattern": "failed_input",
     "invalid_regex": "failed_input",
     "gpu_fatal": "failed_gpu_unavailable",
+    # NIT-3 (#172): the classifier's invalid-device arm (rust_core/src/main.rs
+    # gpu_fatal_native_error_kind) emits this DISTINCT kind instead of the coarse "gpu_fatal" so a
+    # typo'd --gpu-device-ids reads as a user-input error, not "GPU unavailable".
+    "gpu_invalid_device_id": "failed_input",
 }
 _DOCTOR_GPU_PROBE_DEFAULT_FAILURE_STATUS = "failed_other"
+_DOCTOR_GPU_PROBE_PATH_NOT_FOUND_STATUS_CROSS_DOMAIN = "failed_path_bridging"
+_DOCTOR_GPU_PROBE_PATH_NOT_FOUND_STATUS_SAME_DOMAIN = "failed_probe_path"
 
 
 def _doctor_gpu_probe_native_error_kind(stdout: str | None) -> str | None:
@@ -2757,9 +2771,17 @@ def _doctor_gpu_probe_native_error_kind(stdout: str | None) -> str | None:
     return error_kind if isinstance(error_kind, str) and error_kind else None
 
 
-def _doctor_gpu_probe_failure_status(native_error_kind: str | None) -> str:
+def _doctor_gpu_probe_failure_status(
+    native_error_kind: str | None, *, cross_domain: bool = False
+) -> str:
     if native_error_kind is None:
         return _DOCTOR_GPU_PROBE_DEFAULT_FAILURE_STATUS
+    if native_error_kind == "path_not_found":
+        return (
+            _DOCTOR_GPU_PROBE_PATH_NOT_FOUND_STATUS_CROSS_DOMAIN
+            if cross_domain
+            else _DOCTOR_GPU_PROBE_PATH_NOT_FOUND_STATUS_SAME_DOMAIN
+        )
     return _DOCTOR_GPU_PROBE_FAILURE_STATUS_BY_NATIVE_ERROR_KIND.get(
         native_error_kind, _DOCTOR_GPU_PROBE_DEFAULT_FAILURE_STATUS
     )
@@ -2844,7 +2866,9 @@ def _doctor_gpu_search_runtime_probe(native_tg_binary: Path | None) -> dict[str,
     if result.returncode != 0:
         native_error_kind = _doctor_gpu_probe_native_error_kind(result.stdout)
         base["native_error_kind"] = native_error_kind
-        base["status"] = _doctor_gpu_probe_failure_status(native_error_kind)
+        base["status"] = _doctor_gpu_probe_failure_status(
+            native_error_kind, cross_domain=cross_domain
+        )
         base["error"] = (result.stderr or "").strip() or "GPU runtime probe failed"
         return base
 
@@ -3008,6 +3032,12 @@ def _build_doctor_payload(
         _DOCTOR_LSP_PROBE_TIMEOUT_ENV,
     ]
     installed_version = _doctor_installed_version()
+    # NIT-1 + MF-2 (#172): compute rust_binary_version BEFORE the inspect_native_tg_binary call
+    # (it used to be computed after) so it can be threaded through as version_text below --
+    # inspect_native_tg_binary's own internal _native_tg_version call would otherwise spawn a
+    # SECOND `tg --version` subprocess against the identical native_tg_binary that this line
+    # already spawned one for.
+    rust_binary_version = _doctor_rust_binary_version(native_tg_binary)
     # P0-2 (#171): surface the native-frontdoor flavor metadata that inspect_native_tg_binary
     # already computes (merging installed-vs-requested asset flavor) -- until now this was only
     # consumed by benchmarks/run_benchmarks.py and benchmarks/run_gpu_native_benchmarks.py, so
@@ -3016,7 +3046,11 @@ def _build_doctor_payload(
     # in-tree dev build never writes tg-native-metadata.json), so every lookup below is a safe
     # `.get(...)` returning None.
     native_frontdoor_inspection = (
-        inspect_native_tg_binary(native_tg_binary, expected_version=installed_version)
+        inspect_native_tg_binary(
+            native_tg_binary,
+            expected_version=installed_version,
+            version_text=rust_binary_version,
+        )
         if native_tg_binary is not None
         else {}
     )
@@ -3024,7 +3058,6 @@ def _build_doctor_payload(
     native_frontdoor_requested_flavor = native_frontdoor_inspection.get(
         "native_frontdoor_requested_flavor"
     )
-    rust_binary_version = _doctor_rust_binary_version(native_tg_binary)
     native_tg_binary_kind = _doctor_native_tg_binary_kind(native_tg_binary)
     rust_binary_version_matches = _doctor_rust_binary_version_matches(
         installed_version,

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -195,8 +195,18 @@ def inspect_native_tg_binary(
     *,
     repo_root: Path | None = None,
     expected_version: str | None = None,
+    version_text: str | None = None,
 ) -> dict[str, str | None]:
-    """Return non-destructive native tg version metadata for diagnostics."""
+    """Return non-destructive native tg version metadata for diagnostics.
+
+    `version_text`, when provided, is trusted as-is and skips the internal `_native_tg_version`
+    subprocess spawn -- GPU Phase-0 gate-nit #172 NIT-1: the doctor path already spawns its own
+    `tg --version` via `_doctor_rust_binary_version` before calling this function, so spawning a
+    SECOND `--version` subprocess for the identical binary here was pure duplication. Do not
+    `@lru_cache` `_native_tg_version` itself to "fix" this a different way -- it is also called by
+    installer verification, which re-reads the SAME path across a candidate loop after
+    `os.replace`; a path-keyed cache would return a stale pre-replace version there.
+    """
     root = repo_root or _repo_root()
     expected = expected_version or _expected_tg_version()
     try:
@@ -217,7 +227,8 @@ def inspect_native_tg_binary(
     else:
         kind = "external"
 
-    version_text = _native_tg_version(resolved) if resolved.is_file() else None
+    if version_text is None and resolved.is_file():
+        version_text = _native_tg_version(resolved)
     if not resolved.is_file():
         version_status = "missing"
     elif _native_tg_version_matches(expected, version_text):

--- a/tests/unit/test_agent_capsule_gpu_probe.py
+++ b/tests/unit/test_agent_capsule_gpu_probe.py
@@ -60,6 +60,90 @@ def test_agent_gpu_evidence_cross_domain_translates_probe_path(monkeypatch, tmp_
     assert result["status"] != "failed"
 
 
+def test_agent_gpu_evidence_cross_domain_translates_evidence_path(monkeypatch, tmp_path):
+    """NIT-B (#172): the FIRST (probe) command translates `path` when cross_domain, but the
+    SECOND (evidence) command used to append the RAW user `path` -- a Windows-target binary
+    cannot resolve a raw WSL/Linux path any more for the evidence scan than it can for the
+    probe scan. Both commands must translate the same way."""
+    translated_probe_path = "C:\\Users\\x\\AppData\\Local\\Temp\\tg-agent-gpu-probe-abc"
+    translated_evidence_path = "C:\\Users\\x\\repo"
+
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: True)
+
+    def _fake_translate(path):
+        # The probe path is a fresh TemporaryDirectory under the "tg-agent-gpu-probe-" prefix;
+        # the evidence path is the caller's own `path` argument -- assert each is translated
+        # independently rather than the probe's cached translation leaking into the evidence
+        # command's argv.
+        return (
+            translated_probe_path
+            if "tg-agent-gpu-probe-" in str(path)
+            else translated_evidence_path
+        )
+
+    monkeypatch.setattr(agent_capsule, "translate_path_for_windows_binary", _fake_translate)
+
+    captured_calls: list[list[str]] = []
+
+    def _fake_run(command, **_kwargs):
+        captured_calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    result = agent_capsule._agent_gpu_evidence(
+        query="needle_query", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert len(captured_calls) == 2, "expected a probe call and an evidence call"
+    # The evidence call's LAST argv element is the search path -- it must be the TRANSLATED
+    # Windows path, not the raw Linux/WSL `path` argument the capsule was invoked with.
+    assert captured_calls[1][-1] == translated_evidence_path
+    assert str(tmp_path) not in captured_calls[1]
+    assert result["status"] != "path_domain_mismatch"
+    assert result["status"] != "failed"
+
+
+def test_agent_gpu_evidence_path_domain_mismatch_when_evidence_translation_unavailable(
+    monkeypatch, tmp_path
+):
+    """NIT-B (#172): when the probe path translates fine but the EVIDENCE path's translation
+    fails, the function must fail closed with the same honest path_domain_mismatch status
+    instead of shelling out with an unresolvable raw path."""
+    translated_probe_path = "C:\\Users\\x\\AppData\\Local\\Temp\\tg-agent-gpu-probe-abc"
+
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", lambda _binary: True)
+
+    def _fake_translate(path):
+        return translated_probe_path if "tg-agent-gpu-probe-" in str(path) else None
+
+    monkeypatch.setattr(agent_capsule, "translate_path_for_windows_binary", _fake_translate)
+
+    captured_calls: list[list[str]] = []
+
+    def _fake_run(command, **_kwargs):
+        captured_calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, json.dumps(_fake_native_gpu_payload()), "")
+
+    monkeypatch.setattr(agent_capsule.subprocess, "run", _fake_run)
+
+    result = agent_capsule._agent_gpu_evidence(
+        query="needle_query", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert len(captured_calls) == 1, "must not shell out for evidence once translation fails"
+    assert result["status"] == "path_domain_mismatch"
+    assert result["used_for_evidence"] is False
+    assert result["promotion_claim"] is False
+    assert "wslpath" in result["reason"]
+
+
 def test_agent_gpu_evidence_path_domain_mismatch_when_translation_unavailable(
     monkeypatch, tmp_path
 ):

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2333,11 +2333,44 @@ def test_doctor_gpu_runtime_probe_native_error_kind_is_none_on_success(
 # opaque "failed" status. The native binary (run with --json) prints a structured
 # {"error": "<kind>", "detail": ...} object to stdout before exiting non-zero; these pin the
 # doctor's mapping from each known kind to a distinct, honest status.
-def test_doctor_gpu_runtime_probe_maps_path_not_found_to_failed_path_bridging(
+# NIT-2 (#172): failed_path_bridging bakes in a WSL cross-domain assumption -- outside a genuine
+# cross-domain host, a vanished probe path is not a "bridging" failure at all, so the mapping is
+# now CONDITIONAL on is_cross_domain_native_binary(...) (the same collaborator the P0-1 WSL
+# translation logic above already uses). These two tests pin both branches.
+def test_doctor_gpu_runtime_probe_maps_path_not_found_to_failed_probe_path_when_not_cross_domain(
     monkeypatch, tmp_path: Path
 ) -> None:
     native_tg = tmp_path / "tg.exe"
     native_tg.write_text("native", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.cli.main.is_cross_domain_native_binary", lambda _binary: False)
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "path_not_found",
+            "detail": "search path does not exist: <doctor-gpu-probe-file>",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_probe_path"
+    assert probe["native_error_kind"] == "path_not_found"
+    assert probe["exit_code"] == 2
+
+
+def test_doctor_gpu_runtime_probe_maps_path_not_found_to_failed_path_bridging_when_cross_domain(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.cli.main.is_cross_domain_native_binary", lambda _binary: True)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main.translate_path_for_windows_binary", lambda _path: "C:\\translated"
+    )
 
     def _fake_run(command, **_kwargs):
         stdout = json.dumps({
@@ -2414,7 +2447,7 @@ def test_doctor_gpu_runtime_probe_maps_gpu_fatal_to_failed_gpu_unavailable(
             "version": 1,
             "ok": False,
             "error": "gpu_fatal",
-            "detail": "invalid CUDA device id 0; available CUDA devices: (none)",
+            "detail": "CUDA initialization failed: driver too old",
         })
         return subprocess.CompletedProcess(command, 2, stdout, "")
 
@@ -2424,6 +2457,34 @@ def test_doctor_gpu_runtime_probe_maps_gpu_fatal_to_failed_gpu_unavailable(
 
     assert probe["status"] == "failed_gpu_unavailable"
     assert probe["native_error_kind"] == "gpu_fatal"
+
+
+# NIT-3 (#172): the native classifier's invalid-device arm now emits a DISTINCT native error kind
+# (gpu_invalid_device_id, see rust_core/src/main.rs classify_gpu_route_failure +
+# gpu_fatal_native_error_kind) instead of the coarse gpu_fatal every other Fatal reason still
+# uses -- a typo'd --gpu-device-ids now reads as a user-input error (failed_input) rather than
+# misreporting as "GPU unavailable" (failed_gpu_unavailable).
+def test_doctor_gpu_runtime_probe_maps_gpu_invalid_device_id_to_failed_input(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    def _fake_run(command, **_kwargs):
+        stdout = json.dumps({
+            "version": 1,
+            "ok": False,
+            "error": "gpu_invalid_device_id",
+            "detail": "invalid CUDA device id 99; available CUDA devices: (none)",
+        })
+        return subprocess.CompletedProcess(command, 2, stdout, "")
+
+    monkeypatch.setattr("tensor_grep.cli.main.subprocess.run", _fake_run)
+
+    probe = cli_main._doctor_gpu_search_runtime_probe(native_tg)
+
+    assert probe["status"] == "failed_input"
+    assert probe["native_error_kind"] == "gpu_invalid_device_id"
 
 
 def test_doctor_gpu_runtime_probe_maps_unrecognized_error_kind_to_failed_other(
@@ -2490,6 +2551,92 @@ def test_doctor_gpu_runtime_probe_native_error_kind_absent_for_path_domain_misma
 
     assert probe["status"] == "path_domain_mismatch"
     assert probe["native_error_kind"] is None
+
+
+# NIT-1 + MF-2 (#172): _doctor_rust_binary_version and inspect_native_tg_binary (added by #595)
+# each spawned their OWN `tg --version` subprocess for the IDENTICAL resolved native_tg_binary --
+# inspect_native_tg_binary's internal _native_tg_version call was pure duplication, only possible
+# to eliminate by threading the doctor's already-computed text through as version_text, which in
+# turn requires computing rust_binary_version BEFORE (not after) the inspect_native_tg_binary
+# call. These pin the doctor-level effect of that ordering + threading fix.
+def test_doctor_payload_threads_rust_binary_version_into_inspect_native_tg_binary(
+    monkeypatch, tmp_path: Path
+) -> None:
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.75.2")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_binary_version",
+        lambda _binary: "tg 1.75.2",
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+
+    captured_kwargs: list[dict] = []
+    real_inspect = cli_main.inspect_native_tg_binary
+
+    def _capturing_inspect(candidate, **kwargs):
+        captured_kwargs.append(kwargs)
+        return real_inspect(candidate, **kwargs)
+
+    monkeypatch.setattr("tensor_grep.cli.main.inspect_native_tg_binary", _capturing_inspect)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0].get("version_text") == "tg 1.75.2"
+    payload = json.loads(result.stdout)
+    assert payload["rust_binary_version"] == "tg 1.75.2"
+
+
+def test_doctor_payload_does_not_double_spawn_native_tg_version(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The doctor-level spawn-count pin: with rust_binary_version threaded through as
+    version_text, inspect_native_tg_binary's own internal _native_tg_version subprocess call
+    (runtime_paths.py) must never fire for the doctor's resolved native_tg_binary."""
+    from tensor_grep.cli import runtime_paths as runtime_paths_module
+
+    native_tg = tmp_path / "tg.exe"
+    native_tg.write_text("native", encoding="utf-8")
+
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "1.75.2")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: native_tg)
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_rust_binary_version",
+        lambda _binary: "tg 1.75.2",
+    )
+    monkeypatch.setattr(
+        "tensor_grep.cli.main._doctor_session_daemon_status",
+        lambda path: {"running": False},
+    )
+
+    native_tg_version_call_count = 0
+    real_native_tg_version = runtime_paths_module._native_tg_version
+
+    def _counting_native_tg_version(candidate):
+        nonlocal native_tg_version_call_count
+        native_tg_version_call_count += 1
+        return real_native_tg_version(candidate)
+
+    monkeypatch.setattr(
+        "tensor_grep.cli.runtime_paths._native_tg_version", _counting_native_tg_version
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    assert native_tg_version_call_count == 0, (
+        "inspect_native_tg_binary must not spawn its own _native_tg_version subprocess when the "
+        "doctor already threaded version_text through (would double-spawn `tg --version`)"
+    )
 
 
 def test_doctor_json_reports_native_version_mismatch(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -192,6 +192,75 @@ def test_inspect_native_tg_binary_reports_matching_in_tree_binary(monkeypatch, t
     assert inspected["version"] == "tensor-grep 1.12.4"
 
 
+def test_inspect_native_tg_binary_honors_provided_version_text_without_subprocess_spawn(
+    monkeypatch, tmp_path
+):
+    """NIT-1 (#172): the doctor path (main.py's _build_doctor_payload) already computes a
+    binary's version via its own `tg --version` subprocess call (_doctor_rust_binary_version)
+    before calling inspect_native_tg_binary, which -- until this fix -- unconditionally spawned
+    a SECOND `tg --version` subprocess for the identical binary via its own internal
+    _native_tg_version call (added by #595). When the caller already has the text, passing it as
+    version_text must skip that internal spawn entirely."""
+    repo_root = tmp_path / "repo"
+    binary_name = "tg.exe" if sys.platform.startswith("win") else "tg"
+    native_binary = repo_root / "rust_core" / "target" / "release" / binary_name
+    native_binary.parent.mkdir(parents=True, exist_ok=True)
+    native_binary.write_text("current\n", encoding="utf-8")
+
+    call_count = 0
+
+    def _counting_native_tg_version(_candidate):
+        nonlocal call_count
+        call_count += 1
+        return "tg 1.12.4"
+
+    monkeypatch.setattr(runtime_paths, "_native_tg_version", _counting_native_tg_version)
+
+    inspected = runtime_paths.inspect_native_tg_binary(
+        native_binary,
+        repo_root=repo_root,
+        expected_version="1.12.4",
+        version_text="tg 1.12.4",
+    )
+
+    assert call_count == 0, (
+        "inspect_native_tg_binary must not call _native_tg_version when version_text is provided"
+    )
+    assert inspected["version"] == "tg 1.12.4"
+    assert inspected["version_status"] == "matches"
+    assert inspected["kind"] == "in-tree-release"
+
+
+def test_inspect_native_tg_binary_falls_back_to_native_tg_version_when_version_text_omitted(
+    monkeypatch, tmp_path
+):
+    """Baseline: omitting version_text (the pre-existing call shape) preserves the internal
+    _native_tg_version subprocess path -- this NIT must not remove that fallback."""
+    repo_root = tmp_path / "repo"
+    binary_name = "tg.exe" if sys.platform.startswith("win") else "tg"
+    native_binary = repo_root / "rust_core" / "target" / "release" / binary_name
+    native_binary.parent.mkdir(parents=True, exist_ok=True)
+    native_binary.write_text("current\n", encoding="utf-8")
+
+    call_count = 0
+
+    def _counting_native_tg_version(_candidate):
+        nonlocal call_count
+        call_count += 1
+        return "tg 1.12.4"
+
+    monkeypatch.setattr(runtime_paths, "_native_tg_version", _counting_native_tg_version)
+
+    inspected = runtime_paths.inspect_native_tg_binary(
+        native_binary,
+        repo_root=repo_root,
+        expected_version="1.12.4",
+    )
+
+    assert call_count == 1
+    assert inspected["version"] == "tg 1.12.4"
+
+
 def test_expected_tg_version_prefers_repo_source_when_editable_metadata_is_stale(monkeypatch):
     monkeypatch.setattr(
         importlib.metadata,


### PR DESCRIPTION
## Summary

GPU Phase-0 gate-NIT collector (#172): 5 correctness/precision NITs on the doctor GPU-probe +
native classifier + agent-capsule surface, each with a council must-fix baked in, plus one
trivial cleanup NIT surfaced by the same review pass.

- **NIT-B** (`src/tensor_grep/cli/agent_capsule.py`): the GPU-probe's evidence command used to
  append the RAW user `path` even when `cross_domain` was true, while the probe command already
  translated its own sentinel path. Now the evidence command translates `path` the same way and
  fails closed to the same honest `path_domain_mismatch` status on translation failure, mirroring
  the probe command's handling.
- **NIT-1 + MF-2** (`src/tensor_grep/cli/runtime_paths.py`, `src/tensor_grep/cli/main.py`):
  `tg doctor` spawned `tg --version` TWICE against the identical resolved native binary --
  once via `_doctor_rust_binary_version`, once again inside `inspect_native_tg_binary`'s own
  `_native_tg_version` call. Added an optional `version_text` kwarg to `inspect_native_tg_binary`
  that skips its internal subprocess spawn when provided, and reordered `_build_doctor_payload` so
  `rust_binary_version` is computed BEFORE the `inspect_native_tg_binary` call so it can be threaded
  through. `_native_tg_version` itself is intentionally NOT `@lru_cache`d -- it is shared with
  installer verification, which re-reads the same path across a candidate loop after `os.replace`.
- **NIT-2** (`src/tensor_grep/cli/main.py`): `path_not_found` unconditionally mapped to
  `failed_path_bridging`, baking in a WSL cross-domain assumption. Now conditional on
  `is_cross_domain_native_binary(...)`: cross-domain keeps `failed_path_bridging`, same-domain gets
  a neutral `failed_probe_path`. Additive diagnostic -- `CONTRACTS.md` does not enumerate doctor
  GPU-probe failure statuses.
- **NIT-3** (`rust_core/src/main.rs`, `src/tensor_grep/cli/main.py`): every `GpuRouteFailureKind::Fatal`
  emitted the same native kind `"gpu_fatal"`, including the out-of-range `--gpu-device-ids` arm, so a
  typo'd device id misreported as "GPU unavailable" instead of a user-input error. Added a pure,
  directly-testable `gpu_fatal_native_error_kind` helper (string-level check on the classified Fatal
  message, deliberately NOT a 3rd `GpuRouteFailureKind` enum variant) that both emission sites now
  call; it emits the distinct `gpu_invalid_device_id` kind for the invalid-device case. Added the
  matching Python table row `"gpu_invalid_device_id": "failed_input"`.
- **NIT-4 + MF-1** (`rust_core/src/main.rs`, decisive): `classify_gpu_route_failure` and its types
  were `#[cfg(feature = "cuda")]`-gated, and so were their 3 tests -- a default `cargo test` (no
  `--features cuda`) silently never ran them. A bare un-gate of just the tests would not compile
  (the classifier/types would still be absent); a bare un-gate of the classifier alone would leave
  it with zero callers in the default build (production callers stay cuda-gated) and fail
  `cargo clippy -- -D warnings` on `dead_code`. Fix: gate `classify_gpu_route_failure` +
  `GpuRouteFailure` + `GpuRouteFailureKind` + `sanitize_cuda_detail` (+ the new
  `gpu_fatal_native_error_kind`) with `#[cfg(any(feature = "cuda", test))]`, and drop the
  redundant per-test `#[cfg(feature = "cuda")]`. Verified: `cargo clippy -- -D warnings` (default
  features) is clean, and `cargo test` now runs all 4 classifier-family tests.
- **Gate-nit C** (`src/tensor_grep/cli/main.py`, trivial): the P0-5 installer-downgrade warning
  used raw `print(..., file=sys.stderr)`; changed to the house idiom `typer.echo(..., err=True)`.

## Same-PR CI-pin updates

`#595`'s doctor-probe status pins in `tests/unit/test_cli_modes.py` are updated for the NIT-2/
NIT-3 mapping changes: the `path_not_found` test is split into cross-domain
(`failed_path_bridging`) and same-domain (`failed_probe_path`) variants, the `gpu_fatal` test's
fixture `detail` text no longer describes an invalid-device scenario (that now classifies under
the new kind), and a new `gpu_invalid_device_id` -> `failed_input` test was added.

## Test plan

- [x] Rust: `cargo test` (default features) -- 95 passed, including the 3 previously-dead
      `classify_gpu_route_failure_*` tests and the new `gpu_fatal_native_error_kind` test.
- [x] Rust: `cargo clippy -- -D warnings` (default features, no `--tests`) -- clean, no `dead_code`.
- [x] Rust: `cargo check --features cuda` -- clean.
- [x] Rust: `cargo fmt --check` -- clean.
- [x] Python: targeted -- `tests/unit/test_agent_capsule_gpu_probe.py`,
      `tests/unit/test_runtime_paths.py`, `tests/unit/test_cli_modes.py` -- all green.
- [x] Python: `ruff format --preview .` (whole repo) + `ruff check .` -- clean on all files this PR
      touches (4 unrelated `docs/*.md` files show pre-existing CRLF/LF-only churn against `main`,
      not touched here).
- [x] Python: full suite (`uv run --no-sync pytest`) -- see run notes.

Council MF-1 (Rust cfg-gate decisive fix, both council lenses) and MF-2 (doctor ordering fix,
required before `version_text` can be threaded through) are baked in per the task brief. Opus gate
pending; merge held for the current release push-race per house process.
