### PR TITLE
fix: calibrate/doctor GPU guidance honest when no nvidia asset is shipped (CEO dogfood #169)

### DIFF
--- a/rust_core/src/crossover.rs
+++ b/rust_core/src/crossover.rs
@@ -476,34 +476,45 @@ fn user_crossover_config_path() -> Option<PathBuf> {
     })
 }
 
-// P0-4 (GPU Phase-0 honesty): a bare "requires a CUDA-enabled build" / "device unavailable"
-// error leaves a caller with no idea how to fix it. Point at the exact remediation -- the
-// TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR override + `tg upgrade` -- and name the platform's
-// NVIDIA release asset via compile-time cfg. HONESTY: never claim an asset "isn't published
-// yet" (that phrasing goes false the moment the asset profile is flipped on); phrase the
-// linux/windows case conditionally ("if published ... falls back to CPU when it is not") and
-// state the macOS case as the structural fact it is (Apple platforms are not a CUDA target).
-fn crossover_gpu_remediation_hint() -> String {
-    let platform_clause = if cfg!(target_os = "linux") {
-        "on linux this fetches the tg-linux-amd64-nvidia asset, if an NVIDIA asset is \
-         published for this platform on the release page; the installer falls back to CPU \
-         when it is not"
-            .to_string()
-    } else if cfg!(target_os = "windows") {
-        "on windows this fetches the tg-windows-amd64-nvidia.exe asset, if an NVIDIA asset is \
-         published for this platform on the release page; the installer falls back to CPU \
-         when it is not"
-            .to_string()
-    } else {
-        "no NVIDIA asset is published for this platform (Apple platforms are not a CUDA \
-         target); the installer stays on CPU here"
-            .to_string()
-    };
-    format!(
-        "To enable, set env TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia then run `tg upgrade` \
-         ({platform_clause}). Run `tg doctor` to check the requested-vs-installed native \
-         flavor."
-    )
+// P0-4 (GPU Phase-0 honesty, #596) pointed calibrate-failure guidance at
+// TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR + `tg upgrade`, phrased conditionally ("if published ...
+// falls back to CPU when it is not") so it would never assert a false "no NVIDIA asset
+// published" claim. CEO dogfood (v1.76.6) found that phrasing still misleading in practice:
+// no NVIDIA-flavored asset has ever shipped (the release profile that builds one is held
+// off), so the caveated "upgrade" invitation was a permanent dead end dressed up as honest
+// advice. Fix: stop advertising the upgrade from a build that structurally has no CUDA
+// support compiled in -- state plainly that GPU acceleration is experimental and not shipped
+// in *this build*. This is flip-agnostic with NO new signal needed: the moment an
+// NVIDIA-flavored asset actually ships, it is compiled WITH the `cuda` feature, which takes
+// the entirely different arm below (real device enumeration) and never reaches this string
+// at all -- so the claim can never go stale from a future flag-flip. It only ever describes
+// a build with no CUDA compiled in, which is permanently true for that concrete artifact
+// regardless of what the release pipeline later publishes.
+//
+// cfg-gated to match its only call site (the `not(feature = "cuda")` arm of
+// `detect_device_name` below) -- otherwise it is unreachable dead code under a `--features
+// cuda` build and trips `clippy -D warnings` there.
+#[cfg(not(feature = "cuda"))]
+fn crossover_gpu_remediation_hint_no_cuda_build() -> String {
+    "GPU (CUDA) acceleration is experimental and is not shipped in this build (compiled \
+     without CUDA support), so it cannot run GPU calibration here. Run `tg doctor` to confirm \
+     this build's native flavor, and see docs/gpu_crossover.md for the current GPU roadmap."
+        .to_string()
+}
+
+// Distinct from the no-cuda-build hint above: this build DOES have CUDA support compiled in,
+// so telling the caller to go "upgrade to get NVIDIA" would be nonsensical -- the problem is
+// that the requested device id isn't among the enumerated devices (a hardware/driver/config
+// problem), not a missing build.
+//
+// cfg-gated to match its only call site (the `feature = "cuda"` arm of `detect_device_name`
+// below) -- otherwise it is unreachable dead code under a default (non-cuda) build and trips
+// `clippy -D warnings` there.
+#[cfg(feature = "cuda")]
+fn crossover_gpu_remediation_hint_device_not_found() -> String {
+    "Run `tg devices` to list routable GPU device IDs, or `tg doctor` to check GPU runtime \
+     health, then retry calibration with a valid device id."
+        .to_string()
 }
 
 fn detect_device_name(device_id: i32) -> Result<String> {
@@ -519,7 +530,7 @@ fn detect_device_name(device_id: i32) -> Result<String> {
         }
         bail!(
             "CUDA device {device_id} is unavailable for crossover calibration.\n{}",
-            crossover_gpu_remediation_hint()
+            crossover_gpu_remediation_hint_device_not_found()
         );
     }
 
@@ -528,7 +539,7 @@ fn detect_device_name(device_id: i32) -> Result<String> {
         let _ = device_id;
         bail!(
             "crossover calibration requires a CUDA-enabled build.\n{}",
-            crossover_gpu_remediation_hint()
+            crossover_gpu_remediation_hint_no_cuda_build()
         )
     }
 }
