### PR TITLE
fix(daemon): thread the warm-daemon deadline into the refs internal context-pack call (#205)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -15325,7 +15325,17 @@ def build_symbol_refs_from_map(
         payload["coverage_summary"] = _coverage_summary(payload)
         payload["resolution_gaps"] = []
         return payload
-    context_payload = build_context_pack_from_map(repo_map, symbol)
+    # #205: bound context-pack's own symbol-scoring + pagerank loop with the SAME warm-daemon
+    # deadline. Previously called BARE here while the sibling handlers callers/impact threaded it
+    # (repo_map.py:16431 / 15011); on a very large session repo this in-memory stage could still
+    # overrun the 60s budget. Fold its early-break into the refs partial signal below.
+    context_pack_deadline_hit = _DeadlineBreakFlag()
+    context_payload = build_context_pack_from_map(
+        repo_map,
+        symbol,
+        deadline_monotonic=deadline_monotonic,
+        deadline_hit=context_pack_deadline_hit,
+    )
     repo_root = Path(str(repo_map["path"])).resolve()
     refs_universe_files, refs_universe_tests = _repo_map_file_and_test_universe(repo_map)
     bounded_files, refs_ceiling_hit = _cap_caller_scan_files(
@@ -15564,7 +15574,7 @@ def build_symbol_refs_from_map(
         lsp_count=lsp_proof_count,
         fallback_used=fallback_used,
     )
-    if refs_scan_deadline_hit:
+    if refs_scan_deadline_hit or context_pack_deadline_hit.hit:
         payload["partial"] = True
         payload["deadline_limit"] = {
             "deadline_exceeded": True,

--- a/tests/unit/test_refs_context_pack_deadline_205.py
+++ b/tests/unit/test_refs_context_pack_deadline_205.py
@@ -31,9 +31,7 @@ def _project(root: Path) -> Path:
     return project.resolve()
 
 
-def test_refs_threads_deadline_into_internal_context_pack(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_refs_threads_deadline_into_internal_context_pack(tmp_path: Path, monkeypatch: Any) -> None:
     project = _project(tmp_path)
     rmap = repo_map.build_repo_map(str(project))
 

--- a/tests/unit/test_refs_context_pack_deadline_205.py
+++ b/tests/unit/test_refs_context_pack_deadline_205.py
@@ -1,0 +1,56 @@
+"""#205: build_symbol_refs_from_map threads the shared warm-daemon deadline into its INTERNAL
+build_context_pack_from_map call.
+
+The refs handler's DOMINANT reference-scan loop was already deadline-bounded, but it invoked
+``build_context_pack_from_map(repo_map, symbol)`` BARE -- leaving that stage's own in-memory
+symbol-scoring + pagerank loop unbounded on a very large session repo, unlike the sibling
+callers/impact handlers which thread the deadline (repo_map.py:16431 / 15011). Surfaced by the
+#203/#652 Opus gate as a pre-existing parity gap.
+
+This spy test isolates the fix from refs' already-bounded scan loop: a value-level overrun test
+would pass vacuously (refs' dominant loop already trips ``partial`` on an expired deadline), so
+we assert the kwargs actually forwarded to the internal call instead.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli import repo_map
+
+
+def _project(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "m.py").write_text(
+        "def helper():\n    return 1\n\n\ndef other():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    return project.resolve()
+
+
+def test_refs_threads_deadline_into_internal_context_pack(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    project = _project(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+
+    captured: dict[str, Any] = {}
+    original = repo_map.build_context_pack_from_map
+
+    def _spy(rm: Any, symbol: str, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return original(rm, symbol, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_context_pack_from_map", _spy)
+
+    sentinel = time.monotonic() + 10_000.0
+    repo_map.build_symbol_refs_from_map(rmap, "helper", deadline_monotonic=sentinel)
+
+    # #205 (was a bare ``build_context_pack_from_map(repo_map, symbol)``): refs must forward its
+    # deadline + a deadline_hit flag so the internal symbol-scoring / pagerank stage is bounded
+    # and its early break folds into refs' partial signal (mirrors callers repo_map.py:16431).
+    assert captured.get("deadline_monotonic") == sentinel
+    assert "deadline_hit" in captured


### PR DESCRIPTION
Fixes #205 (pre-existing parity gap surfaced by the #203/#652 Opus gate).

## Problem
`build_symbol_refs_from_map`'s dominant reference-scan loop is deadline-bounded, but it called `build_context_pack_from_map(repo_map, symbol)` **bare** (`repo_map.py:15328`) — leaving that stage's own in-memory symbol-scoring + pagerank loop unbounded on a very large session repo, unlike the sibling `callers` (`:16431`) / `impact` (`:15011`) handlers which thread the deadline.

## Fix
Thread `deadline_monotonic` + a `_DeadlineBreakFlag` into the call and fold its early-break into refs' existing partial signal (`refs_scan_deadline_hit or context_pack_deadline_hit.hit`). Mirrors the callers handler exactly (the #203 gate pre-verified that pattern). Honest-partial contract preserved.

## Test
`test_refs_context_pack_deadline_205.py` — an **isolating spy** on the internal call's kwargs (asserts `deadline_monotonic` + `deadline_hit` are forwarded). A value-level overrun test would pass vacuously since refs' dominant loop already trips `partial` on an expired deadline.

Scope: 2 edits + 1 test. Mechanical mirror of the Opus-gated callers pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
