### PR TITLE
fix(importers): resolve directory-index imports (require('./router') -> router/index.js) (#188)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7427,10 +7427,11 @@ def _source_tokens(source_files: list[str]) -> set[str]:
 
 
 # Directory-index reverse-importers fix (tg importers correctness gap, express@4.21.1 dogfood):
-# these are the same "magic" directory-index/package-init stems `_definition_module_parts`
-# (:3200) already strips for BARE/absolute specifier matching -- MINUS "mod" (Rust `mod.rs`),
-# which is a real analogous gap but outside this fix's scope (JS/TS `index` + the Python
-# `__init__` case the fix asks to check symmetrically; do not scope-creep to Rust here).
+# the "magic" directory-index/package-init stems `_definition_module_parts` (:3200) already
+# strips for BARE/absolute specifier matching. Rust `mod.rs` is deliberately EXCLUDED for two
+# reasons: SCOPE (the reported gap is JS/TS `index` + the symmetric Python `__init__`) AND
+# PRECISION -- adding "mod" would extend the accepted bare-specifier false-positive surface
+# documented on `_reverse_importer_extra_aliases` (below) to Rust as well.
 _DIRECTORY_INDEX_STEMS = frozenset({"index", "__init__"})
 
 
@@ -7441,6 +7442,15 @@ def _module_aliases_for_path(path: str) -> frozenset[str]:
     # ~unique-file inputs on a depth-2 blast-radius), so memoization collapses it to one build
     # per distinct path. frozenset return keeps the cached value immutable (all callers iterate
     # it or .update() FROM it; none mutate it).
+    #
+    # DELIBERATELY does NOT emit a directory-index file's PARENT-DIR alias -- that lives in the
+    # reverse-importers-ONLY `_reverse_importer_extra_aliases` (below). This helper is SHARED by
+    # substring/exact RANKING (`_import_graph_bonus`, `_test_import_bonus`, `_test_graph_score`)
+    # and by BLAST-RADIUS scope expansion (set-intersection ~:11542) + the test-coverage gate
+    # (substring match ~:16732). Giving a top-level `pkg/__init__.py` a bare "pkg" alias HERE
+    # would make editing that (often empty) init pull most of the repo into `tg blast-radius`
+    # and mark nearly every test covered (adversarial-review finding, 2026-07-16). Keep it
+    # byte-stable for those consumers; widen only the reverse-importers prefilter.
     current = Path(path)
     aliases = {current.stem.lower()}
     parts = [part.lower() for part in current.with_suffix("").parts]
@@ -7448,29 +7458,47 @@ def _module_aliases_for_path(path: str) -> frozenset[str]:
         aliases.add(".".join(parts))
     if len(parts) > 1:
         aliases.add(".".join(parts[-2:]))
-        # Directory-index recall fix: a bare relative specifier that names a DIRECTORY --
-        # `require('./router')`/`import ... from './router'` (JS/TS) or `from . import router`
-        # where `router` is a subpackage (Python) -- resolves, by Node's/Python's own directory-
-        # index convention, to `router/index.{js,ts,mjs,cjs}` or `router/__init__.py`. That bare
-        # specifier's normalized alias is just the DIRECTORY name ("router"), which never
-        # appeared above -- every alias built so far is anchored on the file's OWN stem
-        # ("index"/"__init__"), never its PARENT directory name. Without this, a directory-index
-        # importer never enters the coarse alias PREFILTER (`_reverse_importers`) as a
-        # candidate for the index/init file, so it never reaches the precise per-candidate
-        # CONFIRM step (`_js_ts_module_matches_definition`/`_python_module_matches_definition`)
-        # that would otherwise resolve it correctly -- that step already mirrors Node's
-        # file-then-index resolution order (`_js_ts_candidate_files`) and already handles Python
-        # packages (`_python_module_candidates`); the gap was purely in this prefilter never
-        # nominating the candidate in the first place. Adding the parent-dir alias only WIDENS
-        # the prefilter's candidate set (the same over-count-then-confirm pattern
-        # `_python_imports_and_symbols`'s `from . import X` fix already established, :1841) --
-        # the CONFIRM step still requires an exact resolved-path match, so this cannot by itself
-        # create a false-positive edge (e.g. `require('./routerX')` normalizes to alias
-        # "routerx", never "router" -- see test_build_file_importers_directory_index_rejects_
-        # prefix_false_match).
-        if current.stem.lower() in _DIRECTORY_INDEX_STEMS:
-            aliases.add(parts[-2])
     return frozenset(alias for alias in aliases if alias)
+
+
+@lru_cache(maxsize=16384)
+def _reverse_importer_extra_aliases(path: str) -> frozenset[str]:
+    """Extra alias a DIRECTORY-INDEX file earns ONLY for the reverse-importers candidate
+    prefilter (`_reverse_importers`) -- deliberately NOT folded into the SHARED
+    `_module_aliases_for_path` (see its note for why that helper must stay byte-stable).
+
+    A bare relative specifier that names a DIRECTORY -- `require('./router')` /
+    `import ... from './router'` (JS/TS) or `from . import router` where `router` is a subpackage
+    (Python) -- resolves, by Node's/Python's own directory-index convention, to
+    `router/index.{js,ts,mjs,cjs}` or `router/__init__.py`. That specifier normalizes to the
+    PARENT DIRECTORY name ("router"), which `_module_aliases_for_path` never emits (every alias
+    it builds is anchored on the file's OWN stem -- "index"/"__init__" -- never its parent dir).
+    Without this alias the directory-index importer never enters the coarse prefilter as a
+    candidate, so it never reaches the precise per-candidate CONFIRM step
+    (`_js_ts_module_matches_definition` / `_python_module_matches_definition`).
+
+    PRECISION -- this alias WIDENS the prefilter; it is NOT a proof of an edge (the CONFIRM step
+    still gates every candidate, and every `_reverse_importers` consumer either confirms edges
+    (`tg importers`) or feeds PageRank SCORING, never raw membership). For a RELATIVE specifier
+    the confirm resolves the exact path, so `./router` -> a real `router/index.js` is an exact
+    edge and `./routerX` is rejected. For a BARE (non-relative) specifier the JS/TS confirm falls
+    through to `_module_path_matches_definition` (:3214) -- a path-SUFFIX compare that itself
+    strips the index/__init__ magic name -- so a bare npm-style `import X from 'react'` WILL
+    match a local `src/react/index.ts` at the pre-existing 0.2 "partial-resolution" confidence.
+    That is INTENTIONAL (correct in pnpm/yarn workspace monorepos where `react` is a real local
+    package dir; a deliberate false-positive only for the rare npm-package-name-vs-local-dir
+    collision) and is exactly the existing bare-suffix heuristic this alias feeds -- NOT a new
+    exactness claim. Pinned by
+    test_build_file_importers_bare_specifier_matches_local_directory_index_package.
+    """
+    current = Path(path)
+    if current.stem.lower() not in _DIRECTORY_INDEX_STEMS:
+        return frozenset()
+    parts = [part.lower() for part in current.with_suffix("").parts]
+    if len(parts) < 2:
+        return frozenset()
+    parent = parts[-2]
+    return frozenset({parent}) if parent else frozenset()
 
 
 def _import_alias_candidates(import_name: str) -> set[str]:
@@ -7538,13 +7566,29 @@ def _reverse_importers(
     all_files: list[str],
     imports_by_file: dict[str, list[str]],
     *,
+    include_directory_index_aliases: bool = False,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, set[str]]:
+    # `include_directory_index_aliases` is opt-in and defaults OFF so this function stays
+    # byte-behaviour-identical to origin/main for its RANKING consumers -- the blast-radius
+    # (:16587) and context/agent-capsule (:3836) callers feed its output into
+    # `_personalized_reverse_import_pagerank` (a SCORING signal), and even a widened reverse edge
+    # there measurably reorders pinned `dependent_files` output
+    # (test_python_termui_symbols_prefer_depth_one_dependents). ONLY the `tg importers`
+    # reverse-resolution (`build_file_importers_from_map`) passes True, because ONLY it runs the
+    # per-candidate CONFIRM step (`_confirm_import_edges`) that turns the widened prefilter back
+    # into exact edges. See `_reverse_importer_extra_aliases` for the alias rationale.
     with _profiling_phase(_profiling_collector, "graph_construction"):
         alias_to_files: dict[str, set[str]] = {}
         for current in all_files:
             for alias in _module_aliases_for_path(current):
                 alias_to_files.setdefault(alias, set()).add(current)
+            if include_directory_index_aliases:
+                # Directory-index recall (express@4.21.1 dogfood): also nominate a directory's
+                # `index.*`/`__init__.py` under its PARENT-DIR alias, so a bare relative specifier
+                # (`require('./router')` / `from . import router`) reaches the CONFIRM step.
+                for alias in _reverse_importer_extra_aliases(current):
+                    alias_to_files.setdefault(alias, set()).add(current)
         reverse: dict[str, set[str]] = {current: set() for current in all_files}
         for importer in all_files:
             for import_name in imports_by_file.get(importer, []):
@@ -15622,7 +15666,15 @@ def build_file_importers_from_map(
         )
         for current in repo_map.get("imports", [])
     }
