### PR TITLE
fix: detect WSL via /proc/version when env signals are stripped (is_wsl_host fallback)

### DIFF
--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -345,11 +345,23 @@ def is_wsl_host() -> bool:
     misread as a real WSL path-domain mismatch. `WSL_DISTRO_NAME`/`WSL_INTEROP` are set by WSL
     itself in every real WSL session and are the standard, filesystem-read-free way to detect it;
     `/run/WSL` (also used by `core.hardware.device_detect`) is the fallback for a stripped
-    subprocess environment that dropped those variables.
+    subprocess environment that dropped those variables. `/proc/version` containing "microsoft"
+    (case-insensitive) is the canonical fallback for a fully stripped environment where a wrapper
+    or service dropped both env vars AND has no `/run/WSL` -- every WSL1/WSL2 kernel stamps this
+    string (e.g. "Linux version 6.6.87.2-microsoft-standard-WSL2"), and no non-WSL Linux kernel
+    does, so this signal is safe and cannot false-positive. The read is wrapped fail-closed:
+    any OSError (missing file, permission denied, etc.) is treated as "not WSL" rather than
+    raising.
     """
     if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
         return True
-    return os.path.exists("/run/WSL")
+    if os.path.exists("/run/WSL"):
+        return True
+    try:
+        with open("/proc/version", encoding="utf-8", errors="replace") as fh:
+            return "microsoft" in fh.read().lower()
+    except OSError:
+        return False
 
 
 def native_binary_targets_windows(binary: Path | str) -> bool:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -652,6 +652,25 @@ class TestIsWslHost:
         )
         assert runtime_paths.is_wsl_host() is True
 
+    def test_true_via_proc_version_when_env_and_run_wsl_both_stripped(self, monkeypatch):
+        """The stripped-environment fallback: a wrapper/service that drops
+        WSL_DISTRO_NAME/WSL_INTEROP and runs on a WSL1-style host with no `/run/WSL` is still
+        detected via `/proc/version`, which every real WSL1/WSL2 kernel stamps with "microsoft"
+        (e.g. "Linux version 6.6.87.2-microsoft-standard-WSL2")."""
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.delenv("WSL_INTEROP", raising=False)
+        original_exists = os.path.exists
+        monkeypatch.setattr(
+            runtime_paths.os.path,
+            "exists",
+            lambda p: False if p == "/run/WSL" else original_exists(p),
+        )
+        monkeypatch.setattr(
+            "builtins.open",
+            mock_open(read_data="Linux version 6.6.87.2-microsoft-standard-WSL2\n"),
+        )
+        assert runtime_paths.is_wsl_host() is True
+
     def test_false_on_plain_linux_without_any_wsl_signal(self, monkeypatch):
         monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
         monkeypatch.delenv("WSL_INTEROP", raising=False)
@@ -661,6 +680,28 @@ class TestIsWslHost:
             "exists",
             lambda p: False if p == "/run/WSL" else original_exists(p),
         )
+        monkeypatch.setattr(
+            "builtins.open",
+            mock_open(read_data="Linux version 6.8.0-generic (buildd@bare-metal)\n"),
+        )
+        assert runtime_paths.is_wsl_host() is False
+
+    def test_false_when_proc_version_unreadable(self, monkeypatch):
+        """A bare/minimal or permission-restricted host where `/proc/version` cannot be opened
+        must fail closed to False, never raise."""
+        monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+        monkeypatch.delenv("WSL_INTEROP", raising=False)
+        original_exists = os.path.exists
+        monkeypatch.setattr(
+            runtime_paths.os.path,
+            "exists",
+            lambda p: False if p == "/run/WSL" else original_exists(p),
+        )
+
+        def _raise_file_not_found(*_args, **_kwargs):
+            raise FileNotFoundError("/proc/version")
+
+        monkeypatch.setattr("builtins.open", _raise_file_not_found)
         assert runtime_paths.is_wsl_host() is False
 
 


### PR DESCRIPTION
## Summary
- `is_wsl_host()` (`src/tensor_grep/cli/runtime_paths.py`) only checked `WSL_DISTRO_NAME`/`WSL_INTEROP` env vars, then `/run/WSL`. A wrapper/service that strips both env vars on a WSL1-style host with no `/run/WSL` makes `is_wsl_host()` wrongly return `False`, which cascades: `is_cross_domain_native_binary()` returns `False` and the GPU probe hands a raw Linux `/tmp` path to the Windows `tg.exe` binary, producing a `path_not_found` fault that reads as "no GPU support" when the GPU route may be fine.
- Adds `/proc/version` (contains `"microsoft"`, case-insensitive, on every WSL1/WSL2 kernel; never on non-WSL Linux — confirmed live: `Linux version 6.6.87.2-microsoft-standard-WSL2`) as a final, read-safe fallback checked *after* the existing env-var and `/run/WSL` checks (cheapest/env-based signals stay first).
- The read is wrapped in `try/except OSError` (covers `FileNotFoundError`) and returns `False` on any failure — never raises.
- This ONLY ADDS a WSL detection signal; it never removes one, so it cannot regress a currently-working WSL config.
- No other function touched: `native_binary_targets_windows`, `is_cross_domain_native_binary`, and `translate_path_for_windows_binary` are unchanged.

## Diff
```diff
 def is_wsl_host() -> bool:
     """True when this process is running inside a WSL (1 or 2) Linux environment.
 
     This is a NARROWER check than "any Linux box" -- it only adds the "genuinely WSL" signal on
     top of the `sys.platform.startswith("linux")` gate already applied by callers, so a
     `.exe`-suffixed path used by an unrelated fixture on a bare Linux CI runner (no WSL) is never
     misread as a real WSL path-domain mismatch. `WSL_DISTRO_NAME`/`WSL_INTEROP` are set by WSL
     itself in every real WSL session and are the standard, filesystem-read-free way to detect it;
     `/run/WSL` (also used by `core.hardware.device_detect`) is the fallback for a stripped
