### PR TITLE
docs(backlog): reconcile the canonical ledger to v1.81.5 (campaign complete) (#190)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,20 @@
 > **Canonical prioritized work list.** Kept in sync with the CLI task store (`TaskUpdate`) and
 > GitHub (`gh pr list` is the source of truth for PRs). **CEO status** = summarize SHIPPING + P0/P1.
 > Update whenever a PR opens/merges or the queue changes. Task-store IDs (`#NNN`) cross-referenced.
-> Last refreshed 2026-07-16 (docs-capture pass). **Live PyPI is v1.78.1** (published; the `tg find`
+> Last refreshed 2026-07-17 (post-v1.81.5 campaign reconcile). **Live PyPI is v1.81.5. PR queue: EMPTY.** The
+> v1.79-v1.81.5 dogfood + deadline-honesty campaign (2026-07-17) is COMPLETE + drained clean, one-per-publish:
+> the warm-daemon `--deadline` surface is now bounded end-to-end. **#200 (HIGH, dogfood-caught):** `tg agent
+> --deadline` silently ignored on the default warm-daemon path -> #642 (cold residual) + #200-A/#647 (warm
+> default deadline, v1.81.2) + #200-B/#648 (front-door anchor, v1.81.3), dogfood-VERIFIED on the published wheel
+> (warm `tg agent --deadline 3` -> exit-2 + 'deadline' partial, 0/4 silent). **#203/#652 (v1.81.4):** bound the
+> ~9 remaining warm cmds (context/defs/impact/refs/callers/file_importers/blast_radius family), independent-Opus
+> -gated (all 9 non-vacuous, fail-closed holds). **#205/#653 (v1.81.5):** the refs internal-context-pack parity
+> nit. **Two recurring release-flakes permanently killed:** #646/#202 (test_lifecycle TCP-connect) + #650/#204
+> (test_index_lock_is_per_root_not_global wall-clock ratio -> overlap-invariant, validated on the flake runner).
+> Also #201/#649 dogfood-harness false-negative, #643 MCP consolidation Phase-1, #198/#644 bench release-intent
+> validator, #645/#199 context-render honesty; #189 CPU-moat research negatives recorded in `docs/PAPER.md` §3.10
+> (#651, all three ColGrep levers dead/negative on REAL data -> lean-(c) accept-the-ceiling). ZERO broken
+> *published* releases across the whole v1.79-v1.81.5 line. The prior `tg find`
 > campaign #189 -- CPU semantic moat / ColGrep response -- shipped CLI (v1.77.0) + MCP tool (v1.78.0)
 > this session on top of the v1.76.x "remaining AI-actionable backlog" wave #176, ZERO broken *published* releases).
 > Shipped 15 PRs (v1.76.x wave): v1.76.0 #601 route-test / v1.76.1 #602 checkpoint-symlink / v1.76.2 #604 perf / v1.76.3 #603 daemon-guard /
@@ -14,7 +27,7 @@
 > Plus the `tg find` campaign #189, now fully MERGED and RELEASED (v1.78.1): v1.77.0 #626 CLI hybrid search (Wave 2b/2c) / v1.78.0 #627 MCP `tg_find` tool (Wave 2d) /
 > #628 `TG_FIND_DENSE_WEIGHT` knob (Wave 3, chore, no-release) / #629 backlog reconcile (docs, no-release) / #632 `mcp` CVE-2026-52870 floor bump (fix, patch-released as v1.78.1);
 > + #624 rank_chunks extraction (Wave 2a) + #625 T8 golden harness (Wave 1), both no-release. **On top of v1.78.1, still unreleased (chore, no-release):** #630 whitespace-gate the
-> dense-weight classifier + nan/inf clamp (flip-prep, #191). **PR queue: 1 open** (`#634`, `fix/find-dense-weight-flip` -- the `TG_FIND_DENSE_WEIGHT`
+> dense-weight classifier + nan/inf clamp (flip-prep, #191). **[v1.78.1-era snapshot; the CURRENT queue is EMPTY per the header above.] PR queue then: 1 open** (`#634`, `fix/find-dense-weight-flip` -- the `TG_FIND_DENSE_WEIGHT`
 > default-flip itself, proposing to move the default from inert `1.0` to the swept 1:5 bm25:dense ratio for multi-word NL queries; per #191's evidence
 > trail this is the still-open CEO checkpoint every skill referencing the knob describes as "not yet flipped" -- verify current PR state with `gh pr view 634`
 > before citing either "flipped" or "still default-OFF" as current).


### PR DESCRIPTION
Reconciles `docs/BACKLOG.md`'s stale header (was 'Live PyPI is v1.78.1 / PR queue: 1 open #634') to the true state: **Live PyPI v1.81.5, PR queue EMPTY**, with the v1.79-v1.81.5 dogfood + deadline-honesty campaign summary (#200 dogfood-verified / #203/#652 9-handler bound / #205/#653 refs parity / two recurring release-flakes killed #646/#650 / #189 negatives in PAPER.md §3.10). Docs only, no release. Closes the #190 docs slice (worktree prune + memory anchor already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)