### PR TITLE
fix: bound cuda GPU engine implicit-walk to mirror the #105 native ceiling

### DIFF
--- a/rust_core/src/gpu_native.rs
+++ b/rust_core/src/gpu_native.rs
@@ -361,6 +361,16 @@ pub struct GpuNativeSearchConfig {
     pub hidden: bool,
     pub max_depth: Option<usize>,
     pub max_batch_bytes: Option<usize>,
+    /// Whether the caller omitted an explicit PATH (the search root defaulted to `.` rather than
+    /// a user-supplied path). Gates `check_gpu_native_implicit_walk_ceiling`, this engine's own
+    /// refuse-before-enumerate guard (audit #109 -- the cuda-native-GPU sibling of
+    /// `NativeSearchConfig::path_was_implicit`, audit #105, itself the native-CPU sibling of
+    /// `RipgrepSearchArgs::path_was_implicit`, audit #100). An explicit, deliberately-scoped PATH
+    /// must never be refused regardless of its size. `Default`'s `false` is NOT a safe fallback for
+    /// the walk guard itself (it means "never refuse"); it only exists so ad hoc test fixtures and
+    /// the always-explicit-`--path` diagnostic commands (`gpu-native-stats`, cuda-graph benchmark)
+    /// get deterministic, non-refusing behavior, mirroring `NativeSearchConfig`'s convention.
+    pub path_was_implicit: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -3784,6 +3794,47 @@ fn ensure_capacity(capacity: usize, required: usize, path: &Path) -> Result<()> 
     ))
 }
 
+/// Bounded refuse-before-enumerate gate for the GPU-native engine's own root walk -- the
+/// cuda-native sibling of `native_search::check_native_implicit_walk_ceiling` (audit #105) and
+/// `rg_passthrough::check_implicit_walk_ceiling` (audit #100). Audit #109 found the GPU-native
+/// engine had NO ceiling at all: `GpuSearchParams::path_was_implicit` (main.rs) was threaded into
+/// the CPU-fallback `RipgrepSearchArgs`/`NativeSearchConfig` redirects (`execute_gpu_native_route`'s
+/// unavailable-GPU fallback path) but never into `GpuNativeSearchConfig` itself, so a bare
+/// implicit-path `tg search PAT --gpu-device-ids 0` on a huge root walked unbounded through this
+/// engine even though the CPU engine (#105) and rg-passthrough engine (#100) were both already
+/// bounded for the exact same shape of request.
+///
+/// Only meaningful when `config.path_was_implicit` -- an explicit, deliberately-scoped PATH is
+/// never refused regardless of size. Called as the FIRST statement of `collect_walked_files`, the
+/// only function in this module that ever hands a root to `WalkBuilder`.
+fn check_gpu_native_implicit_walk_ceiling(
+    config: &GpuNativeSearchConfig,
+    roots: &[PathBuf],
+) -> Option<String> {
+    if !config.path_was_implicit {
+        return None;
+    }
+    let probe_roots: Vec<String> = roots
+        .iter()
+        .map(|root| root.to_string_lossy().into_owned())
+        .collect();
+    if crate::rg_passthrough::implicit_search_walk_exceeds_ceiling(
+        &probe_roots,
+        config.max_depth,
+        config.no_ignore,
+        config.hidden,
+        crate::rg_passthrough::IMPLICIT_SEARCH_WALK_FILE_CEILING,
+    ) {
+        Some(
+            crate::rg_passthrough::format_unbounded_implicit_search_walk_error(
+                crate::rg_passthrough::IMPLICIT_SEARCH_WALK_FILE_CEILING,
+            ),
+        )
+    } else {
+        None
+    }
+}
+
 fn collect_search_files(config: &GpuNativeSearchConfig) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     let mut roots = Vec::new();
