### PR TITLE
fix: guard checkpoint/rollback writes vs symlink swap + interrupt-safe cleanup

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -5043,6 +5043,122 @@ mod tests {
                 .is_empty()
         );
     }
+
+    /// Creates a symlink at `link` pointing to `target`, dispatching to the platform-specific
+    /// primitive (mirrors write_bytes_refuse_symlink's own unix/windows/other split). Tests
+    /// call this and skip gracefully (matching the existing audit-manifest symlink tests) when
+    /// the sandbox lacks symlink privilege instead of failing the whole suite.
+    fn try_symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(target, link)
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_file(target, link)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = (target, link);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "symlinks not supported on this platform",
+            ))
+        }
+    }
+
+    #[test]
+    fn test_create_checkpoint_refuses_symlink_at_index_path() {
+        // #115 Gap 2: checkpoint_index_path (checkpoint_storage_dir(root).join("index.json"))
+        // is a SHARED, PREDICTABLE path across every checkpoint under a given root -- unlike
+        // metadata.json (namespaced under a random checkpoint_id, unpredictable ahead of the
+        // call), an attacker who can write into the checkpoint root can plant a symlink at
+        // index.json in advance of any create_checkpoint call. Confirm create_checkpoint
+        // refuses to follow it instead of silently overwriting whatever the symlink targets.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("fixture.py");
+        std::fs::write(&file_path, "def add(x, y): return x + y\n").unwrap();
+
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_target = outside_dir.path().join("outside-target.json");
+        // Valid (empty-array) JSON so the pre-write "does index.json already exist -> read
+        // + parse it" branch succeeds and execution actually reaches the write call this
+        // test targets, instead of failing earlier on a JSON-parse error.
+        std::fs::write(&outside_target, b"[]").unwrap();
+
+        // Reuse the production scope-detection so the storage dir we plant the symlink under
+        // is byte-identical to the one create_checkpoint computes internally (both must agree
+        // post-canonicalization, or the symlink would land at the wrong path).
+        let path_str = file_path.to_str().unwrap();
+        let scope = detect_checkpoint_scope(path_str);
+        let storage_dir = checkpoint_storage_dir(&scope.root);
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let index_path = storage_dir.join("index.json");
+        if let Err(err) = try_symlink_file(&outside_target, &index_path) {
+            eprintln!(
+                "skipping test_create_checkpoint_refuses_symlink_at_index_path: cannot create a symlink in this environment: {err}"
+            );
+            return;
+        }
+
+        let result = create_checkpoint(path_str);
+        assert!(
+            result.is_err(),
+            "create_checkpoint must refuse to write the shared index through a symlink"
+        );
+        assert_eq!(
+            std::fs::read(&outside_target).unwrap(),
+            b"[]",
+            "the symlink's target outside the checkpoint root must be left untouched"
+        );
+    }
+
+    #[test]
+    fn test_restore_validation_rollback_snapshots_refuses_symlink_at_file_path() {
+        // #115 Gap 3: between "apply the edit" and a failed-validation rollback, an edited
+        // file could be swapped for a symlink pointing outside the project (e.g. via a
+        // hostile --lint-cmd/--test-cmd running between apply and rollback).
+        // restore_validation_rollback_snapshots must refuse to follow it instead of writing
+        // the pre-edit snapshot bytes through the symlink.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("fixture.py");
+        let original_bytes = b"def add(x, y): return x + y\n".to_vec();
+        std::fs::write(&file_path, &original_bytes).unwrap();
+
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_target = outside_dir.path().join("outside-target.py");
+        std::fs::write(&outside_target, b"UNTOUCHED").unwrap();
+
+        let mut snapshots = BTreeMap::new();
+        snapshots.insert(file_path.to_string_lossy().to_string(), original_bytes);
+
+        // Simulate the swap: the tracked file is replaced by a symlink after the pre-apply
+        // snapshot was captured.
+        std::fs::remove_file(&file_path).unwrap();
+        if let Err(err) = try_symlink_file(&outside_target, &file_path) {
+            eprintln!(
+                "skipping test_restore_validation_rollback_snapshots_refuses_symlink_at_file_path: cannot create a symlink in this environment: {err}"
+            );
+            return;
+        }
+
+        let summary = restore_validation_rollback_snapshots(&snapshots);
+
+        assert!(
+            !summary.success,
+            "restore must report failure when a snapshot target is a symlink"
+        );
+        assert!(
+            summary.files_restored.is_empty(),
+            "a refused symlink write must not be counted as restored"
+        );
+        assert_eq!(summary.errors.len(), 1);
+        assert_eq!(
+            std::fs::read(&outside_target).unwrap(),
+            b"UNTOUCHED",
+            "the symlink's target outside the rollback root must be left untouched"
+        );
+    }
 }
 
 fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
