### PR TITLE
fix(gpu): detect WSL2 in device_detect via the same 3 signals as is_wsl_host (#187)

### DIFF
--- a/src/tensor_grep/core/hardware/device_detect.py
+++ b/src/tensor_grep/core/hardware/device_detect.py
@@ -10,6 +10,28 @@ class Platform(Enum):
     WSL2 = auto()
 
 
+def _running_under_wsl() -> bool:
+    """True when running inside WSL (1 or 2), using the same three signals as the canonical
+    ``cli.runtime_paths.is_wsl_host``.
+
+    The logic is duplicated here deliberately: ``core.hardware`` must not import from the ``cli``
+    layer, so a shared helper cannot live in ``runtime_paths``. ``WSL_DISTRO_NAME``/``WSL_INTEROP``
+    are set by every real WSL session; ``/run/WSL`` is the fallback for a stripped subprocess
+    environment that dropped those variables; and ``/proc/version`` containing "microsoft"
+    (case-insensitive) is the canonical fallback that every WSL1/WSL2 kernel stamps and no non-WSL
+    Linux kernel does. The file read is fail-closed -- any OSError is treated as "not WSL".
+    """
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    if os.path.exists("/run/WSL"):
+        return True
+    try:
+        with open("/proc/version", encoding="utf-8", errors="replace") as fh:
+            return "microsoft" in fh.read().lower()
+    except OSError:
+        return False
+
+
 @dataclass(frozen=True)
 class DeviceInfo:
     device_id: int
@@ -275,7 +297,7 @@ class DeviceDetector:
         if sys.platform == "win32":
             return Platform.WINDOWS
         elif sys.platform.startswith("linux"):
-            if os.path.exists("/run/WSL"):
+            if _running_under_wsl():
                 return Platform.WSL2
             return Platform.LINUX
         return Platform.LINUX

--- a/tests/unit/test_device_detect.py
+++ b/tests/unit/test_device_detect.py
@@ -332,4 +332,6 @@ class TestDeviceDetect:
                     stack.enter_context(patch("builtins.open", side_effect=OSError))
                 else:
                     stack.enter_context(patch("builtins.open", mock_open(read_data=proc_version)))
-                assert _running_under_wsl() == is_wsl_host(), f"WSL-detection drift in case {name!r}"
+                assert _running_under_wsl() == is_wsl_host(), (
+                    f"WSL-detection drift in case {name!r}"
+                )

--- a/tests/unit/test_device_detect.py
+++ b/tests/unit/test_device_detect.py
@@ -1,6 +1,11 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
-from tensor_grep.core.hardware.device_detect import DeviceDetector, DeviceInfo, Platform
+from tensor_grep.core.hardware.device_detect import (
+    DeviceDetector,
+    DeviceInfo,
+    Platform,
+    _running_under_wsl,
+)
 
 
 class TestDeviceDetect:
@@ -228,17 +233,17 @@ class TestDeviceDetect:
         assert detector.has_gds() is True
 
     @patch("tensor_grep.core.hardware.device_detect.sys")
-    @patch("os.path.exists")
-    def test_should_detect_platform(self, mock_exists, mock_sys):
-        # Test Linux
+    @patch("tensor_grep.core.hardware.device_detect._running_under_wsl")
+    def test_should_detect_platform(self, mock_wsl, mock_sys):
+        # Test Linux (not WSL)
         mock_sys.platform = "linux"
-        mock_exists.return_value = False
+        mock_wsl.return_value = False
         detector = DeviceDetector()
         assert detector.get_platform() == Platform.LINUX
 
         # Test WSL2
         mock_sys.platform = "linux"
-        mock_exists.return_value = True
+        mock_wsl.return_value = True
         detector = DeviceDetector()
         assert detector.get_platform() == Platform.WSL2
 
@@ -246,3 +251,59 @@ class TestDeviceDetect:
         mock_sys.platform = "win32"
         detector = DeviceDetector()
         assert detector.get_platform() == Platform.WINDOWS
+
+    @patch("tensor_grep.core.hardware.device_detect.sys")
+    def test_get_platform_wsl2_via_proc_version_when_env_stripped(self, mock_sys):
+        # Regression: a stripped-environment WSL2 host (WSL_DISTRO_NAME/WSL_INTEROP dropped and
+        # no /run/WSL) was mis-reported as Platform.LINUX because get_platform only checked
+        # /run/WSL. It now consults /proc/version, matching cli.runtime_paths.is_wsl_host (#615).
+        mock_sys.platform = "linux"
+        proc_version = "Linux version 6.6.87.2-microsoft-standard-WSL2 (root@build) #1 SMP\n"
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("os.path.exists", return_value=False),
+            patch("builtins.open", mock_open(read_data=proc_version)),
+        ):
+            assert DeviceDetector().get_platform() == Platform.WSL2
+
+    def test_running_under_wsl_detects_env_signal(self):
+        with (
+            patch.dict("os.environ", {"WSL_DISTRO_NAME": "Ubuntu"}, clear=True),
+            patch("os.path.exists", return_value=False),
+        ):
+            assert _running_under_wsl() is True
+
+    def test_running_under_wsl_detects_run_wsl_marker(self):
+        # env stripped of WSL vars, but /run/WSL present (the fallback signal)
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("os.path.exists", return_value=True),
+        ):
+            assert _running_under_wsl() is True
+
+    def test_running_under_wsl_detects_proc_version_microsoft(self):
+        # env stripped AND no /run/WSL: fall back to the /proc/version kernel stamp
+        proc_version = "Linux version 6.6.87.2-microsoft-standard-WSL2 (root@build) #1 SMP\n"
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("os.path.exists", return_value=False),
+            patch("builtins.open", mock_open(read_data=proc_version)),
+        ):
+            assert _running_under_wsl() is True
+
+    def test_running_under_wsl_false_on_plain_linux(self):
+        proc_version = "Linux version 6.8.0-45-generic (buildd@lcy02) #45-Ubuntu SMP\n"
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("os.path.exists", return_value=False),
+            patch("builtins.open", mock_open(read_data=proc_version)),
+        ):
+            assert _running_under_wsl() is False
+
+    def test_running_under_wsl_fails_closed_when_proc_version_unreadable(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("os.path.exists", return_value=False),
+            patch("builtins.open", side_effect=OSError("no /proc/version")),
+        ):
+            assert _running_under_wsl() is False

