### PR TITLE
fix: gate-NIT hardening -- daemon-metadata coercion + Rust checkpoint cleanup (#178/#125)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -5120,6 +5120,53 @@ mod tests {
     }
 
     #[test]
+    fn test_create_checkpoint_removes_orphaned_dir_on_index_parse_failure() {
+        // NIT (v1.76 #602 gate, "NIT-3"): checkpoint_store.py::create_checkpoint (the Python
+        // side) already wraps its copy-loop + metadata-write in `except BaseException: rmtree
+        // (snapshot_dir.parent); raise` (audit #125a, shipped in #602) so a failure never
+        // orphans the random-id snapshot dir. The Rust `create_checkpoint` above had NO
+        // equivalent: a failure in the copy loop, the metadata write, OR the index write left
+        // the just-created checkpoint_id directory (snapshot/ + metadata.json) behind forever.
+        //
+        // Force a deterministic, cross-platform failure at the LAST fallible step (the
+        // pre-existing index.json fails to parse) so the copy loop and the metadata.json write
+        // both succeed first -- proving the cleanup covers the whole write sequence, not just
+        // the copy loop.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("fixture.py");
+        std::fs::write(&file_path, "def add(x, y): return x + y\n").unwrap();
+
+        let path_str = file_path.to_str().unwrap();
+        let scope = detect_checkpoint_scope(path_str);
+        let storage_dir = checkpoint_storage_dir(&scope.root);
+        std::fs::create_dir_all(&storage_dir).unwrap();
+        let index_path = storage_dir.join("index.json");
+        std::fs::write(&index_path, b"not valid json").unwrap();
+
+        let result = create_checkpoint(path_str);
+        assert!(
+            result.is_err(),
+            "a corrupt pre-existing index.json must fail create_checkpoint"
+        );
+
+        let remaining: Vec<std::ffi::OsString> = std::fs::read_dir(&storage_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect();
+        assert_eq!(
+            remaining,
+            vec![std::ffi::OsString::from("index.json")],
+            "a failed checkpoint must not leave an orphaned per-checkpoint directory behind: {remaining:?}"
+        );
+        assert_eq!(
+            std::fs::read(&index_path).unwrap(),
+            b"not valid json",
+            "the pre-existing (corrupt) index.json itself must be left untouched"
+        );
+    }
+
+    #[test]
     fn test_restore_validation_rollback_snapshots_refuses_symlink_at_file_path() {
         // #115 Gap 3: between "apply the edit" and a failed-validation rollback, an edited
         // file could be swapped for a symlink pointing outside the project (e.g. via a
@@ -8392,86 +8439,107 @@ fn create_checkpoint(path: &str) -> anyhow::Result<CheckpointCreateSummary> {
         )
     })?;
 
-    for (rel_path, exists) in &entries {
-        if !exists {
-            continue;
-        }
-        let source = root.join(rel_path);
-        let destination = snapshot_dir.join(rel_path);
-        if let Some(parent) = destination.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
+    // NIT (v1.76 #602 gate, "NIT-3"): mirror checkpoint_store.py::create_checkpoint's
+    // `except BaseException: shutil.rmtree(snapshot_dir.parent, ignore_errors=True); raise`
+    // (audit #125a, shipped in #602) on the Rust side. Everything from here on is fallible (a
+    // file copy, the metadata.json write, the index.json read/parse/write) and, before this
+    // fix, a failure at ANY of those steps propagated the error via `?` while leaving the
+    // just-created random-id checkpoint directory -- `checkpoint_dir`, holding both snapshot/
+    // and metadata.json -- behind on disk forever. Run the rest of the write sequence in a
+    // closure (stable Rust has no `try` blocks) and remove that whole directory before
+    // propagating any error; the success (`Ok`) path below is byte-identical to before.
+    let checkpoint_dir = checkpoint_storage_dir(&root).join(&checkpoint_id);
+
+    let write_checkpoint_body = || -> anyhow::Result<CheckpointCreateSummary> {
+        for (rel_path, exists) in &entries {
+            if !exists {
+                continue;
+            }
+            let source = root.join(rel_path);
+            let destination = snapshot_dir.join(rel_path);
+            if let Some(parent) = destination.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!(
+                        "failed to create checkpoint parent dir {}",
+                        parent.display()
+                    )
+                })?;
+            }
+            std::fs::copy(&source, &destination).with_context(|| {
                 format!(
-                    "failed to create checkpoint parent dir {}",
-                    parent.display()
+                    "failed to copy {} into checkpoint snapshot {}",
+                    source.display(),
+                    destination.display()
                 )
             })?;
         }
