### PR TITLE
fix(daemon): bound the 9 remaining warm-daemon commands with the default deadline (#203)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -14643,6 +14643,7 @@ def build_symbol_defs_from_map(
     *,
     semantic_provider: str = "native",
     max_tests: int | None = None,
+    deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
     payload = dict(repo_map)
     payload["files"] = list(repo_map.get("files", []))
@@ -14703,8 +14704,23 @@ def build_symbol_defs_from_map(
     # "69KB for a 1-symbol answer" bug. Route through the SAME relevance filter callers/impact
     # already use so defs stops dumping the manifest, then cap it BEFORE `related_paths` derives
     # below (a leak-back through the second field is the same bug one layer down).
-    payload["tests"] = _relevant_tests_for_symbol(repo_map, symbol, definition_files)
+    # task #203: thread the (now-optional) deadline into this sibling test-relevance scan --
+    # _relevant_tests_for_symbol already supports deadline_monotonic/deadline_hit (used by
+    # impact/callers' own fold-in), but defs never passed either, so a warm-daemon `defs` request
+    # on a repo with many tests ran this loop fully unbounded even when a caller supplied a
+    # deadline. Mirrors build_context_pack_from_map's own_deadline_hit pattern (repo_map.py:13744).
+    defs_related_tests_deadline_hit = _DeadlineBreakFlag()
+    payload["tests"] = _relevant_tests_for_symbol(
+        repo_map,
+        symbol,
+        definition_files,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=defs_related_tests_deadline_hit,
+    )
     _apply_symbol_field_output_limit(payload, field_name="tests", max_count=max_tests)
+    if defs_related_tests_deadline_hit.hit:
+        payload["partial"] = True
+        payload.setdefault("deadline_limit", {"deadline_exceeded": True})
     related_paths = []
     for current in [*definition_files, *payload["tests"]]:
         if current not in related_paths:
@@ -17304,6 +17320,13 @@ def build_symbol_blast_radius_plan_from_map(
         max_symbols=normalized_max_symbols,
         max_depth=max_depth,
         blast_radius_payload=payload,
+        # task #203: this call dropped deadline_monotonic entirely even though it is already in
+        # scope as this function's own parameter -- the identical #642 gate nit-1 gap already fixed
+        # on build_context_edit_plan_from_map's matching call (repo_map.py:12617-12622), unfixed
+        # here. Without this, the edit-plan-seed's validation-test discovery inside
+        # _attach_edit_plan_metadata ran unbounded even when a caller supplied a deadline that DID
+        # bound the build_symbol_blast_radius_from_map call above.
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
     )
     return _attach_profiling(payload, _profiling_collector)
@@ -17380,6 +17403,7 @@ def build_symbol_blast_radius_render_from_map(
     render_profile: str = "full",
     profile: bool = False,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
     collector = _resolve_profiling_collector(profile=profile, collector=_profiling_collector)
@@ -17388,6 +17412,7 @@ def build_symbol_blast_radius_render_from_map(
         symbol,
         max_depth=max_depth,
         semantic_provider=semantic_provider,
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=collector,
     )
     normalized_profile = _normalize_render_profile(render_profile, optimize_context)
@@ -17407,7 +17432,16 @@ def build_symbol_blast_radius_render_from_map(
     # sources are examined first and we degrade gracefully to fewer rendered blocks.
     max_source_candidates = max(max_sources * 8, 24)
     examined_candidates = 0
+    # task #203: bound this per-candidate source-lookup loop with the SAME deadline_monotonic
+    # pattern callers/refs/file_importers already use (checked first, unconditionally, before any
+    # per-candidate filtering) -- the TG-4 comment above already documents this loop running
+    # "~3.5 min on a large repo" with only the COUNT-based max_source_candidates cap and no
+    # wall-clock bound at all.
+    source_loop_deadline_hit = False
     for current_symbol in ranked_symbols:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            source_loop_deadline_hit = True
+            break
         current_file = str(current_symbol["file"])
         if current_file not in top_files:
             continue
@@ -17481,8 +17515,28 @@ def build_symbol_blast_radius_render_from_map(
         max_symbols=max_sources,
         max_depth=max_depth,
         blast_radius_payload=radius_payload,
+        # task #203: thread the deadline into the edit-plan-seed assembly too, mirroring the
+        # identical fix on build_context_edit_plan_from_map (repo_map.py:12617-12622) and
+        # build_symbol_blast_radius_plan_from_map (this file, just above) -- this call previously
+        # dropped deadline_monotonic entirely.
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=collector,
     )
+    # task #203: fold this function's OWN source-lookup loop deadline signal into partial --
+    # `dict(radius_payload)` above already copied forward any partial/deadline_limit that
+    # build_symbol_blast_radius_from_map (or _attach_edit_plan_metadata's own edit_plan_seed fold-in
+    # just above) already stamped, so `setdefault` here never clobbers a richer upstream signal;
+    # this only adds the flag when THIS loop was the one that broke early.
+    if source_loop_deadline_hit:
+        payload["partial"] = True
+        payload.setdefault(
+            "deadline_limit",
+            {
+                "deadline_exceeded": True,
+                "source_candidates_examined": examined_candidates,
+                "source_candidates_total": len(ranked_symbols),
+            },
+        )
     return _attach_profiling(payload, collector)
 
 

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -1182,7 +1182,13 @@ def _serve_session_request_from_payload(
         query = str(request.get("query", "")).strip()
         if not query:
             raise ValueError("context requests require a non-empty query")
-        response = build_context_pack_from_map(repo_map, query)
+        # #203: same warm-daemon default deadline bound as context_render/context_edit_plan below --
+        # build_context_pack_from_map already accepts deadline_monotonic (moat P0-6), but this
+        # branch never threaded one through, so a plain `context` request ran fully unbounded.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
+        response = build_context_pack_from_map(
+            repo_map, query, deadline_monotonic=deadline_monotonic
+        )
         response["session_id"] = session_id
         response["routing_reason"] = "session-context"
         return response
@@ -1277,8 +1283,16 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("defs requests require a non-empty symbol")
+        # #203: same warm-daemon default deadline bound as context above -- build_symbol_defs_from_
+        # map gained deadline_monotonic as part of this fix (it previously had none at all) to
+        # bound its own related-tests sibling scan.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_defs_from_map(
-            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+            repo_map,
+            symbol,
+            semantic_provider=provider,
+            max_tests=max_tests,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-defs"
@@ -1288,8 +1302,17 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("impact requests require a non-empty symbol")
+        # #203: same warm-daemon default deadline bound as context/defs above --
+        # build_symbol_impact_from_map already accepts deadline_monotonic (#52/#103 fixes) and
+        # folds three sibling-loop deadline signals into partial, but this branch never threaded
+        # one through, so a plain `impact` request ran fully unbounded.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_impact_from_map(
-            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+            repo_map,
+            symbol,
+            semantic_provider=provider,
+            max_tests=max_tests,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-impact"
@@ -1299,8 +1322,17 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("refs requests require a non-empty symbol")
+        # #203: same warm-daemon default deadline bound as context/defs/impact above --
+        # build_symbol_refs_from_map already accepts deadline_monotonic (moat P0-6 step 6) and
+        # bounds both its reference-scan and string-refs traversal loops, but this branch never
+        # threaded one through, so a plain `refs` request ran fully unbounded.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_refs_from_map(
-            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+            repo_map,
+            symbol,
+            semantic_provider=provider,
+            max_tests=max_tests,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-refs"
@@ -1310,8 +1342,18 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("callers requests require a non-empty symbol")
+        # #203: same warm-daemon default deadline bound as context/defs/impact/refs above --
+        # build_symbol_callers_from_map already accepts deadline_monotonic (moat P0-6 step 6,
+        # task #61) and folds five sibling-loop deadline signals into partial, but this branch
+        # never threaded one through, so a plain `callers` request ran fully unbounded -- the
+        # exact #390 daemon-path shape this task (#203) closes.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_callers_from_map(
-            repo_map, symbol, semantic_provider=provider, max_tests=max_tests
+            repo_map,
+            symbol,
+            semantic_provider=provider,
+            max_tests=max_tests,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-callers"
@@ -1321,7 +1363,13 @@ def _serve_session_request_from_payload(
         target_file = str(request.get("file", "")).strip()
         if not target_file:
             raise ValueError("file_importers requests require a non-empty file")
-        response = build_file_importers_from_map(repo_map, target_file)
+        # #203: same warm-daemon default deadline bound as the symbol commands above --
+        # build_file_importers_from_map already accepts deadline_monotonic and bounds its
+        # per-candidate confirm-import-edges loop, but this branch never threaded one through.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
+        response = build_file_importers_from_map(
+            repo_map, target_file, deadline_monotonic=deadline_monotonic
+        )
         response["session_id"] = session_id
         response["routing_reason"] = "session-file-importers"
         return response
@@ -1330,11 +1378,16 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("blast_radius requests require a non-empty symbol")
+        # #203: same warm-daemon default deadline bound as callers above -- build_symbol_blast_
+        # radius_from_map already accepts deadline_monotonic and threads it into its own callers/
+        # impact/preferred-definition-files sub-calls, but this branch never threaded one through.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_blast_radius_from_map(
             repo_map,
             symbol,
             max_depth=int(request.get("max_depth", 3)),
             semantic_provider=provider,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-blast-radius"
@@ -1344,6 +1397,12 @@ def _serve_session_request_from_payload(
         symbol = str(request.get("symbol", "")).strip()
         if not symbol:
             raise ValueError("blast_radius_render requests require a non-empty symbol")
+        # #203: build_symbol_blast_radius_render_from_map did NOT already accept deadline_monotonic
+        # (verified against the real code, unlike its blast_radius/blast_radius_plan siblings) --
+        # extended as part of this fix (its own per-candidate source-lookup loop, documented at the
+        # TG-4 comment in repo_map.py as "~3.5 min on a large repo" with only a count-based cap, is
+        # now wall-clock bounded too). Same warm-daemon default deadline as blast_radius above.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_blast_radius_render_from_map(
             repo_map,
             symbol,
@@ -1360,6 +1419,7 @@ def _serve_session_request_from_payload(
             render_profile=str(request.get("render_profile", "full")),
             profile=bool(request.get("profile", False)),
             semantic_provider=provider,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-blast-radius-render"
@@ -1373,6 +1433,10 @@ def _serve_session_request_from_payload(
             "max_repo_files",
             _DEFAULT_SESSION_BLAST_RADIUS_PLAN_REPO_MAP_LIMIT,
         )
+        # #203: same warm-daemon default deadline bound as blast_radius above -- build_symbol_
+        # blast_radius_plan_from_map already accepts deadline_monotonic and threads it into its
+        # build_symbol_blast_radius_from_map call, but this branch never threaded one through.
+        deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS
         response = build_symbol_blast_radius_plan_from_map(
             _limited_session_repo_map(
                 repo_map,
@@ -1385,6 +1449,7 @@ def _serve_session_request_from_payload(
             max_files=int(request.get("max_files", 3)),
             max_symbols=int(request.get("max_symbols", 5)),
             semantic_provider=provider,
+            deadline_monotonic=deadline_monotonic,
         )
         response["session_id"] = session_id
         response["routing_reason"] = "session-blast-radius-plan"

--- a/tests/unit/test_session_daemon_default_deadline.py
+++ b/tests/unit/test_session_daemon_default_deadline.py
@@ -345,3 +345,239 @@ def test_orient_cold_wrapper_stays_unbounded_by_default(tmp_path: Path) -> None:
     project = _project(tmp_path)
     cold = orient_capsule.build_orient_capsule(str(project), max_repo_files=2000)
     assert cold.get("partial") is not True
+
+
+# ------------------------------------------------------------------------------------------
+# #203: extend the SAME dispatch-level default-deadline bound to the 9 warm-daemon commands #200
+# left unbounded -- context, defs, impact, refs, callers, file_importers, blast_radius,
+# blast_radius_render, blast_radius_plan (the #390 daemon-path gap, closed here per-command).
+#
+# verify-plan-against-code finding: unlike #200's agent/orient/context_render/context_edit_plan,
+# MOST of these 9 builders (all except defs and blast_radius_render) already accepted
+# deadline_monotonic from earlier #52/#61/#103/#642 work -- grep -n deadline_monotonic
+# repo_map.py confirms build_symbol_impact_from_map/build_symbol_refs_from_map/
+# build_symbol_callers_from_map/build_file_importers_from_map/build_symbol_blast_radius_from_map/
+# build_symbol_blast_radius_plan_from_map all already had the parameter and already honored it in
+# a hot loop. The gap closed here is purely that _serve_session_request_from_payload never
+# computed+passed the warm-daemon default into them (mirrors #200's fix shape exactly). Only
+# build_symbol_defs_from_map and build_symbol_blast_radius_render_from_map genuinely lacked the
+# parameter (verified against the real code) and were extended as part of this fix, mirroring how
+# #200 extended build_orient_capsule_from_map.
+# ------------------------------------------------------------------------------------------
+
+
+def _project_with_test(root: Path) -> Path:
+    """Like `_project` above, but adds a test file that imports+calls `helper` -- required so the
+    `defs` command's `_relevant_tests_for_symbol` loop and the `file_importers` command's
+    reverse-importers loop each have >=1 item to iterate (an empty candidate list can never
+    observe an already-expired deadline, since the deadline check lives INSIDE the loop body,
+    same reasoning `test_orient_snippet_loop_breaks_mid_loop_not_just_pre_check` above documents
+    for orient's central-files loop)."""
+    project = root / "project"
+    project.mkdir()
+    (project / "m.py").write_text(
+        "def helper():\n    return 1\n\n\ndef other():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    # A regular (non-test) importer -- required so the file_importers command's reverse-importers
+    # prefilter has >=1 candidate: build_file_importers_from_map scopes candidate importers to
+    # repo_map["files"] only (verified via a direct diagnostic run), which does NOT include
+    # test-classified files (those live in the separate repo_map["tests"] list) -- so a test-only
+    # importer of m.py is invisible to this specific command by design, unrelated to #203.
+    (project / "consumer.py").write_text(
+        "import m\n\n\ndef run():\n    return m.helper()\n",
+        encoding="utf-8",
+    )
+    # A genuine test file (bare `import m`, proven to resolve via Python's own same-directory
+    # import search by test_build_file_importers_python_excludes_duplicate_basename_false_edge in
+    # test_file_deps.py) -- needed so the defs command's _relevant_tests_for_symbol loop has >=1
+    # item to iterate (repo_map["tests"] must be non-empty).
+    (project / "test_m.py").write_text(
+        "import m\n\n\ndef test_helper():\n    assert m.helper() == 1\n",
+        encoding="utf-8",
+    )
+    return project.resolve()
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_request", "routing_reason"),
+    [
+        ("context", {"query": "helper"}, "session-context"),
+        ("defs", {"symbol": "helper"}, "session-defs"),
+        ("impact", {"symbol": "helper"}, "session-impact"),
+        ("refs", {"symbol": "helper"}, "session-refs"),
+        ("callers", {"symbol": "helper"}, "session-callers"),
+        ("file_importers", {"file": "m.py"}, "session-file-importers"),
+        ("blast_radius", {"symbol": "helper"}, "session-blast-radius"),
+        ("blast_radius_render", {"symbol": "helper"}, "session-blast-radius-render"),
+        ("blast_radius_plan", {"symbol": "helper"}, "session-blast-radius-plan"),
+    ],
+)
+def test_warm_daemon_default_deadline_overrun_marks_partial_203(
+    tmp_path: Path,
+    monkeypatch: Any,
+    command: str,
+    extra_request: dict[str, Any],
+    routing_reason: str,
+) -> None:
+    """#203: proves the same contract as test_warm_daemon_default_deadline_overrun_marks_partial
+    above, extended to the 9 commands that fix left unbounded. None of these 9 builders (all
+    housed in repo_map.py) sets `partial_reason` -- that field is agent_capsule.py's/
+    orient_capsule.py's own catch-all shape -- so every case here asserts the `deadline_limit`
+    shape only, matching how the parametrized test above already treats context_render/
+    context_edit_plan (verified against the real code, not assumed uniform -- same caution that
+    test's own docstring flags)."""
+    project = _project_with_test(tmp_path)
+    payload = _payload_for(project)
+
+    # Deterministic: force the default budget to already be exhausted BEFORE the builder ever
+    # checks time.monotonic() against it -- same technique as (a) above, no sleep/timing race.
+    monkeypatch.setattr(session_store, "WARM_DAEMON_DEFAULT_DEADLINE_SECONDS", -1000.0)
+
+    request = {"command": command, **extra_request}
+    response = session_store._serve_session_request_from_payload("session-x", request, payload)
+
+    assert response["routing_reason"] == routing_reason
+    assert response.get("partial") is True, response
+    assert isinstance(response.get("deadline_limit"), dict), response
+    assert response["deadline_limit"].get("deadline_exceeded") is True, response
+
+
+def test_warm_daemon_normal_response_unaffected_no_partial_203(tmp_path: Path) -> None:
+    """(c)-equivalent for the #203 commands: the real (non-monkeypatched) 60s default is nowhere
+    near exhausted by a trivial fixture repo -- no spurious partial=True from the new plumbing on
+    the common case."""
+    project = _project_with_test(tmp_path)
+    payload = _payload_for(project)
+
+    for command, extra in (
+        ("context", {"query": "helper"}),
+        ("defs", {"symbol": "helper"}),
+        ("impact", {"symbol": "helper"}),
+        ("refs", {"symbol": "helper"}),
+        ("callers", {"symbol": "helper"}),
+        ("file_importers", {"file": "m.py"}),
+        ("blast_radius", {"symbol": "helper"}),
+        ("blast_radius_render", {"symbol": "helper"}),
+        ("blast_radius_plan", {"symbol": "helper"}),
+    ):
+        request = {"command": command, **extra}
+        response = session_store._serve_session_request_from_payload("session-x", request, payload)
+        assert response.get("partial") is not True, (command, response)
+        assert "partial_reason" not in response, (command, response)
+
+
+# ------------------------------------------------------------------------------------------
+# #203 direct-builder coverage: build_symbol_defs_from_map and
+# build_symbol_blast_radius_render_from_map did NOT already accept deadline_monotonic (verified
+# against the real code, unlike their impact/refs/callers/blast_radius/blast_radius_plan
+# siblings), so both had to be extended as part of this fix -- mirrors the orient_capsule
+# direct-builder coverage above (test_orient_from_map_deadline_none_is_byte_identical_to_omitted
+# through test_orient_snippet_loop_breaks_mid_loop_not_just_pre_check).
+# ------------------------------------------------------------------------------------------
+
+
+def test_defs_from_map_deadline_none_is_byte_identical_to_omitted(tmp_path: Path) -> None:
+    """Golden-parity guard: deadline_monotonic=None (the default, and every pre-#203 call site,
+    including every OTHER symbol builder's internal build_symbol_defs_from_map call, none of
+    which pass this kwarg) must be a no-op."""
+    project = _project_with_test(tmp_path)
+    rm = repo_map.build_repo_map(str(project), max_repo_files=2000)
+    without_kwarg = repo_map.build_symbol_defs_from_map(rm, "helper")
+    with_none = repo_map.build_symbol_defs_from_map(rm, "helper", deadline_monotonic=None)
+    assert without_kwarg == with_none
+
+
+def test_defs_from_map_already_expired_deadline_marks_partial(tmp_path: Path) -> None:
+    """Proves the new deadline_monotonic parameter genuinely bounds defs' related-tests sibling
+    scan (_relevant_tests_for_symbol), not just accepted-and-ignored."""
+    project = _project_with_test(tmp_path)
+    rm = repo_map.build_repo_map(str(project), max_repo_files=2000)
+    result = repo_map.build_symbol_defs_from_map(
+        rm, "helper", deadline_monotonic=time.monotonic() - 1.0
+    )
+    assert result.get("partial") is True, result
+    assert result["deadline_limit"].get("deadline_exceeded") is True, result
+
+
+def test_blast_radius_render_from_map_deadline_none_is_byte_identical_to_omitted(
+    tmp_path: Path,
+) -> None:
+    """Golden-parity guard: deadline_monotonic=None (the default, and the pre-#203 cold wrapper
+    build_symbol_blast_radius_render, which never passes this kwarg) must be a no-op."""
+    project = _project(tmp_path)
+    rm = repo_map.build_repo_map(str(project), max_repo_files=2000)
+    without_kwarg = repo_map.build_symbol_blast_radius_render_from_map(rm, "helper")
+    with_none = repo_map.build_symbol_blast_radius_render_from_map(
+        rm, "helper", deadline_monotonic=None
+    )
+    assert without_kwarg == with_none
+
+
+def test_blast_radius_render_from_map_already_expired_deadline_marks_partial(
+    tmp_path: Path,
+) -> None:
+    """Proves the whole function comes back partial=True on an already-expired deadline instead
+    of running unbounded. Deliberately does NOT assert the specific `deadline_limit` shape: with
+    an ALREADY-expired deadline, the upstream build_symbol_blast_radius_from_map call's own
+    caller-scan loop trips FIRST (before this function's own source-lookup loop ever runs) and
+    its richer deadline_limit (caller_files_scanned/caller_files_total) wins the `setdefault`
+    race in this function's own fold-in -- correct behavior (never clobber a richer upstream
+    signal, the same idiom build_context_pack_from_map uses). The companion mid-loop test below
+    isolates THIS function's own loop specifically by keeping the upstream call inside budget."""
+    project = _project(tmp_path)
+    rm = repo_map.build_repo_map(str(project), max_repo_files=2000)
+    result = repo_map.build_symbol_blast_radius_render_from_map(
+        rm, "helper", deadline_monotonic=time.monotonic() - 1.0
+    )
+    assert result.get("partial") is True, result
+    assert result["deadline_limit"].get("deadline_exceeded") is True, result
+
+
+def test_blast_radius_render_source_loop_breaks_mid_loop_not_just_pre_check(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Strengthens the already-expired-deadline coverage above with the sharper claim (mirrors
+    test_orient_snippet_loop_breaks_mid_loop_not_just_pre_check above): the deadline crosses WHILE
+    THIS function's OWN source-lookup loop is running, with the upstream build_symbol_blast_
+    radius_from_map call (and its callers/impact sub-calls) completing INSIDE budget on this tiny
+    fixture -- isolating this function's own loop as the one that demonstrably stops early, not
+    merely inheriting an already-partial upstream signal. STATIC fake clock, manually advanced
+    only inside the wrapped per-candidate work function (build_symbol_source_from_map), so the
+    result is immune to any OTHER incidental time.monotonic() call elsewhere in the function."""
+    # verify-plan-against-code diagnostic finding: the render loop's candidates come from
+    # radius_payload["symbols"] (context-pack's NAME-relevance-ranked symbol list), which does
+    # NOT include sibling functions from the same file (verified: a helper() called by 6 other
+    # functions in one file yields exactly 1 entry, "helper" itself) -- so a multi-candidate
+    # fixture needs multiple FILES each defining their own same-named `helper`, one definition
+    # (and therefore one ranked_symbols entry) per file, not one file with many functions.
+    project = tmp_path / "project"
+    project.mkdir()
+    for index in range(6):
+        (project / f"m{index}.py").write_text(
+            f"def helper():\n    return {index}\n", encoding="utf-8"
+        )
+    rm = repo_map.build_repo_map(str(project.resolve()), max_repo_files=2000)
+
+    base = 1000.0
+    clock = {"t": base}
+    monkeypatch.setattr(repo_map.time, "monotonic", lambda: clock["t"])
+    original_source_from_map = repo_map.build_symbol_source_from_map
+    call_count = {"n": 0}
+
+    def _advancing_source_from_map(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        call_count["n"] += 1
+        clock["t"] += 1.0
+        return original_source_from_map(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_symbol_source_from_map", _advancing_source_from_map)
+
+    result = repo_map.build_symbol_blast_radius_render_from_map(
+        rm, "helper", max_files=6, max_sources=6, deadline_monotonic=base + 3.0
+    )
+
+    assert result.get("partial") is True, result
+    assert result["deadline_limit"].get("deadline_exceeded") is True, result
+    assert 0 < call_count["n"] < 7, (
+        f"cut short mid-loop, not exhausted -- source_from_map was called {call_count['n']} times"
+    )


### PR DESCRIPTION
Fixes #203. Extends the warm-daemon default deadline (#200-A) to the ~9 remaining unbounded command handlers.

## Problem
`session_store.py::_serve_session_request_from_payload` bounded only 4 commands (context_render/context_edit_plan/orient/agent, via #200-A). The other 9 — `context`, `defs`, `impact`, `refs`, `callers`, `file_importers`, `blast_radius`, `blast_radius_render`, `blast_radius_plan` — dispatched without computing a default deadline, so an agent calling e.g. `tg callers` on a large repo via the warm daemon ran **unbounded** (the #390 agent-loop-hang class).

## Fix
Each dispatch branch now computes `deadline_monotonic = monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS` (per-branch, matching the #200-A style — no shared choke point exists). **verify-plan-against-code** found most `build_*_from_map` builders already accepted+honored `deadline_monotonic` (from #52/#61/#103/#642) — only the dispatch never passed it. Genuinely extended: `build_symbol_defs_from_map` + `build_symbol_blast_radius_render_from_map`. Also fixes a **latent #642-nit-1-class bug**: `blast_radius_plan` dropped the deadline on `_attach_edit_plan_metadata`.

Honest-partial contract preserved (`partial=True` + `deadline_limit` setdefault, never silent-empty).

## Verify
RED→GREEN 14 failed → 27 passed (stash/pop verified); 382-test regression sweep passed; ruff clean. Kept **draft** pending an independent Opus gate on the deadline/partial-contract fidelity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