@@ -542,39 +553,60 @@ enum SearchMode {
 mod tests {
     use super::*;
 
-    // P0-4 RED test: detect_device_name is always-compiled (no `cuda` feature required), so
-    // this runs in the default `test-rust-core` CI matrix (ubuntu/windows/macos x stable/
-    // nightly, `cargo test --no-default-features`). The `#[cfg(feature = "cuda")]` arm's own
-    // edit (crossover.rs:520-523) is only compile-checked by the separate `cuda-feature-check`
-    // job (`cargo check --features cuda`, ubuntu+windows only) -- never test-executed here,
-    // which is an accepted gap (council nit).
+    // Follow-up to #596 (CEO dogfood, v1.76.6): #596's remediation was honest in isolation
+    // ("if published ... falls back to CPU when it is not") but still dangled
+    // TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia + `tg upgrade` as an obtainable path, when in
+    // reality no NVIDIA-flavored asset has ever shipped (the release profile that builds one
+    // is held off) -- a permanent dead end. This RED->GREEN test asserts the no-cuda-build
+    // message states the honest, evergreen fact (GPU experimental / not shipped in this
+    // build) instead of inviting an upgrade dance that always falls back to CPU today.
+    //
+    // detect_device_name is always-compiled (no `cuda` feature required), so this runs in the
+    // default `test-rust-core` CI matrix (ubuntu/windows/macos x stable/nightly, `cargo test
+    // --no-default-features`). The `#[cfg(feature = "cuda")]` arm is only compile-checked by
+    // the separate `cuda-feature-check` job (`cargo check --features cuda`) -- never
+    // test-executed here, which is an accepted pre-existing gap (council nit).
     #[cfg(not(feature = "cuda"))]
     #[test]
-    fn detect_device_name_without_cuda_feature_names_remediation() {
+    fn detect_device_name_without_cuda_feature_states_experimental_not_upgrade_dead_end() {
         let err = detect_device_name(0).expect_err("a non-cuda build must fail closed");
         let message = err.to_string();
         assert!(
-            message.contains("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR"),
-            "message should point at the native-frontdoor flavor override env var: {message}"
+            !message.contains("TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR"),
+            "message must not invite the FLAVOR=nvidia override as an obtainable path: {message}"
         );
         assert!(
-            message.contains("tg upgrade"),
-            "message should tell the user how to fetch an NVIDIA-enabled binary: {message}"
+            !message.contains("tg upgrade"),
+            "message must not invite `tg upgrade` as a way to get GPU support today: {message}"
         );
-        #[cfg(target_os = "linux")]
         assert!(
-            message.contains("tg-linux-amd64-nvidia"),
-            "message should name the linux NVIDIA asset: {message}"
+            message.contains("experimental"),
+            "message should state GPU acceleration is experimental: {message}"
         );
-        #[cfg(target_os = "windows")]
         assert!(
-            message.contains("tg-windows-amd64-nvidia.exe"),
-            "message should name the windows NVIDIA asset: {message}"
+            message.contains("not shipped in this build"),
+            "message should honestly scope the claim to this build, not the whole release: \
+             {message}"
         );
-        #[cfg(target_os = "macos")]
         assert!(
-            message.contains("no NVIDIA asset"),
-            "message should honestly state macOS has no NVIDIA asset: {message}"
+            message.contains("tg doctor"),
+            "message should still point at `tg doctor` for diagnostics: {message}"
         );
+    }
+
+    // Mirror check for the cuda-enabled arm: it must keep its OWN, scenario-correct
+    // remediation (a device/driver/config problem, not a "no GPU build" problem) and must
+    // never regress to claim GPU is "not shipped in this build" when the build plainly HAS
+    // CUDA compiled in. Compile-checked only (no CUDA toolkit available to link/run this arm
+    // outside the release nvidia legs) -- mirrors the existing accepted gap above.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn crossover_gpu_remediation_hint_device_not_found_is_not_a_build_availability_claim() {
+        let hint = crossover_gpu_remediation_hint_device_not_found();
+        assert!(
+            !hint.contains("not shipped in this build"),
+            "a CUDA-enabled build must never be told GPU isn't shipped in it: {hint}"
+        );
+        assert!(hint.contains("tg devices") || hint.contains("tg doctor"));
     }
 }

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7719,18 +7719,24 @@ def calibrate() -> None:
         # audit L10: calibrate is unsupported without the native binary (and on CPU-only
         # boxes the native binary itself exits non-zero when CUDA is unavailable). tg's
         # convention is exit 1 for runtime/unsupported errors, not exit 2 (usage errors).
-        # P0-4 (GPU Phase-0 honesty): don't leave the caller with a dead end -- name the
-        # remediation. This wrapper uses inherited stdio for the real `calibrate` subprocess
-        # below and must NOT capture its stderr (that would break streaming), so only THIS
-        # wrapper-owned missing-binary message gets the pointer; the native binary's own
-        # calibrate-failure remediation text is Rust-owned (crossover.rs).
+        # P0-4 (GPU Phase-0 honesty, #596) named a remediation here so this wasn't a dead end.
+        # CEO dogfood follow-up (v1.76.6): #596's "if published ... falls back to CPU when it
+        # is not" framing still invited TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia + `tg
+        # upgrade` as an obtainable GPU path, but no NVIDIA-enabled asset has ever shipped (the
+        # release profile that builds one is held off) -- a permanent dead end dressed up as
+        # honest advice. State the evergreen, structural fact instead (GPU needs a
+        # CUDA-enabled build, which isn't present here) without claiming an upgrade will --or
+        # won't-- fetch one; `tg doctor` is the live way to check once a binary exists. This
+        # wrapper uses inherited stdio for the real `calibrate` subprocess below and must NOT
+        # capture its stderr (that would break streaming), so only THIS wrapper-owned
+        # missing-binary message gets touched; the native binary's own calibrate-failure
+        # remediation is Rust-owned (crossover.rs) and follows the same discipline there.
         typer.echo(
             "Error: native tg binary not found for calibrate command.\n"
-            "To enable GPU crossover calibration, set env "
-            "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia then run 'tg upgrade' to fetch an "
-            "NVIDIA-enabled native binary, if one is published for this platform on the "
-            "release page; the installer falls back to CPU when it is not. Run 'tg doctor' "
-            "to check the requested-vs-installed native flavor.",
+            "Run 'tg upgrade' to install a native tg binary so calibrate can run. GPU (CUDA) "
+            "acceleration is experimental and is not available without a CUDA-enabled build; "
+            "run 'tg doctor' after upgrading to confirm this install's native flavor before "
+            "relying on TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia.",
             err=True,
         )
         raise typer.Exit(1)

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -267,8 +267,13 @@ def test_l10_calibrate_exits_one_when_unsupported(monkeypatch) -> None:
     # error: tg's convention is exit 1, not the usage-error exit 2.
     assert result.exit_code == 1, result.stdout
     # P0-4 (GPU Phase-0 honesty): the missing-binary message must carry an actionable
-    # remediation pointer -- not just "not found" with no next step -- naming the flavor
-    # override env var, the `tg upgrade` command, and the `tg doctor` diagnostic.
-    assert "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR" in result.output
+    # remediation pointer -- not just "not found" with no next step.
     assert "tg upgrade" in result.output
     assert "tg doctor" in result.output
+    # CEO dogfood follow-up (v1.76.6): the message must state the honest, evergreen fact
+    # (GPU experimental / needs a CUDA-enabled build) instead of inviting
+    # TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia + `tg upgrade` as an obtainable GPU path --
+    # no NVIDIA-enabled asset has ever shipped, so that framing was a permanent dead end.
+    assert "experimental" in result.output
+    assert "if one is published for this platform on the release page" not in result.output
+    assert "NVIDIA-enabled native binary" not in result.output


### PR DESCRIPTION
## Problem (CEO dogfood, v1.76.6, WSL)

`tg calibrate` on a CPU-only build prints a message (`crossover.rs:496` via
`crossover_gpu_remediation_hint()`, and the Python `calibrate()` wrapper's missing-binary
message at `main.py:7727-7735`) that invites `TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia` +
`tg upgrade` as a way to get GPU support, caveated with "if published ... falls back to CPU
when it is not" (shipped in #596 / v1.75.3). That caveat is technically honest, but in
practice it's a **permanent dead end right now**: no NVIDIA-flavored asset has ever been
published for any release (the CI native-asset profile that builds one is held off), so the
invitation always silently falls back to CPU. CEO ask: stop advertising `FLAVOR=nvidia` as
obtainable until it actually is, without hard-coding a claim that goes stale the moment the
profile is flipped on.

## Verified seam (file:line, against current origin/main)

- `rust_core/src/crossover.rs:486-507` (pre-fix) `crossover_gpu_remediation_hint()`, called
  from both arms of `detect_device_name` (:509-534): the `#[cfg(feature = "cuda")]` arm
  (device-not-found, :520-523) and the `#[cfg(not(feature = "cuda"))]` arm (no-cuda-build,
  :529-532).
- `src/tensor_grep/cli/main.py:7714-7739` `calibrate()`, the `native_tg_binary is None`
  missing-binary branch (:7718-7736) -- a separate, Python-owned message for when there's no
  managed native binary present at all (the Rust binary's own stderr, inherited via
  subprocess passthrough at :7738, is untouched by Python and carries the crossover.rs
  message when a binary IS present).

## Fix: flip-agnostic, no new signal needed

Conditioned on the Rust `cuda` Cargo feature itself -- already compile-baked ground truth
about the concrete binary that is running, requiring no network call and no new CI/build-time
plumbing:

- **`crossover_gpu_remediation_hint_no_cuda_build()`** (new, `#[cfg(not(feature = "cuda"))]`):
  states the evergreen fact that GPU acceleration is experimental and **not shipped in *this*
  build**, without inviting `FLAVOR=nvidia` + `tg upgrade` as obtainable. This can never go
  stale on a future flag-flip: the moment an NVIDIA-flavored asset ships, it is compiled WITH
  the `cuda` feature and takes the entirely different arm below (real CUDA device
  enumeration) -- it never reaches this string at all. The claim is scoped to "this build",
  not "the release", so it stays permanently true regardless of what the release pipeline
  later publishes.
- **`crossover_gpu_remediation_hint_device_not_found()`** (renamed/split,
  `#[cfg(feature = "cuda")]`): kept distinct on purpose. A build that DOES have CUDA compiled
  in but can't find the requested device id has a hardware/driver/config problem, not a
  missing-build problem -- the old shared hint would have nonsensically told an
  nvidia-binary user to go "upgrade to get nvidia". Now it points at `tg devices`/`tg doctor`
  instead.
- Both hint functions are **cfg-gated at their definitions**, not just their call sites --
  otherwise each is dead code under the other build configuration and `clippy -D warnings`
  fails there (caught by an adversarial-verify pass before this PR, see Gates below).
- **Python `calibrate()`'s missing-native-binary message**: same discipline. Keeps
  `tg upgrade` (still valid -- needed regardless of GPU, to get any native binary at all) and
  `tg doctor`, drops the specific "if one is published ... release page" dead-end framing in
  favor of the same evergreen "GPU needs a CUDA-enabled build, which isn't present here"
  statement.

I could not find a way to condition on true *release-wide* NVIDIA-asset availability (e.g. "has
any asset ever been published for any release") without either a network call at calibrate
time (out of scope for an offline diagnostic) or new CI-to-compile-time plumbing (env var ->
`option_env!`/build.rs), which would expand this into the release pipeline itself -- a bigger,
separate change with real cache-invalidation-correctness risk, not a small message fix. The
`cuda`-feature conditioning above is the smallest correct signal: it answers "does *this*
concrete binary have GPU support", which is exactly the question calibrate is actually asking,
and is definitionally equivalent to the installer's own nvidia-vs-cpu asset-flavor split (an
nvidia asset is *by construction* compiled with `--features cuda`; a cpu asset without).

## RED -> GREEN

- Rust: updated the existing test (renamed
  `detect_device_name_without_cuda_feature_states_experimental_not_upgrade_dead_end`) to
  assert the message no longer contains `TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR` / `tg upgrade`,
  and does contain `experimental` / `not shipped in this build` / `tg doctor`. Confirmed RED
  against the pre-fix code, GREEN after.
- Added a compile-checked mirror test for the cuda-enabled arm
  (`crossover_gpu_remediation_hint_device_not_found_is_not_a_build_availability_claim`,
  `#[cfg(feature = "cuda")]`) asserting it never claims "not shipped in this build". No CUDA
  toolkit is available in this environment to test-execute it; this matches the pre-existing
  `cuda-feature-check` CI job's own scope (`cargo check --features cuda`, compile-check only,
  never `cargo test --features cuda`) -- an accepted, already-documented gap in the codebase
  for this exact function.