-        std::fs::copy(&source, &destination).with_context(|| {
-            format!(
-                "failed to copy {} into checkpoint snapshot {}",
-                source.display(),
-                destination.display()
-            )
-        })?;
-    }
 
-    let summary = CheckpointCreateSummary {
-        checkpoint_id: checkpoint_id.clone(),
-        mode: mode.clone(),
-        root: checkpoint_display_path(&root),
-        scope: scope.scope_kind().to_string(),
-        original_path: checkpoint_display_path(&scope.original_path),
-        created_at: created_at.clone(),
-        file_count: entries.len(),
-    };
-    let metadata = CheckpointMetadata {
-        version: JSON_OUTPUT_VERSION,
-        checkpoint_id: checkpoint_id.clone(),
-        mode: mode.clone(),
-        root: summary.root.clone(),
-        scope: summary.scope.clone(),
-        original_path: summary.original_path.clone(),
-        created_at: created_at.clone(),
-        file_count: entries.len(),
-        entries,
-    };
-    let metadata_path = checkpoint_metadata_path(&root, &checkpoint_id);
-    if let Some(parent) = metadata_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    write_bytes_refuse_symlink(&metadata_path, &serde_json::to_vec_pretty(&metadata)?)
-        .with_context(|| format!("failed to write {}", metadata_path.display()))?;
-
-    let index_path = checkpoint_index_path(&root);
-    let mut records: Vec<CheckpointIndexRecord> = if index_path.exists() {
-        serde_json::from_slice(
-            &std::fs::read(&index_path)
-                .with_context(|| format!("failed to read {}", index_path.display()))?,
-        )
-        .with_context(|| format!("failed to parse {}", index_path.display()))?
-    } else {
-        Vec::new()
-    };
-    records.insert(
-        0,
-        CheckpointIndexRecord {
+        let summary = CheckpointCreateSummary {
+            checkpoint_id: checkpoint_id.clone(),
+            mode: mode.clone(),
+            root: checkpoint_display_path(&root),
+            scope: scope.scope_kind().to_string(),
+            original_path: checkpoint_display_path(&scope.original_path),
+            created_at: created_at.clone(),
+            file_count: entries.len(),
+        };
+        let metadata = CheckpointMetadata {
             version: JSON_OUTPUT_VERSION,
             checkpoint_id: checkpoint_id.clone(),
-            mode,
+            mode: mode.clone(),
             root: summary.root.clone(),
-            created_at,
-            file_count: summary.file_count,
-        },
-    );
-    if let Some(parent) = index_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    write_bytes_refuse_symlink(&index_path, &serde_json::to_vec_pretty(&records)?)
-        .with_context(|| format!("failed to write {}", index_path.display()))?;
+            scope: summary.scope.clone(),
+            original_path: summary.original_path.clone(),
+            created_at: created_at.clone(),
+            file_count: entries.len(),
+            entries,
+        };
+        let metadata_path = checkpoint_metadata_path(&root, &checkpoint_id);
+        if let Some(parent) = metadata_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        write_bytes_refuse_symlink(&metadata_path, &serde_json::to_vec_pretty(&metadata)?)
+            .with_context(|| format!("failed to write {}", metadata_path.display()))?;
 