@@ -3812,6 +3863,9 @@ fn collect_search_files(config: &GpuNativeSearchConfig) -> Result<Vec<PathBuf>> 
 }
 
 fn collect_walked_files(config: &GpuNativeSearchConfig, roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    if let Some(refusal) = check_gpu_native_implicit_walk_ceiling(config, roots) {
+        return Err(anyhow!(refusal));
+    }
     let builder = build_walk_builder(config, roots)?;
     let walked_files = Arc::new(std::sync::Mutex::new(Vec::new()));
     let shared_files = Arc::clone(&walked_files);
@@ -4288,13 +4342,142 @@ fn ensure_cuda_library_path() {
 #[cfg(test)]
 mod tests {
     use super::{
-        cached_search_kernel_ptx_path, kernel_compile_options_for_compute_capability,
-        line_matches_for_file, load_file_batch_into_pinned_slice, resolve_adaptive_match_capacity,
+        cached_search_kernel_ptx_path, check_gpu_native_implicit_walk_ceiling,
+        collect_search_files, kernel_compile_options_for_compute_capability, line_matches_for_file,
+        load_file_batch_into_pinned_slice, resolve_adaptive_match_capacity,
         resolve_max_match_capacity, validate_requested_cuda_device_ids, BatchedFile, FileBatchPlan,
-        LineDescriptor, PatternMatchPosition,
+        GpuNativeSearchConfig, LineDescriptor, PatternMatchPosition,
     };
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+
+    // --- Audit #109: GPU-native implicit-walk-ceiling gate --------------------------------
+    // Mirrors native_search.rs's audit #105 test suite for `check_native_implicit_walk_ceiling`.
+    // #105 hoisted a walk-ceiling gate into the native-CPU engine but left the GPU-native engine
+    // (this module) with NO ceiling at all -- `GpuNativeSearchConfig` did not even have a
+    // `path_was_implicit` field, so a bare implicit-path `--gpu-device-ids` search on a huge root
+    // walked unbounded through `collect_walked_files`.
+
+    fn make_stub_file_dir(dir: &Path, file_count: usize) {
+        for index in 0..file_count {
+            fs::write(
+                dir.join(format!("stub_{index}.py")),
+                "nothing interesting\n",
+            )
+            .unwrap();
+        }
+    }
+
+    fn config_with_paths(paths: Vec<PathBuf>, path_was_implicit: bool) -> GpuNativeSearchConfig {
+        GpuNativeSearchConfig {
+            patterns: vec!["TODO".to_string()],
+            paths,
+            path_was_implicit,
+            ..GpuNativeSearchConfig::default()
+        }
+    }
+
+    #[test]
+    fn check_gpu_native_implicit_walk_ceiling_refuses_oversized_implicit_walk() {
+        // RED-before-fix: this is the exact shape of the #109 bypass -- an implicit-path search
+        // (no explicit PATH positional) on a root over the 1500-file ceiling.
+        let dir = tempfile::tempdir().unwrap();
+        make_stub_file_dir(dir.path(), 1600);
+        let roots = vec![dir.path().to_path_buf()];
+        let config = config_with_paths(roots.clone(), true);
+
+        let refusal = check_gpu_native_implicit_walk_ceiling(&config, &roots);
+
+        assert!(
+            refusal.is_some(),
+            "an oversized implicit-path walk must be refused"
+        );
+    }
+
+    #[test]
+    fn check_gpu_native_implicit_walk_ceiling_allows_explicit_path_even_when_oversized() {
+        // Non-regression (Trap #3 parity, mirrors native_search.rs/rg_passthrough.rs): an
+        // EXPLICIT, deliberately-scoped PATH must never be refused regardless of size.
+        let dir = tempfile::tempdir().unwrap();
+        make_stub_file_dir(dir.path(), 1600);
+        let roots = vec![dir.path().to_path_buf()];
+        let config = config_with_paths(roots.clone(), false);
+
+        let refusal = check_gpu_native_implicit_walk_ceiling(&config, &roots);
+
+        assert!(
+            refusal.is_none(),
+            "an explicit path must run uninhibited even when the walk exceeds the ceiling"
+        );
+    }
+
+    #[test]
+    fn check_gpu_native_implicit_walk_ceiling_allows_implicit_path_under_ceiling() {
+        // Normal-case non-regression: an implicit path under the ceiling is unaffected -- a
+        // typical repo must never be refused.
+        let dir = tempfile::tempdir().unwrap();
+        make_stub_file_dir(dir.path(), 50);
+        let roots = vec![dir.path().to_path_buf()];
+        let config = config_with_paths(roots.clone(), true);
+
+        let refusal = check_gpu_native_implicit_walk_ceiling(&config, &roots);
+
+        assert!(
+            refusal.is_none(),
+            "a 50-file implicit root must not be refused"
+        );
+    }
+
+    #[test]
+    fn collect_search_files_refuses_oversized_implicit_walk_before_enumerating() {
+        // Hermetic end-to-end test of the actual `collect_search_files` production entry point
+        // `gpu_native_search_paths_multi_with_options` calls before ever touching a CUDA device
+        // (see that function: `collect_search_files(config)?` runs BEFORE `resolve_cuda_devices`),
+        // so this test exercises the real bug with no GPU/CUDA runtime involved. Bounded per
+        // anti-hang-test-protocol: run on a joined worker thread with an explicit timeout so a
+        // regression (the gate silently stops firing) that falls through to the unbounded
+        // parallel walk cannot hang the test runner -- it fails fast with a clear panic instead.
+        let dir = tempfile::tempdir().unwrap();
+        make_stub_file_dir(dir.path(), 1600);
+        let config = config_with_paths(vec![dir.path().to_path_buf()], true);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = collect_search_files(&config).map_err(|error| error.to_string());
+            let _ = tx.send(result);
+        });
+        let result = rx.recv_timeout(std::time::Duration::from_secs(10)).expect(
+            "collect_search_files must return well within 10s -- a hang here means the \
+             walk-ceiling gate did not fire before an unbounded parallel walk",
+        );
+
+        let err = result.expect_err("an oversized implicit-path walk must be refused, not Ok");
+        assert!(
+            crate::rg_passthrough::is_unbounded_implicit_search_walk_refusal(&err),
+            "unexpected error (expected the walk-ceiling refusal): {err}"
+        );
+    }
+
+    #[test]
+    fn collect_search_files_does_not_refuse_explicit_oversized_path() {
+        // Non-regression: an explicit PATH (even oversized) must complete normally, not be
+        // refused -- fail-open for explicit scoping is the whole point of the guard (Trap #3
+        // parity). Bounded per anti-hang-test-protocol.
+        let dir = tempfile::tempdir().unwrap();
+        make_stub_file_dir(dir.path(), 1600);
+        let config = config_with_paths(vec![dir.path().to_path_buf()], false);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = collect_search_files(&config).map_err(|error| error.to_string());
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(20))
+            .expect("collect_search_files must return well within 20s for an explicit path");
+
+        result.expect("an explicit oversized path must not be refused");
+    }
 
     #[test]
     fn validate_requested_cuda_device_ids_preserves_selected_subset_without_expanding() {

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -10542,6 +10542,10 @@ fn gpu_native_config_from_internal_args(args: &GpuNativeStatsArgs) -> GpuNativeS
         hidden: false,
         max_depth: None,
         max_batch_bytes: args.max_batch_bytes,
+        // `GpuNativeStatsArgs::path` is a required `#[arg(long)]` (no default_value) -- this
+        // diagnostic command always has an explicit, deliberately-scoped PATH, never an implicit
+        // one, so the #109 ceiling must never fire here regardless of tree size.
+        path_was_implicit: false,
     }
 }
 
