### PR TITLE
feat: promote tg route-test from hidden to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ It ships as a native CLI on Windows, macOS, and Linux — no server required for
 ### Diagnostics & ops
 - **`tg doctor`** — system, GPU, cache, AST, and daemon diagnostics.
 - **`tg dogfood`** — agent-readiness gate; emits structured JSON with limitation surfaces.
+- **`tg route-test`** — diagnostic: compare `context-render` vs `edit-plan` target routing for the same query, reporting agreement and confidence warnings.
 - **`tg upgrade`** / **`tg update`** — self-upgrade.
 - **`tg repair-launcher`** — fix native vs Python launcher conflicts on Windows.
 

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1137,6 +1137,12 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Diagnose context-render vs edit-plan routing agreement for a query
+    #[command(name = "route-test", disable_help_flag = true)]
+    RouteTest {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 
     #[command(external_subcommand)]
     PythonPassthrough(Vec<String>),
@@ -5159,6 +5165,7 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         Commands::Evidence { args } => handle_python_passthrough("evidence", args),
         Commands::Devices { args } => handle_python_passthrough("devices", args),
         Commands::Context { args } => handle_python_passthrough("context", args),
+        Commands::RouteTest { args } => handle_python_passthrough("route-test", args),
         Commands::PythonPassthrough(args) => {
             let command = args[0].clone();
             let command_args = args[1..].to_vec();

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9365,12 +9365,9 @@ def _build_route_test_payload(
     }
 
 
-# Hidden/experimental: `route-test` (compare context-render vs edit-plan routing) works but is not yet in
-# the public --help surface -- promoting it needs native-binary registration + PUBLIC_TOP_LEVEL_COMMANDS
-# parity (the 4-registration-sites contract). Ships hidden here; a follow-up PR promotes it to visible.
-@app.command(name="route-test", hidden=True)
+@app.command(name="route-test")
 def route_test(
-    path: str = typer.Argument(".", help="File or directory to inventory"),
+    path: str = typer.Argument(".", help="File or directory to test routing for."),
     query_arg: str | None = typer.Argument(
         None, help="Query text to compare through context-render and edit-plan."
     ),
@@ -9413,7 +9410,13 @@ def route_test(
         True, "--json/--text", help="Emit machine-readable JSON output (default)."
     ),
 ) -> None:
-    """Compare context-render and edit-plan target routing for the same query."""
+    """Diagnose routing agreement between context-render and edit-plan for one query.
+
+    Runs the same PATH/QUERY through both target-selection paths and reports their primary
+    targets side by side, so an agent or operator can confirm the two routes agree (same file,
+    symbol, and line) before trusting an edit-plan's target -- or see exactly where and why they
+    diverge.
+    """
     try:
         resolved_path, resolved_query = _resolve_path_and_query(
             path=path,

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -43,6 +43,7 @@ PUBLIC_TOP_LEVEL_COMMANDS = {
     "blast-radius-plan",
     "edit-plan",
     "context-render",
+    "route-test",
     "rulesets",
     "audit-history",
     "audit-diff",

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -6321,6 +6321,27 @@ def test_route_test_json_demotes_low_confidence_to_note_when_routes_agree(monkey
     assert any("confidence 0.650 is below" in note for note in payload["notes"])
 
 
+def test_route_test_is_publicly_visible_in_top_level_help():
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    help_text = _strip_ansi(result.stdout)
+    assert "route-test" in help_text
+
+
+def test_route_test_help_still_documents_its_own_options():
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["route-test", "--help"])
+
+    assert result.exit_code == 0
+    help_text = _strip_ansi(result.stdout)
+    assert "--max-files" in help_text
+    assert "--provider" in help_text
+
+
 def test_agent_capsule_json_returns_actionable_context_capsule(tmp_path):
     runner = CliRunner()
     project = tmp_path / "project"


### PR DESCRIPTION
## Summary
- Promotes `tg route-test` (#58) from a hidden/experimental Typer command to a fully public top-level command, visible in `tg --help`.
- `route-test` is a diagnostic: it runs the same PATH/QUERY through both the `context-render` and `edit-plan` target-selection paths and reports their primary targets side by side (file/symbol/line agreement + confidence warnings), so an agent or operator can confirm the two routing paths agree before trusting an edit-plan's target.
- **Verify-against-code confirmed it was hidden**: `src/tensor_grep/cli/main.py` had `@app.command(name="route-test", hidden=True)`, with an in-repo comment explicitly flagging this exact follow-up ("Ships hidden here; a follow-up PR promotes it to visible").

## Registration sites touched (AGENTS.md "Adding a Command or Flag")
1. `src/tensor_grep/cli/main.py` -- removed `hidden=True`; clarified the docstring and the `path` argument help text (was stale copy-paste, "File or directory to inventory").
2. `src/tensor_grep/cli/commands.py` -- `KNOWN_COMMANDS` already listed `route-test`; no change needed.
3. `tests/e2e/test_routing_parity.py` -- added `route-test` to `PUBLIC_TOP_LEVEL_COMMANDS`, the contract set asserted against both the Python and native `--help` surfaces.
4. `rust_core/src/main.rs` -- added a `Commands::RouteTest` passthrough variant (mirroring the `Context`/`Doctor` sibling diagnostics) + its `handle_python_passthrough("route-test", args)` dispatch arm. This command was previously entirely absent from the native front door.
5. `README.md` -- one-line mention under "Diagnostics & ops" (the 5th site, matching this repo's own precedent for prior command promotions per CHANGELOG.md).

## Tests
- TDD: added two new tests in `tests/unit/test_cli_modes.py` (confirmed RED before the `hidden=True` removal, GREEN after):
  - `test_route_test_is_publicly_visible_in_top_level_help`
  - `test_route_test_help_still_documents_its_own_options`
- Extended `PUBLIC_TOP_LEVEL_COMMANDS` in `tests/e2e/test_routing_parity.py`, the set `test_top_level_help_visible_commands_match_public_contract` and 2 sibling tests assert against for both the Python and native front doors -- all 3 pass (verified in isolation).
- Existing `route-test` functional tests (5 in `test_cli_modes.py`, 2 routing tests in `test_cli_bootstrap.py`) pass unmodified.

## Verification
- `uv run --no-sync ruff format --preview .` (whole repo): 0 reformats needed on any of the 5 touched files. (It also flagged 4 pre-existing, unrelated docs code-fence drift files; reverted those to keep this PR scoped -- not this feature's concern.)
- `uv run --no-sync ruff check .`: all checks passed.
- `cargo fmt --manifest-path rust_core/Cargo.toml -- --check`: clean.
- `cargo clippy -- -D warnings` (from `rust_core/`): clean.
- `uv run --no-sync pytest tests/unit/test_cli_modes.py -k route_test` and `tests/unit/test_cli_bootstrap.py -k route_test`: all pass.
- `tests/e2e/test_routing_parity.py`: rebuilt the native `tg.exe` (`cargo build --manifest-path rust_core/Cargo.toml`) to test native-front-door parity too. The 3 top-level-help contract tests pass cleanly in isolation. The unrelated `COMMAND_CASES` parametrize matrix (search/run/scan flag parity, untouched by this change) hit an intermittent "Native binary not found" failure at a *different* random index across repeated runs -- root-caused to `_native_tg_version()`'s 2-second subprocess timeout under sustained sequential load (each of the ~37 cases re-spawns 3 launcher subprocesses with a fresh `--version` check); the specific failing case passes cleanly every time when re-run in isolation. This is a pre-existing environmental flake in the test's subprocess-timeout design, not a regression from this change -- this PR does not touch `runtime_paths.py` or any search/run/scan code path.

Draft PR -- opening for review before merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