-    subprocess environment that dropped those variables.
+    subprocess environment that dropped those variables. `/proc/version` containing "microsoft"
+    (case-insensitive) is the canonical fallback for a fully stripped environment where a wrapper
+    or service dropped both env vars AND has no `/run/WSL` -- every WSL1/WSL2 kernel stamps this
+    string (e.g. "Linux version 6.6.87.2-microsoft-standard-WSL2"), and no non-WSL Linux kernel
+    does, so this signal is safe and cannot false-positive. The read is wrapped fail-closed:
+    any OSError (missing file, permission denied, etc.) is treated as "not WSL" rather than
+    raising.
     """
     if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
         return True
-    return os.path.exists("/run/WSL")
+    if os.path.exists("/run/WSL"):
+        return True
+    try:
+        with open("/proc/version", encoding="utf-8", errors="replace") as fh:
+            return "microsoft" in fh.read().lower()
+    except OSError:
+        return False
```
Plus 3 new cases added to `TestIsWslHost` in `tests/unit/test_runtime_paths.py` (mocking `builtins.open`, never touching a real filesystem):
1. `test_true_via_proc_version_when_env_and_run_wsl_both_stripped` — the new case, currently `False` on `main`.
2. `test_false_on_plain_linux_without_any_wsl_signal` — extended to mock a bare-Linux `/proc/version` (no "microsoft") to keep the negative case deterministic.
3. `test_false_when_proc_version_unreadable` — `/proc/version` open raises `FileNotFoundError` -> fails closed to `False`, never raises.

The 3 pre-existing cases (env vars set; `/run/WSL` present) are untouched and still pass, proving no regression.

## Test plan
- [x] `uv sync --extra dev` (cargo 1.96.0 on PATH)
- [x] `uv run python -m pytest tests/unit/test_runtime_paths.py -x -q` -> **51 passed, 1 skipped** (skip = real-`wslpath` smoke test, Windows host has no `wslpath`)
- [x] `uv run ruff check src/tensor_grep/cli/runtime_paths.py tests/unit/test_runtime_paths.py` -> All checks passed
- [x] `uv run ruff format --check --preview src/tensor_grep/cli/runtime_paths.py tests/unit/test_runtime_paths.py` -> 2 files already formatted
- [x] `uv run mypy src/tensor_grep` (full package, matches CI's `mypy` step) -> Success: no issues found in 80 source files
- [x] Whole-repo `ruff check .` -> All checks passed. Whole-repo `ruff format --check --preview .` -> 1 pre-existing, **unrelated** finding in `docs/architecture.md` (markdown code-fence formatting drift from an earlier merged commit, not touched by this PR)
- [x] Full `tests/unit` suite with `dev,ast` extras (CI parity for the `test-python` job) -> 3875 passed before an unrelated pre-existing failure in `test_retrieval_dense.py` (missing optional `model2vec` dep, gated behind the `semantic` extra, unrelated to this change) stopped the `-x` run; zero regressions attributable to this change
- [x] ASCII-only + LF verified on the staged git blobs directly (`git cat-file blob :<path>`, not `git show`, to avoid autocrlf smudge): 0 CRLF bytes, no non-ASCII bytes in either file

## Flag for reviewers
This touches the GPU/native-binary cross-domain detection surface (`is_wsl_host` feeds `is_cross_domain_native_binary`) — **needs the mandatory adversarial Opus gate** per this repo's change-control policy before merge.

Not merging this myself; opened as **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)