@@ -10555,6 +10559,10 @@ fn gpu_native_config_from_graph_args(args: &GpuCudaGraphArgs) -> GpuNativeSearch
         hidden: false,
         max_depth: None,
         max_batch_bytes: args.max_batch_bytes,
+        // `GpuCudaGraphArgs::path` is a required `#[arg(long)]` (no default_value) -- this
+        // benchmark command always has an explicit, deliberately-scoped PATH, never an implicit
+        // one, so the #109 ceiling must never fire here regardless of tree size.
+        path_was_implicit: false,
     }
 }
 
@@ -10643,6 +10651,12 @@ fn execute_gpu_native_route(
         hidden: params.hidden,
         max_depth: params.max_depth,
         max_batch_bytes: None,
+        // Audit #109 fix: this field did not exist on `GpuNativeSearchConfig` at all, so the
+        // GPU-native engine had no equivalent of the #105 native-CPU implicit-walk ceiling --
+        // `params.path_was_implicit` was already threaded into the CPU-fallback redirects
+        // (`ripgrep_args_for_gpu_params`, `native_search_config_for_gpu_params`) but silently
+        // dropped here, the one construction site that feeds the actual cuda kernel walk.
+        path_was_implicit: params.path_was_implicit,
     };
 
     let stats = gpu_native_search_paths_multi(&config, device_ids)?;

