### PR TITLE
feat(bench): T8 golden-set eval harness + P5 lane (tg find Wave 1, #189)

### DIFF
--- a/benchmarks/datasets/find_golden_corpus/address/normalizer.py
+++ b/benchmarks/datasets/find_golden_corpus/address/normalizer.py
@@ -1,0 +1,5 @@
+"""Puts a mailing address into a consistent shape."""
+
+
+def canonical_form(street, city, region, postal_code):
+    return f"{street.strip()}, {city.strip()}, {region.strip()} {postal_code.strip()}"

--- a/benchmarks/datasets/find_golden_corpus/auth/lockout_policy.py
+++ b/benchmarks/datasets/find_golden_corpus/auth/lockout_policy.py
@@ -1,0 +1,9 @@
+"""Slows down repeated bad credential guesses from one source."""
+
+_STRIKES = {}
+
+
+def trip_brute_force_lock(source_ip, strike_ceiling=5):
+    count = _STRIKES.get(source_ip, 0) + 1
+    _STRIKES[source_ip] = count
+    return count >= strike_ceiling

--- a/benchmarks/datasets/find_golden_corpus/auth/permission_matrix.py
+++ b/benchmarks/datasets/find_golden_corpus/auth/permission_matrix.py
@@ -1,0 +1,7 @@
+"""Expands a role name into its granted actions."""
+
+_ROLE_GRANTS = {"admin": ["read", "write", "delete"], "viewer": ["read"]}
+
+
+def expand_role_grants(role_name):
+    return list(_ROLE_GRANTS.get(role_name, []))

--- a/benchmarks/datasets/find_golden_corpus/auth/session_guard.py
+++ b/benchmarks/datasets/find_golden_corpus/auth/session_guard.py
@@ -1,0 +1,21 @@
+"""Internal accounts service: credential handling."""
+
+
+def authenticate_user(handle, secret):
+    stored = _lookup_stored_digest(handle)
+    return _constant_time_equal(stored, _digest(secret))
+
+
+def _digest(value):
+    return sum(ord(c) for c in value) % 999983
+
+
+def _lookup_stored_digest(handle):
+    return _ACCOUNTS.get(handle)
+
+
+_ACCOUNTS = {}
+
+
+def _constant_time_equal(a, b):
+    return a == b

--- a/benchmarks/datasets/find_golden_corpus/auth/token_issuer.py
+++ b/benchmarks/datasets/find_golden_corpus/auth/token_issuer.py
@@ -1,0 +1,7 @@
+"""Grants a short-lived bearer credential after sign-in."""
+
+import secrets
+
+
+def mint_access_token(account_id):
+    return f"{account_id}.{secrets.token_hex(16)}"

--- a/benchmarks/datasets/find_golden_corpus/backup/snapshot_writer.py
+++ b/benchmarks/datasets/find_golden_corpus/backup/snapshot_writer.py
@@ -1,0 +1,5 @@
+"""Persists a point-in-time copy of the primary store."""
+
+
+def take_snapshot(source_handle, destination_path):
+    return source_handle.copy_to(destination_path)

--- a/benchmarks/datasets/find_golden_corpus/billing/tax_calculator.py
+++ b/benchmarks/datasets/find_golden_corpus/billing/tax_calculator.py
@@ -1,0 +1,5 @@
+"""Computes the tax owed on a sale amount."""
+
+
+def compute_owed(sale_amount, rate_percent):
+    return round(sale_amount * rate_percent / 100.0, 2)

--- a/benchmarks/datasets/find_golden_corpus/cache/invalidation.py
+++ b/benchmarks/datasets/find_golden_corpus/cache/invalidation.py
@@ -1,0 +1,5 @@
+"""Tells every process to drop a stale cache entry."""
+
+
+def broadcast_cache_bust(key_name, subscriber_list):
+    return [sub.notify(key_name) for sub in subscriber_list]

--- a/benchmarks/datasets/find_golden_corpus/cache/memo_store.py
+++ b/benchmarks/datasets/find_golden_corpus/cache/memo_store.py
@@ -1,0 +1,16 @@
+"""A bounded in-memory lookup table."""
+
+_ORDER = []
+_VALUES = {}
+
+
+def evict_oldest_slot():
+    if not _ORDER:
+        return None
+    oldest_key = _ORDER.pop(0)
+    return _VALUES.pop(oldest_key, None)
+
+
+def remember(key, value):
+    _ORDER.append(key)
+    _VALUES[key] = value

--- a/benchmarks/datasets/find_golden_corpus/cache/warmup.py
+++ b/benchmarks/datasets/find_golden_corpus/cache/warmup.py
@@ -1,0 +1,5 @@
+"""Populates the lookup table ahead of expected demand."""
+
+
+def prefetch_hot_keys(anticipated_keys, loader_fn):
+    return {k: loader_fn(k) for k in anticipated_keys}

--- a/benchmarks/datasets/find_golden_corpus/config/env_profile.py
+++ b/benchmarks/datasets/find_golden_corpus/config/env_profile.py
@@ -1,0 +1,5 @@
+"""Identifies which deployment tier the process is running in."""
+
+
+def detect_deployment_stage(env_map):
+    return env_map.get("APP_STAGE", "development")

--- a/benchmarks/datasets/find_golden_corpus/config/feature_flags.py
+++ b/benchmarks/datasets/find_golden_corpus/config/feature_flags.py
@@ -1,0 +1,9 @@
+"""Per-account capability gating."""
+
+_ENABLED_CAPABILITIES = {"beta_exports", "bulk_invite"}
+
+
+def is_capability_enabled(capability_name, account_tier):
+    if account_tier == "internal":
+        return True
+    return capability_name in _ENABLED_CAPABILITIES

--- a/benchmarks/datasets/find_golden_corpus/config/settings_loader.py
+++ b/benchmarks/datasets/find_golden_corpus/config/settings_loader.py
@@ -1,0 +1,7 @@
+"""Reads deployment settings for the storage tier."""
+
+BACKEND_POOL_SIZE = 20
+
+
+def read_environment_overrides(env_map):
+    return {k[3:]: v for k, v in env_map.items() if k.startswith("APP_")}

--- a/benchmarks/datasets/find_golden_corpus/contact/phone_formatter.py
+++ b/benchmarks/datasets/find_golden_corpus/contact/phone_formatter.py
@@ -1,0 +1,5 @@
+"""Renders a phone number in a consistent display style."""
+
+
+def display_form(digits, country_code):
+    return f"+{country_code} {digits[:3]}-{digits[3:6]}-{digits[6:]}"

--- a/benchmarks/datasets/find_golden_corpus/data/migration_runner.py
+++ b/benchmarks/datasets/find_golden_corpus/data/migration_runner.py
@@ -1,0 +1,5 @@
+"""Applies pending storage schema changes in order."""
+
+
+def apply_pending_schema_change(pending_versions, applied_versions):
+    return [v for v in pending_versions if v not in applied_versions]

--- a/benchmarks/datasets/find_golden_corpus/data/pool_manager.py
+++ b/benchmarks/datasets/find_golden_corpus/data/pool_manager.py
@@ -1,0 +1,19 @@
+"""Shares a fixed set of expensive handles across many callers."""
+
+
+class _Reserve:
+    def __init__(self, capacity):
+        self._free = list(range(capacity))
+
+
+_DEFAULT = _Reserve(8)
+
+
+def lease_handle_from_reserve(reserve=_DEFAULT):
+    if not reserve._free:
+        raise RuntimeError("reserve exhausted")
+    return reserve._free.pop()
+
+
+def return_handle_to_reserve(handle_id, reserve=_DEFAULT):
+    reserve._free.append(handle_id)

--- a/benchmarks/datasets/find_golden_corpus/data/record_mapper.py
+++ b/benchmarks/datasets/find_golden_corpus/data/record_mapper.py
@@ -1,0 +1,15 @@
+"""Bridges storage rows and in-memory domain objects."""
+
+
+class Record:
+    def __init__(self, **fields):
+        self.fields = fields
+
+
+def hydrate_row_to_record(row_tuple, column_names):
+    paired = zip(column_names, row_tuple, strict=False)
+    return Record(**dict(paired))
+
+
+def flatten_record_to_row(obj, column_names):
+    return tuple(obj.fields.get(name) for name in column_names)

--- a/benchmarks/datasets/find_golden_corpus/errors/error_reporter.py
+++ b/benchmarks/datasets/find_golden_corpus/errors/error_reporter.py
@@ -1,0 +1,13 @@
+"""Surfaces faults from unattended automated execution."""
+
+_CAPTURED = []
+
+
+def capture_unhandled_exception(exc, context_label):
+    _CAPTURED.append({"exc": repr(exc), "context": context_label})
+    return _CAPTURED[-1]
+
+
+def drain_captured():
+    items, _CAPTURED[:] = list(_CAPTURED), []
+    return items

--- a/benchmarks/datasets/find_golden_corpus/errors/fault_catalog.py
+++ b/benchmarks/datasets/find_golden_corpus/errors/fault_catalog.py
@@ -1,0 +1,9 @@
+"""Named fault types the transport layer can surface."""
+
+
+class PeerRejectedSocketFault(Exception):
+    """The remote peer actively rejected a new socket."""
+
+
+class PeerUnreachableFault(Exception):
+    """No route to the remote peer exists at all."""

--- a/benchmarks/datasets/find_golden_corpus/errors/timeout_guard.py
+++ b/benchmarks/datasets/find_golden_corpus/errors/timeout_guard.py
@@ -1,0 +1,10 @@
+"""Bounds how long a blocking call may run."""
+
+
+class TimeoutExceededFault(Exception):
+    """Raised once a call has run past its permitted duration."""
+
+
+def enforce_deadline(elapsed_s, ceiling_s):
+    if elapsed_s > ceiling_s:
+        raise TimeoutExceededFault(f"{elapsed_s}s over {ceiling_s}s ceiling")

--- a/benchmarks/datasets/find_golden_corpus/export/pdf_renderer.py
+++ b/benchmarks/datasets/find_golden_corpus/export/pdf_renderer.py
@@ -1,0 +1,5 @@
+"""Turns a report model into a printable document."""
+
+
+def render_document(report_model):
+    return f"%PDF-1.4\n{report_model}"

--- a/benchmarks/datasets/find_golden_corpus/files/quota_tracker.py
+++ b/benchmarks/datasets/find_golden_corpus/files/quota_tracker.py
@@ -1,0 +1,7 @@
+"""Bounds on file transfer volume for a single account."""
+
+MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
+
+
+def remaining_quota(used_bytes):
+    return max(0, MAX_ATTACHMENT_BYTES - used_bytes)

--- a/benchmarks/datasets/find_golden_corpus/files/storage_guard.py
+++ b/benchmarks/datasets/find_golden_corpus/files/storage_guard.py
@@ -1,0 +1,12 @@
+"""Protects a write path from an exhausted volume."""
+
+
+class VolumeExhaustedFault(Exception):
+    pass
+
+
+def reject_when_volume_full(capacity_probe_fn, needed_bytes):
+    free_bytes = capacity_probe_fn()
+    if free_bytes < needed_bytes:
+        raise VolumeExhaustedFault(f"only {free_bytes} bytes free, need {needed_bytes}")
+    return free_bytes

--- a/benchmarks/datasets/find_golden_corpus/files/upload_handler.py
+++ b/benchmarks/datasets/find_golden_corpus/files/upload_handler.py
@@ -1,0 +1,7 @@
+"""Accepts a client file upload in chunks."""
+
+
+def stream_multipart_payload(chunks_iter, sink):
+    for chunk in chunks_iter:
+        sink.write(chunk)
+    return sink

--- a/benchmarks/datasets/find_golden_corpus/geo/location_lookup.py
+++ b/benchmarks/datasets/find_golden_corpus/geo/location_lookup.py
@@ -1,0 +1,5 @@
+"""Maps a coordinate pair to an administrative region name."""
+
+
+def region_for_coordinates(latitude, longitude):
+    return f"region-{int(latitude)}-{int(longitude)}"

--- a/benchmarks/datasets/find_golden_corpus/health/probe_endpoint.py
+++ b/benchmarks/datasets/find_golden_corpus/health/probe_endpoint.py
@@ -1,0 +1,5 @@
+"""Reports whether the process can currently serve traffic."""
+
+
+def liveness_summary(dependency_checks):
+    return {"ok": all(check() for check in dependency_checks)}

--- a/benchmarks/datasets/find_golden_corpus/i18n/fallback_locale.py
+++ b/benchmarks/datasets/find_golden_corpus/i18n/fallback_locale.py
@@ -1,0 +1,7 @@
+"""What to show a visitor whose preference we cannot honor."""
+
+DEFAULT_REGION_TAG = "en-US"
+
+
+def choose_or_default(requested_code, supported_codes):
+    return requested_code if requested_code in supported_codes else DEFAULT_REGION_TAG

--- a/benchmarks/datasets/find_golden_corpus/i18n/locale_resolver.py
+++ b/benchmarks/datasets/find_golden_corpus/i18n/locale_resolver.py
@@ -1,0 +1,9 @@
+"""Chooses which translation catalog a response should use."""
+
+
+def select_response_dialect(accept_header, available_catalogs):
+    for tag in accept_header.split(","):
+        code = tag.strip().split(";")[0]
+        if code in available_catalogs:
+            return code
+    return available_catalogs[0]

--- a/benchmarks/datasets/find_golden_corpus/i18n/message_catalog.py
+++ b/benchmarks/datasets/find_golden_corpus/i18n/message_catalog.py
@@ -1,0 +1,7 @@
+"""Looks up a translated string by key."""
+
+_CATALOG = {"greeting": {"en-US": "hello", "fr-FR": "bonjour"}}
+
+
+def lookup_translated_string(key, locale_code):
+    return _CATALOG.get(key, {}).get(locale_code)

--- a/benchmarks/datasets/find_golden_corpus/importer/csv_reader.py
+++ b/benchmarks/datasets/find_golden_corpus/importer/csv_reader.py
@@ -1,0 +1,5 @@
+"""Loads tabular rows from a delimited text source."""
+
+
+def read_rows(raw_text, delimiter=","):
+    return [line.split(delimiter) for line in raw_text.splitlines()]

--- a/benchmarks/datasets/find_golden_corpus/integrity/checksum_validator.py
+++ b/benchmarks/datasets/find_golden_corpus/integrity/checksum_validator.py
@@ -1,0 +1,14 @@
+"""Confirms a message was not altered or truncated in transit."""
+
+import zlib
+
+
+class CorruptionFault(Exception):
+    pass
+
+
+def verify_checksum_or_reject(message_bytes, expected_crc):
+    actual = zlib.crc32(message_bytes)
+    if actual != expected_crc:
+        raise CorruptionFault(f"crc mismatch: got {actual}, wanted {expected_crc}")
+    return actual

--- a/benchmarks/datasets/find_golden_corpus/logging/debug_toggle.py
+++ b/benchmarks/datasets/find_golden_corpus/logging/debug_toggle.py
@@ -1,0 +1,7 @@
+"""Controls verbose diagnostic output at process start."""
+
+VERBOSE_TRACE_ENV_VAR = "APP_VERBOSE_TRACE"
+
+
+def verbose_mode_requested(env_map):
+    return env_map.get(VERBOSE_TRACE_ENV_VAR, "") == "1"

--- a/benchmarks/datasets/find_golden_corpus/media/image_resizer.py
+++ b/benchmarks/datasets/find_golden_corpus/media/image_resizer.py
@@ -1,0 +1,6 @@
+"""Scales a picture down to fit a target box."""
+
+
+def fit_within_box(width, height, box_width, box_height):
+    scale = min(box_width / width, box_height / height)
+    return int(width * scale), int(height * scale)

--- a/benchmarks/datasets/find_golden_corpus/media/thumbnail_maker.py
+++ b/benchmarks/datasets/find_golden_corpus/media/thumbnail_maker.py
@@ -1,0 +1,5 @@
+"""Produces a small preview image from a source picture."""
+
+
+def make_preview(source_image, max_dimension):
+    return source_image.resize((max_dimension, max_dimension))

--- a/benchmarks/datasets/find_golden_corpus/metrics/counter_registry.py
+++ b/benchmarks/datasets/find_golden_corpus/metrics/counter_registry.py
@@ -1,0 +1,8 @@
+"""Simple named counters for internal telemetry."""
+
+_COUNTS = {}
+
+
+def increment_named_counter(counter_name, amount=1):
+    _COUNTS[counter_name] = _COUNTS.get(counter_name, 0) + amount
+    return _COUNTS[counter_name]

--- a/benchmarks/datasets/find_golden_corpus/metrics/exporter.py
+++ b/benchmarks/datasets/find_golden_corpus/metrics/exporter.py
@@ -1,0 +1,7 @@
+"""Serves counters to the observability scraper."""
+
+TELEMETRY_SOCKET_NUMBER = 9464
+
+
+def bind_address():
+    return ("0.0.0.0", TELEMETRY_SOCKET_NUMBER)

--- a/benchmarks/datasets/find_golden_corpus/middleware/rate_limiter.py
+++ b/benchmarks/datasets/find_golden_corpus/middleware/rate_limiter.py
@@ -1,0 +1,15 @@
+"""Caps how fast one caller can hit the service."""
+
+import time
+
+_HITS = {}
+
+
+def throttle_excess_traffic(caller_key, allowed_per_minute):
+    window = _HITS.setdefault(caller_key, [])
+    now = time.time()
+    window[:] = [t for t in window if now - t < 60]
+    if len(window) >= allowed_per_minute:
+        return True
+    window.append(now)
+    return False

--- a/benchmarks/datasets/find_golden_corpus/middleware/request_logger.py
+++ b/benchmarks/datasets/find_golden_corpus/middleware/request_logger.py
@@ -1,0 +1,5 @@
+"""Records a short trace of each inbound call."""
+
+
+def capture_access_trace(method, path, status_code):
+    return f"{method} {path} -> {status_code}"

--- a/benchmarks/datasets/find_golden_corpus/money/currency_converter.py
+++ b/benchmarks/datasets/find_golden_corpus/money/currency_converter.py
@@ -1,0 +1,5 @@
+"""Converts an amount between two currency denominations."""
+
+
+def convert_amount(amount, rate_table, source_code, target_code):
+    return amount * rate_table[source_code][target_code]

--- a/benchmarks/datasets/find_golden_corpus/net/dns_cache.py
+++ b/benchmarks/datasets/find_golden_corpus/net/dns_cache.py
@@ -1,0 +1,15 @@
+"""Avoids re-resolving the same hostname on every outbound call."""
+
+ADDRESS_TTL_SECONDS = 120
+
+
+_RESOLVED = {}
+
+
+def cached_address(hostname, resolver_fn, now_epoch):
+    entry = _RESOLVED.get(hostname)
+    if entry and now_epoch - entry[1] < ADDRESS_TTL_SECONDS:
+        return entry[0]
+    address = resolver_fn(hostname)
+    _RESOLVED[hostname] = (address, now_epoch)
+    return address

--- a/benchmarks/datasets/find_golden_corpus/net/dns_resolver.py
+++ b/benchmarks/datasets/find_golden_corpus/net/dns_resolver.py
@@ -1,0 +1,7 @@
+"""Looks up an address for a hostname."""
+
+import socket
+
+
+def resolve_hostname(hostname):
+    return socket.gethostbyname(hostname)

--- a/benchmarks/datasets/find_golden_corpus/net/http_bridge.py
+++ b/benchmarks/datasets/find_golden_corpus/net/http_bridge.py
@@ -1,0 +1,15 @@
+"""Relays a call to a partner system and surfaces its outcome."""
+
+
+class PartnerBreakdown(Exception):
+    pass
+
+
+def dispatch_outbound_call(endpoint, body):
+    return {"endpoint": endpoint, "sent": body}
+
+
+def raise_on_upstream_failure(status_code, response_body):
+    if status_code >= 500:
+        raise PartnerBreakdown(f"partner returned {status_code}: {response_body}")
+    return response_body

--- a/benchmarks/datasets/find_golden_corpus/net/listener_guard.py
+++ b/benchmarks/datasets/find_golden_corpus/net/listener_guard.py
@@ -1,0 +1,11 @@
+"""Bounds how many pending sockets a listener will hold."""
+
+
+class BacklogFullFault(Exception):
+    pass
+
+
+def reject_when_backlog_full(pending_count, backlog_ceiling):
+    if pending_count >= backlog_ceiling:
+        raise BacklogFullFault(f"{pending_count} pending >= ceiling {backlog_ceiling}")
+    return pending_count + 1

--- a/benchmarks/datasets/find_golden_corpus/net/retry_policy.py
+++ b/benchmarks/datasets/find_golden_corpus/net/retry_policy.py
@@ -1,0 +1,6 @@
+"""Spaces out repeated attempts against a flaky remote call."""
+
+
+def exponential_delay(attempt_number, base_seconds=0.5, ceiling_seconds=30.0):
+    proposed = base_seconds * (2**attempt_number)
+    return min(proposed, ceiling_seconds)

--- a/benchmarks/datasets/find_golden_corpus/net/socket_watchdog.py
+++ b/benchmarks/datasets/find_golden_corpus/net/socket_watchdog.py
@@ -1,0 +1,13 @@
+"""Frees network handles left open past their useful life."""
+
+import time
+
+_LAST_ACTIVITY = {}
+
+
+def reap_stale_connection(handle_id, idle_ceiling_s):
+    last_seen = _LAST_ACTIVITY.get(handle_id, 0)
+    if time.time() - last_seen > idle_ceiling_s:
+        _LAST_ACTIVITY.pop(handle_id, None)
+        return True
+    return False

--- a/benchmarks/datasets/find_golden_corpus/notify/email_dispatch.py
+++ b/benchmarks/datasets/find_golden_corpus/notify/email_dispatch.py
@@ -1,0 +1,5 @@
+"""Outbound transactional mail."""
+
+
+def send_transactional_message(recipient, template_id, context):
+    return {"to": recipient, "template": template_id, "context": context}

--- a/benchmarks/datasets/find_golden_corpus/notify/sms_gateway.py
+++ b/benchmarks/datasets/find_golden_corpus/notify/sms_gateway.py
@@ -1,0 +1,5 @@
+"""Outbound short text alerts."""
+
+
+def deliver_text_alert(phone_number, body):
+    return {"phone": phone_number, "body": body[:160]}

--- a/benchmarks/datasets/find_golden_corpus/paging/cursor_paginator.py
+++ b/benchmarks/datasets/find_golden_corpus/paging/cursor_paginator.py
@@ -1,0 +1,10 @@
+"""Breaks a long listing into fetchable windows."""
+
+
+def slice_page_window(items, cursor_offset, window_size):
+    return items[cursor_offset : cursor_offset + window_size]
+
+
+def next_cursor(cursor_offset, window_size, total_count):
+    nxt = cursor_offset + window_size
+    return nxt if nxt < total_count else None

--- a/benchmarks/datasets/find_golden_corpus/paging/list_defaults.py
+++ b/benchmarks/datasets/find_golden_corpus/paging/list_defaults.py
@@ -1,0 +1,7 @@
+"""Baseline cap for any unbounded output batch."""
+
+STANDARD_BATCH_LIMIT = 25
+
+
+def normalize_requested_limit(requested):
+    return requested if requested and requested > 0 else STANDARD_BATCH_LIMIT

--- a/benchmarks/datasets/find_golden_corpus/queue/dead_letter.py
+++ b/benchmarks/datasets/find_golden_corpus/queue/dead_letter.py
@@ -1,0 +1,8 @@
+"""Isolates work items that repeatedly cannot complete."""
+
+_PARKED = []
+
+
+def quarantine_failed_item(item_payload, failure_count):
+    _PARKED.append({"payload": item_payload, "attempts": failure_count})
+    return len(_PARKED)

--- a/benchmarks/datasets/find_golden_corpus/queue/job_dispatcher.py
+++ b/benchmarks/datasets/find_golden_corpus/queue/job_dispatcher.py
@@ -1,0 +1,13 @@
+"""Hands items off to asynchronous processors."""
+
+_PENDING = []
+
+
+def enqueue_deferred_item(item_payload):
+    _PENDING.append(item_payload)
+    return len(_PENDING)
+
+
+def drain_pending():
+    items, _PENDING[:] = [*_PENDING], []
+    return items

--- a/benchmarks/datasets/find_golden_corpus/queue/priority_lane.py
+++ b/benchmarks/datasets/find_golden_corpus/queue/priority_lane.py
@@ -1,0 +1,8 @@
+"""Moves an urgent item ahead of the ordinary work list."""
+
+
+def promote_urgent_message(pending_list, message_ref):
+    if message_ref in pending_list:
+        pending_list.remove(message_ref)
+    pending_list.insert(0, message_ref)
+    return pending_list

--- a/benchmarks/datasets/find_golden_corpus/queue/retry_budget.py
+++ b/benchmarks/datasets/find_golden_corpus/queue/retry_budget.py
@@ -1,0 +1,7 @@
+"""Caps how many times a work item may be re-attempted."""
+
+MAX_RETRY_CEILING = 3
+
+
+def attempts_remaining(already_tried):
+    return max(0, MAX_RETRY_CEILING - already_tried)

--- a/benchmarks/datasets/find_golden_corpus/render/asset_pipeline.py
+++ b/benchmarks/datasets/find_golden_corpus/render/asset_pipeline.py
@@ -1,0 +1,7 @@
+"""Names a static bundle so browsers cache it correctly."""
+
+import hashlib
+
+
+def fingerprint_static_bundle(bundle_bytes):
+    return hashlib.sha1(bundle_bytes).hexdigest()[:10]

--- a/benchmarks/datasets/find_golden_corpus/render/template_engine.py
+++ b/benchmarks/datasets/find_golden_corpus/render/template_engine.py
@@ -1,0 +1,5 @@
+"""Assembles response markup from a named layout."""
+
+
+def compose_html_fragment(layout_name, values):
+    return f"<div data-layout='{layout_name}'>{values}</div>"

--- a/benchmarks/datasets/find_golden_corpus/reports/output_paths.py
+++ b/benchmarks/datasets/find_golden_corpus/reports/output_paths.py
@@ -1,0 +1,7 @@
+"""Where finished exports land on the local filesystem."""
+
+EXPORT_OUTPUT_DIR = "/var/data/exports"
+
+
+def build_export_path(export_name):
+    return f"{EXPORT_OUTPUT_DIR}/{export_name}.csv"

--- a/benchmarks/datasets/find_golden_corpus/scheduler/backoff_supervisor.py
+++ b/benchmarks/datasets/find_golden_corpus/scheduler/backoff_supervisor.py
@@ -1,0 +1,10 @@
+"""Restarts a process that stopped responding."""
+
+_RESTART_COUNTS = {}
+
+
+def supervise_process_restart(process_handle):
+    count = _RESTART_COUNTS.get(process_handle, 0) + 1
+    _RESTART_COUNTS[process_handle] = count
+    process_handle.spawn_fresh()
+    return count

--- a/benchmarks/datasets/find_golden_corpus/scheduler/cron_runner.py
+++ b/benchmarks/datasets/find_golden_corpus/scheduler/cron_runner.py
@@ -1,0 +1,8 @@
+"""Executes ready work once its planned moment is reached."""
+
+
+def trigger_ready_tasks(job_table, now_epoch):
+    ready = [job for job in job_table if job["run_at"] <= now_epoch]
+    for job in ready:
+        job["handler"]()
+    return ready

--- a/benchmarks/datasets/find_golden_corpus/scheduler/job_history.py
+++ b/benchmarks/datasets/find_golden_corpus/scheduler/job_history.py
@@ -1,0 +1,5 @@
+"""Keeps a record of completed scheduled runs."""
+
+
+def archive_completed_run(run_id, finished_at):
+    return {"run": run_id, "finished": finished_at}

--- a/benchmarks/datasets/find_golden_corpus/scheduler/watchdog_timer.py
+++ b/benchmarks/datasets/find_golden_corpus/scheduler/watchdog_timer.py
@@ -1,0 +1,7 @@
+"""Notices a recurring run that stopped reporting results."""
+
+
+def flag_silent_job(job_name, last_result_epoch, now_epoch, quiet_ceiling_s):
+    if now_epoch - last_result_epoch > quiet_ceiling_s:
+        return {"job": job_name, "silent_for": now_epoch - last_result_epoch}
+    return None

--- a/benchmarks/datasets/find_golden_corpus/search/index_builder.py
+++ b/benchmarks/datasets/find_golden_corpus/search/index_builder.py
@@ -1,0 +1,9 @@
+"""Prepares free-text content for later lookup."""
+
+
+def build_inverted_index(documents):
+    postings = {}
+    for doc_id, text in documents.items():
+        for term in set(text.lower().split()):
+            postings.setdefault(term, set()).add(doc_id)
+    return postings

--- a/benchmarks/datasets/find_golden_corpus/search/query_planner.py
+++ b/benchmarks/datasets/find_golden_corpus/search/query_planner.py
@@ -1,0 +1,5 @@
+"""Orders candidate documents for a lookup."""
+
+
+def rank_candidate_documents(candidates, weights):
+    return sorted(candidates, key=lambda c: weights.get(c, 0), reverse=True)

--- a/benchmarks/datasets/find_golden_corpus/search/synonym_table.py
+++ b/benchmarks/datasets/find_golden_corpus/search/synonym_table.py
@@ -1,0 +1,5 @@
+"""Expands a single search word into related alternatives."""
+
+
+def related_words(word, table):
+    return table.get(word, [])

--- a/benchmarks/datasets/find_golden_corpus/security/audit_trail.py
+++ b/benchmarks/datasets/find_golden_corpus/security/audit_trail.py
@@ -1,0 +1,16 @@
+"""Tamper-evident logging for privileged operator actions."""
+
+import time
+
+
+def record_privileged_action(actor_id, action_name, target_ref):
+    entry = {"actor": actor_id, "action": action_name, "target": target_ref, "ts": time.time()}
+    _LEDGER.append(entry)
+    return entry
+
+
+_LEDGER = []
+
+
+def export_ledger():
+    return list(_LEDGER)

--- a/benchmarks/datasets/find_golden_corpus/security/key_rotation.py
+++ b/benchmarks/datasets/find_golden_corpus/security/key_rotation.py
@@ -1,0 +1,5 @@
+"""Replaces the active signing key on a schedule."""
+
+
+def rotate_signing_key(current_key, key_generator_fn):
+    return key_generator_fn(current_key)

--- a/benchmarks/datasets/find_golden_corpus/security/secret_vault.py
+++ b/benchmarks/datasets/find_golden_corpus/security/secret_vault.py
@@ -1,0 +1,9 @@
+"""Keeps operator secrets unreadable while stored on disk."""
+
+
+def seal_before_storage(plain_bytes, cipher_key):
+    return bytes(b ^ cipher_key[i % len(cipher_key)] for i, b in enumerate(plain_bytes))
+
+
+def unseal_from_storage(cipher_bytes, cipher_key):
+    return seal_before_storage(cipher_bytes, cipher_key)

--- a/benchmarks/datasets/find_golden_corpus/serialize/codec.py
+++ b/benchmarks/datasets/find_golden_corpus/serialize/codec.py
@@ -1,0 +1,15 @@
+"""Packs and unpacks the internal binary wire frame."""
+
+
+class FrameCorruptFault(Exception):
+    pass
+
+
+def pack_binary_frame(fields):
+    return b"|".join(str(f).encode("ascii") for f in fields)
+
+
+def unpack_binary_frame(raw_bytes):
+    if b"|" not in raw_bytes:
+        raise FrameCorruptFault("no field separator found")
+    return raw_bytes.split(b"|")

--- a/benchmarks/datasets/find_golden_corpus/serialize/json_adapter.py
+++ b/benchmarks/datasets/find_golden_corpus/serialize/json_adapter.py
@@ -1,0 +1,7 @@
+"""Adapts an internal object to the public wire shape."""
+
+import json
+
+
+def to_wire_format(obj):
+    return json.dumps(obj, sort_keys=True)

--- a/benchmarks/datasets/find_golden_corpus/session/session_store.py
+++ b/benchmarks/datasets/find_golden_corpus/session/session_store.py
@@ -1,0 +1,7 @@
+"""Tracks whether a signed-in visitor remains active."""
+
+INACTIVITY_LIMIT_S = 900
+
+
+def expire_inactive_visit(last_seen_epoch, now_epoch):
+    return (now_epoch - last_seen_epoch) > INACTIVITY_LIMIT_S

--- a/benchmarks/datasets/find_golden_corpus/text/spellcheck.py
+++ b/benchmarks/datasets/find_golden_corpus/text/spellcheck.py
@@ -1,0 +1,5 @@
+"""Flags words that do not appear in the known dictionary."""
+
+
+def unknown_words(tokens, dictionary_set):
+    return [t for t in tokens if t.lower() not in dictionary_set]

--- a/benchmarks/datasets/find_golden_corpus/time/zone_shifter.py
+++ b/benchmarks/datasets/find_golden_corpus/time/zone_shifter.py
@@ -1,0 +1,5 @@
+"""Moves a clock reading between two named offsets."""
+
+
+def shift_clock(hour_value, from_offset, to_offset):
+    return (hour_value - from_offset + to_offset) % 24

--- a/benchmarks/datasets/find_golden_corpus/validation/schema_checker.py
+++ b/benchmarks/datasets/find_golden_corpus/validation/schema_checker.py
@@ -1,0 +1,12 @@
+"""Guards a request body against the declared field contract."""
+
+
+class SchemaViolation(Exception):
+    pass
+
+
+def reject_nonconforming_payload(body, required_fields):
+    missing = [name for name in required_fields if name not in body]
+    if missing:
+        raise SchemaViolation(f"missing fields: {missing}")
+    return body

--- a/benchmarks/datasets/find_golden_corpus/webhook/dispatcher.py
+++ b/benchmarks/datasets/find_golden_corpus/webhook/dispatcher.py
@@ -1,0 +1,5 @@
+"""Delivers an outbound event notification to subscribers."""
+
+
+def forward_event_payload(subscriber_url, event_body, http_post_fn):
+    return http_post_fn(subscriber_url, event_body)

--- a/benchmarks/datasets/find_golden_corpus/webhook/signature_verifier.py
+++ b/benchmarks/datasets/find_golden_corpus/webhook/signature_verifier.py
@@ -1,0 +1,8 @@
+"""Confirms an inbound callback originated from a trusted partner."""
+
+import hmac
+
+
+def validate_hmac_signature(raw_body, provided_tag, shared_secret):
+    expected = hmac.new(shared_secret, raw_body, "sha256").hexdigest()
+    return hmac.compare_digest(expected, provided_tag)

--- a/benchmarks/datasets/late_rerank_golden.jsonl
+++ b/benchmarks/datasets/late_rerank_golden.jsonl
@@ -1,0 +1,40 @@
+{"id": "vm-concept-01", "query": "verify login credentials", "category": "concept", "relevant": [{"file": "auth/session_guard.py", "start_line": 4, "end_line": 6}]}
+{"id": "vm-concept-02", "query": "keep track of who did what for compliance", "category": "concept", "relevant": [{"file": "security/audit_trail.py", "start_line": 6, "end_line": 9}]}
+{"id": "vm-concept-03", "query": "turn raw stored bytes into a structured object", "category": "concept", "relevant": [{"file": "data/record_mapper.py", "start_line": 9, "end_line": 11}]}
+{"id": "vm-concept-04", "query": "make sure incoming data is not malformed", "category": "concept", "relevant": [{"file": "validation/schema_checker.py", "start_line": 8, "end_line": 12}]}
+{"id": "vm-concept-05", "query": "figure out which language to show text in", "category": "concept", "relevant": [{"file": "i18n/locale_resolver.py", "start_line": 4, "end_line": 9}]}
+{"id": "vm-concept-06", "query": "confirm a webhook really came from the sender", "category": "concept", "relevant": [{"file": "webhook/signature_verifier.py", "start_line": 6, "end_line": 8}]}
+{"id": "vm-concept-07", "query": "protect a secret so it cannot be read at rest", "category": "concept", "relevant": [{"file": "security/secret_vault.py", "start_line": 4, "end_line": 5}]}
+{"id": "vm-concept-08", "query": "decide whether a user is allowed to use a feature", "category": "concept", "relevant": [{"file": "config/feature_flags.py", "start_line": 6, "end_line": 9}]}
+{"id": "vm-concept-09", "query": "split a big result set into smaller pages", "category": "concept", "relevant": [{"file": "paging/cursor_paginator.py", "start_line": 4, "end_line": 5}]}
+{"id": "vm-concept-10", "query": "convert a document into a searchable structure", "category": "concept", "relevant": [{"file": "search/index_builder.py", "start_line": 4, "end_line": 9}]}
+{"id": "vm-behavior-01", "query": "retry with backoff", "category": "behavior", "relevant": [{"file": "net/retry_policy.py", "start_line": 4, "end_line": 6}]}
+{"id": "vm-behavior-02", "query": "close connections nobody is using anymore", "category": "behavior", "relevant": [{"file": "net/socket_watchdog.py", "start_line": 8, "end_line": 13}]}
+{"id": "vm-behavior-03", "query": "throw away the least recently touched cache entry", "category": "behavior", "relevant": [{"file": "cache/memo_store.py", "start_line": 7, "end_line": 11}]}
+{"id": "vm-behavior-04", "query": "load likely needed data before it is asked for", "category": "behavior", "relevant": [{"file": "cache/warmup.py", "start_line": 4, "end_line": 5}]}
+{"id": "vm-behavior-05", "query": "put a task on the background work list", "category": "behavior", "relevant": [{"file": "queue/job_dispatcher.py", "start_line": 6, "end_line": 8}]}
+{"id": "vm-behavior-06", "query": "set aside a message that keeps failing", "category": "behavior", "relevant": [{"file": "queue/dead_letter.py", "start_line": 6, "end_line": 8}]}
+{"id": "vm-behavior-07", "query": "slow down a client sending too many requests", "category": "behavior", "relevant": [{"file": "middleware/rate_limiter.py", "start_line": 8, "end_line": 15}]}
+{"id": "vm-behavior-08", "query": "bring a crashed worker back online", "category": "behavior", "relevant": [{"file": "scheduler/backoff_supervisor.py", "start_line": 6, "end_line": 10}]}
+{"id": "vm-behavior-09", "query": "fire off jobs whose scheduled time has arrived", "category": "behavior", "relevant": [{"file": "scheduler/cron_runner.py", "start_line": 4, "end_line": 8}]}
+{"id": "vm-behavior-10", "query": "borrow a connection out of a shared pool", "category": "behavior", "relevant": [{"file": "data/pool_manager.py", "start_line": 12, "end_line": 15}]}
+{"id": "vm-error-01", "query": "connection refused when reaching the database", "category": "error-message", "relevant": [{"file": "errors/fault_catalog.py", "start_line": 4, "end_line": 5}]}
+{"id": "vm-error-02", "query": "operation took longer than the allowed time", "category": "error-message", "relevant": [{"file": "errors/timeout_guard.py", "start_line": 4, "end_line": 5}]}
+{"id": "vm-error-03", "query": "a background job crashed and nobody was told", "category": "error-message", "relevant": [{"file": "errors/error_reporter.py", "start_line": 6, "end_line": 8}]}
+{"id": "vm-error-04", "query": "the disk ran out of room while writing a file", "category": "error-message", "relevant": [{"file": "files/storage_guard.py", "start_line": 8, "end_line": 12}]}
+{"id": "vm-error-05", "query": "too many failed login attempts from one place", "category": "error-message", "relevant": [{"file": "auth/lockout_policy.py", "start_line": 6, "end_line": 9}]}
+{"id": "vm-error-06", "query": "a message could not be parsed at all", "category": "error-message", "relevant": [{"file": "serialize/codec.py", "start_line": 12, "end_line": 15}]}
+{"id": "vm-error-07", "query": "a payload arrived that fails an integrity check", "category": "error-message", "relevant": [{"file": "integrity/checksum_validator.py", "start_line": 10, "end_line": 14}]}
+{"id": "vm-error-08", "query": "the server refused to accept a new connection", "category": "error-message", "relevant": [{"file": "net/listener_guard.py", "start_line": 8, "end_line": 11}]}
+{"id": "vm-error-09", "query": "a scheduled task never produced any output", "category": "error-message", "relevant": [{"file": "scheduler/watchdog_timer.py", "start_line": 4, "end_line": 7}]}
+{"id": "vm-error-10", "query": "an external service came back with a server fault", "category": "error-message", "relevant": [{"file": "net/http_bridge.py", "start_line": 12, "end_line": 15}]}
+{"id": "vm-config-01", "query": "where do we set the maximum upload size", "category": "config", "relevant": [{"file": "files/quota_tracker.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-02", "query": "how many database connections can be open at once", "category": "config", "relevant": [{"file": "config/settings_loader.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-03", "query": "how long before an idle session is dropped", "category": "config", "relevant": [{"file": "session/session_store.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-04", "query": "which folder holds generated report files", "category": "config", "relevant": [{"file": "reports/output_paths.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-05", "query": "how many retries before giving up on a job", "category": "config", "relevant": [{"file": "queue/retry_budget.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-06", "query": "what port does the internal metrics server listen on", "category": "config", "relevant": [{"file": "metrics/exporter.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-07", "query": "which environment variable turns on debug logging", "category": "config", "relevant": [{"file": "logging/debug_toggle.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-08", "query": "how long do we cache a dns lookup", "category": "config", "relevant": [{"file": "net/dns_cache.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-09", "query": "what is the default page size for listing results", "category": "config", "relevant": [{"file": "paging/list_defaults.py", "start_line": 3, "end_line": 3}]}
+{"id": "vm-config-10", "query": "which locale do we fall back to when none is specified", "category": "config", "relevant": [{"file": "i18n/fallback_locale.py", "start_line": 3, "end_line": 3}]}

--- a/benchmarks/eval_late_rerank_quality.py
+++ b/benchmarks/eval_late_rerank_quality.py
@@ -1,0 +1,824 @@
+"""T8: LIVE retrieval-quality golden-set harness (design doc
+docs/plans/design-tensor-grep-late-rerank-2026-07-09.md:48, "Golden-set gate").
+
+This is the oracle that gates every future `tg find` / late-rerank promotion decision, so
+trustworthiness is the whole point -- see the 4 mandatory must-fixes (E1-E4) called out below,
+each baked into `tests/unit/test_eval_late_rerank_quality.py`, not just asserted in prose.
+
+Pipeline (LIVE, not replayed): chunk the committed corpus -> build a BM25 index (always) and a
+dense index (if the `semantic` extra is installed and the model is fetched) -> query each leg ->
+fuse with Reciprocal Rank Fusion -> optionally MaxSim-rerank the fused head (if the `rerank`
+extra is installed and the model is fetched) -> score every arm's ranking with the SAME four
+binary-relevance functions from ``tensor_grep.core.retrieval_scoring`` (recall_at_k, precision_at_k,
+mean_reciprocal_rank_at_k, ndcg_at_k) -- no new metric is invented here (verification report
+Correction #7: golden labels are relevant-FILE sets; scoring is file-granularity, matching this
+repo's existing ``eval_bm25_quality.py`` precedent).
+
+Arms: ``bm25`` (always scored), ``dense``/``rrf``/``rrf+maxsim`` (scored when their leg is
+available, else SKIPPED with a loud, specific reason -- never silently degraded into a vacuous
+comparison), ``find``/``find+stack`` (ALWAYS skipped this wave -- ``tg find`` is Wave 2c/Wave 3,
+not built yet; reported as ``skipped: awaiting-wave-2``). A comparison/verdict is REFUSED
+(``GoldenSetError``) whenever either side of the pair is not ``scored`` (E1's "never a vacuous
+comparison" discipline generalized to the arm-skip mechanism, per the review ledger's WAVE 1 E1/E4
+items and plan Correction #2).
+
+The 4 mandatory must-fixes from the adversarial review (tg_find_review_ledger.md, "WAVE 1"):
+
+- **E1 (oracle blind spot):** ``recall_at_k``/``ndcg_at_k`` return a vacuous 1.0 for ANY ranking
+  when ``relevant`` is empty (retrieval_scoring.py:8-9,29-30). :func:`load_golden_queries` asserts
+  every query has a NON-EMPTY ``relevant`` set at load time -- a loud :class:`GoldenSetError`, not
+  a silent perfect score. :func:`validate_oracle` then proves the METRIC itself behaves: a "gold"
+  ranking (every relevant file first) must score ndcg@k == 1.0 EXACTLY; a "reversed" ranking (every
+  relevant file placed last) and an "empty" ranking must score AT OR BELOW a documented ceiling
+  (:func:`_reversed_ceiling`, ported from the discipline in ``scratchpad/bench/validate_oracle.py:56-72``
+  + ``score.py:45-53`` -- compute the ACHIEVABLE floor from the corpus/relevant-set sizes rather
+  than a blanket hardcoded number).
+- **E2 (corpus-hardness gate, machine-checked):** the committed corpus + golden queries are
+  constructed so BM25 alone should score near-floor on them (unlike ``eval_bm25_quality.py``'s own
+  corpus, which SATURATES BM25 at recall 1.0 -- the cautionary example named in the review). This
+  is VERIFIED by ``test_corpus_hardness_bm25_near_floor``, not merely asserted in a docstring.
+- **E3 (drop the fig leaf):** ``--corpus <path>`` is an OPTIONAL, NON-GATING manual override (loud
+  error if the path is given but missing). It is never wired into CI and the external
+  express/click corpora are never claimed as a gate -- the committed synthetic corpus + E2 is the
+  sole blocking discriminator.
+- **E4 (bar power floor):** :func:`paired_comparison` (and the report's PAIRED COMPARISON section)
+  gives a per-query win/loss/tie breakdown between any two SCORED arms, not just an aggregate mean
+  -- so a promotion decision can be checked for a few outlier queries dragging a mean around before
+  it gates a ship decision.
+
+Usage (always via ``uv run --no-sync``, this repo's convention):
+
+    uv run --no-sync python benchmarks/eval_late_rerank_quality.py
+    uv run --no-sync python benchmarks/eval_late_rerank_quality.py --validate-oracle
+    uv run --no-sync python benchmarks/eval_late_rerank_quality.py --runs 3
+    uv run --no-sync python benchmarks/eval_late_rerank_quality.py --corpus /path/to/express-4.21.1
+
+Exit 0 on success (including "every arm skipped but ran cleanly"); exit 1 on a loud config/oracle
+error (missing corpus, malformed golden set, non-deterministic --runs); exit 2 is not used here
+(this is a benchmarks script, not a `tg` command -- no rg-parity exit-code contract applies).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tensor_grep.core.retrieval_bm25 import Bm25Index
+from tensor_grep.core.retrieval_chunker import Chunk, chunk_file
+from tensor_grep.core.retrieval_dense import (
+    DenseIndex,
+    DenseUnavailableError,
+    dense_available,
+    load_dense_model,
+)
+from tensor_grep.core.retrieval_dense import (
+    default_model_dir as default_dense_model_dir,
+)
+from tensor_grep.core.retrieval_fusion import DEFAULT_K, reciprocal_rank_fusion
+from tensor_grep.core.retrieval_late import (
+    LateReranker,
+    LateRerankUnavailableError,
+    late_available,
+    load_late_reranker,
+)
+from tensor_grep.core.retrieval_late import (
+    default_model_dir as default_late_model_dir,
+)
+from tensor_grep.core.retrieval_scoring import (
+    mean_reciprocal_rank_at_k,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+)
+
+DEFAULT_CORPUS_DIR = Path(__file__).resolve().parent / "datasets" / "find_golden_corpus"
+DEFAULT_GOLDEN_PATH = Path(__file__).resolve().parent / "datasets" / "late_rerank_golden.jsonl"
+
+DEFAULT_TOP_KS: tuple[int, ...] = (5, 10)
+# Mirrors reranker.py's _DEFAULT_RERANK_POOL_K (50) -- a fresh LOCAL constant, not an import: that
+# name is a private module constant of reranker.py, not part of its public contract.
+DEFAULT_POOL_K = 50
+
+# find/find+stack depend on Wave 2c (the tg find pipeline) and Wave 3 (the CPU rank stack), which
+# are not built yet -- see docs/BACKLOG.md #189 and tg_find_plan.md Sec.3 WAVE 2/3. Reported as an
+# explicit, permanent skip stub this wave; never silently omitted from the arm list.
+SKIP_AWAITING_WAVE2 = "skipped: awaiting-wave-2 (tg find pipeline not built yet)"
+
+_METRIC_NAMES: tuple[str, ...] = (
+    "recall@5",
+    "recall@10",
+    "precision@10",
+    "ndcg@5",
+    "ndcg@10",
+    "mrr",
+)
+
+
+class GoldenSetError(ValueError):
+    """A loud, non-silent failure for a malformed golden dataset, missing corpus, or an attempt
+    to compare a SKIPPED arm as though it were scored. Never caught and downgraded to a warning --
+    this is the harness refusing to fabricate a result (E1/E4 discipline)."""
+
+
+@dataclass(frozen=True)
+class GoldenQuery:
+    id: str
+    query: str
+    category: str
+    relevant_files: frozenset[str]
+
+
+@dataclass
+class ArmResult:
+    name: str
+    status: str  # "scored" or "skipped"
+    reason: str | None = None
+    # query id -> {metric_name: value}; empty for a skipped arm.
+    per_query: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    def mean(self, metric: str) -> float:
+        values = [row[metric] for row in self.per_query.values()]
+        return sum(values) / len(values) if values else 0.0
+
+
+@dataclass(frozen=True)
+class PairedComparison:
+    arm_a: str
+    arm_b: str
+    metric: str
+    wins_a: int
+    wins_b: int
+    ties: int
+    per_query: tuple[tuple[str, float, float], ...]
+
+
+@dataclass
+class Report:
+    corpus_dir: str
+    file_count: int
+    chunk_count: int
+    queries: list[GoldenQuery]
+    arms: dict[str, ArmResult]
+
+
+# ---------------------------------------------------------------------------------------
+# Loading + loud validation (E1, E3)
+# ---------------------------------------------------------------------------------------
+
+
+def load_golden_queries(path: Path) -> list[GoldenQuery]:
+    """Load the golden JSONL, refusing (loudly) any entry whose ``relevant`` set is empty.
+
+    E1: ``recall_at_k``/``ndcg_at_k`` treat an empty ``relevant`` set as vacuously perfect
+    (retrieval_scoring.py:8-9,29-30) -- a mislabeled query pointing at a renamed/deleted file
+    would otherwise silently inject a perfect score into every arm's mean. This is the single
+    choke point that guarantees that can never happen: every ``GoldenQuery`` this function returns
+    is guaranteed to have a non-empty ``relevant_files`` set, or loading raises.
+    """
+    if not path.is_file():
+        raise GoldenSetError(f"golden query file not found: {path}")
+
+    queries: list[GoldenQuery] = []
+    seen_ids: set[str] = set()
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise GoldenSetError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+
+        query_id = row.get("id")
+        if not query_id:
+            raise GoldenSetError(f"{path}:{line_number}: missing required field 'id'")
+        if query_id in seen_ids:
+            raise GoldenSetError(f"{path}:{line_number}: duplicate query id {query_id!r}")
+        seen_ids.add(query_id)
+
+        query_text = row.get("query")
+        if not query_text:
+            raise GoldenSetError(
+                f"{path}:{line_number} ({query_id}): missing required field 'query'"
+            )
+
+        category = row.get("category")
+        if not category:
+            raise GoldenSetError(
+                f"{path}:{line_number} ({query_id}): missing required field 'category'"
+            )
+
+        relevant_entries = row.get("relevant")
+        if not relevant_entries:
+            # THE E1 GUARD: a query with an empty (or missing) `relevant` set is a broken golden
+            # label, not a legitimate "nothing is relevant" case -- refuse it loudly rather than
+            # silently handing recall_at_k/ndcg_at_k's vacuous-truth branch a query it will score
+            # as a perfect 1.0 for every arm, forever, with no visible signal that anything is
+            # wrong. There is no "documented convention" exemption here (unlike the scratchpad
+            # P4/deps scorer): a `tg find`-style location query ALWAYS has a real, non-empty
+            # answer by construction.
+            raise GoldenSetError(
+                f"{path}:{line_number} ({query_id}): 'relevant' must be a non-empty list -- an "
+                "empty gold-label set would let recall_at_k/ndcg_at_k's vacuous-truth branch "
+                "silently score this query as PERFECT for every arm (retrieval_scoring.py:8-9,"
+                "29-30). Fix the golden label instead of leaving it empty."
+            )
+
+        relevant_files = frozenset(entry["file"] for entry in relevant_entries)
+        queries.append(
+            GoldenQuery(
+                id=query_id, query=query_text, category=category, relevant_files=relevant_files
+            )
+        )
+
+    if not queries:
+        raise GoldenSetError(f"{path}: contained zero golden queries")
+    return queries
+
+
+def load_corpus_files(corpus_dir: Path) -> list[str]:
+    """Return every file under ``corpus_dir``, sorted for determinism, as absolute path strings.
+
+    E3: this is the ONLY corpus-loading path -- ``--corpus`` (main()) swaps ``corpus_dir`` for a
+    manual override, but the loading contract (loud failure on a missing/empty directory) is
+    identical either way. A missing directory is a configuration error, never a silently-empty
+    corpus.
+    """
+    if not corpus_dir.is_dir():
+        raise GoldenSetError(f"corpus directory not found: {corpus_dir}")
+    files = sorted(str(p) for p in corpus_dir.rglob("*") if p.is_file())
+    if not files:
+        raise GoldenSetError(f"corpus directory is empty: {corpus_dir}")
+    return files
+
+
+def _relative_posix(path_str: str, corpus_dir: Path) -> str:
+    return Path(path_str).resolve().relative_to(corpus_dir.resolve()).as_posix()
+
+
+def validate_golden_against_corpus(queries: list[GoldenQuery], corpus_dir: Path) -> None:
+    """Loudly refuse a golden query whose relevant file does not actually exist in the corpus --
+    a stale label (the file was renamed/removed) must never silently score as an unreachable 0
+    forever; it is a dataset bug, not a hard query."""
+    corpus_root = corpus_dir.resolve()
+    for query in queries:
+        for relevant_file in query.relevant_files:
+            if not (corpus_root / relevant_file).is_file():
+                raise GoldenSetError(
+                    f"{query.id}: relevant file {relevant_file!r} does not exist under {corpus_dir}"
+                )
+
+
+# ---------------------------------------------------------------------------------------
+# Ranking -> deduped file order, and scoring (retrieval_scoring.py functions ONLY)
+# ---------------------------------------------------------------------------------------
+
+
+def _dedupe_ranked_files(
+    ranked_chunk_indices: list[int], chunks: list[Chunk], corpus_dir: Path
+) -> list[str]:
+    """Collapse a chunk-index ranking to a file-path ranking, keeping first occurrence only --
+    mirrors ``benchmarks/eval_bm25_quality.py``'s ``_ranked_basenames`` (Correction #7: score at
+    file granularity, the existing precedent, no new graded-relevance metric invented)."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for chunk_index in ranked_chunk_indices:
+        rel = _relative_posix(chunks[chunk_index].file_path, corpus_dir)
+        if rel not in seen:
+            seen.add(rel)
+            ordered.append(rel)
+    return ordered
+
+
+def _score_ranking(
+    ranked_files: list[str], relevant_files: frozenset[str], top_ks: tuple[int, ...]
+) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for k in top_ks:
+        metrics[f"recall@{k}"] = recall_at_k(ranked_files, relevant_files, top_k=k)
+        metrics[f"ndcg@{k}"] = ndcg_at_k(ranked_files, relevant_files, top_k=k)
+    max_k = max(top_ks)
+    metrics["precision@10"] = precision_at_k(ranked_files, relevant_files, top_k=10)
+    metrics["mrr"] = mean_reciprocal_rank_at_k(ranked_files, relevant_files, top_k=max_k)
+    return metrics
+
+
+# ---------------------------------------------------------------------------------------
+# Arms
+# ---------------------------------------------------------------------------------------
+
+
+def run_bm25_arm(
+    chunks: list[Chunk], corpus_dir: Path, queries: list[GoldenQuery], top_ks: tuple[int, ...]
+) -> ArmResult:
+    index = Bm25Index(chunks)
+    per_query: dict[str, dict[str, float]] = {}
+    for query in queries:
+        ranked_idx = [i for i, _score in index.query(query.query, top_k=max(1, len(index.chunks)))]
+        ranked_files = _dedupe_ranked_files(ranked_idx, chunks, corpus_dir)
+        per_query[query.id] = _score_ranking(ranked_files, query.relevant_files, top_ks)
+    return ArmResult(name="bm25", status="scored", per_query=per_query)
+
+
+def build_dense_index(chunks: list[Chunk]) -> tuple[DenseIndex | None, str | None]:
+    """Attempt to build the dense leg via the REAL production probes -- ``dense_available()``
+    (extra installed?) then ``load_dense_model()`` (model fetched?). Returns ``(index, None)`` on
+    success or ``(None, reason)`` on any RECOVERABLE unavailability. A genuine
+    :class:`BackendExecutionError` (corrupt model, encode fault) is NOT caught here -- it
+    propagates per the Backend Fail-Closed Contract (AGENTS.md): a real backend fault must never
+    be swallowed into a plausible-looking "skipped" arm.
+    """
+    available, reason = dense_available()
+    if not available:
+        return None, reason
+    try:
+        model = load_dense_model(default_dense_model_dir())
+    except DenseUnavailableError as exc:
+        return None, str(exc)
+    return DenseIndex(chunks, model), None
+
+
+def run_dense_arm(
+    chunks: list[Chunk],
+    corpus_dir: Path,
+    queries: list[GoldenQuery],
+    top_ks: tuple[int, ...],
+    dense_index: DenseIndex,
+) -> ArmResult:
+    per_query: dict[str, dict[str, float]] = {}
+    for query in queries:
+        ranked_idx = [i for i, _score in dense_index.query(query.query, top_k=max(1, len(chunks)))]
+        ranked_files = _dedupe_ranked_files(ranked_idx, chunks, corpus_dir)
+        per_query[query.id] = _score_ranking(ranked_files, query.relevant_files, top_ks)
+    return ArmResult(name="dense", status="scored", per_query=per_query)
+
+
+def run_rrf_arm(
+    chunks: list[Chunk],
+    corpus_dir: Path,
+    queries: list[GoldenQuery],
+    top_ks: tuple[int, ...],
+    bm25_index: Bm25Index,
+    dense_index: DenseIndex,
+) -> ArmResult:
+    per_query: dict[str, dict[str, float]] = {}
+    total = max(1, len(chunks))
+    for query in queries:
+        bm25_ranking = [i for i, _score in bm25_index.query(query.query, top_k=total)]
+        dense_ranking = [i for i, _score in dense_index.query(query.query, top_k=total)]
+        fused = reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K)
+        ranked_files = _dedupe_ranked_files(fused, chunks, corpus_dir)
+        per_query[query.id] = _score_ranking(ranked_files, query.relevant_files, top_ks)
+    return ArmResult(name="rrf", status="scored", per_query=per_query)
+
+
+def build_late_reranker() -> tuple[LateReranker | None, str | None]:
+    """Mirrors :func:`build_dense_index`: real production probes
+    (``late_available()``/``load_late_reranker()``), recoverable unavailability returns
+    ``(None, reason)``; a :class:`BackendExecutionError` propagates uncaught."""
+    available, reason = late_available()
+    if not available:
+        return None, reason
+    try:
+        return load_late_reranker(default_late_model_dir()), None
+    except LateRerankUnavailableError as exc:
+        return None, str(exc)
+
+
+def run_rrf_maxsim_arm(
+    chunks: list[Chunk],
+    corpus_dir: Path,
+    queries: list[GoldenQuery],
+    top_ks: tuple[int, ...],
+    bm25_index: Bm25Index,
+    dense_index: DenseIndex,
+    late_reranker: LateReranker,
+    *,
+    pool_k: int = DEFAULT_POOL_K,
+) -> ArmResult:
+    """Composes the SAME leg functions ``rrf`` uses, then MaxSim-reranks the fused head.
+
+    Deliberately does NOT call ``reranker.rerank_hybrid`` -- that function operates over
+    ``SearchResult.matches`` (grep-hit reordering) and wraps its late-interaction splice in a
+    wall-clock-budgeted daemon thread (a CLI-latency safety valve, reranker.py:296-351). Both are
+    the wrong shape for a golden-set harness that ranks a whole chunk corpus directly and MUST be
+    deterministic across ``--runs N`` -- a real wall-clock budget is, by construction, a timing
+    dependency. This calls :meth:`LateReranker.rerank` directly (a synchronous, non-threaded,
+    pure computation), so the result is exactly reproducible.
+    """
+    per_query: dict[str, dict[str, float]] = {}
+    total = max(1, len(chunks))
+    for query in queries:
+        bm25_ranking = [i for i, _score in bm25_index.query(query.query, top_k=total)]
+        dense_ranking = [i for i, _score in dense_index.query(query.query, top_k=total)]
+        fused = reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K)
+        head = fused[:pool_k]
+        tail = fused[pool_k:]
+        if head:
+            reordered_head = late_reranker.rerank(query.query, [chunks[i].text for i in head], head)
+        else:
+            reordered_head = head
+        ranked_files = _dedupe_ranked_files(reordered_head + tail, chunks, corpus_dir)
+        per_query[query.id] = _score_ranking(ranked_files, query.relevant_files, top_ks)
+    return ArmResult(name="rrf+maxsim", status="scored", per_query=per_query)
+
+
+def skipped_arm(name: str, reason: str) -> ArmResult:
+    return ArmResult(name=name, status="skipped", reason=reason)
+
+
+# ---------------------------------------------------------------------------------------
+# E4: per-query paired win/loss/tie report
+# ---------------------------------------------------------------------------------------
+
+
+def paired_comparison(arm_a: ArmResult, arm_b: ArmResult, metric: str) -> PairedComparison:
+    """Per-query win/loss/tie between two arms on ``metric`` -- E4: a promotion decision must
+    never rely on a bare aggregate mean, which a handful of outlier queries can dominate.
+
+    Refuses (raises :class:`GoldenSetError`) if EITHER arm is not ``scored`` -- pairing a skipped
+    arm would either crash on a missing key or silently compare against an empty/fabricated
+    ranking, exactly the "comparison verdict over a skipped arm" the review ledger forbids.
+    """
+    if arm_a.status != "scored" or arm_b.status != "scored":
+        raise GoldenSetError(
+            f"cannot pair-compare a skipped arm: {arm_a.name}={arm_a.status!r}, "
+            f"{arm_b.name}={arm_b.status!r} -- a comparison verdict over a skipped arm is refused"
+        )
+    if arm_a.per_query.keys() != arm_b.per_query.keys():
+        raise GoldenSetError(
+            f"cannot pair-compare {arm_a.name} vs {arm_b.name}: scored different query sets"
+        )
+
+    wins_a = wins_b = ties = 0
+    rows: list[tuple[str, float, float]] = []
+    for query_id in sorted(arm_a.per_query):
+        score_a = arm_a.per_query[query_id][metric]
+        score_b = arm_b.per_query[query_id][metric]
+        rows.append((query_id, score_a, score_b))
+        if score_a > score_b:
+            wins_a += 1
+        elif score_b > score_a:
+            wins_b += 1
+        else:
+            ties += 1
+    return PairedComparison(
+        arm_a=arm_a.name,
+        arm_b=arm_b.name,
+        metric=metric,
+        wins_a=wins_a,
+        wins_b=wins_b,
+        ties=ties,
+        per_query=tuple(rows),
+    )
+
+
+# ---------------------------------------------------------------------------------------
+# E1: bidirectional oracle validation
+# ---------------------------------------------------------------------------------------
+
+
+def _reversed_ceiling(relevant_count: int, corpus_size: int, top_k: int) -> float:
+    """The ACHIEVABLE best-case ndcg@top_k for a ranking that places every relevant item as late
+    as possible ("reversed"), given the corpus/relevant-set sizes -- ported from the "ceiling"
+    discipline in ``scratchpad/bench/validate_oracle.py:56-72`` + ``score.py:45-53``: compute the
+    honestly-achievable floor instead of asserting a blind hardcoded threshold.
+
+    When the corpus has room to push every relevant item outside the top_k window
+    (``corpus_size - relevant_count >= top_k``), the true worst case is an EXACT 0.0 -- none of
+    the first ``top_k`` ranked slots can contain a relevant item. If the corpus is too small for
+    that (a pathological golden-set/corpus mismatch), some relevant items are unavoidably forced
+    into the top_k window even in the "worst" placement; this returns the ndcg of that unavoidable
+    best-case-for-BM25 arrangement instead of a value that could never actually be violated
+    (which would make the assertion vacuous) or one that could never be met (flaky).
+    """
+    if corpus_size - relevant_count >= top_k:
+        return 0.0
+    # Fewer than top_k irrelevant slots exist, so `top_k - (corpus_size - relevant_count)`
+    # relevant items are forced into the ranked window even in the worst arrangement. Compute the
+    # ndcg of THAT forced placement (those items pushed as late as possible within the window).
+    import math
+
+    forced_count = top_k - (corpus_size - relevant_count)
+    forced_count = max(0, min(forced_count, relevant_count))
+    if forced_count == 0:
+        return 0.0
+    dcg = sum(1.0 / math.log2(rank + 1) for rank in range(top_k - forced_count + 1, top_k + 1))
+    ideal_hits = min(relevant_count, top_k)
+    idcg = sum(1.0 / math.log2(rank + 1) for rank in range(1, ideal_hits + 1))
+    return dcg / idcg if idcg else 0.0
+
+
+def validate_oracle(
+    queries: list[GoldenQuery], corpus_files_relative: list[str], *, top_k: int = 10
+) -> list[str]:
+    """Bidirectional oracle validation (E1): for every golden query, a GOLD ranking (every
+    relevant file first) must score ndcg@top_k EXACTLY 1.0, and a REVERSED ranking (every
+    relevant file last) plus an EMPTY ranking must score AT OR BELOW the documented achievable
+    ceiling (:func:`_reversed_ceiling`). Returns a list of human-readable failure strings (empty
+    == pass) rather than raising, so callers can print every failure instead of stopping at the
+    first one.
+    """
+    all_files = set(corpus_files_relative)
+    failures: list[str] = []
+
+    for query in queries:
+        relevant = query.relevant_files
+        others = sorted(all_files - relevant)
+
+        gold_ranking = sorted(relevant) + others
+        gold_ndcg = ndcg_at_k(gold_ranking, relevant, top_k=top_k)
+        if gold_ndcg != 1.0:
+            failures.append(
+                f"{query.id}: GOLD ranking scored ndcg@{top_k}={gold_ndcg!r}, expected exactly 1.0"
+            )
+
+        ceiling = _reversed_ceiling(len(relevant), len(all_files), top_k)
+
+        reversed_ranking = others + sorted(relevant)
+        reversed_ndcg = ndcg_at_k(reversed_ranking, relevant, top_k=top_k)
+        if reversed_ndcg > ceiling + 1e-9:
+            failures.append(
+                f"{query.id}: REVERSED ranking scored ndcg@{top_k}={reversed_ndcg!r}, above the "
+                f"documented achievable ceiling {ceiling!r} -- broken oracle"
+            )
+
+        empty_ndcg = ndcg_at_k([], relevant, top_k=top_k)
+        if empty_ndcg > ceiling + 1e-9:
+            failures.append(
+                f"{query.id}: EMPTY ranking scored ndcg@{top_k}={empty_ndcg!r}, above the "
+                f"documented achievable ceiling {ceiling!r} -- broken oracle"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------------------
+# Orchestration + rendering
+# ---------------------------------------------------------------------------------------
+
+
+def build_report(
+    queries: list[GoldenQuery],
+    corpus_dir: Path,
+    top_ks: tuple[int, ...],
+    *,
+    pool_k: int = DEFAULT_POOL_K,
+    dense_index_override: DenseIndex | None = None,
+    dense_reason_override: str | None = None,
+    late_reranker_override: LateReranker | None = None,
+    late_reason_override: str | None = None,
+) -> Report:
+    """Run every arm once and return a fully-populated :class:`Report`.
+
+    ``*_override`` parameters exist ONLY for tests (dependency injection mirroring
+    ``test_search_semantic_rerank.py``'s ``_stub_dense_clean``/``_FakeDenseModel`` and
+    ``test_reranker_hybrid.py``'s ``_FixedVectorModel`` conventions) -- they let a test exercise
+    the "dense/rrf/rrf+maxsim actually SCORED" path deterministically without the `semantic`/
+    `rerank` extras or a fetched model being present in CI. When both are ``None`` (the default,
+    used by the real CLI), availability is probed for real via :func:`build_dense_index` /
+    :func:`build_late_reranker`.
+    """
+    corpus_files = load_corpus_files(corpus_dir)
+    chunks: list[Chunk] = []
+    for path in corpus_files:
+        chunks.extend(chunk_file(path))
+
+    arms: dict[str, ArmResult] = {}
+    bm25_index = Bm25Index(chunks)
+    arms["bm25"] = run_bm25_arm(chunks, corpus_dir, queries, top_ks)
+
+    if dense_index_override is not None:
+        dense_index, dense_reason = dense_index_override, None
+    elif dense_reason_override is not None:
+        dense_index, dense_reason = None, dense_reason_override
+    else:
+        dense_index, dense_reason = build_dense_index(chunks)
+
+    if dense_index is None:
+        arms["dense"] = skipped_arm("dense", dense_reason or "dense leg unavailable")
+        arms["rrf"] = skipped_arm("rrf", f"dense leg unavailable: {dense_reason}")
+        arms["rrf+maxsim"] = skipped_arm("rrf+maxsim", f"dense leg unavailable: {dense_reason}")
+    else:
+        arms["dense"] = run_dense_arm(chunks, corpus_dir, queries, top_ks, dense_index)
+        arms["rrf"] = run_rrf_arm(chunks, corpus_dir, queries, top_ks, bm25_index, dense_index)
+
+        if late_reranker_override is not None:
+            late_reranker, late_reason = late_reranker_override, None
+        elif late_reason_override is not None:
+            late_reranker, late_reason = None, late_reason_override
+        else:
+            late_reranker, late_reason = build_late_reranker()
+
+        if late_reranker is None:
+            arms["rrf+maxsim"] = skipped_arm(
+                "rrf+maxsim", f"late rerank leg unavailable: {late_reason}"
+            )
+        else:
+            arms["rrf+maxsim"] = run_rrf_maxsim_arm(
+                chunks,
+                corpus_dir,
+                queries,
+                top_ks,
+                bm25_index,
+                dense_index,
+                late_reranker,
+                pool_k=pool_k,
+            )
+
+    # find/find+stack: ALWAYS skipped this wave (Wave 2c/Wave 3 not built) -- never silently
+    # omitted from the arm list.
+    arms["find"] = skipped_arm("find", SKIP_AWAITING_WAVE2)
+    arms["find+stack"] = skipped_arm("find+stack", SKIP_AWAITING_WAVE2)
+
+    return Report(
+        corpus_dir=str(corpus_dir),
+        file_count=len(corpus_files),
+        chunk_count=len(chunks),
+        queries=queries,
+        arms=arms,
+    )
+
+
+def _scored_arm_names(report: Report) -> list[str]:
+    return [name for name, arm in report.arms.items() if arm.status == "scored"]
+
+
+def render_report(report: Report, top_ks: tuple[int, ...]) -> str:
+    lines: list[str] = []
+    lines.append("tg find Wave 1 golden-set eval (T8)")
+    lines.append(
+        f"corpus: {report.corpus_dir} ({report.file_count} files, {report.chunk_count} chunks)"
+    )
+
+    by_category: dict[str, int] = {}
+    for query in report.queries:
+        by_category[query.category] = by_category.get(query.category, 0) + 1
+    category_summary = " ".join(f"{cat}={count}" for cat, count in sorted(by_category.items()))
+    lines.append(f"queries: {len(report.queries)} ({category_summary})")
+    lines.append("")
+
+    lines.append("ARM STATUS")
+    for name, arm in report.arms.items():
+        if arm.status == "scored":
+            lines.append(f"  {name:12} scored")
+        else:
+            # `arm.reason` may already carry its own "skipped: ..." framing (e.g. find/find+stack's
+            # SKIP_AWAITING_WAVE2) or a bare unavailability message (e.g. dense's dense_available()
+            # reason) -- a single "--" separator reads cleanly either way, unlike wrapping every
+            # reason in a second, possibly-redundant "skipped (...)".
+            lines.append(f"  {name:12} skipped -- {arm.reason}")
+    lines.append("")
+
+    scored_names = _scored_arm_names(report)
+    lines.append(f"METRICS (scored arms only, mean over {len(report.queries)} queries)")
+    header = "  arm          " + "  ".join(f"{m:>12}" for m in _METRIC_NAMES)
+    lines.append(header)
+    for name in scored_names:
+        arm = report.arms[name]
+        row = "  " + f"{name:12} " + "  ".join(f"{arm.mean(m):12.4f}" for m in _METRIC_NAMES)
+        lines.append(row)
+    if not scored_names:
+        lines.append("  (no scored arms)")
+    lines.append("")
+
+    lines.append("PAIRED COMPARISON (scored arms only, metric=ndcg@10)")
+    if len(scored_names) < 2:
+        lines.append("  fewer than 2 scored arms -- no pair available")
+    else:
+        baseline = "bm25" if "bm25" in scored_names else scored_names[0]
+        for name in scored_names:
+            if name == baseline:
+                continue
+            comparison = paired_comparison(report.arms[baseline], report.arms[name], "ndcg@10")
+            lines.append(
+                f"  {baseline} vs {name}: wins({name})={comparison.wins_b} "
+                f"wins({baseline})={comparison.wins_a} ties={comparison.ties}"
+            )
+    lines.append("")
+
+    lines.append("VERDICT")
+    if len(scored_names) >= 2 and "bm25" in scored_names:
+        for name in scored_names:
+            if name == "bm25":
+                continue
+            bm25_ndcg10 = report.arms["bm25"].mean("ndcg@10")
+            arm_ndcg10 = report.arms[name].mean("ndcg@10")
+            delta = arm_ndcg10 - bm25_ndcg10
+            lines.append(f"  {name} vs bm25: ndcg@10 delta = {delta:+.4f}")
+    else:
+        lines.append(
+            "  not computed -- need >=2 scored arms (bm25 + at least one other) for a comparison"
+        )
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="T8 golden-set retrieval-quality harness (tg find Wave 1)."
+    )
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=None,
+        help=(
+            "OPTIONAL manual corpus override (e.g. a real external repo checkout). Loud error if "
+            "given but missing. Never wired into CI -- the committed synthetic corpus is the gate "
+            f"(default: {DEFAULT_CORPUS_DIR})."
+        ),
+    )
+    parser.add_argument(
+        "--golden", type=Path, default=DEFAULT_GOLDEN_PATH, help="golden query JSONL path"
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        action="append",
+        dest="top_ks",
+        default=None,
+        help="rank cutoff(s) to report (repeatable; default: 5 and 10)",
+    )
+    parser.add_argument(
+        "--pool-k", type=int, default=DEFAULT_POOL_K, help="MaxSim pool size for rrf+maxsim"
+    )
+    parser.add_argument(
+        "--runs",
+        type=int,
+        default=1,
+        help="run the full pipeline this many times and require byte-identical rendered output",
+    )
+    parser.add_argument(
+        "--validate-oracle",
+        action="store_true",
+        help="run ONLY the bidirectional oracle validation (E1) and exit; no arms are scored",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    top_ks = tuple(args.top_ks) if args.top_ks else DEFAULT_TOP_KS
+
+    corpus_dir = args.corpus if args.corpus is not None else DEFAULT_CORPUS_DIR
+    if args.corpus is not None and not args.corpus.is_dir():
+        print(
+            f"tg-eval: ERROR: --corpus path does not exist or is not a directory: {args.corpus}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        queries = load_golden_queries(args.golden)
+        corpus_files = load_corpus_files(corpus_dir)
+        validate_golden_against_corpus(queries, corpus_dir)
+    except GoldenSetError as exc:
+        print(f"tg-eval: ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.validate_oracle:
+        corpus_relative = [_relative_posix(p, corpus_dir) for p in corpus_files]
+        failures = validate_oracle(queries, corpus_relative, top_k=max(top_ks))
+        if failures:
+            print(f"ORACLE VALIDATION FAILED ({len(failures)} issue(s)):")
+            for failure in failures:
+                print(f"  - {failure}")
+            return 1
+        print(
+            f"ORACLE VALIDATION PASSED: {len(queries)} queries, gold ranking scores ndcg@{max(top_ks)}=1.0 "
+            "exactly; reversed and empty rankings score at or below the documented achievable ceiling."
+        )
+        return 0
+
+    runs = max(1, args.runs)
+    rendered_runs: list[str] = []
+    for _ in range(runs):
+        report = build_report(queries, corpus_dir, top_ks, pool_k=args.pool_k)
+        rendered_runs.append(render_report(report, top_ks))
+
+    if any(text != rendered_runs[0] for text in rendered_runs[1:]):
+        print(
+            "tg-eval: ERROR: --runs produced non-identical output across runs (pipeline is not deterministic)",
+            file=sys.stderr,
+        )
+        for index, text in enumerate(rendered_runs):
+            print(f"--- run {index + 1} ---", file=sys.stderr)
+            print(text, file=sys.stderr)
+        return 1
+
+    print(rendered_runs[0])
+    if runs > 1:
+        print(f"\n{runs}/{runs} runs byte-identical.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_eval_late_rerank_quality.py
+++ b/tests/unit/test_eval_late_rerank_quality.py
@@ -1,0 +1,351 @@
+"""Tests for the T8 golden-set retrieval-quality harness (tg find Wave 1, #189).
+
+Bakes in the 4 mandatory must-fixes from the adversarial review
+(``tg_find_review_ledger.md``, "WAVE 1"): E1 (oracle blind spot), E2 (corpus-hardness gate),
+E3 (the `--corpus` override is optional/non-gating), E4 (per-query paired win/loss/tie report).
+
+Loaded via ``importlib.util.spec_from_file_location`` -- the same pattern
+``test_bm25_benchmark_gate.py`` and ``test_benchmark_scripts.py`` already use for testing a
+``benchmarks/*.py`` script that is not part of the installed ``tensor_grep`` package (this repo's
+pytest config sets ``--import-mode=importlib``, so a plain ``import benchmarks.xxx`` is not
+available without this).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+
+def _load_eval_module() -> ModuleType:
+    root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "eval_late_rerank_quality", root / "benchmarks" / "eval_late_rerank_quality.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeDenseModel:
+    """Deterministic dense-encoder stand-in (mirrors
+    ``test_search_semantic_rerank.py``'s ``_FakeDenseModel``) -- lets a test force the dense/rrf/
+    rrf+maxsim arms to be actually SCORED without the `semantic` extra or a fetched model."""
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
+def _fake_late_encode(_text: str) -> np.ndarray:
+    return np.ones((2, 4), dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------------------
+# Governance: the harness must use retrieval_scoring.py's own functions, never a reimplementation.
+# ---------------------------------------------------------------------------------------
+
+
+def test_metrics_are_retrieval_scoring_functions() -> None:
+    mod = _load_eval_module()
+    from tensor_grep.core import retrieval_scoring
+
+    assert mod.recall_at_k is retrieval_scoring.recall_at_k
+    assert mod.precision_at_k is retrieval_scoring.precision_at_k
+    assert mod.mean_reciprocal_rank_at_k is retrieval_scoring.mean_reciprocal_rank_at_k
+    assert mod.ndcg_at_k is retrieval_scoring.ndcg_at_k
+
+
+# ---------------------------------------------------------------------------------------
+# E1: oracle blind spot.
+# ---------------------------------------------------------------------------------------
+
+
+def test_empty_gold_label_is_loud(tmp_path: Path) -> None:
+    """A golden query with an empty `relevant` set must be REFUSED at load time -- otherwise
+    recall_at_k/ndcg_at_k's vacuous-truth branch (retrieval_scoring.py:8-9,29-30) would silently
+    score it as a perfect 1.0 for every arm, forever."""
+    mod = _load_eval_module()
+    bad_golden = tmp_path / "bad.jsonl"
+    bad_golden.write_text(
+        json.dumps({"id": "q1", "query": "does something", "category": "concept", "relevant": []})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(mod.GoldenSetError, match="non-empty"):
+        mod.load_golden_queries(bad_golden)
+
+
+def test_missing_relevant_field_is_also_loud(tmp_path: Path) -> None:
+    mod = _load_eval_module()
+    bad_golden = tmp_path / "bad.jsonl"
+    bad_golden.write_text(
+        json.dumps({"id": "q1", "query": "does something", "category": "concept"}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(mod.GoldenSetError, match="non-empty"):
+        mod.load_golden_queries(bad_golden)
+
+
+def test_reversed_ceiling_is_zero_when_corpus_has_room() -> None:
+    mod = _load_eval_module()
+    assert mod._reversed_ceiling(relevant_count=2, corpus_size=50, top_k=10) == 0.0
+
+
+def test_reversed_ceiling_is_positive_when_corpus_too_small_for_a_clean_worst_case() -> None:
+    mod = _load_eval_module()
+    # 5 relevant out of 8 total files, top_k=10: only 3 irrelevant slots exist, so 2 relevant
+    # items are unavoidably forced into the top-10 window even in the WORST placement -- the
+    # ceiling must reflect that forced placement's ndcg, not a blind 0.0 that could never be met.
+    ceiling = mod._reversed_ceiling(relevant_count=5, corpus_size=8, top_k=10)
+    assert ceiling > 0.0
+
+
+def test_oracle_bidirectional_direct_scenario() -> None:
+    """Direct, hand-verified exercise of validate_oracle: a GOLD ranking scores ndcg@10==1.0
+    exactly; REVERSED and EMPTY rankings score at/below the documented achievable ceiling (which
+    is exactly 0.0 here, since this corpus comfortably exceeds top_k+relevant_count)."""
+    mod = _load_eval_module()
+    queries = [
+        mod.GoldenQuery(
+            id="q1", query="find x", category="concept", relevant_files=frozenset({"a.py"})
+        ),
+        mod.GoldenQuery(
+            id="q2", query="find y", category="behavior", relevant_files=frozenset({"b.py", "c.py"})
+        ),
+    ]
+    corpus_files = [f"f{i}.py" for i in range(20)] + ["a.py", "b.py", "c.py"]
+
+    failures = mod.validate_oracle(queries, corpus_files, top_k=10)
+
+    assert failures == []
+
+
+def test_oracle_bidirectional_catches_a_broken_metric() -> None:
+    """If ndcg_at_k regressed to score a REVERSED ranking above its ceiling, validate_oracle must
+    report it rather than silently pass -- proven by monkeypatching a fake 'always perfect'
+    ndcg function into the loaded module and confirming validate_oracle then reports a failure."""
+    mod = _load_eval_module()
+    queries = [
+        mod.GoldenQuery(
+            id="q1", query="find x", category="concept", relevant_files=frozenset({"a.py"})
+        ),
+    ]
+    corpus_files = [f"f{i}.py" for i in range(20)] + ["a.py"]
+
+    original_ndcg = mod.ndcg_at_k
+    try:
+        mod.ndcg_at_k = lambda ranked, relevant, *, top_k: 1.0  # vacuously "always perfect"
+        failures = mod.validate_oracle(queries, corpus_files, top_k=10)
+    finally:
+        mod.ndcg_at_k = original_ndcg
+
+    assert failures, "a broken always-1.0 metric must be caught by the reversed/empty checks"
+    assert any("REVERSED" in failure for failure in failures)
+
+
+def test_oracle_bidirectional_against_the_real_committed_golden_set() -> None:
+    """The PR receipt: `--validate-oracle` against the real committed corpus + golden queries
+    must pass cleanly -- this IS the exact invocation attached to the PR as evidence."""
+    mod = _load_eval_module()
+
+    exit_code = mod.main(["--validate-oracle"])
+
+    assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------------------
+# E3: --corpus is optional and non-gating, but loud when given-and-missing.
+# ---------------------------------------------------------------------------------------
+
+
+def test_missing_corpus_is_loud(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    mod = _load_eval_module()
+    missing = tmp_path / "does-not-exist"
+
+    exit_code = mod.main(["--corpus", str(missing)])
+
+    assert exit_code != 0
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err
+
+
+def test_default_corpus_used_when_no_override_given() -> None:
+    mod = _load_eval_module()
+    assert mod.DEFAULT_CORPUS_DIR.is_dir()
+    files = mod.load_corpus_files(mod.DEFAULT_CORPUS_DIR)
+    assert len(files) >= 50  # "~50-80 files" per the plan
+
+
+# ---------------------------------------------------------------------------------------
+# E2: corpus-hardness gate, machine-checked (not just asserted in a docstring).
+# ---------------------------------------------------------------------------------------
+
+
+def test_corpus_hardness_bm25_near_floor() -> None:
+    """BM25-alone must score NEAR FLOOR on the committed vocab-mismatch corpus -- unlike
+    ``eval_bm25_quality.py``'s own corpus (which saturates BM25 at recall@k >= 0.60 by design),
+    this corpus is constructed so BM25 alone is a WEAK baseline.
+
+    Calibrated 2026-07-16 against the committed corpus/golden set (74 files, 40 queries): the
+    real measured baseline is recall@10=0.2500, ndcg@10=0.1093 (verified zero-content-token
+    overlap between every query and its own target file). The thresholds below hold roughly a
+    2x safety margin above that measurement so a trivial future corpus edit does not flake this
+    test, while still failing loudly if the corpus drifts back toward BM25-easy.
+    """
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)
+
+    report = mod.build_report(
+        queries,
+        mod.DEFAULT_CORPUS_DIR,
+        (5, 10),
+        dense_reason_override="test: dense leg forced off to isolate the BM25-alone measurement",
+    )
+
+    bm25 = report.arms["bm25"]
+    assert bm25.status == "scored"
+    mean_recall10 = bm25.mean("recall@10")
+    mean_ndcg10 = bm25.mean("ndcg@10")
+
+    assert mean_recall10 <= 0.50, (
+        f"BM25 recall@10={mean_recall10:.4f} is not near-floor -- the corpus is too BM25-friendly"
+    )
+    assert mean_ndcg10 <= 0.30, (
+        f"BM25 ndcg@10={mean_ndcg10:.4f} is not near-floor -- the corpus is too BM25-friendly"
+    )
+
+
+def test_easy_naive_corpus_is_not_near_floor_sanity_check(tmp_path: Path) -> None:
+    """Negative control proving the E2 test above actually discriminates: a NAIVE corpus where
+    the query text is copied straight into the target file scores nowhere near floor -- so the
+    near-floor result on the real corpus is a property of careful construction, not an artifact
+    of the metric or a corpus too small to score anything."""
+    mod = _load_eval_module()
+    easy_dir = tmp_path / "easy_corpus"
+    easy_dir.mkdir()
+    (easy_dir / "target.py").write_text(
+        "def verify_login_credentials():\n    return True\n", encoding="utf-8"
+    )
+    for i in range(10):
+        (easy_dir / f"distractor_{i}.py").write_text(
+            f"def helper_{i}():\n    pass\n", encoding="utf-8"
+        )
+
+    query = mod.GoldenQuery(
+        id="easy-1",
+        query="verify login credentials",
+        category="concept",
+        relevant_files=frozenset({"target.py"}),
+    )
+    report = mod.build_report([query], easy_dir, (5, 10), dense_reason_override="test: bm25-only")
+
+    assert report.arms["bm25"].mean("ndcg@10") == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------------------
+# E4: per-query paired win/loss/tie report; refuses a comparison over a skipped arm.
+# ---------------------------------------------------------------------------------------
+
+
+def test_arm_skipped_vs_scored_distinct() -> None:
+    mod = _load_eval_module()
+    all_queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)
+    queries = all_queries[:6]  # a small subset keeps this test fast
+
+    corpus_files = mod.load_corpus_files(mod.DEFAULT_CORPUS_DIR)
+    chunks = []
+    for path in corpus_files:
+        chunks.extend(mod.chunk_file(path))
+    dense_index = mod.DenseIndex(chunks, _FakeDenseModel())
+    late_reranker = mod.LateReranker(encode=_fake_late_encode)
+
+    report = mod.build_report(
+        queries,
+        mod.DEFAULT_CORPUS_DIR,
+        (5, 10),
+        dense_index_override=dense_index,
+        late_reranker_override=late_reranker,
+    )
+
+    assert report.arms["bm25"].status == "scored"
+    assert report.arms["dense"].status == "scored"
+    assert report.arms["rrf"].status == "scored"
+    assert report.arms["rrf+maxsim"].status == "scored"
+    assert report.arms["find"].status == "skipped"
+    assert report.arms["find"].reason == mod.SKIP_AWAITING_WAVE2
+    assert report.arms["find+stack"].status == "skipped"
+    assert report.arms["find+stack"].reason == mod.SKIP_AWAITING_WAVE2
+
+    # a paired comparison across two SCORED arms works and covers every query exactly once...
+    comparison = mod.paired_comparison(report.arms["bm25"], report.arms["dense"], "ndcg@10")
+    assert comparison.wins_a + comparison.wins_b + comparison.ties == len(queries)
+    assert {row[0] for row in comparison.per_query} == {q.id for q in queries}
+
+    # ...but the identical call against a SKIPPED arm is refused outright, never fabricated.
+    with pytest.raises(mod.GoldenSetError, match="skipped"):
+        mod.paired_comparison(report.arms["bm25"], report.arms["find"], "ndcg@10")
+    with pytest.raises(mod.GoldenSetError, match="skipped"):
+        mod.paired_comparison(report.arms["find"], report.arms["find+stack"], "ndcg@10")
+
+
+def test_dense_rrf_and_maxsim_skip_cleanly_without_the_optional_extras() -> None:
+    """In THIS environment (CI installs only [dev], per test_retrieval_dense.py's own
+    docstring), model2vec/onnxruntime are not installed -- dense/rrf/rrf+maxsim must degrade to
+    a clean, specific SKIPPED status, never crash and never silently score as though they ran."""
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:2]
+
+    report = mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10))
+
+    assert report.arms["bm25"].status == "scored"
+    for name in ("dense", "rrf", "rrf+maxsim"):
+        arm = report.arms[name]
+        assert arm.status == "skipped"
+        assert arm.reason  # a specific, human-readable reason, never a bare None/empty string
+
+
+def test_render_report_never_prints_a_verdict_over_skipped_arms() -> None:
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:2]
+
+    report = mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10))
+    text = mod.render_report(report, (5, 10))
+
+    assert "not computed" in text  # only bm25 is scored -> no >=2-arm verdict is possible
+    assert "find" in text
+    assert mod.SKIP_AWAITING_WAVE2 in text
+
+
+# ---------------------------------------------------------------------------------------
+# Determinism: --runs N must produce byte-identical rendered output.
+# ---------------------------------------------------------------------------------------
+
+
+def test_three_runs_identical(capsys: pytest.CaptureFixture[str]) -> None:
+    mod = _load_eval_module()
+
+    exit_code = mod.main(["--runs", "3"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "3/3 runs byte-identical." in captured.out
+
+
+def test_build_report_is_deterministic_across_repeated_calls() -> None:
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:5]
+
+    first = mod.render_report(mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10)), (5, 10))
+    second = mod.render_report(mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10)), (5, 10))
+
+    assert first == second


### PR DESCRIPTION
## Summary

Wave 1 of the `tg find` plan (see `docs/plans/design-tensor-grep-late-rerank-2026-07-09.md`, "Golden-set gate" at line 48): the T8 LIVE-pipeline golden-set retrieval-quality harness that gates every future `tg find` / late-rerank promotion decision.

- `benchmarks/eval_late_rerank_quality.py` -- LIVE pipeline (chunk -> BM25 index [+ dense index when available] -> query -> Reciprocal Rank Fusion -> optional MaxSim rerank), scored ONLY with `tensor_grep.core.retrieval_scoring`'s existing binary-relevance functions (`recall_at_k`, `precision_at_k`, `mean_reciprocal_rank_at_k`, `ndcg_at_k` -- no new metric invented). Arms: `bm25` (always scored), `dense`/`rrf`/`rrf+maxsim` (scored when their leg is available, else loudly SKIPPED with a specific reason), `find`/`find+stack` (always skipped this wave -- reported `skipped: awaiting-wave-2`, since Wave 2c/3 haven't shipped).
- `benchmarks/datasets/late_rerank_golden.jsonl` -- 40 vocabulary-mismatch queries (10 each: concept / behavior / error-message / config), e.g. `"retry with backoff"` -> `exponential_delay`, `"verify login credentials"` -> `authenticate_user`.
- `benchmarks/datasets/find_golden_corpus/` -- 74 small ASCII Python files (40 query targets + 34 distractors), constructed so every query shares **zero content tokens** with its own target file (verified programmatically, not eyeballed).
- `tests/unit/test_eval_late_rerank_quality.py` -- 17 tests, all green.

## The 4 mandatory must-fixes from the adversarial review (`tg_find_review_ledger.md`, WAVE 1)

- **E1 (oracle blind spot, highest value):** `recall_at_k`/`ndcg_at_k` vacuously return 1.0 for ANY ranking when `relevant` is empty (`retrieval_scoring.py:8-9,29-30`). `load_golden_queries` now refuses (loud `GoldenSetError`) any query with an empty gold-label set at load time. `validate_oracle` then bidirectionally proves the metric itself: a GOLD ranking (every relevant file first) must score `ndcg@10 == 1.0` EXACTLY; a REVERSED ranking (every relevant file last) and an EMPTY ranking must score at/below a documented achievable ceiling (`_reversed_ceiling`, ported from the `scratchpad/bench/validate_oracle.py:56-72` + `score.py:45-53` discipline -- computed from corpus/relevant-set sizes, never a blind hardcoded number).
- **E2 (corpus-hardness gate, machine-checked):** `test_corpus_hardness_bm25_near_floor` asserts BM25-alone scores near-floor on the committed corpus (measured: `recall@10=0.2500`, `ndcg@10=0.1093`, thresholds set with ~2x headroom). A negative-control test (`test_easy_naive_corpus_is_not_near_floor_sanity_check`) proves the assertion actually discriminates -- a naive corpus (query text copied into the target file) scores `ndcg@10=1.0`.
- **E3 (drop the fig leaf):** `--corpus <path>` is an OPTIONAL, non-gating manual override (loud error if given-but-missing, `test_missing_corpus_is_loud`). Never wired into CI; the committed synthetic corpus + E2 is the sole blocking discriminator.
- **E4 (bar power floor):** `paired_comparison` gives a per-query win/loss/tie breakdown between any two SCORED arms (not just an aggregate mean), and REFUSES (raises `GoldenSetError`) a comparison over a skipped arm -- `test_arm_skipped_vs_scored_distinct` proves both the working comparison and the refusal.

## Oracle-validation receipt (`--validate-oracle` against the real committed corpus + golden set)

```
ORACLE VALIDATION PASSED: 40 queries, gold ranking scores ndcg@10=1.0 exactly; reversed and empty rankings score at or below the documented achievable ceiling.
```

## Default report receipt (`--runs 3`, determinism proof)

```
tg find Wave 1 golden-set eval (T8)
corpus: .../benchmarks/datasets/find_golden_corpus (74 files, 74 chunks)
queries: 40 (behavior=10 concept=10 config=10 error-message=10)

ARM STATUS
  bm25         scored
  dense        skipped -- semantic ranking unavailable: model2vec not installed -- pip install 'tensor-grep[semantic]' (No module named 'model2vec')
  rrf          skipped -- dense leg unavailable: ...
  rrf+maxsim   skipped -- dense leg unavailable: ...
  find         skipped -- skipped: awaiting-wave-2 (tg find pipeline not built yet)
  find+stack   skipped -- skipped: awaiting-wave-2 (tg find pipeline not built yet)

METRICS (scored arms only, mean over 40 queries)
  arm              recall@5     recall@10  precision@10        ndcg@5       ndcg@10           mrr
  bm25               0.1000        0.2500        0.0250        0.0608        0.1093        0.0679

PAIRED COMPARISON (scored arms only, metric=ndcg@10)
  fewer than 2 scored arms -- no pair available

VERDICT
  not computed -- need >=2 scored arms (bm25 + at least one other) for a comparison

3/3 runs byte-identical.
```

## Plan nits applied

- Cites the design doc at line 48 alone (not :48-49, which is a T9 line).
- Does not hardcode Wave-3's "+0.17" nDCG delta anywhere (an unvalidated guess per the plan).
- Uses real `src/tensor_grep/` paths throughout (docstrings + imports).

## Notes

- **Benchmarks-only surface** -- no Opus gate required per the plan's Sec.6 gating table; the `--validate-oracle` output above is the receipt.
- Deliberately does NOT call `reranker.rerank_hybrid` for the `rrf+maxsim` arm -- that function wraps its late-interaction splice in a wall-clock-budgeted daemon thread (a CLI-latency safety valve), which is a timing dependency incompatible with the `--runs 3` byte-identical determinism requirement. This harness composes the same leg functions (`Bm25Index`, `DenseIndex`, `reciprocal_rank_fusion`, `LateReranker.rerank`) directly instead.
- The P5 (natural-language query) lane lands in the scratchpad `#72` harness only (`tg_find_baseline()` stub seat in `baselines.py` + 9 `express_tasks.json` NL-query tasks reusing already-verified P1 symbol locations) -- internal, not committed here, numbers stay CEO-gated per `#72`.

## Test plan

- [x] `uv run --no-sync pytest tests/unit/test_eval_late_rerank_quality.py -q` -- 17/17 passed (run via the environment note below)
- [x] `ruff check` + `ruff format --preview --check` clean on all new files (harness script, test file, and all 74 corpus fixture files)
- [x] ASCII-only + LF-only verified across all 77 new files
- [x] RED->GREEN spot-check: temporarily disabled the E1 empty-relevant guard, confirmed `test_empty_gold_label_is_loud` fails, restored, confirmed green again
- [x] `--validate-oracle` and `--runs 3` both run cleanly against the real committed corpus (receipts above)

**Environment note:** this worktree had no synced `.venv` (fresh worktree; a real `uv sync`/`uv pip install -e ".[dev,ast]"` would trigger a `maturin`/`cargo` native compile, which the dispatch explicitly forbade on this shared box). All local verification above used the sibling checkout's already-built `.venv` (`tensor-grep` v1.76.11, confirmed byte-identical for every touched `core/` module against this worktree's HEAD before use) directly via its interpreter path, with zero new native compilation performed. CI's own `test-python` matrix build is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)