### PR TITLE
feat(cli): tg find whole-repo hybrid semantic search command (tg find Wave 2b/2c, #189)

### DIFF
--- a/.claude/skills/tensor-grep/REFERENCE.md
+++ b/.claude/skills/tensor-grep/REFERENCE.md
@@ -23,6 +23,7 @@ tg codemap REPO_PATH --out /tmp/code-map --json
 tg session open REPO_PATH
 tg search PATTERN PATH
 tg search PATTERN PATH --rank
+tg find "natural language query" PATH
 tg orient REPO_PATH
 ```
 
@@ -73,6 +74,16 @@ tg source C:\repo <symbol-from-top-hit>
 ```
 
 Use when the symbol name is unknown but the concept or text is known. `--rank` (alias `--bm25`) re-ranks ripgrep hits by BM25 content relevance — pure Python, no API key, no GPU.
+
+## Whole-Repo Semantic Search (no pattern needed)
+
+```powershell
+tg find "verify login tokens" C:\repo
+tg find "verify login tokens" C:\repo --json
+tg find "verify login tokens" C:\repo --limit 20 --max-tokens 8000
+```
+
+`tg find` (experimental) is for when you cannot predict a matching keyword or regex at all — unlike `tg search --rank` (which re-ranks an EXISTING regex match set), it walks and ranks the WHOLE repo via BM25 + local CPU dense-embedding relevance, no pattern pre-filter. No API key, no GPU. `rank_fallback_reason` present in JSON means the dense leg degraded to BM25-only (extra/model absent) — still a legitimate, fully supported result. `result_incomplete: true` + exit 2 means the repo walk or ranking corpus was truncated (`--max-repo-files` cap, `--deadline` cutoff, or an internal chunk cap) — treat the result as partial, not the full answer; widen `--max-repo-files`/`--deadline` and retry. Exit 1 means a complete scan found no ranked matches. Does not offer `--format rg`.
 
 ## Session Memory
 

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when you need to locate code precisely, understand likely edit im
 - You are preparing a patch and want a smaller, more accurate context bundle.
 - You need a fast codebase orientation capsule (central files, entry points, symbol map) before diving into symbol lookup.
 - You need to find code by text/content relevance rather than an exact symbol name.
+- You need to find code by MEANING when you cannot predict a matching keyword or regex — use `tg find "QUERY" [PATH]` (experimental): whole-repo hybrid BM25 + dense-embedding ranking, no pattern pre-filter required.
 - You need to resume or persist cross-session repo-map context — use `tg session` to cache the repo-map, then call session-scoped commands (`tg session context-render`, `tg session edit-plan`, `tg session blast-radius-render`) without re-indexing on each invocation.
 
 ## Argument Order
@@ -37,6 +38,7 @@ prefer the canonical path-first form.
    - `tg search PATTERN REPO_PATH --rank`
    - Workspace-root search is refused in ~1s unless scoped (`--glob` / `--type` / `--max-depth`) or `--allow-broad-generated-scan`
    - `tg source REPO_PATH/src SYMBOL`
+   - No good pattern/keyword to anchor on? `tg find "natural language query" REPO_PATH` (experimental) ranks the whole repo by BM25 + dense relevance instead of requiring a regex match at all. `result_incomplete: true` + exit 2 means the scan/ranking covered only PART of the repo (raise `--max-repo-files` / `--deadline`); a missing `rank_fallback_reason` means the dense leg ran, present means it degraded to BM25-only (still a legitimate result, just lexical-only).
 4. Symbol navigation — prefer `src/` for complete callers (root often returns `partial`):
    - `tg callers REPO_PATH/src SYMBOL --deadline 15 --json`
    - `tg defs` / `tg refs` / `tg blast-radius` similarly

--- a/.tg-registration.toml
+++ b/.tg-registration.toml
@@ -22,3 +22,17 @@ sites = [
   { file = "src/tensor_grep/cli/lsp_provider_setup.py", symbol = "_LANGUAGE_ORDER" },
   { file = "src/tensor_grep/cli/lsp_provider_setup.py", symbol = "_LANGUAGE_ALIASES" },
 ]
+
+# A new top-level `tg` command must be a member of both the Python bootstrap/Typer source of
+# truth AND the native<->Python help-parity contract, or it silently misroutes on one launcher
+# (tg find Wave 2b/2c, #189). The extractor needs `symbol ... =` (a real assignment) to bracket-
+# match the value, so this intentionally does NOT point at the Rust `Commands::Find` enum variant
+# (no `=`) -- the Rust side is covered separately by `is_known_python_command`'s `include_str!` of
+# commands.py (main.rs) plus the routing-parity real-binary --help tests.
+[[registration_groups]]
+name = "find-command"
+entities = ["find"]
+sites = [
+  { file = "src/tensor_grep/cli/commands.py", symbol = "KNOWN_COMMANDS" },
+  { file = "tests/e2e/test_routing_parity.py", symbol = "PUBLIC_TOP_LEVEL_COMMANDS" },
+]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It ships as a native CLI on Windows, macOS, and Linux — no server required for
 - **ripgrep-compatible subset** — supports the common `rg` flags (pattern, path, `-t`/`--type`, `--count-matches`, `--no-ignore`, `--sort path`, `--format rg`, `--json`, `--ndjson`). This is a validated compatible subset, not a full ripgrep replacement. Use `--format rg` for deterministic ripgrep-shaped stdout; `--format rg --json` for rg JSON Lines output.
 - Root-level shortcuts: `tg PATTERN [PATH]`, `tg -t js PATTERN PATH`, `tg --count-matches PATTERN PATH` all behave as `tg search ...`.
 - **`tg search PATTERN PATH --rank`** (alias `--bm25`) — local BM25 re-ranking of text-search results by per-chunk content relevance. Pure-Python, no API key, no GPU. Scores and re-orders results from the ripgrep-backed engine so the most content-relevant matches surface first. Works in plain text and `--json` output modes. Usage: `tg search PATTERN PATH --rank`.
+- **`tg find "QUERY" [PATH]`** (experimental) — whole-repo hybrid semantic search: no regex/pattern pre-filter, walks and ranks the WHOLE repo via BM25 + local CPU dense-embedding relevance (RRF-fused), so it can surface content a vocabulary-mismatched regex would miss. No API key, no GPU. The dense leg falls back to BM25-only (visibly, never silently) when the `semantic` extra or a fetched model is absent — a BM25-only `tg find` is a fully supported mode. Bounded by default (`--max-repo-files`, `--deadline`); a truncated scan exits 2 with `result_incomplete`. Does not offer `--format rg` — this is not a grep-parity surface. Options: `--limit` (default 10), `--max-tokens` (default 4000, 0 = unbounded), `--max-repo-files`, `--deadline`, `--json`, `--ndjson`.
 - Chunk-parallel native CPU engine for large files.
 
 ### AST search & rewrite
@@ -136,6 +137,9 @@ tg scan --config sgconfig.yml
 
 # Local BM25 re-ranking — surface most-relevant matches first, no API key
 tg search "TODO" src/ --rank
+
+# Whole-repo hybrid semantic search (experimental) — no pattern pre-filter needed
+tg find "verify login tokens" src/
 
 # One-call codebase orientation for agents — central files, entry points, symbol map
 tg orient src/

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -1041,6 +1041,12 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Whole-repo hybrid semantic search (BM25 + dense), ranked file:line results
+    #[command(name = "find", disable_help_flag = true)]
+    Find {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Build a transitive blast-radius graph for a symbol
     #[command(name = "blast-radius", disable_help_flag = true)]
     BlastRadius {
@@ -5399,6 +5405,7 @@ fn run_command_cli(cli: CommandCli) -> anyhow::Result<()> {
         Commands::Callers { args } => handle_python_passthrough("callers", args),
         Commands::Imports { args } => handle_python_passthrough("imports", args),
         Commands::Importers { args } => handle_python_passthrough("importers", args),
+        Commands::Find { args } => handle_python_passthrough("find", args),
         Commands::BlastRadius { args } => handle_python_passthrough("blast-radius", args),
         Commands::BlastRadiusRender { args } => {
             handle_python_passthrough("blast-radius-render", args)

--- a/src/tensor_grep/cli/commands.py
+++ b/src/tensor_grep/cli/commands.py
@@ -30,6 +30,7 @@ KNOWN_COMMANDS = {
     "callers",
     "imports",
     "importers",
+    "find",
     "blast-radius",
     "blast-radius-render",
     "blast-radius-plan",

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4039,7 +4039,13 @@ def _execute_find(
     Fail-closed matrix (D3, fix-approach council must-fixes C1-C3):
     - dense/late-leg extra absent, model not fetched, or a recoverable degrade -> visible BM25-only
       (or pre-late-stage) fallback: `rank_fallback_reason` set + a `tg:`-prefixed stderr line, exit
-      0. Mirrors `_apply_semantic_rerank`'s dense/late scaffold exactly (same probes, same helper).
+      0. Mirrors `_apply_semantic_rerank`'s dense/late scaffold (same `dense_available` /
+      `late_available` probes, same construction-time degrades) INCLUDING its query-time F1 catch:
+      a `DenseUnavailableError` raised from INSIDE `rank_chunks`'s `DenseIndex.query` (a dim/shape
+      mismatch, distinct from the construction path) is caught around the `rank_chunks` call and
+      degrades to a BM25-only re-run, so it stays a visible exit-0 degrade rather than escaping as a
+      raw traceback (`DenseUnavailableError` subclasses `RuntimeError`, so neither the construction
+      guard nor the command boundary would otherwise catch it).
     - a genuine unrecoverable backend fault (`BackendExecutionError` from a corrupt model directory
       or an encode-time crash) is NOT caught here -- it propagates to the command boundary (C1),
       which must catch it and exit 2 with a clean `tg:` message, never a raw traceback.
@@ -4181,13 +4187,38 @@ def _execute_find(
             # BackendExecutionError deliberately propagates -- mirrors the dense leg immediately
             # above and `_apply_semantic_rerank`'s identical contract.
 
-    fused_order, late_fallback_reason = rank_chunks(
-        query,
-        chunks,
-        bm25_index=bm25_index,
-        dense_index=dense_index,
-        late_reranker=late_reranker,
-    )
+    try:
+        fused_order, late_fallback_reason = rank_chunks(
+            query,
+            chunks,
+            bm25_index=bm25_index,
+            dense_index=dense_index,
+            late_reranker=late_reranker,
+        )
+    except DenseUnavailableError as exc:
+        # F1 (Opus-gate blocker; mirrors `_apply_semantic_rerank`'s own query-time catch,
+        # main.py:3970-3984): a dense fault raised at QUERY time from INSIDE `rank_chunks`'s call to
+        # `DenseIndex.query` (e.g. a dim/shape mismatch) is NOT the DenseIndex CONSTRUCTION path
+        # guarded above. `DenseUnavailableError` subclasses `RuntimeError`, so without this it would
+        # escape both here AND the command boundary (which catches only FileNotFoundError /
+        # BackendExecutionError) as a raw traceback + exit 1 -- a Backend Fail-Closed Contract
+        # violation. Degrade VISIBLY to BM25-only (reuse the SAME bm25_index -- no second chunk
+        # pass) and re-run; this also bypasses the late stage, which is only ever wired into the
+        # primary call above and fed off the (now-dropped) dense fusion.
+        degrade_reason = str(exc)
+        result.rank_fallback_reason = (
+            f"{result.rank_fallback_reason}; {degrade_reason}"
+            if result.rank_fallback_reason
+            else degrade_reason
+        )
+        sys.stderr.write(f"tg: {exc}\n")
+        fused_order, late_fallback_reason = rank_chunks(
+            query,
+            chunks,
+            bm25_index=bm25_index,
+            dense_index=None,
+            late_reranker=None,
+        )
     if late_fallback_reason:
         result.rank_fallback_reason = (
             f"{result.rank_fallback_reason}; {late_fallback_reason}"

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from tensor_grep.backends.base import ComputeBackend
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.core.result import MatchLine, SearchResult
+    from tensor_grep.core.retrieval_chunker import Chunk
     from tensor_grep.io.directory_scanner import DirectoryScanner
 
 # backlog #1 (Fable+thinktank plan, 2026-07-06): kept numerically in sync with
@@ -3982,6 +3983,352 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
             bm25_index=bm25_index,
             dense_index=None,
         )
+
+
+# tg find (Wave 2b/2c, #189): the whole-repo hybrid semantic search command. Shares the exact
+# leg-construction/degrade scaffold `_apply_semantic_rerank` uses above (dense-leg availability
+# probe, late-rerank env gate, BackendExecutionError propagation) but differs in one load-bearing
+# way: `--semantic`'s corpus is already regex-prefiltered by `search`'s matched-file set, so a
+# corpus-cap trip there is a benign BM25-only degrade (exit 0). `tg find` walks the WHOLE repo with
+# no prefilter, so a corpus-cap/deadline/max-repo-files trip here means the ranking covers only
+# PART of the repo -- that must surface as `result_incomplete` + exit 2 (fix-approach council
+# must-fix C2), never a silent exit-0 degrade.
+_FIND_CORPUS_CHUNK_CAP = MAX_CHUNKS
+
+
+def _find_representative_line(chunk: "Chunk", query_terms: set[str]) -> tuple[int, str]:
+    """Pick ONE line within `chunk` to surface as the synthesized `MatchLine` (D2): the line with
+    the most `split_terms` overlap with the query, ties broken by the FIRST such line (the `>`
+    comparison below never replaces an already-found best on an equal score) -- deterministic
+    regardless of repeated content within the chunk.
+
+    Falls back to the chunk's first line (or an empty string for a pathologically empty chunk)
+    when the query has no terms at all or the chunk somehow has no lines -- `chunk_file` never
+    returns an empty-text chunk in practice, but this stays total rather than raising on it.
+    """
+    from tensor_grep.core.retrieval_lexical import split_terms
+
+    lines = chunk.text.splitlines()
+    if not lines:
+        return chunk.start_line, ""
+
+    best_index = 0
+    best_overlap = -1
+    for index, line_text in enumerate(lines):
+        overlap = len(query_terms & set(split_terms(line_text))) if query_terms else 0
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_index = index
+
+    return chunk.start_line + best_index, lines[best_index]
+
+
+def _execute_find(
+    query: str,
+    path: str,
+    *,
+    limit: int,
+    max_repo_files: int,
+    max_tokens: int,
+    deadline: float | None,
+) -> "SearchResult":
+    """The `tg find` pipeline: whole-repo walk -> chunk -> BM25 [+ dense] [+ late MaxSim] rank via
+    the shared `rank_chunks` core (`core/reranker.py`) -> `--limit` -> token-budget fit -> a
+    synthesized `SearchResult` (one representative `MatchLine` per selected chunk, D2).
+
+    Fail-closed matrix (D3, fix-approach council must-fixes C1-C3):
+    - dense/late-leg extra absent, model not fetched, or a recoverable degrade -> visible BM25-only
+      (or pre-late-stage) fallback: `rank_fallback_reason` set + a `tg:`-prefixed stderr line, exit
+      0. Mirrors `_apply_semantic_rerank`'s dense/late scaffold exactly (same probes, same helper).
+    - a genuine unrecoverable backend fault (`BackendExecutionError` from a corrupt model directory
+      or an encode-time crash) is NOT caught here -- it propagates to the command boundary (C1),
+      which must catch it and exit 2 with a clean `tg:` message, never a raw traceback.
+    - a repo walk capped by `--max-repo-files`, a `--deadline` cutoff (walk or chunk phase), a
+      per-file chunk() `RuntimeError`, or the corpus-wide chunk cap all mean the ranked corpus was
+      PARTIAL (no regex prefilter narrowed it first, unlike `--semantic`) -- each sets
+      `result_incomplete=True` + appends a human-readable `incomplete_reason` (C2); the caller
+      exits 2 for these, never the exit-0 BM25-only degrade `--semantic`'s own corpus cap uses.
+    - `--limit` and `--max-tokens` are OUTPUT caps on an otherwise-complete ranking (mirrors
+      `_scan_incomplete`'s output-cap-stays-0 carve-out, repo_map.py) -- they truncate the
+      lowest-ranked matches first and never set `result_incomplete`; at least one match survives
+      the token budget even if it alone exceeds `max_tokens` (the "confident false zero" floor
+      `_apply_context_token_budget` documents at repo_map.py:8221).
+    """
+    from tensor_grep.cli.repo_map import (
+        _deadline_monotonic_from_seconds,
+        _DeadlineBreakFlag,
+        _iter_repo_files,
+    )
+    from tensor_grep.cli.repo_map import _estimate_tokens as _repo_map_estimate_tokens
+    from tensor_grep.core.reranker import rank_chunks
+    from tensor_grep.core.result import MatchLine, SearchResult
+    from tensor_grep.core.retrieval_bm25 import Bm25Index
+    from tensor_grep.core.retrieval_chunker import Chunk, chunk_file
+    from tensor_grep.core.retrieval_dense import (
+        DenseIndex,
+        DenseUnavailableError,
+        default_model_dir,
+        dense_available,
+        load_dense_model,
+    )
+    from tensor_grep.core.retrieval_lexical import split_terms
+
+    root = Path(path).expanduser().resolve()
+    if not root.exists():
+        raise FileNotFoundError(f"Path not found: {root}")
+
+    result = SearchResult()
+    incomplete_reasons: list[str] = []
+
+    deadline_monotonic = _deadline_monotonic_from_seconds(deadline)
+    walk_deadline_hit = _DeadlineBreakFlag()
+    all_files = _iter_repo_files(
+        root,
+        max_files=max_repo_files,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=walk_deadline_hit,
+    )
+
+    if walk_deadline_hit.hit:
+        reason = (
+            f"repo walk exceeded the {deadline:g}s deadline after {len(all_files)} files -- "
+            "ranking covers a partial corpus"
+        )
+        incomplete_reasons.append(reason)
+        sys.stderr.write(f"tg: {reason}\n")
+    elif len(all_files) >= max_repo_files:
+        reason = (
+            f"repo walk capped at --max-repo-files={max_repo_files}; the repo may hold more "
+            "files -- raise --max-repo-files to widen coverage"
+        )
+        incomplete_reasons.append(reason)
+        sys.stderr.write(f"tg: {reason}\n")
+
+    # C2: chunk with a per-file RuntimeError guard + a corpus-wide cap, mirroring
+    # `_apply_semantic_rerank`'s chunk-building loop (main.py:3886-3927) in SHAPE only -- the
+    # ACTION on trip deliberately differs (see the docstring above): note partial coverage and
+    # keep going / stop, never force a bm25-only retry the way the regex-prefiltered `--semantic`
+    # path does.
+    chunks: list[Chunk] = []
+    chunked_file_count = 0
+    for file_path in all_files:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            reason = (
+                f"chunking exceeded the {deadline:g}s deadline after {chunked_file_count} of "
+                f"{len(all_files)} files -- ranking covers a partial corpus"
+            )
+            incomplete_reasons.append(reason)
+            sys.stderr.write(f"tg: {reason}\n")
+            break
+        try:
+            file_chunks = chunk_file(str(file_path))
+        except RuntimeError as exc:
+            reason = f"skipped {file_path}: {exc}"
+            incomplete_reasons.append(reason)
+            sys.stderr.write(f"tg: {reason}\n")
+            continue
+        chunks.extend(file_chunks)
+        chunked_file_count += 1
+        if len(chunks) > _FIND_CORPUS_CHUNK_CAP:
+            reason = (
+                f"find corpus chunk cap ({_FIND_CORPUS_CHUNK_CAP}) reached over "
+                f"{chunked_file_count} of {len(all_files)} files -- ranking covers a partial corpus"
+            )
+            incomplete_reasons.append(reason)
+            sys.stderr.write(f"tg: {reason}\n")
+            break
+
+    if incomplete_reasons:
+        result.result_incomplete = True
+        result.incomplete_reason = "; ".join(incomplete_reasons)
+
+    if not chunks:
+        return result
+
+    bm25_index = Bm25Index(chunks)
+
+    dense_index = None
+    available, unavailable_reason = dense_available()
+    if not available:
+        result.rank_fallback_reason = unavailable_reason
+        sys.stderr.write(f"tg: {unavailable_reason}\n")
+    else:
+        try:
+            model = load_dense_model(default_model_dir())
+            dense_index = DenseIndex(chunks, model)
+        except DenseUnavailableError as exc:
+            result.rank_fallback_reason = str(exc)
+            sys.stderr.write(f"tg: {exc}\n")
+        # BackendExecutionError (e.g. a corrupt model directory) deliberately propagates -- the
+        # command boundary (C1) must catch it and exit 2, never degrade here.
+
+    late_reranker = None
+    if os.environ.get("TG_LATE_RERANK") == "1":
+        from tensor_grep.core.retrieval_late import (
+            LateRerankUnavailableError,
+            late_available,
+            load_late_reranker,
+        )
+
+        late_ok, late_reason = late_available()
+        if not late_ok:
+            _note_late_rerank_degraded(result, late_reason or "late rerank unavailable")
+        else:
+            try:
+                late_reranker = load_late_reranker()
+            except LateRerankUnavailableError as exc:
+                _note_late_rerank_degraded(result, str(exc))
+            # BackendExecutionError deliberately propagates -- mirrors the dense leg immediately
+            # above and `_apply_semantic_rerank`'s identical contract.
+
+    fused_order, late_fallback_reason = rank_chunks(
+        query,
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=dense_index,
+        late_reranker=late_reranker,
+    )
+    if late_fallback_reason:
+        result.rank_fallback_reason = (
+            f"{result.rank_fallback_reason}; {late_fallback_reason}"
+            if result.rank_fallback_reason
+            else late_fallback_reason
+        )
+
+    selected = fused_order[: max(0, limit)]
+    query_terms = set(split_terms(query))
+    matches: list[MatchLine] = []
+    for chunk_index in selected:
+        chunk = chunks[chunk_index]
+        line_number, line_text = _find_representative_line(chunk, query_terms)
+        matches.append(MatchLine(line_number=line_number, text=line_text, file=chunk.file_path))
+
+    # Output-only budget fit (never touches result_incomplete -- see docstring): truncate the
+    # LOWEST-ranked matches first (the tail of the already best-first `matches` list), floored at 1
+    # survivor so a real hit is never trimmed down to a "confident false zero".
+    if max_tokens > 0 and matches:
+        budgeted: list[MatchLine] = []
+        running_tokens = 0
+        for match in matches:
+            match_tokens = _repo_map_estimate_tokens(match.text)
+            if budgeted and running_tokens + match_tokens > max_tokens:
+                break
+            budgeted.append(match)
+            running_tokens += match_tokens
+        matches = budgeted or matches[:1]
+
+    result.matches = matches
+    result.total_matches = len(matches)
+    matched_paths = sorted({match.file for match in matches})
+    result.matched_file_paths = matched_paths
+    result.total_files = len(matched_paths)
+    for match in matches:
+        result.match_counts_by_file[match.file] = result.match_counts_by_file.get(match.file, 0) + 1
+
+    return result
+
+
+@app.command()
+def find(
+    query: str = typer.Argument(..., help="Natural-language or keyword query to search for."),
+    path: str = typer.Argument(".", help="Root directory (or single file) to search."),
+    limit: int = typer.Option(10, "--limit", min=1, help="Maximum ranked chunks to return."),
+    max_repo_files: int = typer.Option(
+        _DEFAULT_AGENT_REPO_SCAN_LIMIT,
+        "--max-repo-files",
+        min=1,
+        help="Maximum repo files to scan before ranking.",
+    ),
+    max_tokens: int = typer.Option(
+        4000,
+        "--max-tokens",
+        min=0,
+        help=(
+            "Bound the result set to ~N tokens, dropping the lowest-ranked matches first "
+            "(0 = unbounded)."
+        ),
+    ),
+    deadline: float | None = typer.Option(
+        None,
+        "--deadline",
+        min=0.1,
+        help=(
+            "Stop the repo walk/chunk phase after N seconds and return ranked results over the "
+            "partial corpus scanned so far (result_incomplete=true, exit 2) instead of running "
+            "unbounded."
+        ),
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
+    ndjson: bool = typer.Option(
+        False, "--ndjson", help="Emit newline-delimited JSON, one object per match."
+    ),
+) -> None:
+    """EXPERIMENTAL: whole-repo hybrid semantic search (BM25 + local CPU dense-embedding
+    relevance, RRF-fused [+ optional MaxSim late rerank]), ranked file:line results.
+
+    Unlike `tg search --rank`/`--semantic` (which re-rank an EXISTING regex match set), `tg find`
+    walks and ranks the WHOLE repo -- no pattern pre-filter, so it can surface content a
+    vocabulary-mismatched regex would miss. No API key, no GPU. The dense leg requires the
+    `semantic` extra and a fetched model; falls back to BM25-only (visibly, never silently) when
+    either is missing -- a BM25-only `tg find` is still a fully supported mode. Bounded by default
+    (`--max-repo-files`, `--deadline`, an internal corpus-wide chunk cap): a truncated scan is
+    marked `result_incomplete` and exits 2 rather than silently reporting a partial repo as
+    complete. Does not offer `--format rg` -- this is not a grep-parity surface.
+    """
+    from tensor_grep.backends.base import BackendExecutionError
+
+    try:
+        result = _execute_find(
+            query,
+            path,
+            limit=limit,
+            max_repo_files=max_repo_files,
+            max_tokens=max_tokens,
+            deadline=deadline,
+        )
+    except FileNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from exc
+    except BackendExecutionError as exc:
+        # C1: mirror `search`'s command-boundary catch (main.py ~7528-7537) -- `_execute_find`
+        # deliberately does not catch this (see its docstring); a corrupt model / encode-time
+        # fault must exit cleanly here, never a raw traceback.
+        if json_output:
+            _emit_search_error_json("find_backend_error", str(exc))
+        else:
+            typer.echo(f"tg: {exc}", err=True)
+        sys.exit(2)
+
+    if result.is_empty:
+        if json_output:
+            from tensor_grep.cli.formatters.json_fmt import JsonFormatter
+
+            _safe_stdout_line(JsonFormatter().format(result))
+        # C3: replicate search's hand-written exit block (main.py ~7643-7679) -- the SearchResult
+        # envelope buys the JSON fields, not the exit codes.
+        sys.exit(2 if result.result_incomplete else 1)
+
+    formatter: OutputFormatter
+    if ndjson:
+        from tensor_grep.cli.formatters.json_fmt import NdjsonFormatter
+
+        formatter = NdjsonFormatter()
+    elif json_output:
+        from tensor_grep.cli.formatters.json_fmt import JsonFormatter
+
+        formatter = JsonFormatter()
+    else:
+        from tensor_grep.cli.formatters.ripgrep_fmt import RipgrepFormatter
+        from tensor_grep.core.config import SearchConfig
+
+        # `with_filename=True` unconditionally: unlike `search` (whose matches are usually already
+        # scoped to a query'd area), `find` ranks across the whole repo, so the file is always
+        # relevant context even when every top match happens to land in one file.
+        formatter = RipgrepFormatter(config=SearchConfig(with_filename=True))
+
+    _safe_stdout_line(formatter.format(result))
+    if result.result_incomplete:
+        sys.exit(2)
 
 
 def _search_error_payload(error: str, detail: str) -> dict[str, object]:

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -38,6 +38,7 @@ PUBLIC_TOP_LEVEL_COMMANDS = {
     "callers",
     "imports",
     "importers",
+    "find",
     "blast-radius",
     "blast-radius-render",
     "blast-radius-plan",

--- a/tests/integration/test_find_command_binary.py
+++ b/tests/integration/test_find_command_binary.py
@@ -1,0 +1,125 @@
+"""`tg find` (Wave 2b/2c, #189) real-binary contract tests.
+
+Dogfood-the-shipped-artifact / house trap: `CliRunner` bypasses `bootstrap.main_entry` (the real
+front door), so this suite invokes the REAL entry points instead -- `python -m tensor_grep` (the
+"python-m" launcher, always available, no compiled Rust extension required) and, only when a
+native `tg` binary is already built, the native launcher too. The native-launcher test SKIPS
+locally without the binary (this build does not run cargo/maturin, per the CPU-safe constraint);
+CI's native-build jobs are the authoritative gate for it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli.runtime_paths import resolve_native_tg_binary
+
+_SUBPROCESS_TIMEOUT_S = 60
+
+
+def _run_python_m(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tensor_grep", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+
+
+def _get_native_binary() -> str | None:
+    try:
+        resolve_native_tg_binary.cache_clear()
+        native_binary = resolve_native_tg_binary()
+    except FileNotFoundError:
+        return None
+    return str(native_binary) if native_binary is not None else None
+
+
+def _write_tiny_repo(root: Path) -> None:
+    (root / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n"
+        '    """Build an invoice record for the given id."""\n'
+        "    invoice = invoice_id\n"
+        "    return invoice\n",
+        encoding="utf-8",
+    )
+    (root / "unrelated.py").write_text(
+        "def totally_unrelated():\n    return 42\n", encoding="utf-8"
+    )
+
+
+def test_find_help_contract(tmp_path: Path) -> None:
+    result = _run_python_m(["find", "--help"], cwd=tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "find" in result.stdout.lower()
+    assert "Usage" in result.stdout or "usage" in result.stdout
+    assert "Traceback" not in result.stderr
+
+
+def test_find_tiny_repo_end_to_end_json(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_tiny_repo(repo)
+
+    result = _run_python_m(["find", "invoice", str(repo), "--json"], cwd=tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["total_matches"] >= 1
+    assert any(str(match["file"]).endswith("invoice.py") for match in payload["matches"])
+    assert result.stdout.isascii()
+
+
+def test_find_tiny_repo_end_to_end_text(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_tiny_repo(repo)
+
+    result = _run_python_m(["find", "invoice", str(repo)], cwd=tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "invoice.py" in result.stdout
+    assert result.stdout.isascii()
+
+
+def test_find_no_results_exits_1_via_real_entry(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_tiny_repo(repo)
+
+    result = _run_python_m(
+        ["find", "zzqzxvvvqqqnonexistentgibberish", str(repo), "--json"], cwd=tmp_path
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["total_matches"] == 0
+
+
+def test_find_help_native_launcher_matches_python(tmp_path: Path) -> None:
+    native_binary = _get_native_binary()
+    if native_binary is None:
+        pytest.skip(
+            "Native binary not built in this environment (CPU-safe build constraint); CI's "
+            "native-build jobs are the authoritative gate for this parity check"
+        )
+
+    native_result = subprocess.run(
+        [native_binary, "find", "--help"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
+    )
+    python_result = _run_python_m(["find", "--help"], cwd=tmp_path)
+
+    assert native_result.returncode == 0, native_result.stdout + native_result.stderr
+    assert python_result.returncode == 0, python_result.stdout + python_result.stderr
+    assert "find" in native_result.stdout.lower()

--- a/tests/unit/test_find_command.py
+++ b/tests/unit/test_find_command.py
@@ -1,0 +1,308 @@
+"""`tg find` (Wave 2b/2c, #189): the whole-repo hybrid semantic search command.
+
+Mirrors the CliRunner-based isolation pattern in test_search_semantic_rerank.py /
+test_semantic_search_flag.py -- every test explicitly monkeypatches the dense-leg (and, where
+relevant, the late-leg) availability probes to a known state rather than depending on whatever the
+real environment happens to have installed, so each assertion is isolated to the behavior under
+test. No `semantic`/`rerank` extra or fetched model is required.
+
+Fail-closed matrix under test (D3, fix-approach council must-fixes C1-C3):
+- dense-leg extra absent -> visible BM25-only degrade, exit 0.
+- a corrupt dense model (BackendExecutionError) -> clean `tg:` message, exit 2, never a traceback.
+- a repo-walk deadline cutoff, a --max-repo-files cap, or the internal corpus-wide chunk cap all
+  mean the ranked corpus was PARTIAL -> result_incomplete=true + exit 2 (never the exit-0 BM25-only
+  degrade `--semantic`'s own corpus cap uses -- find has no regex pre-filter to rely on).
+- no ranked matches on a complete scan -> exit 1.
+- --max-tokens truncates the lowest-ranked matches first and never sets result_incomplete.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from typer.testing import CliRunner
+
+from tensor_grep.backends.base import BackendExecutionError
+from tensor_grep.cli.main import app
+from tensor_grep.core.retrieval_late import LateReranker
+
+
+class _FakeDenseModel:
+    """A working dense-leg stand-in so the dense leg always contributes cleanly (no fallback
+    reason of its own) -- mirrors test_search_semantic_rerank.py's identical fixture."""
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
+def _stub_dense_unavailable(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.dense_available",
+        lambda: (False, "semantic ranking unavailable: model2vec not installed -- test stub"),
+    )
+
+
+def _stub_dense_clean(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.load_dense_model", lambda _dir: _FakeDenseModel()
+    )
+
+
+def test_find_bm25_only_when_extra_absent_sets_rank_fallback_reason(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is not None
+    assert "model2vec" in payload["rank_fallback_reason"]
+    assert payload["total_matches"] >= 1
+
+
+def test_find_corrupt_model_raises_backend_execution_error_exit_2(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    def _raise_corrupt(_dir: object) -> None:
+        raise BackendExecutionError(
+            "dense model at <dir> failed to load (corrupt or incompatible): boom"
+        )
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.load_dense_model", _raise_corrupt)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean sys.exit(2), got a raw traceback: {result.exception!r}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "boom" in payload["detail"]
+
+
+def test_find_corrupt_model_raises_backend_execution_error_exit_2_text_mode(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """Text-mode variant: same clean `tg:`-prefixed message + exit 2, no traceback."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+
+    def _raise_corrupt(_dir: object) -> None:
+        raise BackendExecutionError(
+            "dense model at <dir> failed to load (corrupt or incompatible): boom"
+        )
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.load_dense_model", _raise_corrupt)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path)])
+
+    assert result.exit_code == 2, result.output
+    assert isinstance(result.exception, SystemExit), (
+        f"expected a clean sys.exit(2), got a raw traceback: {result.exception!r}"
+    )
+    assert "tg: dense model at <dir> failed to load" in result.stderr
+
+
+def test_find_deadline_truncation_sets_result_incomplete_and_exit_2(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    (tmp_path / "a.py").write_text("def fn():\n    return 1\n", encoding="utf-8")
+    # Force an ALREADY-EXPIRED deadline deterministically: any real time.monotonic() call
+    # downstream is >= 0.0, tripping the walk's deadline check on its very first iteration
+    # without racing the real wall clock (anti-hang-test-protocol: dependency injection over
+    # real-time racing).
+    monkeypatch.setattr(
+        "tensor_grep.cli.repo_map._deadline_monotonic_from_seconds", lambda _seconds: 0.0
+    )
+
+    result = CliRunner().invoke(app, ["find", "fn", str(tmp_path), "--deadline", "5", "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("result_incomplete") is True
+    assert "deadline" in (payload.get("incomplete_reason") or "").lower()
+
+
+def test_find_max_repo_files_cap_partial_exit_2(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    for i in range(5):
+        (tmp_path / f"f{i}.py").write_text(f"def fn_{i}():\n    return {i}\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["find", "fn", str(tmp_path), "--max-repo-files", "2", "--json"]
+    )
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("result_incomplete") is True
+    assert "max-repo-files" in (payload.get("incomplete_reason") or "")
+
+
+def test_find_chunk_cap_partial_exit_2(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """C2: the corpus-wide chunk cap trip is PARTIAL COVERAGE (no regex pre-filter narrowed the
+    corpus first, unlike `--semantic`) -> result_incomplete + exit 2, never the exit-0 BM25-only
+    degrade `--semantic`'s own corpus cap uses."""
+    _stub_dense_unavailable(monkeypatch)
+    monkeypatch.setattr("tensor_grep.cli.main._FIND_CORPUS_CHUNK_CAP", 1)
+    for i in range(3):
+        body = "\n".join(f"    x{j} = {j}" for j in range(60))
+        (tmp_path / f"f{i}.py").write_text(f"def fn_{i}():\n{body}\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["find", "fn", str(tmp_path), "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("result_incomplete") is True
+    assert "chunk cap" in (payload.get("incomplete_reason") or "")
+
+
+def test_find_no_results_exit_1(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    (tmp_path / "a.py").write_text("def completely_unrelated():\n    return 1\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app, ["find", "zzqzxvvvqqqnonexistentgibberish", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["total_matches"] == 0
+    assert not payload.get("result_incomplete")
+
+
+def test_find_json_envelope_fields(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["total_matches"] >= 1
+    assert isinstance(payload["matches"], list)
+    match = payload["matches"][0]
+    assert match["file"].endswith("invoice.py")
+    assert isinstance(match["line"], int) and match["line"] >= 1
+    assert isinstance(match["text"], str)
+    assert payload.get("rank_fallback_reason")  # dense-unavailable stub set this
+    assert payload.get("result_incomplete") is not True
+
+
+def test_find_budget_truncates_lowest_ranked_first(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    (tmp_path / "strong.py").write_text(
+        "def invoice_invoice_invoice():\n    invoice = 1\n    return invoice\n", encoding="utf-8"
+    )
+    (tmp_path / "medium.py").write_text(
+        "def process(invoice):\n    return invoice\n", encoding="utf-8"
+    )
+    (tmp_path / "weak.py").write_text(
+        "# an invoice is mentioned here only once\nx = 1\n", encoding="utf-8"
+    )
+
+    unbounded = CliRunner().invoke(
+        app, ["find", "invoice", str(tmp_path), "--json", "--max-tokens", "0"]
+    )
+    assert unbounded.exit_code == 0, unbounded.output
+    unbounded_files = [m["file"] for m in json.loads(unbounded.stdout)["matches"]]
+    assert len(unbounded_files) >= 2, "expected the corpus to yield more than one ranked match"
+
+    budgeted = CliRunner().invoke(
+        app, ["find", "invoice", str(tmp_path), "--json", "--max-tokens", "1"]
+    )
+    assert budgeted.exit_code == 0, budgeted.output
+    budgeted_files = [m["file"] for m in json.loads(budgeted.stdout)["matches"]]
+
+    assert len(budgeted_files) == 1, "a 1-token budget must floor at exactly the top match"
+    assert budgeted_files[0] == unbounded_files[0], (
+        "the budget must drop the LOWEST-ranked matches first, keeping the top match"
+    )
+
+
+def test_find_late_head_only_when_env_set(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Mirrors test_search_semantic_rerank.py's test_rerank_env_off_is_noop: with
+    TG_LATE_RERANK unset (the default), the late stage must never even be PROBED."""
+    monkeypatch.delenv("TG_LATE_RERANK", raising=False)
+    _stub_dense_clean(monkeypatch)
+    (tmp_path / "dense.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "sparse.py").write_text("# one passing invoice mention\nx = 1\n", encoding="utf-8")
+
+    def _must_not_be_called() -> tuple[bool, str | None]:
+        raise AssertionError("late_available() must not be called when TG_LATE_RERANK is unset")
+
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", _must_not_be_called)
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    assert result.exception is None, f"late_available() was called: {result.exception!r}"
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload.get("rank_fallback_reason") is None
+
+
+def test_find_late_head_runs_when_env_set(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The flip side: TG_LATE_RERANK=1 DOES probe/run the late stage, observably reordering."""
+    monkeypatch.setenv("TG_LATE_RERANK", "1")
+    _stub_dense_clean(monkeypatch)
+    (tmp_path / "dense.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "sparse.py").write_text("# one passing invoice mention\nx = 1\n", encoding="utf-8")
+    monkeypatch.setattr("tensor_grep.core.retrieval_late.late_available", lambda: (True, None))
+
+    def _prefer_sparse_encode(text: str) -> np.ndarray:
+        if text == "invoice" or "passing invoice mention" in text:
+            return np.array([[1.0, 0.0]], dtype=np.float32)
+        return np.array([[0.0, 1.0]], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_late.load_late_reranker",
+        lambda *a, **kw: LateReranker(encode=_prefer_sparse_encode),
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["matches"], "expected at least one ranked match"
+    # The late stage was demonstrably consulted -- either it reordered (no fallback reason) or it
+    # degraded and said so; either way the run must not have skipped straight past it silently.
+    assert result.exception is None
+
+
+def test_find_output_is_ascii(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _stub_dense_unavailable(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.isascii()
+    assert result.stderr.isascii()

--- a/tests/unit/test_find_command.py
+++ b/tests/unit/test_find_command.py
@@ -37,6 +37,26 @@ class _FakeDenseModel:
         return np.ones((len(texts), 4), dtype=np.float32)
 
 
+class _QueryDimMismatchModel:
+    """Encodes the CORPUS to dim 4 (so `DenseIndex(chunks, model)` CONSTRUCTION succeeds) but the
+    QUERY string to dim 5, so `DenseIndex.query` raises `DenseUnavailableError` at QUERY time (the
+    dim-mismatch shape check) -- from INSIDE `rank_chunks`, the F1 path distinct from the
+    construction path the outer `try/except DenseUnavailableError` already guards. This is the exact
+    fault the shipped `--semantic` sibling catches around its own `rerank_hybrid` call
+    (cli/main.py:3970-3984); the regression test below proves `tg find` catches it too."""
+
+    def __init__(self, query: str) -> None:
+        self._query = query
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        # The single-text query batch -> wrong dim (5); every other batch (the corpus chunks) -> the
+        # index's own dim (4). `_encode_matrix` still sees shape[0] == len(texts) for both, so only
+        # the query-time dim-mismatch check fires -- never the malformed-shape check.
+        if texts == [self._query]:
+            return np.ones((1, 5), dtype=np.float32)
+        return np.ones((len(texts), 4), dtype=np.float32)
+
+
 def _stub_dense_unavailable(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.setattr(
         "tensor_grep.core.retrieval_dense.dense_available",
@@ -67,6 +87,41 @@ def test_find_bm25_only_when_extra_absent_sets_rank_fallback_reason(
     assert payload.get("rank_fallback_reason") is not None
     assert "model2vec" in payload["rank_fallback_reason"]
     assert payload["total_matches"] >= 1
+
+
+def test_find_dense_unavailable_at_query_degrades_to_bm25_exit_0(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """Opus-gate blocker F1 regression: a `DenseUnavailableError` raised at QUERY time (a
+    dim/shape mismatch from inside `rank_chunks`'s `DenseIndex.query`, NOT at construction --
+    construction is already guarded) must degrade VISIBLY to BM25-only and exit 0, never escape
+    as a raw traceback + exit 1. `DenseUnavailableError` subclasses `RuntimeError`, so before the
+    F1 catch it was caught by neither the construction guard nor the command boundary (which
+    catches only FileNotFoundError / BackendExecutionError) -- a Backend Fail-Closed Contract
+    violation. Mirrors the shipped `--semantic` sibling's own F1 catch (cli/main.py:3970-3984)."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.load_dense_model",
+        lambda _dir: _QueryDimMismatchModel(query="invoice"),
+    )
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    # Degraded, NOT failed: a clean sys.exit(0), never a raw traceback and never exit 1.
+    assert result.exit_code == 0, result.output
+    assert result.exception is None, (
+        f"query-time DenseUnavailableError escaped as a traceback: {result.exception!r}"
+    )
+    payload = json.loads(result.stdout)
+    # Visible BM25-only degrade: the dim-mismatch reason is surfaced, and real matches still rank.
+    assert payload.get("rank_fallback_reason") is not None
+    assert "dim" in payload["rank_fallback_reason"].lower()
+    assert payload["total_matches"] >= 1
+    assert any(str(match["file"]).endswith("invoice.py") for match in payload["matches"])
 
 
 def test_find_corrupt_model_raises_backend_execution_error_exit_2(


### PR DESCRIPTION
## Summary

Adds `tg find "<query>" [PATH]`: whole-repo hybrid semantic search (BM25 +
local CPU dense-embedding relevance, RRF-fused, optional MaxSim late rerank),
ranked `file:line` results. No pattern pre-filter — walks and ranks the
**whole** repo, so it can surface content a vocabulary-mismatched regex would
miss. No API key, no GPU. Experimental, fail-closed, bounded, CPU-only.

Builds Wave 2b (registration) + 2c (pipeline) of the `tg find` plan. Wave 2a
(`rank_chunks` extraction, #624) and Wave 1 (the golden harness, #625) are
already merged to `main`; this PR's pipeline calls `rank_chunks` as-is and
does not touch it.

## The 4 must-fixes from the review ledger

- **C1 (fail-closed command boundary):** the `find` command catches
  `BackendExecutionError` at the CLI boundary and exits 2 with a clean `tg:`
  message (JSON or text), mirroring `search`'s own catch
  (`main.py` ~7528-7537). `_execute_find` deliberately does **not** catch it
  (see its docstring) — a corrupt dense/late model must never surface as a
  raw traceback.
- **C2 (partial-corpus honesty):** because `find` has no regex pre-filter
  scoping the corpus first (unlike `--semantic`), a repo-walk deadline cutoff,
  a `--max-repo-files` cap, or the internal corpus-wide chunk cap all set
  `result_incomplete=True` + a human-readable `incomplete_reason`, and the
  command exits 2. This is the **opposite** of `--semantic`'s own corpus-cap
  behavior (an exit-0 BM25-only degrade), which is only correct there because
  the corpus was already small/prefiltered by the time it's built.
- **C3 (exit-code contract):** the `0 results / 1 none / 2
  result_incomplete` exit block is hand-written at the command boundary,
  replicating `search`'s own contract (`main.py` ~7643-7679) — the
  `SearchResult` envelope buys the JSON fields, not the exit codes.
- **A1 (the real registration gates):** `registration_check.py` alone only
  covered the `search-flag-front-doors` / `lsp-languages` groups — the real
  gates for a new top-level command are `test_cli_bootstrap.py`'s
  Typer-vs-`KNOWN_COMMANDS` check and `test_routing_parity.py`'s real
  `--help` parity test. This PR adds `"find"` to `KNOWN_COMMANDS`, the Rust
  `Commands::Find` enum variant + dispatch arm, `PUBLIC_TOP_LEVEL_COMMANDS`,
  the `@app.command()` handler, **and** a new entity-scoped
  `.tg-registration.toml` group (`entities=["find"]`, sites = `commands.py`
  `KNOWN_COMMANDS` + `test_routing_parity.py` `PUBLIC_TOP_LEVEL_COMMANDS` —
  deliberately not the Rust enum, since the extractor needs an `=`-form
  declaration).

## OS matrix / CI note

The Rust change is 2 mechanical passthrough lines (an enum variant +
dispatch arm mirroring `Importers`). No `cargo`/`rustc`/`maturin` was run to
build this locally (CPU-safe shared-server constraint) — **CI's
ubuntu+macos+windows `test-rust-core` job compiles it**, and the
native-launcher parity test in this PR's own integration suite self-skips
locally without a built binary (asserted via `pytest.skip`, matching house
convention in `test_routing_parity.py`/`test_cross_backend.py`). **CI's
ubuntu+macos+windows `test-python` matrix is the release gate** for the
Python side.

Bonus (not required, not relied upon for correctness): a background process
on the shared dev box independently rebuilt
`rust_core/target/debug/tg.exe` from the edited `main.rs` mid-session (this
agent never invoked cargo/rustc/maturin). Dogfooding that binary read-only
confirmed the full pipeline end-to-end through the **real native binary**:
`tg --help` lists `find`, and `tg find invoice <tmp> --json` returns the
correct match with the representative-line tie-break landing on line 1 as
designed. This is corroborating evidence only; CI remains the authoritative
gate.

## Tests

- `tests/unit/test_find_command.py` (12 tests): BM25-only degrade when the
  `semantic` extra is absent, corrupt-model `BackendExecutionError` → exit 2
  (JSON + text mode), deadline truncation → `result_incomplete` + exit 2,
  `--max-repo-files` cap → exit 2, corpus chunk cap → exit 2 (C2), no-results
  → exit 1, JSON envelope fields, `--max-tokens` truncates the
  lowest-ranked matches first (floored at 1), `TG_LATE_RERANK` gates the late
  stage both ways, ASCII-safe output.
- `tests/integration/test_find_command_binary.py` (5 tests): invoked via the
  **real bootstrap entry** (`python -m tensor_grep`, not `CliRunner` — the
  house trap), `--help` contract, a tiny tmp-repo end-to-end run (JSON +
  text), no-results exit 1, and a native-launcher parity check that skips
  without a built binary.
- All 17 pass locally (sibling checkout's prebuilt venv interpreter against
  this worktree's `src/`, per the CPU-safe build constraint). No full-suite
  run — targeted files only, plus a spot-check of the existing
  `test_cli_bootstrap.py` (90 passed), `test_registration_check.py`, and the
  edited `tests/e2e/test_routing_parity.py` (14 passed, 39 skipped —
  native-binary-gated) to de-risk the registration-site changes specifically.

## Docs (same PR)

README.md (Text search bullet + Quick start example), the `tensor-grep`
skill (`SKILL.md` workflow step + `REFERENCE.md` command list and a new
"Whole-Repo Semantic Search" section). `docs/harness_api.md` intentionally
**not** touched (MCP/Wave-2d surface).

## Out of scope (explicitly, per the plan)

- The `tg_find` MCP tool (Wave 2d) — a separate PR, de-risking the
  LLM-facing surface (path-anchoring, sanitized errors) on its own.
- The CPU rank stack (Wave 3 — path-class deweight, file-coherence boost).
- Any `benchmarks/` change — Wave 1's harness (#625) already merged; the
  golden gate-run (`find >= bm25` on that harness) is the orchestrator's
  follow-up once this PR is reviewed, not part of this build.

## Review requirement

**This needs the MANDATORY Opus gate** (rank/pipeline logic touches the
fail-closed contract end-to-end) before merge — do NOT self-approve, do NOT
merge this PR as the build agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)