--- a/rust_core/tests/test_gpu_native_graphs.rs
+++ b/rust_core/tests/test_gpu_native_graphs.rs
@@ -46,6 +46,7 @@ fn test_gpu_native_replays_captured_cuda_graphs_without_changing_results() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(4 * 1024),
+        path_was_implicit: false,
     };
 
     let benchmark = benchmark_cuda_graph_search_paths(&config, device_id).unwrap();
@@ -83,6 +84,7 @@ fn test_gpu_native_cuda_graphs_reduce_batch_overhead_by_ten_percent() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(4 * 1024),
+        path_was_implicit: false,
     };
 
     let benchmark = benchmark_cuda_graph_search_paths(&config, device_id).unwrap();

--- a/rust_core/tests/test_gpu_native_integration.rs
+++ b/rust_core/tests/test_gpu_native_integration.rs
@@ -777,6 +777,7 @@ fn test_gpu_native_multi_pattern_falls_back_to_batched_passes_for_large_pattern_
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(8 * 1024),
+        path_was_implicit: false,
     };
 
     let stats = gpu_native_search_paths(&config, device_id).unwrap();
@@ -821,6 +822,7 @@ fn test_gpu_native_three_pattern_dispatch_is_below_two_times_single_pattern() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: None,
+        path_was_implicit: false,
     };
     let multi_config = GpuNativeSearchConfig {
         patterns: vec![
@@ -834,6 +836,7 @@ fn test_gpu_native_three_pattern_dispatch_is_below_two_times_single_pattern() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: None,
+        path_was_implicit: false,
     };
 
     let mut single_samples = Vec::new();

--- a/rust_core/tests/test_gpu_native_long_lines.rs
+++ b/rust_core/tests/test_gpu_native_long_lines.rs
@@ -119,6 +119,7 @@ fn test_gpu_native_adaptive_dispatch_matches_cpu_for_ten_kib_lines() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(256 * 1024),
+        path_was_implicit: false,
     };
 
     let stats = gpu_native_search_paths(&config, device_id).unwrap();
@@ -161,6 +162,7 @@ fn test_gpu_native_adaptive_dispatch_matches_cpu_for_hundred_kib_lines() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(512 * 1024),
+        path_was_implicit: false,
     };
 
     let stats = gpu_native_search_paths(&config, device_id).unwrap();
@@ -202,6 +204,7 @@ fn test_gpu_native_adaptive_dispatch_classifies_mixed_short_medium_and_long_line
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(256 * 1024),
+        path_was_implicit: false,
     };
 
     let stats = gpu_native_search_paths(&config, device_id).unwrap();
