### PR TITLE
fix(agent): final wall-clock catch-all closes the call-site-evidence silent-exit-0 residual (dogfood #1, #639 nit)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -614,6 +614,12 @@ def _collect_capsule_call_site_evidence(
         # carries so an agent sees WHY graph_trust_summary was downgraded, not just that it was.
         "resolution_gaps": _as_list_of_dicts(radius_payload.get("resolution_gaps")),
     }
+    # #639 Opus-gate nit 1 (dogfood #1 RESIDUAL): this rescue scan's own deadline_seconds budget
+    # (floored to >=0.1s above) can itself truncate `radius_payload` -- reuse repo_map's own
+    # `_copy_partial_signal` helper (the exact propagation every other symbol builder in this
+    # codebase uses) so that signal survives into the evidence dict an agent actually reads,
+    # instead of being silently dropped the moment it's repackaged here.
+    repo_map._copy_partial_signal(evidence, radius_payload)
     return related_call_sites, evidence
 
 
@@ -741,6 +747,11 @@ def _collect_capsule_call_site_evidence_from_map(
         "graph_trust_summary": _as_dict(radius_payload.get("graph_trust_summary")),
         "resolution_gaps": _as_list_of_dicts(radius_payload.get("resolution_gaps")),
     }
+    # #639 Opus-gate nit 1: structural parity with the cold sibling above -- the map-based
+    # blast-radius lookup does not run a fresh time-bounded scan itself, but `rm` may already be
+    # partial from an earlier deadline cutoff; propagate that forward the same way rather than
+    # silently dropping it just because this collector was reached via the warm/daemon path.
+    repo_map._copy_partial_signal(evidence, radius_payload)
     return related_call_sites, evidence, False
 
 
