### PR TITLE
perf: cache _expected_tg_version + fix dead import-provenance tag in tg importers

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -6412,12 +6412,20 @@ def _python_module_matches_definition(
     repo_root: Path | str | None = None,
     *,
     level: int = 0,
-) -> bool:
-    return bool(
-        _python_module_match_details(
-            importer_path, module_name, definition_path, repo_root, level=level
-        )["matched"]
+) -> tuple[bool, list[str]]:
+    """Return `(matched, provenance)`.
+
+    Unlike the bool-only `_js_ts_module_matches_definition` / `_rust_module_matches_definition`
+    siblings, this also threads through `_python_module_match_details`'s `provenance` (notably
+    the "sys-path-insert" tag) -- #155 fix: that tag was computed but provably unreachable
+    (this was the only caller, and it discarded everything but the bool) before this change.
+    The sole caller, `_confirm_import_edges`, uses it to report the tag honestly on `tg
+    importers` reverse edges instead of silently collapsing it into a generic label.
+    """
+    details = _python_module_match_details(
+        importer_path, module_name, definition_path, repo_root, level=level
     )
+    return bool(details["matched"]), list(details["provenance"])
 
 
 def _group_symbols_by_file(symbols: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
@@ -15463,6 +15471,7 @@ def _confirm_import_edges(
             # a confirmed edge for an import whose target we can't actually read (precision
             # matters more than recall past this point).
             continue
+        python_provenance: list[str] = []
         if language_id in ("javascript", "typescript"):
             matched = _js_ts_module_matches_definition(
                 candidate_importer, module, target_file, repo_root
@@ -15479,7 +15488,7 @@ def _confirm_import_edges(
             # `_python_module_candidates` resolve a relative import correctly instead of
             # falling back to a bare path-suffix match that ignores directory context.
             level = int(raw_entry.get("level", 0) or 0)
-            matched = _python_module_matches_definition(
+            matched, python_provenance = _python_module_matches_definition(
                 candidate_importer, module, target_file, repo_root, level=level
             )
         if not matched or line in seen_lines:
@@ -15496,6 +15505,16 @@ def _confirm_import_edges(
             "provenance": provenance,
             "resolution_confidence": _import_graph_resolution_confidence(provenance),
         }
+        if python_provenance == ["sys-path-insert"]:
+            # #155 fix: report the sys.path-hack tag honestly on the reverse edge too, mirroring
+            # the forward `tg imports` path (`_resolve_raw_import_entry`). A SEPARATE field, not
+            # an overwrite of `provenance` above -- that string drives
+            # `_import_graph_resolution_confidence`'s enum ("parser-backed"/"heuristic"/
+            # "regex-heuristic", pinned by test_import_span_targeting.py) and this edge is still
+            # exactly as parser-confirmed (exact AST-parsed, exact resolved-path match) as any
+            # other Python edge, just resolved via a sys.path-hacked root instead of a standard
+            # one.
+            edge["path_provenance"] = "sys-path-insert"
         if dynamic:
             # Payload-bloat fix (#93 SUB-1 follow-up, same rationale as
             # _resolve_raw_import_entry): preserve the dynamic markers on an edge that IS

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -84,6 +84,13 @@ def _read_project_version_fallback() -> str:
     return "0.0.0"
 
 
+# Safe to cache (unlike `_native_tg_version` below, whose docstring at `inspect_native_tg_binary`
+# warns against a path-keyed cache going stale across an `os.replace` swap): this function takes
+# no arguments and only reads pyproject.toml + installed package metadata, neither of which change
+# within a single process lifetime. Called on every daemon probe (`_probe_daemon` in
+# session_daemon.py) since the daemon became default-on for symbol commands, so an uncached
+# pyproject.toml read + importlib.metadata scan on every probe is wasted I/O.
+@lru_cache(maxsize=1)
 def _expected_tg_version() -> str:
     source_version = _read_project_version_fallback()
     try:

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -491,6 +491,10 @@ def test_build_file_importers_python_excludes_duplicate_basename_false_edge(
         if current["file"] == str(run_py.resolve())
     )
     assert edge["module"] == "config"
+    # #155 fix companion: a normal (non-sys.path-hacked) Python edge must NOT gain the
+    # "path_provenance" key at all -- same payload-bloat-avoidance rule already applied to
+    # dynamic/dynamic_unresolved (only stamp a key when it says something non-default).
+    assert "path_provenance" not in edge
 
 
 def test_build_file_importers_python_recalls_from_dot_import(tmp_path: Path) -> None:
@@ -1232,6 +1236,14 @@ def test_build_file_importers_finds_sys_path_insert_hacked_importer(tmp_path: Pa
     )
     assert edge["module"] == "mymod"
     assert edge["line"] == 3
+    # #155 fix: the reverse edge must honestly report the sys.path-hack provenance (mirrors the
+    # forward `tg imports` side, which already tags this "sys-path-insert" -- see
+    # test_build_file_imports_resolves_sys_path_insert_hacked_module above) instead of silently
+    # collapsing it into the generic "parser-backed" label. `provenance` itself stays
+    # "parser-backed" (drives resolution_confidence; this edge IS still exactly as
+    # parser-confirmed as any other Python edge) -- the hack is surfaced as a separate field.
+    assert edge["provenance"] == "parser-backed"
+    assert edge["path_provenance"] == "sys-path-insert"
 
 
 def test_sys_path_hack_present_stdlib_import_stays_external(tmp_path: Path) -> None:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -17,9 +17,11 @@ from tensor_grep.cli.runtime_paths import resolve_native_tg_binary, resolve_ripg
 def clear_caches():
     resolve_native_tg_binary.cache_clear()
     resolve_ripgrep_binary.cache_clear()
+    runtime_paths._expected_tg_version.cache_clear()
     yield
     resolve_native_tg_binary.cache_clear()
     resolve_ripgrep_binary.cache_clear()
+    runtime_paths._expected_tg_version.cache_clear()
 
 
 # Task #94 PR-1: env_flag_disabled is the mirror of env_flag_enabled for a default-ON, opt-out


### PR DESCRIPTION
## Summary

Two verified, non-security Python correctness/perf nits from the `#143`/`#155` Opus-gate LOW follow-ups backlog (`docs/BACKLOG.md`). Both were verified against live code (file:line) before implementing, per the repo's `verify-plan-against-code` discipline.

### #143 (perf): cache `_expected_tg_version`

`_expected_tg_version()` in `src/tensor_grep/cli/runtime_paths.py:87-97` re-read `pyproject.toml` and re-scanned `importlib.metadata` on **every call**, uncached — unlike its siblings `resolve_native_tg_binary`/`resolve_ripgrep_binary` (`runtime_paths.py:253`, `:440`), both already `@lru_cache(maxsize=1)`.

It sits on the daemon probe hot path: `_probe_daemon` in `session_daemon.py:505` calls it on every probe, and the session daemon became default-on for all 5 symbol commands as of `#543` — so this was wasted I/O (a file read + a package-metadata scan) on every single probe.

Fix: added `@lru_cache(maxsize=1)`, matching its siblings. This is safe because the function takes no arguments and depends only on `pyproject.toml` + installed package metadata, neither of which changes within a process's lifetime — **unlike** `_native_tg_version` (a different, path-keyed function), whose docstring at `inspect_native_tg_binary` explicitly warns against caching for a reason that does not apply here (an `os.replace` binary-swap race across a candidate loop).

Also added `_expected_tg_version.cache_clear()` to the `clear_caches` autouse fixture in `tests/unit/test_runtime_paths.py`, since an existing test (`test_expected_tg_version_prefers_repo_source_when_editable_metadata_is_stale`) monkeypatches this function's own dependencies directly and needs a clean cache per test.

### #155 (dead-code / precision): honor `sys-path-insert` provenance in `tg importers`

`_python_module_match_details` (`repo_map.py:6371-6405`) computes a `"sys-path-insert"` provenance tag when a Python reverse-import candidate is reached only via a `sys.path.insert`/`.append` hack. Its only caller, `_python_module_matches_definition` (`:6408-6420`), discarded everything but the bool — so `_confirm_import_edges` (`:15488`, the `tg importers` reverse edge-builder) always hardcoded `provenance = "parser-backed"`, even for edges that only resolve through the hack. The forward `tg imports` path (`_resolve_raw_import_entry`, `:15327`) already reports this tag correctly; the reverse path did not — the tag was provably dead on that side.

**Chosen fix (thread-through, not delete):** changed `_python_module_matches_definition`'s return type from bare `bool` to `tuple[bool, list[str]]`, and `_confirm_import_edges` now stamps a **new, separate** `path_provenance: "sys-path-insert"` field on the edge when applicable.

This is deliberately a new field, not an overwrite of the existing `provenance` string: that string is a distinct enum (`"parser-backed"` / `"heuristic"` / `"regex-heuristic"`) that drives `_import_graph_resolution_confidence`'s confidence score and is pinned by `test_import_span_targeting.py`. A sys-path-insert-resolved Python edge is still exactly as parser-confirmed (exact AST-parsed, exact resolved-path match) as any other Python edge — overwriting `provenance` would have silently downgraded its confidence score (0.95 -> 0.75 default) for no real reason, and corrupted a contract pinned elsewhere. The new field is conditionally added, mirroring the existing `dynamic`/`dynamic_unresolved` payload-bloat-avoidance pattern already in the same function.

Note on the PR title: the dispatch brief's suggested title said "drop dead import-provenance lookup," anticipating the delete option. Per the brief's own "pick whichever is cleaner" instruction, I chose the thread-through option (preferred by the brief when clean) since it's a real precision win for `tg importers` callers, and adjusted the title to describe what actually shipped.

## Testing

- Extended `test_build_file_importers_finds_sys_path_insert_hacked_importer` (`tests/unit/test_file_deps.py`) with assertions that `provenance == "parser-backed"` (unchanged) **and** the new `path_provenance == "sys-path-insert"`.
- Added a negative-case assertion to `test_build_file_importers_python_excludes_duplicate_basename_false_edge` proving a normal (non-hacked) Python edge does **not** gain the new key (no payload bloat on the common path).
- Added `_expected_tg_version.cache_clear()` to the `clear_caches` fixture in `test_runtime_paths.py`.

Scope: `runtime_paths.py`, `repo_map.py`, and their tests only. Did not touch `session_daemon.py`/checkpoint/rust (sibling PRs own those) or any docs files (a whole-repo `ruff format --preview .` reformatted 4 unrelated pre-existing-drift markdown files under `docs/`; reverted those before committing to keep this PR's diff scoped to the 4 files above).

## Test plan

- [x] `uv run --no-sync ruff format --preview .` (whole repo) — clean, no changes outside the 4 intended files
- [x] `uv run --no-sync ruff check .` (whole repo) — all checks passed
- [x] `uv run --no-sync pytest tests/unit/test_runtime_paths.py tests/unit/test_file_deps.py tests/unit/test_cross_lang_resolution.py tests/unit/test_cap_fix_chokepoint.py tests/unit/test_mcp_caps.py tests/unit/test_import_span_targeting.py -q` — 168 passed, 1 skipped
- [x] Investigated 2 unrelated test failures hit along the way and confirmed both pre-existing/environmental, not caused by this change: (1) `test_real_daemon_subprocess_writes_current_package_version` is a flaky real-subprocess-spawn test (~15% flake rate reproduced on unmodified `main`, 2/13 trials); (2) the Go cross-lang resolution test failed only because this fresh worktree's venv was missing the `dev` extra's tree-sitter-go grammar — passed once `uv sync --extra dev` was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)