### PR TITLE
test(daemon): harden flaky test_lifecycle_commands_never_counted timeout (#202)

### DIFF
--- a/tests/unit/test_session_daemon_metrics.py
+++ b/tests/unit/test_session_daemon_metrics.py
@@ -30,6 +30,40 @@ def _serve(server: session_daemon._ThreadedSessionDaemon) -> threading.Thread:
     return thread
 
 
+def _daemon_request_with_connect_retry(
+    host: str, port: int, request: dict[str, Any], *, token: str = ""
+) -> dict[str, Any]:
+    """Bounded retry around ``session_daemon._daemon_request`` for CONNECT-level jitter only.
+
+    ``_daemon_request``'s TCP connect phase uses a tight, single-client-tuned timeout
+    (``session_daemon._DAEMON_CONNECT_TIMEOUT_SECONDS``, 0.5s) that is not itself under test
+    here. Under sustained CI-runner contention -- a shared macOS runner deep into a 4600+ test
+    run -- a single connect attempt can transiently exceed that window even though the daemon
+    thread is healthy and already listening: run 29559122313 (test-python macos-latest py3.11,
+    #202) failed this exact test with ``TimeoutError: timed out`` at
+    ``session_daemon.py:518 socket.create_connection(...) -> sock.connect(sa)``, i.e. before a
+    single byte of the request was ever sent. That is the identical connect-jitter class already
+    worked around in ``test_orient_agent_daemon.py::_request_with_connect_retry`` (see its
+    docstring: "under N simultaneous connects the loopback accept backlog can transiently make
+    one attempt time out even though the daemon itself is healthy").
+
+    Retries ONLY on ``(TimeoutError, OSError)`` -- a connect (or response-read) timeout means
+    either no bytes reached the server yet, or the client simply gave up waiting, so a retry is a
+    clean fresh attempt on a brand-new socket (``_daemon_request`` opens one connection per call).
+    Any actual response -- including a WRONG one -- returns immediately on the first attempt, so
+    this can never mask a functional regression in what the test actually asserts (lifecycle
+    commands are never counted in demand_metrics).
+    """
+    last_error: TimeoutError | OSError | None = None
+    for _attempt in range(5):
+        try:
+            return session_daemon._daemon_request(host, port, request, token=token)
+        except (TimeoutError, OSError) as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error
+
+
 def _stub_dispatch(monkeypatch: Any, root: Path) -> None:
     """Route every non-lifecycle command through a cheap fake (mirrors the routing-only stub
     in test_session_daemon_security.py::test_daemon_request_path_field_cannot_escape_root) so
@@ -207,9 +241,9 @@ def test_lifecycle_commands_never_counted(tmp_path: Path, monkeypatch: Any) -> N
         host = str(server.server_address[0])
         port = int(server.server_address[1])
         monkeypatch.setattr(session_daemon.os, "getpid", lambda: 555)
-        session_daemon._daemon_request(host, port, {"command": "ping"}, token="tok")
-        session_daemon._daemon_request(host, port, {"command": "stats"}, token="tok")
-        session_daemon._daemon_request(
+        _daemon_request_with_connect_retry(host, port, {"command": "ping"}, token="tok")
+        _daemon_request_with_connect_retry(host, port, {"command": "stats"}, token="tok")
+        _daemon_request_with_connect_retry(
             host, port, {"command": "health", "session_id": "nope"}, token="tok"
         )
     finally:


### PR DESCRIPTION
## Summary

- Hardens the ONE flaky test that blocked v1.81.0: `tests/unit/test_session_daemon_metrics.py::test_lifecycle_commands_never_counted` (run 29559122313, `test-python (macos-latest, py3.11)`, `TimeoutError: timed out`, 1 failed / 4618 passed).
- Root cause confirmed from the real CI log, not guessed: the failure is a **connect-phase** socket timeout at `src/tensor_grep/cli/session_daemon.py:518` (`socket.create_connection(..., timeout=_DAEMON_CONNECT_TIMEOUT_SECONDS)`, 0.5s) — raised *before* a single byte of the `ping` request was ever sent. This is a different, non-configurable timeout from the already-generous `_DAEMON_RESPONSE_TIMEOUT_SECONDS` (60s), which was not the culprit.
- Fix: a bounded 5-attempt retry (catches only `(TimeoutError, OSError)`) around the 3 `_daemon_request` calls in this one test, mirroring the **already-established** pattern in `test_orient_agent_daemon.py::_request_with_connect_retry` for the identical connect-jitter class ("under N simultaneous connects the loopback accept backlog can transiently make one attempt time out even though the daemon itself is healthy").
- No production code changed. `_DAEMON_CONNECT_TIMEOUT_SECONDS` stays 0.5s, so the deliberate fast-fail daemon-liveness probes (`_probe_daemon`, `_merge_live_daemon_stats`) that intentionally reuse this constant as their `response_timeout` are unaffected.

## Why this fits (per anti-hang-test-protocol + the #167 sidecar-IPC-timeout precedent)

- Recurring flaky-blocks-release class: #120/#156/#167/#183/#202.
- A connect-phase timeout means the server never received the request (`_daemon_request` opens a fresh TCP connection per call), so a retry is a clean fresh attempt — it can never double-count or mask a real `demand_metrics` regression. Any actual response (including a *wrong* one) returns immediately on the first attempt.
- The assertion under test is fully intact: both `assert server.demand_metrics.snapshot() == {}` checks are unchanged — this still catches a real daemon-metrics regression (e.g. a lifecycle command accidentally getting counted).
- Platform-neutral: a pure Python retry loop, no `sys.platform` branching — cannot false-fail or gut the test on Windows/Linux/macOS. This test runs on all three OSes as a release gate.

## Verification

- Ran against the real worktree source (not the stale shared-venv install — verified `tensor_grep.__file__` resolves into the worktree via `PYTHONPATH` override first, per the known stale-venv trap).
- Target test: `tests/unit/test_session_daemon_metrics.py` — **14 passed**.
- Full daemon/session test family (`test_orient_agent_daemon.py`, `test_render_daemon_exit_codes.py`, `test_session_daemon_metadata_ownership.py`, `test_session_daemon_security.py`, `test_session_daemon_version_skew.py`, `test_symbol_daemon_autostart.py`, `test_symbol_daemon_response_cache.py`, `test_session_daemon_metrics.py`, `test_session_serve.py`) — **195 passed, 1 skipped** (an unrelated POSIX-only test).
- The pinned governance test `test_session_serve.py::test_daemon_request_separates_connect_and_response_timeouts` (asserts the connect timeout stays symbolically pinned to `_DAEMON_CONNECT_TIMEOUT_SECONDS` even when `response_timeout` is 60s) still passes — confirms the production connect/response timeout contract is untouched.
- `ruff check` clean (touched file + whole repo). `ruff format --preview` clean on the touched file; whole-repo check shows 4 **pre-existing, unrelated** `.md` doc-fence formatting drifts (`docs/architecture.md`, `docs/planning/PROJECT_PLAN.md`, 2 files under `docs/plans/`) — left untouched, out of scope for this PR.

## Test plan

- [x] `test_lifecycle_commands_never_counted` passes locally against the real worktree source.
- [x] Full daemon/session test family green (195 passed, 1 skipped).
- [x] Pinned connect/response timeout governance test still green.
- [x] `ruff check` + `ruff format --preview` clean on the touched file.
- [ ] CI green on all 3 OS x 2 Python-version matrix cells (this is a draft PR — not merging per push-race discipline; do not merge, awaiting CI + review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