@@ -263,6 +266,7 @@ fn test_gpu_native_long_line_corpus_is_not_slower_than_short_line_corpus() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(2 * 1024 * 1024),
+        path_was_implicit: false,
     };
     let long_config = GpuNativeSearchConfig {
         patterns: vec![pattern.to_string()],
@@ -272,6 +276,7 @@ fn test_gpu_native_long_line_corpus_is_not_slower_than_short_line_corpus() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(2 * 1024 * 1024),
+        path_was_implicit: false,
     };
 
     let mut short_samples = Vec::new();

--- a/rust_core/tests/test_gpu_native_streams.rs
+++ b/rust_core/tests/test_gpu_native_streams.rs
@@ -80,6 +80,7 @@ fn test_gpu_native_search_reports_pinned_double_buffered_stream_pipeline() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(64 * 1024),
+        path_was_implicit: false,
     };
 
     let stats = gpu_native_search_paths(&config, device_id).unwrap();
@@ -107,6 +108,7 @@ fn test_gpu_native_overlap_matches_expected_results_without_races() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(64 * 1024),
+        path_was_implicit: false,
     };
 
     let mut actual = gpu_native_search_paths(&config, device_id)
@@ -138,6 +140,7 @@ fn test_gpu_native_overlap_metrics_show_transfer_compute_overlap() {
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(64 * 1024),
+        path_was_implicit: false,
     };
 
     let stats = gpu_native_search_paths(&config, device_id).unwrap();
@@ -189,6 +192,7 @@ fn test_gpu_native_multi_gpu_balances_distribution_and_matches_single_gpu_result
         hidden: false,
         max_depth: None,
         max_batch_bytes: Some(128 * 1024),
+        path_was_implicit: false,
     };
 
     let single = gpu_native_search_paths(&config, devices[0].device_id).unwrap();


### PR DESCRIPTION
## Summary

