### PR TITLE
fix: tg agent/context-render suggested_scope excludes deweighted/ignored trees (#179)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -2341,9 +2341,19 @@ def build_agent_capsule_from_map(
     # Local import avoids a module-level circular import (orient_capsule imports repo_map, which
     # this module also imports) -- same discipline repo_map.build_context_render's own reuse of
     # this helper uses, and the same reasoning as the _suggested_scope_from_map import below.
-    from tensor_grep.cli.orient_capsule import _apply_ignore_globs
+    from tensor_grep.cli.orient_capsule import _apply_ignore_globs, _detect_vendored_subtrees
 
     rm = _apply_ignore_globs(rm, ignore)
+    # #179: compute the SAME auto-detected vendor/skill/tool-config tree set ONCE, here, against the
+    # final (already `--ignore`-filtered) `rm`, and thread it through every `_suggested_scope_from_map`
+    # call below plus the `suggested_ignore` build near the end of this function. Previously each
+    # `_suggested_scope_from_map(rm)` call below ran with no exclusion set at all (defaulting to
+    # "nothing excluded"), while `suggested_ignore` independently re-ran `_detect_vendored_subtrees(rm)`
+    # for the SAME `rm` -- so `suggested_scope` could point an agent straight at a tree `suggested_
+    # ignore` already flagged in the very same capsule (#179, the tg-agent/context-render sibling of
+    # orient's #168/#606 fix). Sourcing both fields from one shared call makes them provably
+    # consistent, not just coincidentally so, and also drops a redundant second detection pass.
+    deweighted_trees = _detect_vendored_subtrees(rm)
     resolved_path = str(rm["path"])
     requested_semantic_provider = semantic_provider
     effective_semantic_provider = (
@@ -2374,7 +2384,7 @@ def build_agent_capsule_from_map(
     ):
         from tensor_grep.cli.orient_capsule import _suggested_scope_from_map
 
-        suggested_scope_from_map = _suggested_scope_from_map(rm)
+        suggested_scope_from_map = _suggested_scope_from_map(rm, deweighted_trees=deweighted_trees)
         if suggested_scope_from_map is not None:
             payload["suggested_scope"] = suggested_scope_from_map
     # PR-1 (1D): whether the underlying repo scan itself (not the capsule's own snippet/token
@@ -2617,7 +2627,7 @@ def build_agent_capsule_from_map(
     if ambiguity.get("requires_confirmation") and not payload.get("suggested_scope"):
         from tensor_grep.cli.orient_capsule import _suggested_scope_from_map
 
-        tie_suggested_scope = _suggested_scope_from_map(rm)
+        tie_suggested_scope = _suggested_scope_from_map(rm, deweighted_trees=deweighted_trees)
         if tie_suggested_scope is None:
             # `tied_alternatives` (not `ambiguity["tied_alternative_targets"]`) is the definitive
             # source: `requires_confirmation` is only ever True from the `if tied_alternatives:`
@@ -2874,21 +2884,19 @@ def build_agent_capsule_from_map(
     # skill/tool-config subtree roots as ready-to-paste `--ignore` globs. `tg agent` already runs
     # the SAME de-weight during ranking (`_build_context_pack_from_map`'s own `auto_deweight` pass,
     # repo_map.py) but, pre-M2, never surfaced the glob hint itself -- an agent had to hand-derive
-    # `--ignore` globs or fall back to `tg orient` first. Recompute `_detect_vendored_subtrees`
-    # against the SAME (already `--ignore`-filtered) `rm` the ranking pass used above, and reuse
-    # orient's exact glob-builder (`_suggested_ignore_from_deweighted_trees`) -- never a second,
-    # independently hand-rolled hint that could drift from what `tg orient` would say for the same
-    # repo. `_detect_vendored_subtrees` reads only `rm`'s already-in-hand file/import lists plus a
-    # bounded number of manifest-marker existence checks (no new directory walk), so this is cheap
-    # relative to the rest of the capsule build. Additive + conditional, same shape as
-    # `suggested_scope` above: present only when non-empty, so a capsule with nothing deweighted
-    # stays byte-identical to a pre-M2 build.
-    from tensor_grep.cli.orient_capsule import (
-        _detect_vendored_subtrees,
-        _suggested_ignore_from_deweighted_trees,
-    )
+    # `--ignore` globs or fall back to `tg orient` first. Reuse the `deweighted_trees` set already
+    # computed once, near the top of this function (#179), against the SAME (already
+    # `--ignore`-filtered) `rm` the ranking pass used above, and feed it into orient's exact
+    # glob-builder (`_suggested_ignore_from_deweighted_trees`) -- never a second, independently
+    # hand-rolled hint that could drift from what `tg orient` would say for the same repo, and never
+    # a second `_detect_vendored_subtrees` walk over the same `rm` (#179 dedupes what was previously
+    # two independent calls into one shared result, which is also what makes `suggested_scope` above
+    # provably consistent with this hint rather than coincidentally so). Additive + conditional, same
+    # shape as `suggested_scope` above: present only when non-empty, so a capsule with nothing
+    # deweighted stays byte-identical to a pre-M2 build.
+    from tensor_grep.cli.orient_capsule import _suggested_ignore_from_deweighted_trees
 
-    suggested_ignore = _suggested_ignore_from_deweighted_trees(_detect_vendored_subtrees(rm))
+    suggested_ignore = _suggested_ignore_from_deweighted_trees(deweighted_trees)
     if suggested_ignore:
         result["suggested_ignore"] = suggested_ignore
     # DAR: additive CONDITIONAL keys, same pattern as scan_limit/partial above -- zero deps (or

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -12470,11 +12470,21 @@ def build_context_render(
         # import avoids the module-level cycle (orient_capsule imports this module), exactly like the
         # `_apply_ignore_globs` reuse above. Additive + conditional: absent unless the scan was
         # truncated AND a clear winner exists, so a non-truncated render stays byte-identical.
+        #
+        # #179: also thread in the SAME auto-detected vendor/skill/tool-config tree set `tg orient`
+        # (#168/#606) and `tg agent` (agent_capsule.py's own #179 fix) exclude from their own
+        # suggested_scope rollup -- otherwise this wrapper (behind `tg context-render`, and any other
+        # `include_suggested_scope=True` caller) could point an agent at a tree the sibling commands
+        # already know to avoid, on the exact same repo map.
         scan_limit = repo_map.get("scan_limit")
         if isinstance(scan_limit, dict) and scan_limit.get("possibly_truncated"):
-            from tensor_grep.cli.orient_capsule import _suggested_scope_from_map
+            from tensor_grep.cli.orient_capsule import (
+                _detect_vendored_subtrees,
+                _suggested_scope_from_map,
+            )
 
-            suggested_scope = _suggested_scope_from_map(repo_map)
+            deweighted_trees = _detect_vendored_subtrees(repo_map)
+            suggested_scope = _suggested_scope_from_map(repo_map, deweighted_trees=deweighted_trees)
             if suggested_scope is not None:
                 render["suggested_scope"] = suggested_scope
     return render

--- a/tests/unit/test_agent_suggested_scope.py
+++ b/tests/unit/test_agent_suggested_scope.py
@@ -99,3 +99,135 @@ def test_agent_capsule_omits_suggested_scope_when_render_has_none(
 
     result = build_agent_capsule("x", tmp_path)
     assert "suggested_scope" not in result
+
+
+# ---------------------------------------------------------------------------
+# #179: suggested_scope must not point into a tree suggested_ignore already flags -- the tg-agent /
+# tg-context-render sibling of orient's #168/#606 fix (test_orient_suggested_scope.py). #606 only
+# threaded `deweighted_trees` through `build_orient_capsule`'s own `_suggested_scope_from_map` call;
+# `build_context_render` (this module) and `build_agent_capsule_from_map` (agent_capsule.py)
+# independently called `_suggested_scope_from_map(rm)` with no exclusion set at all, so either
+# surface could still point an agent straight at a tree its own `suggested_ignore` already flags.
+# ---------------------------------------------------------------------------
+
+
+def _claude_densest_rm(root: Path) -> dict[str, Any]:
+    """Same fixture shape as test_orient_suggested_scope.py's `_claude_densest_rm` (#168/#606): a
+    hand-built repo map where `.claude/hooks` is the RAW-densest top-level directory (an internal
+    import edge + 6 symbols, clearing the 1.5x margin against `src/` on its own) but is ALSO a
+    STRONG-0 tool-config tree once run through `_detect_vendored_subtrees` (an on-disk
+    `.claude`-named directory, matched on exact basename -- no manifest needed). `src/` is real,
+    less-dense code that must win once `.claude` is excluded from the candidate set."""
+    files = [
+        str(root / ".claude" / "hooks" / "hookmain.cjs"),
+        str(root / ".claude" / "hooks" / "hookb.cjs"),
+        str(root / ".claude" / "hooks" / "hookc.cjs"),
+        str(root / "src" / "hub.py"),
+        str(root / "src" / "leaf_a.py"),
+        str(root / "src" / "leaf_b.py"),
+    ]
+    imports = [
+        {"file": str(root / ".claude" / "hooks" / "hookb.cjs"), "imports": ["hookmain"]},
+        {"file": str(root / ".claude" / "hooks" / "hookc.cjs"), "imports": ["hookmain"]},
+        {"file": str(root / "src" / "leaf_a.py"), "imports": ["hub"]},
+        {"file": str(root / "src" / "leaf_b.py"), "imports": ["hub"]},
+    ]
+    symbols = [
+        {
+            "name": f"Hook{i}",
+            "kind": "function",
+            "file": str(root / ".claude" / "hooks" / "hookmain.cjs"),
+            "line": i + 1,
+        }
+        for i in range(6)
+    ] + [{"name": "Hub", "kind": "function", "file": str(root / "src" / "hub.py"), "line": 1}]
+    return {
+        "path": str(root),
+        "files": files,
+        "imports": imports,
+        "symbols": symbols,
+        "tests": [],
+        "scan_limit": {
+            "max_repo_files": len(files),
+            "scanned_files": len(files),
+            "possibly_truncated": True,
+            "truncation_cause": "project-files",
+        },
+    }
+
+
+def test_context_render_suggested_scope_excludes_claude_tool_config_dir(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """#179: `build_context_render` (the wrapper behind `tg context-render`, and reused by any
+    other `include_suggested_scope=True` caller) must exclude the same auto-detected tool-config
+    tree from its own `_suggested_scope_from_map` call that `tg orient` already excludes (#168/
+    #606) -- otherwise this sibling wrapper could point an agent straight at `.claude/` on a
+    truncated scan of a harness repo."""
+    fake_rm = _claude_densest_rm(tmp_path)
+    monkeypatch.setattr(repo_map, "build_repo_map", lambda *_a, **_k: dict(fake_rm))
+
+    render = repo_map.build_context_render("hook", tmp_path, include_suggested_scope=True)
+
+    assert render["suggested_scope"] is not None
+    assert render["suggested_scope"]["dirs"] == [str(tmp_path / "src")]
+
+
+def test_agent_capsule_suggested_scope_excludes_claude_tool_config_dir_on_truncated_scan(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """#179 end-to-end on `tg agent` (CONFIRMED via dogfood on the shipped v1.76.5 wheel):
+    `.claude/` is the raw-densest top-level directory on a truncated scan of a harness repo, and
+    `suggested_ignore` already flags it (M2, the SAME `_detect_vendored_subtrees` detection). The
+    two fields must not contradict each other -- `suggested_scope` must point at real code (`src/`),
+    never at the tree the SAME capsule tells the agent to ignore. Mirrors orient's #168/#606 fix
+    (test_orient_suggested_scope.py) applied to the agent-capsule TRAP-B call site
+    (agent_capsule.py)."""
+    fake_rm = _claude_densest_rm(tmp_path)
+    monkeypatch.setattr(repo_map, "build_repo_map", lambda *_a, **_k: dict(fake_rm))
+
+    payload = build_agent_capsule("hook", tmp_path, max_tokens=2000)
+
+    assert payload["suggested_ignore"] == [".claude/**"]
+    assert payload["suggested_scope"] is not None
+    assert payload["suggested_scope"]["dirs"] == [str(tmp_path / "src")]
+
+
+def test_agent_capsule_suggested_scope_none_when_only_claude_has_signal(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """#179: if the truncated scan captured ONLY the ignored tool-config tree (no other code
+    directory at all), suggested_scope must degrade to None rather than guess -- mirrors orient's
+    equivalent guard (test_build_orient_capsule_suggested_scope_none_when_only_claude_has_signal)."""
+    files = [
+        str(tmp_path / ".claude" / "hooks" / "hookmain.cjs"),
+        str(tmp_path / ".claude" / "hooks" / "hookb.cjs"),
+    ]
+    fake_rm = {
+        "path": str(tmp_path),
+        "files": files,
+        "imports": [
+            {"file": str(tmp_path / ".claude" / "hooks" / "hookb.cjs"), "imports": ["hookmain"]}
+        ],
+        "symbols": [
+            {
+                "name": "Hook",
+                "kind": "function",
+                "file": str(tmp_path / ".claude" / "hooks" / "hookmain.cjs"),
+                "line": 1,
+            }
+        ],
+        "tests": [],
+        "scan_limit": {
+            "max_repo_files": len(files),
+            "scanned_files": len(files),
+            "possibly_truncated": True,
+            "truncation_cause": "project-files",
+        },
+    }
+    monkeypatch.setattr(repo_map, "build_repo_map", lambda *_a, **_k: dict(fake_rm))
+
+    payload = build_agent_capsule("hook", tmp_path, max_tokens=2000)
+
+    assert payload["suggested_ignore"] == [".claude/**"]
+    assert "suggested_scope" not in payload


### PR DESCRIPTION
## Summary

`tg agent PATH QUERY --json` on a large harness repo could surface a `suggested_scope` pointing at a tool-config directory (e.g. `.claude/`) even though `suggested_ignore` flagged the exact same tree in the same response -- the two fields contradicted each other, misdirecting an agent to scope its work onto tool config instead of code.

**Confirmed via dogfood on the shipped v1.76.5 wheel:**
```
tg agent C:/dev/projects/agent-studio "config loading" --json
```
- Before: `suggested_scope.dirs = [".../agent-studio/.claude"]`, `suggested_ignore = [".claude/**"]` (contradiction)
- After: `suggested_scope.dirs = [".../agent-studio/scripts"]`, `suggested_ignore = [".claude/**"]` (consistent)

## Root cause (verified against the real code, file:line)

#606 (v1.76.5) fixed this for `tg orient` by threading a `deweighted_trees` set into `_suggested_scope_from_map` (`src/tensor_grep/cli/orient_capsule.py:607-651`), but scoped the new kwarg to orient's own call site only. Three other call sites were left calling `_suggested_scope_from_map(rm)` with the implicit `deweighted_trees=None` default ("nothing excluded"):

- `src/tensor_grep/cli/agent_capsule.py:2377` (`build_agent_capsule_from_map`'s scan-truncation gate, the "TRAP B" block)
- `src/tensor_grep/cli/agent_capsule.py:2620` (the same function's confirmation-tie fallback)
- `src/tensor_grep/cli/repo_map.py:12477` (`build_context_render`'s `include_suggested_scope=True` wrapper, shared by `tg context-render` and any other caller)

Meanwhile `suggested_ignore` (`agent_capsule.py`'s M2 block, ~line 2891) independently called `_detect_vendored_subtrees(rm)` on the *same* `rm` -- so the two hints only agreed by coincidence, not by construction.

## Fix

- `agent_capsule.py`: compute `deweighted_trees = _detect_vendored_subtrees(rm)` **once**, right after the `--ignore` filter is applied (`rm` is never reassigned again in this function), and thread that single value into both `_suggested_scope_from_map` calls *and* the `suggested_ignore` build -- replacing what was a second, independent `_detect_vendored_subtrees(rm)` call. This drops a redundant detection pass and makes `suggested_scope`/`suggested_ignore` provably consistent (same source, not just same output).
- `repo_map.py`: `build_context_render` now computes `_detect_vendored_subtrees(repo_map)` inside its existing `possibly_truncated` gate and threads it into `_suggested_scope_from_map`, mirroring orient's fix for this sibling wrapper.
- `orient_capsule.py` is untouched -- `_suggested_scope_from_map` already supports `deweighted_trees` from #606; this PR only threads it through the remaining callers.
- When every candidate directory is ignored, `suggested_scope` still degrades to `None` rather than guessing (preserves the SUB-2 raw-centrality/never-guess intent).
- Considered but left out of scope: `_suggested_scope_from_tied_targets` (the tie fallback's *secondary* heuristic, used only when the whole-repo rollup itself returns `None`) is anchored to the tied candidates' own real files, not a repo-wide guess -- a different mechanism than the one in the confirmed repro, so left untouched.

## TDD

RED: added `test_context_render_suggested_scope_excludes_claude_tool_config_dir`, `test_agent_capsule_suggested_scope_excludes_claude_tool_config_dir_on_truncated_scan`, and `test_agent_capsule_suggested_scope_none_when_only_claude_has_signal` to `tests/unit/test_agent_suggested_scope.py`, reusing the `.claude`-raw-densest-vs-`src` fixture shape from `test_orient_suggested_scope.py`'s #606 tests. Verified RED against the pre-fix code (`.claude` won in all three), then GREEN after the fix.

## Gates

- `ruff check` (whole repo): clean
- `ruff format --preview` (touched files) + `ruff format --check --preview .` (whole-repo release gate): touched files clean; 4 unrelated pre-existing `.md` files flagged (documented pre-existing whole-repo drift, not in this diff)
- `mypy` (touched files + full `src/tensor_grep`): clean
- `pytest tests/unit/test_agent*.py tests/unit/test_*capsule*.py tests/unit/test_orient*.py -q`: **215 passed**
- Broader keyword sweep (`repo_map or context_render or agent or capsule or orient or docs_coverage or suggested`): **679 passed**
- Dogfood: before/after confirmed via a scoped `git stash` round-trip against the real shipped-shape bug on `agent-studio` (see Summary)

## Test plan

- [x] RED tests reproduce the contradiction pre-fix
- [x] GREEN after the fix, all new + existing suggested_scope/suggested_ignore tests pass
- [x] Dogfooded against the real repro repo (`agent-studio`)
- [x] ruff/mypy clean on touched files

Not a mandatory-Opus-gate surface (agent_capsule/repo_map capsule generation, same as the shipped #606 orient fix -- not apply_policy/mcp/backend/index_lock/session_daemon) -- normal review.