-    reverse_map = _reverse_importers(all_files, imports_by_file)
+    # `include_directory_index_aliases=True`: `tg importers` is the ONE reverse consumer that
+    # runs the per-candidate CONFIRM step below (`_confirm_import_edges`), so it is the only one
+    # that may safely widen the prefilter with directory-index parent-dir aliases (a bare
+    # `require('./router')` importer of `router/index.js`). The blast-radius / context callers of
+    # `_reverse_importers` leave this OFF -- they feed its output into PageRank scoring with no
+    # confirm step, and widening it there reorders pinned output (see the note on that function).
+    reverse_map = _reverse_importers(
+        all_files, imports_by_file, include_directory_index_aliases=True
+    )
     prefiltered = sorted(reverse_map.get(target_file, set()))
 
     ceiling_hit = len(prefiltered) > CALLER_SCAN_FILE_CEILING

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7426,6 +7426,14 @@ def _source_tokens(source_files: list[str]) -> set[str]:
     return tokens
 
 
+# Directory-index reverse-importers fix (tg importers correctness gap, express@4.21.1 dogfood):
+# these are the same "magic" directory-index/package-init stems `_definition_module_parts`
+# (:3200) already strips for BARE/absolute specifier matching -- MINUS "mod" (Rust `mod.rs`),
+# which is a real analogous gap but outside this fix's scope (JS/TS `index` + the Python
+# `__init__` case the fix asks to check symmetrically; do not scope-creep to Rust here).
+_DIRECTORY_INDEX_STEMS = frozenset({"index", "__init__"})
+
+
 @lru_cache(maxsize=16384)
 def _module_aliases_for_path(path: str) -> frozenset[str]:
     # Pure function of the path STRING (no file I/O) — safe to cache unconditionally, no mtime
