### PR TITLE
refactor(reranker): extract rank_chunks shared fail-closed core (tg find Wave 2a, #189)

### DIFF
--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -214,6 +214,115 @@ def rerank_by_bm25(
     return dataclasses.replace(result, matches=reranked)
 
 
+def rank_chunks(
+    query: str,
+    chunks: list[Chunk],
+    *,
+    bm25_index: Bm25Index,
+    dense_index: DenseIndex | None,
+    late_reranker: LateReranker | None,
+    k: int = DEFAULT_K,
+) -> tuple[list[int], str | None]:
+    """Fuse BM25 [+ dense] [+ path] chunk rankings via RRF, then optionally MaxSim-rerank the head
+    via ``late_reranker`` -- the pure, fail-closed rank core shared by :func:`rerank_hybrid` and
+    (per the ``tg find`` plan, Wave 2a) any future caller needing the identical ordering. Extracted
+    byte-identically out of ``rerank_hybrid``: callers building their own ``bm25_index`` /
+    ``dense_index`` (and, for ``rerank_hybrid``, the corpus-cap chunking) are unaffected -- this
+    function only fuses and (optionally) late-reranks an already-built corpus.
+
+    Returns ``(fused_order, late_fallback_reason)``:
+
+    - ``fused_order``: chunk indices (into ``chunks``) in final rank order -- RRF-fused, then
+      MaxSim-reordered over its head when ``late_reranker`` is supplied and does not degrade.
+    - ``late_fallback_reason``: ``None`` unless the late-rerank stage degraded (the
+      ``TG_RERANK_BUDGET_MS`` wall-clock budget exceeded, or a recoverable
+      :class:`~tensor_grep.core.retrieval_late.LateRerankUnavailableError`). An UNRECOVERABLE
+      encode-time fault (anything else, including a ``BackendExecutionError`` or a
+      ``KeyboardInterrupt``/``SystemExit`` user-abort) is NOT caught here and propagates to the
+      caller, per the Backend Fail-Closed Contract.
+    """
+    total = max(1, len(chunks))
+    bm25_ranking = [chunk_idx for chunk_idx, _ in bm25_index.query(query, top_k=total)]
+    rankings: list[list[int]] = [bm25_ranking]
+    if dense_index is not None:
+        dense_ranking = [chunk_idx for chunk_idx, _ in dense_index.query(query, top_k=total)]
+        rankings.append(dense_ranking)
+
+    weights: list[float] | None = None
+    if _rrf_channels_enabled():
+        weights = [1.0] * len(rankings)
+        path_ranking = _path_channel_ranking(chunks, query)
+        if path_ranking:
+            rankings.append(path_ranking)
+            weights.append(PATH_CHANNEL_WEIGHT)
+
+    fused_order = reciprocal_rank_fusion(rankings, k=k, weights=weights)
+
+    # T5/T6: the late-interaction splice. Order-only over `fused_order`'s chunk indices -- same
+    # matches, same membership, same JSON shape (design doc "The seam"). `late_reranker=None`
+    # (the default) skips this block entirely: byte-identical to the pre-T5 fused order.
+    late_fallback_reason: str | None = None
+    if late_reranker is not None:
+        pool_k = max(
+            0, min(_int_env(_RERANK_POOL_K_ENV, _DEFAULT_RERANK_POOL_K), _MAX_RERANK_POOL_K)
+        )
+        budget_ms = _int_env(_RERANK_BUDGET_MS_ENV, _DEFAULT_RERANK_BUDGET_MS)
+        head = fused_order[:pool_k]
+        # Real wall-clock deadline (A3, external audit 2026-07-11): the previous post-hoc
+        # `elapsed > budget` check could only DISCARD a rerank that had already RETURNED -- a HUNG
+        # encoder (a wedged model, an infinite loop in the injected reranker) never returns, so
+        # `late_reranker.rerank` blocked `tg search --rank` indefinitely with no bound. Run it on a
+        # daemon thread and `join` on the budget: if it overruns, abandon the thread (it dies with
+        # this short-lived CLI process) and degrade. The Backend Fail-Closed Contract is PRESERVED
+        # across the thread boundary -- a LateRerankUnavailableError (recoverable) degrades to the
+        # plain RRF order; ANYTHING ELSE (a genuine BackendExecutionError encode fault, or a
+        # KeyboardInterrupt/SystemExit user-abort) is re-raised on this thread so it still
+        # propagates to the CLI boundary (cli/main.py ~:6804-6813), exactly as the synchronous
+        # version did. Capturing BaseException (not just Exception) is deliberate: it keeps a
+        # user-abort from being silently swallowed into an RRF degrade AND guarantees exactly one
+        # of the two result holders is populated when the worker finishes (so the `else` splice
+        # below can never IndexError on an empty result).
+        rerank_result: list[list[int]] = []
+        rerank_error: list[BaseException] = []
+
+        def _run_late_rerank() -> None:
+            try:
+                rerank_result.append(
+                    late_reranker.rerank(query, [chunks[i].text for i in head], head)
+                )
+            except (
+                BaseException
+            ) as exc:  # classified + re-raised (if non-recoverable) by the caller
+                rerank_error.append(exc)
+
+        worker = threading.Thread(target=_run_late_rerank, name="tg-late-rerank", daemon=True)
+        worker.start()
+        worker.join(timeout=budget_ms / 1000.0)
+
+        if worker.is_alive():
+            # Still running at the deadline (hung or merely too slow): do NOT wait -- abandon the
+            # daemon thread and degrade. This is the only branch that bounds a genuinely HUNG
+            # encoder; the old post-hoc check could never run for one.
+            late_fallback_reason = (
+                f"late rerank unavailable: budget exceeded (>{budget_ms}ms at pool_k={pool_k})"
+            )
+            sys.stderr.write(f"tg: {late_fallback_reason}\n")
+        elif rerank_error:
+            exc = rerank_error[0]
+            if isinstance(exc, LateRerankUnavailableError):
+                # RECOVERABLE (e.g. a malformed embedding shape): degrade, never crash.
+                late_fallback_reason = str(exc)
+                sys.stderr.write(f"tg: {late_fallback_reason}\n")
+            else:
+                # A genuine encode-time fault -> propagate (Backend Fail-Closed Contract): never
+                # silently degrade a real error into a plausible-but-wrong ranking.
+                raise exc
+        else:
+            fused_order = rerank_result[0] + fused_order[pool_k:]
+
+    return fused_order, late_fallback_reason
+
+
 def rerank_hybrid(
     result: SearchResult,
     query: str,
@@ -271,84 +380,14 @@ def rerank_hybrid(
         bm25_index = Bm25Index(chunks)
     chunks = bm25_index.chunks
 
-    total = max(1, len(chunks))
-    bm25_ranking = [chunk_idx for chunk_idx, _ in bm25_index.query(query, top_k=total)]
-    rankings: list[list[int]] = [bm25_ranking]
-    if dense_index is not None:
-        dense_ranking = [chunk_idx for chunk_idx, _ in dense_index.query(query, top_k=total)]
-        rankings.append(dense_ranking)
-
-    weights: list[float] | None = None
-    if _rrf_channels_enabled():
-        weights = [1.0] * len(rankings)
-        path_ranking = _path_channel_ranking(chunks, query)
-        if path_ranking:
-            rankings.append(path_ranking)
-            weights.append(PATH_CHANNEL_WEIGHT)
-
-    fused_order = reciprocal_rank_fusion(rankings, k=k, weights=weights)
-
-    # T5/T6: the late-interaction splice. Order-only over `fused_order`'s chunk indices -- same
-    # matches, same membership, same JSON shape (design doc "The seam"). `late_reranker=None`
-    # (the default) skips this block entirely: byte-identical to the pre-T5 fused order.
-    late_rank_fallback_reason: str | None = None
-    if late_reranker is not None:
-        pool_k = max(
-            0, min(_int_env(_RERANK_POOL_K_ENV, _DEFAULT_RERANK_POOL_K), _MAX_RERANK_POOL_K)
-        )
-        budget_ms = _int_env(_RERANK_BUDGET_MS_ENV, _DEFAULT_RERANK_BUDGET_MS)
-        head = fused_order[:pool_k]
-        # Real wall-clock deadline (A3, external audit 2026-07-11): the previous post-hoc
-        # `elapsed > budget` check could only DISCARD a rerank that had already RETURNED -- a HUNG
-        # encoder (a wedged model, an infinite loop in the injected reranker) never returns, so
-        # `late_reranker.rerank` blocked `tg search --rank` indefinitely with no bound. Run it on a
-        # daemon thread and `join` on the budget: if it overruns, abandon the thread (it dies with
-        # this short-lived CLI process) and degrade. The Backend Fail-Closed Contract is PRESERVED
-        # across the thread boundary -- a LateRerankUnavailableError (recoverable) degrades to the
-        # plain RRF order; ANYTHING ELSE (a genuine BackendExecutionError encode fault, or a
-        # KeyboardInterrupt/SystemExit user-abort) is re-raised on this thread so it still
-        # propagates to the CLI boundary (cli/main.py ~:6804-6813), exactly as the synchronous
-        # version did. Capturing BaseException (not just Exception) is deliberate: it keeps a
-        # user-abort from being silently swallowed into an RRF degrade AND guarantees exactly one
-        # of the two result holders is populated when the worker finishes (so the `else` splice
-        # below can never IndexError on an empty result).
-        rerank_result: list[list[int]] = []
-        rerank_error: list[BaseException] = []
-
-        def _run_late_rerank() -> None:
-            try:
-                rerank_result.append(
-                    late_reranker.rerank(query, [chunks[i].text for i in head], head)
-                )
-            except (
-                BaseException
-            ) as exc:  # classified + re-raised (if non-recoverable) by the caller
-                rerank_error.append(exc)
-
-        worker = threading.Thread(target=_run_late_rerank, name="tg-late-rerank", daemon=True)
-        worker.start()
-        worker.join(timeout=budget_ms / 1000.0)
-
-        if worker.is_alive():
-            # Still running at the deadline (hung or merely too slow): do NOT wait -- abandon the
-            # daemon thread and degrade. This is the only branch that bounds a genuinely HUNG
-            # encoder; the old post-hoc check could never run for one.
-            late_rank_fallback_reason = (
-                f"late rerank unavailable: budget exceeded (>{budget_ms}ms at pool_k={pool_k})"
-            )
-            sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
-        elif rerank_error:
-            exc = rerank_error[0]
-            if isinstance(exc, LateRerankUnavailableError):
-                # RECOVERABLE (e.g. a malformed embedding shape): degrade, never crash.
-                late_rank_fallback_reason = str(exc)
-                sys.stderr.write(f"tg: {late_rank_fallback_reason}\n")
-            else:
-                # A genuine encode-time fault -> propagate (Backend Fail-Closed Contract): never
-                # silently degrade a real error into a plausible-but-wrong ranking.
-                raise exc
-        else:
-            fused_order = rerank_result[0] + fused_order[pool_k:]
+    fused_order, late_rank_fallback_reason = rank_chunks(
+        query,
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=dense_index,
+        late_reranker=late_reranker,
+        k=k,
+    )
 
     # Position in the fused order is a monotonic proxy for the underlying RRF score: RRF ties are
     # already broken by ascending chunk index before this list is built, so using position

--- a/tests/unit/test_rank_chunks.py
+++ b/tests/unit/test_rank_chunks.py
@@ -1,0 +1,185 @@
+"""Tests for :func:`tensor_grep.core.reranker.rank_chunks` -- the pure, fail-closed rank core
+extracted from :func:`~tensor_grep.core.reranker.rerank_hybrid` (`tg find` plan, Wave 2a, #189).
+
+This module pins `rank_chunks` DIRECTLY (no ``SearchResult``/matches wrapper, no CLI) so both
+`rerank_hybrid` and any future caller (e.g. `tg find`) share ONE tested fusion+late-rerank core.
+The byte-identical-behavior claim for the extraction itself is proven by
+`test_reranker_hybrid.py` and `test_search_semantic_rerank.py` continuing to pass UNCHANGED (they
+pin `rerank_hybrid`'s observable behavior end-to-end); this file additionally pins a path those two
+never reach: a genuine (non-``LateRerankUnavailableError``) fault raised BY THE INJECTED ENCODER
+INSIDE THE DAEMON WORKER THREAD (reranker.py's ``raise exc`` branch) -- see
+``test_rank_chunks_other_exception_from_worker_thread_propagates`` below.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from tensor_grep.core.reranker import rank_chunks
+from tensor_grep.core.retrieval_bm25 import Bm25Index
+from tensor_grep.core.retrieval_chunker import Chunk
+from tensor_grep.core.retrieval_fusion import DEFAULT_K
+from tensor_grep.core.retrieval_late import LateReranker, LateRerankUnavailableError
+
+
+def _build_chunks() -> tuple[list[Chunk], Bm25Index]:
+    """Three single-line chunks; only "invoice" (chunk 0) matches the query "invoice" -- BM25
+    excludes zero-score chunks, so this also gives a non-empty, single-item late-rerank pool
+    without needing any tmp_path file I/O (rank_chunks operates on already-built chunks/indexes)."""
+    chunks = [
+        Chunk(file_path="f1.py", start_line=1, end_line=1, text="parse_invoice"),
+        Chunk(file_path="f2.py", start_line=1, end_line=1, text="helper_one"),
+        Chunk(file_path="f3.py", start_line=1, end_line=1, text="helper_two"),
+    ]
+    return chunks, Bm25Index(chunks)
+
+
+def test_rank_chunks_bm25_only_identity_fuse_is_noop() -> None:
+    """No dense leg, no path channel, no late reranker: RRF over a SINGLE ranking list is an
+    identity permutation of that list -- the plain BM25 order comes back unchanged, and
+    late_fallback_reason stays None (the late stage was never even attempted)."""
+    chunks, bm25_index = _build_chunks()
+
+    fused_order, late_fallback_reason = rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=None,
+        k=DEFAULT_K,
+    )
+
+    expected_bm25_order = [
+        chunk_idx for chunk_idx, _ in bm25_index.query("invoice", top_k=len(chunks))
+    ]
+    assert fused_order == expected_bm25_order == [0]
+    assert late_fallback_reason is None
+
+
+def test_rank_chunks_path_channel_weights_change_fusion_order(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """TG_RRF_CHANNELS=1 is the ONLY branch inside the extracted region that builds an explicit
+    `weights` list (equal 1.0 for the BM25 leg, PATH_CHANNEL_WEIGHT for a non-empty path-channel
+    leg) and threads it into `reciprocal_rank_fusion` -- exercise that "weights path" directly,
+    mirroring test_reranker_hybrid.py's test_path_channel_boosts_filename_match_under_flag but at
+    the rank_chunks level. Both chunks tie on BM25 (identical text); only the second chunk's
+    FILENAME overlaps the query token "invoice"."""
+    chunks = [
+        Chunk(file_path="other_helper.py", start_line=1, end_line=1, text="shared_content"),
+        Chunk(file_path="invoice_parser.py", start_line=1, end_line=1, text="shared_content"),
+    ]
+    bm25_index = Bm25Index(chunks)
+
+    monkeypatch.delenv("TG_RRF_CHANNELS", raising=False)
+    baseline_order, baseline_reason = rank_chunks(
+        "invoice shared",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=None,
+        k=DEFAULT_K,
+    )
+    assert [chunks[i].file_path for i in baseline_order] == [
+        "other_helper.py",
+        "invoice_parser.py",
+    ]
+    assert baseline_reason is None
+
+    monkeypatch.setenv("TG_RRF_CHANNELS", "1")
+    boosted_order, boosted_reason = rank_chunks(
+        "invoice shared",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=None,
+        k=DEFAULT_K,
+    )
+    assert [chunks[i].file_path for i in boosted_order] == [
+        "invoice_parser.py",
+        "other_helper.py",
+    ]
+    assert boosted_reason is None
+
+
+def test_rank_chunks_late_rerank_budget_exceeded_degrades(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """T6: a late reranker whose encode sleeps past TG_RERANK_BUDGET_MS must degrade to the plain
+    RRF order (never apply a slow reorder, never crash) and set late_fallback_reason -- mirrors
+    test_search_semantic_rerank.py's test_rerank_budget_exceeded_degrades_with_reason's
+    `_slow_encode` pattern, exercised directly against rank_chunks instead of through the CLI."""
+    monkeypatch.setenv("TG_RERANK_BUDGET_MS", "1")
+    chunks, bm25_index = _build_chunks()
+
+    def _slow_encode(text: str) -> np.ndarray:
+        time.sleep(0.05)  # 50ms, comfortably over the 1ms budget
+        return np.array([[1.0]], dtype=np.float32)
+
+    fused_order, late_fallback_reason = rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=LateReranker(encode=_slow_encode),
+        k=DEFAULT_K,
+    )
+
+    assert fused_order == [0]  # unchanged: degrades to the pre-late RRF order
+    assert late_fallback_reason is not None
+    assert "budget exceeded" in late_fallback_reason
+
+
+def test_rank_chunks_late_rerank_unavailable_error_degrades() -> None:
+    """A RECOVERABLE LateRerankUnavailableError from the injected encoder (e.g. a malformed
+    embedding shape, or -- as here -- the model simply not being fetched) must degrade to the
+    plain RRF order and surface the reason, never propagate as a crash."""
+    chunks, bm25_index = _build_chunks()
+
+    def _raising_encode(text: str) -> np.ndarray:
+        raise LateRerankUnavailableError("late rerank unavailable: model not fetched")
+
+    fused_order, late_fallback_reason = rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=LateReranker(encode=_raising_encode),
+        k=DEFAULT_K,
+    )
+
+    assert fused_order == [0]  # unchanged: degrades to the pre-late RRF order
+    assert late_fallback_reason is not None
+    assert "model not fetched" in late_fallback_reason
+
+
+def test_rank_chunks_other_exception_from_worker_thread_propagates() -> None:
+    """C-plan-2 (adversarial review must-fix, #189): reranker.py's `raise exc` branch classifies
+    and re-raises any encode-time fault that is NOT a LateRerankUnavailableError -- e.g. a genuine
+    BackendExecutionError, or any other non-recoverable exception. This branch is CURRENTLY
+    UNPINNED through `rerank_hybrid`: the existing corrupt-model tests raise from
+    `load_late_reranker` in the CLI (a different path, before the worker thread ever starts), and
+    `test_retrieval_late.py` exercises `LateReranker` in isolation, never through the thread
+    splice. This test injects the fault directly in the `encode` callable -- which
+    `LateReranker.rerank` invokes from INSIDE the daemon worker thread (`_run_late_rerank`) -- so
+    it proves the propagation genuinely crosses the thread boundary (via the
+    `rerank_error`/`worker.join()` handoff), not merely that the exception type would have been
+    raised had the call been synchronous.
+    """
+
+    class _EncodeBoom(RuntimeError):
+        """A stand-in for a genuine, non-recoverable encode-time fault."""
+
+    def _raising_other(text: str) -> np.ndarray:
+        raise _EncodeBoom("genuine encode-time fault, not recoverable")
+
+    chunks, bm25_index = _build_chunks()
+
+    with pytest.raises(_EncodeBoom, match="genuine encode-time fault"):
+        rank_chunks(
+            "invoice",
+            chunks,
+            bm25_index=bm25_index,
+            dense_index=None,
+            late_reranker=LateReranker(encode=_raising_other),
+            k=DEFAULT_K,
+        )


### PR DESCRIPTION
## Summary

Wave 2a of the `tg find` plan (decision D1): extracts a pure `rank_chunks(query, chunks, *, bm25_index, dense_index, late_reranker, k) -> (fused_order, late_fallback_reason)` helper from `rerank_hybrid`, containing exactly the leg-queries -> weighted RRF -> optional MaxSim-head logic (`reranker.py:274-351` pre-refactor). `rerank_hybrid` now delegates to it for its unchanged tail (fused_score computation, match_score, reason combination). Both `rerank_hybrid` and the future `tg find` command will share this ONE tested, fail-closed rank core instead of forking it.

- **Byte-identical**: `tests/unit/test_reranker_hybrid.py` and `tests/unit/test_search_semantic_rerank.py` pass **completely unchanged** -- they pin `rerank_hybrid`'s end-to-end observable behavior across the extraction boundary.
- **C-plan-1 (must-fix, satisfied)**: `rank_chunks` stays in `reranker.py` (same module) -- the extracted region reads module-level `_int_env` / `_rrf_channels_enabled` / `_path_channel_ranking` / `PATH_CHANNEL_WEIGHT` / the pool+budget consts / `threading` / `sys` / `LateRerankUnavailableError`, so a new module would force moving or importing all of them for no benefit.
- **C-plan-2 (must-fix, satisfied)**: the new `tests/unit/test_rank_chunks.py::test_rank_chunks_other_exception_from_worker_thread_propagates` injects a genuine, non-`LateRerankUnavailableError` fault directly in the injected `encode` callable -- which `LateReranker.rerank()` invokes from *inside* the daemon worker thread -- and asserts it propagates. This mirrors `reranker.py`'s `raise exc` branch (previously line :349), which was unpinned through `rerank_hybrid`: the existing corrupt-model tests raise from `load_late_reranker` in the CLI (a different path, before the worker thread ever starts), and `test_retrieval_late.py` exercises `LateReranker` in isolation, never through the thread splice.

## New tests (`tests/unit/test_rank_chunks.py`, all pass)

1. `test_rank_chunks_bm25_only_identity_fuse_is_noop` -- no late_reranker: plain RRF order back unchanged, reason `None`.
2. `test_rank_chunks_path_channel_weights_change_fusion_order` -- the `TG_RRF_CHANNELS`-gated weighted-fusion branch (the only place the region builds an explicit `weights` list).
3. `test_rank_chunks_late_rerank_budget_exceeded_degrades` -- a slow encode past `TG_RERANK_BUDGET_MS` degrades, never crashes.
4. `test_rank_chunks_late_rerank_unavailable_error_degrades` -- a recoverable `LateRerankUnavailableError` degrades with reason.
5. `test_rank_chunks_other_exception_from_worker_thread_propagates` -- **C-plan-2**: a genuine fault from inside the worker thread propagates.

## Test plan

- [x] `uv run --no-sync pytest tests/unit/test_rank_chunks.py tests/unit/test_reranker_hybrid.py tests/unit/test_search_semantic_rerank.py -x -q` -- **23 passed** (5 new + 13 + 5 existing, both existing files byte-for-byte unchanged).
- [x] `uv run --no-sync ruff format --preview` + `uv run --no-sync ruff check` on both changed files -- clean.
- [x] ASCII-only, LF line endings verified.
- [ ] Full CI matrix (GitHub Actions is the oracle for the rest of the suite + OS matrix).

**This PR needs the MANDATORY Opus adversarial gate** (rank logic, per the review ledger) before merge -- the orchestrator runs it; do not self-approve or merge this PR directly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>