### PR TITLE
fix(agent): bound tg agent + tg codemap --deadline through the post-map stages (dogfood #1)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -24,6 +24,14 @@ _CAPSULE_LSP_CONFIDENCE_BOOST_ENV = "TG_CAPSULE_LSP_CONFIDENCE_BOOST"
 _CAPSULE_LSP_CONFIDENCE_CAP = 0.85
 _CAPSULE_LSP_CONFIDENCE_LANGUAGES = {"javascript", "php", "python", "rust", "typescript"}
 
+# dogfood finding 1: `tg agent`'s CLI front door defaults --deadline to this value (mirrors
+# codemap.DEFAULT_CLI_DEADLINE_SECONDS) so a whole-repo call with no explicit --deadline still
+# terminates in bounded time. `build_agent_capsule`'s own `deadline_seconds: float | None = None`
+# signature default stays unbounded (a direct library call is unaffected) -- only the CLI's cold
+# fallback (main.py's `agent()` body, applied AFTER the warm-daemon gate so a default call still
+# reaches the daemon -- see that function's own comment) reads this constant.
+DEFAULT_AGENT_CLI_DEADLINE_SECONDS = 60.0
+
 # F4: the exact `_build_snippets` omission reason for a source cut by the capsule's OWN token
 # budget (agent_capsule.py `_build_snippets`) -- distinct from the generic "not present in
 # capsule snippets" fallback `_capsule_context_consistency` uses when the primary file never
@@ -875,6 +883,8 @@ def _collect_outbound_dependencies(
     *,
     max_files: int,
     preview_token_budget: int | None,
+    deadline_monotonic: float | None = None,
+    deadline_hit: repo_map._DeadlineBreakFlag | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """DAR (arxiv steal #4): the primary target's outbound dependencies, corroboration-gated.
 
@@ -893,8 +903,19 @@ def _collect_outbound_dependencies(
     FAIL-SAFE (byte-identical contract): every early return here is `([], {})` -- the caller MUST
     treat that as "emit NEITHER `outbound_dependencies` nor `outbound_dependency_evidence`", never
     an empty-but-present key. See `build_agent_capsule`.
+
+    dogfood finding 1 / council must-fix #5: ``deadline_monotonic``/``deadline_hit`` follow the
+    same ``_DeadlineBreakFlag`` readback contract every other deadline-scoped seam in this PR
+    uses. A hit before this function has even started its own FS parse work bails through the
+    SAME fail-safe ``([], {})`` shape as every other early return above -- DAR is opt-in
+    (default OFF) so this is defensive: once opted in, it must never be the reason a --deadline
+    budget is silently blown, even though its own per-primary-file work is normally small.
     """
     if not _capsule_outbound_dependencies_enabled():
+        return [], {}
+    if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+        if deadline_hit is not None:
+            deadline_hit.hit = True
         return [], {}
     primary_file = str(target.get("file") or "")
     primary_symbol = str(target.get("symbol") or "")
@@ -2749,6 +2770,11 @@ def build_agent_capsule_from_map(
     # `related_call_sites`, and deliberately does NOT touch `target`/`confidence`/`consistency`/
     # `ask_reasons` -- see `_collect_outbound_dependencies`'s fail-safe + budget-isolation
     # contract. Never mutates confidence/consistency/trust state (1A owns those).
+    # dogfood finding 1 / council must-fix #5+#2: share the SAME deadline_monotonic this
+    # function's other post-map stages already use, and fold an early bail into the capsule's
+    # own `result["partial"]` below -- mirrors the callers/impact/blast-radius N-way fold-in
+    # pattern (repo_map.py), scoped here to this capsule's own sibling stages.
+    outbound_dependencies_deadline_hit = repo_map._DeadlineBreakFlag()
     outbound_dependencies, outbound_dependency_evidence = _collect_outbound_dependencies(
         query,
         resolved_path,
@@ -2758,6 +2784,8 @@ def build_agent_capsule_from_map(
         related_call_sites,
         max_files=max_files,
         preview_token_budget=outbound_dependency_preview_budget,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=outbound_dependencies_deadline_hit,
     )
     rollback_ref = _command_ref(["tg", "checkpoint", "create", resolved_path])
     route_rationale: list[dict[str, Any]] = [
@@ -2865,11 +2893,16 @@ def build_agent_capsule_from_map(
         result["scan_limit"] = dict(scan_limit)
         if "scan_remediation" in payload:
             result["scan_remediation"] = payload["scan_remediation"]
-    if payload.get("partial"):
+    # dogfood finding 1 / council must-fix #2: fold DAR's own deadline break in alongside the
+    # inner context-render's -- either one broke on --deadline makes this capsule partial, same
+    # "any one of N sibling stages" fold-in the callers/impact/blast-radius seams already use.
+    if payload.get("partial") or outbound_dependencies_deadline_hit.hit:
         result["partial"] = True
         deadline_limit = payload.get("deadline_limit")
         if isinstance(deadline_limit, dict):
             result["deadline_limit"] = dict(deadline_limit)
+        elif outbound_dependencies_deadline_hit.hit:
+            result["deadline_limit"] = {"deadline_exceeded": True}
     if scan_truncated:
         result["result_incomplete"] = True
     # suggested_scope (#133 dogfood): the same centrality-weighted directory narrowing `tg orient`

--- a/src/tensor_grep/cli/codemap.py
+++ b/src/tensor_grep/cli/codemap.py
@@ -28,6 +28,7 @@ import json
 import os
 import re
 import subprocess
+import time
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -564,12 +565,28 @@ def _walk_only_universe(root: Path, *, max_repo_files: int) -> list[str]:
     return [str(f) for f in all_files if _repo_map._is_repo_context_file(f, context_root)]
 
 
-def _all_folder_paths(root: Path, *, max_repo_files: int) -> set[str]:
+def _all_folder_paths(
+    root: Path,
+    *,
+    max_repo_files: int,
+    deadline_monotonic: float | None = None,
+    deadline_hit: _repo_map._DeadlineBreakFlag | None = None,
+) -> set[str]:
     """Every folder (repo-relative POSIX, "" for repo root) containing >=1 file the walk reaches,
     regardless of mapped-suffix status -- used only to report how many folders were excluded from
-    the (mapped-files-only) index table because they hold nothing but unmapped extensions."""
+    the (mapped-files-only) index table because they hold nothing but unmapped extensions.
+
+    dogfood finding 1: this re-walk (a SEPARATE pass from build_repo_map's own scan above) used
+    to accept no deadline at all, so it could keep walking a huge/multi-root tree past --deadline
+    on its own. ``_iter_repo_files`` already supports both params (task #52) -- just forward them.
+    """
     try:
-        all_files = _repo_map._iter_repo_files(root, max_files=max_repo_files)
+        all_files = _repo_map._iter_repo_files(
+            root,
+            max_files=max_repo_files,
+            deadline_monotonic=deadline_monotonic,
+            deadline_hit=deadline_hit,
+        )
     except OSError:
         return set()
     folders: set[str] = set()
@@ -952,18 +969,34 @@ def build_codemap(
         "max_repo_files": max_repo_files,
     }
 
+    # dogfood finding 1: this re-walk + the per-folder render loop below are the POST-MAP "tail"
+    # -- they used to run fully UNBOUNDED even after the MAP-level scan above finished inside
+    # --deadline (a real `tg codemap ROOT --deadline 3` ran ~28s). Both now share the SAME
+    # deadline_monotonic and fold an early break into `tail_deadline_hit`, council must-fix #4.
+    tail_deadline_hit = False
     try:
-        all_folders = _all_folder_paths(root, max_repo_files=max_repo_files)
+        all_folders_deadline_hit = _repo_map._DeadlineBreakFlag()
+        all_folders = _all_folder_paths(
+            root,
+            max_repo_files=max_repo_files,
+            deadline_monotonic=deadline_monotonic,
+            deadline_hit=all_folders_deadline_hit,
+        )
         all_folders = {
             f for f in all_folders if not _is_under_dir(root / f if f else root, out_dir)
         }
         coverage["folders_with_no_mapped_files"] = max(0, len(all_folders) - len(folders))
+        tail_deadline_hit = tail_deadline_hit or all_folders_deadline_hit.hit
     except OSError:
         coverage["folders_with_no_mapped_files"] = 0
 
     written_files: list[Path] = []
     per_page_tokens: dict[str, int] = {}
+    rendered_folders: dict[str, list[str]] = {}
     for folder, files in folders.items():
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            tail_deadline_hit = True
+            break
         page_path = page_paths[folder]
         page_text = _render_folder_page(
             folder,
@@ -979,10 +1012,25 @@ def build_codemap(
         _atomic_write_text(page_path, page_text)
         written_files.append(page_path)
         per_page_tokens[str(page_path)] = _repo_map._estimate_tokens(page_text)
+        rendered_folders[folder] = files
+
+    # council must-fix #4: OR the tail break into the SAME partial boolean + partial_reason
+    # ladder the scan-level cutoff above uses -- never clobber a MORE SPECIFIC existing reason
+    # (scan_limit/self_verify), and never downgrade an already-True partial back to False.
+    if tail_deadline_hit and not coverage["partial"]:
+        coverage["partial"] = True
+        coverage["partial_reason"] = "deadline"
+        coverage["remediation"] = (
+            "The scan hit --deadline before covering the whole tree. Re-run with a higher "
+            "--deadline, or scope PATH to a subdirectory."
+        )
 
     index_text = _render_index(
         root=root,
-        folders=folders,
+        # A deadline-cut tail must never dangling-link the index to a folder page that was never
+        # actually written -- render off `rendered_folders` (a strict subset of `folders` on a
+        # complete run, byte-identical to `folders` itself) rather than the full MAP-level set.
+        folders=rendered_folders,
         symbols_by_file=symbols_by_file,
         blurbs=blurbs,
         central_files=central_files,

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9349,14 +9349,15 @@ def agent(
         help=(
             "Stop the underlying repo scan after N seconds and return a partial capsule "
             "(partial=true, deadline_limit) with whatever was found so far, instead of running "
-            "unbounded. Pass --no-deadline to keep the (already default) unbounded behavior explicit."
+            "unbounded. The cold path (no running session daemon) defaults to 60s so a huge repo "
+            "can't hang an agent loop; pass --no-deadline to disable the bound."
         ),
     ),
     no_deadline: bool = typer.Option(
         False,
         "--no-deadline",
-        help="Accepted for command-surface parity with codemap; a no-op since agent already "
-        "defaults to an unbounded --deadline.",
+        help="Disable the cold path's default 60s --deadline bound; let the scan run unbounded "
+        "(a warm session daemon is unaffected either way).",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9361,7 +9361,10 @@ def agent(
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON output."),
 ) -> None:
     """Return an actionable context capsule for agents before editing."""
-    from tensor_grep.cli.agent_capsule import build_agent_capsule
+    from tensor_grep.cli.agent_capsule import (
+        DEFAULT_AGENT_CLI_DEADLINE_SECONDS,
+        build_agent_capsule,
+    )
 
     try:
         resolved_path, resolved_query = _resolve_path_and_query(
@@ -9432,6 +9435,20 @@ def agent(
                 raise typer.Exit(2)
             return
 
+        # dogfood finding 1 (F4): default the COLD path's --deadline to 60s (mirrors codemap's
+        # #153) so a whole-repo `tg agent` call with no explicit --deadline still terminates in
+        # bounded time. Deliberately computed HERE, AFTER the warm-daemon gate above -- and from
+        # the RAW `deadline`/`no_deadline` params, never by reusing `effective_deadline` -- because
+        # `effective_deadline` intentionally conflates "no --deadline was given" with "--no-deadline
+        # was given" so the gate above treats them identically (a warm session's cached repo_map
+        # cannot honor a fresh per-request deadline either way). Collapsing this 60s default into
+        # THAT variable, or defaulting it on the typer.Option itself, would make effective_deadline
+        # never None on a default call, silently skipping the daemon probe on every single one of
+        # them -- the #108 moat.
+        cold_deadline_seconds = effective_deadline
+        if cold_deadline_seconds is None and not no_deadline:
+            cold_deadline_seconds = DEFAULT_AGENT_CLI_DEADLINE_SECONDS
+
         payload = build_agent_capsule(
             resolved_query,
             resolved_path,
@@ -9444,7 +9461,7 @@ def agent(
             gpu_device_ids=parsed_gpu_device_ids,
             gpu_timeout_s=gpu_timeout_s,
             ignore=tuple(ignore),
-            deadline_seconds=effective_deadline,
+            deadline_seconds=cold_deadline_seconds,
         )
     except (FileNotFoundError, ValueError) as exc:
         typer.echo(str(exc), err=True)

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7607,8 +7607,29 @@ def _personalized_reverse_import_pagerank(
     *,
     alpha: float = 0.85,
     iterations: int = 12,
+    deadline_monotonic: float | None = None,
+    deadline_hit: _DeadlineBreakFlag | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, float]:
+    """dogfood finding 1: this 12-iteration loop ran fully UNBOUNDED even when a caller already
+    had a deadline_monotonic in scope (a real ``tg agent``/``tg codemap`` whole-repo call could
+    run well past --deadline here alone). ``deadline_monotonic``/``deadline_hit`` follow the same
+    ``_DeadlineBreakFlag`` readback contract every other deadline-scoped sibling loop in this
+    module uses -- checked at the ITERATION boundary (not mid-iteration) so a hit is always a
+    clean iteration count, never a half-applied update.
+
+    On expiry this ABANDONS to ``{}`` rather than returning the last-completed iteration's
+    partial ranks: every existing caller already treats a missing/zero graph score as "no
+    centrality signal" via ``.get(x, 0.0)`` (see ``_build_context_pack_from_map`` and
+    ``_relevant_tests_for_symbol``), so ``{}`` is a deterministic, already-handled degrade --
+    never a silently-incomplete ranking presented as complete.
+
+    The per-node ``sorted(reverse_importers.get(current))`` is hoisted OUT of the iteration loop
+    below: ``reverse_importers`` never changes across iterations, so the pre-fix code recomputed
+    the same sort up to 12x per node for nothing. Free, additive speedup, independent of the
+    deadline fix above -- proven numerically identical to the pre-hoist shape by
+    ``test_pagerank_hoisted_sort_matches_reference_computation``.
+    """
     with _profiling_phase(_profiling_collector, "graph_pagerank"):
         if not seed_files:
             return {}
@@ -7632,10 +7653,17 @@ def _personalized_reverse_import_pagerank(
             current: (seed_weight if current in seed_set else 0.0) for current in all_files
         }
         ranks = dict(personalization)
+        sorted_outgoing = {
+            current: sorted(reverse_importers.get(current, set())) for current in all_files
+        }
         for _ in range(iterations):
+            if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+                if deadline_hit is not None:
+                    deadline_hit.hit = True
+                return {}
             updated = {current: (1.0 - alpha) * personalization[current] for current in all_files}
             for current in all_files:
-                outgoing = sorted(reverse_importers.get(current, set()))
+                outgoing = sorted_outgoing[current]
                 if outgoing:
                     share = alpha * ranks[current] / len(outgoing)
                     for importer in outgoing:
@@ -7966,10 +7994,15 @@ def _build_context_pack_from_map(
         if not graph_seed_files:
             graph_seed_files = list(dependency_seed_files)
 
+        # dogfood finding 1: deadline_monotonic/deadline_hit were already in scope in this
+        # function (threaded into the symbol-scoring loop above) but never forwarded to pagerank
+        # -- this 12-iteration whole-repo-file loop ran fully unbounded even past --deadline.
         graph_scores = _personalized_reverse_import_pagerank(
             graph_seed_files,
             all_files,
             reverse_importers,
+            deadline_monotonic=deadline_monotonic,
+            deadline_hit=deadline_hit,
             _profiling_collector=_profiling_collector,
         )
         for current_path in set(dependency_seed_files) | set(file_distances):
@@ -13495,15 +13528,31 @@ def build_context_pack_from_map(
     payload["tests"] = list(repo_map.get("tests", []))
     payload["related_paths"] = list(repo_map.get("related_paths", []))
     payload.pop("_profiling", None)
+    # dogfood finding 1 (council must-fix #2, stamp the partial boolean DIRECTLY): every current
+    # caller of this function (agent/context/edit-plan's own render/pack builders) passes NO
+    # deadline_hit at all, so a sibling loop breaking early INSIDE _build_context_pack_from_map
+    # (symbol-scoring, pagerank) was silently unstamped -- `_copy_partial_signal` can only
+    # PROPAGATE an existing dict's `partial` key forward, it cannot originate one from a bare
+    # _DeadlineBreakFlag. Always own a flag here (reuse the caller's if one WAS supplied, so a
+    # caller folding this into its own wider N-way union -- mirroring the callers/impact/
+    # blast-radius fold-in pattern -- still observes `.hit`).
+    own_deadline_hit = deadline_hit if deadline_hit is not None else _DeadlineBreakFlag()
     payload = _build_context_pack_from_map(
         payload,
         query,
         auto_deweight=auto_deweight,
         _test_source_limit=_test_source_limit,
         deadline_monotonic=deadline_monotonic,
-        deadline_hit=deadline_hit,
+        deadline_hit=own_deadline_hit,
         _profiling_collector=_profiling_collector,
     )
+    if own_deadline_hit.hit:
+        payload["partial"] = True
+        # setdefault, not overwrite: a repo_map already partial from the SCAN stage (build_repo_
+        # map's own --deadline cutoff, copied onto `payload` via `dict(repo_map)` above) carries a
+        # richer deadline_limit (files_scanned/files_total) -- never clobber that with the generic
+        # shape below just because a post-map sibling loop also happened to cross the same budget.
+        payload.setdefault("deadline_limit", {"deadline_exceeded": True})
     return _attach_profiling(payload, _profiling_collector)
 
 

--- a/tests/integration/test_agent_codemap_deadline_scale.py
+++ b/tests/integration/test_agent_codemap_deadline_scale.py
@@ -1,0 +1,288 @@
+"""Real-binary, real-wall-clock proof of dogfood finding 1 (HIGH): `tg agent`/`tg codemap`
+(and, for free, `tg edit-plan`) bound the WHOLE-repo path through --deadline, not just the
+initial repo-map scan, and stamp a fail-closed `partial` on truncation instead of silently
+reporting exit 0.
+
+Pre-fix symptom this module reproduces the shape of: `--deadline` threaded into
+``build_repo_map`` (the scan), which finished in budget, but the POST-MAP stages (context-pack
+graph/symbol scoring shared by agent/context/edit-plan; the folders_with_no_mapped_files re-walk
++ per-folder render loop for codemap) ran fully UNBOUNDED and UNSTAMPED -- `tg agent ROOT Q
+--deadline 8` ran ~20s at exit 0, partial=None (a silent deadline breach); `tg codemap ROOT
+--deadline 3` ran ~28s.
+
+Real subprocess (`python -m tensor_grep`), not CliRunner, per AGENTS.md's "dogfood the real
+binary" rule and the anti-hang-test-protocol skill: a subprocess `timeout=` is a genuine
+OS-level kill if a fix regresses back to unbounded, whereas an in-process CliRunner hang would
+hang the whole pytest run (and every other queued test) with it.
+
+KNOWN, OUT-OF-SCOPE FINDING (documented here, not fixed by this PR -- see the module docstring
+of ``src/tensor_grep/cli/agent_capsule.py``'s ``_collect_capsule_call_site_evidence_from_map``
+call chain and ``codemap.py``'s ``_exclude_output_paths``): profiling this fixture at ~2000
+files surfaced a SEPARATE, pre-existing unbounded cost dominated by repeated ``Path.resolve()``
+(Windows ``nt._getfinalpathname``) calls -- `agent`'s validation-file/test-runner detection
+(``_precomputed_validation_files_for_root``, reached via the call-site-evidence collector) and
+`codemap`'s output-path exclusion (``_exclude_output_paths``). Neither is named in this PR's
+scope (``_personalized_reverse_import_pagerank``, ``_collect_outbound_dependencies``, the
+codemap tail, the F4 60s default) and neither threads a deadline at all. Because of it, the
+WALL-CLOCK assertions below are deliberately generous (they catch a genuine hang/regression to
+fully-unbounded, not a tight deadline-adherence claim this PR cannot back) -- what IS tightly
+proven, and is this PR's actual contract, is that a truncated run is HONESTLY reported
+(exit 2, partial/partial_reason, never a silent exit-0 completeness lie).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Anti-hang (two independent layers, per the anti-hang-test-protocol skill): this subprocess
+# timeout is the inner, OS-level kill -- a regression back to fully-unbounded behavior fails
+# FAST here (TimeoutExpired) instead of hanging the whole pytest run. Callers running this file
+# in CI should also wrap the invocation in an outer shell-level `timeout` per that skill.
+_SUBPROCESS_TIMEOUT_S = 90.0
+
+_FOLDER_COUNT = 200
+_FILES_PER_FOLDER = 10
+_TOTAL_FILES = _FOLDER_COUNT * _FILES_PER_FOLDER + 1  # +1 for hub.py
+
+
+def _run_tg(
+    args: list[str], *, cwd: Path, timeout: float = _SUBPROCESS_TIMEOUT_S
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    # None of these tests are about the warm-daemon path (that is
+    # test_orient_agent_daemon.py / test_cli_deadline_coverage_gaps.py's job) -- force it off so
+    # a real subprocess run never autostarts a background daemon process here (autostart
+    # defaults ON; leaving it on would leak a stray process per test run and add nondeterminism).
+    env["TG_SESSION_DAEMON_AUTOSTART"] = "0"
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return subprocess.run(
+        [sys.executable, "-m", "tensor_grep", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+@pytest.fixture(scope="module")
+def star_import_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """~2000 files (per the plan's RED-test ask) across 200 folders, with a "star" import
+    topology: every leaf imports the same ``hub.py`` (dense reverse-import fan-in -- hub.py's
+    reverse-importer set has ~2000 entries, the worst case for pagerank's pre-fix per-node
+    ``sorted(reverse_importers.get(current))`` recomputed 12x, which the council fix hoists
+    once). Only the first 3 leaves actually CALL ``shared_target`` (the query target below) --
+    keeps the query's own caller-scan cheap (few real callers) while `hub.py`'s IMPORT fan-in
+    (a FILE-level edge, independent of which specific name was imported) stays maximal, so this
+    fixture stresses pagerank specifically rather than an unrelated caller-enumeration cost.
+    """
+    root = tmp_path_factory.mktemp("star_import_repo") / "project"
+    root.mkdir()
+    (root / "hub.py").write_text(
+        "def common_util(value):\n    return value\n\n\n"
+        "def shared_target(value):\n    return common_util(value)\n",
+        encoding="utf-8",
+    )
+    index = 0
+    for folder_index in range(_FOLDER_COUNT):
+        folder = root / f"pkg{folder_index:04d}"
+        folder.mkdir()
+        for _file_index in range(_FILES_PER_FOLDER):
+            target_fn = "shared_target" if index < 3 else "common_util"
+            (folder / f"m{index:05d}.py").write_text(
+                f"from hub import {target_fn}\n\n\n"
+                f"def leaf_{index}():\n    return {target_fn}({index})\n",
+                encoding="utf-8",
+            )
+            index += 1
+    return root
+
+
+# ---------------------------------------------------------------------------------------------
+# `tg agent`: a tight --deadline must terminate the WHOLE post-map path honestly (exit 2,
+# partial=True), not silently exit 0 with partial=None (the pre-fix "~20s exit 0" symptom).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_agent_tight_deadline_exits_2_with_partial_true(star_import_repo: Path) -> None:
+    # Deliberately sub-second: OS file-cache warmth varies run-to-run (a repeat run against the
+    # same fixture directory -- e.g. after an earlier test in this module already read every
+    # file once -- can be several times faster than a cold-cache run), so a "moderately tight"
+    # multi-second deadline was observed to be flaky (sometimes not crossed at all). A budget
+    # this far below any plausible real (scan + post-map) completion time for ~2000 files is
+    # crossed deterministically regardless of cache state.
+    deadline = 0.5
+    started_at = time.monotonic()
+    result = _run_tg(
+        [
+            "agent",
+            str(star_import_repo),
+            "shared_target",
+            # Raised well above _TOTAL_FILES so the file-COUNT scan_limit ceiling never fires --
+            # this test is isolating the DEADLINE mechanism, not the pre-existing file-cap one.
+            "--max-repo-files",
+            "5000",
+            "--deadline",
+            str(deadline),
+            "--json",
+        ],
+        cwd=star_import_repo,
+    )
+    elapsed = time.monotonic() - started_at
+
+    # Generous, NOT a tight deadline-adherence claim (see module docstring's documented,
+    # out-of-scope Path.resolve() finding) -- this catches a genuine regression to fully
+    # unbounded (which would run into the subprocess timeout above and raise TimeoutExpired, an
+    # even louder failure), while tolerating the known separate overhead.
+    assert elapsed < 60.0, (
+        f"tg agent ran {elapsed:.1f}s against a {deadline}s --deadline on a "
+        f"{_TOTAL_FILES}-file repo -- looks fully unbounded, not just slow"
+    )
+    assert result.returncode == 2, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    # THE fix's actual contract: never silently report exit 0 / partial=None on a truncated run.
+    assert payload.get("partial") is True, result.stdout
+    # Not an exact-shape check: whichever stage crossed the deadline first (the SCAN itself, at
+    # this tight a budget, most likely) stamps its OWN (possibly richer) deadline_limit shape --
+    # `build_context_pack_from_map`'s self-stamp only originates the generic
+    # `{"deadline_exceeded": True}` shape via setdefault, deliberately never clobbering a
+    # richer one already present. Either way this key must be True.
+    assert payload.get("deadline_limit", {}).get("deadline_exceeded") is True, result.stdout
+    assert payload.get("result_incomplete") is True, result.stdout
+
+
+def test_agent_default_deadline_still_completes_and_is_bounded(star_import_repo: Path) -> None:
+    """F4: even with NO explicit --deadline, the new 60s cold-path default must still let a
+    real (if unusually dense) ~2000-file repo finish -- proving the default isn't so tight it
+    breaks a legitimate whole-repo call, while still being a real, finite bound (never the
+    pre-existing fully-unbounded behavior)."""
+    started_at = time.monotonic()
+    result = _run_tg(
+        ["agent", str(star_import_repo), "shared_target", "--max-repo-files", "5000", "--json"],
+        cwd=star_import_repo,
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 60.0, f"tg agent (default --deadline) ran {elapsed:.1f}s -- expected <60s"
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload.get("partial") is not True, (
+        "a real run finishing on its own should not ALSO claim a deadline cutoff"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# `tg codemap`: same honesty contract for the MAP-level scan AND the post-map tail
+# (folders_with_no_mapped_files re-walk + per-folder render loop).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_codemap_tight_deadline_exits_2_with_partial_reason_deadline(
+    star_import_repo: Path,
+) -> None:
+    # Sub-second for the same cache-warmth-determinism reason as the agent test above.
+    deadline = 0.5
+    out_dir = star_import_repo / "docs" / "code-map"
+    started_at = time.monotonic()
+    result = _run_tg(
+        [
+            "codemap",
+            str(star_import_repo),
+            "--out",
+            str(out_dir),
+            "--max-repo-files",
+            "5000",
+            "--deadline",
+            str(deadline),
+            "--json",
+        ],
+        cwd=star_import_repo,
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 60.0, (
+        f"tg codemap ran {elapsed:.1f}s against a {deadline}s --deadline -- looks fully "
+        "unbounded, not just slow"
+    )
+    assert result.returncode == 2, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload.get("partial") is True, result.stdout
+    assert payload.get("partial_reason") == "deadline", result.stdout
+    assert payload.get("remediation"), result.stdout
+    # Still a VALID, browsable (partial) map -- the tail bounding must never corrupt output.
+    assert Path(payload["index"]).is_file()
+
+
+def test_codemap_default_no_deadline_flag_completes(star_import_repo: Path) -> None:
+    """Golden-parity companion: `tg codemap`'s OWN CLI default (#153, DEFAULT_CLI_DEADLINE_
+    SECONDS=60.0, pre-existing and unchanged by this PR) must still comfortably complete this
+    fixture -- a regression tightening it would show up here as an unexpected partial=True."""
+    out_dir = star_import_repo / "docs" / "code-map-default"
+    started_at = time.monotonic()
+    result = _run_tg(
+        [
+            "codemap",
+            str(star_import_repo),
+            "--out",
+            str(out_dir),
+            "--max-repo-files",
+            "5000",
+            "--json",
+        ],
+        cwd=star_import_repo,
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 60.0, f"tg codemap (default --deadline) ran {elapsed:.1f}s -- expected <60s"
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload.get("partial") is False, result.stdout
+
+
+# ---------------------------------------------------------------------------------------------
+# `tg edit-plan`: SCOPE per the plan -- edit-plan flows through the SAME shared
+# `_build_context_pack_from_map` seam agent/context do (`repo_map.build_context_edit_plan_
+# from_map` -> `build_context_pack_from_map`), so it inherits the pagerank + self-stamp fix
+# "for free". Proven here with its own exit-2 test rather than left as an unverified assumption.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_edit_plan_tight_deadline_exits_2_with_partial_true_for_free(
+    star_import_repo: Path,
+) -> None:
+    # Sub-second for the same cache-warmth-determinism reason as the agent test above -- this
+    # test in particular runs LAST in the module, by which point every file in the fixture has
+    # already been read (and OS-cached) repeatedly by the earlier agent/codemap tests, so a
+    # multi-second deadline that reliably crossed on a cold cache was observed NOT to cross here.
+    deadline = 0.5
+    started_at = time.monotonic()
+    result = _run_tg(
+        [
+            "edit-plan",
+            str(star_import_repo),
+            "shared_target",
+            "--max-repo-files",
+            "5000",
+            "--deadline",
+            str(deadline),
+            "--json",
+        ],
+        cwd=star_import_repo,
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 60.0, (
+        f"tg edit-plan ran {elapsed:.1f}s against a {deadline}s --deadline -- looks fully "
+        "unbounded, not just slow"
+    )
+    assert result.returncode == 2, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload.get("partial") is True, result.stdout
+    assert payload.get("deadline_limit", {}).get("deadline_exceeded") is True, result.stdout

--- a/tests/integration/test_agent_codemap_deadline_scale.py
+++ b/tests/integration/test_agent_codemap_deadline_scale.py
@@ -112,13 +112,17 @@ def star_import_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 def test_agent_tight_deadline_exits_2_with_partial_true(star_import_repo: Path) -> None:
-    # Deliberately sub-second: OS file-cache warmth varies run-to-run (a repeat run against the
-    # same fixture directory -- e.g. after an earlier test in this module already read every
-    # file once -- can be several times faster than a cold-cache run), so a "moderately tight"
-    # multi-second deadline was observed to be flaky (sometimes not crossed at all). A budget
-    # this far below any plausible real (scan + post-map) completion time for ~2000 files is
-    # crossed deterministically regardless of cache state.
-    deadline = 0.5
+    # Deliberately at the CLI's own enforced floor (`--deadline` has `min=0.1` on every command
+    # that defines it -- see main.py): OS file-cache warmth AND shared-CI-runner speed both vary
+    # run-to-run (a repeat run against the same fixture directory can be several times faster
+    # than a cold-cache run, and a lightly-loaded runner can be several times faster than a
+    # loaded one), so a "moderately tight" budget was observed to be flaky in CI -- run
+    # 29547883118 completed this fixture's WHOLE post-map path (scan + capsule render + call-site
+    # evidence) in under 500ms on an ubuntu-latest/macos-latest py3.11 runner (exit 0, no
+    # truncation) while the same workload took ~3.6s on a separate ubuntu-latest py3.12 runner the
+    # same run. 0.5s was not tight enough; 0.1s is the tightest budget the CLI accepts and is
+    # crossed deterministically regardless of cache state or runner speed.
+    deadline = 0.1
     started_at = time.monotonic()
     result = _run_tg(
         [
@@ -187,8 +191,9 @@ def test_agent_default_deadline_still_completes_and_is_bounded(star_import_repo:
 def test_codemap_tight_deadline_exits_2_with_partial_reason_deadline(
     star_import_repo: Path,
 ) -> None:
-    # Sub-second for the same cache-warmth-determinism reason as the agent test above.
-    deadline = 0.5
+    # At the CLI's own enforced floor (min=0.1) for the same cache-warmth-and-runner-speed
+    # determinism reason as the agent test above.
+    deadline = 0.1
     out_dir = star_import_repo / "docs" / "code-map"
     started_at = time.monotonic()
     result = _run_tg(
@@ -257,11 +262,12 @@ def test_codemap_default_no_deadline_flag_completes(star_import_repo: Path) -> N
 def test_edit_plan_tight_deadline_exits_2_with_partial_true_for_free(
     star_import_repo: Path,
 ) -> None:
-    # Sub-second for the same cache-warmth-determinism reason as the agent test above -- this
-    # test in particular runs LAST in the module, by which point every file in the fixture has
-    # already been read (and OS-cached) repeatedly by the earlier agent/codemap tests, so a
-    # multi-second deadline that reliably crossed on a cold cache was observed NOT to cross here.
-    deadline = 0.5
+    # At the CLI's own enforced floor (min=0.1) for the same cache-warmth-and-runner-speed
+    # determinism reason as the agent test above -- this test in particular runs LAST in the
+    # module, by which point every file in the fixture has already been read (and OS-cached)
+    # repeatedly by the earlier agent/codemap tests, so a multi-second deadline that reliably
+    # crossed on a cold cache was observed NOT to cross here.
+    deadline = 0.1
     started_at = time.monotonic()
     result = _run_tg(
         [

--- a/tests/unit/test_agent_capsule_outbound_deps.py
+++ b/tests/unit/test_agent_capsule_outbound_deps.py
@@ -15,6 +15,7 @@ those keys directly would be silently empty forever. Most tests here build REAL 
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -611,3 +612,149 @@ def test_dar_dedupes_candidates_already_present_in_related_call_sites() -> None:
 
     assert records == []
     assert evidence == {}
+
+
+# ---------------------------------------------------------------------------------------------
+# dogfood finding 1 / council must-fix #5: thread the shared absolute deadline_monotonic through
+# _collect_outbound_dependencies -- before this fix it accepted no deadline at all, so DAR (once
+# opted in) could keep parsing/scanning past --deadline like every other post-map stage this PR
+# bounds. Fail-safe contract preserved: bails to the SAME ([], {}) shape every other early return
+# in this function already uses (see the function's own docstring).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_dar_returns_empty_on_expired_deadline(tmp_path: Path) -> None:
+    paths = _write_dar_project(tmp_path)
+    payload = _dar_context_payload(
+        primary_file=paths["primary"].resolve(),
+        file_summaries=[
+            {
+                "path": str(paths["dependency"].resolve()),
+                "symbols": [{"name": _DEPENDENCY_SYMBOL, "kind": "function", "line": 1}],
+            },
+        ],
+    )
+    target = {"file": str(paths["primary"].resolve()), "symbol": _PRIMARY_SYMBOL}
+    snippets = [
+        {"file": str(paths["primary"].resolve()), "start_line": 1, "source": _PRIMARY_SOURCE},
+    ]
+
+    records, evidence = agent_capsule._collect_outbound_dependencies(
+        _PRIMARY_SYMBOL,
+        str(paths["project"]),
+        target,
+        payload,
+        snippets,
+        [],
+        max_files=3,
+        preview_token_budget=None,
+        deadline_monotonic=time.monotonic() - 1.0,
+    )
+
+    assert records == []
+    assert evidence == {}
+
+
+def test_dar_deadline_hit_flag_is_set_on_expired_deadline(tmp_path: Path) -> None:
+    paths = _write_dar_project(tmp_path)
+    payload = _dar_context_payload(
+        primary_file=paths["primary"].resolve(),
+        file_summaries=[
+            {
+                "path": str(paths["dependency"].resolve()),
+                "symbols": [{"name": _DEPENDENCY_SYMBOL, "kind": "function", "line": 1}],
+            },
+        ],
+    )
+    target = {"file": str(paths["primary"].resolve()), "symbol": _PRIMARY_SYMBOL}
+    snippets = [
+        {"file": str(paths["primary"].resolve()), "start_line": 1, "source": _PRIMARY_SOURCE},
+    ]
+    flag = repo_map._DeadlineBreakFlag()
+
+    agent_capsule._collect_outbound_dependencies(
+        _PRIMARY_SYMBOL,
+        str(paths["project"]),
+        target,
+        payload,
+        snippets,
+        [],
+        max_files=3,
+        preview_token_budget=None,
+        deadline_monotonic=time.monotonic() - 1.0,
+        deadline_hit=flag,
+    )
+
+    assert flag.hit is True
+
+
+def test_dar_deadline_none_still_finds_the_real_dependency(tmp_path: Path) -> None:
+    """Sanity companion: no deadline supplied -> unaffected, still resolves the real dependency
+    (proves the deadline param above is additive, not a behavior change for existing callers)."""
+    paths = _write_dar_project(tmp_path)
+    payload = _dar_context_payload(
+        primary_file=paths["primary"].resolve(),
+        file_summaries=[
+            {
+                "path": str(paths["dependency"].resolve()),
+                "symbols": [{"name": _DEPENDENCY_SYMBOL, "kind": "function", "line": 1}],
+            },
+        ],
+    )
+    target = {"file": str(paths["primary"].resolve()), "symbol": _PRIMARY_SYMBOL}
+    snippets = [
+        {"file": str(paths["primary"].resolve()), "start_line": 1, "source": _PRIMARY_SOURCE},
+    ]
+
+    records, evidence = agent_capsule._collect_outbound_dependencies(
+        _PRIMARY_SYMBOL,
+        str(paths["project"]),
+        target,
+        payload,
+        snippets,
+        [],
+        max_files=3,
+        preview_token_budget=None,
+    )
+
+    assert len(records) == 1
+    assert records[0]["symbol"] == _DEPENDENCY_SYMBOL
+    assert evidence["status"] == "collected"
+
+
+def test_build_agent_capsule_from_map_folds_dar_deadline_hit_into_partial(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Council must-fix #2 (stamp the partial boolean DIRECTLY): DAR's own deadline_hit must fold
+    into the capsule's result["partial"] even when nothing else (context-render, pagerank) broke.
+    Simulated via a direct monkeypatch of _collect_outbound_dependencies -- deterministic,
+    independent of DAR's real internal timing/fixture size (already unit-tested in isolation
+    above) -- proving the CALL-SITE wiring in build_agent_capsule_from_map, not DAR itself."""
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def _fake_collect(*args: object, deadline_hit=None, **kwargs: object):
+        if deadline_hit is not None:
+            deadline_hit.hit = True
+        return [], {}
+
+    monkeypatch.setattr(agent_capsule, "_collect_outbound_dependencies", _fake_collect)
+
+    result = agent_capsule.build_agent_capsule("f", str(tmp_path))
+
+    assert result.get("partial") is True
+    assert result.get("deadline_limit") == {"deadline_exceeded": True}
+
+
+def test_build_agent_capsule_from_map_dar_no_hit_stays_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def _fake_collect(*args: object, deadline_hit=None, **kwargs: object):
+        return [], {}
+
+    monkeypatch.setattr(agent_capsule, "_collect_outbound_dependencies", _fake_collect)
+
+    result = agent_capsule.build_agent_capsule("f", str(tmp_path))
+
+    assert "partial" not in result

--- a/tests/unit/test_cli_deadline_coverage_gaps.py
+++ b/tests/unit/test_cli_deadline_coverage_gaps.py
@@ -115,6 +115,101 @@ def test_defs_daemon_probe_consulted_without_deadline(tmp_path: Path, monkeypatc
 
 
 # ==================================================================================================
+# dogfood finding 1 / F4: `tg agent` defaults --deadline to 60s (mirrors codemap's #153) so a
+# whole-repo call without an explicit --deadline still terminates in bounded time -- but ONLY on
+# the COLD fallback, applied in the command BODY strictly AFTER the warm-daemon gate decides
+# whether to try the daemon (`if effective_deadline is None: ...`). Putting the 60.0 default on
+# the typer.Option itself (codemap's own placement -- codemap has no daemon gate at all) would
+# make `effective_deadline` never None on a default call, silently skipping the daemon probe on
+# EVERY invocation and killing the #108 moat. The tests below prove both halves of that contract
+# at once: the daemon gate is still consulted by default, AND the cold fallback (once the daemon
+# misses/is unavailable) gets exactly 60.0.
+# ==================================================================================================
+
+
+def _agent_cold_spy(recorded: dict):
+    def _spy(query, path, **kwargs):
+        recorded["deadline_seconds"] = kwargs.get("deadline_seconds")
+        return {"path": str(path), "query": query}
+
+    return _spy
+
+
+def test_agent_default_still_reaches_daemon_gate_before_60s_cold_fallback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """THE moat-preservation proof: a default `tg agent` call (no --deadline/--no-deadline) must
+    still ATTEMPT the warm-daemon path, proving the 60s cold-path default cannot have been
+    applied before the gate's `effective_deadline is None` check."""
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    daemon_calls: list = []
+
+    def _daemon_spy(**kwargs):
+        daemon_calls.append(kwargs)
+        return None  # a daemon "miss" -- falls through to cold; only the CALL matters here
+
+    monkeypatch.setattr(main, "_maybe_agent_via_running_daemon", _daemon_spy)
+    cold_recorded: dict = {}
+    monkeypatch.setattr(agent_capsule, "build_agent_capsule", _agent_cold_spy(cold_recorded))
+
+    result = CliRunner().invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert len(daemon_calls) == 1, "the warm-daemon gate must still be consulted by default"
+    assert cold_recorded.get("deadline_seconds") == 60.0, (
+        "the cold fallback after a daemon miss must default to 60s"
+    )
+
+
+def test_agent_no_deadline_flag_also_reaches_daemon_gate_and_cold_stays_unbounded(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """--no-deadline is a real opt-out: the daemon gate is STILL consulted (unchanged from
+    today -- effective_deadline is None either way), but the cold fallback must stay unbounded
+    (None), never silently downgraded to the new 60s default."""
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    daemon_calls: list = []
+
+    def _daemon_spy(**kwargs):
+        daemon_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(main, "_maybe_agent_via_running_daemon", _daemon_spy)
+    cold_recorded: dict = {}
+    monkeypatch.setattr(agent_capsule, "build_agent_capsule", _agent_cold_spy(cold_recorded))
+
+    result = CliRunner().invoke(app, ["agent", str(tmp_path), "f", "--no-deadline", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert len(daemon_calls) == 1
+    assert cold_recorded.get("deadline_seconds") is None
+
+
+def test_agent_explicit_deadline_overrides_the_60s_default(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(main, "_maybe_agent_via_running_daemon", lambda **kwargs: None)
+    cold_recorded: dict = {}
+    monkeypatch.setattr(agent_capsule, "build_agent_capsule", _agent_cold_spy(cold_recorded))
+
+    result = CliRunner().invoke(app, ["agent", str(tmp_path), "f", "--deadline", "30", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert cold_recorded.get("deadline_seconds") == 30.0
+
+
+def test_agent_default_cli_deadline_constant_is_60_seconds() -> None:
+    """Documents/locks the constant agent's body-level default reads. Unlike codemap's own guard
+    test (which pins a literal-duplicated typer.Option default against codemap.DEFAULT_CLI_
+    DEADLINE_SECONDS -- required there because codemap's default sits ON the typer.Option,
+    evaluated at CLI-decoration/module-import time, before codemap.py's heavy import runs),
+    agent's 60s default is applied in the command BODY -- after `agent_capsule` is already
+    lazily imported -- so main.py imports agent_capsule.DEFAULT_AGENT_CLI_DEADLINE_SECONDS
+    DIRECTLY rather than literal-duplicating it. There is no drift to pin; this just locks the
+    value itself."""
+    assert agent_capsule.DEFAULT_AGENT_CLI_DEADLINE_SECONDS == 60.0
+
+
+# ==================================================================================================
 # Item 2: cold-path exit-2 coverage under a REAL --deadline-truncated scan (not a mocked payload).
 # Target `src/tensor_grep` itself (~80 real files) rather than a tiny tmp_path fixture -- a 0.1s
 # deadline needs genuine scan work to truncate against; a 2-file fixture can complete a full repo

--- a/tests/unit/test_codemap.py
+++ b/tests/unit/test_codemap.py
@@ -6,8 +6,10 @@ generated output never touches the checked-in fixture and mtimes are stable with
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -566,6 +568,139 @@ def test_default_invocation_matches_explicit_noop_ignore_and_deadline(tmp_path: 
     assert explicit_payload["partial_reason"] is None
     assert default_payload["files_total"] == explicit_payload["files_total"]
     assert default_payload["tree_manifest_sha256"] == explicit_payload["tree_manifest_sha256"]
+
+
+# ---------------------------------------------------------------------------
+# (18) dogfood finding 1: the POST-MAP tail (the folders_with_no_mapped_files re-walk + the
+# per-folder render loop) ran fully UNBOUNDED even after the MAP-level scan finished inside
+# --deadline -- a real `tg codemap ROOT --deadline 3` ran ~28s. Both must now bound themselves off
+# the SAME deadline_monotonic and fold an early break into the EXISTING partial/partial_reason=
+# "deadline" contract (18a), and the render loop's break must never leave the INDEX PAGE
+# dangling-linking to a folder page that was never written (18b).
+# ---------------------------------------------------------------------------
+
+
+def _make_many_folder_repo(root: Path, folder_count: int) -> Path:
+    """``folder_count`` distinct folders, each holding one trivial file -- enough real per-folder
+    render-loop iterations to prove a MID-loop deadline break, not just a pre-loop check."""
+    project = root / "project"
+    for index in range(folder_count):
+        folder = project / f"pkg{index:04d}"
+        folder.mkdir(parents=True)
+        (folder / "mod.py").write_text(f"def f{index}():\n    return {index}\n", encoding="utf-8")
+    return project
+
+
+def test_all_folder_paths_bounds_walk_on_expired_deadline(tmp_path: Path) -> None:
+    project = _make_many_folder_repo(tmp_path, 5)
+    flag = _codemap._repo_map._DeadlineBreakFlag()
+
+    folders = _codemap._all_folder_paths(
+        project,
+        max_repo_files=100,
+        deadline_monotonic=time.monotonic() - 1.0,
+        deadline_hit=flag,
+    )
+
+    assert folders == set()
+    assert flag.hit is True
+
+
+def test_all_folder_paths_deadline_none_is_unaffected(tmp_path: Path) -> None:
+    project = _make_many_folder_repo(tmp_path, 5)
+
+    folders = _codemap._all_folder_paths(project, max_repo_files=100)
+
+    assert len(folders) == 5
+
+
+def test_tail_render_loop_honors_deadline_mid_loop_and_marks_partial(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """council must-fix #4: the per-folder render loop must break on --deadline and fold that
+    into the SAME partial/partial_reason=deadline contract the scan-level cutoff already uses --
+    proven via a mid-loop break (some but not all folders rendered), not just a pre-loop check."""
+    project = _make_many_folder_repo(tmp_path, 10)
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(_codemap.time, "monotonic", lambda: clock["t"])
+    original_render = _codemap._render_folder_page
+
+    def _advancing_render(*args, **kwargs):
+        clock["t"] += 1.0
+        return original_render(*args, **kwargs)
+
+    monkeypatch.setattr(_codemap, "_render_folder_page", _advancing_render)
+
+    payload = _build(project, deadline_seconds=5.5)
+
+    assert payload["partial"] is True
+    assert payload["partial_reason"] == "deadline"
+    assert payload["remediation"]
+    written_pages = [Path(p) for p in payload["written_files"] if Path(p).stem.startswith("pkg")]
+    # A genuine MID-loop break: some but not all 10 folders got a rendered page.
+    assert 0 < len(written_pages) < 10, (
+        f"expected a partial render (some but not all of 10 folders), got {len(written_pages)}"
+    )
+    for page_path in written_pages:
+        assert page_path.is_file()
+    # The still-valid coverage JSON must agree with the rendered index page.
+    coverage_path = Path(payload["out"]) / _codemap._COVERAGE_FILENAME
+    coverage = json.loads(coverage_path.read_text(encoding="utf-8"))
+    assert coverage["partial"] is True
+    assert coverage["partial_reason"] == "deadline"
+
+
+def test_tail_render_loop_index_never_dangling_links_a_folder_deadline_cut(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """18b: the index page must list (and link to) ONLY folders that actually got a page written
+    -- a dangling link to an unwritten folder page would be a broken-navigation regression."""
+    project = _make_many_folder_repo(tmp_path, 8)
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(_codemap.time, "monotonic", lambda: clock["t"])
+    original_render = _codemap._render_folder_page
+
+    def _advancing_render(*args, **kwargs):
+        clock["t"] += 1.0
+        return original_render(*args, **kwargs)
+
+    monkeypatch.setattr(_codemap, "_render_folder_page", _advancing_render)
+
+    payload = _build(project, deadline_seconds=3.5)
+
+    assert payload["partial"] is True
+    index_path = Path(payload["index"])
+    lines = index_path.read_text(encoding="utf-8").splitlines()
+    # Scope to the "## Folders" table specifically -- the EARLIER "## Top central files" table
+    # also has `| \`pkg0000/mod.py\` | ... |`-shaped rows (a FILE path, no link at all), which a
+    # bare `startswith("| \`pkg")` scan over the whole page would misidentify as folder rows.
+    folders_header = lines.index("## Folders")
+    row_count = 0
+    for line in lines[folders_header:]:
+        if not line.startswith("| `pkg"):
+            continue
+        row_count += 1
+        match = re.search(r"\[[^\]]+\]\(([^)]+)\)", line)
+        assert match, f"folder row missing a map link: {line}"
+        linked_page = (index_path.parent / match.group(1)).resolve()
+        assert linked_page.is_file(), f"index links to an unwritten page: {linked_page}"
+    assert row_count > 0, "fixture produced no folder rows to check"
+    assert row_count < 8, "expected a partial render (fewer rows than the 8 real folders)"
+
+
+def test_tail_no_deadline_renders_every_folder_unaffected(tmp_path: Path) -> None:
+    project = _make_many_folder_repo(tmp_path, 6)
+
+    payload = _build(project)
+
+    assert payload["partial"] is False
+    assert payload["folders_total"] == 6
+    written_pages = [p for p in payload["written_files"] if Path(p).stem.startswith("pkg")]
+    assert len(written_pages) == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -1105,3 +1105,94 @@ def test_step103_callers_no_deadline_context_pack_stays_complete(tmp_path: Path)
 
     assert "partial" not in result
     assert result["graph_completeness"] == "moderate"
+
+
+# ---------------------------------------------------------------------------------------------
+# dogfood finding 1: `tg agent`/`tg codemap` --deadline was threaded into build_repo_map (the
+# SCAN) but the POST-MAP stages (context-pack symbol/graph scoring, feeding agent/context/
+# edit-plan alike) ran unbounded AND unstamped -- a real whole-repo `tg agent --deadline 8`
+# silently overran to ~20s at exit 0, partial=None. build_context_pack_from_map (the public
+# build_context_pack_from_map -> _build_context_pack_from_map seam every one of those commands
+# shares) now self-stamps `partial`/`deadline_limit` from its OWN internal deadline_hit readback
+# even when the caller supplies none -- the pre-fix shape for agent/context/edit-plan, none of
+# which passed a deadline_hit flag before this change.
+# ---------------------------------------------------------------------------------------------
+
+
+def _make_pagerank_stress_repo(root: Path, symbol_count: int) -> None:
+    """``symbol_count`` trivial one-function modules that all import a shared ``hub.py`` --
+    non-empty reverse_importers (a real hub with real fan-in), so pagerank's per-node sort has
+    genuine (if small) work to do, not the trivially-empty-set fast path."""
+    src = root / "src"
+    src.mkdir(parents=True)
+    (src / "hub.py").write_text("def hub_fn():\n    return 0\n", encoding="utf-8")
+    for index in range(symbol_count):
+        (src / f"m{index}.py").write_text(
+            f"from src.hub import hub_fn\n\n\ndef f{index}():\n    return hub_fn() + {index}\n",
+            encoding="utf-8",
+        )
+
+
+def test_build_context_pack_from_map_self_stamps_partial_when_pagerank_abandons(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Council must-fix #2 (stamp the partial boolean DIRECTLY): the symbol-scoring loop finishes
+    INSIDE budget, but the very next sibling stage -- _personalized_reverse_import_pagerank --
+    crosses the SAME shared deadline. Before this fix, build_context_pack_from_map never read
+    back its own deadline_hit flag at all (agent/context/edit-plan all call it with no deadline_
+    hit argument), so this whole class of post-symbol-scoring break was silently unstamped."""
+    _make_pagerank_stress_repo(tmp_path, 6)
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_score = repo_map._score_symbol
+
+    def _advancing_score(*args, **kwargs):
+        clock["t"] += 1.0
+        return original_score(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_score_symbol", _advancing_score)
+
+    # symbol-scoring calls _score_symbol exactly once per symbol in rm["symbols"], checking the
+    # deadline BEFORE each call (clock values base .. base+total-1) -- a deadline of
+    # base+total-0.5 lets every one of those checks through (all strictly less), leaving the
+    # clock parked at base+total once the loop naturally ends. That is exactly the value
+    # pagerank's OWN new iteration-boundary check reads first, so it aborts on iteration 0.
+    total_symbols = len(rm["symbols"])
+    assert total_symbols > 0, "fixture must actually produce symbols to score"
+    deadline_monotonic = base + total_symbols - 0.5
+
+    payload = repo_map.build_context_pack_from_map(rm, "f0", deadline_monotonic=deadline_monotonic)
+
+    assert payload.get("partial") is True
+    assert payload.get("deadline_limit") == {"deadline_exceeded": True}
+
+
+def test_build_context_pack_from_map_no_deadline_stays_complete(tmp_path: Path) -> None:
+    _make_pagerank_stress_repo(tmp_path, 6)
+    rm = repo_map.build_repo_map(str(tmp_path))
+
+    payload = repo_map.build_context_pack_from_map(rm, "f0")  # no deadline
+
+    assert "partial" not in payload
+    assert "deadline_limit" not in payload
+
+
+def test_build_context_pack_from_map_honors_caller_supplied_deadline_hit_too(
+    tmp_path: Path,
+) -> None:
+    """A caller that DOES pass its own `_DeadlineBreakFlag` (mirroring the callers/impact/blast-
+    radius fold-in pattern) must still see it flip to `.hit = True` -- the self-stamp fix must
+    not swallow/replace a caller-supplied flag with an internal one it never reads back."""
+    _make_pagerank_stress_repo(tmp_path, 4)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    flag = repo_map._DeadlineBreakFlag()
+
+    payload = repo_map.build_context_pack_from_map(
+        rm, "f0", deadline_monotonic=time.monotonic() - 1.0, deadline_hit=flag
+    )
+
+    assert payload.get("partial") is True
+    assert flag.hit is True

--- a/tests/unit/test_repo_map_graph.py
+++ b/tests/unit/test_repo_map_graph.py
@@ -89,6 +89,119 @@ def test_reverse_import_pagerank_caps_broad_query_seed_sets() -> None:
     assert elapsed < 10.0
 
 
+# ---------------------------------------------------------------------------------------------
+# dogfood finding 1 (agent/codemap --deadline post-map bounding): _personalized_reverse_import_
+# pagerank ran its 12-iteration loop fully UNBOUNDED even when a caller (context-pack scoring)
+# already had a deadline_monotonic in scope -- the loop was never threaded a deadline at all. Two
+# council must-fixes: (1) ABANDON to {} at the iteration boundary on expiry (deterministic --
+# callers already do `.get(x, 0.0)`, never a partial-ranks lie); (2) hoist the per-node
+# `sorted(reverse_importers.get(current))` OUT of the loop, since reverse_importers never changes
+# across iterations -- a free, additive speedup independent of the deadline fix.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_pagerank_abandons_to_empty_dict_on_already_expired_deadline() -> None:
+    files = [f"C:/repo/src/mod_{index}.py" for index in range(20)]
+    # A real hub (non-empty reverse-importers) so a pre-fix run would still do real sort work on
+    # iteration 0 before this test's expired deadline should stop it from ever getting there.
+    reverse = {files[0]: set(files[1:])}
+    flag = repo_map._DeadlineBreakFlag()
+
+    ranks = repo_map._personalized_reverse_import_pagerank(
+        files[:2],
+        files,
+        reverse,
+        deadline_monotonic=time.monotonic() - 1.0,
+        deadline_hit=flag,
+    )
+
+    assert ranks == {}
+    assert flag.hit is True
+
+
+def test_pagerank_deadline_hit_flag_is_optional() -> None:
+    """A caller that passes deadline_monotonic but no deadline_hit flag must not crash -- the
+    None-guard on `deadline_hit.hit = True` mirrors every sibling _DeadlineBreakFlag call site."""
+    files = [f"C:/repo/src/mod_{index}.py" for index in range(5)]
+    reverse = {files[0]: {files[1]}}
+
+    ranks = repo_map._personalized_reverse_import_pagerank(
+        files[:1],
+        files,
+        reverse,
+        deadline_monotonic=time.monotonic() - 1.0,
+    )
+
+    assert ranks == {}
+
+
+def test_pagerank_deadline_none_is_unaffected() -> None:
+    """No deadline supplied (the pre-existing call sites' shape) -> unchanged, non-empty ranks."""
+    files = [f"C:/repo/src/mod_{index}.py" for index in range(10)]
+    reverse = {files[0]: {files[1], files[2]}}
+
+    ranks = repo_map._personalized_reverse_import_pagerank(files[:1], files, reverse)
+
+    assert ranks
+    assert files[0] in ranks
+
+
+def test_pagerank_hoisted_sort_matches_reference_computation() -> None:
+    """The hoist (sorted(reverse_importers.get(current)) computed ONCE before the 12-iteration
+    loop, not recomputed every iteration) must be numerically a pure refactor. Prove it against an
+    independent reference implementation that keeps the pre-fix recompute-every-iteration shape."""
+    files = [f"C:/repo/src/mod_{index}.py" for index in range(8)]
+    reverse = {
+        files[0]: {files[1], files[2], files[3]},
+        files[1]: {files[4]},
+        files[4]: {files[5], files[6]},
+    }
+
+    def _reference(
+        seed_files: list[str],
+        all_files: list[str],
+        reverse_importers: dict[str, set[str]],
+        *,
+        alpha: float = 0.85,
+        iterations: int = 12,
+    ) -> dict[str, float]:
+        all_file_set = set(all_files)
+        seen: set[str] = set()
+        unique_seeds: list[str] = []
+        for current in seed_files:
+            if current not in all_file_set or current in seen:
+                continue
+            seen.add(current)
+            unique_seeds.append(current)
+        seed_set = set(unique_seeds)
+        seed_weight = 1.0 / len(unique_seeds)
+        personalization = {
+            current: (seed_weight if current in seed_set else 0.0) for current in all_files
+        }
+        ranks = dict(personalization)
+        for _ in range(iterations):
+            updated = {current: (1.0 - alpha) * personalization[current] for current in all_files}
+            for current in all_files:
+                # pre-fix shape: recompute the sort every iteration.
+                outgoing = sorted(reverse_importers.get(current, set()))
+                if outgoing:
+                    share = alpha * ranks[current] / len(outgoing)
+                    for importer in outgoing:
+                        updated[importer] = updated.get(importer, 0.0) + share
+                    continue
+                spill = alpha * ranks[current] / len(unique_seeds)
+                for seed in unique_seeds:
+                    updated[seed] = updated.get(seed, 0.0) + spill
+            ranks = updated
+        return {current: rank for current, rank in ranks.items() if rank > 0.0}
+
+    expected = _reference(files[:2], files, reverse)
+    actual = repo_map._personalized_reverse_import_pagerank(files[:2], files, reverse)
+
+    assert actual == expected
+    assert actual  # sanity: the fixture actually produces non-trivial ranks
+
+
 def test_context_tests_skip_framework_scan_without_cheap_test_evidence(monkeypatch) -> None:
     def _fail_unrelated_framework_scan(test_path: str) -> tuple[str, ...]:
         raise AssertionError(f"unexpected framework scan for {test_path}")


### PR DESCRIPTION
## Summary

Dogfood finding 1 (HIGH): `--deadline` was threaded into `build_repo_map` (the scan), which
finished in budget, but the POST-MAP stages ran fully unbounded and unstamped:
- `tg agent ROOT Q --deadline 8` ran ~20s at **exit 0** with **`partial=None`** (a silent
  deadline breach) instead of honestly reporting truncation.
- `tg codemap ROOT --deadline 3` ran ~28s the same way.

The exit-2 gate (`_scan_incomplete`) keys solely on `payload["partial"]`, so an unstamped
truncation silently exits 0 as if the result were complete.

## What changed

- **`_personalized_reverse_import_pagerank`** (repo_map.py): abandons to `{}` at the
  12-iteration boundary once `deadline_monotonic` expires (deterministic -- every caller
  already does `.get(x, 0.0)`, never a partial-ranks lie), and hoists the per-node
  `sorted(reverse_importers.get(current))` out of the loop (free, additive speedup, proven
  numerically identical to the pre-hoist shape by a dedicated reference-implementation test).
- **`build_context_pack_from_map`** (repo_map.py) now self-stamps `partial`/`deadline_limit`
  from its own `deadline_hit` readback. Every current caller (agent/context/edit-plan) passes
  no flag at all today, so a sibling-loop break inside `_build_context_pack_from_map` was
  previously silently unstamped -- `_copy_partial_signal` can only *propagate* an existing
  `partial` key, it cannot *originate* one from a bare `_DeadlineBreakFlag`.
- **`_collect_outbound_dependencies`** (agent_capsule.py, DAR -- opt-in, default OFF) now
  threads `deadline_monotonic` and bails through its existing `([], {})` fail-safe shape;
  `build_agent_capsule_from_map` folds its own `deadline_hit` into `result["partial"]`
  alongside the context-render signal.
- **`tg agent`'s 60s default deadline** is applied in the command **body**, strictly *after*
  the warm-daemon gate (`if effective_deadline is None: ...`) -- putting it on the
  `typer.Option` default (codemap's own placement) would make `effective_deadline` never
  `None` on a default call, silently skipping the daemon probe on *every* invocation (the
  #108 moat). `--no-deadline` stays a real opt-out; the library default
  (`build_agent_capsule`) stays unbounded.
- **codemap's post-map "tail"** (the `folders_with_no_mapped_files` re-walk + the per-folder
  render loop) now shares the same `deadline_monotonic`, folds an early break into the
  existing `partial`/`partial_reason="deadline"` ladder, and renders the index off only the
  folders that were actually written -- a deadline-cut tail never dangling-links to an
  unwritten page.
- **`tg edit-plan`** inherits the pagerank + self-stamp fix for free (same
  `build_context_pack_from_map` seam agent/context share) -- verified with its own exit-2
  test rather than left as an unverified assumption.

## Traps avoided (the 3 named in the plan)

1. **Daemon-moat trap**: the 60s default lives in the command body, computed *after* the
   `if effective_deadline is None` daemon gate, from the *raw* `deadline`/`no_deadline`
   params -- not by reusing `effective_deadline` and not on the `typer.Option`. Proven by
   `test_agent_default_still_reaches_daemon_gate_before_60s_cold_fallback`, which asserts
   the daemon probe is still *called* (not just that its result is unused) on a default
   invocation, and that the cold fallback still gets exactly 60.0.
2. **Stamp-origination trap**: `_copy_partial_signal` can only propagate an existing
   `partial` key forward; it cannot originate one from a bare `_DeadlineBreakFlag`. Every
   new post-map break (pagerank abandon, DAR cut, codemap tail break) stamps
   `payload["partial"] = True` directly, mirroring the callers/impact/blast-radius N-way
   fold-in pattern already established in repo_map.py.
3. **Codemap-boolean trap**: the tail break ORs into the *existing* `partial` boolean +
   `partial_reason` ladder (never clobbering a more specific `scan_limit`/`self_verify`
   reason, never downgrading an already-True partial back to False), verified end-to-end on
   the real binary via `exit_code == 2` + `partial_reason == "deadline"`.

## TDD

RED tests written first against the unfixed code (confirmed failing for the right reason --
`TypeError: unexpected keyword argument`, `AttributeError: no attribute 'time'`, or a wrong
assertion value) before each fix landed. Layers:

- **Unit (deterministic fake-clock)**: `tests/unit/test_repo_map_graph.py`,
  `tests/unit/test_repo_map_deadline.py`, `tests/unit/test_agent_capsule_outbound_deps.py`,
  `tests/unit/test_cli_deadline_coverage_gaps.py`, `tests/unit/test_codemap.py` -- mirrors
  the existing task #52/#61/#103 deadline-test idiom (advancing-clock hooks, already-expired
  deadlines), including a reference-implementation correctness test for the pagerank hoist
  and a dangling-link regression test for the codemap tail.
- **Real-binary integration** (`tests/integration/test_agent_codemap_deadline_scale.py`,
  new file): `python -m tensor_grep` subprocess (not CliRunner, per AGENTS.md's
  "dogfood the real binary" rule), `timeout=` anti-hang guard, against a ~2000-file
  "star-import" fixture (every leaf imports one hub -- maximal reverse-import fan-in, the
  worst case pagerank's pre-fix per-node resort targeted) sized per the plan's RED-test ask.
  Covers `tg agent` (tight + default deadline), `tg codemap` (tight + default deadline), and
  `tg edit-plan` (tight deadline, the "for free" claim).

All 226 targeted unit tests + 5 integration tests pass; the 4 touched source files + 6 new/
edited test files are ASCII-only (738/738 added lines) and clean under `ruff check .` /
`ruff format --preview --check .` (repo-wide). Verified zero regressions by running the
broader ~1250-test surface touching these shared functions, and confirmed the 5 pre-existing
failures found there (`mcp_server`/rewrite-embedded-fallback, one GPU-inventory search test)
are unrelated and reproduce identically against a clean `origin/main` checkout.

## Deviation (documented, out of scope for this PR)

Profiling the ~2000-file fixture surfaced a **separate, pre-existing** unbounded cost
dominated by repeated `Path.resolve()` calls on Windows (`nt._getfinalpathname`):
`tg agent`'s validation-file/test-runner detection (reached via the call-site-evidence
collector, `_precomputed_validation_files_for_root`) and codemap's
`_exclude_output_paths`. Neither is named in this PR's scope and neither threads a deadline
at all. Because of it, real-binary wall-clock is not tightly bound to `--deadline` end-to-end
today -- but the **honesty contract this PR exists to fix** (exit 2, `partial=True`, never a
silent exit-0 completeness lie) is proven to hold regardless, since the shared absolute
deadline has always already expired by the time execution reaches whichever stage this PR
bounds. The new integration tests' wall-clock assertions are deliberately generous to reflect
this known, separate gap honestly rather than overclaim tight deadline adherence this PR does
not deliver alone. Flagging as a follow-up dogfood finding for the large-repo-scale campaign.

## Test plan

- [x] RED confirmed for every fix before implementing
- [x] `ruff check .` clean (whole repo)
- [x] `ruff format --preview --check .` clean (whole repo)
- [x] Targeted unit suites green (226 tests across 7 files)
- [x] Real-binary integration suite green, run twice for timing reliability (5 tests)
- [x] Zero regressions verified against a clean `origin/main` baseline worktree
- [x] Do NOT merge -- per the campaign's push-race discipline, the orchestrator drains this
      PR after the in-flight release publishes and the ubuntu/macos `test-python` matrix is
      green.

Generated with Claude Code
