### PR TITLE
fix: checkpoint snapshot must not follow symlinks (out-of-root disclosure) + cleanup completeness (#178)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -8511,14 +8511,23 @@ fn collect_checkpoint_entries(scope: &CheckpointScope) -> anyhow::Result<BTreeMa
 /// follow_symlinks=False)` (checkpoint_store.py:853-855, audit HIGH -- symlink disclosure).
 /// `std::fs::copy` FOLLOWS symlinks, so a plain copy here would read a source symlink's
 /// (possibly out-of-root) TARGET content and bake it into the snapshot -- an out-of-root
-/// disclosure (audit #178). This matters doubly because this Rust binary implements no
-/// checkpoint RESTORE of its own -- `tg checkpoint` (list/undo) is a full Python passthrough,
-/// see `Commands::Checkpoint` below -- so the only restore path is
-/// `checkpoint_store.py::undo_checkpoint`, which ALSO uses `follow_symlinks=False` and
-/// therefore expects a stored snapshot entry to still BE a symlink; materializing the target's
-/// bytes here would silently turn a restored symlink into a plain file on undo, on top of the
-/// disclosure. Recreate the symlink AS a symlink instead of following it; fall back to a
-/// normal file copy for every non-symlink entry.
+/// disclosure (audit #178). Recreate the symlink AS a symlink instead of following it; fall
+/// back to a normal file copy for every non-symlink entry.
+///
+/// Round-trip contract (verified against `checkpoint_store.py::undo_checkpoint`, the only
+/// restore path -- `tg checkpoint` list/undo is a full Python passthrough, see
+/// `Commands::Checkpoint` below). Storing the link AS a link (not its target's bytes) is what
+/// keeps an out-of-root symlink FAIL-CLOSED rather than a disclosure on undo -- but it does NOT
+/// make every symlink restorable, and this comment must not claim a full round-trip. undo's
+/// read-only pre-flight `_resolve_within_root` (checkpoint_store.py:124-139, called at
+/// :1232-1235) RESOLVES each stored snapshot symlink and, before touching any working-tree
+/// file, REFUSES it (ValueError) when the resolved target escapes the snapshot root; the later
+/// missing-source probe (:1246-1257) raises CheckpointCorruptError for a dangling target. So an
+/// out-of-root OR dangling symlink checkpoint is refused fail-closed on undo -- no disclosure,
+/// no data loss, working tree left intact, but NOT restorable. Only an in-root symlink whose
+/// resolved target exists inside the snapshot is actually restored. That fail-closed refusal is
+/// the correct, safe behavior; the alternative (following the link here) would materialize
+/// out-of-root content into the snapshot and then into the tree on undo.
 fn copy_checkpoint_entry(source: &Path, destination: &Path) -> std::io::Result<()> {
     if std::fs::symlink_metadata(source)?.file_type().is_symlink() {
         let link_target = std::fs::read_link(source)?;
@@ -8551,11 +8560,32 @@ fn create_checkpoint_symlink(target: &Path, link: &Path) -> std::io::Result<()> 
             .and_then(|candidate| std::fs::metadata(candidate).ok())
             .map(|metadata| metadata.is_dir())
             .unwrap_or(false);
-        if resolved_is_dir {
+        let result = if resolved_is_dir {
             std::os::windows::fs::symlink_dir(target, link)
         } else {
             std::os::windows::fs::symlink_file(target, link)
-        }
+        };
+        // audit #178 F2a: creating a symlink on Windows needs SeCreateSymbolicLinkPrivilege
+        // (admin, or Developer Mode). Without it the OS returns ERROR_PRIVILEGE_NOT_HELD (1314),
+        // which the caller's `.with_context("failed to copy ... into checkpoint snapshot ...")`
+        // would otherwise surface as a bare, misleading "copy failed". Re-message that one errno
+        // so the real cause (a privilege gap, not a copy fault) is visible; leave every other
+        // error untouched.
+        result.map_err(|err| {
+            const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
+            if err.raw_os_error() == Some(ERROR_PRIVILEGE_NOT_HELD) {
+                std::io::Error::new(
+                    err.kind(),
+                    format!(
+                        "creating checkpoint symlink {} requires administrator privileges or \
+                         Windows Developer Mode (ERROR_PRIVILEGE_NOT_HELD)",
+                        link.display()
+                    ),
+                )
+            } else {
+                err
+            }
+        })
     }
     #[cfg(not(any(unix, windows)))]
     {

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -5124,9 +5124,12 @@ mod tests {
         // NIT (v1.76 #602 gate, "NIT-3"): checkpoint_store.py::create_checkpoint (the Python
         // side) already wraps its copy-loop + metadata-write in `except BaseException: rmtree
         // (snapshot_dir.parent); raise` (audit #125a, shipped in #602) so a failure never
-        // orphans the random-id snapshot dir. The Rust `create_checkpoint` above had NO
-        // equivalent: a failure in the copy loop, the metadata write, OR the index write left
-        // the just-created checkpoint_id directory (snapshot/ + metadata.json) behind forever.
+        // orphans the random-id snapshot dir -- audit #178 later widened that same Python guard
+        // to also cover the index write (see checkpoint_store.py::create_checkpoint), closing
+        // the one gap that earlier widening had not yet reached. The Rust `create_checkpoint`
+        // above had NO equivalent at all: a failure in the copy loop, the metadata write, OR
+        // the index write left the just-created checkpoint_id directory (snapshot/ +
+        // metadata.json) behind forever.
         //
         // Force a deterministic, cross-platform failure at the LAST fallible step (the
         // pre-existing index.json fails to parse) so the copy loop and the metadata.json write
@@ -5163,6 +5166,90 @@ mod tests {
             std::fs::read(&index_path).unwrap(),
             b"not valid json",
             "the pre-existing (corrupt) index.json itself must be left untouched"
+        );
+    }
+
+    #[test]
+    fn test_create_checkpoint_does_not_disclose_symlink_target() {
+        // Item 1 (audit #178, surfaced by the #610 gate): `std::fs::copy` FOLLOWS symlinks, so
+        // a source-tree symlink pointing OUTSIDE the checkpoint root previously had its
+        // TARGET's content copied into the snapshot -- an out-of-root disclosure. Mirrors the
+        // Python-side regression test `test_create_checkpoint_does_not_disclose_symlink_target`
+        // in tests/unit/test_checkpoint_containment.py (checkpoint_store.py:853-855).
+        let repo_parent = tempfile::tempdir().unwrap();
+        let repo_path = repo_parent.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        std::fs::write(repo_path.join("real.py"), b"in-repo content\n").unwrap();
+
+        let outside_dir = tempfile::tempdir().unwrap();
+        let secret = outside_dir.path().join("secret.txt");
+        std::fs::write(&secret, b"SECRET-OUT-OF-ROOT\n").unwrap();
+
+        let link_path = repo_path.join("link.txt");
+        if let Err(err) = try_symlink_file(&secret, &link_path) {
+            eprintln!(
+                "skipping test_create_checkpoint_does_not_disclose_symlink_target: cannot create a symlink in this environment: {err}"
+            );
+            return;
+        }
+
+        let path_str = repo_path.to_str().unwrap();
+        let result = create_checkpoint(path_str).expect("checkpoint creation must still succeed");
+
+        let scope = detect_checkpoint_scope(path_str);
+        let snapshot_dir = checkpoint_snapshot_dir(&scope.root, &result.checkpoint_id);
+        let snapshotted_link = snapshot_dir.join("link.txt");
+
+        // The snapshot entry must itself be a symlink -- never a regular file holding the
+        // target's bytes -- proving the target's content was never read/copied.
+        let snapshotted_type = std::fs::symlink_metadata(&snapshotted_link)
+            .expect("snapshotted symlink entry must exist")
+            .file_type();
+        assert!(
+            snapshotted_type.is_symlink(),
+            "checkpoint snapshot must store the symlink itself, not its resolved target content"
+        );
+
+        // Belt-and-suspenders: no regular file anywhere under the snapshot may contain the
+        // out-of-root secret's content.
+        for entry in walkdir::WalkDir::new(&snapshot_dir) {
+            let entry = entry.unwrap();
+            if entry.file_type().is_file() {
+                let text = std::fs::read_to_string(entry.path()).unwrap_or_default();
+                assert!(
+                    !text.contains("SECRET-OUT-OF-ROOT"),
+                    "checkpoint snapshot must not disclose the out-of-root secret's content: {}",
+                    entry.path().display()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_create_checkpoint_still_copies_regular_files_byte_identical() {
+        // Regression guard for the copy_checkpoint_entry symlink fix above: an ordinary
+        // (non-symlink) source tree must still be captured with byte-identical content, and a
+        // normal (no-symlink) checkpoint create must be entirely unaffected by the new
+        // is_symlink() branch.
+        let dir = tempfile::tempdir().unwrap();
+        let repo_path = dir.path().join("repo");
+        std::fs::create_dir_all(repo_path.join("pkg")).unwrap();
+        std::fs::write(repo_path.join("a.py"), b"alpha\n").unwrap();
+        std::fs::write(repo_path.join("pkg").join("b.py"), b"beta\n").unwrap();
+
+        let path_str = repo_path.to_str().unwrap();
+        let result = create_checkpoint(path_str).expect("checkpoint creation must succeed");
+        assert_eq!(result.file_count, 2);
+
+        let scope = detect_checkpoint_scope(path_str);
+        let snapshot_dir = checkpoint_snapshot_dir(&scope.root, &result.checkpoint_id);
+        assert_eq!(
+            std::fs::read(snapshot_dir.join("a.py")).unwrap(),
+            b"alpha\n"
+        );
+        assert_eq!(
+            std::fs::read(snapshot_dir.join("pkg").join("b.py")).unwrap(),
+            b"beta\n"
         );
     }
 
@@ -8419,6 +8506,67 @@ fn collect_checkpoint_entries(scope: &CheckpointScope) -> anyhow::Result<BTreeMa
     }
 }
 
+/// Copies one checkpoint source entry into the snapshot, mirroring
+/// `checkpoint_store.py::create_checkpoint`'s `shutil.copy2(source, destination,
+/// follow_symlinks=False)` (checkpoint_store.py:853-855, audit HIGH -- symlink disclosure).
+/// `std::fs::copy` FOLLOWS symlinks, so a plain copy here would read a source symlink's
+/// (possibly out-of-root) TARGET content and bake it into the snapshot -- an out-of-root
+/// disclosure (audit #178). This matters doubly because this Rust binary implements no
+/// checkpoint RESTORE of its own -- `tg checkpoint` (list/undo) is a full Python passthrough,
+/// see `Commands::Checkpoint` below -- so the only restore path is
+/// `checkpoint_store.py::undo_checkpoint`, which ALSO uses `follow_symlinks=False` and
+/// therefore expects a stored snapshot entry to still BE a symlink; materializing the target's
+/// bytes here would silently turn a restored symlink into a plain file on undo, on top of the
+/// disclosure. Recreate the symlink AS a symlink instead of following it; fall back to a
+/// normal file copy for every non-symlink entry.
+fn copy_checkpoint_entry(source: &Path, destination: &Path) -> std::io::Result<()> {
+    if std::fs::symlink_metadata(source)?.file_type().is_symlink() {
+        let link_target = std::fs::read_link(source)?;
+        create_checkpoint_symlink(&link_target, destination)
+    } else {
+        std::fs::copy(source, destination).map(|_| ())
+    }
+}
+
+/// Recreates a symlink (never its target's content) at `link`, pointing at the same raw
+/// `target` text the original symlink stored (relative or absolute, copied verbatim -- exactly
+/// what `os.readlink()` + `os.symlink()` do on the Python side, so a relative target resolves
+/// the same way it always would relative to a symlink's own directory; this is an existing,
+/// accepted property of symlink-preserving copies -- e.g. Python's own `shutil.copytree(...,
+/// symlinks=True)` -- not a new gap introduced here).
+fn create_checkpoint_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(target, link)
+    }
+    #[cfg(windows)]
+    {
+        // Windows symlinks are typed (file vs. directory reparse point). Resolve the target
+        // relative to the link's own parent directory to pick the right type; a target that
+        // cannot be resolved (dangling symlink) defaults to a file symlink, same as Python's
+        // `os.symlink(target, dst)` (which defaults `target_is_directory=False`).
+        let resolved_is_dir = link
+            .parent()
+            .map(|parent| parent.join(target))
+            .and_then(|candidate| std::fs::metadata(candidate).ok())
+            .map(|metadata| metadata.is_dir())
+            .unwrap_or(false);
+        if resolved_is_dir {
+            std::os::windows::fs::symlink_dir(target, link)
+        } else {
+            std::os::windows::fs::symlink_file(target, link)
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (target, link);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "symlinks not supported on this platform",
+        ))
+    }
+}
+
 fn create_checkpoint(path: &str) -> anyhow::Result<CheckpointCreateSummary> {
     let scope = detect_checkpoint_scope(path);
     let root = scope.root.clone();
@@ -8441,13 +8589,15 @@ fn create_checkpoint(path: &str) -> anyhow::Result<CheckpointCreateSummary> {
 
     // NIT (v1.76 #602 gate, "NIT-3"): mirror checkpoint_store.py::create_checkpoint's
     // `except BaseException: shutil.rmtree(snapshot_dir.parent, ignore_errors=True); raise`
-    // (audit #125a, shipped in #602) on the Rust side. Everything from here on is fallible (a
-    // file copy, the metadata.json write, the index.json read/parse/write) and, before this
-    // fix, a failure at ANY of those steps propagated the error via `?` while leaving the
-    // just-created random-id checkpoint directory -- `checkpoint_dir`, holding both snapshot/
-    // and metadata.json -- behind on disk forever. Run the rest of the write sequence in a
-    // closure (stable Rust has no `try` blocks) and remove that whole directory before
-    // propagating any error; the success (`Ok`) path below is byte-identical to before.
+    // (audit #125a, shipped in #602; widened by audit #178 to also cover the index write, so
+    // it is now a true mirror end-to-end -- see checkpoint_store.py::create_checkpoint) on the
+    // Rust side. Everything from here on is fallible (a file copy, the metadata.json write,
+    // the index.json read/parse/write) and, before this fix, a failure at ANY of those steps
+    // propagated the error via `?` while leaving the just-created random-id checkpoint
+    // directory -- `checkpoint_dir`, holding both snapshot/ and metadata.json -- behind on disk
+    // forever. Run the rest of the write sequence in a closure (stable Rust has no `try`
+    // blocks) and remove that whole directory before propagating any error; the success (`Ok`)
+    // path below is byte-identical to before.
     let checkpoint_dir = checkpoint_storage_dir(&root).join(&checkpoint_id);
 
     let write_checkpoint_body = || -> anyhow::Result<CheckpointCreateSummary> {
@@ -8465,7 +8615,7 @@ fn create_checkpoint(path: &str) -> anyhow::Result<CheckpointCreateSummary> {
                     )
                 })?;
             }
-            std::fs::copy(&source, &destination).with_context(|| {
+            copy_checkpoint_entry(&source, &destination).with_context(|| {
                 format!(
                     "failed to copy {} into checkpoint snapshot {}",
                     source.display(),

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -871,12 +871,39 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
             scope_kind=scope.scope_kind,
             original_path=scope.original_path,
         )
+
+        # audit #178 (surfaced by the #610 gate): the guarded region must also extend through
+        # the index write below -- q10's load->mutate->write RMW of index.json, cross-process
+        # and cross-thread (see _index_lock.index_lock docstring / AGENTS.md Backend Fail-Closed
+        # Contract). Before this fix that RMW ran entirely OUTSIDE this try/except: a failure
+        # loading, parsing, or writing index.json after the copy loop AND metadata.json had both
+        # already fully succeeded still orphaned the fully-populated per-checkpoint directory
+        # forever -- audit #125a's widening (below) only reached the metadata write, not this
+        # index write. Retention selection stays inside the lock (pure, no I/O); the actual
+        # rmtree of dropped (OTHER, already-retired) snapshot dirs happens AFTER this try/except
+        # -- once our own new checkpoint is durably indexed, a failure pruning old dirs is a
+        # separate, best-effort concern and must not roll back the checkpoint just committed.
+        with index_lock(_index_path(root)):
+            records = _load_index(root)
+            records.insert(
+                0,
+                CheckpointRecord(
+                    version=_CHECKPOINT_VERSION,
+                    checkpoint_id=checkpoint_id,
+                    mode=mode,
+                    root=str(root),
+                    created_at=created_at,
+                    file_count=len(entries),
+                ),
+            )
+            records, dropped_dirs = _select_retained_checkpoints(root, records)
+            _write_index(root, records)
     except BaseException:
         # audit #125a: catch BaseException, not Exception -- KeyboardInterrupt/SystemExit
         # subclass BaseException directly (not Exception), so a Ctrl+C here previously escaped
         # this handler entirely and left an uncleaned checkpoint dir behind. The guarded region
-        # also now extends through the metadata write below (not just the copy loop above): a
-        # failure writing metadata.json after a fully successful copy must not orphan that
+        # extends through the metadata write AND (audit #178) the index write above: a failure
+        # writing metadata.json OR index.json after a fully successful copy must not orphan that
         # directory either -- audit H4's original cleanup only covered the copy loop. Remove the
         # WHOLE per-checkpoint dir (metadata.json may or may not have been written yet, but
         # snapshot_dir's own parent must go too, not just the snapshot/ subdir) -- matches how
@@ -885,26 +912,6 @@ def create_checkpoint(path: str = ".") -> CheckpointCreateResult:
         shutil.rmtree(snapshot_dir.parent, ignore_errors=True)
         raise
 
-    # q10 RMW race: load->mutate->write must be atomic w.r.t. every other writer of this
-    # index.json, cross-process and cross-thread, or a concurrent insert can be lost (see
-    # _index_lock.index_lock docstring / AGENTS.md Backend Fail-Closed Contract). Retention
-    # selection stays inside the lock (pure, no I/O); the actual rmtree of dropped snapshot
-    # dirs happens AFTER release so the lock is never held across slow directory removal.
-    with index_lock(_index_path(root)):
-        records = _load_index(root)
-        records.insert(
-            0,
-            CheckpointRecord(
-                version=_CHECKPOINT_VERSION,
-                checkpoint_id=checkpoint_id,
-                mode=mode,
-                root=str(root),
-                created_at=created_at,
-                file_count=len(entries),
-            ),
-        )
-        records, dropped_dirs = _select_retained_checkpoints(root, records)
-        _write_index(root, records)
     for directory in dropped_dirs:
         shutil.rmtree(directory, ignore_errors=True)
     _prime_bounded_discovery_caches_for_root(root)

--- a/tests/unit/test_checkpoint_containment.py
+++ b/tests/unit/test_checkpoint_containment.py
@@ -160,6 +160,117 @@ def test_create_checkpoint_does_not_disclose_symlink_target(tmp_path: Path) -> N
             assert "SECRET-OUT-OF-ROOT" not in path.read_text(encoding="utf-8", errors="ignore")
 
 
+def _write_rust_format_metadata(repo: Path, checkpoint_id: str, entries: dict[str, bool]) -> None:
+    """Write a checkpoint metadata.json in the RUST create path's exact wire format.
+
+    The native `create_checkpoint` (rust_core/src/main.rs `CheckpointMetadata`) serializes only
+    {version, checkpoint_id, mode, root, scope, original_path, created_at, file_count, entries}
+    -- it does NOT emit the Python-only ``active`` / ``skipped_nested_repos`` fields that
+    ``checkpoint_store._write_checkpoint_metadata`` adds. Writing the leaner Rust shape here makes
+    these tests double as a cross-language contract guard: they fail if ``undo_checkpoint`` ever
+    starts requiring a Python-only metadata field a Rust-created checkpoint never wrote.
+    """
+    meta_path = checkpoint_store._metadata_path(repo, checkpoint_id)
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": checkpoint_store._CHECKPOINT_VERSION,
+        "checkpoint_id": checkpoint_id,
+        "mode": "filesystem-snapshot",
+        "root": str(repo),
+        "scope": "tree",
+        "original_path": str(repo),
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "file_count": len(entries),
+        "entries": entries,
+    }
+    meta_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_rust_created_out_of_root_symlink_checkpoint_fails_closed_on_undo(tmp_path: Path) -> None:
+    """audit #178 F1: pin the Python-undo half of the Rust-create -> Python-undo contract for an
+    OUT-OF-ROOT symlink.
+
+    The fixed Rust create path (`tg run/rewrite --apply --checkpoint`, main.rs
+    `copy_checkpoint_entry`) now stores a tracked out-of-root symlink AS a symlink in the
+    snapshot instead of following it and baking the target's bytes in -- proved on the create
+    side by rust_core test ``test_create_checkpoint_does_not_disclose_symlink_target``. This test
+    reproduces exactly that snapshot state (an out-of-root symlink stored as a symlink, plus a
+    metadata.json in Rust's wire format) and pins the OTHER half: ``undo_checkpoint`` must FAIL
+    CLOSED -- undo's read-only pre-flight ``_resolve_within_root`` (checkpoint_store.py:124-139,
+    called at :1232-1235) resolves the stored snapshot symlink and refuses it (ValueError)
+    because its target escapes the snapshot root, BEFORE mutating a single working-tree file. So
+    the out-of-root target's content is never materialized into the repo and the working tree is
+    left completely intact (fail-closed-but-not-restorable -- the accurate round-trip contract).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    keep = repo / "keep.py"
+    keep.write_text("original in-repo content\n", encoding="utf-8")
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET-OUT-OF-ROOT\n", encoding="utf-8")
+
+    checkpoint_id = "ckpt-20260101000000-deadbeef"
+    snapshot_dir = checkpoint_store._snapshot_path(repo, checkpoint_id)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    (snapshot_dir / "keep.py").write_text("original in-repo content\n", encoding="utf-8")
+
+    # Mirror the Rust create path: the tracked symlink is stored AS a symlink pointing at its
+    # original out-of-root target -- never the target's bytes.
+    try:
+        (snapshot_dir / "link.txt").symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+
+    _write_rust_format_metadata(repo, checkpoint_id, {"keep.py": True, "link.txt": True})
+
+    with pytest.raises(ValueError):
+        checkpoint_store.undo_checkpoint(checkpoint_id, str(repo))
+
+    # Fail-closed: the out-of-root target is untouched and its content was NOT written anywhere
+    # into the working tree, and the pre-existing in-repo file is unchanged.
+    assert secret.read_text(encoding="utf-8") == "SECRET-OUT-OF-ROOT\n"
+    assert keep.read_text(encoding="utf-8") == "original in-repo content\n"
+    for path in repo.rglob("*"):
+        if (
+            path.is_file()
+            and not path.is_symlink()
+            and checkpoint_store._CHECKPOINT_DIRNAME not in path.parts
+        ):
+            assert "SECRET-OUT-OF-ROOT" not in path.read_text(encoding="utf-8", errors="ignore")
+
+
+def test_rust_created_dangling_symlink_checkpoint_fails_closed_on_undo(tmp_path: Path) -> None:
+    """audit #178 F1 (companion): a tracked DANGLING symlink (target missing) captured via the
+    Rust create path is likewise refused fail-closed on undo -- the stored snapshot symlink
+    resolves in-root but its target does not exist, so undo's missing-source probe
+    (checkpoint_store.py:1246-1257) raises CheckpointCorruptError before any working-tree file is
+    touched. Pins the dangling half of the round-trip comment's fail-closed claim."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    keep = repo / "keep.py"
+    keep.write_text("original in-repo content\n", encoding="utf-8")
+
+    checkpoint_id = "ckpt-20260101000000-feedface"
+    snapshot_dir = checkpoint_store._snapshot_path(repo, checkpoint_id)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    (snapshot_dir / "keep.py").write_text("original in-repo content\n", encoding="utf-8")
+
+    # An in-root RELATIVE symlink whose target does not exist in the snapshot (dangling).
+    try:
+        (snapshot_dir / "link.txt").symlink_to("missing_sibling")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+
+    _write_rust_format_metadata(repo, checkpoint_id, {"keep.py": True, "link.txt": True})
+
+    with pytest.raises(checkpoint_store.CheckpointCorruptError):
+        checkpoint_store.undo_checkpoint(checkpoint_id, str(repo))
+
+    # Fail-closed: working tree left intact, no partial restore.
+    assert keep.read_text(encoding="utf-8") == "original in-repo content\n"
+
+
 def test_create_checkpoint_prunes_to_retention_cap(tmp_path: Path, monkeypatch) -> None:
     """Round-4 DoS: the checkpoint store had no retention cap, so every `tg checkpoint create`
     copied the whole scope into a new snapshot dir with unbounded disk growth. Retain only the

--- a/tests/unit/test_checkpoint_disk_budget.py
+++ b/tests/unit/test_checkpoint_disk_budget.py
@@ -178,6 +178,33 @@ def test_create_checkpoint_cleans_up_snapshot_dir_on_metadata_write_failure(
     )
 
 
+def test_create_checkpoint_cleans_up_snapshot_dir_on_index_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Item 2 (audit #178, surfaced by the #610 gate): audit #125a's cleanup try/except widened
+    to cover the copy loop AND the metadata write, but the index.json read/parse/write that
+    follows (the q10 RMW block) ran entirely OUTSIDE that try/except. A failure while loading or
+    writing index.json -- after the copy loop AND metadata.json had both already fully succeeded
+    -- previously orphaned the fully-populated per-checkpoint directory forever. The guard must
+    widen once more to also cover the index write."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "a.py").write_text("a\n", encoding="utf-8")
+
+    def _boom_write_index(*args, **kwargs):
+        raise OSError("simulated index write failure")
+
+    monkeypatch.setattr(checkpoint_store, "_write_index", _boom_write_index)
+
+    with pytest.raises(OSError):
+        checkpoint_store.create_checkpoint(str(root))
+
+    assert _storage_dir_entries(root) == [], (
+        "a fully-copied-and-metadata-written checkpoint dir was left behind after an "
+        "index-write failure"
+    )
+
+
 def test_create_checkpoint_respects_raised_env_cap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Security hardening bundle from #178 (surfaced by the #610 Opus gate). Each item below was
independently VERIFIED against current `origin/main` (cite `file:line`) before touching anything.

> **Amendment (Opus gate returned SHIP-WITH-NITS):** second commit on this branch addresses the gate:
> **F1 (comment)** -- the `copy_checkpoint_entry` round-trip comment (main.rs) previously overstated
> undo restorability; corrected to state that recreate-as-symlink keeps out-of-root symlinks
> **fail-closed on undo** (refused by `_resolve_within_root`, working tree untouched, NOT restorable),
> and only in-root symlinks restore. **F1 (test)** -- added two Python `undo_checkpoint` fail-closed
> tests pinning that Rust-created out-of-root/dangling symlink checkpoints are refused before any
> working-tree mutation (details under "Tests added"). **F2a (nit)** -- the Windows symlink-creation
> privilege failure (`ERROR_PRIVILEGE_NOT_HELD`) is now re-messaged in `create_checkpoint_symlink`
> instead of surfacing as a bare, misleading "failed to copy ... into checkpoint snapshot".

### Item 1 -- IMPLEMENTED: Rust checkpoint snapshot followed symlinks (out-of-root disclosure)

- `rust_core/src/main.rs:8468` (pre-fix): the per-file snapshot copy in `create_checkpoint`'s
  `write_checkpoint_body` closure used `std::fs::copy(&source, &destination)`, which **follows**
  symlinks -- it reads and copies the bytes the symlink *points to*, not the link itself.
- `src/tensor_grep/cli/checkpoint_store.py:853-855` (the Python sibling) deliberately does the
  opposite: `shutil.copy2(source, destination, follow_symlinks=False)`, explicitly commented
  `# audit HIGH -- symlink disclosure`.
- Impact: a repo containing a symlink pointing outside the checkpoint root (e.g. `link -> ../../secret`
  or `link -> /etc/passwd`) would have the **target's content** captured into the on-disk snapshot
  when the checkpoint was created via the Rust-native path (`tg run --apply --checkpoint`,
  `main.rs:9831-9839` / `10074-10082`) -- an out-of-root disclosure, exactly the CWE class in
  AGENTS.md's "Security Hardening Patterns" lens.

**Policy chosen: recreate the symlink AS a symlink (never follow it)** -- matching Python exactly.
Rationale, verified against the real restore path:
- This Rust binary implements **no checkpoint restore of its own**. `tg checkpoint` (list/undo) is a
  full Python passthrough (`main.rs:1002-1004` `Commands::Checkpoint`, dispatched at `main.rs:5306`
  via `handle_python_passthrough("checkpoint", args)`). The **only** restore engine that exists is
  `checkpoint_store.py::undo_checkpoint`.
- Storing the link AS a link (not its target's bytes) is what keeps an out-of-root symlink
  **fail-closed rather than a disclosure** on undo. **Accurate round-trip contract (per Opus gate F1):**
  this does NOT make every symlink restorable. `undo_checkpoint`'s read-only pre-flight
  `_resolve_within_root` (checkpoint_store.py:124-139, called at :1232-1235) RESOLVES each stored
  snapshot symlink and, **before touching any working-tree file**, refuses it (`ValueError`) when the
  resolved target escapes the snapshot root; the later missing-source probe (:1246-1257) raises
  `CheckpointCorruptError` for a dangling target. So an **out-of-root OR dangling** symlink checkpoint
  is refused **fail-closed on undo** -- no disclosure, no data loss, working tree left intact, but NOT
  restorable. Only an **in-root** symlink whose resolved target exists inside the snapshot is actually
  restored. Following the link at create time (the bug) would instead materialize out-of-root content
  into the snapshot and then into the tree on undo.
- "skip/refuse the symlink at create time" was also rejected: `collect_filesystem_checkpoint_entries`
  / `collect_git_checkpoint_entries` already list a symlink as an "entry" (`exists: true`) in
  `metadata.json`; if the Rust copy step then silently skipped copying it, `undo_checkpoint`'s
  pre-flight would find the recorded entry missing on disk and raise `CheckpointCorruptError` -- so
  even an **in-root** symlink checkpoint would become un-undoable. Recreating it as a symlink is what
  Python's `shutil.copy2(..., follow_symlinks=False)` already does on both restore legs
  (checkpoint_store.py:1294, :1350), so the create sides now match.

Fix: added `copy_checkpoint_entry` (checks `symlink_metadata(source).file_type().is_symlink()`; if so,
`read_link` + recreate via a new `create_checkpoint_symlink` helper -- `#[cfg(unix)]` uses
`std::os::unix::fs::symlink`; `#[cfg(windows)]` resolves file-vs-dir typing best-effort and falls back
to a file symlink for a dangling target, matching Python's `os.symlink(...)` default
`target_is_directory=False`; else falls back to a plain `std::fs::copy`). The link's raw target text
is copied verbatim (relative or absolute) -- identical to what `os.readlink()`/`os.symlink()` do, so a
relative-target symlink resolves the same way it always would; this is an existing, accepted property
of symlink-preserving copies (e.g. Python's own `shutil.copytree(..., symlinks=True)`), not a new gap.

**Create-side tests** in `rust_core/src/main.rs` (`mod tests`):
- `test_create_checkpoint_does_not_disclose_symlink_target` -- RED before the fix (snapshot held a
  regular file with the secret's bytes), GREEN after (snapshot entry is itself a symlink; no
  regular file anywhere under the snapshot contains `SECRET-OUT-OF-ROOT`).
- `test_create_checkpoint_still_copies_regular_files_byte_identical` -- regression guard: an ordinary
  (non-symlink) tree is still captured byte-identical, unaffected by the new branch.

**Undo-side fail-closed tests (Opus gate F1)** in `tests/unit/test_checkpoint_containment.py` -- pin the
Python-undo half of the Rust-create -> Python-undo contract. Both reproduce the exact post-fix
Rust-created snapshot state (symlink stored as a symlink) plus a metadata.json in **Rust's wire
format** (only the fields `CheckpointMetadata` serializes -- no Python-only `active`/
`skipped_nested_repos` -- so they double as a cross-language metadata-compat guard), then call the real
`checkpoint_store.undo_checkpoint`:
- `test_rust_created_out_of_root_symlink_checkpoint_fails_closed_on_undo` -- an out-of-root symlink is
  refused with `ValueError` by `_resolve_within_root` before any working-tree mutation; asserts the
  out-of-root target is untouched and its content is written **nowhere** into the repo. **Verified this
  test genuinely pins the fix**: temporarily swapping the snapshot symlink for a regular file holding
  the secret bytes (the *pre-fix* Rust state) makes it go RED (`DID NOT RAISE ValueError` -- undo would
  restore the secret into the tree); reverted to the real symlink -> GREEN.
- `test_rust_created_dangling_symlink_checkpoint_fails_closed_on_undo` -- an in-root dangling symlink is
  refused with `CheckpointCorruptError` (missing-source probe), working tree left intact.

### Item 2 -- IMPLEMENTED: Python cleanup guard did not cover the index write

- `src/tensor_grep/cli/checkpoint_store.py::create_checkpoint` (pre-fix): the `except BaseException:`
  guard (then at lines ~846-886) wrapped the copy loop *and* the metadata write
  (`_write_checkpoint_metadata`), confirming audit #125a/#602 really did widen it that far -- but the
  index-write RMW block (`with index_lock(...): records = _load_index(root); ...;
  _write_index(root, records)`, then at lines ~888-907) ran **entirely outside** that try/except, as
  a separate statement afterward.
- Verified this is real (not already fixed): a forced failure in `_load_index`/`_write_index` *after*
  the copy loop and metadata.json write both fully succeed propagated straight past the
  `except BaseException:` handler, leaving the fully-populated per-checkpoint directory
  (`snapshot/` + `metadata.json`) orphaned on disk forever.

Fix: moved the `with index_lock(...): ...` block to be the last statement *inside* the `try:`, so a
failure anywhere in load/insert/select-retained/write now trips the same
`shutil.rmtree(snapshot_dir.parent, ignore_errors=True); raise` cleanup as the copy loop and metadata
write. Left `for directory in dropped_dirs: ...` and `_prime_bounded_discovery_caches_for_root(root)`
**outside** the try/except deliberately: those run only after our new checkpoint is already durably
indexed, prune *other*, already-retired checkpoint dirs, and are a separate best-effort concern that
must not roll back the checkpoint that was just successfully committed.

Test added in `tests/unit/test_checkpoint_disk_budget.py`:
- `test_create_checkpoint_cleans_up_snapshot_dir_on_index_write_failure` -- monkeypatches
  `checkpoint_store._write_index` to raise after the copy loop and metadata write both succeed.
  Verified RED on the pre-fix code (orphaned checkpoint dir left behind) and GREEN after (dir fully
  removed), by physically toggling the fix out/in with `git stash` and rerunning.

### Item 3 -- IMPLEMENTED (narrower than described): comment accuracy

The dispatch brief described the current comment as claiming Python uses `except Exception:` -- that
premise doesn't hold: `checkpoint_store.py:874` (verified) already reads `except BaseException:`,
which is exactly what the Rust comment at `main.rs` (`create_checkpoint`, the "NIT (v1.76 #602 gate,
NIT-3)" block) already quotes correctly. (There *is* a different `except Exception:` at
`checkpoint_store.py:1354` -- but that's inside `undo_checkpoint`'s unrelated best-effort
commit-phase revert-on-failure logic, not `create_checkpoint`.) So no exception-type correction was
needed.

The real, narrower gap: pre-Item-2, Python's guard stopped at the metadata write while Rust's already
covered copy + metadata + index -- so the comment's "mirror ... on the Rust side" framing overclaimed
parity. Updated both the `create_checkpoint` doc-comment and the sibling explanation inside
`test_create_checkpoint_removes_orphaned_dir_on_index_parse_failure` to explicitly cite audit #178 and
state the guard is now a true end-to-end mirror on both sides.

## Gates

- `uv run --no-sync ruff format --preview .` -- only the 3 intended files touched; reformatted 4
  unrelated pre-existing docs/*.md files (known whole-repo ruff-format drift, see project memory
  "Whole-repo ruff-format gap + git-show-smudge (2026-07-12)") were reverted, confirmed present on
  clean `origin/main` too (unrelated to this change).
- `ruff check` -- clean on both touched Python files.
- `ruff format --check --preview .` -- clean on the 3 touched files (whole-repo run still reports the
  same pre-existing 4-file docs drift, confirmed identical on clean `origin/main`).
- `mypy src/tensor_grep/cli/checkpoint_store.py` -- `Success: no issues found in 1 source file`.
- `cargo fmt --check` -- clean (one wrapped `assert_eq!` line auto-fixed by `cargo fmt`).
- `cargo clippy --all-targets -- -D warnings` -- **pre-existing, unrelated failure** on both this
  branch and clean `origin/main`: `field_reassign_with_default` in `rg_passthrough.rs:781` (a
  test-only helper, untouched by this PR), confirmed present before any of my edits by stashing this
  branch's diff and rerunning clippy on bare `origin/main` (same single error, same line, real exit
  code 101). Verified my actual changes are clippy-clean by temporarily silencing that one unrelated
  lint locally (not committed) and rerunning `-D warnings` -- exit 0, zero additional warnings from my
  new code.
- `cargo test --bin tg checkpoint` -- 4 passed (both original + the amendment's comment/F2a changes;
  full `cargo test --bin tg` = 100 passed on the pre-amendment commit).
- Python checkpoint suite: 88 passed pre-amendment; the amendment adds 2 tests to
  `test_checkpoint_containment.py` (now 20 passed there) -- `test_checkpoint_containment.py` +
  `test_checkpoint_disk_budget.py` = 30 passed together post-amendment.
- `tests/unit/test_mcp_server.py -k embedded`: 3 of 4 fail -- confirmed identical on clean
  `origin/main` (worktree lacks the compiled native extension; passes in CI). Ignored per dispatch
  note, not chased.
- ASCII-only / LF-only: verified every line this PR *adds* is pure ASCII with LF endings (diff-scoped
  check); the pre-existing em-dash characters already in both files predate this change.

**Amendment re-run (Opus gate fixes):** `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings`
exit 0 with the pre-existing `rg_passthrough.rs:781` lint silenced locally (my new F2a code adds zero
warnings); `cargo test --bin tg checkpoint` 4 passed; `ruff check` + `ruff format --preview` clean on the
touched test file; the two new undo tests GREEN (and the out-of-root one proven RED against a simulated
pre-fix snapshot, then GREEN).

## Scope

Touched only `rust_core/src/main.rs`, `src/tensor_grep/cli/checkpoint_store.py`, and their tests
(`tests/unit/test_checkpoint_disk_budget.py`, and `tests/unit/test_checkpoint_containment.py` for the
amendment's undo fail-closed tests). No restore-side Rust code needed changes (there is no Rust-side
restore function -- see Item 1). No unrelated churn.

**This touches the checkpoint create/restore path (rust + python) -- MANDATORY adversarial Opus gate
pending before merge**, per AGENTS.md Campaign Orchestration Disciplines.
