### PR TITLE
fix: session daemon removes only its own metadata (stale-daemon orphan pileup)

### DIFF
--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -372,12 +372,69 @@ def _release_daemon_start_lock(root: Path) -> None:
         pass
 
 
-def _remove_daemon_metadata(root: Path) -> None:
+def _remove_daemon_metadata(
+    root: Path, *, expected_pid: int | None = None, expected_port: int | None = None
+) -> None:
+    """Remove ``daemon.json`` for ``root``, guarded against deleting a REPLACEMENT daemon's metadata.
+
+    Task #143a-a (stale-daemon-metadata race): when ``_probe_daemon`` rejects a daemon over a
+    ``package_version`` mismatch (see the skew check in ``_probe_daemon`` below), the client spawns
+    a replacement daemon (call it B) while the old daemon (A) keeps running until its own
+    idle/max-uptime self-shutdown fires. If A's shutdown path (or ``stop_session_daemon``'s
+    PID-kill fallback) unlinked ``daemon.json`` unconditionally, it would delete WHATEVER metadata
+    currently exists -- including B's, the healthy replacement -- orphaning B (it keeps serving,
+    but no client can discover it) and silently piling up orphaned daemon processes over time.
+
+    Passing ``expected_pid``/``expected_port`` re-reads the CURRENT on-disk metadata immediately
+    before unlinking and only proceeds if its ``pid``/``port`` fields still match -- i.e. the file
+    still identifies the exact instance the caller intends to remove. A mismatch (a replacement has
+    since published its own metadata), a missing file, or an unparseable/corrupt file are all
+    treated as "not mine" and left untouched -- the fail-safe choice, since we cannot prove the file
+    is safe to delete, and a corrupt file self-heals the next time a daemon is (re)started via
+    ``_spawn_daemon_subprocess``'s unconditional clear below.
+
+    When BOTH ``expected_pid`` and ``expected_port`` are omitted (the default), removal is
+    unconditional -- this mode exists for exactly one legitimate caller, ``_spawn_daemon_subprocess``,
+    which holds the daemon-start lock (excluding any concurrent spawn for this root) and is clearing
+    the slate for a brand-new instance it is about to launch, so there is no prior "self" identity to
+    compare against yet. Every other caller must supply at least one ``expected_*`` value, or skip
+    the call entirely when it cannot establish one (see ``stop_session_daemon``).
+    """
     metadata_path = _daemon_metadata_path(root)
+    if expected_pid is not None or expected_port is not None:
+        current = _read_daemon_metadata(root)
+        if current is None:
+            return
+        if expected_pid is not None and current.get("pid") != expected_pid:
+            return
+        if expected_port is not None and current.get("port") != expected_port:
+            return
     try:
         metadata_path.unlink()
     except OSError:
         pass
+
+
+def _daemon_identity(metadata: dict[str, Any] | None) -> tuple[int | None, int | None]:
+    """Best-effort ``(pid, port)`` extraction from daemon metadata (task #143a-a).
+
+    Used by callers of the guarded ``_remove_daemon_metadata`` above to compute the specific
+    instance they intend to remove. Missing or non-numeric fields resolve to ``None`` rather than
+    raising, so a malformed or partial metadata dict never turns into a removal call the guard
+    cannot safely reason about -- the caller is expected to skip the removal when either half of
+    the pair it needs comes back ``None`` (see ``stop_session_daemon``).
+    """
+    if not metadata:
+        return None, None
+    try:
+        pid: int | None = int(metadata["pid"])
+    except (KeyError, TypeError, ValueError):
+        pid = None
+    try:
+        port: int | None = int(metadata["port"])
+    except (KeyError, TypeError, ValueError):
+        port = None
+    return pid, port
 
 
 def _pid_looks_like_tg_daemon(pid: int) -> bool:
