### PR TITLE
fix(security): symlink-refusing atomic write for evidence emit + audit bundle-create outputs (CWE-59, audit C4)

### DIFF
--- a/src/tensor_grep/cli/audit_manifest.py
+++ b/src/tensor_grep/cli/audit_manifest.py
@@ -199,9 +199,21 @@ def create_review_bundle(
     payload["bundle_sha256"] = _sha256_hex(_canonical_review_bundle_bytes(payload))
 
     if output_path is not None:
-        resolved_output = Path(output_path).expanduser().resolve()
-        resolved_output.parent.mkdir(parents=True, exist_ok=True)
-        resolved_output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        from tensor_grep.cli.session_store import _write_json_atomic
+
+        # audit C4 / CWE-59: check for a symlink BEFORE `.resolve()` -- resolving first would
+        # follow the symlink to its real target and make `is_symlink()` on the result always
+        # False, silently defeating `_write_json_atomic`'s own symlink guard (mirrors
+        # evidence_signing.generate_keypair's identical ordering fix). `_write_json_atomic` also
+        # makes this write atomic (temp file + fsync + os.replace) instead of the previous bare
+        # `write_text`, which could leave a truncated bundle on a crash mid-write.
+        expanded_output = Path(output_path).expanduser()
+        if expanded_output.is_symlink():
+            raise OSError(
+                f"Refusing to write the review bundle through a symlink: {expanded_output}"
+            )
+        resolved_output = expanded_output.resolve()
+        _write_json_atomic(resolved_output, payload)
 
     return payload
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -15144,9 +15144,38 @@ def evidence_emit(
         raise typer.Exit(code=1) from exc
 
     if output_path is not None:
-        resolved_output = Path(output_path).expanduser().resolve()
-        resolved_output.parent.mkdir(parents=True, exist_ok=True)
-        resolved_output.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+        from tensor_grep.cli.session_store import _write_json_atomic
+
+        try:
+            # audit C4 / CWE-59: check for a symlink BEFORE `.resolve()` -- resolving first
+            # would follow the symlink to its real target and make `is_symlink()` on the
+            # result always False, silently defeating `_write_json_atomic`'s own symlink guard
+            # (mirrors evidence_signing.generate_keypair's identical ordering fix).
+            # `_write_json_atomic` also makes this write atomic (temp file + fsync +
+            # os.replace) instead of the previous bare `write_text`, which could leave a
+            # truncated receipt on a crash mid-write.
+            expanded_output = Path(output_path).expanduser()
+            if expanded_output.is_symlink():
+                raise OSError(
+                    f"Refusing to write the evidence receipt through a symlink: {expanded_output}"
+                )
+            resolved_output = expanded_output.resolve()
+            _write_json_atomic(resolved_output, receipt)
+        except OSError as exc:
+            # Backend Fail-Closed Contract: never leak a raw traceback for a refused/failed
+            # write -- report the same structured error shape the two except blocks above use.
+            if json_output:
+                typer.echo(
+                    json.dumps(
+                        _evidence_error_payload(
+                            str(exc), code="write_error", routing_reason="evidence-receipt-emit"
+                        ),
+                        indent=2,
+                    )
+                )
+            else:
+                typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
 
     if json_output:
         typer.echo(json.dumps(receipt, indent=2))

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -423,6 +423,23 @@ def _load_index(root: Path) -> list[SessionRecord]:
 
 def _write_json_atomic(path: Path, payload: Any, *, mode: int | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    # audit C4 / CWE-59: refuse to write THROUGH a pre-existing symlink at the destination --
+    # mirrors evidence_signing._write_private_key_atomic's guard. Without this, `os.replace`
+    # below would not corrupt the symlink's TARGET (POSIX rename() atomically replaces the link
+    # entry itself, not what it points to) but it would still silently destroy the caller's
+    # symlink with no signal that something unexpected was already at the destination -- refusing
+    # outright is the same fail-closed posture the private-key writer already takes. Every caller
+    # of this shared helper (session payloads/index, the daemon token + metrics files, and, via
+    # the C4 fix, the evidence-receipt and review-bundle CLI/MCP writers) gets the same
+    # protection. Callers that first `.expanduser().resolve()` a caller-supplied path MUST check
+    # `is_symlink()` on the pre-resolve path themselves (mirrors evidence_signing.generate_keypair)
+    # -- `.resolve()` follows symlinks, so by the time a resolved path reaches this function the
+    # symlink-ness of the ORIGINAL destination is already lost; this check remains as
+    # defense-in-depth against a symlink planted directly at an already-resolved leaf path (e.g.
+    # the session/daemon internal callers below, which never round-trip through a caller-supplied
+    # string) and against the narrow TOCTOU window between an outer check and this call.
+    if path.is_symlink():
+        raise OSError(f"Refusing to write through a symlink: {path}")
     tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
     data = json.dumps(payload, indent=2)
     if mode is not None:

--- a/tests/unit/test_evidence_bundle_atomic_write.py
+++ b/tests/unit/test_evidence_bundle_atomic_write.py
@@ -1,0 +1,274 @@
+"""Regression tests for audit C4 (CWE-59 symlink-follow write + non-atomic write-integrity).
+
+Two CLI writers used to emit a caller-specified output path via a bare
+``resolved.write_text(json.dumps(...), encoding="utf-8")`` -- no symlink refusal, no atomic
+temp+rename:
+
+  * ``tg evidence emit --out <path>``            (tensor_grep.cli.main.evidence_emit)
+  * ``tg review-bundle create --output <path>``  (tensor_grep.cli.audit_manifest.create_review_bundle)
+
+A pre-existing symlink at the destination let ``write_text`` follow it and overwrite the
+symlink's TARGET (CWE-59); a crash/kill mid-write had no atomic fallback and could publish a
+truncated receipt/bundle. Both sites now route through the same hardened
+``session_store._write_json_atomic`` helper already used for session/daemon state, extended
+here with a symlink-refusal guard mirroring ``evidence_signing._write_private_key_atomic``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from tensor_grep.cli import audit_manifest, session_store
+from tensor_grep.cli.main import app
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirrors tests/unit/test_review_bundles.py's manifest shape)
+# ---------------------------------------------------------------------------
+
+
+def _canonical_manifest_bytes(manifest: dict[str, object]) -> bytes:
+    canonical = dict(manifest)
+    canonical.pop("manifest_sha256", None)
+    canonical.pop("signature", None)
+    return json.dumps(canonical, indent=2).encode("utf-8")
+
+
+def _write_audit_manifest(path: Path, *, project_root: Path) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "version": 1,
+        "kind": "rewrite-audit-manifest",
+        "created_at": "2026-03-23T12:00:00Z",
+        "lang": "python",
+        "path": str(project_root),
+        "plan_total_edits": 1,
+        "applied_edit_ids": ["edit-1"],
+        "checkpoint": None,
+        "validation": None,
+        "files": [
+            {
+                "path": "src/sample.py",
+                "edit_ids": ["edit-1"],
+                "before_sha256": "a" * 64,
+                "after_sha256": "b" * 64,
+            }
+        ],
+        "previous_manifest_sha256": None,
+    }
+    payload["manifest_sha256"] = hashlib.sha256(_canonical_manifest_bytes(payload)).hexdigest()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return payload
+
+
+def _make_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    (project / ".tensor-grep" / "audit").mkdir(parents=True)
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "sample.py").write_text("print('hello')\n", encoding="utf-8")
+    return project
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported / not privileged on this platform")
+
+
+# ---------------------------------------------------------------------------
+# 1. Writing to a path that is a pre-existing SYMLINK is REFUSED, and the symlink's target is
+#    never touched, for BOTH `evidence emit --out` and `audit bundle-create --output` (a.k.a.
+#    `review-bundle create --output`, the actual registered command name -- see
+#    tensor_grep.cli.main.review_bundle_create / app.add_typer(review_bundle_app,
+#    name="review-bundle")).
+# ---------------------------------------------------------------------------
+
+
+def test_create_review_bundle_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    manifest_path = project / ".tensor-grep" / "audit" / "manifest.json"
+    _write_audit_manifest(manifest_path, project_root=project)
+
+    real_target = tmp_path / "real_target.txt"
+    real_target.write_text("do-not-touch-me", encoding="utf-8")
+    link_path = tmp_path / "bundle_output.json"
+    _symlink_or_skip(link_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        audit_manifest.create_review_bundle(manifest_path, output_path=link_path)
+
+    # The refused attempt must leave the symlink -- and its target's content -- untouched.
+    assert link_path.is_symlink()
+    assert real_target.read_text(encoding="utf-8") == "do-not-touch-me"
+
+
+def test_evidence_emit_cli_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real_target.txt"
+    real_target.write_text("do-not-touch-me", encoding="utf-8")
+    link_path = tmp_path / "receipt.json"
+    _symlink_or_skip(link_path, real_target)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    result = CliRunner().invoke(app, ["evidence", "emit", str(repo), "--out", str(link_path)])
+
+    assert result.exit_code != 0
+    # A clean, fail-closed CLI error -- never an unhandled exception/raw traceback.
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert real_target.read_text(encoding="utf-8") == "do-not-touch-me"
+    assert link_path.is_symlink()
+
+
+def test_evidence_emit_cli_refuses_symlink_cleanly_in_json_mode(tmp_path: Path) -> None:
+    """The --json error envelope must also fail closed (not just the text-mode path)."""
+    real_target = tmp_path / "real_target.txt"
+    real_target.write_text("do-not-touch-me", encoding="utf-8")
+    link_path = tmp_path / "receipt.json"
+    _symlink_or_skip(link_path, real_target)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    result = CliRunner().invoke(
+        app, ["evidence", "emit", str(repo), "--out", str(link_path), "--json"]
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    error_payload = json.loads(result.output)
+    assert error_payload["error"]["code"] == "write_error"
+    assert "symlink" in error_payload["error"]["message"]
+    assert real_target.read_text(encoding="utf-8") == "do-not-touch-me"
+
+
+# ---------------------------------------------------------------------------
+# 2. A normal write still produces a valid, complete JSON file.
+# ---------------------------------------------------------------------------
+
+
+def test_create_review_bundle_writes_a_valid_complete_json_file(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    manifest_path = project / ".tensor-grep" / "audit" / "manifest.json"
+    _write_audit_manifest(manifest_path, project_root=project)
+    output_path = tmp_path / "bundle.json"
+
+    bundle = audit_manifest.create_review_bundle(manifest_path, output_path=output_path)
+
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert on_disk == bundle
+    assert on_disk["bundle_sha256"] == bundle["bundle_sha256"]
+
+
+def test_evidence_emit_cli_writes_a_valid_complete_json_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output_path = tmp_path / "receipt.json"
+
+    result = CliRunner().invoke(app, ["evidence", "emit", str(repo), "--out", str(output_path)])
+
+    assert result.exit_code == 0, result.output
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert on_disk["kind"] == "evidence-receipt"
+    assert "receipt_sha256" in on_disk
+
+
+def test_create_review_bundle_write_still_creates_parent_dirs(tmp_path: Path) -> None:
+    """Preserve the pre-fix behavior of creating missing parent directories."""
+    project = _make_project(tmp_path)
+    manifest_path = project / ".tensor-grep" / "audit" / "manifest.json"
+    _write_audit_manifest(manifest_path, project_root=project)
+    output_path = tmp_path / "nested" / "dir" / "bundle.json"
+
+    audit_manifest.create_review_bundle(manifest_path, output_path=output_path)
+
+    assert output_path.exists()
+    assert json.loads(output_path.read_text(encoding="utf-8"))["bundle_sha256"]
+
+
+# ---------------------------------------------------------------------------
+# 3. The write is atomic: a simulated crash mid-write never leaves a partial/corrupted file at
+#    the destination. Both C4 sites now route through the exact same shared helper
+#    (session_store._write_json_atomic) for their disk I/O, so exercising it here through the
+#    real `create_review_bundle` entry point covers both -- and proves the write genuinely goes
+#    through the fsync'd temp-then-rename path (patching `os.fsync` has NO effect on the
+#    pre-fix bare `write_text`, which never called fsync at all).
+# ---------------------------------------------------------------------------
+
+
+def test_create_review_bundle_write_is_atomic_on_simulated_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _make_project(tmp_path)
+    manifest_path = project / ".tensor-grep" / "audit" / "manifest.json"
+    _write_audit_manifest(manifest_path, project_root=project)
+    output_path = tmp_path / "bundle.json"
+    output_path.write_text('{"stale": "pre-existing-valid-json"}', encoding="utf-8")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated crash before fsync completes")
+
+    monkeypatch.setattr(session_store.os, "fsync", _boom)
+
+    with pytest.raises(OSError):
+        audit_manifest.create_review_bundle(manifest_path, output_path=output_path)
+
+    # The destination must still hold the OLD, complete content -- never truncated/partial.
+    assert output_path.read_text(encoding="utf-8") == '{"stale": "pre-existing-valid-json"}'
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "stale": "pre-existing-valid-json"
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Shared-helper unit coverage: `_write_json_atomic` itself refuses a symlinked destination
+#    without disturbing its existing callers' contract (mode=None default write, mode=0o600
+#    restrictive write used by session_daemon's IPC token file).
+# ---------------------------------------------------------------------------
+
+
+def test_write_json_atomic_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    link_path = tmp_path / "link.json"
+    _symlink_or_skip(link_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        session_store._write_json_atomic(link_path, {"attacker": "payload"})
+
+    assert link_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}
+
+
+def test_write_json_atomic_existing_callers_unaffected_default_mode(tmp_path: Path) -> None:
+    dest = tmp_path / "payload.json"
+
+    session_store._write_json_atomic(dest, {"a": 1, "b": [1, 2, 3]})
+
+    assert json.loads(dest.read_text(encoding="utf-8")) == {"a": 1, "b": [1, 2, 3]}
+
+
+def test_write_json_atomic_existing_callers_unaffected_restrictive_mode(tmp_path: Path) -> None:
+    """Regression guard: extending `_write_json_atomic` with a symlink guard must not disturb
+    the existing `mode=` callers (e.g. session_daemon's 0600 IPC token file)."""
+    dest = tmp_path / "secret.json"
+
+    session_store._write_json_atomic(dest, {"token": "abc"}, mode=0o600)
+
+    assert json.loads(dest.read_text(encoding="utf-8")) == {"token": "abc"}
+
+
+def test_write_json_atomic_overwrite_of_a_regular_file_still_succeeds(tmp_path: Path) -> None:
+    """A regular (non-symlink) pre-existing file at the destination must still be overwritable
+    -- the guard targets symlinks specifically, not "anything already there"."""
+    dest = tmp_path / "existing.json"
+    dest.write_text('{"old": true}', encoding="utf-8")
+
+    session_store._write_json_atomic(dest, {"new": True})
+
+    assert json.loads(dest.read_text(encoding="utf-8")) == {"new": True}


### PR DESCRIPTION
## Summary

Two CLI writers emitted a caller-specified output path via a bare
`resolved.write_text(json.dumps(...), encoding="utf-8")` -- no symlink refusal, no atomic
temp+rename:

- `tg evidence emit --out <path>` -- `src/tensor_grep/cli/main.py` (`evidence_emit`)
- `tg review-bundle create --output <path>` (a.k.a. "audit bundle-create" -- the real registered
  command is `review-bundle create`; there is no separate `tg audit bundle-create` command) --
  `src/tensor_grep/cli/audit_manifest.py` (`create_review_bundle`, also reused by the MCP
  `tg_review_bundle_create` tool)

**Failure scenarios fixed:**
- **(a) CWE-59 symlink-follow write:** a pre-existing symlink at the destination let
  `write_text` follow it and overwrite the symlink's TARGET.
- **(b) Non-atomic write:** a crash/kill mid-write had no atomic fallback and could publish a
  truncated receipt/bundle.

## Fix -- reused the existing hardened helper

Both sites now route through `session_store._write_json_atomic` (already used for
session/daemon state -- session payloads/index, the daemon token, the daemon metrics file),
**extended** with a symlink-refusal guard mirroring
`evidence_signing._write_private_key_atomic`'s existing `is_symlink()` check. I did not add a
new shared helper -- `_write_json_atomic`'s existing no-`mode` write path already produces a
world-readable JSON artifact (no `chmod`), which is exactly the semantic both C4 sites need
(not the 0600 private-key mode).

Each call site also checks `is_symlink()` **before** `.resolve()`: resolving first follows the
symlink to its real target and makes `is_symlink()` on the *result* always `False`, which would
silently defeat the guard. This mirrors the identical ordering fix
`evidence_signing.generate_keypair` already applies to `_write_private_key_atomic` (see its
docstring). Without this ordering, swapping in `_write_json_atomic` alone would NOT have closed
C4 -- I verified this is a real trap, not a theoretical one (see Testing below).

`evidence_emit`'s write is now wrapped in `try/except OSError`, reporting through the command's
existing structured error contract (`--json` error envelope or a clean stderr message + exit 1)
instead of leaking a raw traceback -- previously this write sat *outside* the function's
existing try/except, so any failure (this new symlink refusal included) would have crashed with
an unhandled exception. `create_review_bundle`'s raised `OSError` needed no new CLI-layer
wrapping: it already falls through `review_bundle_create`'s (and the MCP
`tg_review_bundle_create`'s) existing catch-all `except Exception` handler.

**Existing callers of `_write_json_atomic` unaffected (grepped):** `session_store.py`'s
`_write_index`/`open_session`/`refresh_session` and `session_daemon.py`'s
`_write_daemon_metadata` (POSIX path, `mode=0o600`) / demand-metrics writer all pass internally
constructed paths (never round-tripped through a caller-supplied symlink), so the added guard is
a strict safety improvement with no behavior change for legitimate use -- confirmed by the full
`test_session_cli.py` / `test_session_daemon_*.py` suites staying green.

**Out of scope (noted, not touched):** `checkpoint_store.py` and `dogfood.py` each have their
own separate, module-private `_write_json_atomic` duplicate (not imported from
`session_store.py`) that also lack a symlink guard. Fixing those wasn't part of the cited C4
sites; flagging for a possible follow-up.

## Testing (TDD, RED verified against unmodified code)

New file `tests/unit/test_evidence_bundle_atomic_write.py` (11 tests):
1. **Symlink refusal** for both sites (`create_review_bundle` direct call + `tg evidence emit`
   CLI in both text and `--json` mode) -- raises/exits non-zero, symlink target byte-identical
   after the refused attempt.
2. **Normal write** still produces a valid, complete JSON file for both sites, including parent
   directory creation.
3. **Atomicity**: patching `os.fsync` to raise simulates a mid-write crash. Post-fix this
   correctly aborts before `os.replace`, leaving the destination's old content untouched.
   Pre-fix, patching `fsync` has **no effect** (the old `write_text` never called it) --
   `create_review_bundle` returns normally instead of raising, which is itself a second,
   independent proof that the write previously bypassed any atomicity guarantee.
4. Direct unit coverage of the extended `_write_json_atomic` (symlink refusal + both existing
   `mode=None`/`mode=0o600` call shapes unaffected + overwriting a regular file still works).

RED confirmed via `git stash` A/B on the 3 source files (keeping the new test file): 5/11 tests
failed against unmodified code (all 4 symlink tests + the atomicity test), 6/11 already passed
(baseline/regression coverage). GREEN confirmed after restoring the fix: 11/11 pass.

Full regression sweep (226+ targeted tests: `test_evidence_*`, `test_audit_*`,
`test_review_bundles.py`, `test_session_cli.py`, `test_session_daemon_*.py`,
`test_main_cli_contracts.py`, `test_trust_parity.py`, `test_mcp_server.py`) all green. 4
pre-existing `test_mcp_server.py` failures (native-binary/embedded-Rust-fallback tests,
unrelated code path) were confirmed via git-stash A/B to be byte-identical with and without this
fix.

`ruff format --preview` + `ruff check` clean on all 4 changed files.

## Test plan
- [x] RED: new symlink/atomicity tests fail against unmodified code (git-stash verified)
- [x] GREEN: all 11 new tests pass with the fix
- [x] `test_evidence_receipt.py`, `test_evidence_signing.py`, `test_review_bundles.py`,
      `test_audit_manifest_*.py`, `test_audit_diff.py`, `test_audit_history*.py`,
      `test_audit_workflow_contract.py` all pass
- [x] `test_session_cli.py`, `test_session_daemon_*.py` (5 files) all pass -- shared-helper
      callers unaffected
- [x] `test_mcp_server.py`, `test_trust_parity.py`, `test_main_cli_contracts.py` pass (minus 4
      confirmed-pre-existing unrelated failures)
- [x] `ruff format --preview` + `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)