Audit #109: the cuda GPU-native search engine had no equivalent of the #105 native-CPU
implicit-walk ceiling, so a bare `tg search PAT --gpu-device-ids 0` with no explicit PATH
on a huge root could walk unbounded through the GPU engine (a DoS ceiling gap on the GPU
leg, mirroring the pre-#105 native-CPU bug and the pre-#100 rg-passthrough bug).

## Confirmed seams (file:line, verified against current main before writing any code)

1. `rust_core/src/main.rs:10017` `struct GpuSearchParams<'a>` carries `path_was_implicit: bool`
   at `main.rs:10061`. Its doc comment (added by #105) says it is threaded into the CPU-fallback
   redirects -- confirmed true for both: `ripgrep_args_for_gpu_params` (`main.rs:10155`,
   `path_was_implicit: params.path_was_implicit`) and `native_search_config_for_gpu_params`
   (`main.rs:10835`, same).
2. `rust_core/src/main.rs:10625-10674` `execute_gpu_native_route` (pre-fix) built
   `GpuNativeSearchConfig` at `main.rs:10638-10646` with 7 fields, **omitting** `path_was_implicit`
   entirely -- the one construction site that feeds the actual cuda-native kernel walk.
3. `rust_core/src/native_search.rs:1033-1059` `check_native_implicit_walk_ceiling` -- the pattern
   mirrored. It is a thin wrapper over 3 shared primitives in `rg_passthrough.rs`:
   `IMPLICIT_SEARCH_WALK_FILE_CEILING` (`:153`, `pub const ... = 1500`),
   `implicit_search_walk_exceeds_ceiling` (`:163`, `pub fn`), and
   `format_unbounded_implicit_search_walk_error` (`:225`, `pub fn`).
4. `rust_core/src/gpu_native.rs:356-364` (pre-fix) `GpuNativeSearchConfig` had **no**
   `path_was_implicit` field at all -- confirmed via `#[derive(Debug, Clone, Default)] pub struct
   GpuNativeSearchConfig { patterns, paths, no_ignore, glob, hidden, max_depth, max_batch_bytes }`.
5. `rust_core/src/gpu_native.rs:3865` (pre-fix) `collect_walked_files` -- the **only** function in
   this module that ever hands a root to `WalkBuilder` (mirrors `native_search.rs`'s own structure
   exactly, confirmed by reading both `collect_walked_files`/`build_walk_builder` pairs side by
   side) -- had no ceiling check at all.

All 5 confirmed as claimed; no seam differed from the brief. Gap was real.

## Architecture finding (materially affects how "runs under plain `cargo test`" was satisfied)

`gpu_native.rs` is gated as a **whole module**: `lib.rs:9-10` reads
`#[cfg(feature = "cuda")] pub mod gpu_native;`. This is structurally different from `main.rs`,
where individual cuda-only items get their own `#[cfg(any(feature = "cuda", test))]` gate (the
"MF-1" pattern, documented at `main.rs:10252-10263`, applied to `classify_gpu_route_failure` /
`sanitize_cuda_detail` / `GpuRouteFailureKind` / `GpuRouteFailure`). Because the *module* itself
is excluded under default features, no per-item cfg on anything inside `gpu_native.rs` can make it
visible to a plain `cargo test` -- the module doesn't exist there, full stop. This is true for
**every** pre-existing test already in that file (`validate_requested_cuda_device_ids_*`,
`kernel_compile_options_*`, etc.) -- confirmed by running `cargo test` with default features and
grepping the output for `gpu_native`: zero matches, before and after this change.

Given that, the new tests are co-located in `gpu_native.rs`'s existing `mod tests` (the primary
option offered), consistent with every existing test there, and verified via
`cargo test --features cuda --lib gpu_native::` -- the only invocation that can actually execute
this module's tests. I proved genuine RED -> GREEN this way (see Tests below) rather than force a
gating scheme that can't work for this file.

## TDD: RED -> GREEN (actually executed, not asserted)

Sequenced the change to get a genuine *behavioral* red, not just a compile error:
1. Added `path_was_implicit` to `GpuNativeSearchConfig` + fixed the 3 main.rs construction sites
   (compiles).
2. Added `check_gpu_native_implicit_walk_ceiling` (implemented, but **not yet wired** into
   `collect_walked_files`) + 5 new tests (3 direct unit tests of the checker, 2 testing
   `collect_search_files` -- the real production entry point -- end to end).
3. Ran `cargo test --features cuda --lib gpu_native::`: **13 passed, 1 failed** --
   `collect_search_files_refuses_oversized_implicit_walk_before_enumerating` panicked because
   `collect_search_files` returned `Ok(<1600 files>)` instead of refusing. Genuine RED: the
   standalone checker function was already correct, but nothing in the production path called it
   yet.
4. Wired the check as the first statement of `collect_walked_files` (2-line change).
5. Re-ran: **14 passed, 0 failed.** GREEN.

## Diff shape

- `rust_core/src/gpu_native.rs`: `+path_was_implicit` field (documented), new
  `check_gpu_native_implicit_walk_ceiling` (mirrors `native_search.rs`'s
  `check_native_implicit_walk_ceiling` line for line, reusing the same shared `rg_passthrough`
  primitives -- no new logic invented), 2-line wire-in at `collect_walked_files`, 5 new tests
  (+ import list extension).
- `rust_core/src/main.rs`: forwards `params.path_was_implicit` at `execute_gpu_native_route`'s
  `GpuNativeSearchConfig` literal (the fix); sets `path_was_implicit: false` at the two
  diagnostic-command builders `gpu_native_config_from_internal_args` /
  `gpu_native_config_from_graph_args` (both take a required `--path` clap arg with no
  `default_value` -- confirmed via their `GpuNativeStatsArgs`/`GpuCudaGraphArgs` definitions, so
  `false` is correct, not a guess).
- 4 integration test files (`rust_core/tests/test_gpu_native_{graphs,integration,long_lines,
  streams}.rs`): adding the new required field to a public struct broke compilation at 14
  pre-existing exhaustive struct literals. Every single one always passes an explicit
  tempdir-scoped path (verified by reading all 14), so `path_was_implicit: false` is mechanical
  and behavior-preserving -- confirmed each file's insertion count matches its construction-site
  count exactly (2+3+5+4=14) and every diff is pure-insertion (no lines removed/modified).

No other files touched; no incidental churn.

## Gates

| Gate | Result |
|---|---|
| `cargo build --features cuda` | **PASS** -- clean, 29.89s |
| `cargo test` (default features) | **PASS** -- 126 tests across lib + 7 integration binaries, 0 failed, 0 new warnings, 0 `gpu_native` symbols compiled (as expected, unchanged from before this PR) |
| `cargo clippy --all-targets -- -D warnings` (as literally specified) | **BLOCKED**, pre-existing -- see below |
| `cargo fmt -- --check` | **PASS** (after fixing one real formatting issue in my own new test code -- an `assert!` line rustfmt wanted wrapped) |

### Clippy detail

The literal gate command has two problems, both discovered while running it, neither introduced by
this PR:

1. **It cannot compile this PR's new code at all.** `gpu_native.rs` only compiles with
   `--features cuda`; the mandated command doesn't pass that flag, and no CI job (checked all of
   `.github/workflows/ci.yml`) ever runs `clippy --all-targets --features cuda` together -- the
   only existing cuda-Rust CI gate is `cuda-feature-check`'s `cargo check --features cuda`
   (comment at `ci.yml:465-469`: intentionally toolkit-free, compile-only, no clippy, no
   `--all-targets`).
