### PR TITLE
ci(release-intent): accept the documented `bench:` no-release commit type in validate_pr_title_semver (#198)

### DIFF
--- a/scripts/validate_pr_title_semver.py
+++ b/scripts/validate_pr_title_semver.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 _TITLE_PATTERN = re.compile(
-    r"^(?P<type>feat|fix|perf|refactor|docs|test|build|ci|chore)"
+    r"^(?P<type>feat|fix|perf|refactor|docs|test|build|ci|chore|bench)"
     r"(?:\([^)]+\))?(?P<breaking>!)?: (?P<summary>\S.*)$"
 )
 
@@ -22,6 +22,7 @@ _RELEASE_INTENTS = {
     "build": "none",
     "ci": "none",
     "chore": "none",
+    "bench": "none",
 }
 
 

--- a/tests/unit/test_validate_pr_title_semver.py
+++ b/tests/unit/test_validate_pr_title_semver.py
@@ -54,3 +54,12 @@ def test_validate_pr_title_semver_should_read_github_event_payload(tmp_path: Pat
 
     assert result.returncode == 0
     assert "release_intent=patch" in result.stdout
+
+
+def test_validate_pr_title_semver_should_accept_bench_title_as_no_release() -> None:
+    # `bench:` is a documented no-release commit type (docs/chore/test/build/ci/bench all map to
+    # "none" per the change-control ground truth), used for benchmark-artifact-only PRs (#198).
+    result = _run_validator("--title", "bench(find): x")
+
+    assert result.returncode == 0
+    assert "release_intent=none" in result.stdout


### PR DESCRIPTION
## Summary
- Fixes a doc-vs-enforcement drift (#198): `bench:` is an established no-release commit type in this repo's actual practice (12+ merged commits, e.g. `bench(find): ...`, `bench: refresh windows text baseline`) but `scripts/validate_pr_title_semver.py`'s `_TITLE_PATTERN` / `_RELEASE_INTENTS` never recognized it, so a `bench:`-titled PR fails the `release-intent` CI check.
- Adds `bench` to both `_TITLE_PATTERN`'s type alternation and `_RELEASE_INTENTS` (mapped to `"none"`, same as docs/test/chore/ci/build).

## Verified before implementing
- Confirmed `bench` was absent from both `_TITLE_PATTERN` and `_RELEASE_INTENTS` (introduced together in `c07633e`, never included `bench`).
- Confirmed this is enforcement catching up to already-established practice, not a docs contradiction: the AGENTS.md "PR Title And Release Intent" prose table also omits `refactor:` (an already-supported patch type), and `.claude/skills/tensor-grep-change-control/SKILL.md:250` explicitly documents that `_RELEASE_INTENTS` — not the AGENTS.md prose table — is the release-intent ground truth. Same shape of gap, same resolution.
- Checked for a separate semantic-release config that would also need to learn `bench`: `pyproject.toml`'s `[tool.semantic_release]` has no custom `commit_parser`/`allowed_tags` override, so `python-semantic-release` (v9, via the GH Action) uses its default conventional-commit parser, which already treats an unrecognized type as no-bump. The 12+ merged `bench:` commits already on `main` confirm this empirically (clean, sequential version history with no bench-attributed bumps). No change needed there — this PR only fixes the release-intent *check*, not release behavior.

## Test plan
- [x] RED: added `test_validate_pr_title_semver_should_accept_bench_title_as_no_release`, confirmed it failed against the pre-fix pattern (`returncode=1`).
- [x] GREEN: after adding `bench` -> `"none"`, all 6 tests in `tests/unit/test_validate_pr_title_semver.py` pass.
- [x] Dogfooded the real script directly: `bench(find): x` -> `release_intent=none`, exit 0; `refactor: cleanup` still -> `release_intent=patch` (no regression); an invalid title still rejects with exit 1.
- [x] `ruff check` clean on both changed files.
- [x] `ruff format --check --preview .` (whole repo): both changed files already formatted. (3 unrelated pre-existing docs-fence files flagged — untouched by this branch, confirmed zero diff vs `origin/main`; this is the known tracked whole-repo-format gap, out of scope here.)
- [x] Targeted governance tests unaffected: `test_should_require_release_intent_job_and_semantic_pr_title_validator`, `test_should_require_release_intent_job_to_be_pull_request_only`, `test_should_require_release_checklist_to_document_semantic_pr_title_contract` all pass.

This is a `ci:` commit (no-release). Opened as **draft** per instructions — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