@@ -7440,6 +7448,28 @@ def _module_aliases_for_path(path: str) -> frozenset[str]:
         aliases.add(".".join(parts))
     if len(parts) > 1:
         aliases.add(".".join(parts[-2:]))
+        # Directory-index recall fix: a bare relative specifier that names a DIRECTORY --
+        # `require('./router')`/`import ... from './router'` (JS/TS) or `from . import router`
+        # where `router` is a subpackage (Python) -- resolves, by Node's/Python's own directory-
+        # index convention, to `router/index.{js,ts,mjs,cjs}` or `router/__init__.py`. That bare
+        # specifier's normalized alias is just the DIRECTORY name ("router"), which never
+        # appeared above -- every alias built so far is anchored on the file's OWN stem
+        # ("index"/"__init__"), never its PARENT directory name. Without this, a directory-index
+        # importer never enters the coarse alias PREFILTER (`_reverse_importers`) as a
+        # candidate for the index/init file, so it never reaches the precise per-candidate
+        # CONFIRM step (`_js_ts_module_matches_definition`/`_python_module_matches_definition`)
+        # that would otherwise resolve it correctly -- that step already mirrors Node's
+        # file-then-index resolution order (`_js_ts_candidate_files`) and already handles Python
+        # packages (`_python_module_candidates`); the gap was purely in this prefilter never
+        # nominating the candidate in the first place. Adding the parent-dir alias only WIDENS
+        # the prefilter's candidate set (the same over-count-then-confirm pattern
+        # `_python_imports_and_symbols`'s `from . import X` fix already established, :1841) --
+        # the CONFIRM step still requires an exact resolved-path match, so this cannot by itself
+        # create a false-positive edge (e.g. `require('./routerX')` normalizes to alias
+        # "routerx", never "router" -- see test_build_file_importers_directory_index_rejects_
+        # prefix_false_match).
+        if current.stem.lower() in _DIRECTORY_INDEX_STEMS:
+            aliases.add(parts[-2])
     return frozenset(alias for alias in aliases if alias)
 
 

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -536,6 +536,39 @@ def test_build_file_importers_directory_index_no_double_count_two_specifier_form
     assert lines == [1, 2]
 
 