@@ -630,6 +687,12 @@ def _spawn_daemon_subprocess(root: Path) -> None:
     ``daemon.json`` to appear and does not touch the start-lock -- the caller is responsible for
     both (holding the lock across this call, and deciding whether/how long to wait afterward).
     """
+    # Task #143a-a: unconditional (force) removal is intentional and safe here -- every caller
+    # holds the daemon-start lock for `root` (excluding any concurrent spawn), so nothing else can
+    # be publishing fresh metadata for this root while we hold it, and we are about to Popen a
+    # brand-new instance that will publish its OWN metadata momentarily. There is no prior "self"
+    # identity to compare against yet, unlike the guarded callers in stop_session_daemon and
+    # run_session_daemon_server's shutdown path below.
     _remove_daemon_metadata(root)
     creationflags = 0
     env = os.environ.copy()
@@ -772,7 +835,16 @@ def stop_session_daemon(path: str = ".") -> dict[str, Any]:
         # socket is wedged). Fall back to terminating the recorded pid if it validates.
         stale_metadata = _read_daemon_metadata(root)
         killed = _terminate_daemon_by_pid(stale_metadata)
-        _remove_daemon_metadata(root)
+        # Task #143a-a: only remove the metadata that still identifies the STALE daemon we just
+        # targeted -- never whatever happens to be on disk by the time we get here. A concurrent
+        # autostart elsewhere may have already spawned and published a healthy replacement's
+        # daemon.json in the window between the failed probe above and this cleanup; an
+        # unconditional unlink would delete that replacement's metadata too. When the stale
+        # metadata itself cannot be identified (missing/corrupt), there is nothing safe to
+        # remove -- skip rather than guess.
+        stale_pid, stale_port = _daemon_identity(stale_metadata)
+        if stale_pid is not None:
+            _remove_daemon_metadata(root, expected_pid=stale_pid, expected_port=stale_port)
         return {
             "version": _SESSION_VERSION,
             "root": str(root),
@@ -802,7 +874,12 @@ def stop_session_daemon(path: str = ".") -> dict[str, Any]:
         # validated pid terminate so a wedged daemon is not left running.
         if _terminate_daemon_by_pid(metadata):
             stop_method = "pid"
-    _remove_daemon_metadata(root)
+    # Task #143a-a: only remove daemon.json if it still identifies the SAME daemon this call
+    # targeted (captured in `metadata` above) -- a replacement may have spawned and published its
+    # own metadata in the window since. See _remove_daemon_metadata's docstring for the full race.
+    target_pid, target_port = _daemon_identity(metadata)
+    if target_pid is not None:
+        _remove_daemon_metadata(root, expected_pid=target_pid, expected_port=target_port)
     response["running"] = False
     response["root"] = str(root)
     response["stopped"] = True
@@ -1965,7 +2042,13 @@ def run_session_daemon_server(path: str = ".") -> None:
         finally:
             stop_event.set()
             _flush_demand_metrics_if_dirty(server, force=True)
-            _remove_daemon_metadata(root)
+            # Task #143a-a: this daemon must only ever remove ITS OWN daemon.json on shutdown
+            # (idle timeout, max-uptime, or a cooperative "stop" command). If a client already
+            # rejected this daemon over a package_version mismatch and spawned a healthy
+            # replacement, that replacement's metadata is what is on disk by the time THIS daemon
+            # finally shuts itself down -- an unconditional unlink here would delete it out from
+            # under the replacement, orphaning it with no discoverable daemon.json.
+            _remove_daemon_metadata(root, expected_pid=os.getpid(), expected_port=int(port))
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/tests/unit/test_session_daemon_metadata_ownership.py
+++ b/tests/unit/test_session_daemon_metadata_ownership.py
@@ -1,0 +1,266 @@
+"""TDD for task #143a-a: the session daemon must remove only ITS OWN daemon.json.
+
+Before this fix, ``_remove_daemon_metadata`` unlinked ``daemon.json`` unconditionally regardless
+of caller. When ``_probe_daemon`` rejects a daemon over a ``package_version`` mismatch (task #94
+PR-1, see test_session_daemon_version_skew.py), the client spawns a REPLACEMENT daemon while the
+rejected one (still alive) keeps running until its own idle/max-uptime self-shutdown fires. That
+old daemon's shutdown path -- and ``stop_session_daemon``'s PID-kill fallback -- called
+``_remove_daemon_metadata`` unconditionally, deleting WHATEVER metadata currently existed,
+including the healthy replacement's. Result: silent orphan-daemon pileup (the old daemon exits,
+taking the replacement's only discoverable record with it) and a live daemon no client can find.
+
+The fix: ``_remove_daemon_metadata`` accepts optional ``expected_pid``/``expected_port`` and only
+unlinks when the CURRENT on-disk metadata still matches -- i.e. it still identifies the exact
+instance the caller intends to remove. ``run_session_daemon_server``'s shutdown ``finally`` and
+both ``stop_session_daemon`` cleanup paths now pass their own target identity; only
+``_spawn_daemon_subprocess`` (protected by the daemon-start lock, and about to publish a brand new
+instance's metadata) still uses the unconditional (force) mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli import session_daemon
+
+
+def _payload(*, pid: int, port: int, token: str = "tok") -> dict[str, Any]:
+    return {
+        "version": 1,
+        "package_version": "irrelevant-for-these-tests",
+        "root": "irrelevant",
+        "host": "127.0.0.1",
+        "port": port,
+        "pid": pid,
+        "started_at": "test",
+        "token": token,
+    }
+
+
+# ------------------------------------------------------------------------- _daemon_identity
+
+
+def test_daemon_identity_extracts_pid_and_port() -> None:
+    assert session_daemon._daemon_identity(_payload(pid=111, port=2222)) == (111, 2222)
+
+
+def test_daemon_identity_handles_missing_and_malformed() -> None:
+    assert session_daemon._daemon_identity(None) == (None, None)
+    assert session_daemon._daemon_identity({}) == (None, None)
+    assert session_daemon._daemon_identity({"pid": "not-an-int", "port": 1}) == (None, 1)
+    assert session_daemon._daemon_identity({"pid": 1, "port": "not-an-int"}) == (1, None)
+
+
+# --------------------------------------------------------- _remove_daemon_metadata: force mode
+
+
+def test_remove_daemon_metadata_force_mode_removes_unconditionally(tmp_path: Path) -> None:
+    # Locks in _spawn_daemon_subprocess's contract: no expected_* kwargs -> unconditional
+    # removal, regardless of whose metadata is currently on disk.
+    root = tmp_path.resolve()
+    session_daemon._write_daemon_metadata(root, _payload(pid=999, port=9999))
+    metadata_path = session_daemon._daemon_metadata_path(root)
+    assert metadata_path.exists()
+
+    session_daemon._remove_daemon_metadata(root)
+
+    assert not metadata_path.exists()
+
+
+def test_remove_daemon_metadata_force_mode_is_noop_when_file_missing(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    session_daemon._remove_daemon_metadata(root)  # must not raise
+    assert not session_daemon._daemon_metadata_path(root).exists()
+
+
+# ------------------------------------------------------- _remove_daemon_metadata: guarded mode
+
+
+def test_remove_daemon_metadata_guarded_removes_when_identity_matches(tmp_path: Path) -> None:
+    # "A's own normal shutdown DOES remove A's metadata when A still owns it."
+    root = tmp_path.resolve()
+    session_daemon._write_daemon_metadata(root, _payload(pid=111, port=2222))
+
+    session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)
+
+    assert session_daemon._read_daemon_metadata(root) is None
+
+
+def test_remove_daemon_metadata_guarded_preserves_replacement_on_pid_mismatch(
+    tmp_path: Path,
+) -> None:
+    # The core #143a-a race: daemon-A writes metadata, a replacement daemon-B overwrites
+    # daemon.json with B's pid/port, then daemon-A's shutdown path runs _remove_daemon_metadata
+    # (exactly as run_session_daemon_server's finally does, passing A's own pid/port) -- assert
+    # daemon.json STILL holds B's identity afterward (A did not delete B's).
+    root = tmp_path.resolve()
+    session_daemon._write_daemon_metadata(root, _payload(pid=111, port=2222))  # A starts
+    session_daemon._write_daemon_metadata(root, _payload(pid=222, port=3333))  # B replaces A
+
+    # A's shutdown path believes it owns pid=111/port=2222 -- it does not, anymore.
+    session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)
+
+    survivor = session_daemon._read_daemon_metadata(root)
+    assert survivor is not None, "the replacement daemon's metadata must survive"
+    assert survivor["pid"] == 222
+    assert survivor["port"] == 3333
+
+
+def test_remove_daemon_metadata_guarded_preserves_replacement_on_port_mismatch(
+    tmp_path: Path,
+) -> None:
+    # Defense in depth: a port mismatch alone (pid coincidentally equal, e.g. pid reuse across
+    # process churn) must also block the delete -- both fields are checked independently.
+    root = tmp_path.resolve()
+    session_daemon._write_daemon_metadata(root, _payload(pid=111, port=2222))
+    session_daemon._write_daemon_metadata(root, _payload(pid=111, port=3333))  # same pid, new port
+
+    session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)
+
+    survivor = session_daemon._read_daemon_metadata(root)
+    assert survivor is not None
+    assert survivor["port"] == 3333
+
+
+def test_remove_daemon_metadata_guarded_noop_when_file_missing(tmp_path: Path) -> None:
+    root = tmp_path.resolve()
+    session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)
+    assert session_daemon._read_daemon_metadata(root) is None
+
+
+def test_remove_daemon_metadata_guarded_leaves_corrupt_file_untouched(tmp_path: Path) -> None:
+    # Fail-safe choice: an unparseable file's identity cannot be verified, so it is left alone
+    # rather than guessed-and-deleted. It self-heals via _spawn_daemon_subprocess's force mode
+    # the next time a daemon is (re)started for this root.
+    root = tmp_path.resolve()
+    metadata_path = session_daemon._daemon_metadata_path(root)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text("{not valid json", encoding="utf-8")
+
+    session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)
+
+    assert metadata_path.exists()
+    assert metadata_path.read_text(encoding="utf-8") == "{not valid json"
+
+
+# ----------------------------------------------------- stop_session_daemon call-site coverage
+
+
+def test_stop_session_daemon_stale_fallback_preserves_concurrent_replacement(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Reproduces the #143a-a race at the stop_session_daemon layer (the ~775 fallback branch):
+    the cooperative probe fails (version mismatch / wedged socket), so stop_session_daemon falls
+    back to reading + pid-killing the STALE metadata. If a replacement daemon B publishes its own
+    daemon.json in the narrow window between that read and the cleanup unlink, the (formerly)
+    unconditional unlink deleted B's metadata too. The guarded removal must leave B's file alone.
+    """
+    root = (tmp_path / "project").resolve()
+    root.mkdir()
+    session_daemon._write_daemon_metadata(root, _payload(pid=424242, port=11111, token="stale"))
+
+    def _fake_terminate(metadata: dict[str, Any] | None) -> bool:
+        # Simulate daemon B publishing its own metadata WHILE A is being torn down -- the exact
+        # narrow window the guard must protect.
+        session_daemon._write_daemon_metadata(
+            root, _payload(pid=434343, port=22222, token="replacement")
+        )
+        return False  # irrelevant to this test whether the pid-kill itself "succeeded"
+
+    monkeypatch.setattr(session_daemon, "_probe_daemon", lambda _root: None)
+    monkeypatch.setattr(session_daemon, "_terminate_daemon_by_pid", _fake_terminate)
+
+    result = session_daemon.stop_session_daemon(str(root))
+
+    assert result["running"] is False
+    survivor = session_daemon._read_daemon_metadata(root)
+    assert survivor is not None, "the replacement daemon's metadata must survive"
+    assert survivor["pid"] == 434343
+    assert survivor["port"] == 22222
+
+
+def test_stop_session_daemon_cooperative_path_preserves_concurrent_replacement(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Mirrors the fallback-branch test above but for the main cooperative-stop tail (the ~805
+    branch): the probe succeeds once (stop_session_daemon captures a live `metadata`), the stop
+    command is dispatched, and by the time the post-stop poll observes the daemon gone, a
+    replacement has already published its own metadata. The cleanup unlink must target only the
+    ORIGINAL daemon's identity, not whatever is currently on disk."""
+    root = (tmp_path / "project").resolve()
+    root.mkdir()
+    target_metadata = _payload(pid=111, port=2222, token="a")
+
+    probe_calls = {"count": 0}
+
+    def _fake_probe(_root: Path) -> dict[str, Any] | None:
+        probe_calls["count"] += 1
+        if probe_calls["count"] == 1:
+            return target_metadata
+        return None  # every subsequent probe: the daemon has (apparently) stopped
+
+    def _fake_daemon_request(
+        host: str,
+        port: int,
+        request: dict[str, Any],
+        *,
+        response_timeout: float | None = None,
+        token: str = "",
+    ) -> dict[str, Any]:
+        if request.get("command") == "stop":
+            # A replacement daemon B publishes its own metadata in the window while A processes
+            # the stop request.
+            session_daemon._write_daemon_metadata(root, _payload(pid=222, port=3333, token="b"))
+            return {"version": 1, "ok": True, "stopping": True}
+        return {"version": 1, "ok": True}
+
+    monkeypatch.setattr(session_daemon, "_probe_daemon", _fake_probe)
+    monkeypatch.setattr(session_daemon, "_daemon_request", _fake_daemon_request)
+
+    result = session_daemon.stop_session_daemon(str(root))
+
+    assert result["running"] is False
+    assert result["stopped"] is True
+    survivor = session_daemon._read_daemon_metadata(root)
+    assert survivor is not None, "the replacement daemon's metadata must survive"
+    assert survivor["pid"] == 222
+    assert survivor["port"] == 3333
+
+
+def test_stop_session_daemon_removes_own_metadata_when_uncontested(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    # The happy path must behave exactly as before the fix: when nothing races in, stopping the
+    # daemon removes its own (uncontested) metadata.
+    root = (tmp_path / "project").resolve()
+    root.mkdir()
+    target_metadata = _payload(pid=111, port=2222, token="a")
+    session_daemon._write_daemon_metadata(root, target_metadata)
+
+    probe_calls = {"count": 0}
+
+    def _fake_probe(_root: Path) -> dict[str, Any] | None:
+        probe_calls["count"] += 1
+        if probe_calls["count"] == 1:
+            return target_metadata
+        return None
+
+    def _fake_daemon_request(
+        host: str,
+        port: int,
+        request: dict[str, Any],
+        *,
+        response_timeout: float | None = None,
+        token: str = "",
+    ) -> dict[str, Any]:
+        return {"version": 1, "ok": True, "stopping": True}
+
+    monkeypatch.setattr(session_daemon, "_probe_daemon", _fake_probe)
+    monkeypatch.setattr(session_daemon, "_daemon_request", _fake_daemon_request)
+
+    result = session_daemon.stop_session_daemon(str(root))
+
+    assert result["running"] is False
+    assert result["stopped"] is True
+    assert session_daemon._read_daemon_metadata(root) is None


### PR DESCRIPTION
## The race

`_remove_daemon_metadata(root)` unlinked `daemon.json` unconditionally, regardless of who called it.

When `_probe_daemon()` rejects a daemon over a `package_version` mismatch (task #94 PR-1, the
version-skew check), the client spawns a *replacement* daemon (call it B) while the rejected
daemon (A) keeps running -- nothing tells A to stop just because a client stopped trusting it. A
only exits later, on its own idle-shutdown or max-uptime timer.

By the time A's `run_session_daemon_server` `finally` block runs, `daemon.json` no longer belongs
to A -- B has already published its own metadata there. The old, unconditional
`_remove_daemon_metadata(root)` call deleted it anyway: B's PID/port/token, gone, even though B is
still alive and serving. Result: a silent orphan-daemon pileup (A exits, but so does B's only
discoverable record) and a live daemon no client can ever find again. `stop_session_daemon`'s
PID-kill fallback (probe failed -> read stale metadata -> kill by pid -> unconditional remove) and
its main cooperative-stop tail had the identical shape of bug.

## The guard

`_remove_daemon_metadata` now accepts optional `expected_pid`/`expected_port`. When given, it
re-reads the *current* on-disk metadata immediately before unlinking and only proceeds if the
`pid`/`port` fields still match -- i.e. the file still identifies the exact instance the caller
intends to remove. A mismatch (replacement already published), a missing file, or a corrupt/
unparseable file are all treated as "not mine" and left untouched -- the fail-safe choice, since an
unverifiable file can't be proven safe to delete, and a corrupt file self-heals the next time a
daemon (re)starts via `_spawn_daemon_subprocess`'s unconditional clear.

Guarded call sites:
- `run_session_daemon_server`'s shutdown `finally` -- the primary bug site (idle/max-uptime/
  cooperative-stop self-shutdown), now passes `expected_pid=os.getpid(), expected_port=int(port)`.
- `stop_session_daemon`'s stale-fallback branch (probe failed, PID-kill path) -- now derives the
  expected identity from the `stale_metadata` it just read and killed by pid; skips the removal
  entirely if that identity can't be established.
- `stop_session_daemon`'s main cooperative-stop tail -- now derives the expected identity from the
  `metadata` captured at function entry (the daemon this call actually targeted).

`_spawn_daemon_subprocess` is the one caller that keeps the old unconditional (force) mode: it
holds the daemon-start lock (excluding any concurrent spawn for the root) and is about to publish a
brand-new instance's own metadata, so there is no prior "self" identity to compare against yet.

## Tests (TDD, `tests/unit/test_session_daemon_metadata_ownership.py`, 12 new tests)

- `_daemon_identity` extraction (happy path + missing/malformed fields).
- `_remove_daemon_metadata` force mode: locks in `_spawn_daemon_subprocess`'s unconditional
  contract, and no-ops cleanly when the file is absent.
- `_remove_daemon_metadata` guarded mode: removes on an identity match (the "A's own normal
  shutdown still works" case); preserves a replacement on a **pid** mismatch and, independently, on
  a **port** mismatch; no-ops on a missing file; leaves a corrupt file untouched.
- `stop_session_daemon`'s stale-fallback branch and cooperative-stop tail, each exercised
  end-to-end with a simulated concurrent replacement publishing its own metadata mid-call --
  asserts the replacement's metadata survives.
- A happy-path regression check: uncontested `stop_session_daemon` still removes its own metadata
  exactly as before the fix.

## Verification

- `ruff format --preview .` / `ruff check .` -- clean.
- `mypy src/tensor_grep/cli/session_daemon.py` (`--strict`) -- clean.
- `pytest tests/unit/test_session_daemon*.py tests/unit/test_index_lock*.py -q` -- 88 passed, 1
  unrelated skip, confirmed across multiple repeated runs.
- Note: this machine intermittently hits a **pre-existing, unrelated** flake in real-subprocess
  daemon-spawn tests (`start_session_daemon`'s 5s startup bound occasionally races under system
  load) -- reproduced on completely untouched tests in `test_session_daemon_version_skew.py` and
  `test_session_cli.py`, and confirmed via a head-to-head timing comparison against a clean
  `origin/main` checkout of `session_daemon.py` (both versions showed the same 0.9s-4.6s spread
  across repeated runs). Not caused by this change and out of this PR's scope.

## Scope

Files touched: `src/tensor_grep/cli/session_daemon.py` and its new test file only. No changes to
`runtime_paths`, `checkpoint`, or the Rust core.

**`session_daemon.py` is in scope for the mandatory adversarial security gate (AGENTS.md A3,
index-or-session-lock trigger) -- Opus review pending before merge.**