2. **As literally specified (no `--features cuda`) it fails on a pre-existing, unrelated issue**:
   `clippy::field_reassign_with_default` in a test helper at `rg_passthrough.rs:779-785`
   (`args_with`, inside `mod tests`). Confirmed via `git diff origin/main -- rust_core/src/
   rg_passthrough.rs` = 0 lines -- this file is untouched by this PR and the lint fires purely
   because `--all-targets` compiles the test target, which CI's actual gate (`cargo clippy --
   -D warnings`, no `--all-targets`, confirmed at `ci.yml:314`) never does.

Ran the exact CI invocation (`cargo clippy -- -D warnings`) standalone: **clean**. Ran
`cargo clippy --all-targets --features cuda -- -D warnings` (the only invocation that actually
compiles this PR's new code) plus `--keep-going` for a complete single-pass picture. Total 5 files
flagged; every one individually verified pre-existing:

| File | Finding | Verification |
|---|---|---|
| `crossover.rs:543` | unused `super::*` | zero diff from origin/main |
| `rg_passthrough.rs:781` | field-reassign-with-default | zero diff from origin/main |
| `test_sidecar_ipc.rs:628,848` | 2x dead helper fns | zero diff from origin/main |
| `gpu_native.rs:4343` | items-after-test-module | `mod tests` already followed by `cuda_library_search_paths` on origin/main (same relative order; I only inserted content, never reordered top-level items) |
| `test_gpu_native_long_lines.rs:68,307` | `bool::then` in `filter_map`; `len() > 0` | exact code confirmed present on origin/main at line 69 / 302 respectively -- shifted by exactly this diff's own insertion count (my inserted lines are all *before* these, pure addition) |

Zero clippy findings attributable to this diff's own new code.

## Dogfood note

This machine has the real CUDA 13.1 toolkit installed (`cudarc`'s `cuda-13010` feature target),
so `cargo build --features cuda` / `cargo test --features cuda` here are genuine compiles against
real CUDA headers -- stronger evidence than CI's own `cuda-feature-check` job, which the comment at
`ci.yml:465-469` says intentionally runs toolkit-free. No physical GPU was available/needed: the
new tests (and the walk-ceiling check itself) run entirely in `collect_search_files`, which
`gpu_native_search_paths_multi_with_options` calls *before* `resolve_cuda_devices` -- confirmed by
reading that function (`gpu_native.rs:1720-1721`).

## Risk / merge gate

Touches cuda/gpu_native path -> **mandatory adversarial Opus gate pending before merge (do not
merge on green alone).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
