### PR TITLE
fix(rerank): role-aware query encoding for the MaxSim late-rerank (#189 Item 1)

### DIFF
--- a/src/tensor_grep/core/retrieval_late.py
+++ b/src/tensor_grep/core/retrieval_late.py
@@ -101,10 +101,22 @@ class LateReranker:
     the ``rerank`` extra). Mirrors :class:`~tensor_grep.core.retrieval_dense.DenseIndex`'s
     dependency-injection shape (retrieval_dense.py:155, the model is passed in already loaded)
     rather than owning model lifecycle itself.
+
+    ``encode_query`` (#189 Item 1 fix, optional): a SECOND, role-aware encoder used for the query
+    text only; ``encode`` continues to encode every candidate chunk. When omitted (``None``, the
+    default), ``encode`` serves both roles -- byte-identical to the pre-fix single-encoder
+    contract, so existing callers (and their order-only tests) are unaffected. See
+    :func:`load_late_reranker` for the real ONNX wiring that supplies role-correct encoders
+    (``[Q] `` vs ``[D] `` prefix + per-role max length) via :func:`build_late_encoder`.
     """
 
-    def __init__(self, encode: Callable[[str], np.ndarray]) -> None:
+    def __init__(
+        self,
+        encode: Callable[[str], np.ndarray],
+        encode_query: Callable[[str], np.ndarray] | None = None,
+    ) -> None:
         self._encode = encode
+        self._encode_query = encode_query
 
     def rerank(self, query: str, chunks: list[str], indices: list[int]) -> list[int]:
         """Return ``indices`` permuted by MaxSim(query, chunk) descending; ties break by
@@ -112,15 +124,17 @@ class LateReranker:
 
         Output is EXACTLY ``indices`` reordered -- never adds, never drops (the seam this feeds,
         ``rerank_hybrid``, splices this back over a ``fused_order`` head slice and must preserve
-        membership; design doc "The seam"). An empty pool returns ``[]`` without invoking
-        ``encode`` at all.
+        membership; design doc "The seam"). An empty pool returns ``[]`` without invoking either
+        encoder at all.
 
         ``chunks[i]`` must correspond to ``indices[i]`` (same length, position-aligned) -- the
-        caller's already-pooled candidate set.
+        caller's already-pooled candidate set. The query is encoded via ``encode_query`` when one
+        was supplied to the constructor, else via ``encode`` (the pre-fix, single-encoder
+        behavior) -- every chunk always goes through ``encode``.
         """
         if not indices:
             return []
-        query_matrix = self._encode(query)
+        query_matrix = (self._encode_query or self._encode)(query)
         doc_matrices = [self._encode(chunk) for chunk in chunks]
         scores = maxsim_scores(query_matrix, doc_matrices)
         return rank_by_maxsim(scores, indices)
@@ -323,18 +337,23 @@ def build_late_encoder(model: LateModel, *, is_query: bool) -> Callable[[str], n
 
 
 def load_late_reranker(model_dir: str | Path | None = None) -> LateReranker:
-    """Convenience constructor: load the model and wire a real encoder into :class:`LateReranker`.
+    """Convenience constructor: load the model and wire ROLE-AWARE encoders into
+    :class:`LateReranker` (#189 Item 1 fix).
 
-    NOTE: :meth:`LateReranker.rerank` (T2) calls the SAME injected ``encode`` for both the query
-    text and every candidate chunk -- it does not yet distinguish roles. This constructor wires
-    the DOCUMENT-role encoder (chunks dominate call volume: one query encode vs N chunk encodes
-    per search) as a conservative default. The asymmetric ``query_prefix``/``document_prefix`` +
-    ``query_length``/``document_length`` in ``onnx_config.json`` are both read and available via
-    ``build_late_encoder(model, is_query=True/False)`` for T5's seam wiring to route correctly.
+    The query text is encoded via the QUERY-role encoder (``query_prefix`` + ``query_length``);
+    every candidate chunk via the DOCUMENT-role encoder (``document_prefix`` + ``document_length``)
+    -- both built from the same loaded ``model`` via ``build_late_encoder(model, is_query=True/
+    False)``. Prior to this fix, a single DOCUMENT-role encoder was wired for both roles, so the
+    query was encoded with the wrong prefix/length (``[D] `` instead of ``[Q] ``) -- the wrong
+    ColBERT sub-space, which scrambled MaxSim's ranking (see #189 ledger, "role-aware query
+    encoding").
     """
     resolved_dir = model_dir if model_dir is not None else default_model_dir()
     model = load_late_model(resolved_dir)
-    return LateReranker(build_late_encoder(model, is_query=False))
+    return LateReranker(
+        build_late_encoder(model, is_query=False),
+        encode_query=build_late_encoder(model, is_query=True),
+    )
 
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/unit/test_retrieval_late.py
+++ b/tests/unit/test_retrieval_late.py
@@ -335,6 +335,74 @@ class TestBuildLateEncoder:
             encode("hello")
 
 
