### PR TITLE
fix(mcp): cap tg_query workspace_roots fan-out + share the wall-clock deadline across roots (audit C3)

### DIFF
--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import asynccontextmanager
 from functools import lru_cache
@@ -45,6 +46,7 @@ from tensor_grep.cli.main import (
 from tensor_grep.cli.orient_capsule import build_orient_capsule_json
 from tensor_grep.cli.repo_map import (
     _apply_context_token_budget,
+    _deadline_monotonic_from_seconds,
     build_context_pack,
     build_context_render,
     build_file_importers,
@@ -731,6 +733,19 @@ def _meta_missing_param_error(tool: str, action: str, param: str) -> str:
 def _meta_confinement_error(tool: str, action: str, exc: ValueError) -> str:
     payload = _meta_envelope(tool=tool, action=action)
     payload["error"] = {"code": "invalid_input", "message": str(exc)}
+    return json.dumps(payload, indent=2)
+
+
+def _meta_workspace_roots_cap_error(tool: str, action: str, *, count: int, cap: int) -> str:
+    payload = _meta_envelope(tool=tool, action=action)
+    payload["error"] = {
+        "code": "invalid_input",
+        "message": (
+            f"{tool} action={action!r} received {count} workspace_roots, exceeding the "
+            f"{cap}-root limit (each root re-runs the full action as an independent scan "
+            "pass). Split the call across multiple workspace_roots batches."
+        ),
+    }
     return json.dumps(payload, indent=2)
 
 
@@ -6564,6 +6579,19 @@ def tg_impact(
         return json.dumps(payload, indent=2)
 
 
+# [SEC] Cap the NUMBER of workspace_roots tg_query fans out across in one call, and (below)
+# share ONE wall-clock `deadline` across that fan-out instead of handing every root its own
+# full copy of it. Each root re-runs the FULL requested action (`text`/`ast`/`find`/`index`)
+# as an independent scan pass with its own compute cost; before this cap, an uncapped
+# workspace_roots list combined with a `deadline` that was passed UNCHANGED to every root's
+# `_tg_query_dispatch` call turned a documented "wall-clock budget in seconds" for the WHOLE
+# call into a per-root budget instead -- e.g. tg_query(action="find", deadline=60,
+# workspace_roots=[r1..r20]) could run up to 20x60=1200s from a single MCP call. Mirrors
+# _MAX_INLINE_RULES's fan-out-count cap (tg_ruleset_scan) for the same DoS-via-fan-out shape.
+# (audit C3.)
+_MAX_WORKSPACE_ROOTS = 8
+
+
 _TG_QUERY_ACTIONS = ("text", "ast", "find", "index")
 
 
@@ -6705,13 +6733,18 @@ def tg_query(
             explicitly unbounded.
         deadline: Optional wall-clock budget in seconds (action="find"). Partial results are
             flagged via result_incomplete, never silently truncated.
-        workspace_roots: Optional list of additional workspace roots. When supplied
-            (non-empty), EACH element is independently confined to the MCP server root; if
-            ANY element escapes, the WHOLE call is refused fail-closed (no partial/
-            best-effort root list). The SAME action then runs once per confined root, and
-            results are aggregated under a top-level `results_by_root` map keyed by the
-            confined root path, instead of the single-root envelope this tool normally
-            returns.
+        workspace_roots: Optional list of additional workspace roots (max
+            _MAX_WORKSPACE_ROOTS). When supplied (non-empty), EACH element is independently
+            confined to the MCP server root; if ANY element escapes, or the list exceeds the
+            cap, the WHOLE call is refused fail-closed (no partial/best-effort root list). The
+            SAME action then runs once per confined root, and results are aggregated under a
+            top-level `results_by_root` map keyed by the confined root path, instead of the
+            single-root envelope this tool normally returns. A `deadline`, when set, bounds
+            the WHOLE multi-root call as ONE shared wall-clock budget rather than being handed
+            to every root in full: any root whose turn would start only after that shared
+            budget is already exhausted is skipped (never dispatched) instead of silently
+            multiplying the total cost by the root count. Skipped roots are reported via a
+            top-level `omitted_roots` list plus `partial: true`, never silently dropped.
     """
     try:
         confined_path = str(_confine_mcp_path(path, label="path"))
@@ -6720,6 +6753,13 @@ def tg_query(
 
     confined_roots: list[str] | None = None
     if workspace_roots:
+        if len(workspace_roots) > _MAX_WORKSPACE_ROOTS:
+            return _meta_workspace_roots_cap_error(
+                "tg_query",
+                action,
+                count=len(workspace_roots),
+                cap=_MAX_WORKSPACE_ROOTS,
+            )
         try:
             confined_roots = [
                 str(_confine_mcp_path(root, label="workspace_roots")) for root in workspace_roots
@@ -6756,7 +6796,27 @@ def tg_query(
             )
 
         results_by_root: dict[str, Any] = {}
+        omitted_roots: list[str] = []
+        # Share ONE absolute wall-clock deadline across every root in this loop, mirroring the
+        # deadline_monotonic -> remaining-deadline_seconds pattern agent_capsule.py's call-site
+        # evidence rescue scan already uses (agent_capsule.py:565-567) -- computed ONCE, outside
+        # the loop, so root 2 does not get a fresh copy of `deadline` just because root 1 already
+        # consumed the budget (audit C3: previously EVERY root got the full `deadline`
+        # unchanged, so N roots could cost up to N x deadline wall-clock time instead of one
+        # shared `deadline` for the whole call).
+        loop_deadline_monotonic = _deadline_monotonic_from_seconds(deadline)
         for root in confined_roots:
+            if loop_deadline_monotonic is not None and time.monotonic() >= loop_deadline_monotonic:
+                # The shared budget is already spent -- skip (never dispatch) rather than
+                # silently granting this root its own fresh deadline or silently dropping it
+                # from the response with no signal (reported via omitted_roots/partial below).
+                omitted_roots.append(root)
+                continue
+            root_deadline = (
+                None
+                if loop_deadline_monotonic is None
+                else max(0.1, loop_deadline_monotonic - time.monotonic())
+            )
             single_text = _tg_query_dispatch(
                 action,
                 pattern=pattern,
@@ -6780,21 +6840,28 @@ def tg_query(
                 semantic=semantic,
                 limit=limit,
                 max_tokens=max_tokens,
-                deadline=deadline,
+                deadline=root_deadline,
             )
             try:
                 results_by_root[root] = json.loads(single_text)
             except json.JSONDecodeError:
                 results_by_root[root] = single_text
 
+        extra: dict[str, Any] = {
+            "path": confined_path,
+            "workspace_roots": confined_roots,
+            "results_by_root": results_by_root,
+        }
+        if omitted_roots:
+            # Schema-additive: only present when the shared deadline actually truncated the
+            # root fan-out, so a call that never hits the budget keeps the exact pre-existing
+            # response shape.
+            extra["omitted_roots"] = omitted_roots
+            extra["partial"] = True
         payload = _meta_envelope(
             tool="tg_query",
             action=action,
-            extra={
-                "path": confined_path,
-                "workspace_roots": confined_roots,
-                "results_by_root": results_by_root,
-            },
+            extra=extra,
         )
         return json.dumps(payload, indent=2)
     except Exception as exc:

--- a/tests/unit/test_mcp_tg_query_fanout_cap.py
+++ b/tests/unit/test_mcp_tg_query_fanout_cap.py
@@ -1,0 +1,220 @@
+"""Audit C3 (MCP fan-out amplifier): `tg_query`'s `workspace_roots` param had no cap on the
+number of roots, and its per-root dispatch loop handed the SAME full `deadline` to every root
+with no shared wall-clock budget -- `tg_query(action="find", deadline=60,
+workspace_roots=[r1..r20])` could run up to 20x60=1200s from a single MCP call instead of the
+documented "wall-clock budget in seconds" bounding the WHOLE call.
+
+Covers, RED-then-GREEN against `tensor_grep/cli/mcp_server.py::tg_query`:
+  1. workspace_roots over the `_MAX_WORKSPACE_ROOTS` cap -> fail-closed structured error,
+     never a crash and never a silent truncation to the cap.
+  2. the shared-deadline behavior -- once the shared wall-clock budget is exhausted, the
+     remaining roots are OMITTED (never dispatched) and reported via `omitted_roots` +
+     `partial: true`, instead of each root getting its own fresh copy of `deadline`.
+  3. a normal multi-root call with an ample deadline still dispatches every root and returns
+     the pre-existing response shape unchanged (no `omitted_roots`/`partial` noise).
+
+Sibling file: test_mcp_server.py (see test_tg_query_workspace_roots_dispatches_once_per_root /
+test_tg_query_workspace_roots_one_bad_element_fails_whole_call for the pre-existing
+confinement-only coverage this file must not regress).
+"""
+
+import json
+import time
+from unittest.mock import MagicMock
+
+
+def test_tg_query_workspace_roots_over_cap_fails_closed(monkeypatch, tmp_path):
+    """More than _MAX_WORKSPACE_ROOTS roots (all otherwise valid, in-root paths) must be
+    refused fail-closed BEFORE any root is dispatched -- never a crash, never a silent
+    truncation to the first N roots."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    cap = mcp_server._MAX_WORKSPACE_ROOTS
+    roots = []
+    for i in range(cap + 1):
+        name = f"root_{i}"
+        (tmp_path / name).mkdir()
+        roots.append(name)
+
+    spy = MagicMock(return_value="{}")
+    monkeypatch.setattr(mcp_server, "tg_search", spy)
+
+    out = mcp_server.tg_query(action="text", pattern="foo", workspace_roots=roots)
+    payload = json.loads(out)
+
+    assert payload["error"]["code"] == "invalid_input"
+    assert str(cap) in payload["error"]["message"]
+    assert "results_by_root" not in payload
+    spy.assert_not_called()  # fail-closed BEFORE any root is queried
+
+
+def test_tg_query_workspace_roots_at_cap_is_not_rejected(monkeypatch, tmp_path):
+    """Exactly _MAX_WORKSPACE_ROOTS roots is the boundary-legal case -- must NOT be rejected
+    (the cap is a limit, not an off-by-one trap)."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    cap = mcp_server._MAX_WORKSPACE_ROOTS
+    roots = []
+    for i in range(cap):
+        name = f"root_{i}"
+        (tmp_path / name).mkdir()
+        roots.append(name)
+
+    spy = MagicMock(side_effect=lambda **kwargs: json.dumps({"path": kwargs["path"]}))
+    monkeypatch.setattr(mcp_server, "tg_search", spy)
+
+    out = mcp_server.tg_query(action="text", pattern="foo", workspace_roots=roots)
+    payload = json.loads(out)
+
+    assert "error" not in payload
+    assert spy.call_count == cap
+    assert len(payload["results_by_root"]) == cap
+
+
+def test_tg_query_workspace_roots_shared_deadline_omits_remaining_roots(monkeypatch, tmp_path):
+    """The `deadline` must bound the WHOLE multi-root call as ONE shared wall-clock budget,
+    not be handed unchanged to every root. Simulates a slow first root (via a monkeypatched
+    clock that jumps forward inside the dispatch spy) that alone consumes the entire shared
+    deadline; the remaining roots must be skipped (never dispatched) and reported via
+    `omitted_roots` + `partial: true` rather than each getting a fresh full deadline."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    root_a = tmp_path / "root_a"
+    root_b = tmp_path / "root_b"
+    root_c = tmp_path / "root_c"
+    for root in (root_a, root_b, root_c):
+        root.mkdir()
+
+    clock = {"now": 0.0}
+    # Patch the actual stdlib `time` module (not an mcp_server-local alias) -- mcp_server.py's
+    # own `import time` binds the SAME module object, so this is visible there too, and the
+    # test exercises the real loop against unfixed code instead of erroring on setup.
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+
+    def slow_dispatch(*args, **kwargs):
+        # Simulate the first root's search alone consuming the entire shared deadline
+        # budget (far more than the 10s `deadline` below).
+        clock["now"] += 100.0
+        return json.dumps({"path": kwargs["path"]})
+
+    spy = MagicMock(side_effect=slow_dispatch)
+    monkeypatch.setattr(mcp_server, "_tg_query_dispatch", spy)
+
+    out = mcp_server.tg_query(
+        action="find",
+        query="x",
+        deadline=10,
+        workspace_roots=["root_a", "root_b", "root_c"],
+    )
+    payload = json.loads(out)
+
+    # Only the first root was actually dispatched -- the shared budget was gone before the
+    # loop reached root_b/root_c.
+    assert spy.call_count == 1
+    assert payload["partial"] is True
+    assert len(payload["omitted_roots"]) == 2
+    assert set(payload["results_by_root"]) == {str(root_a.resolve())}
+    # The un-run roots are explicitly named, never silently dropped.
+    assert str(root_b.resolve()) in payload["omitted_roots"]
+    assert str(root_c.resolve()) in payload["omitted_roots"]
+
+
+def test_tg_query_workspace_roots_deadline_not_multiplied_per_root(monkeypatch, tmp_path):
+    """Direct regression test for the audit-C3 amplifier shape: each dispatched root must
+    receive the REMAINING shared budget, not a fresh copy of the original `deadline` value.
+    The second root's forwarded deadline must be smaller than the first root's."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    root_a = tmp_path / "root_a"
+    root_b = tmp_path / "root_b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    clock = {"now": 0.0}
+    # Patch the actual stdlib `time` module (not an mcp_server-local alias) -- mcp_server.py's
+    # own `import time` binds the SAME module object, so this is visible there too, and the
+    # test exercises the real loop against unfixed code instead of erroring on setup.
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+
+    def dispatch_and_advance(*args, **kwargs):
+        clock["now"] += 20.0  # each root "takes" 20s of wall-clock time
+        return json.dumps({"path": kwargs["path"]})
+
+    spy = MagicMock(side_effect=dispatch_and_advance)
+    monkeypatch.setattr(mcp_server, "_tg_query_dispatch", spy)
+
+    mcp_server.tg_query(
+        action="find",
+        query="x",
+        deadline=60,
+        workspace_roots=["root_a", "root_b"],
+    )
+
+    assert spy.call_count == 2
+    first_deadline = spy.call_args_list[0].kwargs["deadline"]
+    second_deadline = spy.call_args_list[1].kwargs["deadline"]
+    # Root 1 gets ~the full 60s budget; root 2 must get strictly less (the remaining ~40s),
+    # never another fresh 60s -- this is the exact amplifier the audit flagged.
+    assert first_deadline > second_deadline
+    assert second_deadline <= 40.0 + 1e-6
+
+
+def test_tg_query_workspace_roots_ample_deadline_returns_all_roots_unchanged(monkeypatch, tmp_path):
+    """A normal multi-root call whose deadline is never actually exhausted must dispatch every
+    root and preserve the EXISTING response shape exactly -- no `omitted_roots`/`partial` keys
+    at all when nothing was omitted (schema-additive, not schema-noisy)."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    root_a = tmp_path / "root_a"
+    root_b = tmp_path / "root_b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    spy = MagicMock(side_effect=lambda **kwargs: json.dumps({"path": kwargs["path"]}))
+    monkeypatch.setattr(mcp_server, "tg_find", spy)
+
+    out = mcp_server.tg_query(
+        action="find",
+        query="foo",
+        deadline=9999,
+        workspace_roots=["root_a", "root_b"],
+    )
+    payload = json.loads(out)
+
+    assert spy.call_count == 2
+    assert "omitted_roots" not in payload
+    assert "partial" not in payload
+    called_paths = {call.kwargs["path"] for call in spy.call_args_list}
+    assert called_paths == {str(root_a.resolve()), str(root_b.resolve())}
+    assert set(payload["results_by_root"]) == called_paths
+    # First root should be handed close to the full budget (only a tiny slice elapsed).
+    assert spy.call_args_list[0].kwargs["deadline"] > 9990
+
+
+def test_tg_query_workspace_roots_no_deadline_unchanged_behavior(monkeypatch, tmp_path):
+    """When no `deadline` is supplied at all (the pre-existing default), behavior must be
+    byte-for-byte unchanged: every root dispatched with `deadline=None`, no omitted_roots."""
+    from tensor_grep.cli import mcp_server
+
+    monkeypatch.chdir(tmp_path)
+    root_a = tmp_path / "root_a"
+    root_b = tmp_path / "root_b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    spy = MagicMock(side_effect=lambda **kwargs: json.dumps({"path": kwargs["path"]}))
+    monkeypatch.setattr(mcp_server, "tg_search", spy)
+
+    out = mcp_server.tg_query(action="text", pattern="foo", workspace_roots=["root_a", "root_b"])
+    payload = json.loads(out)
+
+    assert spy.call_count == 2
+    assert "omitted_roots" not in payload
+    assert "partial" not in payload
+    for call in spy.call_args_list:
+        assert call.kwargs.get("deadline") is None


### PR DESCRIPTION
## The bug (audit C3 — MCP fan-out amplifier)

`tg_query`'s `workspace_roots` MCP parameter (`list[str]`) had two unbounded-fan-out gaps in
its per-root loop:

1. **No cap** on the number of roots.
2. The per-root dispatch loop passed the **same full `deadline` value to every root's**
   `_tg_query_dispatch` call — no budget division, no shared wall-clock stop across the loop.

So `tg_query(action="find", deadline=60, workspace_roots=[r1..r20])` could run up to
**20×60=1200s** from a single MCP call, even though the docstring documents `deadline` as a
"wall-clock budget in seconds" for the whole call. Reachable via MCP, no auth beyond normal
tool access.

## The fix

**Root cap:** `_MAX_WORKSPACE_ROOTS = 8`, a module-level constant local to `tg_query` (mirrors
the existing `_MAX_INLINE_RULES = 100` fan-out-count-cap precedent guarding
`tg_ruleset_scan`'s inline-rules DoS — same shape, smaller number because each `tg_query` root
re-runs a *full* search/find pass, not a single fast ast-grep rule). Over the cap fails closed
via a new `_meta_workspace_roots_cap_error` helper returning a structured
`{"code": "invalid_input", ...}` payload — mirrors the existing
`_meta_missing_param_error`/`_meta_confinement_error` shape exactly. Checked *before*
confinement so an oversized list never even resolves paths.

**Wall-clock: shared deadline, not divided.** Chose "one shared monotonic deadline, stop
dispatching once exceeded" over dividing `deadline` by root count, because division either
starves complex roots that legitimately need more time or wastes budget on roots that finish
early — a shared deadline lets an early-finishing root "give back" its unused time to the
rest of the loop, which is strictly more honest about what actually ran. Implementation reuses
two patterns **already established elsewhere in this file**, rather than inventing a new one:
- `_deadline_monotonic_from_seconds` (already used by `_execute_find`/`agent_capsule.py`/
  `codemap.py`) converts the relative `deadline` to one absolute `time.monotonic()` budget,
  computed once before the loop.
- The per-iteration "remaining budget" computation mirrors `agent_capsule.py:565-567`'s
  `max(0.1, deadline_monotonic - time.monotonic())` call-site-evidence pattern exactly (same
  floor, same shape).

A root whose turn starts only after the shared budget is exhausted is **skipped, never
dispatched** — not silently granted a fresh deadline, and not silently dropped from the
response with no signal. Skipped roots are named in a new top-level `omitted_roots` list plus
`partial: true`.

**Schema-additive.** `omitted_roots`/`partial` only appear when the shared deadline actually
truncated the fan-out. A call that never hits the budget — including the pre-existing
no-`deadline` default — keeps the *exact* pre-existing `tg_query` response shape (verified by
a dedicated regression test + the full existing `test_mcp_server.py` suite).

## Tests (`tests/unit/test_mcp_tg_query_fanout_cap.py`, RED verified first)

RED was confirmed by stashing only the `mcp_server.py` fix and running the new test file
against unfixed `origin/main` code before restoring the fix:
- `test_tg_query_workspace_roots_over_cap_fails_closed` / `..._at_cap_is_not_rejected` —
  boundary coverage for the cap (over → `AttributeError` on missing `_MAX_WORKSPACE_ROOTS`
  pre-fix; exactly-at-cap must never be rejected).
- `test_tg_query_workspace_roots_shared_deadline_omits_remaining_roots` — a monkeypatched
  clock that jumps forward inside a spied `_tg_query_dispatch` proves the pre-fix loop
  dispatches **all 3** roots (`assert 3 == 1` failure) regardless of budget; post-fix only the
  first root (which alone exhausts the shared budget) is dispatched, the other two land in
  `omitted_roots` + `partial: true`.
- `test_tg_query_workspace_roots_deadline_not_multiplied_per_root` — the direct amplifier
  regression: pre-fix both roots receive the *identical* `deadline=60` (`assert 60 > 60`
  failure, i.e. no reduction at all); post-fix root 2's forwarded deadline is strictly less
  than root 1's (the remaining budget, not a fresh copy).
- `test_tg_query_workspace_roots_ample_deadline_returns_all_roots_unchanged` /
  `..._no_deadline_unchanged_behavior` — regression guards proving the existing
  single-root/normal-multi-root/no-deadline response shape is preserved byte-for-byte
  (no `omitted_roots`/`partial` noise when nothing was actually truncated).

## Verification

- `tests/unit/test_mcp_tg_query_fanout_cap.py`: 6/6 passed (RED confirmed pre-fix, GREEN
  post-fix).
- `tests/unit/test_mcp_server.py` (the tg_query dispatch/confinement/plural-confinement-ratchet/
  envelope-shape coverage for this consolidated, security-hardened MCP surface): 485/485
  passed, unchanged.
- `tests/unit/` full suite: green (see CI; also verified locally).
- `mypy --strict` on the changed file: clean.
- `ruff format --preview` + `ruff check` on both changed files: clean.
- Verified `tensor_grep.__file__` resolves into this worktree (not a stale venv) before
  trusting any of the above.
- Python-only change; no `rust_core`/native code touched, no compile required.

Draft PR — not merging per house process (adversarial security gate + steward review before
merge on a security-hardening change).