### PR TITLE
feat(find): adaptive dense-weight knob (default-off) + literal golden slice (Wave 3, #189)

### DIFF
--- a/benchmarks/datasets/literal_golden.jsonl
+++ b/benchmarks/datasets/literal_golden.jsonl
@@ -1,0 +1,10 @@
+{"id": "lit-01", "query": "bind_address", "category": "literal", "relevant": [{"file": "metrics/exporter.py", "start_line": 6, "end_line": 7}]}
+{"id": "lit-02", "query": "remember", "category": "literal", "relevant": [{"file": "cache/memo_store.py", "start_line": 14, "end_line": 16}]}
+{"id": "lit-03", "query": "take_snapshot", "category": "literal", "relevant": [{"file": "backup/snapshot_writer.py", "start_line": 4, "end_line": 5}]}
+{"id": "lit-04", "query": "resolve_hostname", "category": "literal", "relevant": [{"file": "net/dns_resolver.py", "start_line": 6, "end_line": 7}]}
+{"id": "lit-05", "query": "CorruptionFault", "category": "literal", "relevant": [{"file": "integrity/checksum_validator.py", "start_line": 6, "end_line": 7}]}
+{"id": "lit-06", "query": "attempts_remaining", "category": "literal", "relevant": [{"file": "queue/retry_budget.py", "start_line": 6, "end_line": 7}]}
+{"id": "lit-07", "query": "next_cursor", "category": "literal", "relevant": [{"file": "paging/cursor_paginator.py", "start_line": 8, "end_line": 10}]}
+{"id": "lit-08", "query": "PartnerBreakdown", "category": "literal", "relevant": [{"file": "net/http_bridge.py", "start_line": 4, "end_line": 5}]}
+{"id": "lit-09", "query": "make_preview", "category": "literal", "relevant": [{"file": "media/thumbnail_maker.py", "start_line": 4, "end_line": 5}]}
+{"id": "lit-10", "query": "read_rows", "category": "literal", "relevant": [{"file": "importer/csv_reader.py", "start_line": 4, "end_line": 5}]}

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3995,6 +3995,55 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
 # must-fix C2), never a silent exit-0 degrade.
 _FIND_CORPUS_CHUNK_CAP = MAX_CHUNKS
 
+# #189 (ledger DENSE-WEIGHT SWEEP, agent a8580b6e 2026-07-16): the golden-set sweep measured a
+# real ndcg@10/recall lift (1:5 bm25:dense -> +0.1419 ndcg@10, recall 0.55->0.80, ZERO
+# per-category regression) on the 40 NL vocab-mismatch golden queries -- but that set is 100% NL
+# and cannot see the opposite failure mode: a short/lexical query (the canary `vm-behavior-10`)
+# where BM25 is the stronger leg and boosting dense regresses it. `TG_FIND_DENSE_WEIGHT` is the
+# knob (default "1.0" = today's equal-weight fusion, a byte-identical no-op -- see
+# `core/reranker.py`'s `rank_chunks(dense_weight=...)`); `_find_dense_weight` below is the guard
+# that keeps a non-default env value scoped to the query shape the sweep actually validated.
+_FIND_DENSE_WEIGHT_ENV = "TG_FIND_DENSE_WEIGHT"
+_FIND_DENSE_WEIGHT_DEFAULT = 1.0
+# split_terms(query) token count strictly ABOVE this is treated as NL/multi-word; at or below it
+# is treated as a short identifier/literal (grep-style) query. Chosen from the golden-set sweep's
+# own corpus split: the NL set's split_terms token count is min 3 (never <=2), so ">2" is the
+# tightest floor that cannot misclassify any of the 40 measured NL queries while still catching a
+# bare 1-2-word literal search.
+_FIND_DENSE_WEIGHT_ADAPTIVE_TOKEN_FLOOR = 2
+
+
+def _find_dense_weight(query: str) -> float:
+    """Query-adaptive `dense_weight` for `tg find`'s `rank_chunks` calls ONLY (#189) -- DEFAULT-OFF:
+    `TG_FIND_DENSE_WEIGHT` unset, empty, or unparseable as a float always returns 1.0 (the
+    byte-identical no-op fusion weight), regardless of the query's shape. This mirrors
+    `reranker._int_env`'s "a malformed override must degrade gracefully" contract for a float
+    instead of an int.
+
+    When the env var IS set to a valid float, the dense leg is boosted ONLY for NL/multi-word
+    queries -- `split_terms(query)` yielding MORE than
+    :data:`_FIND_DENSE_WEIGHT_ADAPTIVE_TOKEN_FLOOR` tokens -- where the sweep measured the lift
+    with zero per-category regression. A short query (a bare identifier, function/class name, or a
+    1-2 word literal/grep-style search -- `tg find`'s own "literal" golden slice,
+    `benchmarks/datasets/literal_golden.jsonl`) instead routes to 1.0 (the un-boosted 1:1 fusion):
+    the sweep's canary case proved BM25 is the stronger leg there, so boosting dense would regress
+    it -- this is the guard that keeps the knob scoped to where it was actually measured to help,
+    not a blind flip.
+    """
+    raw = os.environ.get(_FIND_DENSE_WEIGHT_ENV)
+    if not raw:
+        return _FIND_DENSE_WEIGHT_DEFAULT
+    try:
+        weight = float(raw)
+    except ValueError:
+        return _FIND_DENSE_WEIGHT_DEFAULT
+
+    from tensor_grep.core.retrieval_lexical import split_terms
+
+    if len(split_terms(query)) > _FIND_DENSE_WEIGHT_ADAPTIVE_TOKEN_FLOOR:
+        return weight
+    return _FIND_DENSE_WEIGHT_DEFAULT
+
 
 def _find_representative_line(chunk: "Chunk", query_terms: set[str]) -> tuple[int, str]:
     """Pick ONE line within `chunk` to surface as the synthesized `MatchLine` (D2): the line with
@@ -4194,6 +4243,7 @@ def _execute_find(
             bm25_index=bm25_index,
             dense_index=dense_index,
             late_reranker=late_reranker,
+            dense_weight=_find_dense_weight(query),
         )
     except DenseUnavailableError as exc:
         # F1 (Opus-gate blocker; mirrors `_apply_semantic_rerank`'s own query-time catch,
@@ -4218,6 +4268,7 @@ def _execute_find(
             bm25_index=bm25_index,
             dense_index=None,
             late_reranker=None,
+            dense_weight=_find_dense_weight(query),
         )
     if late_fallback_reason:
         result.rank_fallback_reason = (

--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -222,6 +222,7 @@ def rank_chunks(
     dense_index: DenseIndex | None,
     late_reranker: LateReranker | None,
     k: int = DEFAULT_K,
+    dense_weight: float = 1.0,
 ) -> tuple[list[int], str | None]:
     """Fuse BM25 [+ dense] [+ path] chunk rankings via RRF, then optionally MaxSim-rerank the head
     via ``late_reranker`` -- the pure, fail-closed rank core shared by :func:`rerank_hybrid` and
@@ -229,6 +230,19 @@ def rank_chunks(
     byte-identically out of ``rerank_hybrid``: callers building their own ``bm25_index`` /
     ``dense_index`` (and, for ``rerank_hybrid``, the corpus-cap chunking) are unaffected -- this
     function only fuses and (optionally) late-reranks an already-built corpus.
+
+    ``dense_weight`` (#189, ledger DENSE-WEIGHT SWEEP): a per-call multiplier on the dense leg's
+    RRF weight, relative to the BM25 leg's fixed 1.0 -- ``weights=[1.0, dense_weight]`` when
+    ``dense_index`` is present and ``dense_weight`` is non-default. ``dense_weight=1.0`` (the
+    default) is a byte-identical no-op: no ``weights`` list is even built for this reason alone, so
+    fusion falls through to the exact same ``weights=None`` call ``rerank_hybrid`` (which never
+    passes ``dense_weight``) has always made. Composes with the ``TG_RRF_CHANNELS`` path channel
+    below: when both are active, the path leg's ``PATH_CHANNEL_WEIGHT`` is appended AFTER the dense
+    weight, so ``weights`` becomes ``[1.0, dense_weight, PATH_CHANNEL_WEIGHT]`` -- one entry per
+    ``rankings`` leg, in the same order they were built. Ignored (no effect) when
+    ``dense_index is None``: there is no dense leg to weight. Callers own picking a non-default
+    value; `tg find` is the only current caller that ever does (``cli/main.py``'s
+    ``_find_dense_weight``, itself gated behind ``TG_FIND_DENSE_WEIGHT`` and default-OFF).
 
     Returns ``(fused_order, late_fallback_reason)``:
 
@@ -249,8 +263,10 @@ def rank_chunks(
         rankings.append(dense_ranking)
 
     weights: list[float] | None = None
+    if dense_index is not None and dense_weight != 1.0:
+        weights = [1.0, dense_weight]
     if _rrf_channels_enabled():
-        weights = [1.0] * len(rankings)
+        weights = weights if weights is not None else [1.0] * len(rankings)
         path_ranking = _path_channel_ranking(chunks, query)
         if path_ranking:
             rankings.append(path_ranking)

--- a/tests/unit/test_find_command.py
+++ b/tests/unit/test_find_command.py
@@ -361,3 +361,73 @@ def test_find_output_is_ascii(tmp_path: Path, monkeypatch) -> None:  # type: ign
     assert result.exit_code == 0, result.output
     assert result.stdout.isascii()
     assert result.stderr.isascii()
+
+
+def _spy_on_rank_chunks(monkeypatch) -> list[float]:  # type: ignore[no-untyped-def]
+    """Wrap the REAL `rank_chunks` (reranker.py) so every call's `dense_weight` kwarg is recorded
+    before delegating -- `_execute_find` imports `rank_chunks` via a LOCAL
+    `from tensor_grep.core.reranker import rank_chunks` at call time (main.py), so the module
+    attribute on `tensor_grep.core.reranker` (not `tensor_grep.cli.main`) is the correct monkeypatch
+    target: the local import re-resolves the name from that module's namespace on every call."""
+    from tensor_grep.core import reranker as reranker_module
+
+    real_rank_chunks = reranker_module.rank_chunks
+    captured: list[float] = []
+
+    def _spy(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(kwargs.get("dense_weight", 1.0))
+        return real_rank_chunks(*args, **kwargs)
+
+    monkeypatch.setattr(reranker_module, "rank_chunks", _spy)
+    return captured
+
+
+def test_find_dense_weight_default_is_noop(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """TG_FIND_DENSE_WEIGHT unset (the default, #189) must be a byte-identical no-op: `_execute_find`
+    always calls `rank_chunks` with `dense_weight=1.0`, regardless of query shape -- including a
+    multi-word NL query, the ONE case the adaptive rule would treat differently if the default were
+    not truly inert. Mirrors `test_find_late_head_only_when_env_set`'s "prove the default never
+    changes behavior" strategy, at the `dense_weight` kwarg instead of the late-rerank probe."""
+    monkeypatch.delenv("TG_FIND_DENSE_WEIGHT", raising=False)
+    _stub_dense_clean(monkeypatch)
+    captured = _spy_on_rank_chunks(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    # A multi-word (>2 split_terms tokens) query -- the adaptive rule's NL branch -- so this test
+    # would catch an accidental "adaptive rule ignores the env-unset default" bug, not just an
+    # accidental non-1.0 literal default.
+    result = CliRunner().invoke(app, ["find", "invoice processing helper", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert captured, "rank_chunks was never called"
+    assert all(weight == 1.0 for weight in captured), (
+        f"expected dense_weight=1.0 (no-op) on every call with the env unset, got {captured}"
+    )
+
+
+def test_find_dense_weight_adaptive_nl_vs_literal(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """TG_FIND_DENSE_WEIGHT=5.0 (#189, ledger DENSE-WEIGHT SWEEP): a multi-word/NL query (>2
+    `split_terms` tokens) gets the boosted dense_weight; a short (<=2 token) identifier/literal
+    query is protected at 1.0 -- the adaptive rule's whole point (the golden-set sweep's canary,
+    `vm-behavior-10`, showed dense-only regresses a short lexical-overlap query, hence NOT a blind
+    flip)."""
+    monkeypatch.setenv("TG_FIND_DENSE_WEIGHT", "5.0")
+    _stub_dense_clean(monkeypatch)
+    captured = _spy_on_rank_chunks(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    nl_result = CliRunner().invoke(
+        app, ["find", "invoice processing helper text", str(tmp_path), "--json"]
+    )
+    assert nl_result.exit_code == 0, nl_result.output
+    assert captured[-1] == 5.0, f"multi-word query must get the boosted weight, got {captured}"
+
+    literal_result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+    assert literal_result.exit_code == 0, literal_result.output
+    assert captured[-1] == 1.0, f"a 1-token literal query must stay at 1.0, got {captured}"

--- a/tests/unit/test_rank_chunks.py
+++ b/tests/unit/test_rank_chunks.py
@@ -21,6 +21,7 @@ import pytest
 from tensor_grep.core.reranker import rank_chunks
 from tensor_grep.core.retrieval_bm25 import Bm25Index
 from tensor_grep.core.retrieval_chunker import Chunk
+from tensor_grep.core.retrieval_dense import DenseIndex
 from tensor_grep.core.retrieval_fusion import DEFAULT_K
 from tensor_grep.core.retrieval_late import LateReranker, LateRerankUnavailableError
 
@@ -183,3 +184,132 @@ def test_rank_chunks_other_exception_from_worker_thread_propagates() -> None:
             late_reranker=LateReranker(encode=_raising_other),
             k=DEFAULT_K,
         )
+
+
+class _FixedVectorModel:
+    """Deterministic stand-in dense encoder: maps each EXACT input string to a hand-picked
+    vector, mirroring ``test_reranker_hybrid.py``'s identical fixture -- a scenario's dense-leg
+    cosine ranking is fully predictable."""
+
+    def __init__(self, vectors_by_text: dict[str, list[float]]) -> None:
+        self._vectors_by_text = vectors_by_text
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        return np.array([self._vectors_by_text[t] for t in texts], dtype=np.float32)
+
+
+def test_rank_chunks_dense_weight(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """``dense_weight`` (#189, ledger DENSE-WEIGHT SWEEP): a per-call RRF weight multiplier on the
+    dense leg, relative to the BM25 leg's fixed 1.0.
+
+    - ``dense_weight=1.0`` (the default, and the value an omitted kwarg implies) MUST be a
+      byte-identical no-op: ``reciprocal_rank_fusion`` must be called with ``weights=None``,
+      exactly as it always was before this kwarg existed -- proven here by spying on
+      ``reranker.reciprocal_rank_fusion`` and asserting the captured ``weights`` arg is ``None``,
+      not merely that the fused order happens to match (a coincidental match would not catch e.g.
+      an accidental ``weights=[1.0, 1.0]`` substitution, which -- per
+      ``retrieval_fusion.reciprocal_rank_fusion``'s own docstring -- IS numerically identical to
+      ``None`` for THIS scenario, but is not the same call shape ``rerank_hybrid`` has always made).
+    - ``dense_weight=5.0`` must thread ``weights=[1.0, 5.0]`` into fusion (bm25 leg at 1.0, dense
+      leg boosted 5x), and this must be OBSERVABLE: a scenario where the BM25-preferred chunk and
+      the dense-preferred chunk differ enough that boosting the dense leg flips which one fuses to
+      the TOP rank. ``k=1`` (rather than the production ``DEFAULT_K=60``) is used deliberately to
+      keep the scenario to 4 small, hand-computable chunks -- RRF's ``1/(k+rank)`` term is far more
+      rank-sensitive at a small ``k``, so a clean top-rank flip needs neither a large corpus nor an
+      extreme weight to demonstrate.
+    """
+    from tensor_grep.core import reranker as reranker_module
+
+    real_fusion = reranker_module.reciprocal_rank_fusion
+    captured_weights: list[list[float] | None] = []
+
+    def _spy_fusion(rankings, *, k=DEFAULT_K, weights=None):  # type: ignore[no-untyped-def]
+        captured_weights.append(list(weights) if weights is not None else None)
+        return real_fusion(rankings, k=k, weights=weights)
+
+    monkeypatch.setattr(reranker_module, "reciprocal_rank_fusion", _spy_fusion)
+
+    # chunk 0 is the ONLY bm25 match for "invoice" and the WORST (last, rank 4) dense match;
+    # chunk 1 is the BEST (rank 1) dense match and absent from bm25 entirely; chunks 2/3 are
+    # dense-only filler at ranks 2/3 so chunk 1's dense rank is unambiguously "1st of 4", not "1st
+    # of 2" (a degenerate 2-chunk scenario RRF would not meaningfully distinguish from bm25 alone).
+    chunks = [
+        Chunk(file_path="bm25_pick.py", start_line=1, end_line=1, text="invoice request"),
+        Chunk(file_path="dense_pick.py", start_line=1, end_line=1, text="filler_a"),
+        Chunk(file_path="filler_b.py", start_line=1, end_line=1, text="filler_b"),
+        Chunk(file_path="filler_c.py", start_line=1, end_line=1, text="filler_c"),
+    ]
+    bm25_index = Bm25Index(chunks)
+    dense_model = _FixedVectorModel({
+        "invoice": [1.0, 0.0],  # the QUERY's own vector
+        "invoice request": [
+            0.0,
+            1.0,
+        ],  # chunk 0: orthogonal to the query -> cosine 0, rank 4 (last)
+        "filler_a": [1.0, 0.0],  # chunk 1: cosine 1.0, rank 1 (best)
+        "filler_b": [1.0, 0.1],  # chunk 2: cosine ~0.995, rank 2
+        "filler_c": [1.0, 0.2],  # chunk 3: cosine ~0.981, rank 3
+    })
+    dense_index = DenseIndex(chunks, dense_model)
+
+    # Sanity-check the scenario setup itself before trusting the fused assertions below.
+    assert [i for i, _ in bm25_index.query("invoice", top_k=4)] == [0]
+    assert [i for i, _ in dense_index.query("invoice", top_k=4)] == [1, 2, 3, 0]
+
+    order_default, _ = rank_chunks(
+        "invoice", chunks, bm25_index=bm25_index, dense_index=dense_index, late_reranker=None, k=1
+    )
+    assert captured_weights[-1] is None, (
+        "dense_weight defaulting to 1.0 must not build a weights list at all"
+    )
+    assert order_default[0] == 0, "equal weight: the bm25-favored chunk fuses to rank 1"
+
+    order_explicit_default, _ = rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=dense_index,
+        late_reranker=None,
+        k=1,
+        dense_weight=1.0,
+    )
+    assert captured_weights[-1] is None, (
+        "an EXPLICIT dense_weight=1.0 must also skip the weights list entirely"
+    )
+    assert order_explicit_default == order_default, (
+        "dense_weight=1.0 must be byte-identical to omitting the kwarg"
+    )
+
+    order_boosted, _ = rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=dense_index,
+        late_reranker=None,
+        k=1,
+        dense_weight=5.0,
+    )
+    assert captured_weights[-1] == [1.0, 5.0]
+    assert order_boosted[0] == 1, "boosted 5x: the dense-favored chunk overtakes the bm25 favorite"
+    assert order_boosted != order_default, "the weight change must be OBSERVABLE in the fused order"
+
+
+def test_rank_chunks_dense_weight_ignored_without_dense_index() -> None:
+    """``dense_weight`` has nothing to weight when there is no dense leg at all -- passing a
+    non-default value with ``dense_index=None`` must be silently inert, not an error, mirroring
+    `tg find`'s own F1 BM25-only re-run (main.py), which passes ``dense_weight=`` unconditionally
+    even on the ``dense_index=None`` degrade path."""
+    chunks, bm25_index = _build_chunks()
+
+    baseline, _ = rank_chunks(
+        "invoice", chunks, bm25_index=bm25_index, dense_index=None, late_reranker=None
+    )
+    with_weight, _ = rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=None,
+        dense_weight=5.0,
+    )
+    assert with_weight == baseline == [0]


### PR DESCRIPTION
## Summary

Ships the `tg find` dense-weight knob + query-adaptive rule + a literal-query golden slice as
evidence-gathering infrastructure for the ledger's DENSE-WEIGHT SWEEP recommendation (design pass,
agent a8580b6e, 2026-07-16). **This PR ships DEFAULT-OFF and changes no default behavior** -- see
"Byte-identical by default" below. The actual default-flip (turning `TG_FIND_DENSE_WEIGHT` on in
any environment) is a **SEPARATE, later, conscious decision** made after reviewing this evidence --
not part of this PR.

### Background

The prior design pass swept `bm25:dense` RRF weight ratios on the 40-query NL golden set
(`benchmarks/datasets/late_rerank_golden.jsonl`) and found 1:5 lifts `ndcg@10` +0.14 / `recall@10`
+0.25 with zero per-category regression -- but that golden set is 100% NL/vocab-mismatch queries,
so it cannot see the opposite risk: a short, literal/identifier query where BM25 is the *stronger*
leg and boosting dense could regress it (the sweep's own canary, `vm-behavior-10`, hinted at this).
This PR adds the knob, an adaptive rule that only boosts NL-shaped queries, and a literal-query
golden slice to close that blind spot -- so a future default-flip decision has real evidence for
both sides, not just the NL side.

### What changed

1. **The knob** -- `src/tensor_grep/core/reranker.py`, `rank_chunks` gains `dense_weight: float =
   1.0`. When `dense_index` is present and `dense_weight != 1.0`, `weights=[1.0, dense_weight]` is
   threaded into `reciprocal_rank_fusion` (BM25 leg fixed at 1.0, dense leg multiplied). This
   composes correctly with the existing `TG_RRF_CHANNELS` path-channel append -- when both are
   active, `weights` becomes `[1.0, dense_weight, PATH_CHANNEL_WEIGHT]`, one entry per fusion leg
   in the order they're built.
2. **The adaptive rule** -- `src/tensor_grep/cli/main.py` gains `_find_dense_weight(query) ->
   float`, reading a new env `TG_FIND_DENSE_WEIGHT` (default `1.0`; unset/empty/unparseable all
   degrade gracefully to `1.0`, mirroring `reranker._int_env`'s "malformed override degrades
   gracefully" convention). Query-adaptive: `split_terms(query)` yielding **more than 2 tokens**
   (NL/multi-word) returns the env value; **2 tokens or fewer** (a bare identifier,
   function/class name, or a short literal/grep-style search) always returns `1.0` -- routing
   short queries to the un-boosted 1:1 fusion the sweep already validated as safe.
3. **Wired into `tg find` ONLY** -- both `rank_chunks` calls inside `_execute_find` (the primary
   call and the F1 BM25-only degrade re-run) now pass `dense_weight=_find_dense_weight(query)`.
   `_apply_semantic_rerank` / `tg search --semantic` is **untouched** (its own prefiltered path
   stays 1:1, per its docstring). The MCP `tg_find` tool inherits the wiring for free since it
   calls the same shared `_execute_find` -- no separate edit needed there, and its own test suite
   (`test_mcp_tg_find.py`) passes unchanged.
4. **Literal-query golden slice** -- new `benchmarks/datasets/literal_golden.jsonl`, 10 queries
   targeting verbatim, single-file-unique identifier/function/class names already present in
   `find_golden_corpus/` (e.g. `bind_address`, `CorruptionFault`, `resolve_hostname`). Every query
   is <=2 `split_terms` tokens by construction, so it exercises exactly the adaptive rule's
   "literal" branch the 100%-NL existing golden set structurally cannot reach.

### Byte-identical by default

`TG_FIND_DENSE_WEIGHT` unset (the default everywhere today) means `_find_dense_weight` always
returns `1.0` regardless of query shape, and `rank_chunks(dense_weight=1.0)` never builds a
`weights` list at all -- fusion falls through to the exact `weights=None` call `rerank_hybrid` has
always made. No existing test was modified to make this pass:
`tests/unit/test_reranker_hybrid.py`, `tests/unit/test_search_semantic_rerank.py`,
`tests/unit/test_find_command.py`, and `tests/unit/test_mcp_tg_find.py` all pass **unchanged**.

### Re-sweep evidence (real dense leg, potion-code-16M, both golden sets)

Ran the real production `rank_chunks` + `_find_dense_weight` (not a reimplementation) over both
golden sets at `TG_FIND_DENSE_WEIGHT` unset (baseline, always 1.0) and `=5.0` (adaptive). Both
oracles pass `--validate-oracle`-equivalent bidirectional validation first.

| Dataset | Run | mean ndcg@10 | mean recall@10 | vs baseline (ndcg@10) |
|---|---|---|---|---|
| NL (40 queries, `late_rerank_golden.jsonl`) | baseline (1.0) | 0.3047 | 0.5500 | -- |
| NL (40 queries) | adaptive (5.0) | 0.4466 | 0.8000 | **21 wins / 3 losses / 16 ties** |
| literal (10 queries, `literal_golden.jsonl`, NEW) | baseline (1.0) | 1.0000 | 1.0000 | -- |
| literal (10 queries) | adaptive (5.0) | 1.0000 | 1.0000 | **0 wins / 0 losses / 10 ties** |

- The NL baseline (0.3047/0.5500) reproduces the ledger's prior measured `rrf` arm numbers
  (0.305/0.55) exactly, and the adaptive win/loss/tie split (21W/3L/16T) matches the ledger's prior
  sweep exactly -- cross-validating this PR's implementation against the original design-pass
  numbers.
- The literal slice is **byte-identical** at both settings: `_find_dense_weight` returns `1.0` for
  all 10 queries under `TG_FIND_DENSE_WEIGHT=5.0` (confirmed by instrumenting the actual call), so
  the adaptive rule's routing is verified correct, not just assumed.
- **Honest caveat**: on this literal slice specifically, even *force-applying* `dense_weight=5.0`
  (bypassing the adaptive guard entirely, as an adversarial check) did not regress any of the 10
  queries, nor 4 additional short-but-indirect 2-token probes tried against the same corpus (e.g.
  `"shared pool"` -> `pool_manager.py`). The `find_golden_corpus` synthetic corpus is small (74
  files/chunks) and each concept is cleanly separated, so BM25 and dense already agree strongly on
  unique-identifier and short-phrase queries there. This PR's short-query guard is therefore a
  **principled, conservative-by-design** protection (matching the task spec exactly) rather than
  one this specific corpus independently proves was *necessary* -- the risk it guards against is
  evidenced by the ledger's own NL-side canary (`vm-behavior-10`, a longer indirect query where
  dense measurably hurts), not by a directly-reproduced short-query regression. Flagging this so
  the eventual default-flip decision isn't oversold on the literal-side evidence specifically.

### Gate

This touches rank logic and **requires the MANDATORY Opus rank-logic gate before merge** -- not
self-approved, per house rules. **Do not merge this PR** without it. The default-flip itself (any
environment ever setting `TG_FIND_DENSE_WEIGHT` to a non-1.0 value) is intentionally a separate,
later, conscious decision made after reviewing this evidence -- out of scope here.

## Test plan

- [x] RED->GREEN TDD: every new test written first and confirmed failing before the corresponding
      implementation landed.
- [x] `tests/unit/test_rank_chunks.py::test_rank_chunks_dense_weight` -- `dense_weight=1.0` is
      byte-identical to omitting the kwarg (`weights=None` captured via a fusion spy);
      `dense_weight=5.0` threads `weights=[1.0, 5.0]` and produces an observable top-rank flip.
- [x] `tests/unit/test_rank_chunks.py::test_rank_chunks_dense_weight_ignored_without_dense_index`
      -- a non-default weight is inert when there is no dense leg.
- [x] `tests/unit/test_find_command.py::test_find_dense_weight_default_is_noop` -- env unset ->
      `rank_chunks` always called with `dense_weight=1.0`, including for a multi-word query.
- [x] `tests/unit/test_find_command.py::test_find_dense_weight_adaptive_nl_vs_literal` -- env=5.0:
      a multi-word query gets 5.0, a short query stays at 1.0.
- [x] GREEN GATE: `test_reranker_hybrid.py` + `test_search_semantic_rerank.py` +
      `test_find_command.py` + `test_mcp_tg_find.py` pass unchanged (70 targeted tests total, run
      both with and without the `semantic` extra present, matching CI's `[dev]`-only install).
- [x] `ruff format --preview` + `ruff check` clean on every touched file.
- [x] Harness re-sweep against the real dense model (potion-code-16M) over both golden sets,
      `--validate-oracle`-equivalent bidirectional oracle validation passing on both.
- [ ] MANDATORY Opus rank-logic gate (blocking merge).
- [ ] CI (the authoritative gate per house rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
