### PR TITLE
test: widen index-lock heartbeat freshness bound for loaded CI runners (flaked v1.76.9 on windows)

### DIFF
--- a/tests/unit/test_index_lock.py
+++ b/tests/unit/test_index_lock.py
@@ -204,12 +204,14 @@ def test_heartbeat_keeps_mtime_fresh_during_long_hold(tmp_path: Path) -> None:
     lock_path = _index_lock._lock_path_for(index_path)
     # Absolute values are deliberately generous: the property under test is that the
     # heartbeat keeps mtime younger than stale_after_s, which only requires the heartbeat
-    # interval to be a small fraction of stale_after_s. Tight sub-100ms bounds flake on
-    # loaded 2-core CI runners where the heartbeat thread can be GIL-starved for >150ms
-    # (observed: 0.152s > 0.15s on macos-latest). stale_after_s here is 12x the heartbeat
-    # interval, so realistic scheduling jitter stays well clear of the bound.
-    stale_after_s = 0.6
-    hold_s = 1.5  # several multiples of stale_after_s
+    # interval to be a small fraction of stale_after_s. Tight bounds flake on loaded 2-core
+    # CI runners where the heartbeat thread can be GIL-starved well past the heartbeat
+    # interval (observed: 0.152s > 0.15s on macos-latest; then 0.784s > 0.6s on
+    # windows-latest 2026-07-15, which blocked the v1.76.9 release run). stale_after_s here
+    # is 40x the heartbeat interval -- roughly 2.5x headroom over the worst observed
+    # starvation of 0.78s -- so realistic CI scheduling jitter stays well clear of the bound.
+    stale_after_s = 2.0
+    hold_s = 4.0  # several multiples of stale_after_s
 
     max_observed_age = 0.0
     stop_observer = threading.Event()


### PR DESCRIPTION
## Summary

- `test_heartbeat_keeps_mtime_fresh_during_long_hold` flaked on `windows-latest py3.11` CI and blocked the v1.76.9 release run: `assert max_observed_age < stale_after_s` failed with `0.7837355136871338 < 0.6`.
- Root cause: the heartbeat thread was GIL-starved for ~0.78s on the loaded 2-core CI runner -- longer than the test's `stale_after_s=0.6` bound. The heartbeat mechanism itself is not broken; the test's bound was too tight for realistic CI starvation. Same flakiness class the test's own comment already documents from the prior #120 macOS hardening (`0.152s > 0.15s`).
- Fix (test-only): widen `stale_after_s` 0.6 -> 2.0 and `hold_s` 1.5 -> 4.0 (absolute headroom: ~2.5x the worst observed starvation of 0.78s). `heartbeat_interval_s` stays at 0.05, so the stale_after_s:heartbeat ratio grows to 40x, reinforcing the "heartbeat interval is a small fraction of the bound" property under test. Comment updated to record the 2026-07-15 windows observation alongside the existing macOS note.
- No production code changed (nothing under `src/`).

## RED-GREEN verification

- **GREEN** (real `heartbeat_interval_s=0.05`): `max_observed_age ~= 0.0643s`, comfortably under the new `stale_after_s=2.0` bound. `pytest tests/unit/test_index_lock.py::test_heartbeat_keeps_mtime_fresh_during_long_hold -x -v` -> PASSED.
- **RED** (heartbeat sabotaged to `heartbeat_interval_s=999`, never fires during the 4.0s hold): `max_observed_age ~= 3.977s`. Re-ran the same test with the sabotage in place -> FAILED with `assert 3.97721529006958 < 2.0`, confirming the widened bound still discriminates a working heartbeat from a dead one. Sabotage was then reverted (diff against origin/main confirms only the intended constants/comment changed).
- Whole-file sibling check: `pytest tests/unit/test_index_lock.py -x -q` -> 10 passed, no regression.
- Gates: `ruff check tests/unit/test_index_lock.py` and `ruff format --check --preview tests/unit/test_index_lock.py` both clean. Changed lines verified ASCII-only and LF-only via `git cat-file blob` (not `git show`, which applies autocrlf smudge).

## Why `test:` (no release)

This is a test-only hardening change with a `test:` conventional-commit prefix -- semantic-release will not cut a release for it, which is correct since no user-facing behavior changed.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_index_lock.py::test_heartbeat_keeps_mtime_fresh_during_long_hold -x -v` (GREEN)
- [x] Sabotage `heartbeat_interval_s=999` + re-run -> FAILED as expected (RED), then reverted
- [x] `uv run python -m pytest tests/unit/test_index_lock.py -x -q` -> 10 passed
- [x] `uv run ruff check tests/unit/test_index_lock.py`
- [x] `uv run ruff format --check --preview tests/unit/test_index_lock.py`
- [ ] CI `test-python (windows-latest, py3.11)` green on this PR

Not merging -- holding as draft per the release push-race discipline (the orchestrator merges after v1.76.9 publishes).