### PR TITLE
fix(agent): stderr note distinguishing a trustworthy deadline-partial from a genuine incomplete

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9361,6 +9361,14 @@ def _agent_trustworthy_deadline_partial_note(payload: dict[str, Any]) -> str | N
     A genuine needs-attention exit-2 -- ``ask_user_before_editing.required`` true, low confidence,
     or a non-deadline partial -- gets no note and keeps reading as needs-attention, unchanged.
 
+    Fail-safe on a malformed capsule (independent-gate nit): a present-but-non-dict
+    ``confidence``/``ask_user_before_editing``, or a bool/non-numeric ``confidence.overall``
+    (bool subclasses int and would otherwise coerce to 1.0), suppresses the note (returns
+    ``None``) rather than raising -- matching the ``scan_limit``/``caller_scan_limit``
+    ``isinstance`` guards below. Unreachable from ``build_agent_capsule_from_map``'s
+    single-return output (it always emits dict-shaped ``confidence``/``ask_user_before_editing``),
+    but an advisory helper must never be what crashes an exit-2 path.
+
     Additive/advisory only: never changes the exit code, the stdout JSON, or the capsule schema --
     called only at the two existing ``raise typer.Exit(2)`` sites inside ``agent()``, stderr-only.
     """
@@ -9374,10 +9382,16 @@ def _agent_trustworthy_deadline_partial_note(payload: dict[str, Any]) -> str | N
             return None
     if payload.get("caller_scan_truncated"):
         return None
-    if bool(payload.get("ask_user_before_editing", {}).get("required")):
+    ask_user_before_editing = payload.get("ask_user_before_editing", {})
+    if not isinstance(ask_user_before_editing, dict):
         return None
-    overall = payload.get("confidence", {}).get("overall")
-    if not isinstance(overall, (int, float)):
+    if bool(ask_user_before_editing.get("required")):
+        return None
+    confidence = payload.get("confidence", {})
+    if not isinstance(confidence, dict):
+        return None
+    overall = confidence.get("overall")
+    if isinstance(overall, bool) or not isinstance(overall, (int, float)):
         return None
 
     from tensor_grep.cli.agent_capsule import _capsule_low_confidence_ask_reason

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9328,6 +9328,69 @@ def context_render(
         raise typer.Exit(2)
 
 
+# v1.81.6 dogfood finding #1 (CEO-relayed, both dogfood reports flagged it as the #1 agent
+# confusion): `tg agent --deadline N` can exit 2 with `partial: true` / a deadline-type
+# `partial_reason` while `confidence.overall` is high and `ask_user_before_editing.required` is
+# false -- a genuinely USABLE answer that merely stopped collecting SECONDARY evidence (the
+# call-site rescue scan / outbound-dependency preview / the final wall-clock backstop in
+# `agent_capsule.build_agent_capsule_from_map`, all AFTER the primary-target ranking/render already
+# completed) before the deadline. An agent keying on the exit code alone misreads this as a hard
+# failure. `tg agent` is scoped ONLY here (not `edit-plan`/`map`/`context-render`/`blast-radius`,
+# which share `_scan_incomplete` but not this stderr note) per the finding's exact ask.
+_AGENT_DEADLINE_PARTIAL_REASONS = frozenset({"deadline", "deadline_exceeded"})
+
+
+def _agent_trustworthy_deadline_partial_note(payload: dict[str, Any]) -> str | None:
+    """Return a one-line ASCII stderr note when (and ONLY when) `tg agent`'s exit-2 is caused
+    SOLELY by a trustworthy `--deadline` cutoff, else ``None``.
+
+    "Solely" means every one of these holds against the SAME capsule that is about to exit 2:
+      * ``partial`` is true with a deadline-type ``partial_reason`` (``deadline``/
+        ``deadline_exceeded``) -- a `--deadline` cutoff, not some other truncation.
+      * Neither ``scan_limit`` nor ``caller_scan_limit`` is ``possibly_truncated``, and
+        ``caller_scan_truncated`` is not set -- a genuine scan-coverage gap (the repo-file-count
+        ceiling or the caller-scan file ceiling) is a DIFFERENT, non-deadline truncation vector
+        even when it happens to coincide with a deadline hit, so it must never read as
+        "trustworthy" -- this stays silent (returns ``None``) and the plain exit-2 stands.
+      * ``ask_user_before_editing.required`` is false -- the capsule itself never asked for
+        confirmation.
+      * ``confidence.overall`` is at/above the capsule's own confident threshold, reusing
+        ``agent_capsule._capsule_low_confidence_ask_reason`` (currently 0.75) rather than a
+        second hardcoded cutoff that could silently drift from the real ask-gate.
+
+    A genuine needs-attention exit-2 -- ``ask_user_before_editing.required`` true, low confidence,
+    or a non-deadline partial -- gets no note and keeps reading as needs-attention, unchanged.
+
+    Additive/advisory only: never changes the exit code, the stdout JSON, or the capsule schema --
+    called only at the two existing ``raise typer.Exit(2)`` sites inside ``agent()``, stderr-only.
+    """
+    if not payload.get("partial"):
+        return None
+    if payload.get("partial_reason") not in _AGENT_DEADLINE_PARTIAL_REASONS:
+        return None
+    for key in ("scan_limit", "caller_scan_limit"):
+        limit = payload.get(key)
+        if isinstance(limit, dict) and limit.get("possibly_truncated"):
+            return None
+    if payload.get("caller_scan_truncated"):
+        return None
+    if bool(payload.get("ask_user_before_editing", {}).get("required")):
+        return None
+    overall = payload.get("confidence", {}).get("overall")
+    if not isinstance(overall, (int, float)):
+        return None
+
+    from tensor_grep.cli.agent_capsule import _capsule_low_confidence_ask_reason
+
+    if _capsule_low_confidence_ask_reason(float(overall)) is not None:
+        return None
+    return (
+        f"note: partial result -- stopped at the --deadline (confidence {float(overall):.2f}, "
+        "no ask required); the answer is usable. Re-run with a larger --deadline for full "
+        "coverage."
+    )
+
+
 @app.command(name="agent")
 def agent(
     path: str = typer.Argument(".", help="File or directory to inventory"),
@@ -9488,6 +9551,9 @@ def agent(
                 if gpu_device_ids:
                     typer.echo(f"gpu_acceleration={gpu_acceleration.get('status', 'unknown')}")
             if _scan_incomplete(daemon_payload):
+                deadline_partial_note = _agent_trustworthy_deadline_partial_note(daemon_payload)
+                if deadline_partial_note is not None:
+                    typer.echo(deadline_partial_note, err=True)
                 raise typer.Exit(2)
             return
 
@@ -9568,6 +9634,9 @@ def agent(
             typer.echo(f"gpu_acceleration={gpu_acceleration.get('status', 'unknown')}")
 
     if _scan_incomplete(payload):
+        deadline_partial_note = _agent_trustworthy_deadline_partial_note(payload)
+        if deadline_partial_note is not None:
+            typer.echo(deadline_partial_note, err=True)
         raise typer.Exit(2)
 
 

--- a/tests/unit/test_agent_deadline_partial_stderr.py
+++ b/tests/unit/test_agent_deadline_partial_stderr.py
@@ -1,0 +1,328 @@
+"""TDD for the v1.81.6 dogfood finding #1 (CEO-relayed, both dogfood reports flagged it as the
+#1 agent confusion): `tg agent <path> --deadline N` can exit 2 with `partial: true` / a
+deadline-type `partial_reason` while `confidence.overall` is high (e.g. 0.9) and
+`ask_user_before_editing.required` is false -- a genuinely USABLE answer that merely got
+truncated collecting SECONDARY evidence after the deadline, not a real failure. Agents keying on
+the exit code alone misread this as a hard failure.
+
+The fix (`main._agent_trustworthy_deadline_partial_note`, wired at both `raise typer.Exit(2)`
+sites inside `main.agent`) is additive/advisory-only: it never changes the exit code (stays 2),
+never changes the stdout JSON, and never changes the capsule schema -- it only ever adds ONE
+stderr line, and ONLY when the exit-2 is caused solely by a trustworthy deadline-partial. A
+genuine needs-attention exit-2 (ask required, low confidence, or a non-deadline partial such as a
+`scan_limit`/`caller_scan_limit` possibly-truncated cap) must get no note and keep reading as
+needs-attention, unchanged.
+
+Two layers of coverage:
+  * Direct unit tests of the pure predicate (`_agent_trustworthy_deadline_partial_note`) -- fast,
+    precise pins of every branch, mirroring how `test_render_daemon_exit_codes.py` unit-tests the
+    sibling `_scan_incomplete` gate directly.
+  * CliRunner end-to-end tests through both `tg agent` exit-2 call sites (the cold path via a
+    monkeypatched `agent_capsule.build_agent_capsule`, and the warm-daemon path via a
+    monkeypatched `main._maybe_agent_via_running_daemon`) -- proving the note actually reaches
+    stderr (not stdout) at the real CLI boundary, and that stdout JSON is byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+import tensor_grep.cli.agent_capsule as agent_capsule
+import tensor_grep.cli.main as main
+from tensor_grep.cli.main import _agent_trustworthy_deadline_partial_note, app
+
+runner = CliRunner()
+
+
+def _trustworthy_deadline_partial_capsule(
+    path: Path | str, query: str, *, overall: float = 0.9
+) -> dict[str, Any]:
+    """A capsule shaped like a real `build_agent_capsule_from_map` result (agent_capsule.py
+    :2860-2947): a deadline cutoff hit AFTER the primary-target ranking/render already completed
+    (e.g. the call-site rescue scan or the final wall-clock backstop), so confidence is high and
+    no confirmation was required -- the "genuinely usable" case this fix targets."""
+    return {
+        "capsule_version": 1,
+        "path": str(path),
+        "query": query,
+        "primary_target": {"file": "m.py", "line": 1, "symbol": "f", "confidence": overall},
+        "alternative_targets": [],
+        "confidence": {"overall": overall, "downgrade_reasons": []},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "ambiguity": {"status": "none", "requires_confirmation": False},
+        "context_consistency": {},
+        "validation_commands": [],
+        "partial": True,
+        "partial_reason": "deadline",
+        "deadline_limit": {"deadline_exceeded": True},
+    }
+
+
+# ==================================================================================================
+# Layer 1: direct unit tests of the pure predicate.
+# ==================================================================================================
+
+
+def test_note_present_on_trustworthy_deadline_partial() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q", overall=0.9)
+    note = _agent_trustworthy_deadline_partial_note(payload)
+    assert note is not None
+    assert note.startswith("note:")
+    assert "--deadline" in note
+    assert "0.90" in note
+    assert "usable" in note
+    assert note.isascii(), "CLI-rendered stderr text must stay ASCII-only (cp1252 console rule)"
+
+
+def test_note_present_on_deadline_exceeded_reason_variant() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["partial_reason"] = "deadline_exceeded"
+    assert _agent_trustworthy_deadline_partial_note(payload) is not None
+
+
+def test_note_absent_when_not_partial() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["partial"] = False
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_on_ask_required() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["ask_user_before_editing"] = {
+        "required": True,
+        "reasons": ["primary target is ambiguous"],
+    }
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_on_low_confidence() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q", overall=0.5)
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_just_below_confidence_threshold() -> None:
+    # Mirrors agent_capsule._capsule_low_confidence_ask_reason's own "< 0.75" cutoff exactly, by
+    # calling through that real helper rather than a second hardcoded literal -- this pins the
+    # boundary without risking drift between the two thresholds.
+    payload = _trustworthy_deadline_partial_capsule("p", "q", overall=0.749)
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_present_exactly_at_confidence_threshold() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q", overall=0.75)
+    assert _agent_trustworthy_deadline_partial_note(payload) is not None
+
+
+def test_note_absent_on_non_deadline_partial_reason() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["partial_reason"] = "self_verify"
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_on_missing_partial_reason() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    del payload["partial_reason"]
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_on_scan_limit_truncation_only() -> None:
+    """A `--max-repo-files` scan-coverage cap, no deadline at all -- the genuine "the scan did
+    not cover the whole repo" case the finding says must keep reading as needs-attention."""
+    payload = {
+        "path": "p",
+        "query": "q",
+        "confidence": {"overall": 0.9},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "scan_limit": {"possibly_truncated": True, "files_scanned": 100, "files_total": 500},
+    }
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_on_caller_scan_limit_truncation_only() -> None:
+    payload = {
+        "path": "p",
+        "query": "q",
+        "confidence": {"overall": 0.9},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "caller_scan_limit": {"possibly_truncated": True},
+    }
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_on_caller_scan_truncated_flag() -> None:
+    payload = {
+        "path": "p",
+        "query": "q",
+        "confidence": {"overall": 0.9},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "caller_scan_truncated": True,
+    }
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_when_deadline_partial_combined_with_scan_limit_truncation() -> None:
+    """ "Solely" semantics: a deadline-partial that ALSO carries a scan_limit possibly_truncated
+    cap is a compound truncation, not a solely-trustworthy deadline-partial -- must stay silent
+    even though `partial`/`partial_reason` alone would otherwise qualify."""
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["scan_limit"] = {"possibly_truncated": True, "files_scanned": 10, "files_total": 999}
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_when_confidence_missing() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    del payload["confidence"]
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_absent_when_confidence_overall_not_numeric() -> None:
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["confidence"] = {"overall": "unknown"}
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+# ==================================================================================================
+# Layer 2: CliRunner end-to-end, cold path (`build_agent_capsule` monkeypatched).
+# ==================================================================================================
+
+
+def _stub_cold_path(monkeypatch, payload: dict[str, Any]) -> None:
+    """Force the cold path deterministically regardless of the local TG_SESSION_DAEMON_AUTOSTART
+    default: a clean daemon "miss" plus a fixed `build_agent_capsule` return, mirroring
+    test_cli_deadline_coverage_gaps.py's `_agent_cold_spy` pattern."""
+    monkeypatch.setattr(main, "_maybe_agent_via_running_daemon", lambda **kwargs: None)
+    monkeypatch.setattr(agent_capsule, "build_agent_capsule", lambda *a, **k: payload)
+
+
+def test_cli_agent_cold_path_trustworthy_deadline_partial_emits_stderr_note(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = _trustworthy_deadline_partial_capsule(tmp_path, "f")
+    _stub_cold_path(monkeypatch, payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert "note: partial result" in result.stderr
+    assert "--deadline" in result.stderr
+    assert "0.90" in result.stderr
+    # stdout JSON is byte-for-byte the untouched capsule -- the note is stderr-only.
+    assert json.loads(result.stdout) == payload
+    assert "note:" not in result.stdout
+
+
+def test_cli_agent_cold_path_ask_required_suppresses_note(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = _trustworthy_deadline_partial_capsule(tmp_path, "f")
+    payload["ask_user_before_editing"] = {
+        "required": True,
+        "reasons": ["alternative target confidence ties primary target"],
+    }
+    _stub_cold_path(monkeypatch, payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == payload
+
+
+def test_cli_agent_cold_path_low_confidence_suppresses_note(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = _trustworthy_deadline_partial_capsule(tmp_path, "f", overall=0.55)
+    _stub_cold_path(monkeypatch, payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == payload
+
+
+def test_cli_agent_cold_path_non_deadline_partial_suppresses_note(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A `--max-repo-files` scan-coverage cap (no --deadline involved at all) must still exit 2
+    via `_scan_incomplete`'s `scan_limit` branch, but get no trustworthy-deadline note."""
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = {
+        "path": str(tmp_path),
+        "query": "f",
+        "primary_target": {"file": "m.py", "line": 1, "symbol": "f", "confidence": 0.9},
+        "alternative_targets": [],
+        "confidence": {"overall": 0.9},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "ambiguity": {"status": "none"},
+        "context_consistency": {},
+        "validation_commands": [],
+        "scan_limit": {"possibly_truncated": True, "files_scanned": 3, "files_total": 3000},
+    }
+    _stub_cold_path(monkeypatch, payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == payload
+
+
+def test_cli_agent_cold_path_complete_result_no_note_no_exit2(tmp_path: Path, monkeypatch) -> None:
+    """Sanity/regression guard: a COMPLETE (non-truncated) capsule must stay exit 0 with no
+    stderr note at all -- the fix must never touch the untruncated happy path."""
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = {
+        "path": str(tmp_path),
+        "query": "f",
+        "primary_target": {"file": "m.py", "line": 1, "symbol": "f", "confidence": 0.9},
+        "alternative_targets": [],
+        "confidence": {"overall": 0.9},
+        "ask_user_before_editing": {"required": False, "reasons": []},
+        "ambiguity": {"status": "none"},
+        "context_consistency": {},
+        "validation_commands": [],
+    }
+    _stub_cold_path(monkeypatch, payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == payload
+
+
+# ==================================================================================================
+# Layer 2b: CliRunner end-to-end, warm-daemon path (`_maybe_agent_via_running_daemon`
+# monkeypatched directly -- exercises the OTHER `raise typer.Exit(2)` site this fix touches).
+# ==================================================================================================
+
+
+def test_cli_agent_daemon_path_trustworthy_deadline_partial_emits_stderr_note(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = _trustworthy_deadline_partial_capsule(tmp_path, "f")
+    monkeypatch.setattr(main, "_maybe_agent_via_running_daemon", lambda **kwargs: payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert "note: partial result" in result.stderr
+    assert json.loads(result.stdout) == payload
+
+
+def test_cli_agent_daemon_path_ask_required_suppresses_note(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    payload = _trustworthy_deadline_partial_capsule(tmp_path, "f")
+    payload["ask_user_before_editing"] = {"required": True, "reasons": ["no snippets included"]}
+    monkeypatch.setattr(main, "_maybe_agent_via_running_daemon", lambda **kwargs: payload)
+
+    result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+    assert result.exit_code == 2, result.output
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == payload

--- a/tests/unit/test_agent_deadline_partial_stderr.py
+++ b/tests/unit/test_agent_deadline_partial_stderr.py
@@ -185,6 +185,33 @@ def test_note_absent_when_confidence_overall_not_numeric() -> None:
     assert _agent_trustworthy_deadline_partial_note(payload) is None
 
 
+def test_note_fail_safe_on_present_but_non_dict_confidence() -> None:
+    """Independent-gate nit: a malformed capsule with `confidence` present but NOT a dict must
+    fail SAFE -- suppress the note (return None), never raise -- matching the helper's own
+    scan_limit/caller_scan_limit isinstance guards. Unreachable from the real builder
+    (`build_agent_capsule_from_map`'s single return always emits a dict `confidence`), pinned so
+    this advisory helper can never be what crashes an exit-2 path on a weird capsule."""
+    for malformed in (None, 0.9, "high", [0.9], True):
+        payload = _trustworthy_deadline_partial_capsule("p", "q")
+        payload["confidence"] = malformed
+        assert _agent_trustworthy_deadline_partial_note(payload) is None, repr(malformed)
+    # bool subclasses int: a bare isinstance(overall, (int, float)) would coerce True -> 1.0 and
+    # emit "confidence 1.00" for a malformed capsule -- reject bools cleanly instead.
+    payload = _trustworthy_deadline_partial_capsule("p", "q")
+    payload["confidence"] = {"overall": True}
+    assert _agent_trustworthy_deadline_partial_note(payload) is None
+
+
+def test_note_fail_safe_on_present_but_non_dict_ask_user_before_editing() -> None:
+    """Same fail-safe pin for `ask_user_before_editing`: present-but-non-dict suppresses the note
+    instead of raising AttributeError. (An ABSENT key still reads as "no ask required" -- that
+    pre-nit semantic is deliberately unchanged.)"""
+    for malformed in (None, True, [], "x", 1):
+        payload = _trustworthy_deadline_partial_capsule("p", "q")
+        payload["ask_user_before_editing"] = malformed
+        assert _agent_trustworthy_deadline_partial_note(payload) is None, repr(malformed)
+
+
 # ==================================================================================================
 # Layer 2: CliRunner end-to-end, cold path (`build_agent_capsule` monkeypatched).
 # ==================================================================================================
@@ -293,6 +320,26 @@ def test_cli_agent_cold_path_complete_result_no_note_no_exit2(tmp_path: Path, mo
     assert result.exit_code == 0, result.output
     assert result.stderr == ""
     assert json.loads(result.stdout) == payload
+
+
+def test_cli_agent_cold_path_malformed_capsule_fail_safe_no_note_no_crash(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Independent-gate nit, CLI boundary: a malformed capsule (present-but-non-dict
+    `confidence` or `ask_user_before_editing`) reaching the exit-2 gate must not crash the CLI
+    and must get no note -- exit code stays 2, stdout JSON byte-unchanged, stderr empty. (A
+    helper AttributeError here would surface as exit 1 with a traceback, breaking both pins.)"""
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    for field, malformed in (("confidence", 0.9), ("ask_user_before_editing", True)):
+        payload = _trustworthy_deadline_partial_capsule(tmp_path, "f")
+        payload[field] = malformed
+        _stub_cold_path(monkeypatch, payload)
+
+        result = runner.invoke(app, ["agent", str(tmp_path), "f", "--json"])
+
+        assert result.exit_code == 2, (field, result.output)
+        assert result.stderr == "", field
+        assert json.loads(result.stdout) == payload
 
 
 # ==================================================================================================


### PR DESCRIPTION
## Finding (v1.81.6 dogfood, CEO-relayed -- #1 agent confusion in both reports)

`tg agent <path> --deadline N` can exit **2** with `partial: true` / `partial_reason` indicating
a deadline stop, **while** `confidence.overall` is high (e.g. 0.9) and `ask.required`
(`ask_user_before_editing.required`) is false. Agents keying on the exit code alone misread this
"deadline-partial but trustworthy" result as a failure -- it's actually a usable answer that was
merely truncated collecting *secondary* evidence after the deadline. The genuinely-incomplete
case (`ask.required: true`, low confidence, or a non-deadline partial) must keep reading as
needs-attention.

The JSON already distinguishes these two cases (`partial`, `partial_reason`, `deadline_limit`,
`confidence.overall`, `ask_user_before_editing.required`), so this PR does **not** touch the exit
code or the JSON schema -- the gap was that there's no human/log-visible signal. The dogfood
report explicitly endorsed "clearer stderr" as the fix.

## The fix

One additive stderr line, emitted at both `raise typer.Exit(2)` sites inside `main.agent`:

```
note: partial result -- stopped at the --deadline (confidence 0.90, no ask required); the answer
is usable. Re-run with a larger --deadline for full coverage.
```

### Hook sites (verified against real code, not guessed)

- `src/tensor_grep/cli/main.py:9395` -- `def agent(...)`, the `tg agent` command body.
- `src/tensor_grep/cli/main.py:9551-9558` -- the **warm-daemon** exit-2 site (`if
  _scan_incomplete(daemon_payload): ... raise typer.Exit(2)`), now calls the new helper on
  `daemon_payload` first.
- `src/tensor_grep/cli/main.py:9634-9640` -- the **cold-path** exit-2 site (`if
  _scan_incomplete(payload): ... raise typer.Exit(2)`), now calls the new helper on `payload`
  first.
- `src/tensor_grep/cli/main.py:9331-9390` -- the new helper itself,
  `_agent_trustworthy_deadline_partial_note(payload) -> str | None`, placed directly above the
  `agent()` command it exclusively serves.

Both call sites feed the SAME capsule dict that is about to be JSON-dumped to stdout (the daemon
payload and the cold-build `payload`, respectively) -- the exact dict whose real field names were
confirmed by reading `agent_capsule.build_agent_capsule_from_map`'s final assembly
(`src/tensor_grep/cli/agent_capsule.py:2860-2947`).

### Fields used (real names, confirmed by reading the capsule builder -- not guessed)

| Field | Path in payload | Source |
|---|---|---|
| Deadline-partial flag | `payload["partial"]` | `agent_capsule.py:2940` |
| Deadline-partial reason | `payload["partial_reason"]` (only ever literal `"deadline"` today for `tg agent`; `"deadline_exceeded"` accepted defensively) | `agent_capsule.py:2941` |
| Scan-coverage truncation (must be ABSENT for the note to fire) | `payload["scan_limit"]["possibly_truncated"]` / `payload["caller_scan_limit"]["possibly_truncated"]` / `payload["caller_scan_truncated"]` | `main.py:_scan_incomplete`, `agent_capsule.py:2913-2917` |
| Ask-gate | `payload["ask_user_before_editing"]["required"]` (**not** `ask.required` -- the real top-level key is `ask_user_before_editing`) | `agent_capsule.py:2899-2902` |
| Confidence | `payload["confidence"]["overall"]` | `agent_capsule.py:2898` |
| Confident threshold | reused live from `agent_capsule._capsule_low_confidence_ask_reason` (currently `< 0.75`) instead of a second hardcoded literal that could drift from the real ask-gate | `agent_capsule.py:1862-1867` |

### "Solely" semantics (the important correctness edge)

A deadline-partial capsule that **also** carries a `scan_limit`/`caller_scan_limit`
`possibly_truncated` cap is a *compound* truncation (a real scan-coverage gap coinciding with a
deadline hit), not a *solely*-trustworthy deadline-partial -- the note stays silent in that case
even though `partial`/`partial_reason` alone would otherwise qualify. Pinned by
`test_note_absent_when_deadline_partial_combined_with_scan_limit_truncation`.

### Contract guarantees

- **Exit code unchanged**: always still `raise typer.Exit(2)` -- the note is emitted (or not)
  strictly before the raise, never replaces or short-circuits it.
- **stdout JSON unchanged**: the note is written via `typer.echo(note, err=True)` -- stderr only,
  never touches the `json.dumps(payload, ...)` call already there.
- **Capsule schema unchanged**: no new keys added to the capsule dict itself.
- **Scoped to `tg agent` only**, per the finding's exact ask -- `edit-plan`/`map`/
  `context-render`/`blast-radius` share the same `_scan_incomplete` gate but are deliberately left
  untouched.

### Before / after

**Before** (agent sees only):
```
$ tg agent . "some query" --deadline 3 --json
{...capsule json, partial: true, partial_reason: "deadline", confidence.overall: 0.9,
 ask_user_before_editing.required: false...}
$ echo $?
2
```
Nothing on stderr -- an agent branching on exit code alone treats this as a hard failure and may
retry, escalate, or ask the user unnecessarily, even though the JSON already told the whole story.

**After** (same JSON/exit code, plus one stderr line):
```
$ tg agent . "some query" --deadline 3 --json
{...byte-identical capsule json...}
$ echo $?
2
```
stderr now carries:
```
note: partial result -- stopped at the --deadline (confidence 0.90, no ask required); the answer
is usable. Re-run with a larger --deadline for full coverage.
```

A genuinely incomplete result (ask required / low confidence / non-deadline partial) gets **no**
stderr note -- unchanged from today.

## Test plan

- [x] TDD: `tests/unit/test_agent_deadline_partial_stderr.py` written first, confirmed **RED**
      (`ImportError`) against pre-fix code via `git stash`, then **GREEN** after the fix -- 22
      tests: 14 direct predicate unit tests (every branch: deadline vs `deadline_exceeded`,
      not-partial, ask-required, low-confidence, exactly-at/just-below the 0.75 threshold,
      non-deadline `partial_reason`, missing `partial_reason`, `scan_limit`-only,
      `caller_scan_limit`-only, `caller_scan_truncated`-only, the combined "solely" edge,
      missing/non-numeric confidence) + 8 CliRunner end-to-end tests across both the cold path
      and the warm-daemon path (note present + stdout-JSON-unchanged; note suppressed on
      ask-required / low-confidence / non-deadline-partial; untruncated happy path stays exit 0
      with no note).
- [x] Existing agent/deadline/exit-code battery: 418 tests across
      `test_agent_capsule_*`, `test_agent_*`, `test_cli_deadline_*`, `test_orient_agent_daemon`,
      `test_refs_context_pack_deadline_205`, `test_render_daemon_exit_codes`,
      `test_repo_map_deadline`, `test_rg_exit2_partial`, `test_session_daemon_default_deadline` --
      all green, no regressions.
- [x] `test_main_cli_contracts.py` (49 tests, incl. the `_scan_incomplete`
      cross-module-parity pin) -- green.
- [x] `ruff format --preview` + `ruff check` on both changed files -- clean (format
      auto-fixed one line-wrap in the new test file before commit).
- [x] Verified interpreter resolves `tensor_grep.__file__` into this worktree's `src/`
      before trusting any result (stale-venv trap).
- [ ] Rust **not** recompiled -- Python-only change, CI compiles the native asset.

Draft -- not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