@@ -2896,13 +2907,33 @@ def build_agent_capsule_from_map(
     # dogfood finding 1 / council must-fix #2: fold DAR's own deadline break in alongside the
     # inner context-render's -- either one broke on --deadline makes this capsule partial, same
     # "any one of N sibling stages" fold-in the callers/impact/blast-radius seams already use.
-    if payload.get("partial") or outbound_dependencies_deadline_hit.hit:
+    # #639 Opus-gate nit 1 (dogfood #1 RESIDUAL): that fold-in only named the sibling stages it
+    # explicitly threaded a deadline-break flag through -- the call-site-evidence rescue scan's
+    # OWN partial signal (now propagated onto `call_site_evidence` above) was silently dropped,
+    # and nothing re-checked the shared wall-clock budget one FINAL time before this capsule
+    # returns. Add both: `call_site_evidence.get("partial")` as a third named sibling source, and
+    # an absolute-deadline recheck as the honesty BACKSTOP -- if the budget has been blown by the
+    # time we reach this return, regardless of which stage (checkpointed or not) actually
+    # consumed the time, this capsule must never silently report exit 0 / partial-not-True (the
+    # exact silent lie dogfood #1 originally flagged). Mirrors codemap.py's own `tail_deadline_hit`
+    # catch-all for the same class of gap.
+    deadline_exceeded_at_return = (
+        deadline_monotonic is not None and time.monotonic() >= deadline_monotonic
+    )
+    if (
+        payload.get("partial")
+        or outbound_dependencies_deadline_hit.hit
+        or call_site_evidence.get("partial")
+        or deadline_exceeded_at_return
+    ):
         result["partial"] = True
-        deadline_limit = payload.get("deadline_limit")
-        if isinstance(deadline_limit, dict):
-            result["deadline_limit"] = dict(deadline_limit)
-        elif outbound_dependencies_deadline_hit.hit:
-            result["deadline_limit"] = {"deadline_exceeded": True}
+        result["partial_reason"] = "deadline"
+        deadline_limit = payload.get("deadline_limit") or call_site_evidence.get("deadline_limit")
+        result["deadline_limit"] = (
+            dict(deadline_limit)
+            if isinstance(deadline_limit, dict)
+            else {"deadline_exceeded": True}
+        )
     if scan_truncated:
         result["result_incomplete"] = True
     # suggested_scope (#133 dogfood): the same centrality-weighted directory narrowing `tg orient`

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1142,13 +1142,32 @@ def _path_is_relative_to(path: Path, parent: Path) -> bool:
 def _precomputed_validation_files_for_root(
     root: Path,
     file_paths: list[str | Path] | None,
+    *,
+    deadline_monotonic: float | None = None,
+    deadline_hit: _DeadlineBreakFlag | None = None,
 ) -> list[Path] | None:
+    """#639 Opus-gate nit 1 (dogfood #1 RESIDUAL): this loop does one filesystem ``Path.resolve()``
+    syscall per entry in ``file_paths`` -- on a large repo map's ``related_paths``/``files``+
+    ``tests`` list (up to ``DEFAULT_AGENT_REPO_MAP_LIMIT`` entries) this was the dominant,
+    entirely UNBOUNDED cost behind ``tg agent ROOT Q --deadline 8`` running ~20s despite the scan
+    itself finishing in budget (Windows ``nt._getfinalpathname`` is comparatively expensive per
+    call; see ``tests/integration/test_agent_codemap_deadline_scale.py``'s documented finding).
+    ``deadline_monotonic``/``deadline_hit`` are optional (default ``None``, fully backward
+    compatible with the other call sites of this function that pass no deadline at all) and follow
+    the same ``_DeadlineBreakFlag`` readback contract as every other deadline-scoped sibling loop
+    in this module: on expiry, stop resolving further entries and return whatever was already
+    collected instead of walking the rest of the list regardless.
+    """
     if file_paths is None:
         return None
     normalized_root = root.expanduser().resolve()
     selected: list[Path] = []
     seen: set[str] = set()
     for raw_path in file_paths:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            if deadline_hit is not None:
+                deadline_hit.hit = True
+            break
         current = Path(str(raw_path)).expanduser()
         if not current.is_absolute():
             current = normalized_root / current
@@ -3945,6 +3964,8 @@ def _discover_validation_tests_for_primary_file(
     query: str,
     limit: int,
     precomputed_file_paths: list[str | Path] | None = None,
+    deadline_monotonic: float | None = None,
+    deadline_hit: _DeadlineBreakFlag | None = None,
 ) -> list[str]:
     if not primary_file:
         return []
@@ -3969,6 +3990,8 @@ def _discover_validation_tests_for_primary_file(
     candidate_files = _precomputed_validation_files_for_root(
         validation_root,
         precomputed_file_paths,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=deadline_hit,
     )
     if candidate_files is None:
         candidate_files = _iter_repo_files(
@@ -3976,6 +3999,14 @@ def _discover_validation_tests_for_primary_file(
             max_files=_VALIDATION_RUNNER_SCAN_LIMIT,
         )
     for current in candidate_files:
+        # #639 Opus-gate nit 1: the resolve loop above can be bounded and still hand back a
+        # partial `candidate_files` list -- also bound THIS scoring loop directly (test-file
+        # detection + node:test probe + path scoring below are each their own, non-trivial cost)
+        # so a large candidate set can't itself run the shared budget past zero.
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            if deadline_hit is not None:
+                deadline_hit.hit = True
+            break
         if not _is_test_file(current):
             continue
         resolved = current.resolve()
@@ -11757,6 +11788,8 @@ def _build_edit_plan_seed(
     max_depth: int = _DEFAULT_EDIT_PLAN_MAX_DEPTH,
     blast_radius_payload: dict[str, Any] | None = None,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
+    deadline_hit: _DeadlineBreakFlag | None = None,
 ) -> dict[str, Any]:
     primary_file = next(iter(payload.get("files", [])), None)
     primary_symbol = next(
@@ -11868,6 +11901,8 @@ def _build_edit_plan_seed(
             query=query,
             limit=max(1, min(max_files, 3)) - len(validation_tests),
             precomputed_file_paths=validation_file_paths,
+            deadline_monotonic=deadline_monotonic,
+            deadline_hit=deadline_hit,
         ):
             if current not in validation_tests:
                 validation_tests.append(current)
@@ -12069,6 +12104,7 @@ def _attach_edit_plan_metadata(
     max_depth: int = _DEFAULT_EDIT_PLAN_MAX_DEPTH,
     blast_radius_payload: dict[str, Any] | None = None,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     with _profiling_phase(_profiling_collector, "edit_plan_assembly"):
@@ -12133,6 +12169,15 @@ def _attach_edit_plan_metadata(
                     if isinstance(scope, dict):
                         resolved_blast_radius_payload["edit_plan_blast_radius_scope"] = dict(scope)
         with _profiling_phase(_profiling_collector, "edit_plan_seed"):
+            # #639 Opus-gate nit 1 (dogfood #1 RESIDUAL): the validation-file discovery this seed
+            # runs (_discover_validation_tests_for_primary_file -> _precomputed_validation_files_
+            # for_root) does a per-file Path.resolve() pass over the repo map's file list -- a
+            # pre-existing UNBOUNDED cost (see that function's own docstring) that let a `tg agent
+            # --deadline` request overrun in this tail even after the checkpointed scan + pack
+            # stage finished in budget. Own a flag here (mirrors build_context_pack_from_map's own
+            # `own_deadline_hit` pattern) and fold an early break into `payload["partial"]` below,
+            # same "any one sibling stage" fold-in shape every other deadline-scoped seam uses.
+            edit_plan_seed_deadline_hit = _DeadlineBreakFlag()
             payload["edit_plan_seed"] = _build_edit_plan_seed(
                 repo_map,
                 payload,
@@ -12142,7 +12187,14 @@ def _attach_edit_plan_metadata(
                 max_depth=max_depth,
                 blast_radius_payload=resolved_blast_radius_payload,
                 semantic_provider=semantic_provider,
+                deadline_monotonic=deadline_monotonic,
+                deadline_hit=edit_plan_seed_deadline_hit,
             )
+            if edit_plan_seed_deadline_hit.hit:
+                payload["partial"] = True
+                # setdefault, not overwrite: never clobber a richer deadline_limit already present
+                # from the SCAN stage or build_context_pack_from_map's own self-stamp.
+                payload.setdefault("deadline_limit", {"deadline_exceeded": True})
         payload["graph_trust_summary"] = (
             dict(resolved_blast_radius_payload.get("graph_trust_summary", {}))
             if resolved_blast_radius_payload is not None
@@ -13417,6 +13469,7 @@ def build_context_render_from_map(
             max_symbols=max_sources,
             max_depth=_DEFAULT_EDIT_PLAN_MAX_DEPTH,
             semantic_provider=semantic_provider,
+            deadline_monotonic=deadline_monotonic,
             _profiling_collector=collector,
         )
     else:

--- a/tests/unit/test_cli_deadline_coverage_gaps.py
+++ b/tests/unit/test_cli_deadline_coverage_gaps.py
@@ -303,12 +303,23 @@ def test_agent_second_scan_deadline_clamps_to_floor(tmp_path: Path, monkeypatch)
     result = CliRunner().invoke(
         app, ["agent", str(tmp_path), "helper", "--deadline", "0.3", "--json"]
     )
-    assert result.exit_code == 0, result.output
+    # #639 Opus-gate nit 1 (dogfood #1 RESIDUAL): this scenario's shared deadline has ALREADY
+    # elapsed by the time the rescue scan even starts (0.5s injected delay > 0.3s budget) -- pre-
+    # fix that silently reported exit 0 (the rescue scan itself still succeeded inside its floored
+    # 0.1s sub-budget, so nothing individually named in the old fold-in ever flagged it), which was
+    # itself an instance of the exact silent lie this PR closes: a `--deadline 0.3` request that
+    # actually ran ~0.5s+ must never report success as if it finished in budget. The FINAL
+    # wall-clock catch-all now correctly reports exit 2 / partial=True here, even though the rescue
+    # scan's OWN substantive result (found the caller) is still present and still useful.
+    assert result.exit_code == 2, result.output
     payload = json.loads(result.output)  # must not crash/hang -- valid JSON either way
     assert payload["primary_target"]["symbol"] == "helper"
     assert payload["call_site_evidence"]["status"] == "collected"
-    # The item-3 assertion: the shared deadline had already elapsed (0.5s sleep > 0.3s budget), so
-    # the rescue scan must receive the FLOORED 0.1s budget, never a negative or zero value.
+    assert payload.get("partial") is True, result.output
+    assert payload.get("partial_reason") == "deadline", result.output
+    # The item-3 assertion (unchanged): the shared deadline had already elapsed (0.5s sleep > 0.3s
+    # budget), so the rescue scan must receive the FLOORED 0.1s budget, never a negative or zero
+    # value -- proven by the substantive "collected" result above despite the overall lateness.
     assert recorded.get("deadline_seconds") == 0.1
 
 
@@ -336,3 +347,110 @@ def test_agent_second_scan_skips_gracefully_on_full_deadline_exhaustion(
     assert payload.get("partial") is True
     assert payload["deadline_limit"]["deadline_exceeded"] is True
     assert payload["call_site_evidence"]["status"] == "skipped"
+
+
+# ==================================================================================================
+# Item 4 (dogfood #1 RESIDUAL, #639 Opus-gate nit 1): #639 (W1b) bounded the CHECKPOINTED post-map
+# stages (build_context_pack_from_map's own pagerank/scoring loop, DAR's outbound-dependency
+# collection) and folded each one's own deadline-break flag into the capsule's `result["partial"]`.
+# But that fold-in only named the sibling stages it explicitly threaded a flag through -- the
+# call-site-evidence rescue scan's OWN partial signal was silently dropped, and NOTHING re-checked
+# the shared wall-clock budget one final time before the capsule returns. So a `tg agent --deadline`
+# request whose SCAN and RENDER both finish in budget, but whose (uninstrumented) tail work pushes
+# elapsed time past the deadline, still silently reported exit 0 / partial-not-True -- the exact
+# silent lie dogfood #1 originally flagged, just relocated one stage later. Fixed by: (a) a FINAL
+# wall-clock catch-all in build_agent_capsule_from_map that stamps partial=True/partial_reason=
+# "deadline" regardless of which stage actually consumed the time; (b) propagating call-site-
+# evidence's own radius_payload["partial"] into the evidence dict (agent_capsule.py's existing
+# _copy_partial_signal helper, reused verbatim); (c) bounding _precomputed_validation_files_for_
+# root's per-entry Path.resolve() loop (repo_map.py, see test_repo_map_deadline.py), the
+# pre-existing unbounded cost documented in test_agent_codemap_deadline_scale.py's module docstring.
+# ==================================================================================================
+
+
+def test_agent_tail_overrun_after_checkpointed_pack_stage_still_reports_partial(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Deterministic (no wall-clock racing, mirrors test_agent_second_scan_deadline_clamps_to_
+    floor's proven technique above): force the shared deadline to have ALREADY elapsed by the
+    time execution reaches the tail (validation-file discovery + call-site-evidence), while the
+    CHECKPOINTED scan + build_context_pack_from_map stage itself finishes well within budget --
+    the exact "scan+render fit, tail overruns" shape the existing 0.1s integration tests (which
+    cross the deadline in the scan itself) do not cover. On this small a fixture neither the
+    validation-file-resolve tail nor the rescue blast-radius scan individually takes measurable
+    time, so this specifically isolates the FINAL catch-all (fix item 1), not items 2/3's more
+    targeted bounds.
+    """
+    _write_helper_and_caller(tmp_path)
+    original_pack = repo_map.build_context_pack_from_map
+
+    def _slow_pack(rm, query, **kwargs):
+        result = original_pack(rm, query, **kwargs)
+        time.sleep(0.5)
+        return result
+
+    monkeypatch.setattr(repo_map, "build_context_pack_from_map", _slow_pack)
+
+    result = CliRunner().invoke(
+        app, ["agent", str(tmp_path), "helper", "--deadline", "0.3", "--json"]
+    )
+
+    # RED pre-fix: this was exit_code == 0 / payload.get("partial") in (None, False) -- the silent
+    # lie. GREEN post-fix: the final catch-all in build_agent_capsule_from_map re-checks the shared
+    # absolute deadline before returning, regardless of which stage actually overran.
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.output)
+    assert payload.get("partial") is True, result.output
+    assert payload.get("partial_reason") == "deadline", result.output
+    assert payload.get("deadline_limit", {}).get("deadline_exceeded") is True, result.output
+
+
+def test_agent_no_overrun_stays_exit_0_partial_absent(tmp_path: Path) -> None:
+    """Companion golden-parity case: a real run that finishes on its own, well within a generous
+    deadline, must NOT gain a spurious partial=True from the new catch-all (it only fires on an
+    ACTUAL wall-clock overrun, never unconditionally)."""
+    _write_helper_and_caller(tmp_path)
+    result = CliRunner().invoke(
+        app, ["agent", str(tmp_path), "helper", "--deadline", "30", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload.get("partial") is not True, result.output
+    assert "partial_reason" not in payload, result.output
+
+
+def test_collect_capsule_call_site_evidence_propagates_inner_partial_signal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Fix item 2: _collect_capsule_call_site_evidence's own (possibly deadline-truncated)
+    build_symbol_blast_radius rescue scan can come back partial, but the evidence dict built from
+    its radius_payload silently dropped that signal -- an agent reading call_site_evidence in
+    isolation had no way to know the caller set was truncated, and the capsule-level fold-in the
+    sibling test above depends on could never observe it either."""
+    partial_radius = {
+        "callers": [],
+        "output_limit": {},
+        "graph_trust_summary": {},
+        "resolution_gaps": [],
+        "partial": True,
+        "deadline_limit": {"deadline_exceeded": True},
+    }
+    monkeypatch.setattr(
+        agent_capsule.repo_map,
+        "build_symbol_blast_radius",
+        lambda *a, **k: dict(partial_radius),
+    )
+
+    related_call_sites, evidence = agent_capsule._collect_capsule_call_site_evidence(
+        "helper",
+        str(tmp_path),
+        {"symbol": "helper", "confidence": 0.9},
+        include_blast_radius=True,
+        max_files=3,
+        max_repo_files=None,
+        seed_confidence=0.9,
+    )
+
+    assert related_call_sites == []
+    assert evidence.get("partial") is True, evidence
+    assert evidence.get("deadline_limit", {}).get("deadline_exceeded") is True, evidence

--- a/tests/unit/test_repo_map_deadline.py
+++ b/tests/unit/test_repo_map_deadline.py
@@ -141,6 +141,45 @@ def test_m1_blast_radius_plan_deadline_none_is_unaffected(tmp_path: Path) -> Non
     assert "deadline_limit" not in result
 
 
+# --- #639 Opus-gate nit 1 (dogfood #1 RESIDUAL): _precomputed_validation_files_for_root did a
+# per-entry Path.resolve() filesystem syscall with NO deadline awareness at all -- on a large repo
+# map's file list (up to DEFAULT_AGENT_REPO_MAP_LIMIT entries) this was the dominant unbounded cost
+# behind a `tg agent --deadline` request overrunning in the validation-file-discovery tail even
+# though the scan itself finished in budget (see tests/integration/test_agent_codemap_deadline_
+# scale.py's documented finding, and test_cli_deadline_coverage_gaps.py's Item 4 for the end-to-end
+# capsule-level proof). ---
+
+
+def test_precomputed_validation_files_for_root_bounds_on_expired_deadline(tmp_path: Path) -> None:
+    # Many entries so an unbounded loop would be observably slower than a bounded one, but no
+    # wall-clock racing is needed -- mirrors test_deadline_already_expired_returns_partial_
+    # immediately's technique: the deadline is already expired before the call even starts, so a
+    # bounded loop must break before doing (meaningfully) more resolve work, not walk the list
+    # regardless.
+    file_paths = [f"file_{index}.py" for index in range(5000)]
+    deadline_hit = repo_map._DeadlineBreakFlag()
+
+    selected = repo_map._precomputed_validation_files_for_root(
+        tmp_path,
+        file_paths,
+        deadline_monotonic=time.monotonic() - 1.0,
+        deadline_hit=deadline_hit,
+    )
+
+    assert selected == []
+    assert deadline_hit.hit is True
+
+
+def test_precomputed_validation_files_for_root_deadline_none_is_unbounded(tmp_path: Path) -> None:
+    # Golden-parity companion: the new deadline_monotonic/deadline_hit params are additive -- every
+    # pre-existing call site (none of which passes them) must see byte-identical behavior.
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("y = 2\n", encoding="utf-8")
+    selected = repo_map._precomputed_validation_files_for_root(tmp_path, ["a.py", "b.py"])
+    assert selected is not None
+    assert len(selected) == 2
+
+
 def _make_caller_repo(root: Path, callers: int) -> None:
     src = root / "src"
     src.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Fast-follow to #639 (W1b). The Opus gate on that PR flagged one residual (nit 1): `tg agent`'s cold path could still silently report exit 0 / `partial` not `True` when the shared `--deadline` budget was blown in an **un-checkpointed tail stage** (the call-site-evidence rescue scan, or validation-file discovery), even though the checkpointed scan + render stages finished in budget.

- `_collect_capsule_call_site_evidence` bounds its inner blast-radius call (floored to >=0.1s) but silently dropped `radius_payload["partial"]` when repackaging it into the evidence dict.
- `_precomputed_validation_files_for_root`'s per-file `Path.resolve()` loop had no deadline awareness at all (the pre-existing unbounded cost `tests/integration/test_agent_codemap_deadline_scale.py`'s own docstring documents as "KNOWN, OUT-OF-SCOPE").

## Changes

1. **`build_agent_capsule_from_map`** (`agent_capsule.py`): the existing "any one of N sibling stages" fold-in now also names `call_site_evidence.get("partial")`, and adds a FINAL absolute-deadline recheck (`time.monotonic() >= deadline_monotonic`) as an honesty backstop -- if the budget has been blown by the time the capsule returns, it's marked `partial=True` / `partial_reason="deadline"` regardless of which stage consumed the time. Mirrors `codemap.py`'s own `tail_deadline_hit` catch-all.
2. **`_collect_capsule_call_site_evidence[_from_map]`**: propagates `radius_payload["partial"]` into the evidence dict via `repo_map`'s existing `_copy_partial_signal` helper (both cold and warm/daemon collectors).
3. **`_precomputed_validation_files_for_root`**: now accepts optional `deadline_monotonic`/`deadline_hit` (default `None`, fully backward compatible) and breaks early on expiry. Threaded through the `tg agent` edit-plan-seed tail: `build_context_render_from_map` -> `_attach_edit_plan_metadata` -> `_build_edit_plan_seed` -> `_discover_validation_tests_for_primary_file` (whose own scoring loop is also bounded).

## Test plan

- [x] New RED->GREEN tests force the overrun deterministically into the tail (injected sleep / already-expired deadline -- no wall-clock racing), isolating this residual from the scan-crossing shape the existing 0.1s tests cover.
- [x] Updated one pre-existing test (`test_agent_second_scan_deadline_clamps_to_floor`) whose `exit_code == 0` expectation was itself an instance of the same silent lie (a `--deadline 0.3` request that actually ran ~0.5s+ reported success) -- now asserts the corrected `exit 2` / `partial=True` contract.
- [x] `tests/integration/test_agent_codemap_deadline_scale.py` (real subprocess binary, 2001-file fixture) all green -- no regression on the checkpointed scan-crossing path.
- [x] ~700 targeted unit tests (agent_capsule, repo_map, deadline, exit-code, docs-governance) green via `PYTHONPATH=src`.
- [x] `ruff check .` and `ruff format --preview --check` clean on every touched file.

**Not merging** -- held for the orchestrator's Opus gate per campaign discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
