### PR TITLE
feat(find): checksum-pinned fetch for the dense-embedding model (potion-code-16M)

### DIFF
--- a/src/tensor_grep/core/retrieval_dense.py
+++ b/src/tensor_grep/core/retrieval_dense.py
@@ -17,11 +17,26 @@ Fail-closed contract (see AGENTS.md "Backend Fail-Closed Contract"):
   dim-mismatch shape check in :meth:`DenseIndex.query`, which is intentionally recoverable (see
   its docstring) so a broken encoder degrades visibly instead of crashing deep inside a numpy
   matrix multiply.
+
+This module also owns a checksum-pinned fetch of the potion-code-16M model files themselves --
+:func:`fetch_dense_model` (importable) and ``python -m tensor_grep.core.retrieval_dense --fetch``
+(CLI), mirroring :func:`~tensor_grep.core.retrieval_late.fetch_late_model`'s precedent exactly: a
+pinned HF commit SHA (never ``main``), a per-file SHA-256 + exact-byte-size manifest, a
+byte-capped + time-bound + wall-clock-deadline-bounded download, atomic verify-before-install, and
+fail-closed refuse + cleanup on any mismatch -- never a partial install. Never auto-downloads at
+query time; fetch is an explicit user action only.
 """
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import os
+import shutil
+import sys
+import tempfile
+import time
+import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -92,11 +107,9 @@ def load_dense_model(model_dir: str | Path) -> Any:
     if not path.is_dir():
         raise DenseUnavailableError(
             "semantic ranking unavailable: model not fetched -- expected a model2vec "
-            f"StaticModel directory at {path}. There is no `tg` fetch command for this leg yet; "
-            "fetch it yourself via model2vec's own HuggingFace integration, e.g. "
-            "`StaticModel.from_pretrained('minishlab/potion-code-16M').save_pretrained(<dir>)`, "
-            "then point TG_SEMANTIC_MODEL_DIR at <dir> (or save_pretrained directly to "
-            f"{path})"
+            f"StaticModel directory at {path}; run "
+            "`python -m tensor_grep.core.retrieval_dense --fetch` (or set TG_SEMANTIC_MODEL_DIR) "
+            "to provide one"
         )
     try:
         from model2vec import StaticModel
@@ -194,3 +207,186 @@ class DenseIndex:
         scores = self._matrix @ query_vec
         ranked = sorted(enumerate(scores.tolist()), key=lambda item: (-item[1], item[0]))
         return ranked[:top_k]
+
+
+# ---------------------------------------------------------------------------------------------
+# Checksum-pinned fetch of the potion-code-16M model files (mirrors
+# ``retrieval_late.py``'s LateOn-Code-edge fetch -- see that module for the full design
+# rationale). Never auto-downloads at query time; fetch is an explicit user action only, via
+# ``python -m tensor_grep.core.retrieval_dense --fetch``.
+# ---------------------------------------------------------------------------------------------
+
+# `minishlab/potion-code-16M` (MIT; see NOTICE). Pinned to a fixed commit SHA via a
+# `resolve/<sha>/...` URL (never `/resolve/main/...`) so the fetched content is immutable
+# regardless of future upstream changes. Resolved 2026-07-16 via `git ls-remote
+# https://huggingface.co/minishlab/potion-code-16M` (the repo's `refs/heads/main` at fetch time).
+_HF_REPO = "minishlab/potion-code-16M"
+_HF_REVISION = "1b0ff71095656b23306542bbad34a09109673720"
+_HF_RESOLVE_BASE = f"https://huggingface.co/{_HF_REPO}/resolve/{_HF_REVISION}"
+
+# filename -> (sha256_hex, exact_byte_size). This is exactly the 3-file model2vec "native" layout
+# `StaticModel.from_pretrained` requires (model2vec's `persistence/datamodels.py`
+# `FOLDER_LAYOUTS[0]`: `config.json` + `model.safetensors` + `tokenizer.json`, verified against
+# the model2vec source). The upstream repo ALSO carries `modules.json` and `README.md`, but
+# neither is read by the loader (`persistence/persistence.py::load_pretrained`), so both are
+# deliberately excluded from the pinned manifest -- fewer pinned files means less to verify and
+# less that can silently drift.
+#
+# Computed by downloading each file from the pinned revision above and hashing locally, verified
+# 2026-07-16 via THREE independent tools (Python `hashlib.sha256`, PowerShell `Get-FileHash`, and
+# `certutil -hashfile`, all byte-identical) -- see supply-chain-hardening skill H6
+# "SHA-confirmation discipline": never trust an agent-reported or sidecar SHA, always
+# download+hash to confirm. `model.safetensors`' hash additionally cross-checks the HF API tree
+# endpoint's LFS pointer `oid` (sha256) for the pinned revision, obtained WITHOUT downloading the
+# file first (`GET /api/models/minishlab/potion-code-16M/tree/<revision>`) -- all four independent
+# sources agree.
+_FETCH_MANIFEST: dict[str, tuple[str, int]] = {
+    "model.safetensors": (
+        "ca6159081a6e96cebe4ad878e5e8437bfccc761e8db16223370149cd2faa6c0b",
+        64_299_272,
+    ),
+    "tokenizer.json": (
+        "8e84217af15e70e8127c855435fc3d8a4cd91d7bbe686f72e75f188118ec78ae",
+        1_041_917,
+    ),
+    "config.json": (
+        "edf07552b5d768d556ded176d19f3a34f25360548de3a246d226ce8e28647914",
+        97,
+    ),
+}
+
+_MAX_DOWNLOAD_BYTES = 128 * 1024 * 1024  # per-file cap; the largest pinned file is ~64.3 MB
+_DOWNLOAD_TIMEOUT_S = 60.0
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def _download_bounded(url: str, *, max_bytes: int, timeout_s: float) -> bytes:
+    """Stream ``url`` fully into memory, refusing to exceed ``max_bytes``
+    (supply-chain-hardening H2: byte-capped + time-bound). The cap is enforced per-chunk during
+    the read, not after buffering the whole body, so an oversized response cannot exhaust memory
+    before the cap trips.
+
+    ALSO enforces a total wall-clock deadline across the whole streamed read
+    (``TG_SEMANTIC_FETCH_DEADLINE_S``, default 300s -- generous for a ~65MB download on a slow
+    link). ``timeout_s`` only bounds a SINGLE ``resp.read()`` call, so a malicious/compromised
+    server that keeps every individual recv just under ``timeout_s`` (and every chunk under
+    ``max_bytes``) -- a slow-drip -- could otherwise hang the fetch indefinitely. This is an
+    ADDITIVE third bound: it does not change the per-recv socket timeout or the byte cap. Mirrors
+    ``retrieval_late._download_bounded`` exactly (see that module for the original design note,
+    Opus security-gate nit #87).
+
+    Raises a plain ``OSError``/``ValueError`` on any failure (network error, timeout, the byte
+    cap, or the wall-clock deadline). The caller (:func:`fetch_dense_model`) wraps ALL of this
+    uniformly into :class:`~tensor_grep.backends.base.BackendExecutionError`.
+    """
+    deadline_s = float(os.environ.get("TG_SEMANTIC_FETCH_DEADLINE_S", "300"))
+    start = time.monotonic()
+    request = urllib.request.Request(url, headers={"User-Agent": "tensor-grep-semantic-fetch"})
+    with urllib.request.urlopen(request, timeout=timeout_s) as resp:
+        buffer = bytearray()
+        while True:
+            chunk = resp.read(_DOWNLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            buffer.extend(chunk)
+            if len(buffer) > max_bytes:
+                raise ValueError(f"{url} exceeded the {max_bytes}-byte cap")
+            if time.monotonic() - start > deadline_s:
+                raise ValueError(f"{url} exceeded the {deadline_s}s total download deadline")
+        return bytes(buffer)
+
+
+def fetch_dense_model(dest_dir: str | Path | None = None) -> Path:
+    """Download the 3 pinned potion-code-16M files into ``dest_dir``, checksum-gated + atomic.
+
+    Fail-closed contract (supply-chain-hardening H2/H3): each file is streamed with a byte cap +
+    timeout, verified against a hard-coded SHA-256 pin from a PINNED HF revision (``_HF_REVISION``,
+    never ``main``) BEFORE anything lands at ``dest_dir``. On any download failure or checksum
+    mismatch, the temp download directory is discarded and :class:`BackendExecutionError` is
+    raised -- no partial or unverified file is ever left where :func:`load_dense_model` would find
+    it.
+
+    The final install step (moving the verified temp directory to ``dest_dir``) is a single
+    ``os.replace`` -- atomic on both POSIX and Windows PROVIDED ``dest_dir`` does not already
+    exist. If ``dest_dir`` already holds a previous install (a re-fetch), it is removed
+    immediately before the replace: ``os.replace`` cannot atomically overwrite a non-empty
+    directory on Windows (verified empirically: ``PermissionError [WinError 5] Access is
+    denied``), so a plain overwrite is not available cross-platform. This narrows, but does not
+    eliminate, the crash window between the rmtree and the replace; the new copy is fully
+    verified before the old one is ever touched, and a re-run of ``--fetch`` is idempotent.
+
+    Mirrors :func:`~tensor_grep.core.retrieval_late.fetch_late_model` exactly (see that module for
+    the original design note); NEVER called automatically at query time -- fetch is an explicit
+    user action only (``python -m tensor_grep.core.retrieval_dense --fetch``).
+    """
+    dest = Path(dest_dir) if dest_dir is not None else default_model_dir()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_dir = tempfile.mkdtemp(dir=str(dest.parent), prefix=".tg-semantic-fetch-")
+    tmp_path = Path(tmp_dir)
+    try:
+        for filename, (expected_sha256, expected_size) in _FETCH_MANIFEST.items():
+            url = f"{_HF_RESOLVE_BASE}/{filename}"
+            try:
+                data = _download_bounded(
+                    url, max_bytes=_MAX_DOWNLOAD_BYTES, timeout_s=_DOWNLOAD_TIMEOUT_S
+                )
+            except Exception as exc:
+                raise BackendExecutionError(
+                    f"dense model fetch failed downloading {filename} from {url}: {exc}"
+                ) from exc
+
+            actual_sha256 = hashlib.sha256(data).hexdigest()
+            if actual_sha256 != expected_sha256 or len(data) != expected_size:
+                raise BackendExecutionError(
+                    f"dense model fetch checksum mismatch for {filename}: expected "
+                    f"sha256={expected_sha256} size={expected_size}, got "
+                    f"sha256={actual_sha256} size={len(data)} -- refusing to install (the fetch "
+                    "is PINNED to a fixed HF revision and must never silently accept changed "
+                    "content)"
+                )
+            (tmp_path / filename).write_bytes(data)
+
+        if dest.exists():
+            shutil.rmtree(dest)
+        os.replace(tmp_path, dest)
+    finally:
+        # A no-op if the `os.replace` above already moved `tmp_path` away (success path);
+        # cleans up the partial download on any failure path (checksum mismatch, network error).
+        shutil.rmtree(tmp_path, ignore_errors=True)
+    return dest
+
+
+def _fetch_cli(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m tensor_grep.core.retrieval_dense --fetch``."""
+    parser = argparse.ArgumentParser(
+        prog="python -m tensor_grep.core.retrieval_dense",
+        description=(
+            "Fetch the pinned potion-code-16M dense-embedding model files (checksum-verified)."
+        ),
+    )
+    parser.add_argument(
+        "--fetch",
+        action="store_true",
+        help="Download the 3 pinned model files to the model cache directory.",
+    )
+    parser.add_argument(
+        "--model-dir",
+        default=None,
+        help="Override the fetch destination (else TG_SEMANTIC_MODEL_DIR, or the default cache dir).",
+    )
+    args = parser.parse_args(argv)
+    if not args.fetch:
+        parser.print_help()
+        return 2
+    try:
+        dest = fetch_dense_model(args.model_dir)
+    except Exception as exc:
+        print(f"tg: dense model fetch failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"tg: dense model fetched to {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_fetch_cli())

--- a/tests/unit/test_retrieval_dense_fetch.py
+++ b/tests/unit/test_retrieval_dense_fetch.py
@@ -1,0 +1,414 @@
+"""Tests for the checksum-pinned potion-code-16M dense-embedding model fetch (mirrors
+``test_retrieval_late_fetch.py``'s T4 LateOn-Code-edge precedent -- see that file's module
+docstring for the full rationale; this is the twin for the DENSE leg, closing the gap where
+``DenseUnavailableError`` used to say "There is no `tg` fetch command for this leg yet").
+
+NO real network access here -- `urllib.request.urlopen` is monkeypatched to a deterministic fake
+response for every test (supply-chain-hardening H2/H3: byte-capped + time-bound downloads,
+checksum-gated fail-closed installs). `retrieval_dense._FETCH_MANIFEST` (the real pinned
+~64.3MB/1.0MB/97B manifest) is also monkeypatched to a small synthetic manifest in the tests that
+need a file to actually pass verification -- SHA-256 is preimage-resistant, so there is no way to
+construct a small fake payload that matches the REAL pinned hashes; the checksum-mismatch/atomicity
+tests instead intentionally serve WRONG bytes against the real manifest.
+
+The ONE real-network fetch (proving the pinned manifest against the actual HuggingFace host) lives
+in ``scripts/dogfood/`` (opt-in), never in this unit suite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import sys
+import types
+import urllib.request
+from typing import Any
+
+import pytest
+
+from tensor_grep.backends.base import BackendExecutionError
+from tensor_grep.core import retrieval_dense
+
+
+class _FakeHTTPResponse:
+    """Duck-typed stand-in for the context-managed object `urllib.request.urlopen` returns."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            chunk = self._data[self._pos :]
+            self._pos = len(self._data)
+            return chunk
+        chunk = self._data[self._pos : self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+class _FakeDripResponse:
+    """Duck-typed fake response that ignores the requested read size and instead yields a fixed
+    sequence of small chunks, one per `.read()` call, then EOF -- simulates a slow-drip server
+    that returns a little data on every recv (each individual read small/fast enough to dodge the
+    per-recv socket timeout and the byte cap) without ever finishing the file. Deliberately
+    FINITE, not an infinite generator: if the total-deadline check under test were missing or
+    broken, this response still drains normally and the test fails fast on an assertion mismatch
+    instead of hanging the suite (anti-hang-test-protocol).
+    """
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = [*chunks, b""]  # trailing b"" = EOF once the scripted chunks run out
+        self._idx = 0
+
+    def read(self, n: int = -1) -> bytes:
+        chunk = self._chunks[self._idx] if self._idx < len(self._chunks) else b""
+        self._idx += 1
+        return chunk
+
+    def __enter__(self) -> _FakeDripResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+def _make_fake_urlopen(payloads: dict[str, bytes]) -> Any:
+    """Build a fake `urlopen(request, timeout=...)` keyed by the request URL's final path
+    segment (the filename) -- looks up `payloads[filename]` and returns it wrapped as a fake
+    HTTP response; raises `KeyError` (a test bug, not a production path) for an unexpected URL.
+    """
+
+    def fake_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        filename = request.full_url.rsplit("/", 1)[-1]
+        return _FakeHTTPResponse(payloads[filename])
+
+    return fake_urlopen
+
+
+def test_fetch_rejects_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # Every file downloads "successfully" (200 OK, bytes returned) but the content does not
+    # match ANY of the real pinned SHA-256 hashes -- must be rejected, not silently accepted.
+    wrong_payloads = {
+        name: b"wrong bytes, not the pinned content for " + name.encode()
+        for name in retrieval_dense._FETCH_MANIFEST
+    }
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(wrong_payloads))
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="checksum mismatch"):
+        retrieval_dense.fetch_dense_model(dest)
+
+    # Fail-closed: no files land, no partial state left behind anywhere under tmp_path.
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_is_atomic_on_partial_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # file_a downloads AND verifies successfully; file_b's declared checksum does not match what
+    # the fake server actually returns. The whole multi-file fetch must be all-or-nothing: even
+    # though file_a is fully valid on its own, its verified bytes must NOT be left behind
+    # anywhere once file_b's failure aborts the overall fetch.
+    good_bytes = b"real verified content for file A"
+    fake_manifest = {
+        "file_a.bin": (hashlib.sha256(good_bytes).hexdigest(), len(good_bytes)),
+        "file_b.bin": (hashlib.sha256(b"the CORRECT content for file B").hexdigest(), 30),
+    }
+    monkeypatch.setattr(retrieval_dense, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        _make_fake_urlopen({
+            "file_a.bin": good_bytes,
+            "file_b.bin": b"WRONG bytes served for file B!",
+        }),
+    )
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="checksum mismatch"):
+        retrieval_dense.fetch_dense_model(dest)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_download_error_becomes_backend_execution_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A raw network failure (not a checksum mismatch) must ALSO be wrapped, never propagate as a
+    # bare OSError, and must ALSO leave no partial state behind.
+    def _raising_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        raise OSError("simulated connection reset")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raising_urlopen)
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="simulated connection reset"):
+        retrieval_dense.fetch_dense_model(dest)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_download_exceeding_byte_cap_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # H2 byte-cap enforcement: shrink the cap to 10 bytes and serve 11 -- must be refused, not
+    # silently truncated or accepted.
+    monkeypatch.setattr(retrieval_dense, "_MAX_DOWNLOAD_BYTES", 10)
+    oversized = b"x" * 11
+    first_filename = next(iter(retrieval_dense._FETCH_MANIFEST))
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen({first_filename: oversized}))
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="byte cap"):
+        retrieval_dense.fetch_dense_model(dest)
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_download_exceeds_total_deadline_raises(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # `_download_bounded` must bound the TOTAL wall-clock time of a download, not just the
+    # per-recv socket timeout and the total byte cap. A malicious/compromised HF server could
+    # slow-drip bytes forever -- each individual recv small and fast enough to dodge both existing
+    # bounds -- and hang the fetch indefinitely (mirrors retrieval_late's Opus security-gate nit
+    # #87 fix).
+    #
+    # No real sleep: the fake response drips 2 small chunks (well under the byte cap) and
+    # `time.monotonic` is monkeypatched to jump past a shrunk 1s deadline on the SECOND deadline
+    # check, so the total-deadline path trips deterministically and fast.
+    def fake_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        return _FakeDripResponse([b"a" * 8, b"b" * 8])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setenv("TG_SEMANTIC_FETCH_DEADLINE_S", "1")
+
+    # `_download_bounded`'s `time.monotonic()` call order: (1) `start`; (2) the deadline check
+    # after the 1st chunk read (must NOT trip yet -- only "0.5s" elapsed); (3) the deadline check
+    # after the 2nd chunk read (must trip -- "5.0s" elapsed, past the shrunk 1s deadline). The
+    # schedule then repeats "5.0" forever so any incidental extra call never raises StopIteration.
+    monotonic_values = itertools.chain([0.0, 0.5], itertools.repeat(5.0))
+    monkeypatch.setattr(retrieval_dense.time, "monotonic", lambda: next(monotonic_values))
+
+    dest = tmp_path / "model-dest"
+    with pytest.raises(BackendExecutionError, match="deadline"):
+        retrieval_dense.fetch_dense_model(dest)
+
+    # Fail-closed: no files land, no partial state left behind anywhere under tmp_path.
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_fetch_respects_TG_SEMANTIC_MODEL_DIR(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    target_dir = tmp_path / "env-configured-model-dir"
+    monkeypatch.setenv("TG_SEMANTIC_MODEL_DIR", str(target_dir))
+
+    fake_payloads = {
+        name: f"synthetic content for {name}".encode() for name in retrieval_dense._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_dense, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    # No explicit dest_dir -- must fall back to default_model_dir(), which itself must honor
+    # TG_SEMANTIC_MODEL_DIR.
+    result = retrieval_dense.fetch_dense_model()
+
+    assert result == target_dir
+    for name, data in fake_payloads.items():
+        assert (target_dir / name).read_bytes() == data
+
+
+def test_fetch_succeeds_end_to_end_and_is_idempotent_on_refetch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A full successful fetch, followed by a SECOND successful fetch to the same destination
+    # (e.g. a user re-running `--fetch` to refresh) -- the second run must also succeed and
+    # correctly replace the first install (exercises the "dest already exists" removal path,
+    # which is required on Windows: os.replace cannot overwrite a non-empty directory there).
+    dest = tmp_path / "model-dest"
+    fake_payloads = {
+        name: f"content v1 for {name}".encode() for name in retrieval_dense._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_dense, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    result1 = retrieval_dense.fetch_dense_model(dest)
+    assert result1 == dest
+    for name, data in fake_payloads.items():
+        assert (dest / name).read_bytes() == data
+
+    # Re-fetch with DIFFERENT content under the same filenames -- must fully replace, not merge.
+    fake_payloads_v2 = {
+        name: f"content v2 for {name}".encode() for name in retrieval_dense._FETCH_MANIFEST
+    }
+    fake_manifest_v2 = {
+        name: (hashlib.sha256(data).hexdigest(), len(data))
+        for name, data in fake_payloads_v2.items()
+    }
+    monkeypatch.setattr(retrieval_dense, "_FETCH_MANIFEST", fake_manifest_v2)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads_v2))
+
+    result2 = retrieval_dense.fetch_dense_model(dest)
+    assert result2 == dest
+    for name, data in fake_payloads_v2.items():
+        assert (dest / name).read_bytes() == data
+
+
+def test_fetch_cli_returns_zero_on_success(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    fake_payloads = {
+        name: f"cli content for {name}".encode() for name in retrieval_dense._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_dense, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    dest = tmp_path / "cli-model-dest"
+    exit_code = retrieval_dense._fetch_cli(["--fetch", "--model-dir", str(dest)])
+
+    assert exit_code == 0
+    for name, data in fake_payloads.items():
+        assert (dest / name).read_bytes() == data
+
+
+def test_fetch_cli_without_fetch_flag_prints_help_and_exits_nonzero() -> None:
+    exit_code = retrieval_dense._fetch_cli([])
+    assert exit_code == 2
+
+
+def test_fetch_cli_returns_nonzero_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    def _raising_urlopen(request: urllib.request.Request, timeout: float | None = None) -> Any:
+        raise OSError("simulated connection reset")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _raising_urlopen)
+
+    dest = tmp_path / "cli-model-dest"
+    exit_code = retrieval_dense._fetch_cli(["--fetch", "--model-dir", str(dest)])
+
+    assert exit_code == 1
+    assert not dest.exists()
+
+
+def test_not_fetched_error_names_the_new_fetch_command(tmp_path) -> None:
+    """The DenseUnavailableError raised for "not fetched" must point at the module CLI this PR
+    adds (F2 council must-fix: module CLI only, no new `tg`-registered surface) -- not the old
+    "fetch it yourself via model2vec's own HuggingFace integration" workaround text."""
+    missing_dir = tmp_path / "does-not-exist"
+    with pytest.raises(retrieval_dense.DenseUnavailableError) as exc_info:
+        retrieval_dense.load_dense_model(missing_dir)
+
+    message = str(exc_info.value)
+    assert "not fetched" in message
+    assert "python -m tensor_grep.core.retrieval_dense --fetch" in message
+    assert "save_pretrained" not in message  # the old unpinned/unchecksummed workaround is gone
+
+
+def test_fetch_then_load_activates_hybrid_dense_leg_over_bm25_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """End-to-end proof that this PR's fetch front door is what the dense leg needed to go from
+    BM25-only to genuinely fused hybrid ranking -- the concrete gap this PR closes.
+
+    1. A (mocked-network) ``--fetch`` populates a model directory that satisfies
+       :func:`~tensor_grep.core.retrieval_dense.load_dense_model`'s "is it fetched" check.
+    2. An injected fake ``model2vec.StaticModel`` (no real model2vec install or real weights
+       required -- that is ``TestRealFetchedModel``'s job in test_retrieval_dense.py, gated on the
+       real fetched model) proves ``load_dense_model`` hands back something usable once the
+       directory exists.
+    3. Feeding that into :func:`~tensor_grep.core.reranker.rerank_hybrid` produces a DIFFERENT
+       match order than :func:`~tensor_grep.core.reranker.rerank_by_bm25` alone -- the dense leg
+       is genuinely contributing, reproducing test_reranker_hybrid.py's proven BM25-vs-hybrid
+       disagreement fixture, but sourced through the real fetch+load path instead of a
+       directly-constructed DenseIndex.
+    """
+    from tensor_grep.core.reranker import rerank_by_bm25, rerank_hybrid
+    from tensor_grep.core.result import MatchLine, SearchResult
+    from tensor_grep.core.retrieval_bm25 import Bm25Index
+    from tensor_grep.core.retrieval_chunker import Chunk
+    from tensor_grep.core.retrieval_dense import DenseIndex
+
+    # --- 1. Mocked-network happy-path fetch (small synthetic manifest). ---
+    dest = tmp_path / "model-dest"
+    fake_payloads = {
+        name: f"synthetic content for {name}".encode() for name in retrieval_dense._FETCH_MANIFEST
+    }
+    fake_manifest = {
+        name: (hashlib.sha256(data).hexdigest(), len(data)) for name, data in fake_payloads.items()
+    }
+    monkeypatch.setattr(retrieval_dense, "_FETCH_MANIFEST", fake_manifest)
+    monkeypatch.setattr(urllib.request, "urlopen", _make_fake_urlopen(fake_payloads))
+
+    result_dir = retrieval_dense.fetch_dense_model(dest)
+    assert result_dir == dest
+    for name in fake_manifest:
+        assert (dest / name).is_file()
+
+    # --- 2. Inject a fake model2vec so load_dense_model succeeds on the fetched (synthetic) dir,
+    # WITHOUT a real model2vec install or real weights. ---
+    vectors_by_text = {
+        "parse_invoice": [0.0, 1.0],
+        "helper_one": [1.0, 1.0],
+        "helper_two": [1.0, 0.0],
+        "invoice": [1.0, 0.0],
+    }
+
+    class _FakeStaticModel:
+        def __init__(self, vectors: dict[str, list[float]]) -> None:
+            self._vectors = vectors
+
+        def encode(self, texts: list[str]) -> Any:
+            import numpy as np
+
+            return np.array([self._vectors[t] for t in texts], dtype=np.float32)
+
+        @classmethod
+        def from_pretrained(cls, path: str) -> _FakeStaticModel:
+            return cls(vectors_by_text)
+
+    fake_module = types.ModuleType("model2vec")
+    fake_module.StaticModel = _FakeStaticModel  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "model2vec", fake_module)
+
+    # Must NOT raise DenseUnavailableError("not fetched") anymore -- the directory now exists.
+    model = retrieval_dense.load_dense_model(dest)
+
+    # --- 3. Same disagreement fixture as test_reranker_hybrid.py's _build_scenario: the dense
+    # leg is crafted to disagree with BM25 so fusing the two legs is observable in the output. ---
+    chunks = [
+        Chunk(file_path="f1.py", start_line=1, end_line=1, text="parse_invoice"),
+        Chunk(file_path="f2.py", start_line=1, end_line=1, text="helper_one"),
+        Chunk(file_path="f3.py", start_line=1, end_line=1, text="helper_two"),
+    ]
+    bm25_index = Bm25Index(chunks)
+    dense_index = DenseIndex(chunks, model)
+    result = SearchResult(
+        matches=[
+            MatchLine(line_number=1, text="parse_invoice", file="f1.py"),
+            MatchLine(line_number=1, text="helper_one", file="f2.py"),
+            MatchLine(line_number=1, text="helper_two", file="f3.py"),
+        ],
+        total_matches=3,
+    )
+
+    bm25_only = rerank_by_bm25(result, "invoice", [], index=bm25_index)
+    hybrid = rerank_hybrid(result, "invoice", [], bm25_index=bm25_index, dense_index=dense_index)
+
+    # SAME set of matches, but a DIFFERENT order -- the dense leg fetched+loaded via this PR's
+    # front door is genuinely engaged, not a no-op that degrades back to BM25-only.
+    assert {m.file for m in bm25_only.matches} == {m.file for m in hybrid.matches}
+    assert [m.file for m in bm25_only.matches] == ["f1.py", "f2.py", "f3.py"]
+    assert [m.file for m in hybrid.matches] == ["f1.py", "f3.py", "f2.py"]


### PR DESCRIPTION
## Summary

`tg find`'s dense leg silently degraded to BM25-only whenever the model wasn't fetched, and there
was no `tg` fetch front door for it — `retrieval_dense.py`'s `DenseUnavailableError` literally said
*"There is no `tg` fetch command for this leg yet"* and told users to run an **unpinned,
unchecksummed** `StaticModel.from_pretrained('minishlab/potion-code-16M').save_pretrained(<dir>)`.

The late-rerank leg (`retrieval_late.py`, LateOn-Code-edge) already has the full hardened fetch
precedent for exactly this gap — pinned HF commit SHA, per-file SHA-256 manifest, byte-capped +
time-bound + deadline-bounded download, atomic verify-before-install, fail-closed refuse on any
mismatch. This PR clones that precedent for the dense leg, by symbol.

- `fetch_dense_model(dest_dir=None) -> Path` — checksum-gated + atomic install, mirrors
  `retrieval_late.fetch_late_model` exactly.
- `python -m tensor_grep.core.retrieval_dense --fetch [--model-dir ...]` — the **only** new
  surface. Deliberately a **module CLI only** (council must-fix F2): no new `tg models fetch`
  command, no `tg find --fetch-model` flag, zero new `tg`-CLI registration surface.
- `DenseUnavailableError`'s message now names the new fetch command instead of the old
  unpinned/unchecksummed workaround.
- Fetch is never invoked automatically at query time — explicit user action only.

Dogfood finding 4 / campaign #189.

## Pinned revision + manifest

Pinned commit SHA: `1b0ff71095656b23306542bbad34a09109673720`, resolved via
`git ls-remote https://huggingface.co/minishlab/potion-code-16M` (was `refs/heads/main` at
resolution time).

`config.json` / `model.safetensors` / `tokenizer.json` are exactly the 3 files model2vec's native
`StaticModel.from_pretrained` layout reads (verified against the model2vec source —
`persistence/datamodels.py`'s `FOLDER_LAYOUTS[0]`); the upstream repo also carries `modules.json`
and `README.md`, but neither is read by the loader, so both are deliberately excluded from the
pinned manifest.

| file | sha256 | size |
|---|---|---|
| `model.safetensors` | `ca6159081a6e96cebe4ad878e5e8437bfccc761e8db16223370149cd2faa6c0b` | 64,299,272 |
| `tokenizer.json` | `8e84217af15e70e8127c855435fc3d8a4cd91d7bbe686f72e75f188118ec78ae` | 1,041,917 |
| `config.json` | `edf07552b5d768d556ded176d19f3a34f25360548de3a246d226ce8e28647914` | 97 |

Verified via **three independent tools** (Python `hashlib.sha256`, PowerShell `Get-FileHash`,
`certutil -hashfile`) after downloading each file once from the pinned revision — all
byte-identical. `model.safetensors`' hash additionally cross-checks the HF API tree endpoint's LFS
pointer `oid` (sha256), obtained *without* downloading the file
(`GET /api/models/minishlab/potion-code-16M/tree/<revision>`) — 4 independent sources agree.

## Fail-closed matrix

| condition | result |
|---|---|
| checksum or size mismatch | `BackendExecutionError`, refuse install, no partial state left on disk |
| byte cap exceeded | `BackendExecutionError`, refused mid-stream |
| slow-drip past the wall-clock deadline (`TG_SEMANTIC_FETCH_DEADLINE_S`) | `BackendExecutionError`, refused |
| network error | `BackendExecutionError`, no partial state |
| happy path | atomic tmp-dir + `os.replace` install |
| re-fetch to an existing dest | idempotent, fully replaces (required on Windows — `os.replace` cannot overwrite a non-empty dir there) |

## Tests (RED confirmed first)

`tests/unit/test_retrieval_dense_fetch.py`, fully network-mocked:

- `test_fetch_rejects_checksum_mismatch`
- `test_fetch_is_atomic_on_partial_failure`
- `test_fetch_download_error_becomes_backend_execution_error`
- `test_fetch_download_exceeding_byte_cap_is_rejected`
- `test_download_exceeds_total_deadline_raises`
- `test_fetch_respects_TG_SEMANTIC_MODEL_DIR`
- `test_fetch_succeeds_end_to_end_and_is_idempotent_on_refetch`
- `test_fetch_cli_returns_zero_on_success`
- `test_fetch_cli_without_fetch_flag_prints_help_and_exits_nonzero`
- `test_fetch_cli_returns_nonzero_on_failure`
- `test_not_fetched_error_names_the_new_fetch_command`
- `test_fetch_then_load_activates_hybrid_dense_leg_over_bm25_only` — the dense-leg activation
  integration proof: a mocked-network fetch populates the model dir, an injected fake
  `model2vec.StaticModel` proves `load_dense_model` hands back something usable once the
  directory exists, then feeding that into `rerank_hybrid` produces a genuinely different match
  order than `rerank_by_bm25` alone (BM25-only → hybrid), reproducing
  `test_reranker_hybrid.py`'s proven disagreement fixture but sourced through the real fetch+load
  path.

RED confirmed against the real worktree source before implementing (verified
`tensor_grep.__file__` resolves into this worktree's `src/`, not the shared venv's stale
site-packages copy — a false-green trap this repo has hit before).

The **one** real-network fetch (proving the shipped `--fetch` CLI against the actual HuggingFace
host, not just `curl`) was run ad hoc during development, mirroring the late-rerank precedent
(which also has no committed `scripts/dogfood/` entry for its own fetch): exit 0, all 3 files
byte-for-byte and hash-for-hash identical to the manifest above, and idempotent on a second run.

## Verification

- New suite: 12/12 passing.
- `test_retrieval_dense.py` + `test_retrieval_late.py` + `test_retrieval_late_fetch.py` +
  `test_reranker_hybrid.py` + `test_retrieval_fusion.py` + `test_reranker.py`: 100 passed, 7
  skipped (expected real-model-gated skips once `TG_SEMANTIC_MODEL_DIR`/`TG_RERANK_MODEL_DIR`
  point at clean nonexistent dirs, matching CI).
- Full unit suite: 1107 passed, 9 skipped, 1 pre-existing failure
  (`test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`) confirmed **unrelated** via
  git-stash bisection — fails identically on pristine `origin/main` in this environment.
- `ruff check` and `ruff format --preview --check` both clean on the two touched files (4
  pre-existing unrelated `docs/*.md` formatting gaps exist repo-wide, untouched by this change).

## Deviations from the brief

None of substance. One thing worth flagging for review: the byte cap is 128 MiB (vs. the largest
pinned file's ~64.3 MB) rather than the late-rerank precedent's ~3.7x-proportional headroom, to
keep the cap meaningfully bounding worst-case memory/DoS exposure while still tolerating minor
future re-verification drift.

Not merging this myself — please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