+def test_build_file_importers_bare_specifier_matches_local_directory_index_package(
+    tmp_path: Path,
+) -> None:
+    """DOCUMENTED accepted-heuristic behavior (adversarial-review finding A, 2026-07-16): the
+    directory-index parent-dir alias also lets a BARE (non-relative) specifier that happens to
+    match a LOCAL directory's name be reported as an importer -- `import { x } from 'react'` when
+    the repo has `src/react/index.ts`. The reverse CONFIRM step's bare-specifier arm
+    (`_module_path_matches_definition`) is a path-SUFFIX compare that strips the index magic name,
+    so this matches at the pre-existing low "partial-resolution" confidence.
+
+    This is CORRECT in pnpm/yarn workspace monorepos (where `react` is a real local package dir)
+    and a deliberate false-positive for the rare npm-package-name-vs-local-dir collision -- NOT an
+    exact edge. Pinned so the behavior is INTENTIONAL and reviewed, not a silent surprise. (The
+    parent-dir alias is confined to the reverse-importers prefilter, so this heuristic does NOT
+    leak into ranking or blast-radius -- see the confinement + non-inflation tests below.)"""
+    project = tmp_path / "project"
+    react_dir = project / "src" / "react"
+    react_dir.mkdir(parents=True)
+    target = react_dir / "index.ts"
+    target.write_text("export const x = 1;\n", encoding="utf-8")
+    consumer = project / "src" / "app.ts"
+    consumer.write_text("import { x } from 'react';\n", encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    # The bare specifier IS reported (the accepted workspace-monorepo heuristic).
+    assert str(consumer.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(consumer.resolve())
+    )
+    assert edge["module"] == "react"
+
+
 def test_build_file_importers_finds_tsconfig_alias_importer(tmp_path: Path) -> None:
     """Prefilter recall: a tsconfig path-alias importer must still be found (not just plain
     relative imports)."""
@@ -711,6 +744,72 @@ def test_build_file_importers_directory_index_python_rejects_prefix_false_match(
 
     assert str(decoy_consumer.resolve()) not in set(payload["importer_files"])
     assert payload["importer_count"] == 0
+
+
+# ---------------------------------------------------------------------------------------------
+# Shared-helper confinement (adversarial-review finding B, 2026-07-16): the directory-index
+# parent-dir alias must live ONLY in the reverse-importers prefilter, NOT in the SHARED
+# `_module_aliases_for_path` (which also feeds substring/exact ranking + blast-radius scope
+# expansion + the test-coverage gate). A top-level `pkg/__init__.py` gaining a bare "pkg" alias
+# in the shared helper would make editing that (often empty) init pull most of the repo into
+# `tg blast-radius` and mark nearly every test covered.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_directory_index_parent_alias_confined_to_reverse_importers() -> None:
+    """The SHARED `_module_aliases_for_path` must NOT emit a directory-index file's parent-dir
+    (bare-package) alias; that alias lives ONLY in the reverse-importers-only helper."""
+    # Shared helper: byte-stable -- no bare parent-dir alias for either language's index file.
+    assert "pkg" not in repo_map._module_aliases_for_path("pkg/__init__.py")
+    assert "router" not in repo_map._module_aliases_for_path("lib/router/index.js")
+    # Confined helper: emits exactly the parent-dir alias, and only for index/__init__ stems.
+    assert repo_map._reverse_importer_extra_aliases("pkg/__init__.py") == frozenset({"pkg"})
+    assert repo_map._reverse_importer_extra_aliases("lib/router/index.js") == frozenset({"router"})
+    assert repo_map._reverse_importer_extra_aliases("lib/router/index.ts") == frozenset({"router"})
+    # A non-index file earns no extra alias (it already resolves by its own stem).
+    assert repo_map._reverse_importer_extra_aliases("lib/router/route.js") == frozenset()
+    assert repo_map._reverse_importer_extra_aliases("pkg/service.py") == frozenset()
+    # A bare top-level index with no parent directory earns nothing (no parent to alias).
+    assert repo_map._reverse_importer_extra_aliases("index.js") == frozenset()
+
+
+def test_edit_plan_blast_radius_scope_not_inflated_by_top_level_init(tmp_path: Path) -> None:
+    """Finding B, at the EXACT flagged vector: `_scoped_repo_map_for_edit_plan_blast_radius` (the
+    `tg edit-plan` blast-radius scoping) expands scope by intersecting each selected file's
+    `_module_aliases_for_path` with importers' alias candidates
+    (`definition_aliases & imported_aliases`). A top-level `pkg/__init__.py` must NOT alias to
+    bare "pkg" in that shared helper, or EDITING it would drag every unrelated `import pkg.*` file
+    into the edit-plan radius (the gate's worst case). With the parent-dir alias confined to the
+    reverse-importers prefilter, the shared helper stays byte-stable and the scope does not
+    inflate. RED on the first fix (which put "pkg" in `_module_aliases_for_path`)."""
+    root = tmp_path / "repo"
+    init_file = str(root / "pkg" / "__init__.py")
+    service = str(root / "pkg" / "service.py")
+    other = str(root / "pkg" / "other.py")
+    helpers = str(root / "pkg" / "helpers.py")
+    map_data = {
+        "path": str(root),
+        "files": [init_file, service, other, helpers],
+        "symbols": [{"name": "top_level_init_symbol", "file": init_file, "kind": "function"}],
+        # service.py / other.py import a DIFFERENT submodule of the package, never the init symbol.
+        "imports": [
+            {"file": service, "imports": ["pkg.helpers"]},
+            {"file": other, "imports": ["pkg.helpers"]},
+        ],
+        "tests": [],
+    }
+    payload = {"files": [init_file], "tests": []}
+
+    scoped = repo_map._scoped_repo_map_for_edit_plan_blast_radius(
+        map_data, payload, "top_level_init_symbol", max_files=5
+    )
+
+    scoped_files = set(scoped["files"])
+    assert init_file in scoped_files  # the edited file itself is always in scope
+    # The unrelated `import pkg.helpers` files must NOT be scope-expanded into the radius.
+    assert service not in scoped_files
+    assert other not in scoped_files
+    assert scoped["edit_plan_blast_radius_scope"]["scoped_file_count"] == 1
 
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -420,6 +420,122 @@ def test_build_file_importers_confirms_real_importer_and_excludes_precision_trap
     assert edge["kind"] == "import-consumer"
 
 
+# ---------------------------------------------------------------------------------------------
+# Reverse directory-index recall (express@4.21.1 dogfood bug): a bare relative specifier that
+# names a DIRECTORY -- `require('./router')` -- resolves, by Node's own directory-index
+# convention, to `router/index.js` (the forward `tg imports` side already proves this via
+# test_build_file_imports_resolves_require_via_index_probe above). The reverse side used to miss
+# it entirely: the coarse alias PREFILTER (`_reverse_importers`, built from
+# `_module_aliases_for_path`) never gave `router/index.js` a "router" alias -- every alias it
+# generated was anchored on the file's OWN stem ("index"), never its PARENT directory name -- so
+# a bare-specifier importer never became a prefilter CANDIDATE and never reached the precise
+# per-candidate CONFIRM step (`_js_ts_module_matches_definition`) that would have resolved it
+# correctly. `tg importers lib/router/index.js` on express@4.21.1 returned `importer_count: 0`
+# despite `lib/application.js`/`lib/express.js` both doing `require('./router')`.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_importers_finds_directory_index_bare_require_specifier(
+    tmp_path: Path,
+) -> None:
+    """The express@4.21.1 repro: `require('./router')` must be a confirmed importer of
+    `router/index.js`, not just an unresolved/invisible reference."""
+    project = tmp_path / "project"
+    router_dir = project / "lib" / "router"
+    router_dir.mkdir(parents=True)
+    target = router_dir / "index.js"
+    target.write_text("module.exports = {};\n", encoding="utf-8")
+    consumer = project / "lib" / "app.js"
+    consumer.write_text('var Router = require("./router");\n', encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    importer_files = set(payload["importer_files"])
+    assert str(consumer.resolve()) in importer_files
+    assert payload["importer_count"] == 1
+    edge = payload["importers"][0]
+    assert edge["file"] == str(consumer.resolve())
+    assert edge["line"] == 1
+    assert edge["module"] == "./router"
+    assert edge["edge_kind"] == "reverse-import"
+
+
+def test_build_file_importers_finds_directory_index_bare_esm_import_specifier(
+    tmp_path: Path,
+) -> None:
+    """Same directory-index gap, ESM form (`import Router from './router'`) -- the bug report's
+    alternate phrasing; proves the fix is not require()-specific."""
+    project = tmp_path / "project"
+    router_dir = project / "lib" / "router"
+    router_dir.mkdir(parents=True)
+    target = router_dir / "index.js"
+    target.write_text("export default {};\n", encoding="utf-8")
+    consumer = project / "lib" / "app.js"
+    consumer.write_text('import Router from "./router";\n', encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(consumer.resolve()) in set(payload["importer_files"])
+
+
+def test_build_file_importers_directory_index_rejects_prefix_false_match(
+    tmp_path: Path,
+) -> None:
+    """Guardrail: `require('./routerX')` must NOT be counted as an importer of
+    `router/index.js` -- the new parent-directory alias ("router") must not substring/prefix-
+    match a sibling directory/file whose name merely starts with the same characters
+    ("routerX" normalizes to "routerx", never "router")."""
+    project = tmp_path / "project"
+    lib_dir = project / "lib"
+    router_dir = lib_dir / "router"
+    router_dir.mkdir(parents=True)
+    target = router_dir / "index.js"
+    target.write_text("module.exports = {};\n", encoding="utf-8")
+
+    # A REAL, distinct decoy file one character away from the directory name.
+    decoy = lib_dir / "routerX.js"
+    decoy.write_text("module.exports = { decoy: true };\n", encoding="utf-8")
+    decoy_consumer = lib_dir / "appx.js"
+    decoy_consumer.write_text('var RouterX = require("./routerX");\n', encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(decoy_consumer.resolve()) not in set(payload["importer_files"])
+    assert payload["importer_count"] == 0
+
+    # Sanity: the decoy importer's OWN forward resolution still correctly targets routerX.js,
+    # not router/index.js -- proving this is a genuine two-different-targets negative, not an
+    # accidental "nothing resolves" false negative.
+    decoy_imports = repo_map.build_file_imports(decoy_consumer)
+    assert decoy_imports["imports"][0]["resolved"] == str(decoy.resolve())
+
+
+def test_build_file_importers_directory_index_no_double_count_two_specifier_forms(
+    tmp_path: Path,
+) -> None:
+    """Guardrail: a single file that imports the SAME directory two different ways (bare
+    `require('./router')` and explicit `require('./router/index')`) must be counted once in
+    `importer_files` and produce exactly one edge PER real statement (2), never deduplicated to
+    fewer or multiplied by cross-matching aliases to more."""
+    project = tmp_path / "project"
+    router_dir = project / "lib" / "router"
+    router_dir.mkdir(parents=True)
+    target = router_dir / "index.js"
+    target.write_text("module.exports = {};\n", encoding="utf-8")
+    consumer = project / "lib" / "app.js"
+    consumer.write_text(
+        'var Router = require("./router");\nvar RouterAgain = require("./router/index");\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert payload["importer_files"] == [str(consumer.resolve())]
+    assert payload["importer_count"] == 2
+    lines = sorted(int(edge["line"]) for edge in payload["importers"])
+    assert lines == [1, 2]
+
+
 def test_build_file_importers_finds_tsconfig_alias_importer(tmp_path: Path) -> None:
     """Prefilter recall: a tsconfig path-alias importer must still be found (not just plain
     relative imports)."""
@@ -544,6 +660,57 @@ def test_build_file_importers_python_dotted_import_precision(tmp_path: Path) -> 
 
     assert str(consumer.resolve()) in set(app_payload["importer_files"])
     assert str(consumer.resolve()) not in set(tools_payload["importer_files"])
+
+
+def test_build_file_importers_finds_directory_index_python_package_bare_from_import(
+    tmp_path: Path,
+) -> None:
+    """Python symmetric case of the express directory-index bug: `from . import router` where
+    `router` is a SUBPACKAGE (`router/__init__.py`), not a plain sibling module. The reverse
+    alias prefilter must give the package's `__init__.py` a "router" alias (its parent directory
+    name), the same way it now does for JS/TS `index.js` -- `_module_aliases_for_path` backs
+    both languages' reverse prefilter identically."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    router_pkg = pkg / "router"
+    router_pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = router_pkg / "__init__.py"
+    target.write_text("class Router:\n    pass\n", encoding="utf-8")
+    consumer = pkg / "main.py"
+    consumer.write_text("from . import router\n", encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(consumer.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(consumer.resolve())
+    )
+    assert edge["module"] == "router"
+    assert edge["line"] == 1
+
+
+def test_build_file_importers_directory_index_python_rejects_prefix_false_match(
+    tmp_path: Path,
+) -> None:
+    """Guardrail, Python side: `from . import routerX` (a real sibling MODULE, not the
+    `router` subpackage) must never be counted as an importer of `router/__init__.py`."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    router_pkg = pkg / "router"
+    router_pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = router_pkg / "__init__.py"
+    target.write_text("class Router:\n    pass\n", encoding="utf-8")
+
+    (pkg / "routerX.py").write_text("DECOY = True\n", encoding="utf-8")
+    decoy_consumer = pkg / "mainx.py"
+    decoy_consumer.write_text("from . import routerX\n", encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(decoy_consumer.resolve()) not in set(payload["importer_files"])
+    assert payload["importer_count"] == 0
 
 
 # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What
`tg importers <dir>/index.js` missed importers that reference the directory by its bare specifier — a file doing `require('./router')` (Node resolves to `lib/router/index.js`) was not found. A real correctness gap in a moat primitive, **surfaced by the #72 tokens-per-correct benchmark re-run** (it capped P4 recall for directory-index files).

## Fix (confined + adversarially gated)
Root cause: the reverse-importer candidate **prefilter** never aliased an `index.js`/`__init__.py` file by its parent directory name, so bare-specifier importers never became candidates for the (already-correct) per-candidate confirm step.

- New `_reverse_importer_extra_aliases()` adds the parent-dir alias **only for `tg importers`** (`build_file_importers_from_map`) — the one consumer with a per-candidate CONFIRM gate. The shared `_module_aliases_for_path` is left **byte-identical** to origin/main, so `tg blast-radius`, ranking, and context PageRank are provably untouched.
- Applied symmetrically to Python `__init__.py`; Rust `mod.rs` deliberately excluded (precision — avoids extending the bare-specifier heuristic surface).

## Gate + remediation
Adversarial Opus gate returned SHIP-WITH-NITS: (a) a comment overclaimed no false-positive was possible — softened + documented (a bare `import from 'react'` matching a local `src/react/index.ts` extends the pre-existing 0.2-confidence heuristic — correct in monorepos, a rare collision otherwise); (b) the original used the shared helper — now confined. The remediation also caught that the gate's *own* suggested confine (all `_reverse_importers` callers) still regressed a pinned blast-radius PageRank test, so it confined tighter to `tg importers` only.

## Verification
- Express corpus (real `tg`): `tg importers lib/router/index.js` importer_count **0 → 2**; `./router/route` correctly excluded (no over-match).
- New tests: confinement, blast-radius non-inflation on top-level `__init__.py` edit, bare-specifier behavior. 6 original RED→GREEN. 156 + 94 regression tests (importers/callers/blast-radius/context/edit-plan/agent-capsule) green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)