### PR TITLE
chore(dogfood): swallow TemporaryDirectory cleanup errors on Windows (#201)

### DIFF
--- a/scripts/dogfood/dogfood_features.py
+++ b/scripts/dogfood/dogfood_features.py
@@ -94,7 +94,12 @@ def main() -> int:
     code, ver, _ = _run(["--version"])
     print(f"version: {ver.strip()} (exit {code})\n")
 
-    with tempfile.TemporaryDirectory() as td:
+    # ignore_cleanup_errors: on Windows, AV/the search indexer can hold a
+    # transient lock on tg-touched files, so rmtree at __exit__ raises
+    # PermissionError AFTER every check passed -> the harness exited 1 on a
+    # 10/10 green run (false negative). Swallow only the cleanup rmtree error;
+    # check outcomes are already recorded in _RESULTS inside the block. (#201)
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as td:
         fixture = Path(td) / "repo"
         _build_fixture(fixture)
         fx = str(fixture)


### PR DESCRIPTION
Fixes #201.

## Problem
`scripts/dogfood/dogfood_features.py` runs 10 feature checks then exits **1 on Windows despite 10/10 PASS**. Root cause: the `with tempfile.TemporaryDirectory()` block's cleanup (`rmtree`) at `__exit__` (the dedent after the checks) raises `PermissionError` when AV / the Windows Search indexer holds a transient lock on files `tg` just created. That fires **after** every check passed but **before** `main()` computes `failures` and returns 0, so the exception propagates to `sys.exit(main())` → traceback → exit 1. A false negative in the post-release verification harness that could mask a real dogfood failure.

## Fix
`tempfile.TemporaryDirectory(ignore_cleanup_errors=True)` (stdlib, Python 3.10+; repo floor is 3.11). It swallows **only** the rmtree cleanup error at block exit — check outcomes are recorded in `_RESULTS` inside the block, so a genuine check failure still returns 1. It cannot mask a real failure.

## Scope / release
Dev/CI verification script only — no shipped-code change → **no release** (`chore:`, no push-race). Verified by CI (ruff format/lint) + the next real dogfood run on the published wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
