### PR TITLE
fix(symbols): thread the stage-1 defs-scan deadline through all 6 symbol builders + cold wrappers (audit C1/C2)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -14630,10 +14630,39 @@ def build_symbol_defs(
     payload = build_repo_map(
         path, max_repo_files=max_repo_files, deadline_monotonic=deadline_monotonic
     )
+    # audit C1/C2: this call used to be BARE, dropping the deadline entirely --
+    # build_symbol_defs_from_map's OWN internal _relevant_tests_for_symbol scan (repo_map.py:3812)
+    # already accepts deadline_monotonic (#203), it just never received one from here, so a `tg
+    # defs --deadline N` request ran that stage-1 scan fully unbounded (dogfood: `--deadline 40`
+    # -> 113.5s, exit 0, partial:null). main.py's daemon gate skips the warm fast path whenever
+    # --deadline is set, so THIS cold wrapper is the only path an explicit-deadline caller exercises.
     result = build_symbol_defs_from_map(
-        payload, symbol, semantic_provider=semantic_provider, max_tests=max_tests
+        payload,
+        symbol,
+        semantic_provider=semantic_provider,
+        max_tests=max_tests,
+        deadline_monotonic=deadline_monotonic,
     )
     _copy_partial_signal(result, payload)
+    # C1 defense-in-depth: mirrors build_context_pack's #642-style return-time backstop
+    # (repo_map.py:8380-8392) -- a final absolute wall-clock recheck so ANY stage inside
+    # build_symbol_defs_from_map (instrumented or not) can never silently return exit 0 once the
+    # caller's --deadline budget is gone, regardless of which internal loop actually consumed the
+    # time. Does NOT set `partial_reason` -- that field is reserved for the
+    # agent/context/context-render/edit-plan family (docs/CONTRACTS.md); the symbol commands'
+    # existing convention (impact/refs/callers/blast-radius fold-ins above) is partial +
+    # deadline_limit only.
+    deadline_exceeded_at_return = (
+        deadline_monotonic is not None and time.monotonic() >= deadline_monotonic
+    )
+    if result.get("partial") or deadline_exceeded_at_return:
+        result["partial"] = True
+        existing_deadline_limit = result.get("deadline_limit")
+        result["deadline_limit"] = (
+            dict(existing_deadline_limit)
+            if isinstance(existing_deadline_limit, dict)
+            else {"deadline_exceeded": True}
+        )
     return result
 
 
@@ -14845,10 +14874,15 @@ def build_symbol_source(
         deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
     )
+    # audit C1/C2: thread the same deadline into the _from_map core -- previously
+    # dropped here even though build_symbol_source already computed it (dogfood: `tg source
+    # --deadline` overran by 47.0s). build_symbol_source_from_map gains deadline_monotonic below
+    # (site 6); this cold wrapper is site 7.
     result = build_symbol_source_from_map(
         repo_map,
         symbol,
         semantic_provider=semantic_provider,
+        deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
     )
     _copy_partial_signal(result, repo_map)
@@ -14860,9 +14894,19 @@ def build_symbol_source_from_map(
     symbol: str,
     *,
     semantic_provider: str = "native",
+    deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
-    defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
+    # audit C1/C2: `deadline_monotonic` is a NEW parameter here (site 6) -- this
+    # function previously had no deadline awareness at all, so its bare build_symbol_defs_from_map
+    # call below silently ran the stage-1 related-tests scan unbounded regardless of any caller's
+    # --deadline. Defaults to None -> byte-identical for every pre-existing call site that does not
+    # pass it (mirrors the documented _iter_repo_files convention, repo_map.py:993-998).
+    # `_copy_partial_signal(payload, defs_payload)` below already folds defs_payload's partial
+    # signal into this function's own fresh envelope, so threading the deadline is the whole fix.
+    defs_payload = build_symbol_defs_from_map(
+        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+    )
     default_agreement, default_status = _default_provider_metadata(
         Path(str(repo_map["path"])).resolve(),
         repo_map,
@@ -14976,7 +15020,15 @@ def build_symbol_impact_from_map(
     max_tests: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
-    defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
+    # audit C1/C2: this call used to be BARE, dropping the deadline this function
+    # itself received -- build_symbol_defs_from_map's OWN internal _relevant_tests_for_symbol
+    # scan (repo_map.py:3812) ran unbounded regardless of --deadline (dogfood: `tg impact
+    # --deadline 1` -> 85.4s). `_copy_partial_signal(payload, defs_payload)` below already folds
+    # defs_payload's partial signal into this function's own return, so threading the deadline
+    # here is the whole fix at this site.
+    defs_payload = build_symbol_defs_from_map(
+        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+    )
     default_agreement, default_status = _default_provider_metadata(
         Path(str(repo_map["path"])).resolve(),
         repo_map,
@@ -15316,7 +15368,16 @@ def build_symbol_refs_from_map(
     deadline_monotonic: float | None = None,
     max_tests: int | None = None,
 ) -> dict[str, Any]:
-    payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
+    # audit C1/C2: this call used to be BARE, dropping the deadline this function
+    # itself received -- build_symbol_defs_from_map's OWN internal _relevant_tests_for_symbol
+    # scan (repo_map.py:3812) ran unbounded regardless of --deadline (dogfood: `tg refs
+    # --deadline` overran by 47.4s). `payload` here IS the defs return value, mutated in place
+    # for the rest of this function, so threading the deadline is the whole fix at this site --
+    # defs_payload's own partial/deadline_limit (if set) survive untouched through every mutation
+    # below since nothing resets those keys before the final return.
+    payload = build_symbol_defs_from_map(
+        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+    )
     if payload.get("no_match"):
         payload["routing_reason"] = "symbol-refs"
         payload["references"] = []
@@ -16110,7 +16171,15 @@ def build_symbol_callers_from_map(
     max_tests: int | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
-    defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
+    # audit C1/C2: this call used to be BARE, dropping the deadline this function
+    # itself received -- build_symbol_defs_from_map's OWN internal _relevant_tests_for_symbol
+    # scan (repo_map.py:3812) ran unbounded regardless of --deadline (dogfood: `tg callers
+    # --deadline` overran by 20.2s). `_copy_partial_signal(payload, defs_payload)` below already
+    # folds defs_payload's partial signal into this function's own return, so threading the
+    # deadline here is the whole fix at this site.
+    defs_payload = build_symbol_defs_from_map(
+        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+    )
     if defs_payload.get("no_match"):
         payload = dict(defs_payload)
         payload["routing_reason"] = "symbol-callers"
@@ -16808,7 +16877,16 @@ def build_symbol_blast_radius_from_map(
     deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> dict[str, Any]:
-    defs_payload = build_symbol_defs_from_map(repo_map, symbol, semantic_provider=semantic_provider)
+    # audit C1/C2: this call used to be BARE, dropping the deadline this function
+    # itself received -- build_symbol_defs_from_map's OWN internal _relevant_tests_for_symbol
+    # scan (repo_map.py:3812) ran unbounded regardless of --deadline. This is blast-radius' OWN
+    # DIRECT defs call (distinct from the deadline-aware callers_payload/impact_payload sub-calls
+    # below, which already threaded deadline_monotonic through their own now-fixed sibling defs
+    # calls) -- fixing only the sub-calls would leave THIS call blocking before either of them
+    # ever runs. Folded into this function's own partial stamp below (defs_payload.get("partial")).
+    defs_payload = build_symbol_defs_from_map(
+        repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
+    )
     default_agreement, default_status = _default_provider_metadata(
         Path(str(repo_map["path"])).resolve(),
         repo_map,
@@ -17189,10 +17267,16 @@ def build_symbol_blast_radius_from_map(
     # impact_payload["file_matches"]/["tests"]/["imports"]/["symbols"] directly (below), so a
     # deadline-truncated impact scan makes THIS result incomplete too, even when callers_payload
     # and this function's own direct preferred-definition-files call both finished inside budget.
+    # audit C1/C2: ALSO OR in defs_payload's own partial signal -- defs_payload is
+    # this function's OWN direct build_symbol_defs_from_map call above (distinct from the nested
+    # defs calls inside callers_payload/impact_payload, which already fold into THEIR OWN partial
+    # fields read above); a deadline blown during THIS call's stage-1 scan must not go unreported
+    # just because it isn't otherwise read by name past this point.
     if (
         callers_payload.get("partial")
         or preferred_definition_deadline_hit_blast.hit
         or impact_payload.get("partial")
+        or defs_payload.get("partial")
     ):
         payload["partial"] = True
         payload["graph_completeness"] = "partial"
@@ -17203,6 +17287,8 @@ def build_symbol_blast_radius_from_map(
             payload["deadline_limit"] = {"deadline_exceeded": True}
         elif isinstance(impact_payload.get("deadline_limit"), dict):
             payload["deadline_limit"] = dict(impact_payload["deadline_limit"])
+        elif isinstance(defs_payload.get("deadline_limit"), dict):
+            payload["deadline_limit"] = dict(defs_payload["deadline_limit"])
     if callers_payload.get("result_incomplete"):
         # backlog #1 chokepoint: the direct-caller scan's internal ceiling (CALLER_SCAN_FILE_CEILING)
         # dropped files the map covers -> the blast radius built on top of it is not exhaustive

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -1553,7 +1553,10 @@ def test_repo_map_impact_propagates_semantic_provider(tmp_path: Path, monkeypatc
     monkeypatch.setattr(
         repo_map,
         "build_symbol_defs_from_map",
-        lambda repo_map_payload, symbol, semantic_provider="native": {
+        # **_kwargs swallows additive params real callers may pass (e.g. audit C1/C2's
+        # deadline_monotonic thread-through) -- mirrors the sibling blast-radius test below
+        # (lambda root, symbol, **kwargs: ...), which already tolerates this.
+        lambda repo_map_payload, symbol, semantic_provider="native", **_kwargs: {
             "path": str(tmp_path.resolve()),
             "definitions": [
                 {

--- a/tests/unit/test_symbol_defs_stage_deadline_c1c2.py
+++ b/tests/unit/test_symbol_defs_stage_deadline_c1c2.py
@@ -1,0 +1,271 @@
+"""C1/C2 audit: ``build_symbol_defs_from_map`` is called BARE (no ``deadline_monotonic``) as the
+stage-1 processing step inside ``build_symbol_defs`` (the cold ``tg defs`` wrapper) and its 5
+sibling ``_from_map`` builders (impact/refs/callers/blast-radius/source), so its internal
+``_relevant_tests_for_symbol`` scan (repo_map.py:3812, the "related" loop ~3919-3947) runs
+unbounded regardless of ``--deadline``. Live repros on origin/main (e2553aa): ``tg defs search
+--deadline 40`` -> 113.5s, exit 0, ``partial:null`` (silent 3x overrun); ``tg impact search
+--deadline 1`` -> 85.4s; refs 47.4s; callers 20.2s; source 47.0s.
+
+This mirrors ``test_refs_context_pack_deadline_205.py``'s spy pattern: the sibling builders'
+OWN sibling-loop deadline checks (refs' bounded_files scan, callers'/impact's existing
+fold-ins, blast-radius' nested callers_payload/impact_payload sub-calls) are ALREADY
+deadline-aware and would trip ``partial=True`` on an already-expired deadline independent of
+this bug -- a naive "expired-deadline -> assert partial" value test on those OUTER functions
+would therefore pass VACUOUSLY whether or not this fix is applied (see that file's docstring).
+We isolate the fix with spy tests asserting the SPECIFIC bare ``build_symbol_defs_from_map``
+call now forwards ``deadline_monotonic``, plus one confound-free end-to-end fold-in assertion
+on ``source`` (whose only internal time-sensitive stage IS the defs call) and a dedicated
+backstop test for the new C1 defense-in-depth return-time recheck on ``build_symbol_defs``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tensor_grep.cli import repo_map
+
+
+def _project_with_test(root: Path) -> Path:
+    project = root / "project"
+    project.mkdir()
+    (project / "m.py").write_text(
+        "def helper():\n    return 1\n\n\ndef other():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    tests_dir = project / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_m.py").write_text(
+        "from m import helper\n\n\ndef test_helper():\n    assert helper() == 1\n",
+        encoding="utf-8",
+    )
+    return project.resolve()
+
+
+def _spy_call_through(monkeypatch: Any, target_name: str) -> list[dict[str, Any]]:
+    """Wrap ``repo_map.<target_name>`` with a call-recording spy that still calls through to the
+    real implementation (mirrors test_refs_context_pack_deadline_205.py's ``_spy``)."""
+    captured_calls: list[dict[str, Any]] = []
+    original = getattr(repo_map, target_name)
+
+    def _wrapped(*args: Any, **kwargs: Any) -> Any:
+        captured_calls.append(dict(kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, target_name, _wrapped)
+    return captured_calls
+
+
+# ---------------------------------------------------------------------------
+# Site 1: build_symbol_defs (cold wrapper, repo_map.py:14615-14637)
+# ---------------------------------------------------------------------------
+
+
+def test_defs_cold_wrapper_threads_deadline_into_from_map(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project_with_test(tmp_path)
+    sentinel = time.monotonic() + 10_000.0
+    monkeypatch.setattr(repo_map, "_deadline_monotonic_from_seconds", lambda seconds: sentinel)
+
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_defs_from_map")
+    repo_map.build_symbol_defs("helper", str(project), deadline_seconds=30.0)
+
+    assert captured_calls, "build_symbol_defs_from_map was never called"
+    assert captured_calls[0].get("deadline_monotonic") == sentinel
+
+
+def test_defs_cold_wrapper_backstop_catches_late_return(tmp_path: Path, monkeypatch: Any) -> None:
+    """C1 defense-in-depth: mirrors build_context_pack's #642-style return-time recheck
+    (repo_map.py:8380-8392) -- even when build_symbol_defs_from_map's OWN return carries no
+    partial signal (every stage it ran completed "successfully"), build_symbol_defs must still
+    flag the response partial if the shared deadline was already blown by return time, so a slow
+    stage this function doesn't specifically instrument can never silently produce exit 0."""
+    project = tmp_path / "project"
+    project.mkdir()
+    fake_repo_map_result: dict[str, Any] = {
+        "path": str(project),
+        "files": [],
+        "symbols": [],
+        "imports": [],
+        "tests": [],
+        "related_paths": [],
+    }
+    fake_defs_result: dict[str, Any] = {
+        "path": str(project),
+        "definitions": [],
+        "no_match": True,
+        "message": "No exact definition found for symbol 'helper'.",
+        "files": [],
+        "symbols": [],
+        "imports": [],
+        "tests": [],
+        "related_paths": [],
+    }
+    # Both collaborators are fully mocked (neither ever sets "partial") so the ONLY way the
+    # final result can become partial is the NEW return-time backstop in build_symbol_defs.
+    monkeypatch.setattr(repo_map, "build_repo_map", lambda *a, **k: dict(fake_repo_map_result))
+    monkeypatch.setattr(
+        repo_map, "build_symbol_defs_from_map", lambda *a, **k: dict(fake_defs_result)
+    )
+
+    result = repo_map.build_symbol_defs("helper", str(project), deadline_seconds=-1000.0)
+
+    assert result.get("partial") is True
+    assert isinstance(result.get("deadline_limit"), dict)
+    assert result["deadline_limit"].get("deadline_exceeded") is True
+
+
+# ---------------------------------------------------------------------------
+# Site 2: build_symbol_impact_from_map (repo_map.py:14970-14979)
+# ---------------------------------------------------------------------------
+
+
+def test_impact_threads_deadline_into_defs_from_map(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_defs_from_map")
+
+    sentinel = time.monotonic() + 10_000.0
+    repo_map.build_symbol_impact_from_map(rmap, "helper", deadline_monotonic=sentinel)
+
+    assert captured_calls, "build_symbol_defs_from_map was never called"
+    assert captured_calls[0].get("deadline_monotonic") == sentinel
+
+
+# ---------------------------------------------------------------------------
+# Site 3: build_symbol_refs_from_map (repo_map.py:15311-15319)
+# ---------------------------------------------------------------------------
+
+
+def test_refs_threads_deadline_into_defs_from_map(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_defs_from_map")
+
+    sentinel = time.monotonic() + 10_000.0
+    repo_map.build_symbol_refs_from_map(rmap, "helper", deadline_monotonic=sentinel)
+
+    assert captured_calls, "build_symbol_defs_from_map was never called"
+    assert captured_calls[0].get("deadline_monotonic") == sentinel
+
+
+# ---------------------------------------------------------------------------
+# Site 4: build_symbol_callers_from_map (repo_map.py:16104-16113)
+# ---------------------------------------------------------------------------
+
+
+def test_callers_threads_deadline_into_defs_from_map(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_defs_from_map")
+
+    sentinel = time.monotonic() + 10_000.0
+    repo_map.build_symbol_callers_from_map(rmap, "helper", deadline_monotonic=sentinel)
+
+    assert captured_calls, "build_symbol_defs_from_map was never called"
+    assert captured_calls[0].get("deadline_monotonic") == sentinel
+
+
+# ---------------------------------------------------------------------------
+# Site 5: build_symbol_blast_radius_from_map (repo_map.py:16802-16811)
+# ---------------------------------------------------------------------------
+
+
+def test_blast_radius_threads_deadline_into_defs_from_map(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_defs_from_map")
+
+    sentinel = time.monotonic() + 10_000.0
+    repo_map.build_symbol_blast_radius_from_map(rmap, "helper", deadline_monotonic=sentinel)
+
+    # blast-radius calls build_symbol_defs_from_map directly AND transitively (via its own
+    # callers_payload/impact_payload sub-calls) -- every one of those calls must carry the SAME
+    # shared deadline, never a dropped/None one.
+    assert captured_calls, "build_symbol_defs_from_map was never called"
+    for captured in captured_calls:
+        assert captured.get("deadline_monotonic") == sentinel
+
+
+def test_blast_radius_folds_own_defs_partial_signal(tmp_path: Path, monkeypatch: Any) -> None:
+    """Additive fold-in (site 5): blast-radius' own DIRECT defs_payload call (the first of the 3
+    build_symbol_defs_from_map calls this function triggers) must be OR'd into blast-radius' own
+    partial stamp, not just callers_payload/impact_payload's (pre-existing) partial signals."""
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+    original = repo_map.build_symbol_defs_from_map
+    call_count = {"n": 0}
+
+    def _only_first_call_partial(rm: Any, symbol: str, **kwargs: Any) -> Any:
+        call_count["n"] += 1
+        result = original(rm, symbol, **kwargs)
+        if call_count["n"] == 1:
+            # Simulate ONLY blast-radius's own direct stage-1 defs call (repo_map.py:16811)
+            # overrunning; leave callers_payload's/impact_payload's OWN nested defs calls
+            # (2nd/3rd, called later in this function) clean -- isolates the NEW
+            # `defs_payload.get("partial")` fold-in this fix adds from the PRE-EXISTING
+            # callers_payload/impact_payload partial propagation.
+            result["partial"] = True
+            result.setdefault("deadline_limit", {"deadline_exceeded": True})
+        return result
+
+    monkeypatch.setattr(repo_map, "build_symbol_defs_from_map", _only_first_call_partial)
+
+    result = repo_map.build_symbol_blast_radius_from_map(rmap, "helper")
+
+    assert call_count["n"] == 3, "expected exactly 3 nested build_symbol_defs_from_map calls"
+    assert result.get("partial") is True
+    assert isinstance(result.get("deadline_limit"), dict)
+
+
+# ---------------------------------------------------------------------------
+# Sites 6 & 7: build_symbol_source_from_map gains deadline_monotonic (repo_map.py:14858-14865)
+# and build_symbol_source threads its own deadline into it (repo_map.py:14829-14855)
+# ---------------------------------------------------------------------------
+
+
+def test_source_from_map_accepts_and_threads_deadline(tmp_path: Path, monkeypatch: Any) -> None:
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_defs_from_map")
+
+    sentinel = time.monotonic() + 10_000.0
+    # Pre-fix this raises TypeError: build_symbol_source_from_map() got an unexpected keyword
+    # argument 'deadline_monotonic' -- the missing parameter itself IS the site-6 gap.
+    repo_map.build_symbol_source_from_map(rmap, "helper", deadline_monotonic=sentinel)
+
+    assert captured_calls, "build_symbol_defs_from_map was never called"
+    assert captured_calls[0].get("deadline_monotonic") == sentinel
+
+
+def test_source_from_map_folds_defs_partial_end_to_end(tmp_path: Path, monkeypatch: Any) -> None:
+    """Confound-free end-to-end assertion (task requirement): unlike impact/refs/callers/
+    blast-radius, build_symbol_source_from_map has NO sibling deadline-aware loop of its own --
+    its entire time-sensitivity is inherited from the defs stage. An already-expired deadline can
+    therefore only produce partial:true here if the defs-stage threading fix actually works,
+    never vacuously from a pre-existing unrelated loop."""
+    project = _project_with_test(tmp_path)
+    rmap = repo_map.build_repo_map(str(project))  # built WITHOUT a deadline: guaranteed non-partial
+    assert not rmap.get("partial"), "fixture repo_map must start non-partial for this to be valid"
+
+    already_expired = time.monotonic() - 1.0
+    result = repo_map.build_symbol_source_from_map(
+        rmap, "helper", deadline_monotonic=already_expired
+    )
+
+    assert result.get("partial") is True
+    assert isinstance(result.get("deadline_limit"), dict)
+
+
+def test_source_cold_wrapper_threads_deadline_into_from_map(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    project = _project_with_test(tmp_path)
+    sentinel = time.monotonic() + 10_000.0
+    monkeypatch.setattr(repo_map, "_deadline_monotonic_from_seconds", lambda seconds: sentinel)
+
+    captured_calls = _spy_call_through(monkeypatch, "build_symbol_source_from_map")
+    repo_map.build_symbol_source("helper", str(project), deadline_seconds=30.0)
+
+    assert captured_calls, "build_symbol_source_from_map was never called"
+    assert captured_calls[0].get("deadline_monotonic") == sentinel


### PR DESCRIPTION
## Summary

Audit findings C1/C2: `build_symbol_defs_from_map` was called **bare** (no `deadline_monotonic`)
as the stage-1 processing step inside `build_symbol_defs` (the cold `tg defs` wrapper) and its 5
sibling `_from_map` builders (impact/refs/callers/blast-radius/source), so its internal
`_relevant_tests_for_symbol` scan (`repo_map.py:3812`, the "related" loop ~3919-3947) ran
unbounded regardless of `--deadline`, even though that scan has accepted `deadline_monotonic`
since #203.

Live repros on origin/main (e2553aa) before this fix:
- `tg defs search --deadline 40` -> 113.5s, exit 0, `partial:null` (silent ~3x overrun)
- `tg impact search --deadline 1` -> 85.4s
- `tg refs search --deadline` -> overran by 47.4s
- `tg callers search --deadline` -> overran by 20.2s
- `tg source search --deadline` -> overran by 47.0s

The warm session-daemon path (`session_store.py`) already threads `deadline_monotonic` into the
top-level `build_symbol_{impact,refs,callers,blast_radius}_from_map` calls (the #203/#652
program) -- but since those functions' *own* internal bare call to `build_symbol_defs_from_map`
dropped it, the warm daemon's 60s default budget was ALSO silently blown by this bug. Fixing the
7 sites below fixes both the cold CLI path and the warm daemon path at once, since both route
through the same core `_from_map` builders.

## The 7 sites (file:line is the pre-fix bare-call line; all cited against origin/main e2553aa)

1. `build_symbol_defs` (cold wrapper, `repo_map.py:14633-14635` pre-fix) -- computed
   `deadline_monotonic` but never threaded it into `build_symbol_defs_from_map`.
2. `build_symbol_impact_from_map` (`repo_map.py:14979` pre-fix)
3. `build_symbol_refs_from_map` (`repo_map.py:15319` pre-fix)
4. `build_symbol_callers_from_map` (`repo_map.py:16113` pre-fix)
5. `build_symbol_blast_radius_from_map` (`repo_map.py:16811` pre-fix) -- its OWN direct
   `defs_payload` call, distinct from its (already-threaded) nested `callers_payload`/
   `impact_payload` sub-calls; also added `defs_payload.get("partial")` to its existing
   partial fold-in condition (`repo_map.py:17267-17269` post-fix) as defense-in-depth.
6. `build_symbol_source_from_map` (`repo_map.py:14894` post-fix signature) -- previously had
   **no** `deadline_monotonic` parameter at all; added it (defaults to `None`, byte-identical
   for every pre-existing call site that doesn't pass it).
7. `build_symbol_source` (cold wrapper, `repo_map.py:14877` post-fix) -- threads its own
   computed deadline into the now-deadline-aware `build_symbol_source_from_map`.

## Pattern: mirrors the shipped #205 fix, does not invent a new shape

`build_symbol_refs_from_map`'s existing #205 fix (repo_map.py, PR #653) threads
`deadline_monotonic` + a local `_DeadlineBreakFlag` into its internal `build_context_pack_from_map`
call and folds the flag into its own `partial`/`deadline_limit` stamp. This PR applies the exact
same shape one call earlier in the SAME functions: `build_symbol_defs_from_map` already accepts
`deadline_monotonic` (added by #203) and already manages its own internal
`_DeadlineBreakFlag`/partial stamping -- it was simply never being handed the deadline by its 5
siblings + 2 cold wrappers. Reading each site's existing fold-in mechanism showed the propagation
plumbing was **already there** in 4 of 5 `_from_map` siblings:
- `impact`/`callers` already call `_copy_partial_signal(payload, defs_payload)` -- threading the
  deadline into the `defs_payload` call alone is the whole fix at those two sites.
- `refs` mutates and returns the SAME dict `build_symbol_defs_from_map` returns (no fresh
  envelope) -- a `partial` flag set inside the defs stage survives untouched to the final return.
- `source` already calls `_copy_partial_signal(payload, defs_payload)` -- once it accepts and
  threads `deadline_monotonic` (a new, backward-compatible optional param), the existing call
  does the rest.
- `blast-radius` was the one site needing an additive OR-clause (`defs_payload.get("partial")`)
  alongside its pre-existing `callers_payload`/`impact_payload`/local-flag fold-in, since its own
  direct `defs_payload` result isn't otherwise read past that point.

**No schema change** -- this folds into the existing `partial` + `deadline_limit` contract
(`docs/CONTRACTS.md`'s three-state exit-code contract: `0`=complete, `1`=genuine not-found,
`2`=incomplete/truncated). No new field, no `partial_reason` added to the symbol-command family
(that field stays scoped to `agent`/`context`/`context-render`/`edit-plan` per the existing
convention -- verified `partial_reason` is set at exactly 3 pre-existing sites, none of them
symbol commands).

## C1 defense-in-depth: return-time backstop on `build_symbol_defs`

Mirrors `build_context_pack`'s existing #642-style return-time recheck (`repo_map.py:8380-8392`):
a final absolute wall-clock check (`time.monotonic() >= deadline_monotonic`) right before
`build_symbol_defs` returns, so ANY internal stage -- instrumented or not -- can never silently
produce exit 0 once the caller's `--deadline` budget is gone. Added only to `build_symbol_defs`
(the cold wrapper), matching the audit's specific citation; `main.py`'s daemon gate skips the warm
fast path whenever `--deadline` is set, so this cold wrapper is the only path an explicit-deadline
`tg defs` caller ever exercises.

## Tests

New file `tests/unit/test_symbol_defs_stage_deadline_c1c2.py` (10 tests, RED-then-GREEN
confirmed against unmodified origin/main before any fix was applied):
- One spy test per site (1-6) asserting the specific bare call now forwards
  `deadline_monotonic` (mirrors `test_refs_context_pack_deadline_205.py`'s pattern).
- `test_blast_radius_folds_own_defs_partial_signal` isolates the additive OR-clause at site 5
  from the pre-existing `callers_payload`/`impact_payload` propagation (marks only the FIRST of
  3 nested `build_symbol_defs_from_map` calls partial and confirms it still surfaces).
- `test_source_from_map_folds_defs_partial_end_to_end` is a confound-free end-to-end assertion:
  `source` has no sibling deadline-aware loop of its own (unlike impact/refs/callers/blast-radius,
  whose own pre-existing loops would trip on an already-expired deadline independent of this bug
  and make a naive value-level test pass vacuously), so an already-expired deadline can only
  produce `partial:true` here if the defs-stage threading fix actually works.
- `test_defs_cold_wrapper_backstop_catches_late_return` isolates the NEW C1 backstop in
  isolation (mocks both `build_repo_map` and `build_symbol_defs_from_map` to return clean,
  non-partial results; the only way the final result becomes partial is the new return-time
  recheck).

Also fixed one pre-existing test whose mock lambda's strict signature
(`tests/unit/test_semantic_provider_navigation.py::test_repo_map_impact_propagates_semantic_provider`)
didn't tolerate the new `deadline_monotonic` kwarg now legitimately flowing through
`build_symbol_impact_from_map` -> `build_symbol_defs_from_map`; widened it to `**_kwargs`,
matching the already-robust sibling test two lines below.

## Test plan

- [x] New file: 10/10 RED against unmodified origin/main, 10/10 GREEN after the fix
- [x] `test_refs_context_pack_deadline_205.py` (the house #205 pattern) -- still green
- [x] Deadline/daemon batteries: `test_cli_deadline_flag.py`, `test_cli_deadline_frontdoor_anchor.py`,
      `test_cli_deadline_coverage_gaps.py`, `test_repo_map_deadline.py`,
      `test_repo_map_partial_propagation.py`, `test_session_daemon_default_deadline.py` -- green
- [x] Symbol-command contract tests: `test_main_cli_contracts.py`, `test_answer_first_symbol_payloads.py` -- green
- [x] Full sweep of all ~30 test files that reference the touched builder functions -- green
      (1 pre-existing test's overly-strict mock fixed, see above)
- [x] `ruff format --preview` + `ruff check` clean on all 3 changed files
- [x] Python-only change; no Rust/native code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
