### PR TITLE
fix(perf): defer fast-path-unused bootstrap imports to cut public-shim cold-start (#48)

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -15,12 +15,21 @@ from tensor_grep.cli.runtime_paths import (
     resolve_ripgrep_binary,
 )
 from tensor_grep.cli.subprocess_policy import run_subprocess as run_subprocess
-from tensor_grep.io.directory_scanner import (
-    BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
-    BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
-    BROAD_WORKSPACE_PROJECT_MARKERS,
-    UNBOUNDED_VENDORED_ROOT_DIR_NAMES,
-)
+
+# perf/#48: `tensor_grep.io.directory_scanner` is deliberately NOT imported at module level.
+# bootstrap.py only needs its 4 constants (BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
+# BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD, BROAD_WORKSPACE_PROJECT_MARKERS,
+# UNBOUNDED_VENDORED_ROOT_DIR_NAMES) inside the search broad-scan guard helpers below
+# (`_path_has_project_marker`, `_search_paths_include_workspace_root`,
+# `_search_paths_include_vendored_root`), which run only for an actual search invocation -- never
+# for `tg --version`/`-V` (the diagnosed cold-start case, ~135ms vs rg's ~7ms). `directory_scanner`
+# itself does `from tensor_grep.core.config import SearchConfig` at ITS OWN module level, which
+# transitively pulls in the stdlib `dataclasses` module -- and `dataclasses` imports `inspect`
+# (plus `ast`/`dis`/`tokenize`/`copy`/`weakref`), a chain measured at ~25ms cumulative
+# (`python -X importtime -c "import tensor_grep.cli.bootstrap"`, warm cache) that a trivial
+# `--version` call has no reason to pay. Each of the 3 helper functions does its own
+# function-local `from tensor_grep.io.directory_scanner import ...` instead; see
+# `tests/unit/test_bootstrap_fast_path_imports.py` for the regression test that pins this.
 
 # Saved at import time so _streaming_passthrough_returncode can detect when
 # run_subprocess has been monkey-patched by a test (old mock pattern).
@@ -146,10 +155,10 @@ _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "venv",
 }
 # Single source of truth: `io/directory_scanner.py` (item #154) -- keeps this file and
-# `cli/main.py`'s equivalent guard from drifting out of sync.
-_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
-_BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
-_BROAD_WORKSPACE_PROJECT_MARKERS = BROAD_WORKSPACE_PROJECT_MARKERS
+# `cli/main.py`'s equivalent guard from drifting out of sync. perf/#48: no longer aliased at
+# module level -- `_path_has_project_marker` / `_search_paths_include_workspace_root` below
+# import these constants function-locally (fast-path-unused; see the deferred-import note above
+# the `tensor_grep.cli.subprocess_policy` import).
 _SEARCH_PATTERN_FLAGS = {"-e", "--regexp"}
 _SEARCH_LITERAL_FLAGS = {"-F", "--fixed-strings"}
 _SEARCH_PCRE2_FLAGS = {"-P", "--pcre2"}
@@ -626,7 +635,9 @@ def _search_args_paths_defaulted(search_args: list[str]) -> bool:
 
 
 def _path_has_project_marker(path: Path) -> bool:
-    for marker in _BROAD_WORKSPACE_PROJECT_MARKERS:
+    from tensor_grep.io.directory_scanner import BROAD_WORKSPACE_PROJECT_MARKERS
+
+    for marker in BROAD_WORKSPACE_PROJECT_MARKERS:
         try:
             if (path / marker).exists():
                 return True
@@ -660,6 +671,11 @@ def _search_paths_include_generated_root(paths: list[str]) -> bool:
 
 
 def _search_paths_include_workspace_root(paths: list[str]) -> bool:
+    from tensor_grep.io.directory_scanner import (
+        BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
+        BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
+    )
+
     for raw_path in paths:
         if not raw_path or raw_path == "-" or raw_path.startswith("-"):
             continue
@@ -672,9 +688,9 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
             # marked children (the higher "marked-root" threshold) before it counts as a
             # workspace parent too.
             threshold = (
-                _BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+                BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
                 if _path_has_project_marker(path)
-                else _BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+                else BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
             )
             project_children = 0
             for child in path.iterdir():
@@ -716,11 +732,10 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
 # per-file deadline), so refusing it was a pure false positive against every ordinary
 # Node/React repo. Imported (not hardcoded) from `io/directory_scanner.py` so this set and
 # cli/main.py's equivalent guard can never drift out of sync.