@@ -8317,7 +8433,7 @@ fn create_checkpoint(path: &str) -> anyhow::Result<CheckpointCreateSummary> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    std::fs::write(&metadata_path, serde_json::to_vec_pretty(&metadata)?)
+    write_bytes_refuse_symlink(&metadata_path, &serde_json::to_vec_pretty(&metadata)?)
         .with_context(|| format!("failed to write {}", metadata_path.display()))?;
 
     let index_path = checkpoint_index_path(&root);
@@ -8345,7 +8461,7 @@ fn create_checkpoint(path: &str) -> anyhow::Result<CheckpointCreateSummary> {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
-    std::fs::write(&index_path, serde_json::to_vec_pretty(&records)?)
+    write_bytes_refuse_symlink(&index_path, &serde_json::to_vec_pretty(&records)?)
         .with_context(|| format!("failed to write {}", index_path.display()))?;
 
     Ok(summary)
@@ -8965,7 +9081,7 @@ fn restore_validation_rollback_snapshots(
     let mut errors = Vec::new();
 
     for (file, bytes) in snapshots {
-        match std::fs::write(file, bytes) {
+        match write_bytes_refuse_symlink(Path::new(file), bytes) {
             Ok(()) => files_restored.push(file.clone()),
             Err(error) => errors.push(format!("failed to restore {file}: {error}")),
         }
@@ -9000,6 +9116,11 @@ fn emit_rollback_status(summary: &ValidationRollbackSummary) {
 /// previously followed by a plain `std::fs::write` -- a confined write could escape its
 /// anchor. Mirrors the confine-then-open discipline `_write_json_refuse_symlink` already
 /// uses on the Python side (`src/tensor_grep/cli/main.py`).
+///
+/// audit #115: also guards `create_checkpoint`'s metadata.json + the shared/predictable
+/// index.json write, and `restore_validation_rollback_snapshots`'s per-file restore write --
+/// the same TOCTOU class, just with the checkpoint/rollback root standing in for
+/// `--audit-manifest`'s confined target.
 fn write_bytes_refuse_symlink(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     use std::fs::OpenOptions;
 

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -853,32 +853,37 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
             # follow_symlinks=False: store a symlink AS a link, never copy its (possibly
             # out-of-root) target content into the snapshot (audit HIGH — symlink disclosure).
             shutil.copy2(source, destination, follow_symlinks=False)
-    except Exception:
-        # audit H4: never leave a half-copied checkpoint dir behind on any abort, budget-
-        # related or not (e.g. disk fills mid-copy despite the pre-flight, or a file
-        # vanishes/grows mid-loop). Remove the WHOLE per-checkpoint dir (metadata.json has not
-        # been written yet at this point, but snapshot_dir's own parent must go too, not just
-        # the snapshot/ subdir) -- matches how _prune_checkpoint_records removes a checkpoint.
+
+        result = CheckpointCreateResult(
+            checkpoint_id=checkpoint_id,
+            mode=mode,
+            root=str(root),
+            created_at=created_at,
+            file_count=len(entries),
+            undo_argv=_undo_argv(scope, checkpoint_id),
+            undo_command=_display_command(_undo_argv(scope, checkpoint_id)),
+            skipped_nested_repos=skipped_nested_repos,
+        )
+        _write_checkpoint_metadata(
+            root,
+            result,
+            entries,
+            scope_kind=scope.scope_kind,
+            original_path=scope.original_path,
+        )
+    except BaseException:
+        # audit #125a: catch BaseException, not Exception -- KeyboardInterrupt/SystemExit
+        # subclass BaseException directly (not Exception), so a Ctrl+C here previously escaped
+        # this handler entirely and left an uncleaned checkpoint dir behind. The guarded region
+        # also now extends through the metadata write below (not just the copy loop above): a
+        # failure writing metadata.json after a fully successful copy must not orphan that
+        # directory either -- audit H4's original cleanup only covered the copy loop. Remove the
+        # WHOLE per-checkpoint dir (metadata.json may or may not have been written yet, but
+        # snapshot_dir's own parent must go too, not just the snapshot/ subdir) -- matches how
+        # _prune_checkpoint_records removes a checkpoint. Always re-raise: the interrupt or
+        # exception must still propagate to the caller, never be swallowed here.
         shutil.rmtree(snapshot_dir.parent, ignore_errors=True)
         raise
-
-    result = CheckpointCreateResult(
-        checkpoint_id=checkpoint_id,
-        mode=mode,
-        root=str(root),
-        created_at=created_at,
-        file_count=len(entries),
-        undo_argv=_undo_argv(scope, checkpoint_id),
-        undo_command=_display_command(_undo_argv(scope, checkpoint_id)),
-        skipped_nested_repos=skipped_nested_repos,
-    )
-    _write_checkpoint_metadata(
-        root,
-        result,
-        entries,
-        scope_kind=scope.scope_kind,
-        original_path=scope.original_path,
-    )
 
     # q10 RMW race: load->mutate->write must be atomic w.r.t. every other writer of this
     # index.json, cross-process and cross-thread, or a concurrent insert can be lost (see

--- a/tests/unit/test_checkpoint_disk_budget.py
+++ b/tests/unit/test_checkpoint_disk_budget.py
@@ -123,6 +123,61 @@ def test_create_checkpoint_cleans_up_snapshot_dir_on_mid_copy_failure(
     assert _storage_dir_entries(root) == [], "a half-copied checkpoint dir was left behind"
 
 
+def test_create_checkpoint_cleans_up_snapshot_dir_on_mid_copy_keyboard_interrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """audit #125a: KeyboardInterrupt/SystemExit are BaseException, not Exception -- a Ctrl+C
+    mid-copy must trigger the same half-copied-dir cleanup as an ordinary OSError (see
+    test_create_checkpoint_cleans_up_snapshot_dir_on_mid_copy_failure above), and the interrupt
+    must still propagate to the caller afterward, not be swallowed by the cleanup handler."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "a.py").write_text("a\n", encoding="utf-8")
+    (root / "b.py").write_text("b\n", encoding="utf-8")
+
+    original_copy2 = checkpoint_store.shutil.copy2
+    calls = {"n": 0}
+
+    def _interrupt_on_second_copy(src, dst, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise KeyboardInterrupt
+        return original_copy2(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(checkpoint_store.shutil, "copy2", _interrupt_on_second_copy)
+
+    with pytest.raises(KeyboardInterrupt):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], (
+        "a half-copied checkpoint dir was left behind after a KeyboardInterrupt"
+    )
+
+
+def test_create_checkpoint_cleans_up_snapshot_dir_on_metadata_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """audit #125a: the cleanup try/except must extend through the metadata-write step, not
+    stop at the end of the copy loop -- a failure while writing metadata.json (after the copy
+    has fully succeeded) must not orphan the now fully-copied-but-unindexed per-checkpoint
+    directory."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "a.py").write_text("a\n", encoding="utf-8")
+
+    def _boom_metadata_write(*args, **kwargs):
+        raise OSError("simulated metadata write failure")
+
+    monkeypatch.setattr(checkpoint_store, "_write_checkpoint_metadata", _boom_metadata_write)
+
+    with pytest.raises(OSError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], (
+        "a fully-copied checkpoint dir was left behind after a metadata-write failure"
+    )
+
+
 def test_create_checkpoint_respects_raised_env_cap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Two verified checkpoint/rollback hardening fixes in the same subsystem. Checkpoint create/undo is MCP-reachable via `tg_checkpoint_undo` -- **Opus gate pending before merge**, per the repo's Backend Fail-Closed Contract / security-adjacent-change policy. Build is clean; this PR is opened as a draft specifically to hold for that review.

- **#115 (Rust)**: three `std::fs::write` call sites in `rust_core/src/main.rs` wrote checkpoint/rollback files WITHOUT the symlink guard the repo already uses for the audit-manifest write (`write_bytes_refuse_symlink`, added in #500 for audit #110). All three now route through that guard:
  - `create_checkpoint`'s `metadata.json` write
  - `create_checkpoint`'s `index.json` write -- a SHARED, PREDICTABLE path across every checkpoint under a root (the highest-risk of the three: no random checkpoint id needs to be guessed)
  - `restore_validation_rollback_snapshots`'s per-file rollback-restore write (the target is `&String`, wrapped as `Path::new(file)`)
- **#125a (Python)**: `create_checkpoint`'s cleanup handler in `src/tensor_grep/cli/checkpoint_store.py` caught `except Exception:`, which does NOT catch `KeyboardInterrupt`/`SystemExit` (both are `BaseException`, not `Exception`) -- a Ctrl+C mid-copy bypassed cleanup entirely and left a half-copied checkpoint dir behind. Now `except BaseException:`, and the guarded region is widened to also cover the metadata-write step (previously outside the try/except, so a metadata-write failure orphaned a fully-copied dir too). Still unconditionally re-raises -- the interrupt/exception is never swallowed.

## Tests (TDD, RED confirmed before each fix)

- Rust (`rust_core/src/main.rs`, `mod tests`):
  - `test_create_checkpoint_refuses_symlink_at_index_path` -- plants a symlink at the shared `index.json` path before calling `create_checkpoint` (using the production `detect_checkpoint_scope`/`checkpoint_storage_dir` helpers so the planted path matches exactly what the function computes internally), asserts it refuses and the symlink's outside target is untouched.
  - `test_restore_validation_rollback_snapshots_refuses_symlink_at_file_path` -- swaps an edited file for a symlink between apply and rollback, asserts the restore refuses and the outside target is untouched.
  - Both skip gracefully (mirroring the existing audit-manifest symlink tests) if the sandbox lacks symlink privilege.
- Python (`tests/unit/test_checkpoint_disk_budget.py`):
  - `test_create_checkpoint_cleans_up_snapshot_dir_on_mid_copy_keyboard_interrupt` -- raises `KeyboardInterrupt` mid-copy, asserts it propagates AND the half-copied dir is cleaned up.
  - `test_create_checkpoint_cleans_up_snapshot_dir_on_metadata_write_failure` -- raises during `_write_checkpoint_metadata`, asserts the now-fully-copied dir is still cleaned up.

Verified RED against the pre-fix code (via `git stash push`/`pop` on just the source file, keeping the new tests in place) before applying each fix, then GREEN after.

## CI parity (run locally on Windows)

- `cargo test --no-default-features` (rust_core) -- all tests touching checkpoint/rollback/audit-manifest code pass, including the 2 new tests and the pre-existing `test_ast_rewrite.rs` audit-manifest symlink suite. Encountered 4 unrelated flakes on the first full run under heavy concurrent system load on this shared box (`index_lock::two_threads_never_observe_the_lock_simultaneously`, an rg-passthrough CLI-parity test that hit a transient shared-Python-install race, and 2 tests that hit a 5s subprocess timeout) -- all 4 re-verified GREEN in isolation and confirmed to live in code this PR does not touch.
- `cargo clippy -- -D warnings` (rust_core) -- clean.
- `cargo fmt -- --check` (rust_core) -- clean.
- `ruff check .` -- clean ("All checks passed!").
- `ruff format --check --preview .` -- clean for all 3 changed files. (4 unrelated pre-existing `.md` doc files also need reformatting repo-wide; confirmed via `git diff --stat origin/main` that this PR does not touch them -- out of scope here.)
- `mypy src/tensor_grep/cli/checkpoint_store.py` -- clean (bonus check).
- `pytest tests/unit/test_checkpoint*.py -q` -- 74/74 passed (run twice for consistency).

## Scope

Touches only `rust_core/src/main.rs`, `src/tensor_grep/cli/checkpoint_store.py`, and their tests (`tests/unit/test_checkpoint_disk_budget.py`). Does not touch session_daemon/runtime_paths/gpu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)