### PR TITLE
feat(find): flip TG_FIND_DENSE_WEIGHT default to adaptive dense-favored weight for multi-word NL queries (#191)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -4001,11 +4001,26 @@ _FIND_CORPUS_CHUNK_CAP = MAX_CHUNKS
 # per-category regression) on the 40 NL vocab-mismatch golden queries -- but that set is 100% NL
 # and cannot see the opposite failure mode: a short/lexical query (the canary `vm-behavior-10`)
 # where BM25 is the stronger leg and boosting dense regresses it. `TG_FIND_DENSE_WEIGHT` is the
-# knob (default "1.0" = today's equal-weight fusion, a byte-identical no-op -- see
-# `core/reranker.py`'s `rank_chunks(dense_weight=...)`); `_find_dense_weight` below is the guard
-# that keeps a non-default env value scoped to the query shape the sweep actually validated.
+# knob (see `core/reranker.py`'s `rank_chunks(dense_weight=...)`); `_find_dense_weight` below is
+# the guard that keeps the boost scoped to the query shape the sweep actually validated.
+#
+# #191 (THE FLIP): the env-unset default is no longer the inert 1.0 no-op. With the classifier
+# hardened (whitespace gate, below) and the flip-prep NITs closed (nan/inf clamp, 3-token
+# identifier re-sweep), env-unset now applies the SAME adaptive rule a valid explicit override
+# would: a multi-word NL query gets `_FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT` (5.0, the ledger-swept
+# 1:5 bm25:dense ratio); a single whitespace-free token stays at the protected 1.0. A malformed or
+# non-finite override (a typo, `nan`, `inf`) is now treated exactly like unset -- it resolves to
+# the SAME adaptive default rather than silently opting a typo'd operator OUT of the improved
+# default (thinktank rank-lens must-fix, 2026-07-16). An operator who wants the OLD equal-weight
+# fusion back must set `TG_FIND_DENSE_WEIGHT=1.0` explicitly.
 _FIND_DENSE_WEIGHT_ENV = "TG_FIND_DENSE_WEIGHT"
 _FIND_DENSE_WEIGHT_DEFAULT = 1.0
+# The ledger-validated adaptive weight (#191, DENSE-WEIGHT SWEEP): encodes the swept 1:5
+# bm25:dense ratio -- `rank_chunks` fixes the bm25 leg at 1.0, so `dense_weight=5.0` IS the 1:5
+# ratio (tg_find_review_ledger.md DENSE-WEIGHT SWEEP). This is now the env-UNSET (and
+# env-malformed/non-finite) resolution for a genuinely multi-word query; a single-token query
+# still resolves to `_FIND_DENSE_WEIGHT_DEFAULT` above via the whitespace gate.
+_FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT = 5.0
 # Whitespace-based NL-vs-literal classifier (dogfood finding, #191): a query with MORE THAN ONE
 # whitespace-separated word is NL/multi-word and gets the adaptive weight; a single whitespace-free
 # token is a literal identifier (a symbol name, a grep-style search) and stays at 1.0. The prior
@@ -4019,21 +4034,24 @@ _FIND_DENSE_WEIGHT_DEFAULT = 1.0
 
 
 def _find_dense_weight(query: str) -> float:
-    """Query-adaptive `dense_weight` for `tg find`'s `rank_chunks` calls ONLY (#189) -- DEFAULT-OFF:
-    `TG_FIND_DENSE_WEIGHT` unset, empty, unparseable, or non-finite (see flip-prep NIT 1 below)
-    always returns 1.0 (the byte-identical no-op fusion weight), regardless of the query's shape.
-    This mirrors `reranker._int_env`'s "a malformed override must degrade gracefully" contract for
-    a float instead of an int.
+    """Query-adaptive `dense_weight` for `tg find`'s `rank_chunks` calls ONLY (#189, flipped ON by
+    #191): with `TG_FIND_DENSE_WEIGHT` unset -- or set to something malformed/unparseable/
+    non-finite (see flip-prep NIT 1 below) -- a genuinely multi-word NL query now gets the
+    ledger-validated `_FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT` (5.0) instead of the old inert 1.0
+    no-op. A single whitespace-free token ALWAYS stays at the protected
+    `_FIND_DENSE_WEIGHT_DEFAULT` (1.0), regardless of the env var's state -- the whitespace gate
+    below applies uniformly to the adaptive default, a malformed/non-finite fallback, AND an
+    explicit override alike.
 
-    When the env var IS set to a valid FINITE float, the dense leg is boosted ONLY for genuinely
-    multi-word NL queries -- `query.split()` yielding MORE than ONE whitespace-separated word --
-    where the golden-set sweep measured the lift with zero per-category regression. A single
-    whitespace-free token (a bare identifier, a function/class/symbol name, a grep-style literal
-    search -- `tg find`'s own "literal" and "identifier3" golden slices,
+    When the env var IS set to a valid FINITE float, that EXPLICIT value replaces the adaptive
+    default for a multi-word query -- `TG_FIND_DENSE_WEIGHT=1.0` is the explicit opt-out back to
+    the old equal-weight fusion; any other finite value (e.g. `=3.0`) is honored verbatim. A
+    single whitespace-free token (a bare identifier, a function/class/symbol name, a grep-style
+    literal search -- `tg find`'s own "literal" and "identifier3" golden slices,
     `benchmarks/datasets/literal_golden.jsonl` + `identifier3_golden.jsonl`) instead routes to 1.0
-    (the un-boosted 1:1 fusion): the sweep's canary case proved BM25 is the stronger leg for a
-    lexical query, so boosting dense would risk regressing it -- this is the guard that keeps the
-    knob scoped to where it was actually measured to help, not a blind flip.
+    (the un-boosted 1:1 fusion) NO MATTER what the env var says: the sweep's canary case proved
+    BM25 is the stronger leg for a lexical query, so boosting dense would risk regressing it --
+    this is the guard that keeps the knob scoped to where it was actually measured to help.
 
     Whitespace, NOT morphemes (dogfood finding, #191): the classifier gates on whitespace-separated
     word count, never `split_terms(query)` morpheme count. `split_terms` splits snake_case/camelCase
@@ -4044,29 +4062,46 @@ def _find_dense_weight(query: str) -> float:
     identifier queries wrongly boosted, only the 2-morpheme `rank_chunks` protected); the
     whitespace gate is the dogfood's own recommended fix.
 
+    KNOWN SCOPE (thinktank rank-lens, 2026-07-16): the whitespace gate is purely structural -- a
+    2-word LEXICAL phrase (e.g. `"return None"`, `"TODO fixme"`) is indistinguishable from a
+    2-word NL phrase and ALSO receives the adaptive boost. The 1:5 sweep is 100% NL queries and
+    the literal/identifier3 golden slices are single-token by construction, so this exact shape is
+    UNMEASURED. This is a deliberate non-goal, not an oversight: building a lexical-vs-NL content
+    classifier here would repeat the exact mistake the morpheme classifier made (a content-based
+    heuristic that silently misclassifies real queries) -- see
+    `test_find_dense_weight_default_boosts_two_word_lexical_canary` for the regression-catching
+    canary this scope decision needs. `TG_FIND_DENSE_WEIGHT=1.0` remains the escape hatch for a
+    precise 2-word literal search; `potion-code-16M` is a CODE-domain embedding model, which makes
+    boosting a 2-word code fragment defensible too, not just prose NL.
+
     Flip-prep NIT 1 (tg_find_review_ledger.md FLIP-PREP): `float("nan")` / `float("inf")` /
     `float("-inf")` all PARSE successfully -- `ValueError` alone never catches them, and `nan` in
     particular compares unequal to everything (including itself), so a downstream `!= 1.0` check
-    would treat it as "non-default" too. Left unclamped, a malformed-but-parseable
-    `TG_FIND_DENSE_WEIGHT=nan` would flow into `rank_chunks(dense_weight=nan)`, building a
-    degenerate `weights=[1.0, nan]` list for `reciprocal_rank_fusion`'s sort. `math.isfinite`
-    rejects `nan` and both infinities the same way the `except ValueError` branch above rejects
-    outright garbage, before the query-shape check ever runs.
+    would treat it as "non-default" too. `math.isfinite` rejects `nan` and both infinities the same
+    way the `except ValueError` branch below rejects outright garbage -- both now fall through to
+    the SAME adaptive-default resolution as an unset env var (#191 must-fix 2: a typo must not
+    silently opt an operator OUT of the improved default), rather than being clamped to the old
+    1.0. Either way, a non-finite value never reaches `rank_chunks(dense_weight=...)`:
+    `weights=[1.0, nan]` would otherwise build a degenerate list for `reciprocal_rank_fusion`'s
+    sort.
     """
     raw = os.environ.get(_FIND_DENSE_WEIGHT_ENV)
-    if not raw:
-        return _FIND_DENSE_WEIGHT_DEFAULT
-    try:
-        weight = float(raw)
-    except ValueError:
-        return _FIND_DENSE_WEIGHT_DEFAULT
-    if not math.isfinite(weight):
-        return _FIND_DENSE_WEIGHT_DEFAULT
+    weight = _FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT
+    if raw:
+        try:
+            explicit = float(raw)
+        except ValueError:
+            explicit = None
+        if explicit is not None and math.isfinite(explicit):
+            weight = explicit
+        # else: malformed or non-finite -- treated exactly like an unset env var (falls through to
+        # the adaptive default above), per #191 must-fix 2.
 
     # A single whitespace-free token (or an empty/whitespace-only query, whose `split()` -> []) is a
-    # literal identifier -> stay at the protected 1.0. Only a genuinely multi-word (space-separated)
-    # query is NL and gets the adaptive weight. Whitespace, not `split_terms` morphemes -- see the
-    # module comment above `_FIND_DENSE_WEIGHT_ENV` for the dogfood finding (#191) this fixes.
+    # literal identifier -> stay at the protected 1.0, regardless of the env var's state. Only a
+    # genuinely multi-word (space-separated) query is NL and gets the resolved `weight` above.
+    # Whitespace, not `split_terms` morphemes -- see the module comment above `_FIND_DENSE_WEIGHT_ENV`
+    # for the dogfood finding (#191) this fixes.
     if len(query.split()) <= 1:
         return _FIND_DENSE_WEIGHT_DEFAULT
     return weight

--- a/tests/unit/test_find_command.py
+++ b/tests/unit/test_find_command.py
@@ -382,12 +382,19 @@ def _spy_on_rank_chunks(monkeypatch) -> list[float]:  # type: ignore[no-untyped-
     return captured
 
 
-def test_find_dense_weight_default_is_noop(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """TG_FIND_DENSE_WEIGHT unset (the default, #189) must be a byte-identical no-op: `_execute_find`
-    always calls `rank_chunks` with `dense_weight=1.0`, regardless of query shape -- including a
-    multi-word NL query, the ONE case the adaptive rule would treat differently if the default were
-    not truly inert. Mirrors `test_find_late_head_only_when_env_set`'s "prove the default never
-    changes behavior" strategy, at the `dense_weight` kwarg instead of the late-rerank probe."""
+def test_find_dense_weight_default_is_adaptive_end_to_end(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """#191 (the default flip): with TG_FIND_DENSE_WEIGHT UNSET -- today's production env, and the
+    ONLY thing this PR changes -- a genuinely multi-word NL query must now thread the
+    ledger-validated ADAPTIVE weight (5.0, `tg_find_review_ledger.md` DENSE-WEIGHT SWEEP: 1:5
+    bm25:dense -> +0.1419 ndcg@10, recall 0.55->0.80, zero per-category regression) into
+    `rank_chunks`, not the old inert 1.0 no-op. A single-token query must stay at the protected
+    1.0 -- the whitespace gate applies to the new adaptive default exactly as it does to an
+    explicit env override (see `test_find_dense_weight_adaptive_nl_vs_literal` below).
+
+    Was RED before the flip: `_execute_find` used to call `rank_chunks(dense_weight=1.0)`
+    unconditionally when the env was unset, regardless of query shape. This is the end-to-end
+    proof the flip actually reaches the real call chain, not just the helper in isolation -- see
+    `test_find_dense_weight_default_protects_literal_identifiers` for the direct-call companion."""
     monkeypatch.delenv("TG_FIND_DENSE_WEIGHT", raising=False)
     _stub_dense_clean(monkeypatch)
     captured = _spy_on_rank_chunks(monkeypatch)
@@ -396,16 +403,59 @@ def test_find_dense_weight_default_is_noop(tmp_path: Path, monkeypatch) -> None:
         encoding="utf-8",
     )
 
-    # A multi-word (>1 whitespace-separated word) query -- the adaptive rule's NL branch -- so this
-    # test would catch an accidental "adaptive rule ignores the env-unset default" bug, not just an
-    # accidental non-1.0 literal default.
-    result = CliRunner().invoke(app, ["find", "invoice processing helper", str(tmp_path), "--json"])
-
-    assert result.exit_code == 0, result.output
-    assert captured, "rank_chunks was never called"
-    assert all(weight == 1.0 for weight in captured), (
-        f"expected dense_weight=1.0 (no-op) on every call with the env unset, got {captured}"
+    # A multi-word (>1 whitespace-separated word) query -- the adaptive rule's NL branch.
+    nl_result = CliRunner().invoke(
+        app, ["find", "invoice processing helper", str(tmp_path), "--json"]
     )
+    assert nl_result.exit_code == 0, nl_result.output
+    assert captured, "rank_chunks was never called"
+    assert captured[-1] == 5.0, (
+        f"env-unset multi-word query must now get the adaptive weight, got {captured}"
+    )
+
+    # A single whitespace-free token must stay at the protected no-op weight, env-unset or not.
+    literal_result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+    assert literal_result.exit_code == 0, literal_result.output
+    assert captured[-1] == 1.0, (
+        f"env-unset single-token query must stay at the protected 1.0, got {captured}"
+    )
+
+
+def test_find_dense_weight_default_protects_literal_identifiers(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """#191 (the default flip), direct-call companion to the end-to-end test above: pins the
+    ADAPTIVE-by-default behavior at the `_find_dense_weight` helper level, across the real
+    dogfood-caught identifier shapes (`tg_find_review_ledger.md` REAL-REPO DOGFOOD) -- with
+    TG_FIND_DENSE_WEIGHT UNSET, every one of these single-token, multi-morpheme identifiers must
+    still resolve to the protected 1.0 (the whitespace gate does not care whether the weight it is
+    guarding came from an explicit env override or the new adaptive default), while genuinely
+    multi-word NL queries resolve to the adaptive 5.0. Mirrors
+    `test_find_dense_weight_multimorpheme_identifier_protected`'s identifier list, env UNSET
+    instead of env=5.0."""
+    from tensor_grep.cli.main import _find_dense_weight
+
+    monkeypatch.delenv("TG_FIND_DENSE_WEIGHT", raising=False)
+
+    protected_identifiers = [
+        "mint_access_token",  # snake_case, 3 morphemes
+        "getUserName",  # camelCase, 3 morphemes
+        "_confine_mcp_path",  # leading underscore, 3 morphemes
+        "BackendExecutionError",  # PascalCase, 3 morphemes
+        "reciprocal_rank_fusion",  # 3 morphemes
+        "_iter_repo_files",  # 3 morphemes
+        "rank_chunks",  # 2 morphemes (the ONE the old rule happened to protect)
+    ]
+    for identifier in protected_identifiers:
+        assert _find_dense_weight(identifier) == 1.0, (
+            f"single-token identifier {identifier!r} must stay at 1.0 under the adaptive default, "
+            "not just under an explicit env override"
+        )
+
+    # Genuinely multi-word NL queries get the adaptive default instead of the old inert 1.0.
+    assert _find_dense_weight("how does the retry backoff work") == 5.0
+    assert _find_dense_weight("borrow a connection out of a shared pool") == 5.0
+    assert _find_dense_weight("verify login credentials") == 5.0
+    # Boundary: even a bare 2-word phrase is multi-word -> adaptive (whitespace, not word length).
+    assert _find_dense_weight("shared pool") == 5.0
 
 
 def test_find_dense_weight_adaptive_nl_vs_literal(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -484,24 +534,98 @@ def test_find_dense_weight_multimorpheme_identifier_protected(monkeypatch) -> No
     assert _find_dense_weight("shared pool") == 5.0
 
 
-def test_find_dense_weight_nonfinite_env_clamps_to_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """Flip-prep NIT 1 (tg_find_review_ledger.md FLIP-PREP): `float("nan")` / `float("inf")` /
-    `float("-inf")` all PARSE without raising `ValueError`, so the pre-existing `except ValueError`
-    guard alone never rejected them -- left unclamped, `_find_dense_weight` would return `nan`/`inf`
-    for a multi-word query, and `rank_chunks(dense_weight=nan)` would thread a degenerate
-    `weights=[1.0, nan]` list into `reciprocal_rank_fusion`'s sort. Mirrors
-    `test_reranker.py::test_rank_corpus_chunk_cap_non_positive_or_malformed_env_falls_back_to_default`'s
-    direct-import-and-call pattern for a malformed-override guard. A multi-word (>1
-    whitespace-separated word) query is used so the adaptive branch is actually reached -- a
-    single-token literal query already returns 1.0 unconditionally (see
-    test_find_dense_weight_multimorpheme_identifier_protected above) and would never exercise this
-    guard at all."""
+def test_find_dense_weight_explicit_env_override_wins_over_adaptive_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """#191 flip-safety pin: an explicit TG_FIND_DENSE_WEIGHT env value always wins over the new
+    adaptive default -- the flip only changes what happens when the env is ABSENT, never when an
+    operator has set one. `=1.0` is the explicit opt-out (must NOT be silently upgraded to the
+    adaptive 5.0 just because 1.0 also happens to be the literal-path fallback); `=3.0` is an
+    arbitrary explicit override distinct from both 1.0 and the adaptive 5.0, proving the env value
+    itself is threaded through rather than clobbered by the new default. The whitespace gate still
+    protects single-token identifiers under an explicit override, unchanged from before the flip
+    (see test_find_dense_weight_multimorpheme_identifier_protected above)."""
     from tensor_grep.cli.main import _find_dense_weight
 
-    for bad_value in ("nan", "-nan", "NaN", "inf", "-inf", "Infinity", "-Infinity"):
+    monkeypatch.setenv("TG_FIND_DENSE_WEIGHT", "1.0")
+    assert _find_dense_weight("invoice processing helper") == 1.0, (
+        "an explicit TG_FIND_DENSE_WEIGHT=1.0 opt-out must be honored, not upgraded to adaptive"
+    )
+    assert _find_dense_weight("_confine_mcp_path") == 1.0
+
+    monkeypatch.setenv("TG_FIND_DENSE_WEIGHT", "3.0")
+    assert _find_dense_weight("invoice processing helper") == 3.0, (
+        "an explicit TG_FIND_DENSE_WEIGHT=3.0 override must win over the adaptive default"
+    )
+    assert _find_dense_weight("_confine_mcp_path") == 1.0, (
+        "the whitespace gate must still protect a single-token identifier under an explicit override"
+    )
+
+
+def test_find_dense_weight_nonfinite_env_clamps_to_adaptive_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Flip-prep NIT 1 (tg_find_review_ledger.md FLIP-PREP) + thinktank rank-lens must-fix 2
+    (2026-07-16): `float("nan")` / `float("inf")` / `float("-inf")` all PARSE without raising
+    `ValueError`, so the `except ValueError` guard alone never rejected them -- and plain
+    ValueError-triggering garbage (`"banana"`, `"12abc"`) hits the OTHER branch. Pre-#191 both
+    branches clamped to the inert 1.0. POST-#191 must-fix 2, a malformed/non-finite override is
+    instead treated EXACTLY like an unset env var: it now resolves to the SAME adaptive default a
+    multi-word query would get anyway, so a typo'd `TG_FIND_DENSE_WEIGHT` value never silently
+    opts an operator OUT of the improved default. The finiteness guard itself is NOT weakened: a
+    non-finite value still never reaches `rank_chunks(dense_weight=...)` -- `weights=[1.0, nan]`
+    would otherwise build a degenerate list for `reciprocal_rank_fusion`'s sort; it now clamps to
+    5.0 instead of 1.0. Mirrors
+    `test_reranker.py::test_rank_corpus_chunk_cap_non_positive_or_malformed_env_falls_back_to_default`'s
+    direct-import-and-call pattern for a malformed-override guard. A multi-word (>1
+    whitespace-separated word) query is used so the adaptive branch is actually reached; a
+    single-token query is also checked to prove the whitespace gate still protects literals even
+    under a malformed override (see test_find_dense_weight_multimorpheme_identifier_protected for
+    the SET-to-a-valid-value sibling of this protection)."""
+    from tensor_grep.cli.main import _find_dense_weight
+
+    bad_values = (
+        "nan",
+        "-nan",
+        "NaN",
+        "inf",
+        "-inf",
+        "Infinity",
+        "-Infinity",
+        "banana",
+        "12abc",
+    )
+    for bad_value in bad_values:
         monkeypatch.setenv("TG_FIND_DENSE_WEIGHT", bad_value)
         weight = _find_dense_weight("invoice processing helper")
-        assert weight == 1.0, f"non-finite env value {bad_value!r} was not clamped, got {weight!r}"
+        assert weight == 5.0, (
+            f"malformed/non-finite env value {bad_value!r} must now resolve to the adaptive "
+            f"default (treated like unset), got {weight!r}"
+        )
+        literal_weight = _find_dense_weight("_confine_mcp_path")
+        assert literal_weight == 1.0, (
+            f"a single-token identifier must stay protected at 1.0 even under a malformed env "
+            f"value {bad_value!r}, got {literal_weight!r}"
+        )
+
+
+def test_find_dense_weight_default_boosts_two_word_lexical_canary(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Thinktank rank-lens must-fix 1 (2026-07-16): the whitespace gate is purely structural, so a
+    2-word LEXICAL phrase (not natural language) is indistinguishable from a 2-word NL phrase and
+    ALSO receives the adaptive boost when TG_FIND_DENSE_WEIGHT is unset. The 1:5 sweep is 100% NL
+    queries and the literal/identifier3 golden slices are single-token by construction, so this
+    exact shape (a short literal CODE phrase) is UNMEASURED by either. This canary is a
+    VISIBILITY/regression-catch test, not a new classifier: it documents and pins the current,
+    intentional behavior so a future change to the gate is a conscious decision, not a silent
+    drift. `TG_FIND_DENSE_WEIGHT=1.0` remains the escape hatch for an operator who hits a
+    regression on a precise 2-word literal search; `potion-code-16M` is a CODE-domain embedding
+    model, which makes boosting a 2-word code fragment defensible too, not just prose NL."""
+    from tensor_grep.cli.main import _find_dense_weight
+
+    monkeypatch.delenv("TG_FIND_DENSE_WEIGHT", raising=False)
+
+    for lexical_query in ("return None", "TODO fixme"):
+        assert _find_dense_weight(lexical_query) == 5.0, (
+            f"a 2-word lexical query {lexical_query!r} is expected to receive the adaptive boost "
+            "under the whitespace gate (documented scope, not a bug) -- if this now fails, the "
+            "gate's shape changed and the PR body / docstring KNOWN SCOPE note need updating too"
+        )
 
 
 def test_find_dense_weight_nonfinite_env_never_reaches_rank_chunks(
@@ -510,7 +634,9 @@ def test_find_dense_weight_nonfinite_env_never_reaches_rank_chunks(
     """End-to-end companion to the unit test above: proves the clamp holds through the FULL `tg
     find` call chain, not just the helper in isolation -- `rank_chunks` must never observe a
     non-finite `dense_weight` kwarg for a real invocation, which is the actual danger (a degenerate
-    `weights=[1.0, nan]` reaching `reciprocal_rank_fusion`'s sort)."""
+    `weights=[1.0, nan]` reaching `reciprocal_rank_fusion`'s sort). Post-#191 must-fix 2, a
+    non-finite env value resolves to the ADAPTIVE default (5.0) for this multi-word query, treated
+    exactly like an unset env var -- not the old inert 1.0."""
     monkeypatch.setenv("TG_FIND_DENSE_WEIGHT", "nan")
     _stub_dense_clean(monkeypatch)
     captured = _spy_on_rank_chunks(monkeypatch)
@@ -525,6 +651,7 @@ def test_find_dense_weight_nonfinite_env_never_reaches_rank_chunks(
 
     assert result.exit_code == 0, result.output
     assert captured, "rank_chunks was never called"
-    assert all(weight == 1.0 for weight in captured), (
-        f"expected dense_weight=1.0 for every call with a non-finite env value, got {captured}"
+    assert all(weight == 5.0 for weight in captured), (
+        f"expected dense_weight=5.0 (adaptive, treated like unset) for every call with a "
+        f"non-finite env value, got {captured}"
     )


### PR DESCRIPTION
## Summary

Flips the `tg find` dense-weight default from inert (`1.0`, byte-identical no-op) to **adaptive**
for multi-word natural-language queries, per #191. `TG_FIND_DENSE_WEIGHT` shipped default-OFF in
#628; the whitespace NL-vs-literal gate + nan/inf finiteness clamp landed as flip-prep in #630
(merged, still default-OFF). This PR is the flip itself, plus two must-fixes a thinktank rank-lens
review raised mid-build.

- **Evidence** (`tg_find_review_ledger.md`, DENSE-WEIGHT SWEEP, agent a8580b6e 2026-07-16): the
  golden-set sweep over 40 NL vocab-mismatch queries measured **1:5 bm25:dense → +0.1419 ndcg@10
  (0.305→0.447), recall 0.55→0.80, ZERO per-category regression**. `rank_chunks` fixes the bm25
  leg's RRF weight at `1.0`, so `dense_weight=5.0` *is* the swept 1:5 ratio.
- **Protected path unchanged:** a single whitespace-free token (a bare identifier, function/class
  name, or grep-style literal search) always stays at the protected `1.0`, regardless of the env
  var's state — the whitespace gate (dogfood finding, #191) applies uniformly whether the weight
  came from the new adaptive default, a malformed override, or an explicit value.
- **Reversible:** `TG_FIND_DENSE_WEIGHT=1.0` is a one-line operator opt-out back to the old
  equal-weight fusion. This commit is also a clean one-line revert — only `_find_dense_weight` and
  its docstrings/comments changed; no call-site or signature changes.

## Two must-fixes folded in (thinktank rank-lens, mid-build correction)

1. **Malformed-env rule changed.** Pre-flip, garbage/`nan`/`inf` in the env degraded to `1.0`.
   Post-flip that would silently opt a typo'd operator OUT of the improved default, so a
   malformed, unparseable, or non-finite value now resolves to the **adaptive default** instead —
   treated exactly like an unset env var. The `math.isfinite` clamp is not weakened: a non-finite
   value still never reaches `rank_chunks(dense_weight=...)` (which would otherwise build a
   degenerate `weights=[1.0, nan]` list for `reciprocal_rank_fusion`'s sort); it now clamps to
   `5.0` instead of `1.0`. I searched `tests/` and `docs/` for any governance/contract test pinning
   the old 1.0-degrade and found none, so there was no conflicting contract to preserve.
2. **Multi-word-lexical canary added.** The 1:5 sweep is 100% NL queries, and the
   `literal_golden.jsonl` / `identifier3_golden.jsonl` slices are single-token by construction, so
   a 2-word **lexical** phrase (e.g. `"return None"`, `"TODO fixme"`) is structurally unmeasured —
   the whitespace gate is purely structural and boosts it exactly like a 2-word NL phrase. This is
   documented as a **deliberate, known scope limit**, not a bug, and is deliberately **not** fixed
   with a new lexical-vs-NL content classifier (that would repeat the exact mistake the old
   morpheme classifier made — see #191's dogfood finding). A regression-catching canary test pins
   the current behavior so a future change to the gate is a conscious decision. Documenting here
   per the review ask: `TG_FIND_DENSE_WEIGHT=1.0` remains the escape hatch for an operator who
   needs a precise 2-word literal search; `potion-code-16M` is a CODE-domain embedding model,
   which makes boosting a 2-word code fragment defensible too, not just prose NL.

## Tests (`tests/unit/test_find_command.py`) — RED before the flip, GREEN after

- `test_find_dense_weight_default_is_adaptive_end_to_end` — rewrites
  `test_find_dense_weight_default_is_noop`, whose asserted invariant this PR intentionally breaks
  (env-unset multi-word query now threads `5.0` into `rank_chunks`, not `1.0`).
- `test_find_dense_weight_default_protects_literal_identifiers` — new; direct-call companion
  proving the real dogfood-caught identifiers (`_confine_mcp_path`, `mint_access_token`,
  `getUserName`, `BackendExecutionError`, etc.) stay at `1.0` under the new default too.
- `test_find_dense_weight_nonfinite_env_clamps_to_adaptive_default` — rewrites
  `test_find_dense_weight_nonfinite_env_clamps_to_default` for must-fix 1 (now asserts `5.0`, not
  `1.0`); extended with plain `ValueError`-garbage cases (`"banana"`, `"12abc"`).
- `test_find_dense_weight_default_boosts_two_word_lexical_canary` — new, must-fix 2.
- `test_find_dense_weight_nonfinite_env_never_reaches_rank_chunks` — same name/purpose, assertion
  target updated `1.0` → `5.0` for must-fix 1.

Confirmed unaffected (env-SET-to-a-valid-value path is byte-identical to before), still green:
`test_find_dense_weight_adaptive_nl_vs_literal`, `test_find_dense_weight_multimorpheme_identifier_protected`;
plus a new explicit regression pin, `test_find_dense_weight_explicit_env_override_wins_over_adaptive_default`
(`=1.0` opt-out and `=3.0` override both honored, single-token protection holds under an override too).

**No golden fixture files needed touching.** I grepped every `tg find` invocation across the whole
`tests/` tree for a multi-word query string; the only three call sites already lived inside
`test_find_command.py`'s dense-weight section (each either explicitly sets the env var, so
unaffected, or is the one test rewritten above). Every other test in this file,
`test_mcp_tg_find.py`, `test_find_command_binary.py`, and `test_routing_parity.py` uses a
single-token query, which the whitespace gate protects unconditionally regardless of this flip.

## Verification

- RED confirmed by temporarily reverting only the implementation (`git stash` on `main.py` alone,
  keeping the new tests) — 5 tests failed exactly as expected; the 3 SET-path tests stayed green.
  Restored and re-ran: all 21 tests in `test_find_command.py` GREEN.
- Broader targeted sweep (95 tests): `test_find_command.py`, `test_rank_chunks.py`,
  `test_mcp_tg_find.py`, `test_reranker.py`, `test_reranker_hybrid.py`,
  `test_eval_late_rerank_quality.py`, `test_search_semantic_rerank.py` — all green.
- `ruff check .` (whole repo): all checks passed.
- `ruff format --preview --check .` (whole repo): 4 files flagged, all pre-existing and unrelated
  (`docs/architecture.md`, `docs/planning/PROJECT_PLAN.md`,
  `docs/plans/backlog-100/cluster-124-evidence-signing.md`,
  `docs/plans/design-tensor-grep-2026-04-29_01-45-34.md`) — confirmed via `git stash` that these
  are byte-identical drift already on `origin/main` with or without this diff. Both files this PR
  touches format clean on their own.

## Test plan (for the reviewer / merge gate)

- [ ] Opus rank-logic gate (per house rules for `tg find` ranking changes)
- [ ] CI `test-python` matrix (ubuntu/macos) — this is a pure-Python, OS-agnostic change but the
      matrix is the authoritative gate, not this Windows-only local run
- [ ] `ruff check` + `ruff format --preview --check` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