+class TestLateRerankerRoleAwareQueryEncoding:
+    """#189 Item 1 fix: the query text must route through the QUERY-role encoder (`[Q] ` prefix)
+    and every candidate chunk through the DOCUMENT-role encoder (`[D] ` prefix) -- prior to this
+    fix, `load_late_reranker` wired ONE document-role encoder for both roles (see the removed NOTE
+    that used to sit on its docstring), so a query was encoded into the wrong ColBERT sub-space
+    (`[D] ` prefix + document_length instead of `[Q] ` + query_length). Both tests fail against the
+    pre-fix code: the first because `load_late_reranker` had no second encoder to route through at
+    all, the second because `LateReranker.__init__` did not yet accept `encode_query`.
+    """
+
+    def test_load_late_reranker_routes_query_through_query_prefix(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        # `load_late_model` is monkeypatched to a fake -- no real ONNX model needed for this
+        # assertion, mirroring the fakes `TestBuildLateEncoder` already uses.
+        model = _fake_late_model()
+        monkeypatch.setattr(
+            "tensor_grep.core.retrieval_late.load_late_model", lambda _model_dir: model
+        )
+
+        reranker = load_late_reranker(tmp_path)
+        reranker.rerank("how do I open a file", ["def read(): pass", "def write(): pass"], [1, 2])
+
+        # Both encoders share the SAME underlying `model.tokenizer` (one `load_late_model` call),
+        # so `encoded_texts` is a single flat list in call order: the query first, then each chunk
+        # -- see `LateReranker.rerank`'s call order below.
+        assert model.tokenizer.encoded_texts[0] == "[Q] how do I open a file"
+        assert model.tokenizer.encoded_texts[1:] == [
+            "[D] def read(): pass",
+            "[D] def write(): pass",
+        ]
+
+    def test_late_reranker_uses_query_encoder_for_query_only(self) -> None:
+        query_calls: list[str] = []
+        doc_calls: list[str] = []
+
+        def encode_query(text: str) -> np.ndarray:
+            query_calls.append(text)
+            return np.array([[1.0, 0.0]], dtype=np.float32)
+
+        def encode_doc(text: str) -> np.ndarray:
+            doc_calls.append(text)
+            return np.array([[1.0, 0.0]], dtype=np.float32)
+
+        reranker = LateReranker(encode_doc, encode_query=encode_query)
+
+        reranker.rerank("query", ["chunk-a", "chunk-b"], [10, 20])
+
+        assert query_calls == ["query"]
+        assert doc_calls == ["chunk-a", "chunk-b"]
+
+    def test_encode_query_none_falls_back_to_encode_backward_compat(self) -> None:
+        # `encode_query=None` (the default, and every pre-fix call site via `LateReranker(encode)`
+        # or `LateReranker(encode=...)`) must remain byte-identical to the single-encoder contract:
+        # the SAME callable serves both roles.
+        calls: list[str] = []
+
+        def encode(text: str) -> np.ndarray:
+            calls.append(text)
+            return np.array([[1.0, 0.0]], dtype=np.float32)
+
+        reranker = LateReranker(encode)
+
+        reranker.rerank("query", ["chunk-a"], [1])
+
+        assert calls == ["query", "chunk-a"]
+
+
 def _real_late_model_dir():
     candidate = default_model_dir()
     return candidate if candidate.is_dir() else None


### PR DESCRIPTION
## Summary

- **The bug** (`#189` ledger, "role-aware query encoding"): `load_late_reranker` (`retrieval_late.py`) wired **one document-role encoder** for both the query and every candidate chunk. `LateReranker.rerank` then encoded the query with the `[D] ` prefix + document max-length instead of `[Q] ` + query max-length — the wrong ColBERT sub-space, which scrambled MaxSim's ranking. The fix infra (`build_late_encoder(model, is_query=True/False)`) already existed and was unit-tested; the gap was that `LateReranker`/`load_late_reranker` never used the query-role encoder.
- **The fix** (3 seams, ~20 LOC, backward-compatible): `LateReranker.__init__` gains an optional second encoder `encode_query: Callable[[str], np.ndarray] | None = None` (falls back to `encode` when omitted — byte-identical to the old contract); `.rerank` routes the query through `encode_query or encode`; `load_late_reranker` now wires both a document-role and a query-role encoder. No other call site changes — `cli/main.py`'s two `load_late_reranker()` call sites and the eval harness inherit the fix automatically.
- `TG_LATE_RERANK` stays **default-OFF**. This PR is a correctness fix + a decisive measurement, not a flip.

## TDD

RED confirmed against unfixed `origin/main`, GREEN after the fix:
- `test_load_late_reranker_routes_query_through_query_prefix` — asserts the query is encoded `"[Q] <query>"` and every chunk `"[D] <chunk>"` via the fake tokenizer's recorded call list. Failed pre-fix (query got `[D] `).
- `test_late_reranker_uses_query_encoder_for_query_only` — distinct `encode`/`encode_query` stubs; `encode_query` called once (query), `encode` called once per chunk. Failed pre-fix (`TypeError`, no `encode_query` kwarg).
- `test_encode_query_none_falls_back_to_encode_backward_compat` — pins the `encode_query=None` fallback explicitly.
- All 4 pre-existing single-encoder order-only tests pass **unchanged**.
- Full `retrieval_late` / `reranker` / `rank_chunks` / `find` / `search_semantic_rerank` suites: **137 tests pass**, including `TestRealFetchedModel` run against the actual fetched `lightonai/LateOn-Code-edge` model (not a mock).

Two pre-existing, environment-driven failures in `test_eval_late_rerank_quality.py` (`test_dense_rrf_and_maxsim_skip_cleanly_without_the_optional_extras`, `test_render_report_never_prints_a_verdict_over_skipped_arms`) were verified to reproduce identically on a clean `origin/main` checkout in this same sandbox — the sandbox happens to have the `rerank`/`semantic` extras + fetched models installed, which those two tests' own docstrings assume is absent ("CI installs only [dev]"). Unrelated to this change.

## Decisive eval

`benchmarks/eval_late_rerank_quality.py --runs 3` (3/3 byte-identical), NL golden set, 40 queries:

| arm | ndcg@10 | recall@10 |
|---|---|---|
| bm25 | 0.1093 | 0.2500 |
| dense | 0.6026 | 0.9000 |
| rrf | 0.3047 | 0.5500 |
| rrf+maxsim | 0.0679 | 0.2000 |

**The role-aware fix does not recover the regression.** rrf+maxsim ndcg@10 stayed at 0.068 — statistically indistinguishable from the pre-fix 0.083 the ledger recorded — and far below rrf's 0.305.

The two lexical guard slices (`--golden literal_golden.jsonl` / `identifier3_golden.jsonl`, 10 queries each, 3/3 byte-identical) are worse: bm25/dense/rrf all score a **perfect 1.0** ndcg@10, but rrf+maxsim collapses to **0.082** and **0.029** respectively (delta -0.92 / -0.97 vs bm25) — MaxSim actively destroys an already-perfect ranking on literal/identifier lookups.

**Root-cause diagnostic** (not part of the diff, see PR discussion): with the fix applied, raw MaxSim rank of the truly-relevant chunk over the whole 74-chunk golden corpus averages **~41/74** across the 40 NL queries — close to the ~37.5 expected under a uniform-random ordering — while RRF (bm25+dense) averages **~16.4**, a real signal. The 17M-param, 48-dim, int8-quantized LateOn-Code-edge model appears too weak on this corpus/domain to add signal on top of RRF, independent of the role-encoding bug.

**My read**: the fix is a genuine correctness improvement (queries now hit the right ColBERT sub-space) and should ship regardless of the eval outcome — shipping known role-blind encoding would be indefensible even if it happened to score acceptably. But it is **not sufficient** to make `+maxsim` competitive: this lands in the roadmap's "still <= rrf" branch → **not flip-eligible**. Whether to keep `TG_LATE_RERANK` default-OFF-experimental or formally retire the negative result to `docs/PAPER.md` is left to the reviewing engineer, per the roadmap's own framing ("either is a clean result").

## Deferred (not bundled)

Un-stubbing a production-faithful `find` arm (calling `core.reranker.rank_chunks(dense_weight=..., late_reranker=...)` instead of the harness's own equal-weight inline fusion) needs: a new cross-module import boundary (`benchmarks/` → `cli.main` for the query-adaptive `_find_dense_weight`), threading a **per-query** weight through `run_rrf_arm`/`run_rrf_maxsim_arm` without reintroducing the threaded/non-deterministic late-rerank path `run_rrf_maxsim_arm` deliberately avoids, and new dedicated tests to match this file's existing E1-E4 coverage bar. More than modest effort, so left as a follow-up rather than bloating this PR. Pointers: `eval_late_rerank_quality.py:632-635` (stub sites), `cli/main.py:4036` (`_find_dense_weight`), `core/reranker.py:217` (`rank_chunks`).

## Test plan

- [x] RED tests fail against unfixed `origin/main` (confirmed via `git stash`)
- [x] GREEN after the fix, all 3 new tests + all pre-existing tests pass
- [x] `ruff check` clean on changed files
- [x] `ruff format --preview` clean on changed files (whole-repo check shows 4 pre-existing unrelated `.md` drift files, not touched by this PR)
- [x] 137 tests pass across the full retrieval_late/reranker/rank_chunks/find/search-semantic-rerank suites
- [x] `--validate-oracle` passes (40 queries, gold=1.0 exactly, reversed/empty at-or-below ceiling)
- [x] Decisive eval run 3x, byte-identical, on NL golden set + 2 lexical guard slices
- [ ] Not merged — awaiting review + the push-race queue behind v1.81.0/#639

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