- Python: updated `test_l10_calibrate_exits_one_when_unsupported` the same way (RED confirmed,
  GREEN after).

## Gates

- `cargo fmt --check` -- clean.
- `cargo test --no-default-features --lib` -- 106/106 passed.
- `cargo clippy --no-default-features --all-targets -- -D warnings` -- clean once the
  pre-existing, unrelated `rg_passthrough.rs:781` lint is suppressed for verification (`git
  blame` confirms it predates this change -- last touched 2026-07-04, untouched by this diff).
- `cargo clippy --features cuda --all-targets -- -D warnings` -- surfaces pre-existing debt in
  *other* files (`gpu_native.rs`, `test_gpu_native_long_lines.rs`, `test_sidecar_ipc.rs`), none
  in the touched code. CI's actual `cuda-feature-check` job only runs `cargo check --features
  cuda` (not clippy, not tests) -- I ran that exact command and it's clean.
- Python: targeted + keyword-filtered pytest (105 tests: `test_medlow_main_cli.py` full file,
  `test_cli_modes.py -k "gpu or doctor or frontdoor or calibrat"`, plus the
  `test_cli_bootstrap.py` calibrate test) -- all green.
- `ruff format --preview`, `ruff check`, `ruff format --check --preview`, `mypy` -- all clean
  on the touched files.
- ASCII-only, LF line endings confirmed on all added lines.

## Scope

Touches only the calibrate-message code (Rust `crossover.rs` + Python `main.py`) and its
tests. No unrelated churn. Searched the repo for any other "invite FLAVOR=nvidia as obtainable"
site (doctor's own flavor-mismatch note, `agent_capsule.py`) -- neither duplicates this
dead-end pattern, so neither needed touching.

## Gate classification

This touches the GPU native calibrate path (`crossover.rs` / `detect_device_name`), which is a
mandatory-Opus-gate surface per the project's GPU Phase-0 hardening convention (the same gate
applied to #594-#597). Flagging for the mandatory adversarial Opus review before merge -- not a
normal-review-suffices change, despite the diff being small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)