### PR TITLE
docs(agents): capture session orchestration patterns + reconcile skill index + CI divergence gate + GPU doc reframe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,15 @@ concrete failure observed this session.
   `&` in a `run_in_background` wrapper orphaned it). Each fire is short-lived, so nothing can be killed
   mid-run. Push-race gate per fire: the latest `chore(release)` tag must be on PyPI AND `main` CI
   `completed` before merging.
-- **A3 — Mandatory adversarial security gate before merge.** Every security PR — touching `apply_policy`
-  / `mcp_server` / `*_backend` / an index-or-session lock / auth / money / migration — gets an Opus "try
-  to BREAK it, cite `file:line`, default FIX-FIRST if uncertain" review *before* merge. Not a rubber
-  stamp: this session it returned SHIP on some and caught real issues on others (a symlink RCE bypass; a
-  lock-release TOCTOU). `codex` is the nominal second vendor but its WSL path is unreliable → Opus is the
+- **A3 -- Mandatory adversarial security gate before merge.** Every security PR -- touching `apply_policy`
+  / `mcp_server` / `*_backend` / an index-or-session lock / auth / money / migration / native asset /
+  installer / doctor-probe construction -- gets an Opus "try to BREAK it, cite `file:line`, default
+  FIX-FIRST if uncertain" review *before* merge. Not a rubber stamp: this session it returned SHIP on some
+  and caught real issues on others (a symlink RCE bypass; a lock-release TOCTOU). The native-asset /
+  installer / doctor-probe trigger was added after the v1.75.1-v1.75.3 GPU wave (#594-#596: WSL
+  path-domain probe bridging, doctor probe failure taxonomy, calibrate/installer remediation) ran every PR
+  through this same gate and it returned real `SHIP-WITH-NIT` / `SHIP` verdicts off 8/8 clean probes rather
+  than a rubber stamp. `codex` is the nominal second vendor but its WSL path is unreliable -> Opus is the
   reliable substitute. Verdict shape: `SHIP` | `FIX-FIRST(+file:line + repro + minimal fix)`.
 - **A4 — Resume a dead agent from its transcript.** A background subagent that dies with "terminated
   early due to an API error: 500" is REVIVED by `SendMessage` to its `agentId` (partial work intact) — do
@@ -69,12 +73,53 @@ concrete failure observed this session.
 - **A8 — Fable is reachable only via `Agent(model:fable)`.** A Workflow `agent()` call cannot reach Fable —
   it silently falls back to the session model. Dispatch Fable design/audit seats as `Agent` subagents,
   never inside a `Workflow`.
