### PR TITLE
fix(daemon): default wall-clock deadline on the warm dispatch path (#200)

### DIFF
--- a/src/tensor_grep/cli/orient_capsule.py
+++ b/src/tensor_grep/cli/orient_capsule.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -775,6 +776,7 @@ def build_orient_capsule_from_map(
     render_profile: str = "compact",
     ignore: tuple[str, ...] = (),
     auto_deweight: bool = True,
+    deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
     """Task #108 (Tier-2 daemon moat): the map-based core of ``build_orient_capsule``, taking an
     already-built ``rm`` (e.g. the warm session daemon's cached ``repo_map``) instead of scanning
@@ -786,7 +788,19 @@ def build_orient_capsule_from_map(
     result field -- reconstructed below from ``rm["scan_limit"]["max_repo_files"]`` (populated by
     ``build_repo_map`` whenever a cap was applied), so there is exactly one source of truth for
     what cap actually produced ``rm`` instead of a second, independently-supplied value that could
-    drift from it."""
+    drift from it.
+
+    ``deadline_monotonic`` (#200): an ABSOLUTE ``time.monotonic()`` budget for THIS function's own
+    post-map work (the snippet-building loop below reads real files via ``_ast_chunked_snippet``,
+    and the centrality/entry-point passes above it are O(cached-map-size)). Unlike its siblings
+    (``build_agent_capsule_from_map``, ``build_context_render_from_map``,
+    ``build_context_edit_plan_from_map``), this function did NOT already accept one -- added here
+    so the warm session daemon (``session_store._serve_session_request_from_payload``) can bound
+    it the same way. Deliberately NOT threaded from ``build_orient_capsule`` (the cold CLI
+    wrapper): ``tg orient`` intentionally stays unbounded by default on the cold path (see this
+    module's ``build_orient_capsule`` docstring and its ``--no-deadline`` CLI help) -- only the
+    warm daemon dispatch path supplies a value, so ``deadline_monotonic=None`` (every existing
+    call site) remains a byte-identical no-op."""
     rm = _apply_ignore_globs(rm, ignore)
 
     deweighted_trees = _detect_vendored_subtrees(rm) if auto_deweight else {}
@@ -835,7 +849,14 @@ def build_orient_capsule_from_map(
     snippets: list[dict[str, Any]] = []
     token_budget_used = 0
     budget_truncated = False
+    # #200: the only real-file I/O left in this function (_ast_chunked_snippet reads+parses each
+    # central file from disk) -- cheap monotonic check per iteration, mirrors the checkpoint
+    # style build_context_pack_from_map's own per-symbol loop already uses.
+    snippet_loop_deadline_hit = False
     for cf in central_files[:max_snippet_files]:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            snippet_loop_deadline_hit = True
+            break
         file_path = cf["file"]
         snippet_text = _ast_chunked_snippet(file_path, symbol_map.get(file_path, []))
         if not snippet_text:
@@ -919,6 +940,27 @@ def build_orient_capsule_from_map(
     # this does not change orient's documented always-exit-0 behavior; it only makes a truncated
     # scan visible in the payload, the same way `scan_limit`/`truncated` already are.
     _repo_map._copy_partial_signal(result, rm)
+    # #200: final wall-clock catch-all, mirrors build_agent_capsule_from_map's own
+    # deadline_exceeded_at_return check (agent_capsule.py). `_copy_partial_signal` above only
+    # forwards a SCAN-level partial signal already present on `rm` (build_repo_map's own
+    # --deadline, which the warm daemon path never re-applies since `rm` is an already-cached
+    # map) -- this is the independent POST-map bound: even when the snippet loop above didn't
+    # need to break early, the in-memory centrality/entry-point work before it is still
+    # O(cached-map-size) and could itself have consumed the whole warm-daemon budget on an
+    # unusually large cached map. Re-check the shared absolute deadline one final time before
+    # returning, regardless of which part of this function actually consumed the time. No-op
+    # when deadline_monotonic is None (every cold-path call), so cold output stays byte-identical.
+    if deadline_monotonic is not None and (
+        snippet_loop_deadline_hit or time.monotonic() >= deadline_monotonic
+    ):
+        result["partial"] = True
+        result["partial_reason"] = "deadline"
+        existing_deadline_limit = result.get("deadline_limit")
+        result["deadline_limit"] = (
+            dict(existing_deadline_limit)
+            if isinstance(existing_deadline_limit, dict)
+            else {"deadline_exceeded": True}
+        )
     return result
 
 

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -1330,6 +1330,16 @@ def _serve_daemon_response_with_cache(
     # WARM_DAEMON_DEFAULT_DEADLINE_SECONDS budget (session_store.py). Excluding it from the cache
     # entirely is the simplest correct option: a follow-up identical request just recomputes with
     # its own fresh budget instead of replaying a stale truncation.
+    #
+    # Opus-gate nit (PR #647): this guard is SHARED by every command this function serves,
+    # including the 5 symbol commands (defs/impact/refs/callers/blast_radius), not just the 4
+    # #200 targets. It is currently a proven no-op for the symbol commands: `open_session` builds
+    # the cached map with no deadline (session_store.open_session), and the warm symbol path
+    # never threads a per-request deadline into their builders either (the still-open #390 gap),
+    # so a warm symbol response can never be `partial=True` today. If #390 is ever closed by
+    # threading a deadline into the symbol commands too, this guard starts applying to them as
+    # well -- which is the CORRECT behavior (a truncated symbol answer must not be cached either),
+    # but flagging it here so that future change doesn't have to rediscover this coupling.
     if not response.get("partial"):
         with server._response_cache_lock:
             server.response_cache.put(response_cache_key, response)

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -58,8 +58,12 @@ _DAEMON_RESPONSE_TIMEOUT_SECONDS = 60.0
 # moat P0-6 step 5: the client-side socket read timeout for a daemon response is env-configurable so
 # a large repo whose warm-daemon graph query legitimately needs >60s is NOT killed by a hard cap that
 # returns a bare "timed out" / exit 1 / zero JSON (the recurring dogfood "60s cap errors" complaint).
-# Full partial-at-deadline for the DAEMON path needs a separate traversal-deadline (the served graph
-# commands run on the cached map, so the scan-deadline of steps 1-4 does not bound them) -- tracked.
+# #200 added the separate traversal-deadline this comment used to flag as "tracked" -- but only for
+# the 4 commands session_store.WARM_DAEMON_DEFAULT_DEADLINE_SECONDS covers (agent/orient/
+# context_render/context_edit_plan, the DEFAULT no-flag case). The 5 symbol commands (defs/impact/
+# refs/callers/blast_radius) plus blast_radius_render/blast_radius_plan/file_importers/context still
+# run unbounded on THIS daemon path -- that residual is #390, still open (see
+# tensor-grep-large-repo-scale-campaign skill, "#390 -- daemon-path deadline gap").
 _DAEMON_RESPONSE_TIMEOUT_ENV = "TG_SESSION_DAEMON_RESPONSE_TIMEOUT_SECONDS"
 _DAEMON_START_TIMEOUT_SECONDS = 5.0
 _DAEMON_SESSION_LOOKUP_RETRY_SECONDS = 0.25
@@ -1318,8 +1322,17 @@ def _serve_daemon_response_with_cache(
         # test_session_daemon_refresh_on_added_file_response_is_cached).
         session_request["refresh_on_stale"] = False
     response = serve_session_request(session_id, session_request, path, payload=payload)
-    with server._response_cache_lock:
-        server.response_cache.put(response_cache_key, response)
+    # #200: a deadline-truncated (`partial=True`) response must NEVER be cached and replayed to a
+    # later request that would have had a full budget to finish -- the response cache has no TTL
+    # tied to "how much of the original deadline is left", so a cached partial answer would be
+    # served indefinitely to every subsequent identical request, silently downgrading them all to
+    # the same truncated result even though each gets its own fresh
+    # WARM_DAEMON_DEFAULT_DEADLINE_SECONDS budget (session_store.py). Excluding it from the cache
+    # entirely is the simplest correct option: a follow-up identical request just recomputes with
+    # its own fresh budget instead of replaying a stale truncation.
+    if not response.get("partial"):
+        with server._response_cache_lock:
+            server.response_cache.put(response_cache_key, response)
     return response, "miss"
 
 

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -62,6 +62,19 @@ _DEFAULT_SESSION_SYMBOL_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
 # distinct behavior.
 _DEFAULT_SESSION_ORIENT_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
 _DEFAULT_SESSION_AGENT_REPO_MAP_LIMIT = DEFAULT_AGENT_REPO_MAP_LIMIT
+# #200 (Backend Fail-Closed / scale-honesty gap): `_serve_session_request_from_payload` serves
+# agent/orient/context_render/context_edit_plan from an ALREADY-CACHED repo_map, so
+# build_repo_map's own --deadline (agent_capsule.DEFAULT_AGENT_CLI_DEADLINE_SECONDS on the cold
+# CLI path) never applies here -- the scan already happened, possibly long ago. Before this fix
+# these 4 warm-daemon branches never threaded ANY wall-clock budget into their builders (`grep -n
+# deadline session_store.py` was ZERO matches), so the DEFAULT (no --deadline flag) warm-daemon
+# request ran fully unbounded. Matches the cold path's own default exactly (a SAFE first cut: a
+# warm response finishing inside 60s, the overwhelming common case, is unaffected; a tighter
+# warm-specific value is a benchmark-gated follow-on, not this fix) so a warm request that
+# genuinely runs long now comes back partial=True/exit-2 instead of blocking the daemon worker
+# forever. See session_daemon.py's _DAEMON_RESPONSE_TIMEOUT_SECONDS comment, which already
+# flagged this exact gap as "tracked" before this fix closed it.
+WARM_DAEMON_DEFAULT_DEADLINE_SECONDS = 60.0
 # audit I2: bound on-disk session retention; keep at most N newest explicit sessions per root
 # so per-open cost and disk usage stay bounded. Configurable via TG_SESSION_MAX.
 _SESSION_MAX_ENV = "TG_SESSION_MAX"
@@ -1182,6 +1195,13 @@ def _serve_session_request_from_payload(
             "max_repo_files",
             _DEFAULT_SESSION_CONTEXT_RENDER_REPO_MAP_LIMIT,
         )
+        # #200: give this warm-daemon post-map computation the SAME default wall-clock honesty
+        # bound the cold CLI path defaults to (WARM_DAEMON_DEFAULT_DEADLINE_SECONDS, module
+        # docstring above) -- build_repo_map's own --deadline never reaches here because the
+        # daemon serves an ALREADY-CACHED map. A response that finishes inside the 60s budget
+        # (the overwhelming common case) is byte-identical to before; only a genuine overrun now
+        # stamps partial=True instead of running forever.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_context_render_from_map(
             _limited_session_repo_map(
                 repo_map,
@@ -1205,6 +1225,7 @@ def _serve_session_request_from_payload(
             optimize_context=bool(request.get("optimize_context", False)),
             render_profile=str(request.get("render_profile", "full")),
             profile=bool(request.get("profile", False)),
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-context-render"
@@ -1221,6 +1242,8 @@ def _serve_session_request_from_payload(
                 None if max_repo_files in (None, "") else int(cast(int | str, max_repo_files))
             ),
         )
+        # #200: same warm-daemon default deadline bound as context_render above.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_context_edit_plan_from_map(
             scoped_repo_map,
             query,
@@ -1232,6 +1255,7 @@ def _serve_session_request_from_payload(
                 None if request.get("max_tokens") in (None, "") else int(request["max_tokens"])
             ),
             max_symbols=int(request.get("max_symbols", 5)),
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-context-edit-plan"
@@ -1374,12 +1398,15 @@ def _serve_session_request_from_payload(
         # having scanned only N files (importers of the dropped files would still count edges
         # into files no longer present), so it must see the whole cached map, exactly like the 5
         # symbol commands above (none of which slice either).
+        # #200: same warm-daemon default deadline bound as context_render above.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_orient_capsule_from_map(
             repo_map,
             max_tokens=int(request.get("max_tokens", 3000)),
             max_central_files=int(request.get("max_central_files", 10)),
             ignore=tuple(request.get("ignore") or ()),
             auto_deweight=bool(request.get("auto_deweight", True)),
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-orient"
@@ -1394,6 +1421,8 @@ def _serve_session_request_from_payload(
         # evidence) both need the whole cached map, not a per-call subset.
         raw_max_tokens = request.get("max_tokens", 1200)
         raw_max_repo_files = request.get("max_repo_files", _DEFAULT_SESSION_AGENT_REPO_MAP_LIMIT)
+        # #200: same warm-daemon default deadline bound as context_render/orient above.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_agent_capsule_from_map(
             repo_map,
             query,
@@ -1410,6 +1439,7 @@ def _serve_session_request_from_payload(
             model=(None if request.get("model") in (None, "") else str(request["model"])),
             semantic_provider=provider,
             ignore=tuple(request.get("ignore") or ()),
+            deadline_monotonic=deadline_monotonic,
             # include_blast_radius/gpu_device_ids/gpu_timeout_s deliberately NOT threaded from
             # `request` -- the CLI has no flag reaching the first, and the client wrapper
             # (main._maybe_agent_via_running_daemon) refuses to route a --gpu-device-ids request

--- a/tests/unit/test_session_daemon_default_deadline.py
+++ b/tests/unit/test_session_daemon_default_deadline.py
@@ -293,6 +293,50 @@ def test_orient_from_map_already_expired_deadline_marks_partial(tmp_path: Path) 
     assert result.get("partial_reason") == "deadline"
 
 
+def test_orient_snippet_loop_breaks_mid_loop_not_just_pre_check(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Strengthens the already-expired-deadline coverage above with the sharper claim (Opus-gate
+    nit, PR #647): the deadline crosses WHILE the snippet loop is running, not merely pre-expired
+    before the first iteration -- so only SOME central files get a snippet and the loop
+    demonstrably stopped early rather than exhausting all of them. Mirrors
+    test_repo_map_deadline.py's proven ...breaks_mid_loop_not_just_pre_check technique: a STATIC
+    fake clock, manually advanced only inside the wrapped per-item work function
+    (_ast_chunked_snippet), so the result is immune to any OTHER incidental time.monotonic() call
+    elsewhere in the function (a `lambda: clock["t"]` read-only patch has no side effect on its
+    own -- only the wrapper's explicit `clock["t"] += 1.0` moves the clock)."""
+    project = tmp_path / "project"
+    src = project / "src"
+    src.mkdir(parents=True)
+    for index in range(6):
+        (src / f"m{index:03d}.py").write_text(
+            f"def helper_{index}():\n    return {index}\n", encoding="utf-8"
+        )
+    rm = repo_map.build_repo_map(str(project.resolve()), max_repo_files=2000)
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(orient_capsule.time, "monotonic", lambda: clock["t"])
+    original_snippet = orient_capsule._ast_chunked_snippet
+    call_count = {"n": 0}
+
+    def _advancing_snippet(path_str: str, symbols: list[Any]) -> str | None:
+        call_count["n"] += 1
+        clock["t"] += 1.0
+        return original_snippet(path_str, symbols)
+
+    monkeypatch.setattr(orient_capsule, "_ast_chunked_snippet", _advancing_snippet)
+
+    result = orient_capsule.build_orient_capsule_from_map(
+        rm, max_central_files=6, max_snippet_files=6, deadline_monotonic=base + 3.0
+    )
+
+    assert result.get("partial") is True
+    assert result.get("partial_reason") == "deadline"
+    assert 0 < call_count["n"] < 6, "cut short mid-loop, not exhausted"
+    assert len(result["snippets"]) < 6, "partial snippet set, not the full 6"
+
+
 def test_orient_cold_wrapper_stays_unbounded_by_default(tmp_path: Path) -> None:
     """The cold CLI path (`tg orient`, no --deadline) is a deliberate product decision to stay
     unbounded (see orient_capsule.build_orient_capsule's docstring + the CLI --no-deadline help

--- a/tests/unit/test_session_daemon_default_deadline.py
+++ b/tests/unit/test_session_daemon_default_deadline.py
@@ -1,0 +1,303 @@
+"""TDD for #200: the warm session-daemon dispatch path (``_serve_session_request_from_payload``)
+never threaded a wall-clock deadline into the post-map builders for ``agent``/``orient``/
+``context_render``/``context_edit_plan``. The cold CLI path's implicit 60s bound
+(``agent_capsule.DEFAULT_AGENT_CLI_DEADLINE_SECONDS``) lives INSIDE the cold branch only, so a
+request served warm -- the DEFAULT, no ``--deadline`` flag -- ran fully unbounded: ``grep -n
+deadline session_store.py`` was ZERO matches before this fix.
+
+This module proves:
+
+(a) a warm-daemon ``agent``/``orient``/``context_render``/``context_edit_plan`` request whose
+    underlying builder overruns the new default deadline comes back ``partial=True``/
+    ``partial_reason="deadline"`` (``session_store.WARM_DAEMON_DEFAULT_DEADLINE_SECONDS``), and
+    the CLI surfaces that as exit 2 -- never a silent exit 0.
+(b) a ``partial=True`` response is NEVER written into the daemon's response cache -- a follow-up
+    identical request RECOMPUTES instead of replaying a truncated answer that a later, unhurried
+    request could have finished (``session_daemon._serve_daemon_response_with_cache``).
+(c) a normal (well within budget) warm response is unaffected -- no spurious ``partial`` -- and
+    still cached exactly as before.
+
+Deterministic latency injection only (mirrors ``test_repo_map_deadline.py`` /
+``test_cli_deadline_coverage_gaps.py``'s proven technique: an ALREADY-EXPIRED absolute
+``deadline_monotonic``, no sleep/timing race). Section (a)'s dispatcher-level cases call
+``_serve_session_request_from_payload`` directly (no daemon spawn); one end-to-end case drives
+the real in-process threaded daemon + CLI (reusing ``test_symbol_daemon_autostart.py``'s proven
+harness) to prove the full exit-2 contract, not just the internal dict shape.
+
+Also covers the orient-specific deviation this fix required: unlike
+``build_agent_capsule_from_map``/``build_context_render_from_map``/
+``build_context_edit_plan_from_map`` (which already accepted ``deadline_monotonic`` per
+#639/#642/#645), ``build_orient_capsule_from_map`` did NOT -- verified against the real code,
+not assumed. Extending it was necessary to avoid a ``TypeError`` the moment the dispatcher passed
+the new kwarg, since ``tg orient``'s COLD path deliberately defaults to unbounded (see
+``orient_capsule.build_orient_capsule``'s own docstring/CLI help) and was left untouched; only
+the warm-daemon dispatch path supplies a deadline now.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from tensor_grep.cli import orient_capsule, repo_map, session_daemon, session_store
+from tensor_grep.cli.main import app
+from tests.unit.test_symbol_daemon_autostart import (
+    _autostart_env,
+    _probe_fake_for,
+    _real_daemon,
+    _serve,
+)
+
+runner = CliRunner()
+
+
+def _project(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "m.py").write_text(
+        "def helper():\n    return 1\n\n\ndef other():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    return project.resolve()
+
+
+def _payload_for(project: Path) -> dict[str, Any]:
+    opened = session_store.open_session(str(project))
+    return session_store.get_session(opened.session_id, str(project))
+
+
+# ------------------------------------------------------------------------------------------
+# (a) an already-overrun default deadline stamps partial=True / partial_reason="deadline" for
+#     each of the 4 named commands, instead of silently completing.
+# ------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_request", "routing_reason", "expect_partial_reason"),
+    [
+        # agent/orient stamp partial_reason="deadline" (agent_capsule.py's existing catch-all
+        # shape, mirrored for orient by this fix -- see orient_capsule.py).
+        ("agent", {"query": "helper"}, "session-agent", True),
+        ("orient", {}, "session-orient", True),
+        # context_render/context_edit_plan route through repo_map.build_context_pack_from_map,
+        # whose PRE-EXISTING deadline contract (test_repo_map_deadline.py) is partial=True +
+        # deadline_limit only -- it never sets partial_reason. Verified against the real code,
+        # not assumed uniform: this test originally asserted partial_reason for all 4 commands
+        # and caught its own wrong assumption when it went red post-fix on these two.
+        ("context_render", {"query": "helper"}, "session-context-render", False),
+        ("context_edit_plan", {"query": "helper"}, "session-context-edit-plan", False),
+    ],
+)
+def test_warm_daemon_default_deadline_overrun_marks_partial(
+    tmp_path: Path,
+    monkeypatch: Any,
+    command: str,
+    extra_request: dict[str, Any],
+    routing_reason: str,
+    expect_partial_reason: bool,
+) -> None:
+    project = _project(tmp_path)
+    payload = _payload_for(project)
+
+    # Deterministic: force the default budget to already be exhausted BEFORE the builder ever
+    # checks time.monotonic() against it -- no sleep, no timing race (same technique
+    # test_repo_map_deadline.py uses via a raw `deadline_monotonic=time.monotonic() - 1.0`).
+    monkeypatch.setattr(session_store, "WARM_DAEMON_DEFAULT_DEADLINE_SECONDS", -1000.0)
+
+    request = {"command": command, **extra_request}
+    response = session_store._serve_session_request_from_payload("session-x", request, payload)
+
+    assert response["routing_reason"] == routing_reason
+    assert response.get("partial") is True, response
+    if expect_partial_reason:
+        assert response.get("partial_reason") == "deadline", response
+    else:
+        assert isinstance(response.get("deadline_limit"), dict), response
+        assert response["deadline_limit"].get("deadline_exceeded") is True, response
+
+
+def test_agent_warm_daemon_deadline_overrun_exits_2_end_to_end(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """True end-to-end proof of (a): `tg agent` (no --deadline flag -- the daemon's own default)
+    exits 2 with partial=True in the JSON when the warm daemon's default deadline is already
+    exhausted, never a silent exit 0. Real in-process threaded daemon (test_orient_agent_daemon.py's
+    proven harness), monkeypatch applies in-process so the daemon thread sees the same patched
+    constant."""
+    project = _project(tmp_path)
+    monkeypatch.setattr(session_store, "WARM_DAEMON_DEFAULT_DEADLINE_SECONDS", -1000.0)
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        result = runner.invoke(app, ["agent", str(project), "helper", "--json"])
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.output)
+    assert payload["routing_reason"] == "session-agent"
+    assert payload.get("partial") is True, payload
+    assert payload.get("partial_reason") == "deadline", payload
+
+
+def test_warm_daemon_normal_response_unaffected_no_partial(tmp_path: Path) -> None:
+    """(c): the real (non-monkeypatched) 60s default is nowhere near exhausted by a trivial
+    fixture repo -- no spurious partial=True from the new plumbing on the common case."""
+    project = _project(tmp_path)
+    payload = _payload_for(project)
+
+    for command, extra in (
+        ("agent", {"query": "helper"}),
+        ("orient", {}),
+        ("context_render", {"query": "helper"}),
+        ("context_edit_plan", {"query": "helper"}),
+    ):
+        request = {"command": command, **extra}
+        response = session_store._serve_session_request_from_payload("session-x", request, payload)
+        assert response.get("partial") is not True, (command, response)
+        assert "partial_reason" not in response, (command, response)
+
+
+# ------------------------------------------------------------------------------------------
+# (b) a partial=True response must never be written into the daemon's response cache -- a
+#     follow-up identical request RECOMPUTES rather than replaying a truncated answer.
+# ------------------------------------------------------------------------------------------
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.response_cache = session_daemon._SessionResponseCache()
+        self._response_cache_lock = threading.Lock()
+
+
+def test_partial_response_is_not_cached_and_recomputes(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project(tmp_path)
+    payload = _payload_for(project)
+    server = _FakeServer()
+
+    calls = {"count": 0}
+
+    def _fake_serve(
+        _session_id: str, _request: dict[str, Any], _path: str, *, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls["count"] += 1
+        return {
+            "session_id": "session-x",
+            "routing_reason": "session-agent",
+            "partial": True,
+            "partial_reason": "deadline",
+        }
+
+    monkeypatch.setattr(session_daemon, "serve_session_request", _fake_serve)
+
+    request = {"command": "agent", "query": "helper", "path": str(project)}
+    first, _first_status = session_daemon._serve_daemon_response_with_cache(
+        server=server,
+        command="agent",
+        session_id="session-x",
+        path=str(project),
+        request=request,
+        payload=payload,
+    )
+    second, _second_status = session_daemon._serve_daemon_response_with_cache(
+        server=server,
+        command="agent",
+        session_id="session-x",
+        path=str(project),
+        request=request,
+        payload=payload,
+    )
+
+    assert first.get("partial") is True
+    assert second.get("partial") is True
+    assert calls["count"] == 2, "a partial response must force a recompute, never a cache hit"
+    assert server.response_cache.entry_count == 0, "a partial response must never be cached"
+
+
+def test_non_partial_response_is_still_cached(tmp_path: Path, monkeypatch: Any) -> None:
+    """Companion golden-parity case: the exclusion is SPECIFIC to partial=True, not a general
+    cache regression -- a normal complete response is cached exactly as before."""
+    project = _project(tmp_path)
+    payload = _payload_for(project)
+    server = _FakeServer()
+
+    calls = {"count": 0}
+
+    def _fake_serve(
+        _session_id: str, _request: dict[str, Any], _path: str, *, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls["count"] += 1
+        return {"session_id": "session-x", "routing_reason": "session-agent"}
+
+    monkeypatch.setattr(session_daemon, "serve_session_request", _fake_serve)
+
+    request = {"command": "agent", "query": "helper", "path": str(project)}
+    session_daemon._serve_daemon_response_with_cache(
+        server=server,
+        command="agent",
+        session_id="session-x",
+        path=str(project),
+        request=request,
+        payload=payload,
+    )
+    _second, second_status = session_daemon._serve_daemon_response_with_cache(
+        server=server,
+        command="agent",
+        session_id="session-x",
+        path=str(project),
+        request=request,
+        payload=payload,
+    )
+
+    assert calls["count"] == 1, "a normal response should be served from cache on the 2nd call"
+    assert second_status == "hit"
+    assert server.response_cache.entry_count == 1
+
+
+# ------------------------------------------------------------------------------------------
+# orient_capsule.build_orient_capsule_from_map: direct unit coverage of the NEW deadline_monotonic
+# parameter. This builder did NOT already accept one (verified against the real code -- unlike
+# its 3 siblings, which already did per #639/#642/#645) so it had to be extended as part of #200.
+# ------------------------------------------------------------------------------------------
+
+
+def test_orient_from_map_deadline_none_is_byte_identical_to_omitted(tmp_path: Path) -> None:
+    """Golden-parity guard: deadline_monotonic=None (the default, and every pre-#200 call site,
+    including the cold `build_orient_capsule` wrapper) must be a no-op -- required by
+    test_orient_agent_daemon.py's existing warm==cold byte-identity contract, which never passes
+    this kwarg at all."""
+    project = _project(tmp_path)
+    rm = repo_map.build_repo_map(str(project), max_repo_files=2000)
+    without_kwarg = orient_capsule.build_orient_capsule_from_map(rm)
+    with_none = orient_capsule.build_orient_capsule_from_map(rm, deadline_monotonic=None)
+    assert without_kwarg == with_none
+
+
+def test_orient_from_map_already_expired_deadline_marks_partial(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    rm = repo_map.build_repo_map(str(project), max_repo_files=2000)
+    result = orient_capsule.build_orient_capsule_from_map(
+        rm, deadline_monotonic=time.monotonic() - 1.0
+    )
+    assert result.get("partial") is True
+    assert result.get("partial_reason") == "deadline"
+
+
+def test_orient_cold_wrapper_stays_unbounded_by_default(tmp_path: Path) -> None:
+    """The cold CLI path (`tg orient`, no --deadline) is a deliberate product decision to stay
+    unbounded (see orient_capsule.build_orient_capsule's docstring + the CLI --no-deadline help
+    text) -- #200 only bounds the WARM daemon dispatch path, so the cold wrapper must never gain
+    a spurious partial=True."""
+    project = _project(tmp_path)
+    cold = orient_capsule.build_orient_capsule(str(project), max_repo_files=2000)
+    assert cold.get("partial") is not True


### PR DESCRIPTION
## Summary
- The warm session daemon's `_serve_session_request_from_payload` served `agent`/`orient`/`context_render`/`context_edit_plan` from an already-cached `repo_map` but never threaded a wall-clock budget into the post-map builders (`grep -n deadline session_store.py` was zero matches pre-fix) — the cold path's implicit 60s bound (`DEFAULT_AGENT_CLI_DEADLINE_SECONDS`) lives inside the cold branch only, so a **default** (no `--deadline` flag) warm-daemon request ran fully unbounded.
- Adds `WARM_DAEMON_DEFAULT_DEADLINE_SECONDS = 60.0` (matches the cold path's own default — a safe first cut, no new truncation for any response that already finishes inside budget) and threads `deadline_monotonic` into all 4 named dispatcher branches.
- **Deviation from the original verify (flagged explicitly, not silently absorbed):** `build_orient_capsule_from_map` did **not** already accept `deadline_monotonic`, unlike its 3 siblings (`build_agent_capsule_from_map` / `build_context_render_from_map` / `build_context_edit_plan_from_map`, which already did per #639/#642/#645). Extended it to accept + honor the parameter (bounds the snippet-building file-read loop + a final wall-clock catch-all mirroring `build_agent_capsule_from_map`'s existing `deadline_exceeded_at_return` pattern). The cold CLI wrapper (`build_orient_capsule`) is deliberately left untouched — `tg orient`'s cold path intentionally stays unbounded by default (see its own docstring / `--no-deadline` CLI help), so only the warm daemon path now supplies a value.
- Excludes `partial=True` responses from the daemon's response cache (`session_daemon._serve_daemon_response_with_cache`) so a deadline-truncated answer is never replayed to a later request that would have had a fresh budget to finish.

## Test plan
- [x] TDD: `tests/unit/test_session_daemon_default_deadline.py` (RED confirmed pre-fix, GREEN post-fix) — deterministic already-expired-deadline overrun stamps `partial=True` for all 4 commands (+ end-to-end exit-2 proof for `agent` via a real in-process daemon), partial responses excluded from the cache (recompute, not replay), normal in-budget responses unaffected (no spurious `partial`), and direct coverage of the new `orient_capsule.build_orient_capsule_from_map(deadline_monotonic=...)` parameter incl. a byte-identity golden-parity guard for `deadline_monotonic=None`.
- [x] Full regression sweep (~1400 tests) across every session/daemon/orient/deadline-touching test file: `test_orient_agent_daemon.py`, `test_orient_capsule.py`, `test_symbol_daemon_response_cache.py`, `test_symbol_daemon_autostart.py`, `test_session_*.py`, `test_repo_map_deadline.py`, `test_cli_deadline_coverage_gaps.py`, `test_cli_deadline_flag.py`, `test_mcp_server.py`, `test_agent_codemap_deadline_scale.py` (integration), docs-governance — all green, zero regressions.
- [x] `ruff check .`, `ruff format --check --preview .` (changed files clean; repo has 4 unrelated pre-existing Windows-CRLF-vs-preview-md drift files, untouched by this PR), `mypy src/tensor_grep` (strict) — all pass.
- [x] Confirmed no fast-path latency change: the deadline check is a single cheap `monotonic()` read per dispatcher branch plus existing checkpoint sites; a normal (<60s) response is unaffected.

Draft only, not to be merged without further review (Opus gate pending). #390 (the 5 symbol commands — defs/impact/refs/callers/blast_radius — plus blast_radius_render/blast_radius_plan/file_importers/context still running unbounded on the daemon path) remains open and out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