-_UNBOUNDED_VENDORED_ROOT_DIR_NAMES = UNBOUNDED_VENDORED_ROOT_DIR_NAMES
-
-
 def _search_paths_include_vendored_root(paths: list[str]) -> bool:
     """O(top-level-entries) probe: never walks -- only `Path.iterdir()` one level deep."""
+    from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+
     for raw_path in paths:
         if not raw_path or raw_path == "-" or raw_path.startswith("-"):
             continue
@@ -729,7 +744,7 @@ def _search_paths_include_vendored_root(paths: list[str]) -> bool:
             if not path.is_dir():
                 continue
             for child in path.iterdir():
-                if child.is_dir() and child.name.lower() in _UNBOUNDED_VENDORED_ROOT_DIR_NAMES:
+                if child.is_dir() and child.name.lower() in UNBOUNDED_VENDORED_ROOT_DIR_NAMES:
                     return True
         except OSError:
             continue

--- a/tests/unit/test_bootstrap_fast_path_imports.py
+++ b/tests/unit/test_bootstrap_fast_path_imports.py
@@ -1,0 +1,112 @@
+"""perf/#48 regression: bootstrap.py's trivial fast paths (currently just ``tg --version`` /
+``-V``, the only branch of ``main_entry`` that returns before ever calling ``_run_full_cli``,
+native dispatch, or the search broad-scan guards) must not pay the import cost of
+``tensor_grep.io.directory_scanner`` -- which itself transitively pulls in
+``tensor_grep.core.config`` (and, via its ``from dataclasses import dataclass``, the stdlib
+``dataclasses``/``inspect``/``ast``/``dis``/``tokenize`` chain). Those modules are only needed by
+the plain-text-search unbounded-broad-scan guard (``_search_args_include_unbounded_broad_scan``
+and the three helpers it calls: ``_path_has_project_marker``,
+``_search_paths_include_workspace_root``, ``_search_paths_include_vendored_root``), which never
+runs for ``--version``.
+
+Measured on this machine (``python -X importtime -c "import tensor_grep.cli.bootstrap"``,
+warm-cache): deferring this import saves ~25ms of the ~78ms total bootstrap import cost.
+
+Subprocess-based, deliberately NOT an in-process ``sys.modules`` check: pytest's own process may
+already have ``tensor_grep.io.directory_scanner`` (and ``tensor_grep.core.config``) loaded via
+unrelated test collection in the same session (e.g. any test module that imports
+``tensor_grep.cli.main``, which uses ``DirectoryScanner`` directly) -- that would make an
+in-process assertion pass trivially regardless of whether bootstrap.py's OWN import graph still
+pulls it in. A fresh subprocess guarantees a clean ``sys.modules`` baseline so this test actually
+exercises what a real cold ``tg --version`` invocation pays for.
+
+Note: ``tensor_grep.cli.runtime_paths`` (``resolve_native_tg_binary`` / ``resolve_ripgrep_binary``
+/ ``env_flag_enabled``) is deliberately NOT deferred and is NOT asserted absent here -- ~90
+existing tests in ``test_cli_bootstrap.py`` do
+``monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", ...)``, which requires that name to
+stay a directly-bound module attribute of ``bootstrap`` (pytest's ``monkeypatch.setattr`` raises
+``AttributeError`` by default when the target attribute does not already exist, and a
+function-local import would create a local binding that silently shadows any monkeypatched
+module attribute instead of being intercepted by it). Deferring it would require rewriting that
+entire mocking contract -- out of scope for this fast-path-import PR.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+# Kept as a single string (not a helper module) so the subprocess starts from a totally clean
+# interpreter state -- no pytest plugins, no already-imported tensor_grep submodules.
+_PROBE_TEMPLATE = """
+import sys
+sys.argv = {argv!r}
+import tensor_grep.cli.bootstrap as bootstrap
+try:
+    bootstrap.main_entry()
+except SystemExit:
+    pass
+import json
+print(json.dumps({{
+    "directory_scanner_loaded": "tensor_grep.io.directory_scanner" in sys.modules,
+    "core_config_loaded": "tensor_grep.core.config" in sys.modules,
+}}))
+"""
+
+
+def _run_fast_path_probe(argv: list[str]) -> dict[str, bool]:
+    probe_source = _PROBE_TEMPLATE.format(argv=argv)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [sys.executable, "-c", probe_source],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"probe subprocess failed (argv={argv!r}): "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # main_entry() may print e.g. the version banner to stdout ahead of our JSON marker line.
+    last_line = result.stdout.strip().splitlines()[-1]
+    return json.loads(last_line)
+
+
+def test_version_fast_path_does_not_import_directory_scanner_or_core_config() -> None:
+    status = _run_fast_path_probe(["tg", "--version"])
+    assert status["directory_scanner_loaded"] is False, (
+        "tg --version must not import tensor_grep.io.directory_scanner -- it is fast-path-unused "
+        "(only the search broad-scan guard needs it) and costs ~25ms including its transitive "
+        "tensor_grep.core.config/dataclasses/inspect pull"
+    )
+    assert status["core_config_loaded"] is False, (
+        "tg --version must not import tensor_grep.core.config (pulled in transitively by "
+        "directory_scanner's `from tensor_grep.core.config import SearchConfig`)"
+    )
+
+
+def test_short_version_flag_fast_path_does_not_import_directory_scanner() -> None:
+    status = _run_fast_path_probe(["tg", "-V"])
+    assert status["directory_scanner_loaded"] is False
+    assert status["core_config_loaded"] is False
+
+
+def test_plain_search_still_imports_directory_scanner_when_actually_needed(
+    tmp_path: Path,
+) -> None:
+    """Non-regression: the deferral must not make the broad-scan guard silently unavailable for
+    a real search invocation. `main_entry`'s `guarded_broad_root` check
+    (`_search_args_include_unbounded_broad_scan`, which needs `directory_scanner`'s constants)
+    runs unconditionally for any search-shaped argv -- BEFORE the native/rg/full-CLI branch
+    decision -- so this must hold regardless of what native/rg binaries happen to be resolvable
+    in the test environment's PATH. Proves this is genuinely "loaded when needed", not
+    "permanently broken"."""
+    status = _run_fast_path_probe(["tg", "search", "needle", str(tmp_path)])
+    assert status["directory_scanner_loaded"] is True

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -36,10 +36,46 @@ def test_vendored_root_dir_names_match_source_of_truth() -> None:
     """Review finding L1 (PR #400): cli/bootstrap.py's front-door vendored-root mirror and
     cli/main.py's `_should_refuse_unbounded_vendored_root_scan` guard must trigger on
     exactly the same set of heavy top-level dir names, or the two front doors (native/rg
-    fast path vs full CLI) can disagree about whether a root is unbounded."""
-    assert (
-        bootstrap._UNBOUNDED_VENDORED_ROOT_DIR_NAMES == cli_main._UNBOUNDED_VENDORED_ROOT_DIR_NAMES
-    ), "bootstrap's vendored-root trigger set must match cli/main.py's exactly"
+    fast path vs full CLI) can disagree about whether a root is unbounded.
+
+    perf/#48: bootstrap.py no longer binds `_UNBOUNDED_VENDORED_ROOT_DIR_NAMES` as a
+    persistent module attribute -- `_search_paths_include_vendored_root` now does its own
+    function-local `from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES`
+    so that heavy import (which transitively pulls in `tensor_grep.core.config` and stdlib
+    `dataclasses`/`inspect`) is not paid by the `tg --version` fast path
+    (`tests/unit/test_bootstrap_fast_path_imports.py` pins that). Structurally this makes
+    bootstrap.py's copy DRIFT-PROOF -- it always re-reads the canonical set fresh, it can no
+    longer hold a stale independent copy -- so this test now (a) checks cli/main.py's own
+    still-module-level copy against the canonical source directly, and (b) behaviorally proves
+    bootstrap's guard function actually consults that same canonical set."""
+    from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+
+    assert cli_main._UNBOUNDED_VENDORED_ROOT_DIR_NAMES == UNBOUNDED_VENDORED_ROOT_DIR_NAMES, (
+        "cli/main.py's vendored-root trigger set must match the canonical source of truth exactly"
+    )
+    assert UNBOUNDED_VENDORED_ROOT_DIR_NAMES, (
+        "canonical set must be non-empty for this test to mean anything"
+    )
+
+
+def test_vendored_root_guard_triggers_on_every_canonical_name(tmp_path: Path) -> None:
+    """Companion behavioral check to the drift test above: bootstrap's front-door guard must
+    fire for a root whose top-level child is ANY name in the canonical
+    `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` set, and must NOT fire for an unrelated child name --
+    proving the perf/#48 function-local import actually wires the guard to the real set rather
+    than silently going stale/empty."""
+    from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+
+    for name in UNBOUNDED_VENDORED_ROOT_DIR_NAMES:
+        root = tmp_path / f"root-{name}"
+        (root / name).mkdir(parents=True)
+        assert bootstrap._search_paths_include_vendored_root([str(root)]) is True, (
+            f"guard must trigger on canonical vendored dir name {name!r}"
+        )
+
+    unrelated_root = tmp_path / "root-unrelated"
+    (unrelated_root / "not_a_vendored_dir").mkdir(parents=True)
+    assert bootstrap._search_paths_include_vendored_root([str(unrelated_root)]) is False
 
 
 def test_typer_app_commands_match_source_of_truth() -> None:


### PR DESCRIPTION
## Summary

- Defers `tensor_grep.io.directory_scanner`'s import in `bootstrap.py` from module-level to
  function-local, so invocations that return before the broad-scan guard stop paying for a
  module they never touch.
- Adds a subprocess-based regression test
  (`tests/unit/test_bootstrap_fast_path_imports.py`) that pins the deferral: red against the
  unmodified module, green after.
- Code-only. No semantic change to `main_entry()`'s routing decisions, the `--deadline` anchor
  logic (#200-B/#648), or any fail-closed behavior — only *when* 4 constants get imported
  changed, never what they resolve to.

## Which invocations actually skip the import (gate-verified scope)

The deferred import is avoided **only** on paths that return *before* the broad-scan guard at
`bootstrap.py:1134`. An independent Opus gate verified the exact boundary:

- **Benefits** (skips `directory_scanner`): `tg --version` / `-V` (SystemExit at
  `bootstrap.py:1076-1078`), and native-dispatch of `run` / `scan` / `test` / `ast-info`
  (returns at `bootstrap.py:1104`, before the guard).
- **Does NOT benefit** (still loads it): `tg --help` / `tg <cmd> --help` (routes to
  `_run_full_cli()` at `bootstrap.py:1080`), and — importantly — **`tg search`** (the broad-scan
  DoS guard at `:1134` runs before native search delegation at `:1147-1162`, so it imports the
  module anyway).

So the win lands on `--version` and the common `run`/`scan`/`test`/`ast-info` native
fast-dispatch, **not** on `search` or `--help`. Extending it to the `search` path would require
reordering the broad-scan guard relative to native delegation — a security-sensitive change (the
guard is the unbounded-walk DoS ceiling, #100/#105), deliberately deferred to a separate design.

## Why `directory_scanner` and not the other candidates named in #48

Read `bootstrap.py` fully (`main_entry` + every fast-path branch) before touching anything, per
this repo's verify-against-code discipline. For each candidate:

| Import | Reachable only after the broad-scan guard (deferrable)? | Deferred? |
|---|---|---|
| `tensor_grep.io.directory_scanner` (4 constants) | Yes — only inside the 3 broad-scan guard helpers (`_path_has_project_marker`, `_search_paths_include_workspace_root`, `_search_paths_include_vendored_root`), reachable only from an actual search invocation | **Yes** |
| `tensor_grep.cli.runtime_paths` (`resolve_native_tg_binary`, `resolve_ripgrep_binary`, `env_flag_enabled`) | No — and ~90 existing tests in `test_cli_bootstrap.py` do `monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", ...)` | **No** — see below |
| `tensor_grep.cli.commands` (`KNOWN_COMMANDS`, `PYTHON_FULL_HELP_COMMANDS`) | No — it *is* the KNOWN_COMMANDS routing decision itself | No (also free: 0 imports of its own) |
| `tensor_grep.cli.subprocess_policy` (`run_subprocess`) | No | No — `_ORIG_RUN_SUBPROCESS = run_subprocess` executes at true module-load time (bootstrap.py:27) |
| stdlib `os`/`re`/`subprocess`/`sys`/`time`/`pathlib.Path` | Needed early (`subprocess`/`sys` for native dispatch; `Path` for `_print_version`'s fallback) | No — not flagged by the diagnosis; `re`'s ~7ms cost is already sunk by `tensor_grep/__init__.py`'s own transitive `typing` import, which runs before bootstrap.py's body even starts (a much broader change, out of scope) |

**The `runtime_paths` blocker, precisely:** a function-local `from tensor_grep.cli.runtime_paths
import resolve_native_tg_binary` inside `main_entry()` creates a *local* binding in that
function's scope. It does not consult `bootstrap.__dict__`, so
`monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: ...)` would either raise
`AttributeError` (the attribute would no longer exist on the module) or be silently shadowed by
the fresh local import — either way breaking ~90 test call sites' mocking contract (53 of them
directly `setattr(bootstrap, "resolve_native_tg_binary", ...)`, per the gate). This means #48's
~12ms `runtime_paths` share of the import tax is **not** closed by this PR.

## Before/after evidence

`python -X importtime -c "import tensor_grep.cli.bootstrap"`, warm cache, 3 runs each,
`.venv` Python 3.12.12, `PYTHONPATH=<worktree>/src`:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before (origin/main) | 77730 us | 78110 us | 78143 us | **~78.1 ms** |
| after (this branch)  | 61934 us | 60077 us | 58559/56364 us | **~59.3 ms** |

**Delta: ~18.8ms (~24%) off the total `import tensor_grep.cli.bootstrap` cost**, and the
deferred subtree (`tensor_grep.io.directory_scanner` → `tensor_grep.core.config` →
`dataclasses` → `inspect`/`ast`/`dis`/`tokenize`/`copy`/`weakref`) is now **completely absent**
from a bare `import tensor_grep.cli.bootstrap` trace (0 occurrences; confirmed via grep on the
full trace).

Real end-to-end `tg --version` wall-clock (subprocess spawn + full import + execute, 8 runs
each, same machine/interpreter) — noisier (Windows process-spawn/AV overhead dominates, ~90ms
run-to-run spread) but directionally consistent:
- before: median 278.9ms, min 236.8ms
- after: median 235.0ms, min 193.9ms
- delta: ~43ms median, ~43ms min

The `-X importtime` number is the more reliable one (isolates import cost from OS process-spawn
noise); both point the same direction and are in the diagnosed "~30-50ms import tax" ballpark.

## No semantic change / claim-update is CEO-gated & out of scope

Per the task brief: this PR does not touch any README/docs speed numbers or claims — #48's
speed-claim update is CEO-gated and out of scope. This PR is code + tests only.

## Closes #48?

**NO — partial win.** This closes the `directory_scanner`/`core.config`/`dataclasses`/`inspect`
share of the diagnosed tax (~19–25ms of the module-import cost) for the `--version` and
`run`/`scan` native-dispatch paths, but not: the `runtime_paths` share (~12ms, blocked by the
monkeypatch contract above), the `search`/`--help` paths (still hit the broad-scan guard), or
the underlying **Python-interpreter startup floor** (~30-40ms of `site`/`encodings`/venv
activation visible at the top of every trace, before `tensor_grep` is even reached). That floor
bounds how close a Python console-entry shim can get to `rg`'s ~7ms native-binary start,
regardless of how many tensor_grep-side imports are deferred — closing that gap is the separate
"native front door" architectural question.

## Verification (independently Opus-gated: SHIP-WITH-NITS, all 6 falsification checks cleared)

- `tests/unit/test_bootstrap_fast_path_imports.py` (new): red against unmodified bootstrap.py,
  green after. Gate confirmed **non-vacuous** by revert-to-prove (restoring the module-level
  import flips the test to FAIL).
- `test_cli_bootstrap.py`: 78 passed (the one modified test,
  `test_vendored_root_dir_names_match_source_of_truth`, was made **stronger** — it now pins to
  the canonical `directory_scanner` source directly + adds a non-empty guard + a behavioral
  companion).
- Files importing `bootstrap` directly: all pass except one **pre-existing, confirmed-unrelated**
  failure (`test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`, GPU device-inventory
  in `cli/main.py` — reproduced identically on unmodified `origin/main` via `git stash`;
  CliRunner-based, bypasses bootstrap).
- `--deadline` anchor tests re-run: 100/100 passed; the gate confirmed the anchor logic
  (`bootstrap.py:971-977`) and `main_entry` (`1073-1182`) are **untouched** by the diff.
- `ruff format --preview` + `ruff check` clean on all 3 changed files.
- Rust NOT compiled (Python-only worktree); relying on CI's ubuntu/macos/windows `test-python`
  matrix for native-binary-dependent paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
