### PR TITLE
fix: orient suggested_scope excludes deweighted/ignored trees (#168)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -589,19 +589,52 @@ def _top_level_dir(file_path: str, root: Path) -> str | None:
     return parts[0]
 
 
-def _suggested_scope_from_map(rm: dict[str, Any]) -> dict[str, Any] | None:
+def _file_in_any_tree(file_path: str, tree_roots: list[str]) -> bool:
+    """True if `file_path` lives inside any of `tree_roots` (absolute directory paths -- the
+    ``_detect_vendored_subtrees`` dict keys). Standalone helper (#168) rather than reusing
+    `_central_files_from_map`'s inline tree-membership loop, so that function's existing,
+    already-tested de-weight logic is left untouched."""
+    candidate = Path(file_path)
+    for tree_root in tree_roots:
+        try:
+            candidate.relative_to(tree_root)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def _suggested_scope_from_map(
+    rm: dict[str, Any],
+    *,
+    deweighted_trees: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
     """Centrality-weighted directory rollup: sum each code file's composite centrality
     (`_file_centrality_scores`) up to its top-level directory, rank directories, and suggest the
     top one only when it clearly outranks the runner-up. Returns None (never a guess) when there
     are no candidate subdirectories, the signal is entirely flat (all zero), or the top two
     directories are tied/near-tied. Callers gate the call itself on the repo map's
-    ``scan_limit.possibly_truncated`` -- a complete scan has nothing left to narrow."""
+    ``scan_limit.possibly_truncated`` -- a complete scan has nothing left to narrow.
+
+    ``deweighted_trees`` (#168): the same auto-detected vendor/skill/tool-config subtree set
+    ``_detect_vendored_subtrees`` produces for ``suggested_ignore`` (e.g. ``.claude/**`` on a
+    Claude-Code-harness repo whose scan truncates). A file inside any of these trees is EXCLUDED
+    from the directory rollup entirely -- not merely de-weighted -- so `suggested_scope` can never
+    point an agent at the exact tree `suggested_ignore` already says to ignore; the two fields must
+    never contradict each other. This only shrinks the candidate set: whatever directory remains is
+    still ranked on the raw, un-de-weighted score (preserving the SUB-2 design -- see
+    `_central_files_from_map`'s docstring). ``None``/omitted -- the default -- means "nothing to
+    exclude" and reproduces the pre-#168 behavior exactly; the `agent_capsule.py` and `repo_map.py`
+    call sites do not thread a deweight set through yet and are unaffected by this parameter."""
     code_files, centrality = _file_centrality_scores(rm)
     if not code_files:
         return None
     root = Path(str(rm.get("path", ".")))
+    tree_roots = list(deweighted_trees.keys()) if deweighted_trees else []
     dir_scores: dict[str, float] = {}
     for file_path in code_files:
+        if tree_roots and _file_in_any_tree(file_path, tree_roots):
+            continue  # #168: never roll an ignored tree's files into a scope candidate
         top_dir = _top_level_dir(file_path, root)
         if top_dir is None:
             continue
@@ -770,7 +803,13 @@ def build_orient_capsule_from_map(
     scan_possibly_truncated = bool(
         isinstance(scan_limit_info, dict) and scan_limit_info.get("possibly_truncated")
     )
-    suggested_scope = _suggested_scope_from_map(rm) if scan_possibly_truncated else None
+    # `deweighted_trees` (#168) is threaded through so suggested_scope can never point an agent at
+    # the same tree suggested_ignore (below) already says to ignore -- the two fields must agree.
+    suggested_scope = (
+        _suggested_scope_from_map(rm, deweighted_trees=deweighted_trees)
+        if scan_possibly_truncated
+        else None
+    )
     # The capsule's own simplified `scan_limit` int (see the docstring above): the cap that
     # produced `rm`, read back off the map itself rather than threaded through as a second,
     # independently-suppliable parameter.

--- a/tests/unit/test_orient_suggested_scope.py
+++ b/tests/unit/test_orient_suggested_scope.py
@@ -207,3 +207,195 @@ def test_build_orient_capsule_suggested_scope_is_well_formed_on_real_truncated_s
     if scope is not None:
         assert scope["confidence"] == "heuristic"
         assert isinstance(scope["dirs"], list) and scope["dirs"]
+
+
+# ---------------------------------------------------------------------------
+# #168: suggested_scope must not point into a tree suggested_ignore already flags. Previously
+# _suggested_scope_from_map read ONLY the raw, un-de-weighted centrality with no knowledge of the
+# auto-detected vendor/skill/tool-config trees, so on a harness repo whose scan truncates while
+# `.claude/` still looks like the densest directory, orient told an agent to both "ignore .claude"
+# (suggested_ignore) AND "scope to .claude" (suggested_scope) -- a self-contradictory capsule.
+# ---------------------------------------------------------------------------
+
+
+def _claude_densest_rm(root: Path) -> dict[str, Any]:
+    """A hand-built repo map where `.claude/hooks` is the RAW-densest top-level directory (an
+    internal import edge + 6 symbols, clearing the 1.5x margin against `src/` on its own) but is
+    ALSO a STRONG-0 tool-config tree once run through `_detect_vendored_subtrees` (an on-disk
+    `.claude`-named directory, matched on exact basename -- no manifest needed). `src/` is real,
+    less-dense code that must win once `.claude` is excluded from the candidate set. Distinct stems
+    (hookmain/hookb/hookc vs hub/leaf_a/leaf_b) avoid any by-stem import-resolution collision
+    between the two trees."""
+    files = [
+        str(root / ".claude" / "hooks" / "hookmain.cjs"),
+        str(root / ".claude" / "hooks" / "hookb.cjs"),
+        str(root / ".claude" / "hooks" / "hookc.cjs"),
+        str(root / "src" / "hub.py"),
+        str(root / "src" / "leaf_a.py"),
+        str(root / "src" / "leaf_b.py"),
+    ]
+    imports = [
+        {"file": str(root / ".claude" / "hooks" / "hookb.cjs"), "imports": ["hookmain"]},
+        {"file": str(root / ".claude" / "hooks" / "hookc.cjs"), "imports": ["hookmain"]},
+        {"file": str(root / "src" / "leaf_a.py"), "imports": ["hub"]},
+        {"file": str(root / "src" / "leaf_b.py"), "imports": ["hub"]},
+    ]
+    symbols = [
+        {
+            "name": f"Hook{i}",
+            "kind": "function",
+            "file": str(root / ".claude" / "hooks" / "hookmain.cjs"),
+        }
+        for i in range(6)
+    ] + [{"name": "Hub", "kind": "function", "file": str(root / "src" / "hub.py")}]
+    return {
+        "path": str(root),
+        "files": files,
+        "imports": imports,
+        "symbols": symbols,
+    }
+
+
+def test_suggested_scope_raw_winner_is_the_tool_config_dir_without_exclusion(
+    tmp_path: Path,
+) -> None:
+    # Control/sanity: confirm the premise -- absent any exclusion, `.claude/` really is the raw
+    # densest directory (10 vs src's 5, clearing the 1.5x margin), so the fix below is exercising a
+    # real conflict and not a vacuously-true test.
+    rm = _claude_densest_rm(tmp_path)
+    scope = _suggested_scope_from_map(rm)
+    assert scope is not None
+    assert scope["dirs"] == [str(tmp_path / ".claude")]
+
+
+def test_suggested_scope_excludes_deweighted_tool_config_dir(tmp_path: Path) -> None:
+    rm = _claude_densest_rm(tmp_path)
+    deweighted_trees = {
+        str(tmp_path / ".claude"): {
+            "reasons": ["tool-config-name:.claude"],
+            "ignore_glob": ".claude/**",
+        }
+    }
+
+    scope = _suggested_scope_from_map(rm, deweighted_trees=deweighted_trees)
+
+    assert scope is not None
+    assert scope["dirs"] == [str(tmp_path / "src")]
+
+
+def test_suggested_scope_none_when_only_ignored_dir_has_signal(tmp_path: Path) -> None:
+    # Everything scanned lives inside the ignored tree -- once excluded, there is nothing left to
+    # suggest. Better no hint than a wrong one.
+    root = tmp_path
+    rm = {
+        "path": str(root),
+        "files": [
+            str(root / ".claude" / "hooks" / "hookmain.cjs"),
+            str(root / ".claude" / "hooks" / "hookb.cjs"),
+        ],
+        "imports": [
+            {"file": str(root / ".claude" / "hooks" / "hookb.cjs"), "imports": ["hookmain"]}
+        ],
+        "symbols": [
+            {
+                "name": "Hook",
+                "kind": "function",
+                "file": str(root / ".claude" / "hooks" / "hookmain.cjs"),
+            }
+        ],
+    }
+    deweighted_trees = {
+        str(root / ".claude"): {
+            "reasons": ["tool-config-name:.claude"],
+            "ignore_glob": ".claude/**",
+        }
+    }
+
+    assert _suggested_scope_from_map(rm, deweighted_trees=deweighted_trees) is None
+
+
+def test_suggested_scope_normal_repo_unaffected_by_empty_deweighted_trees() -> None:
+    # Non-harness case unchanged: an ordinary repo with nothing deweighted (the real call site's
+    # shape when _detect_vendored_subtrees found nothing) must still get its densest code dir --
+    # same fixture/assertion as test_suggested_scope_picks_clear_centrality_winner above.
+    root = Path("/repo")
+    rm = {
+        "path": str(root),
+        "files": [
+            str(root / "core" / "hub.py"),
+            str(root / "core" / "a.py"),
+            str(root / "core" / "b.py"),
+            str(root / "misc" / "lonely.py"),
+        ],
+        "imports": [
+            {"file": str(root / "core" / "a.py"), "imports": ["hub"]},
+            {"file": str(root / "core" / "b.py"), "imports": ["hub"]},
+        ],
+        "symbols": [
+            {"name": f"Sym{i}", "kind": "function", "file": str(root / "core" / "hub.py")}
+            for i in range(6)
+        ],
+    }
+    scope = _suggested_scope_from_map(rm, deweighted_trees={})
+    assert scope is not None
+    assert scope["dirs"] == [str(root / "core")]
+
+
+def test_build_orient_capsule_suggested_scope_excludes_claude_tool_config_dir(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """#168 end-to-end: `.claude/` is the raw-densest top-level directory on a truncated scan of a
+    harness repo, and `suggested_ignore` already flags it. The two fields must not contradict each
+    other -- suggested_scope must point at real code (`src/`), never at the tree the SAME capsule
+    tells the agent to ignore."""
+    fake_rm = dict(_claude_densest_rm(tmp_path))
+    fake_rm["scan_limit"] = {
+        "max_repo_files": len(fake_rm["files"]),
+        "scanned_files": len(fake_rm["files"]),
+        "possibly_truncated": True,
+        "truncation_cause": "project-files",
+    }
+    monkeypatch.setattr(oc._repo_map, "build_repo_map", lambda *_a, **_k: fake_rm)
+
+    payload = build_orient_capsule(tmp_path, max_snippet_files=0)
+
+    assert payload["suggested_ignore"] == [".claude/**"]
+    assert payload["suggested_scope"] is not None
+    assert payload["suggested_scope"]["dirs"] == [str(tmp_path / "src")]
+
+
+def test_build_orient_capsule_suggested_scope_none_when_only_claude_has_signal(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """#168: if the truncated scan captured ONLY the ignored tool-config tree (no other code
+    directory at all), suggested_scope must degrade to None rather than guess."""
+    files = [
+        str(tmp_path / ".claude" / "hooks" / "hookmain.cjs"),
+        str(tmp_path / ".claude" / "hooks" / "hookb.cjs"),
+    ]
+    fake_rm = {
+        "path": str(tmp_path),
+        "files": files,
+        "imports": [
+            {"file": str(tmp_path / ".claude" / "hooks" / "hookb.cjs"), "imports": ["hookmain"]}
+        ],
+        "symbols": [
+            {
+                "name": "Hook",
+                "kind": "function",
+                "file": str(tmp_path / ".claude" / "hooks" / "hookmain.cjs"),
+            }
+        ],
+        "scan_limit": {
+            "max_repo_files": len(files),
+            "scanned_files": len(files),
+            "possibly_truncated": True,
+            "truncation_cause": "project-files",
+        },
+    }
+    monkeypatch.setattr(oc._repo_map, "build_repo_map", lambda *_a, **_k: fake_rm)
+
+    payload = build_orient_capsule(tmp_path, max_snippet_files=0)
+
+    assert payload["suggested_ignore"] == [".claude/**"]
+    assert payload["suggested_scope"] is None


### PR DESCRIPTION
## Summary

`tg orient`'s `suggested_scope` field (emitted only when the repo scan was truncated) read the
raw, un-de-weighted centrality with no awareness of the auto-detected vendor/skill/tool-config
tree set. On a large harness repo whose scan truncates, `.claude/` can be the raw-densest
top-level directory (many files, internal `require` edges), so orient emitted a
self-contradictory capsule: `suggested_ignore` said "ignore `.claude/**`" while `suggested_scope`
said "scope to `.claude`".

## Confirmed seam (cited file:line, pre-fix)

- `_suggested_scope_from_map(rm)` -- `src/tensor_grep/cli/orient_capsule.py:592` -- took only `rm`,
  no access to the deweighted/ignored tree set.
- Gate: `src/tensor_grep/cli/orient_capsule.py:806` (`build_orient_capsule_from_map`) --
  `suggested_scope = _suggested_scope_from_map(rm) if scan_possibly_truncated else None`.
- `deweighted_trees = _detect_vendored_subtrees(rm) if auto_deweight else {}` is computed at
  `orient_capsule.py:792`, **14 lines before** the `suggested_scope` call -- already in scope,
  no new computation needed to thread it through.
- `suggested_ignore` is derived from that same `deweighted_trees` dict via
  `_suggested_ignore_from_deweighted_trees` (`orient_capsule.py:484`).
- The SUB-2 design intent (docstring on `_central_files_from_map`, `orient_capsule.py:531`) is
  preserved: `_suggested_scope_from_map` must keep reading the **raw**, un-de-weighted
  `_file_centrality_scores` output -- confirmed still true after this fix (pinned by the
  pre-existing `test_file_centrality_scores_are_raw_not_deweighted` in
  `test_orient_deweight_vendored.py`, untouched).
- `_suggested_scope_from_map` is also called from 3 other sites (`agent_capsule.py:2377`,
  `agent_capsule.py:2620`, `repo_map.py:12469`) that do **not** have an equivalent deweight set
  threaded through them -- out of scope per the task, so the new parameter defaults to `None`
  (no filtering), reproducing the exact pre-fix behavior there.

## Fix

- Added `_file_in_any_tree(file_path, tree_roots)` -- a small standalone helper (kept separate
  from `_central_files_from_map`'s existing, already-tested de-weight loop so that function is
  untouched).
- `_suggested_scope_from_map` now takes an optional `deweighted_trees: dict[str, dict[str, Any]] |
  None = None` kwarg. Any file under one of those tree roots is **excluded** from the directory
  rollup entirely (not merely de-weighted/rescaled) -- so a top-level directory that is wholly an
  ignored tree drops out of the candidate set (e.g. `.claude`), while a directory that only
  partially overlaps an ignored subtree (e.g. `core/skills/` inside `core/`) still gets ranked on
  its remaining, non-ignored files. If every candidate directory is ignored, returns `None` --
  "no suggestion" beats a wrong one, consistent with the existing tie-degrades-to-`None`
  convention.
- `build_orient_capsule_from_map` now passes `deweighted_trees=deweighted_trees` (the already-computed
  dict) into the call.

## TDD

- 5 new tests added to `tests/unit/test_orient_suggested_scope.py`:
  - `test_suggested_scope_raw_winner_is_the_tool_config_dir_without_exclusion` -- control/sanity,
    confirms `.claude/` really is the raw-densest dir absent filtering (10 vs `src/`'s 5).
  - `test_suggested_scope_excludes_deweighted_tool_config_dir` -- with `deweighted_trees` passed,
    `suggested_scope` now picks `src/`.
  - `test_suggested_scope_none_when_only_ignored_dir_has_signal` -- everything scanned is inside
    the ignored tree -> `None`.
  - `test_suggested_scope_normal_repo_unaffected_by_empty_deweighted_trees` -- non-harness case
    unchanged.
  - `test_build_orient_capsule_suggested_scope_excludes_claude_tool_config_dir` +
    `test_build_orient_capsule_suggested_scope_none_when_only_claude_has_signal` -- end-to-end
    through `build_orient_capsule`.
- Confirmed RED before the fix (TypeError on the unsupported kwarg / wrong directory suggested),
  GREEN after.
- All existing `test_orient*.py` + `test_*capsule*.py` tests preserved and passing (161 total,
  including the 3 other `_suggested_scope_from_map` call sites in `agent_capsule.py`).

## Gates

- `ruff format --preview` (scoped to the 2 touched files): clean, no reformats.
- `ruff check` (scoped): all checks passed.
- `ruff format --check --preview .` (whole-repo release gate): the 2 touched files are already
  formatted; 4 unrelated pre-existing doc-drift files are out of scope for this PR (known gap,
  see repo memory on the whole-repo ruff-format doc drift).
- `mypy src/tensor_grep` (the exact CI gate command): `Success: no issues found in 80 source
  files`.
- `pytest tests/unit/test_orient*.py tests/unit/test_*capsule*.py`: 161 passed.

## Dogfood

- Direct (non-mocked) `build_orient_capsule()` call against a synthetic truncated harness fixture:
  `suggested_scope` -> `src/`, `suggested_ignore` -> `.claude/**` (agree, not contradictory).
- Real `tg` CLI entry point (`tensor_grep.cli.bootstrap:main_entry`, not `CliRunner`) against
  `agent-studio` (121k files, 44,599 under `.claude/` -- the same repo the original #164 dogfood
  used): scan truncated at the default 2000-file cap, `.claude` detected
  (`["import-island", "tool-config-name:.claude"]`), and `suggested_scope` now points at
  `scripts/` (real product code) instead of `.claude`, agreeing with `suggested_ignore` for the
  first time.

## Scope + hygiene

- Touches only `src/tensor_grep/cli/orient_capsule.py` and
  `tests/unit/test_orient_suggested_scope.py`. No unrelated churn (the whole-repo `ruff format
  --preview .` run initially reformatted 4 unrelated markdown docs; those were reverted before
  committing).
- ASCII-only, LF endings (matches existing file conventions).

**Not a mandatory-Opus-gate surface**: `orient_capsule.py` is read-only capsule generation (no
`apply_policy`/`mcp`/backend/`index_lock`/`session_daemon` involvement), so a normal review
suffices per the repo's change-control skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)