### PR TITLE
fix(gpu): honest calibrate/crossover messaging -- drop residual FLAVOR=nvidia dead-end (#612 gate NITs, #182)

### DIFF
--- a/rust_core/src/crossover.rs
+++ b/rust_core/src/crossover.rs
@@ -597,8 +597,14 @@ mod tests {
     // Mirror check for the cuda-enabled arm: it must keep its OWN, scenario-correct
     // remediation (a device/driver/config problem, not a "no GPU build" problem) and must
     // never regress to claim GPU is "not shipped in this build" when the build plainly HAS
-    // CUDA compiled in. Compile-checked only (no CUDA toolkit available to link/run this arm
-    // outside the release nvidia legs) -- mirrors the existing accepted gap above.
+    // CUDA compiled in. #182 NIT-2 (honest coverage): unlike the production fn -- which IS
+    // compile-checked via its real call site at :533 under `cargo check --features cuda` --
+    // this `#[cfg(feature = "cuda")]` TEST fn is compiled by NO CI job (`cuda-feature-check`
+    // runs `cargo check --features cuda` WITHOUT `--tests`, and `test-rust-core` is cuda-off),
+    // so it is neither run NOR compile-checked in CI today; it is checked only by a local
+    // `cargo test --features cuda`. Accepted gap: adding `--all-targets` to cuda-feature-check
+    // would compile-check it but risks surfacing pre-existing cuda test debt in
+    // main.rs/test_routing.rs -- deferred deliberately, not silently skipped.
     #[cfg(feature = "cuda")]
     #[test]
     fn crossover_gpu_remediation_hint_device_not_found_is_not_a_build_availability_claim() {

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -7726,17 +7726,20 @@ def calibrate() -> None:
         # release profile that builds one is held off) -- a permanent dead end dressed up as
         # honest advice. State the evergreen, structural fact instead (GPU needs a
         # CUDA-enabled build, which isn't present here) without claiming an upgrade will --or
-        # won't-- fetch one; `tg doctor` is the live way to check once a binary exists. This
+        # won't-- fetch one; `tg doctor` is the live way to check once a binary exists.
+        # #182 NIT-1: the v1.76.6 revision still name-dropped
+        # TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia in a "confirm before relying on" aside --
+        # dropped here so this Python wrapper matches the Rust side (crossover.rs), whose
+        # detect_device_name test forbids that override as an obtainable path. This
         # wrapper uses inherited stdio for the real `calibrate` subprocess below and must NOT
         # capture its stderr (that would break streaming), so only THIS wrapper-owned
         # missing-binary message gets touched; the native binary's own calibrate-failure
         # remediation is Rust-owned (crossover.rs) and follows the same discipline there.
         typer.echo(
             "Error: native tg binary not found for calibrate command.\n"
-            "Run 'tg upgrade' to install a native tg binary so calibrate can run. GPU (CUDA) "
-            "acceleration is experimental and is not available without a CUDA-enabled build; "
-            "run 'tg doctor' after upgrading to confirm this install's native flavor before "
-            "relying on TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia.",
+            "Run 'tg upgrade' to install the native tg binary that calibrate requires. GPU "
+            "(CUDA) acceleration is experimental and is not shipped in any current build; run "
+            "'tg doctor' after upgrading to check this install's native flavor.",
             err=True,
         )
         raise typer.Exit(1)

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -277,3 +277,8 @@ def test_l10_calibrate_exits_one_when_unsupported(monkeypatch) -> None:
     assert "experimental" in result.output
     assert "if one is published for this platform on the release page" not in result.output
     assert "NVIDIA-enabled native binary" not in result.output
+    # #182 NIT-1: the residual FLAVOR name-drop is dropped so this Python wrapper matches the
+    # Rust side (crossover.rs detect_device_name test), which forbids the override entirely.
+    # A "confirm before relying on TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia" aside dangled
+    # an override that no shipped asset honors -- the same permanent dead end, asymmetric.
+    assert "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR" not in result.output


### PR DESCRIPTION
Resolves the 3 non-blocking NITs from the SHIP-WITH-NITS Opus gate on #612 (GPU calibrate honesty), task #182. All text-only -- no logic, no control-flow, no CI-config change.

## NIT-1 (honesty-consistency) -- the real fix
The Python `calibrate()` no-binary message still name-dropped `TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia` in a "confirm before relying on" aside. That is **asymmetric** with the Rust side (`crossover.rs::detect_device_name`), whose RED->GREEN test explicitly **forbids** that override as an obtainable path -- because no nvidia-flavored asset has ever shipped (the release profile that builds one is held off). The aside dangled the same permanent dead end the #612 comment claimed it had removed.

- Dropped the `FLAVOR=nvidia` name-drop from the message.
- Added the symmetric assertion `assert "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR" not in result.output` -- RED on the shipped message, GREEN after.

## NIT-3 (wording)
`"...so calibrate can run"` -> `"...that calibrate requires"`. On a CPU-only box, calibrate still fails-closed **after** `tg upgrade` (the native binary itself exits non-zero without CUDA), so the old phrasing over-promised.

## NIT-2 (crossover.rs, comment-only)
The `#[cfg(feature = "cuda")]` mirror-**test** fn is compiled by **no CI job** -- `cuda-feature-check` runs `cargo check --features cuda` *without* `--tests`, and `test-rust-core` builds cuda-off. The old `"Compile-checked only"` comment overstated coverage. Corrected to state the real gap honestly: the **production fn** it guards IS compile-checked via its `:533` call site under `cargo check --features cuda`; only this assertion is uncovered. The comment also names why `--all-targets` is deferred (risks surfacing pre-existing cuda test debt in `main.rs`/`test_routing.rs`) -- deferred deliberately, not silently.

## Verification
- `test_l10_calibrate_exits_one_when_unsupported` GREEN (main venv, worktree src on PYTHONPATH).
- `ruff format --check --preview` + `ruff check` clean on both touched .py files.
- Rust change is comment-only inside `#[cfg(test)]` -- cannot alter compilation; CI `test-rust-core` + `cuda-feature-check` confirm.

Mandatory adversarial Opus gate run (GPU/native surface) before merge.