--- a/tests/unit/test_device_detect.py
+++ b/tests/unit/test_device_detect.py
@@ -307,3 +307,29 @@ class TestDeviceDetect:
             patch("builtins.open", side_effect=OSError("no /proc/version")),
         ):
             assert _running_under_wsl() is False
+
+    def test_running_under_wsl_matches_is_wsl_host(self):
+        # `_running_under_wsl` is a deliberate copy of `cli.runtime_paths.is_wsl_host`
+        # (core.hardware must not import the cli layer). Pin the two equal across every
+        # signal so a future hardening of one (e.g. #615 added /proc/version) cannot
+        # silently drift from the other.
+        from contextlib import ExitStack
+
+        from tensor_grep.cli.runtime_paths import is_wsl_host
+
+        cases = [
+            ("env_signal", {"WSL_INTEROP": "/run/WSL/x_interop"}, False, None),
+            ("run_wsl_marker", {}, True, None),
+            ("proc_microsoft", {}, False, "Linux version 6.6.87.2-microsoft-standard-WSL2\n"),
+            ("plain_linux", {}, False, "Linux version 6.8.0-45-generic #45-Ubuntu\n"),
+            ("proc_unreadable", {}, False, None),
+        ]
+        for name, env, run_wsl_exists, proc_version in cases:
+            with ExitStack() as stack:
+                stack.enter_context(patch.dict("os.environ", env, clear=True))
+                stack.enter_context(patch("os.path.exists", return_value=run_wsl_exists))
+                if proc_version is None:
+                    stack.enter_context(patch("builtins.open", side_effect=OSError))
+                else:
+                    stack.enter_context(patch("builtins.open", mock_open(read_data=proc_version)))
+                assert _running_under_wsl() == is_wsl_host(), f"WSL-detection drift in case {name!r}"


### PR DESCRIPTION
## What

`DeviceDetector.get_platform()` (`core/hardware/device_detect.py`) detected WSL2 **only** via `os.path.exists("/run/WSL")` -- the same limited check #615 hardened in `cli.runtime_paths.is_wsl_host`. So a **stripped-environment WSL2 host** (WSL_DISTRO_NAME/WSL_INTEROP dropped, no `/run/WSL`) was mis-classified as `Platform.LINUX`.

**Impact (reporting honesty, no behavior bug):** `get_platform()` is consumed at `core/hardware/device_inventory.py:63` as `get_platform().name.lower()` -> the `platform` field of the GPU device-inventory report. So `tg devices` reported `platform: "linux"` on a stripped-env WSL host -- the same WSL/GPU-honesty theme as #612/#615.

## Fix

Add a module-private `_running_under_wsl()` mirroring `is_wsl_host`'s 3 signals (`WSL_DISTRO_NAME`/`WSL_INTEROP` -> `/run/WSL` -> `/proc/version` "microsoft", fail-closed on OSError). **Duplicated, not imported** -- `core.hardware` must not depend on the `cli` layer (a shared helper would be the wrong direction). `Platform.WSL2`/`LINUX` have **no control-flow consumer** (grep-confirmed: only read for the report string), so broadening WSL2 detection is strictly more-accurate and cannot regress a code path.

## Verification
- **RED->GREEN:** a `/proc/version`-only WSL host now returns `WSL2` (was `LINUX`).
- Full `test_device_detect.py`: 21 passed. Adds an end-to-end regression test + per-signal coverage for the helper.
- `ruff format --check --preview` + `ruff check` clean.

Adversarial Opus review requested (GPU/hardware surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)