+- **A9 -- Probe liveness via `SendMessage` before any `TaskStop`.** A background subagent's output-file
+  mtime/size is UNRELIABLE (0KB for 40-57 min while foreground-compiling). The reliable alive-vs-paused
+  tell is a `SendMessage` probe: a reply of "Message queued...at its next tool round" means ALIVE;
+  "had no active task; resumed from transcript" means it WAS PAUSED. Corroborate with Pyright
+  `<new-diagnostics>` on its file-writes plus the active build-process count. Cross-ref A5 ("don't kill on
+  staleness") -- this probe is the mechanism A5's "trust the completion notification" actually relies on.
+- **A10 -- A no-verdict council seat is a FAILED seat, not a blocker.** The codex thinktank seat can hang
+  on an MCP-auth spin (cloudflare/sentry `invalid_token`) -> 0KB output, no anchored verdict. Treat it as
+  FAILED: kill it, sweep the orphaned processes it left behind (20+ stale codex processes found in one
+  session), and synthesize from the surviving Opus lenses instead of waiting on it.
+- **A11 -- Design-review-before-build** (CEO directive #174). Fable designs a plan -> a thinktank council
+  certifies the PLAN itself is sound and ready (not findings, not a diff) -> bake must-fixes into the plan
+  -> Sonnet builds TDD-first (worktree, foreground-gate) -> mandatory adversarial Opus gate (now including
+  native-asset/installer/doctor-probe work, see the A3 extension above) -> drain one PR per publish. This
+  sequence caught a CI-reddening fix, an ordering bug, and a GPU-oversell claim BEFORE any code was built
+  this session.
 
 ## Current Handoff
 
 release_docs_current_tag: v1.75.4
 
 As of 2026-06-26, the current tagged release state is `v1.75.4`, and the latest complete public PyPI/release-asset distribution is also `v1.75.4`. The stable installer, release-native asset publication, managed-native `tg upgrade` refresh path, stale tensor-grep-owned `tg.com` bridge refresh after upgrade, native-front-door CLI parity fixes, Windows `.cmd` quoted-pattern launcher fix, native-first Windows PATH ordering, top-level validation-command contract, local default `classify`, classify provider provenance, fixed multi-pattern native CPU search, GPU scale benchmark correctness gates, launcher-route observability, benchmark launcher attribution, scoped GPU device probing, benchmark launcher warnings, opt-in `tg agent` Actionable Context Capsule, mixed-language capsule confidence/validation alignment, GPU benchmark recommendation hygiene, edit JSON/rollback safety, explicit language/file-name agent ranking, Windows validation-command quoting, docs/version governance, `$file` / `{file}` validation placeholder substitution, native CUDA correctness gates, ambiguous capsule alternative-target surfacing, root help-menu diagnostics, foreign launcher diagnostics, benchmark promotion-gate taxonomy, agent workflow benchmark governance, capsule alternative-confidence capping, generic provider-token `secrets-basic` regex rules, release-docs synchronization, release wheel Cargo prefetch retries, native GPU/search accuracy hardening, explicit Windows Python subprocess launcher repair, agent capsule hardcase routing, Windows subprocess bridge ranking hardening, and long-lived agent-loop memory/cache caps are released through `v1.75.4` GitHub assets and PyPI. Follow-up work should focus on context/session latency, GPU production viability, token economy, call-site evidence, AST parity roadmap, classify provider/cache UX, and keeping docs synchronized with release proof.
+
+**2026-07-14 Current-Handoff addendum -- GPU Phase-0 hardening wave (v1.75.1-v1.75.4, audit #171).** Four
+PRs closed audit #171's P0-1 through P0-5 GPU findings, each behind the mandatory Opus adversarial gate
+(SHIP / SHIP-WITH-NIT verdicts, 8/8 probes clean): `#594` (v1.75.1) bridged a WSL path-domain mismatch in
+the doctor/agent GPU probes (a Windows-target binary resolved from WSL cannot open a `/tmp/...` sentinel
+path -- the probe now detects cross-domain, translates the path via `wslpath -w`, and fails closed to a
+distinct `path_domain_mismatch` status instead of a generic "failed") and added a `cargo check --features
+cuda` anti-bit-rot CI gate so the `cuda` Cargo feature -- normally compiled only by release legs gated on
+the `TENSOR_GREP_RELEASE_NATIVE_ASSET_PROFILE` repository variable equalling `native-frontdoor-gpu` -- is
+checked on every PR instead of rotting silently between releases; `#595` (v1.75.2) replaced the doctor's
+opaque GPU-probe `status="failed"` with a structured `native_error_kind` taxonomy (`failed_path_bridging`
+/ `failed_input` / `failed_gpu_unavailable` / `failed_other`) and added an honest out-of-range
+`--gpu-device-ids` warning instead of an indistinguishable silent CPU fallback; `#596` (v1.75.3) added a
+`calibrate` remediation message on both native bail arms plus a loud nvidia-requested/cpu-delivered
+installer downgrade warning; `#597` (v1.75.4) closed 5 gate-nits from the Opus review of the prior three
+(evidence-path translation, doctor version dedup/reorder, a cross-domain-conditional `path_not_found`
+fix, an invalid-device-id classification fix, and co-gating `sanitize_cuda_detail` plus its callers under
+`#[cfg(any(feature = "cuda", test))]` so a default `cargo test` actually compiles and runs its unit tests
+instead of silently skipping them -- see the CI/Release Rules bullet on this pattern below). Separately,
+`#593` (v1.75.0) shipped an unrelated `tg orient` / `tg agent` improvement (M1+M2: broadened
+`suggested_ignore` whole vendor/skill-tree detection with a new STRONG-0 promotion tier) that landed in
+the same version range by coincidence of publish order, not as part of the GPU wave -- verify-before-cite
+matters even for a version range handed down in a task brief. See `docs/gpu_crossover.md` for the GPU
+promotion-status read and the Roadmap Sequencing section for the Phase 0/1/2 framing this wave completes
+Phase 0 of.
 
 - Recent fix commits:
   - `a840cd4 fix(search): tg search --rank errored in plain-text mode (#275)`
@@ -281,15 +326,49 @@ This contract is violated repeatedly. The recurring anti-pattern is a bare `exce
 
 The same discipline applies beyond backends: any router/pipeline that can silently override an explicit user intent (e.g. an explicit `--gpu` request quietly routed to CPU) must instead raise `ConfigurationError` or emit a diagnostic. A systemic `SafeBackendMixin` + a fault-injection conformance CI gate (every registered backend must raise, not return empty, when its engine call fails) is the planned structural fix so this stops recurring one file at a time.
 
-## Roadmap Sequencing (2026-07-02)
+## Roadmap Sequencing (2026-07-02, GPU phase structure added 2026-07-14)
 
-The GPU native-backend program (the P1 CUDA-PFAC kernel and beyond) is **held at the already-shipped P0 harness** — the correctness taxonomy, the loud non-promotional fallback, and the `doctor`/proof fields. Do **not** advance to P2–P4 (kernel, correctness gates, fair-bench, device/CI proof) until three CPU-only, every-install wins ship first:
+The GPU native-backend program runs a 3-phase sequence gated on evidence, not a blanket "hold until N CPU
+wins ship" rule:
 
-1. **Local hybrid semantic search** (BM25 + CPU dense embeddings fused with RRF, no API key) — the #1 validated user ask and the biggest competitive gap. Reference architecture: MinishLab `Semble` (tree-sitter chunking + `potion-code-16M` Model2Vec + BM25 + RRF, CPU-only, MIT).
-2. **`tg registration-check` productized** as a first-class command — a real-use-validated agent-native differentiator no plain grep/ast-grep offers.
-3. **A Bloom-filter n-gram chunk prefilter** for the slow non-literal-regex full-scan path in `rust_core`, which is far more broadly felt than the GPU program's narrow many-pattern-resident niche.
+- **Phase 0 -- shipped, gated OFF by default.** The correctness taxonomy, the loud non-promotional CPU
+  fallback, the `doctor`/proof fields, and (v1.75.1-v1.75.4, audit #171 P0-1..P0-5 -- see the Current
+  Handoff addendum above) the WSL path-domain probe bridging, doctor probe failure taxonomy, honest
+  `--gpu-device-ids` validation, `calibrate` remediation messaging, and the loud nvidia->cpu installer
+  downgrade warning are all SHIPPED and locally correctness-proven (RTX 4070 / RTX 5070, 1GB/5GB). The
+  native `cuda` Cargo feature only compiles into release assets when the repository variable
+  `TENSOR_GREP_RELEASE_NATIVE_ASSET_PROFILE` is explicitly set to `native-frontdoor-gpu`; the shipped
+  default (`native-frontdoor`) never builds or ships a GPU asset, so Phase 0 landing is a code-complete,
+  correctness-gated capability with zero public exposure until an operator opts in.
+- **Phase 1 -- reversible flag-flip, not yet authorized.** Flipping the release variable to build and ship
+  a GPU native asset is a reversible, single-variable change, but shipping the ASSET is not the same as
+  PROMOTING it: no crossover has been proven (GPU remains slower than `rg` / `tg_cpu` for single-pattern
+  search; see `docs/gpu_crossover.md`), and the public promotion gate
+  (`.github/workflows/public-gpu-proof.yml`, dispatch-only) has not been run to a `public_gpu_proof =
+  true` / `public_managed_promotion_ready = true` verdict -- the exact requirements are pinned in
+  [docs/CONTRACTS.md](docs/CONTRACTS.md) (the "Public managed GPU promotion" bullets, currently around
+  lines 80-82). Do not flip the variable to promote GPU as a default route until that gate passes.
+- **Phase 2 -- self-hosted GPU CI runner, CEO-gated.** Proving Phase 1's crossover claim at 1GB/5GB scale
+  in CI (rather than only on local RTX 4070/5070 dogfood boxes) requires a self-hosted GPU-capable runner
+  wired into `public-gpu-proof.yml`. That is a real recurring infra cost and access-control surface, so
+  provisioning it is explicitly CEO-gated, not an engineering-capacity decision.
 
-Rationale: the project's own docs place raw search speed (where GPU competes) in the **parity tier, not the moat**; GPU is currently slower than CPU with no promotion-ready path; and the heuristic auto-GPU route is effectively dead code whenever ripgrep is installed (the common case). The moat is the **agent-native context layer** (`orient` / `callers` / blast-radius / the token-efficient capsule), so engineering capacity funds that first. Explicit `--gpu-device-ids` stays supported and must fail loud when it cannot be honored (see the Backend Fail-Closed Contract).
+The original CPU-only "3 wins before GPU advances" gate (2026-07-02) is superseded by this phase
+structure, but its first win already shipped and validates the sequencing logic: **local hybrid semantic
+search** (BM25 + CPU dense embeddings fused with RRF, no API key, no GPU) -- the #1 validated user ask --
+shipped as `tg search --semantic` (`retrieval_dense.py` + `retrieval_fusion.py`, default-OFF, gated on
+the `semantic` extra; see the `tensor-grep-semantic-search-campaign` skill). Reference architecture:
+MinishLab `Semble` (tree-sitter chunking + `potion-code-16M` Model2Vec + BM25 + RRF, CPU-only, MIT). The
+other two original CPU-only items -- `tg registration-check` productized as a first-class command, and a
+Bloom-filter n-gram chunk prefilter for the slow non-literal-regex full-scan path in `rust_core` -- have
+not shipped and remain live backlog items, independent of GPU phase gating.
+
+Rationale (unchanged): the project's own docs place raw search speed (where GPU competes) in the
+**parity tier, not the moat**; the heuristic auto-GPU route is effectively dead code whenever ripgrep is
+installed (the common case). The moat is the **agent-native context layer** (`orient` / `callers` /
+blast-radius / the token-efficient capsule), so engineering capacity funds that first. Explicit
+`--gpu-device-ids` stays supported and must fail loud when it cannot be honored (see the Backend
+Fail-Closed Contract).
 
 ## Security Hardening Patterns (Round-3 audit lens)
 
@@ -316,11 +395,12 @@ Three kinds of skills apply to this repo; load the relevant one before non-trivi
   - `verify-plan-against-code` — before building an AI/subagent-drafted plan, verify every seam claim (file paths, the command/flag registration sites above, routing) against the real code with `file:line` citations; bake corrections in first.
   - `supply-chain-hardening` — before writing any download / extract / install / self-upgrade / toolchain-bootstrap code, apply the 5 checks (zip-slip guard, byte-capped/time-bound downloads, fail-closed checksum incl. detached helpers, `--locked` pinned CI tools, fail-closed unverified toolchains). Shipped patterns: #283/#284/#285/#287.
   - `worktree-fanout-verification-gate` — before integrating agent branches from a worktree fan-out: remove worktrees before checkout (`git worktree remove --force <path>` — else checkout is blocked and tests silently run main's code); re-run pytest/ruff/mypy in the real venv (worktrees have no `.venv`; agents' "tests pass" claims are hypotheses until then); run `ruff format --preview` on ALL agent-touched files (not only hand-fixed ones); and treat scoped-local-green as a hypothesis, not a merge signal.
-- **Carrying the project forward — the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **16 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent:
+- **Carrying the project forward -- the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **20 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent -- this exact bucket list is kept byte-identical with `CLAUDE.md`'s skill index; `tests/unit/test_skill_index_sync.py` fails if either doc drifts from the real `.claude/skills/` folder set:
   - **Change safely:** `tensor-grep-change-control` (the gates), `tensor-grep-debugging-playbook`, `tensor-grep-failure-archaeology` (don't re-fight settled battles), `tensor-grep-validation-and-qa`.
   - **Understand:** `tensor-grep-architecture-contract`, `code-search-and-retrieval-reference` (domain theory), `tensor-grep-config-and-flags`.
   - **Operate:** `tensor-grep-build-and-env`, `tensor-grep-run-and-operate`, `tensor-grep-diagnostics-and-tooling`, `tensor-grep-docs-and-writing`, `tensor-grep-release-and-positioning`, `tensor-grep-workspace-dogfood` (multi-repo stress dogfood), `tensor-grep-enterprise-agent` (enterprise readiness gaps + agent hard-stops).
-  - **Advance (SOTA):** `tensor-grep-semantic-search-campaign`, `tensor-grep-benchmark-and-proof-toolkit`, `tensor-grep-research-frontier`, `tensor-grep-research-methodology`.
+  - **Advance (SOTA):** `tensor-grep-semantic-search-campaign`, `tensor-grep-benchmark-and-proof-toolkit`, `tensor-grep-research-frontier`, `tensor-grep-research-methodology`, `tensor-grep-large-repo-scale-campaign` (bounding scale/deadline on large repos).
+  - **Orchestrate:** `tensor-grep-backlog-campaign` (the multi-PR drain+build campaign playbook).
 - When working ON tensor-grep, use `tg search`/`tg defs`/`tg callers` for code navigation rather than generic grep/find — this exercises the tool's own surfaces and catches routing regressions early (mind the scoped-path workaround above).
 
 These encode the "Adding a Command or Flag", "Dogfood the Real Binary", and "Verify AI-Drafted Plans" sections above as reusable, project-independent skills.
@@ -511,6 +591,19 @@ Any new download / extract / install / self-upgrade helper must apply the v1.17.
 (e) uv's `.ps1` installer LACKS binary checksum verification (uv issue #13074) while the `.sh` self-verifies (uv >=0.11.0, pinned 0.11.25); Windows fix = download the pinned uv RELEASE BINARY + verify a COMMITTED dual-arch (x86_64 + aarch64) SHA-256 fail-closed before use (implemented in `scripts/install.ps1` + a new `scripts/uv_checksums.json`, landing with PR #302 — not yet on `main`); discipline: ALWAYS download + `Get-FileHash` to CONFIRM a committed SHA — never trust an agent's "fetched from the sidecar" value.
 (f) ACCEPTED BOOTSTRAP TRUST BOUNDARY (documented, not a gap): the toolchain bootstrappers are trusted-over-HTTPS + version-pinned, NOT checksum-gated like the release artifacts WE download — uv's `.sh` self-verifies its binary (uv >=0.11.0, pinned 0.11.25), and rustup is fetched via `curl https://sh.rustup.rs | sh` in the semantic-release `build_command` (pyproject.toml) then pinned with `rustup default 1.96.0` (rustup self-verifies the toolchain). This is a deliberately different posture from (a)-(e), which checksum-gate artifacts WE fetch/extract. De-piping rustup to a pinned-binary + committed-checksum download is a tracked follow-up — it touches the release `build_command`, so it is ATTENDED (do not change it autonomously).
 
+Any Rust helper reachable only from a `#[cfg(feature = "cuda")]`-gated test must be re-gated
+`#[cfg(any(feature = "cuda", test))]` -- co-gating every helper it transitively calls -- instead of
+staying plain `#[cfg(feature = "cuda")]`. A default `cargo test` (no `--features cuda`, what CI's
+release-gating static-analysis job runs) never compiles a plain-`cuda`-gated test at all, so a test
+written against a plain-`cuda`-gated helper silently never runs; separately, un-gating only the test
+without also re-gating
+the helper leaves the helper with zero default-build callers and fails `cargo clippy -- -D warnings` on
+`dead_code`. `any(feature = "cuda", test)` solves both at once: the helper compiles whenever `cuda` is
+enabled (unchanged production behavior) OR whenever `cfg(test)` is set, so the test has something to call
+and is not itself dead code, while staying absent from the default non-test release build. Precedent:
+`GpuRouteFailureKind` / `sanitize_cuda_detail` / `classify_gpu_route_failure` in `rust_core/src/main.rs`
+(gate-nit #172 NIT-4 / MF-1, shipped in `#597` / v1.75.4).
+
 Do not casually edit:
 
 - `.github/workflows/ci.yml`
@@ -585,12 +678,30 @@ Preferred approach:
 5. open a PR with the correct conventional title and wait for PR CI/CodeQL to pass
 6. if the change is release-bearing and intended to ship now, squash-merge the PR to `main`
 7. wait for main CI and semantic-release complete successfully, plus CodeQL, `publish-github-release-assets`, PyPI/package artifact validation, `publish-pypi`, and `publish-success-gate`
-8. verify the GitHub release assets, PyPI latest version, and any affected public installer/update path. PyPI/public installer availability is verified before final release status is reported
-9. after semantic-release completes, `git fetch origin main --tags` and fast-forward local `main` to the release commit before reporting the final version state
+8. also check the `release-tag-smoke` JOB's own conclusion inside the release run (`gh run view <id>
+   --json jobs`), not just latest-main-green -- it is `needs`-gated on `[release, publish-success-gate]`
+   (not `continue-on-error`), checks out the actual published tag and runs `agent_readiness.py` against
+   it, and sat red across `v1.64.4`+ while PyPI kept publishing, masking a real regression for 4 releases
+9. verify the GitHub release assets, PyPI latest version, and any affected public installer/update path. PyPI/public installer availability is verified before final release status is reported
+10. after semantic-release completes, `git fetch origin main --tags` and fast-forward local `main` to the release commit before reporting the final version state
 
 Do not report a release-bearing fix as complete after only a branch push, open PR, or green PR checks. The final report must name the PR, merge commit, main CI run, CodeQL run, released tag/version, PyPI/package publish status, and any local/public installer dogfood result.
 
 For docs/test/chore-only work, use a non-release PR title, wait for PR CI, and merge only when requested or clearly required. After merge, main CI should pass but semantic-release should skip release publishing.
+
+### Build ahead of a release gate (pipelining)
+
+The push-race gate above blocks the *merge* step, not the *build* step. Once `origin/main` has advanced
+past a collision-blocked PR's base, that PR can safely rebase, rebuild, and re-run its full local/CI
+validation **in parallel with an in-flight release** -- only the final squash-merge must still wait for
+the prior release to fully publish (the `chore(release)` commit on `main` plus PyPI). Doing the
+rebase/rebuild/verify work eagerly, instead of sitting idle until the release window closes, saves
+roughly 40 minutes per PR across a multi-PR drain campaign. This is the same shape as three well-known
+patterns, named here so it is recognizable rather than reinvented: a **merge queue** / speculative CI
+(validate against a projected future base before the real merge lands), a **release train** (fixed
+publish cadence; work queues up between departures without blocking on any single publish), and
+**build-once-promote-everywhere** (a single verified artifact is promoted through gates rather than
+rebuilt at each one). Only the merge itself is push-race-gated; the build is not.
 
 ## PR Title And Release Intent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,15 +40,12 @@ Claude Code guidance for the **tensor-grep** repository.
 ## Skills that apply here
 
 - **Using `tg`**: `.claude/skills/tensor-grep/SKILL.md` (+ `REFERENCE.md`).
-- **Carrying the project forward (in-repo onboarding library, 18 skills)**: `.claude/skills/tensor-grep-*`
-  + `code-search-and-retrieval-reference` — the retirement handbook so a new engineer or a Sonnet-class
-  session can debug, extend, validate, and advance `tg`. Change: `change-control`, `debugging-playbook`,
-  `failure-archaeology`, `validation-and-qa`. Understand: `architecture-contract`,
-  `code-search-and-retrieval-reference`, `config-and-flags`. Operate: `build-and-env`, `run-and-operate`,
-  `diagnostics-and-tooling`, `docs-and-writing`, `release-and-positioning`. Advance:
-  `semantic-search-campaign`, `benchmark-and-proof-toolkit`, `research-frontier`, `research-methodology`,
-  `large-repo-scale-campaign`. Orchestrate: `backlog-campaign` (the multi-PR drain+build campaign playbook).
-  Each auto-loads by task; this is the index.
+- **Carrying the project forward -- the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **20 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent -- this exact bucket list is kept byte-identical with `AGENTS.md`'s skill index; `tests/unit/test_skill_index_sync.py` fails if either doc drifts from the real `.claude/skills/` folder set:
+  - **Change safely:** `tensor-grep-change-control` (the gates), `tensor-grep-debugging-playbook`, `tensor-grep-failure-archaeology` (don't re-fight settled battles), `tensor-grep-validation-and-qa`.
+  - **Understand:** `tensor-grep-architecture-contract`, `code-search-and-retrieval-reference` (domain theory), `tensor-grep-config-and-flags`.
+  - **Operate:** `tensor-grep-build-and-env`, `tensor-grep-run-and-operate`, `tensor-grep-diagnostics-and-tooling`, `tensor-grep-docs-and-writing`, `tensor-grep-release-and-positioning`, `tensor-grep-workspace-dogfood` (multi-repo stress dogfood), `tensor-grep-enterprise-agent` (enterprise readiness gaps + agent hard-stops).
+  - **Advance (SOTA):** `tensor-grep-semantic-search-campaign`, `tensor-grep-benchmark-and-proof-toolkit`, `tensor-grep-research-frontier`, `tensor-grep-research-methodology`, `tensor-grep-large-repo-scale-campaign` (bounding scale/deadline on large repos).
+  - **Orchestrate:** `tensor-grep-backlog-campaign` (the multi-PR drain+build campaign playbook).
 - **Build/release discipline** (global, `~/.claude/skills/`): `dogfood-the-shipped-artifact`,
   `verify-plan-against-code`, `supply-chain-hardening`, `worktree-fanout-verification-gate`,
   `anti-hang-test-protocol` (hang-class test hygiene: shell-timeout + fix-before-red-test),

--- a/docs/gpu_crossover.md
+++ b/docs/gpu_crossover.md
@@ -36,6 +36,42 @@ Current native evidence:
 
 The latest user dogfood also reported the native harness as `passed = false` because the speed target and error-test expectations did not pass. That is the intended decision: correctness evidence is necessary, but it is not enough to enable or market GPU auto-routing.
 
+## 2026-07-14 GPU Phase-0 Hardening Wave (Audit #171, v1.75.1-v1.75.4)
+
+Four PRs closed audit #171's P0-1 through P0-5 findings against the GPU doctor/agent probe surface and
+the installer/calibrate remediation paths, each gated by the mandatory Opus adversarial review (SHIP /
+SHIP-WITH-NIT verdicts, 8/8 probes clean). This wave hardens *evidence quality and operator messaging*
+around the existing GPU surface; it does not change the promotion decision above -- native CUDA
+correctness remains locally proven, and public managed promotion remains unmet.
+
+- `#594` (v1.75.1): fixed a WSL path-domain mismatch in the doctor and agent GPU probes. On WSL,
+  `resolve_native_tg_binary()` can return a Windows-target binary; both probes were writing a GPU-route
+  sentinel under a Linux `TemporaryDirectory` and passing that `/tmp/...` path as argv to a Windows PE,
+  which cannot resolve it, so a path-domain mismatch previously read as "no GPU support" rather than its
+  real cause. Fixed by detecting genuine WSL cross-domain execution, translating the sentinel path via
+  `wslpath -w`, and failing closed to a distinct `path_domain_mismatch` status when translation is
+  unavailable. Also added a `cargo check --features cuda` anti-bit-rot CI gate (runs on every PR, no CUDA
+  toolkit required) so the `cuda` Cargo feature -- normally compiled only by release legs gated on the
+  `TENSOR_GREP_RELEASE_NATIVE_ASSET_PROFILE` repository variable equalling `native-frontdoor-gpu` --
+  cannot rot silently between releases.
+- `#595` (v1.75.2): replaced the doctor's opaque GPU-probe `status="failed"` (which collapsed every
+  nonzero exit code from the native binary into one undifferentiated status) with a structured
+  `native_error_kind` taxonomy (`failed_path_bridging` / `failed_input` / `failed_gpu_unavailable` /
+  `failed_other`), and added an honest pre-flight warning when a requested `--gpu-device-ids` value is
+  out of range for the local device inventory instead of an indistinguishable silent CPU fallback.
+- `#596` (v1.75.3): added a `calibrate` remediation message on both native bail arms, plus a loud
+  nvidia-requested/cpu-delivered installer downgrade warning (guarded so it never fires on a host with no
+  NVIDIA candidate at all, which would be a false claim rather than a true one).
+- `#597` (v1.75.4): closed 5 gate-nits from the Opus review of the prior three PRs, including re-gating
+  `GpuRouteFailureKind` / `sanitize_cuda_detail` / `classify_gpu_route_failure` in `rust_core/src/main.rs`
+  from `#[cfg(feature = "cuda")]` to `#[cfg(any(feature = "cuda", test))]` so a default `cargo test` (no
+  `--features cuda`) actually compiles and runs their unit tests instead of silently skipping them -- see
+  `AGENTS.md`'s CI/Release Rules section for this pattern generalized as a standing rule.
+
+Separately, `#593` (v1.75.0) shipped an unrelated `tg orient` / `tg agent` improvement (broadened
+`suggested_ignore` vendor/skill-tree detection) that landed in the same version range by coincidence of
+publish order; it is not part of this GPU wave and is not summarized here.
+
 ## 2026-06-29 Wave-2 Promotion-Schema Audit
 
 A structured audit of the promotion-gate schema and `public-gpu-proof.yml` workflow was performed as part of the wave-2 hardening cycle.

--- a/tests/unit/test_skill_index_sync.py
+++ b/tests/unit/test_skill_index_sync.py
@@ -1,0 +1,139 @@
+"""Governance gate: the `.claude/skills/` folder set and the AGENTS.md / CLAUDE.md skill indices
+must never drift apart.
+
+Mirrors the content-pinning style of `tests/unit/test_public_docs_governance.py` (anchor every doc
+path to the repo root via `__file__`, read the real doc text, assert on extracted facts) but instead
+of pinning specific prose fragments, this file cross-checks two docs against a third source of
+truth: the real folder listing on disk. A skill folder added without a doc update, or a doc mention
+of a skill folder that does not (or no longer) exists, fails loudly here instead of silently
+drifting -- exactly the class of bug this gate exists to catch (see AGENTS.md's CLAUDE.md skill-index
+fix and the "24 vs 21" reconciliation note in the PR that introduced this test).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# __file__-anchored, not cwd-relative -- see test_public_docs_governance.py's flake #37 note.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
+AGENTS_DOC_PATH = _REPO_ROOT / "AGENTS.md"
+CLAUDE_DOC_PATH = _REPO_ROOT / "CLAUDE.md"
+
+AGENTS_SECTION_START = "## Skills\n"
+AGENTS_SECTION_END = "\n## Dogfood follow-up workflow"
+CLAUDE_SECTION_START = "## Skills that apply here"
+CLAUDE_SECTION_END = None  # runs to end of file
+
+# A skill name is mentioned in a doc in one of three shapes, and this gate must recognize all
+# three so a future reformat (e.g. switching backtick names to hyperlinks) cannot silently defeat
+# it:
+#   1. a standalone backtick-quoted identifier: `tensor-grep-change-control`
+#   2. a markdown link, optionally with backtick-quoted link text:
+#      [tensor-grep-change-control](...) or [`tensor-grep-change-control`](...)
+#   3. a `.claude/skills/<name>/...` path reference (how the single non-bucketed `tensor-grep`
+#      skill is named, e.g. "`.claude/skills/tensor-grep/SKILL.md`" -- the folder name there is
+#      not independently backtick-quoted, so patterns 1/2 alone would miss it)
+_BACKTICK_TOKEN_RE = re.compile(r"`([a-z][a-z0-9-]*)`")
+_LINK_TOKEN_RE = re.compile(r"\[`?([a-z][a-z0-9-]*)`?\]\([^)]*\)")
+_SKILLS_PATH_RE = re.compile(r"\.claude[/\\]skills[/\\]([a-z][a-z0-9_-]*)[/\\]")
+
+
+def _looks_like_skill_name(token: str) -> bool:
+    # Real onboarding-library folders are always `tensor-grep` (bare) or `tensor-grep-*`, plus the
+    # one non-prefixed skill `code-search-and-retrieval-reference`. Filtering on this shape before
+    # comparing against the real folder set drops unrelated backtick-quoted tokens (flag names,
+    # env vars, other doc paths) that would otherwise register as false "phantom skills".
+    return (
+        token == "tensor-grep"
+        or token == "code-search-and-retrieval-reference"
+        or token.startswith("tensor-grep-")
+    )
+
+
+def _extract_section(text: str, start_marker: str, end_marker: str | None) -> str:
+    start = text.index(start_marker)
+    remainder = text[start:]
+    if end_marker is None:
+        return remainder
+    end = remainder.index(end_marker)
+    return remainder[:end]
+
+
+def _skill_tokens_in(section_text: str) -> set[str]:
+    tokens = {m.group(1) for m in _BACKTICK_TOKEN_RE.finditer(section_text)}
+    tokens |= {m.group(1) for m in _LINK_TOKEN_RE.finditer(section_text)}
+    tokens |= {m.group(1) for m in _SKILLS_PATH_RE.finditer(section_text)}
+    return {token for token in tokens if _looks_like_skill_name(token)}
+
+
+def _real_skill_folders() -> set[str]:
+    return {skill_doc.parent.name for skill_doc in SKILLS_DIR.glob("*/SKILL.md")}
+
+
+def _agents_skills_section() -> str:
+    agents = AGENTS_DOC_PATH.read_text(encoding="utf-8")
+    return _extract_section(agents, AGENTS_SECTION_START, AGENTS_SECTION_END)
+
+
+def _claude_skills_section() -> str:
+    claude = CLAUDE_DOC_PATH.read_text(encoding="utf-8")
+    return _extract_section(claude, CLAUDE_SECTION_START, CLAUDE_SECTION_END)
+
+
+def test_skills_directory_has_a_plausible_folder_count() -> None:
+    # Bidirectional-oracle guard: if `.claude/skills/` went missing or the glob pattern broke, the
+    # comparison tests below would compare empty-set-to-empty-set and vacuously pass. Fail loudly
+    # on an implausibly small real-folder count instead of trusting a silent zero.
+    real = _real_skill_folders()
+    assert len(real) >= 15, (
+        f"Only found {len(real)} `.claude/skills/*/SKILL.md` folders -- the glob pattern or "
+        "SKILLS_DIR path is probably broken, not the repo."
+    )
+
+
+def test_every_real_skill_folder_is_named_in_agents_md() -> None:
+    real = _real_skill_folders()
+    mentioned = _skill_tokens_in(_agents_skills_section())
+
+    missing = real - mentioned
+    phantom = mentioned - real
+    assert not missing, (
+        f"AGENTS.md Skills section is missing these real skill folders: {sorted(missing)}"
+    )
+    assert not phantom, (
+        f"AGENTS.md Skills section names these phantom skills (no matching .claude/skills/ folder): "
+        f"{sorted(phantom)}"
+    )
+
+
+def test_every_real_skill_folder_is_named_in_claude_md() -> None:
+    real = _real_skill_folders()
+    mentioned = _skill_tokens_in(_claude_skills_section())
+
+    missing = real - mentioned
+    phantom = mentioned - real
+    assert not missing, (
+        f"CLAUDE.md Skills section is missing these real skill folders: {sorted(missing)}"
+    )
+    assert not phantom, (
+        f"CLAUDE.md Skills section names these phantom skills (no matching .claude/skills/ folder): "
+        f"{sorted(phantom)}"
+    )
+
+
+def test_agents_and_claude_skill_indices_name_the_same_skills() -> None:
+    # AGENTS.md and CLAUDE.md are meant to be kept byte-identical for this specific enumeration
+    # (see both docs' "kept byte-identical" cross-reference sentence). This is the set-level half
+    # of that contract: even if the surrounding prose or bucket formatting diverges, the two docs
+    # must never claim a different skill roster.
+    agents_mentioned = _skill_tokens_in(_agents_skills_section())
+    claude_mentioned = _skill_tokens_in(_claude_skills_section())
+
+    assert agents_mentioned == claude_mentioned, (
+        "AGENTS.md and CLAUDE.md skill indices have drifted apart -- "
+        f"only in AGENTS.md: {sorted(agents_mentioned - claude_mentioned)}; "
+        f"only in CLAUDE.md: {sorted(claude_mentioned - agents_mentioned)}"
+    )


### PR DESCRIPTION
## Summary

Captures this session's orchestration learnings into tensor-grep's canonical agent-guidance docs, adds a new CI governance gate, and reframes the GPU roadmap doc. Audit-verified by workflow `wnia2ckzd`. Docs + governance only, no release (this PR does not ship code).

### AGENTS.md
- **A9** "Probe liveness via `SendMessage` before any `TaskStop`" -- background-agent output-file mtime/size is unreliable; the reliable tell is a `SendMessage` probe, corroborated by Pyright diagnostics + build-process count. Cross-references A5.
- **A10** "A no-verdict council seat is a FAILED seat, not a blocker" -- treat a hung codex thinktank seat (MCP-auth spin) as failed, kill + sweep orphaned procs, synthesize from surviving lenses.
- **A11** "Design-review-before-build" (CEO directive #174) -- Fable designs -> thinktank certifies the plan -> Sonnet TDD builds -> mandatory adversarial Opus gate -> drain one-per-publish.
- **A3 extension** -- added native asset / installer / doctor-probe construction to the mandatory-adversarial-gate trigger list, citing the real v1.75.1-v1.75.3 GPU wave (#594-#596) evidence (SHIP-WITH-NIT / SHIP verdicts, 8/8 probes clean).
- **Current-Handoff addendum** (dated 2026-07-14) -- verified, detailed summary of the real v1.75.1-v1.75.4 GPU Phase-0 hardening wave (#594-#597, audit #171 P0-1..P0-5), each behind the mandatory Opus gate. Also notes that `#593` (v1.75.0) is an unrelated `tg orient`/`tg agent` feature that happened to land in the same version range -- the task brief's "v1.75.0-v1.75.4 GPU wave (#593-#597)" framing didn't survive a `git log` check, so this doc says what's actually true instead.
- **Roadmap Sequencing rewrite** -- replaced the old "held at P0 / wait for 3 CPU wins" framing with an explicit Phase 0 (shipped, gated off via the `TENSOR_GREP_RELEASE_NATIVE_ASSET_PROFILE` repo variable) / Phase 1 (reversible flag-flip, promotion gate unmet, cites `public-gpu-proof.yml` + `docs/CONTRACTS.md:80-82`) / Phase 2 (self-hosted GPU CI runner, CEO-gated) structure. Notes win #1 (local hybrid semantic search) already shipped as `tg search --semantic`; the other two original CPU-only items have not shipped.
- **CI/Release Rules bullet** -- generalizes the `#[cfg(any(feature = "cuda", test))]` co-gating pattern (a plain `#[cfg(feature = "cuda")]`-gated helper's tests silently never run under a default `cargo test`) as a standing rule, citing the real precedent (`sanitize_cuda_detail` in `rust_core/src/main.rs`, shipped in `#597`).
- **New "Build ahead of a release gate (pipelining)" subsection** under Push Discipline -- a collision-blocked PR may rebase/rebuild/verify off a now-merged main in parallel with an in-flight release; only the merge itself stays push-race-gated. (This PR's own rebase onto `#598` mid-session, with zero file overlap, is a live example.)
- **Push-race checklist step** -- also check the `release-tag-smoke` job's own conclusion inside the release run, not just latest-main-green; it's `needs`-gated (not `continue-on-error`) and checks out the actually-published tag.

### CLAUDE.md + AGENTS.md skill-index reconciliation (CORRECTED from the task brief -- see note below)
Both docs claimed stale/wrong skill counts (CLAUDE.md said 18, AGENTS.md said 16) and had drifted apart (CLAUDE.md had `backlog-campaign` + `large-repo-scale-campaign` but not `workspace-dogfood`/`enterprise-agent`; AGENTS.md had the reverse). Real count under `.claude/skills/` on this branch (committed, on `origin/main`) is **20** onboarding-library skills (`tensor-grep-*` + `code-search-and-retrieval-reference`, excluding the base `tensor-grep` skill which is documented separately) -- 21 folders total including that base skill.

**Correction from the task brief, independently confirmed mid-session by the coordinator:** the brief asserted 24 skills including `tensor-grep-gpu`, `tensor-grep-enterprise-review-bundle`, and `tensor-grep-multi-project-search`. I checked the sibling `docs/skills-reconcile-v175x` worktree (which owns `.claude/skills/*`) and confirmed those 3 folders are untracked WIP in the shared checkout and are not on `origin/main` or any branch. Per this task's explicit "do not touch `.claude/skills/*`" instruction, I did not invent them -- both docs enumerate exactly the real, committed 20 skills so the new sync gate below is genuinely self-consistent right now (and will stay self-consistent in CI, where only the committed folders exist). `tensor-grep-enterprise-agent` and `tensor-grep-workspace-dogfood` ARE committed, real folders -- both are included. When the skills-reconcile PR lands the 3 new folders, a trivial follow-up adds their names to both docs -- and the new gate will correctly flag the gap in the meantime instead of silently ignoring it.

Both docs' skill-bucket enumeration (Change safely / Understand / Operate / Advance / Orchestrate, all 20 skills) is now byte-identical text.

### docs/gpu_crossover.md
Added a dated "2026-07-14 GPU Phase-0 Hardening Wave" section detailing `#594`-`#597` (WSL path-domain probe bridging + `cargo check --features cuda` anti-bit-rot gate; doctor probe failure taxonomy + honest device-id validation; calibrate remediation + installer downgrade warning; 5 gate-nits including the `cfg(any(...))` fix). All existing promotion-status conclusions (no crossover proven, assets != promotion, public managed proof unmet) preserved verbatim.

### docs/CONTRACTS.md -- verified, zero edits needed
The task asked me to bump `release_docs_current_tag: v1.74.0 -> v1.75.4` and a "For the current `vX` release line" prose sentence. Both were already correctly at `v1.75.4` before I started. I verified this is genuinely auto-managed, not accidentally-already-done:
- `scripts/stamp_release_assets.py` has `docs/CONTRACTS.md` in `RELEASE_DOC_PATHS`, with anchored regexes for both the `release_docs_current_tag:` line and the `current \`vX.Y.Z\` release line` prose pattern.
- `git show --stat` on the `v1.75.4` release commit (`658bb58`) confirms it touched `AGENTS.md`, `docs/CONTRACTS.md`, and `docs/gpu_crossover.md` (2 lines each) -- the stamp ran and is NOT the "unanchored regex silently stopped advancing" failure mode from prior memory.
- The existing governance test `test_contracts_should_record_windows_shell_and_ordering_limits` already pins the "current release line" phrase against the live version, and it passes.

Per this task's own instruction ("if the stamp is auto-managed, do NOT hand-edit a stamped line"), `docs/CONTRACTS.md` has zero diff in this PR.

### New CI governance gate: `tests/unit/test_skill_index_sync.py`
Lists the real `.claude/skills/*/SKILL.md` folder names by globbing the actual checkout directly (the same thing `ls .claude/skills` would show -- committed state only, no untracked WIP), parses the skill names named in AGENTS.md's and CLAUDE.md's Skills sections (robust to standalone-backtick, markdown-link, and `.claude/skills/<name>/...` path-reference formats), and asserts: every real folder is named in both docs, neither doc names a phantom skill, and both docs name the same set. Mirrors the content-pinning style of `tests/unit/test_public_docs_governance.py`. Passes now, against the corrected docs, on the real folder set -- and will keep passing in CI, where only the committed folders exist.

## CI parity (run locally, all green)

```
uv run --no-sync ruff format --check --preview .     # only 4 pre-existing unrelated files flagged (untouched by this PR)
uv run --no-sync python -m pytest tests/unit/test_public_docs_governance.py tests/unit/test_skill_index_sync.py -q
# 47 passed
```

Also ran `ruff check` and `mypy` on the new test file (both clean), and confirmed zero non-ASCII characters in all newly-added prose per the task's ASCII-only-in-new-text rule.

## Test plan

- [x] `uv run --no-sync ruff format --check --preview .` -- clean except 4 pre-existing unrelated files (not touched by this PR)
- [x] `uv run --no-sync python -m pytest tests/unit/test_public_docs_governance.py tests/unit/test_skill_index_sync.py -q` -- 47 passed
- [x] `uv run --no-sync ruff check` + `mypy` on the new test file -- clean
- [x] Rebased cleanly onto `origin/main` after sibling PR #598 merged mid-session (zero file overlap: #598 only touched `docs/BACKLOG.md`)
- [ ] CI (PR checks, no release expected -- `docs:` title)

audit-verified by workflow wnia2ckzd; docs+governance, no release.

Generated with [Claude Code](https://claude.com/claude-code)