-    Ok(summary)
+        let index_path = checkpoint_index_path(&root);
+        let mut records: Vec<CheckpointIndexRecord> = if index_path.exists() {
+            serde_json::from_slice(
+                &std::fs::read(&index_path)
+                    .with_context(|| format!("failed to read {}", index_path.display()))?,
+            )
+            .with_context(|| format!("failed to parse {}", index_path.display()))?
+        } else {
+            Vec::new()
+        };
+        records.insert(
+            0,
+            CheckpointIndexRecord {
+                version: JSON_OUTPUT_VERSION,
+                checkpoint_id: checkpoint_id.clone(),
+                mode,
+                root: summary.root.clone(),
+                created_at,
+                file_count: summary.file_count,
+            },
+        );
+        if let Some(parent) = index_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        write_bytes_refuse_symlink(&index_path, &serde_json::to_vec_pretty(&records)?)
+            .with_context(|| format!("failed to write {}", index_path.display()))?;
+
+        Ok(summary)
+    };
+
+    let result = write_checkpoint_body();
+    if result.is_err() {
+        // Best-effort: already on the error path, so a cleanup failure must never mask (or
+        // panic over) the original error being returned.
+        let _ = std::fs::remove_dir_all(&checkpoint_dir);
+    }
+    result
 }
 
 fn load_batch_rewrite_config(config_path: &Path) -> anyhow::Result<BatchRewriteConfig> {

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -405,9 +405,20 @@ def _remove_daemon_metadata(
         current = _read_daemon_metadata(root)
         if current is None:
             return
-        if expected_pid is not None and current.get("pid") != expected_pid:
+        # NIT (v1.76 #603 gate, "NIT-D3"): compare through `_daemon_identity` on BOTH sides
+        # instead of `current.get("pid") != expected_pid` directly. Every writer today always
+        # stores pid/port as JSON ints, so the direct compare happens to work -- but trusting
+        # that on-disk shape is not type-safe: a future writer that stored either field as a
+        # string (or any other non-int JSON value) would make the direct compare silently NEVER
+        # match, so this guard would never delete that metadata -- a permanent orphan leak
+        # instead of a loud failure. `_daemon_identity` already coerces via `int(...)` (and
+        # resolves to `None` on anything unparseable), so routing the on-disk read through it
+        # here makes the compare type-safe the same way the callers computing `expected_pid`/
+        # `expected_port` already do (see `_daemon_identity`'s callers below).
+        current_pid, current_port = _daemon_identity(current)
+        if expected_pid is not None and current_pid != expected_pid:
             return
-        if expected_port is not None and current.get("port") != expected_port:
+        if expected_port is not None and current_port != expected_port:
             return
     try:
         metadata_path.unlink()

--- a/tests/unit/test_session_daemon_metadata_ownership.py
+++ b/tests/unit/test_session_daemon_metadata_ownership.py
@@ -123,6 +123,29 @@ def test_remove_daemon_metadata_guarded_preserves_replacement_on_port_mismatch(
     assert survivor["port"] == 3333
 
 
+def test_remove_daemon_metadata_guarded_matches_string_pid_and_port_on_disk(
+    tmp_path: Path,
+) -> None:
+    """NIT (v1.76 #603 gate, "NIT-D3"): the guarded compare must coerce the ON-DISK pid/port
+    through ``_daemon_identity`` (the same helper used for the caller's expected identity)
+    instead of comparing ``current.get("pid") != expected_pid`` directly. Today every writer
+    always stores ``pid``/``port`` as JSON ints, so the direct compare happens to work -- but a
+    future writer that stores them as strings (or any other non-int JSON type) would make the
+    direct compare silently NEVER match, so the metadata is never removed and orphans forever.
+    Simulate that future writer here: write pid/port as strings and confirm the guarded removal
+    still recognizes the file as the caller's own instance and deletes it.
+    """
+    root = tmp_path.resolve()
+    payload = _payload(pid=111, port=2222)
+    payload["pid"] = "111"
+    payload["port"] = "2222"
+    session_daemon._write_daemon_metadata(root, payload)
+
+    session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)
+
+    assert session_daemon._read_daemon_metadata(root) is None
+
+
 def test_remove_daemon_metadata_guarded_noop_when_file_missing(tmp_path: Path) -> None:
     root = tmp_path.resolve()
     session_daemon._remove_daemon_metadata(root, expected_pid=111, expected_port=2222)


### PR DESCRIPTION
## Summary

Small hardening bundle of 3 gate-NITs logged against the v1.76 Opus gates (task #178, referencing
#602/#603). Each was independently re-verified against current `origin/main` before implementing —
one was already fully resolved and is SKIPPED with citations below rather than forced.

## NIT 1 (IMPLEMENTED) -- daemon-metadata coercion (#603 gate, "NIT-D3")

**Seam**: `src/tensor_grep/cli/session_daemon.py:408-411` (pre-fix) -- `_remove_daemon_metadata`
compared the on-disk metadata's `pid`/`port` directly (`current.get("pid") != expected_pid`),
trusting the on-disk field is already an `int`. True today (every writer always stores ints), but a
future non-int write (e.g. a string) would make the guard silently never-match, so the metadata is
never deleted -- a permanent orphan leak instead of a loud failure.

**Fix**: route the on-disk read through the existing `_daemon_identity()` helper
(`session_daemon.py:429`), which already coerces via `int(...)` and resolves to `None` on anything
unparseable -- the same coercion the caller-side `expected_pid`/`expected_port` values already get
everywhere else in this module. Compare is now type-safe on both sides.

**RED -> GREEN**: `tests/unit/test_session_daemon_metadata_ownership.py::test_remove_daemon_metadata_guarded_matches_string_pid_and_port_on_disk`
-- writes `daemon.json` with `pid`/`port` stored as JSON strings (`"111"`/`"2222"`), then asserts
`_remove_daemon_metadata(root, expected_pid=111, expected_port=2222)` still recognizes and deletes
it. Confirmed RED pre-fix (`"111" != 111` -> guard never matched -> metadata survived), GREEN
post-fix.

## NIT 2 (IMPLEMENTED) -- Rust checkpoint on-failure cleanup (#602 gate, "NIT-3")

**Seam**: `rust_core/src/main.rs` `create_checkpoint` (pre-fix, ~line 8422-8521) had NO on-failure
cleanup -- a failed file copy, metadata.json write, or index.json read/parse/write propagated the
error via `?` while leaving the just-created random-id checkpoint directory (`snapshot/` +
`metadata.json`) orphaned on disk forever. The Python sibling
(`checkpoint_store.py::create_checkpoint`, audit #125a, shipped in #602) already wraps its
copy-loop + metadata-write in `except BaseException: shutil.rmtree(snapshot_dir.parent,
ignore_errors=True); raise` -- the Rust side never got the equivalent.

**Fix**: `rust_core/src/main.rs:8451` computes `checkpoint_dir` up front
(`checkpoint_storage_dir(&root).join(&checkpoint_id)`); the rest of the write sequence (copy loop
+ metadata write + index read/parse/write) now runs inside a `write_checkpoint_body` closure
(`main.rs:8453`, stable Rust has no `try` blocks); on any `Err`, `main.rs:~8536-8541` removes the
whole `checkpoint_dir` before propagating the original error. The success (`Ok`) path is
byte-identical to before.

**RED -> GREEN**: `rust_core/src/main.rs::tests::test_create_checkpoint_removes_orphaned_dir_on_index_parse_failure`
-- plants a corrupt (invalid-JSON) pre-existing `index.json` so the copy loop and metadata.json
write both succeed first, then the index-parse step fails deterministically (no symlink/permission
trickery needed, cross-platform). Confirmed RED pre-fix (orphaned `ckpt-<id>/` directory left
behind alongside `index.json`), GREEN post-fix (only `index.json` remains, untouched).

## NIT 3 (SKIPPED) -- #125b, checkpoint create-vs-undo symlink consistency

Verified against current code and against the #602 commit (`f22ffa5`) message itself: **already
fully consistent, no fix needed.**

- `create_checkpoint`'s two Rust-side writes -- `metadata.json` (`main.rs`, via
  `write_bytes_refuse_symlink`) and the shared `index.json` (`main.rs`, same helper) -- both route
  through `write_bytes_refuse_symlink` (`main.rs:9199`).
- The only Rust-side "restore/rollback" analog, `restore_validation_rollback_snapshots`
  (`main.rs:9152`), ALSO routes its per-file restore write through the exact same
  `write_bytes_refuse_symlink` helper (`main.rs:9161` in the pre-existing code).
- `write_bytes_refuse_symlink`'s own doc comment (`main.rs:9195-9198`) confirms this was a
  deliberate, already-completed pairing: *"audit #115: also guards `create_checkpoint`'s
  metadata.json + the shared/predictable index.json write, and
  `restore_validation_rollback_snapshots`'s per-file restore write -- the same TOCTOU class."*
- Commit `f22ffa5` ("guard checkpoint/rollback writes vs symlink swap + interrupt-safe cleanup
  (#602)") states explicitly: *"Routes the 3 unguarded Rust checkpoint/rollback writes
  (metadata.json, index.json, restore_validation_rollback_snapshots) through
  write_bytes_refuse_symlink."* All 3 -- confirmed already done.
- Existing passing tests already lock this in: `test_create_checkpoint_refuses_symlink_at_index_path`
  and `test_restore_validation_rollback_snapshots_refuses_symlink_at_file_path` (both in `main.rs`'s
  `mod tests`).
- On the Python side (the actual user-facing `tg checkpoint create`/`tg checkpoint undo` -- note
  Rust's `create_checkpoint` above is a *separate*, internal function used only by `tg rewrite
  --checkpoint`/batch-rewrite's pre-apply safety snapshot; `tg checkpoint` itself is 100% Python,
  `rust_core/src/main.rs` `Commands::Checkpoint` passes straight through to Python):
  `checkpoint_store.py::create_checkpoint` (line ~855) and `::undo_checkpoint` (lines ~1294, ~1350)
  both consistently use `shutil.copy2(..., follow_symlinks=False)`.

No code change made for NIT 3 -- forcing one where the seam is already consistent would be
unrelated churn.

**Observation (not fixed, out of scope, FYI only)**: while verifying NIT 3, noticed Rust's
`create_checkpoint` per-file copy loop (copying tracked working-tree files INTO the snapshot) uses
plain `std::fs::copy(&source, &destination)`, which dereferences a symlinked tracked file (copies
the target's bytes as a regular file) rather than preserving it as a symlink -- unlike Python's
create path, which explicitly uses `follow_symlinks=False` for exactly this reason
(`checkpoint_store.py:853-855`, "audit HIGH -- symlink disclosure"). This is a different class of
issue than the write-through-symlink TOCTOU class #125b asks about (which IS fully consistent) --
it's a data-fidelity gap in the Rust pre-rewrite-checkpoint path, not a security regression in this
PR's scope, and fixing it needs non-trivial unix/windows symlink-preserving-copy logic. Flagging for
a future task rather than forcing it into this "small NIT" bundle.

## Gates

- `uv run --no-sync ruff format --preview .` (touched files): clean, 2 files unchanged.
- `uv run --no-sync ruff check .` (touched files): all checks passed.
- `uv run --no-sync mypy src/tensor_grep` (full package, matches CI's exact invocation): Success,
  no issues found in 80 source files.
- Whole-repo `ruff format --check --preview .` (the actual release gate): 4 files WOULD be
  reformatted -- all 4 are pre-existing, unrelated `.md` docs (`docs/architecture.md`,
  `docs/planning/PROJECT_PLAN.md`, `docs/plans/backlog-100/cluster-124-evidence-signing.md`,
  `docs/plans/design-tensor-grep-2026-04-29_01-45-34.md`), none touched by this PR -- matches the
  already-documented whole-repo ruff-format/code-fence gap. Not fixed (out of scope).
- `cargo fmt --check`: clean.
- `cargo clippy -- -D warnings` (the exact command CI runs, `.github/workflows/ci.yml:314`): clean.
- `cargo clippy --all-targets -- -D warnings` (broader, requested scope): 1 PRE-EXISTING failure in
  `rust_core/src/rg_passthrough.rs` (a `#[cfg(test)]`-only helper, untouched by this PR, invisible
  to CI's actual narrower clippy scope) -- confirmed unrelated, not fixed.
- `cargo test` (whole crate: lib + both bin targets `tg`/`tg-search-fast` + 6 integration test
  files + doctests): 106 (lib) + 98 (`tg` bin, includes the new NIT-2 test) + 81 (`tg-search-fast`
  bin) + 45 (integration files) + 0 (doctests) = 330 tests, all passing, 0 failures.
- Targeted Python suite (session-daemon + checkpoint dependents, 21 files incl. both new tests):
  1337 passed, 1 skipped, 4 pre-existing unrelated failures (see below), 0 new failures caused by
  this PR.
- The 4 pre-existing failures are a single cluster, all in `tests/unit/test_mcp_server.py`'s
  "embedded rewrite fallback without native binary" tests (`resolve_native_tg_binary` mocked to
  `None`, so these exercise the pure-Python embedded rewrite path -- neither the Rust
  `create_checkpoint` this PR touches, nor `session_daemon.py`, is reachable from them):
  `test_tg_rewrite_plan_uses_embedded_fallback_without_native_binary` (`KeyError: 'total_edits'`),
  `test_execute_rewrite_apply_json_embedded_checkpoint_when_native_binary_missing`,
  `test_execute_rewrite_plan_json_should_restore_windows_variadic_metavar_escaping`, and
  `test_execute_rewrite_apply_json_should_use_embedded_rust_when_native_binary_missing` (all 3
  `assert exit_code == 0` -> `1 == 0`). All 4 independently reproduced on a clean, unmodified
  `origin/main` checkout (disposable worktree, HEAD `e384806`, same venv) -- confirmed pre-existing
  and unrelated to this PR's 3 files. Worth a CEO/steward FYI as its own fix, out of scope here.

## Scope

Touched only: `src/tensor_grep/cli/session_daemon.py`, `rust_core/src/main.rs`, and their tests
(`tests/unit/test_session_daemon_metadata_ownership.py`). `checkpoint_store.py` was read/verified
but required no change (NIT 3 skip). No unrelated churn.

**NOTE**: touches `session_daemon.py` + the Rust checkpoint path -> MANDATORY adversarial Opus gate
pending before merge, per the Backend Fail-Closed / checkpoint hardening history on this repo. Do
not merge on green CI alone.
