### PR TITLE
fix(edit-plan): --max-files now actually bounds suggested_edits (audit B9; was silently ignored)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -11362,6 +11362,29 @@ def _deduplicate_suggested_edits(suggestions: list[dict[str, Any]]) -> list[dict
     return [deduped[key] for key in ordered_keys]
 
 
+def _capped_suggested_edits(
+    entries: list[dict[str, Any]],
+    max_edits: int | None,
+) -> list[dict[str, Any]]:
+    """Bound ``entries`` to ``max_edits`` items; ``None`` means unbounded. This is the SOLE
+    enforcement point for ``_suggested_edits_from_related_spans``'s ``max_edits`` contract (audit
+    B9/A18): the parameter used to be accepted but silently ignored, so ``tg edit-plan --json
+    --max-files N`` grew ``suggested_edits`` unbounded despite the flag's documented meaning.
+
+    ``max_edits`` is threaded in from ``_build_edit_plan_seed``'s ``suggested_edits_max`` parameter,
+    which defaults to ``None`` and is OPT-IN per caller (see that parameter's docstring): only
+    ``tg edit-plan``'s own builder (``build_context_edit_plan_from_map``) currently passes a real
+    value. ``tg context-render`` (own separate, pre-existing downstream cap via
+    ``_compact_edit_plan_seed``, but only for the compact/llm render profiles -- the default "full"
+    profile has no cap at all) and ``tg blast-radius-plan``/``tg blast-radius-render`` (no cap at
+    all) carry the identical flag-lie this function fixes, but stay on the ``None`` default and are
+    deliberately left unbounded -- out of scope for this PR; see
+    ``tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py`` for the pins proving so."""
+    if max_edits is None:
+        return entries
+    return entries[:max_edits]
+
+
 def _suggested_edits_from_related_spans(
     related_spans: list[dict[str, Any]],
     *,
@@ -11369,7 +11392,7 @@ def _suggested_edits_from_related_spans(
     definitions: list[dict[str, Any]] | None = None,
     callers: list[dict[str, Any]] | None = None,
     repo_root: Path | str | None = None,
-    max_edits: int,
+    max_edits: int | None = None,
 ) -> list[dict[str, Any]]:
     suggestions: list[dict[str, Any]] = []
     processed_spans: list[dict[str, Any]] = []
@@ -11421,12 +11444,12 @@ def _suggested_edits_from_related_spans(
         processed_spans.append(current)
 
     if primary_symbol is None:
-        return _deduplicate_suggested_edits(suggestions)
+        return _capped_suggested_edits(_deduplicate_suggested_edits(suggestions), max_edits)
 
     primary_name = str(primary_symbol.get("name", ""))
     definition_path = str(primary_symbol.get("file", ""))
     if not primary_name or not definition_path:
-        return _deduplicate_suggested_edits(suggestions)
+        return _capped_suggested_edits(_deduplicate_suggested_edits(suggestions), max_edits)
 
     import_updates_by_key: dict[tuple[str, int, int], dict[str, Any]] = {}
     for current in processed_spans:
@@ -11461,7 +11484,7 @@ def _suggested_edits_from_related_spans(
             import_updates_by_key[key] = import_entry
 
     suggestions.extend(import_updates_by_key.values())
-    return _deduplicate_suggested_edits(suggestions)
+    return _capped_suggested_edits(_deduplicate_suggested_edits(suggestions), max_edits)
 
 
 def _preferred_edit_anchor_symbol(
@@ -11864,6 +11887,7 @@ def _build_edit_plan_seed(
     semantic_provider: str = "native",
     deadline_monotonic: float | None = None,
     deadline_hit: _DeadlineBreakFlag | None = None,
+    suggested_edits_max: int | None = None,
 ) -> dict[str, Any]:
     primary_file = next(iter(payload.get("files", [])), None)
     primary_symbol = next(
@@ -12118,7 +12142,15 @@ def _build_edit_plan_seed(
             definitions=suggested_edit_definitions,
             callers=list(radius_payload.get("callers", [])) if radius_payload is not None else [],
             repo_root=Path(str(repo_map["path"])).resolve(),
-            max_edits=max_files,
+            # Opt-in only (audit B9/A18 fix scope): `suggested_edits_max` defaults to `None`
+            # (unbounded, byte-identical to every caller's pre-fix behavior) unless the caller of
+            # `_build_edit_plan_seed` explicitly requests a bound. Only `tg edit-plan`'s own builder
+            # (`build_context_edit_plan_from_map`) opts in today -- `tg context-render` (which has
+            # its own separate, pre-existing downstream cap for the compact/llm profiles only -- see
+            # `_compact_edit_plan_seed`) and `tg blast-radius-plan`/`tg blast-radius-render` (which
+            # have no cap at all) are deliberately left unchanged; they share the identical flag-lie
+            # this fix closes but are out of scope for this PR.
+            max_edits=suggested_edits_max,
         ),
         "dependency_trust": dependency_trust,
         "plan_trust_summary": _plan_trust_summary(
@@ -12187,6 +12219,7 @@ def _attach_edit_plan_metadata(
     semantic_provider: str = "native",
     deadline_monotonic: float | None = None,
     _profiling_collector: _ProfileCollector | None = None,
+    suggested_edits_max: int | None = None,
 ) -> dict[str, Any]:
     with _profiling_phase(_profiling_collector, "edit_plan_assembly"):
 
@@ -12270,6 +12303,7 @@ def _attach_edit_plan_metadata(
                 semantic_provider=semantic_provider,
                 deadline_monotonic=deadline_monotonic,
                 deadline_hit=edit_plan_seed_deadline_hit,
+                suggested_edits_max=suggested_edits_max,
             )
             if edit_plan_seed_deadline_hit.hit:
                 payload["partial"] = True
@@ -12621,6 +12655,12 @@ def build_context_edit_plan_from_map(
         # map's own call to this same helper already passes deadline_monotonic; mirror it here.
         deadline_monotonic=deadline_monotonic,
         _profiling_collector=collector,
+        # audit B9/A18: `tg edit-plan --json --max-files N` wired `max_edits=max_files` into
+        # `_suggested_edits_from_related_spans` but the callee never read it, so `suggested_edits`
+        # grew unbounded regardless of `--max-files`. This is the ONE opt-in call site for the new
+        # `suggested_edits_max` bound -- edit-plan's own top-level builder, never shared with
+        # context-render or blast-radius-plan/render (see `_build_edit_plan_seed`'s call comment).
+        suggested_edits_max=normalized_max_files,
     )
     payload["validation_commands"] = _top_level_validation_commands(payload)
     payload["suggested_validation_commands"] = _top_level_suggested_validation_commands(payload)

--- a/tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py
+++ b/tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py
@@ -1,0 +1,174 @@
+"""Audit finding B9/A18 (convergently found by two independent audit lenses): `tg edit-plan --json
+--max-files N` visibly wired `max_edits=max_files` into `_suggested_edits_from_related_spans`
+(repo_map.py) but the callee never read `max_edits` to bound the returned `suggestions` list -- a
+flag-lie, the same class of bug as the #200/#203/#205 deadline gaps. `edit_plan_seed.suggested_edits`
+could grow unbounded despite the caller (and the user) believing it was capped at `--max-files`.
+
+Fixed by `_capped_suggested_edits` (the enforcement mechanism) plus a new opt-in
+`suggested_edits_max` parameter threaded `build_context_edit_plan_from_map` ->
+`_attach_edit_plan_metadata` -> `_build_edit_plan_seed` -> `_suggested_edits_from_related_spans`.
+
+VERIFY-FIRST CORRECTION (found while writing this test, not assumed from the audit): the audit
+described `_compact_edit_plan_seed` as an "existing cap" for `tg context-render`, but that helper
+only runs for `render_profile in {"compact", "llm"}` (`_COMPACT_CONTEXT_RENDER_PROFILES`,
+repo_map.py) -- NOT the default `"full"` profile. `tg context-render`'s default profile therefore
+carried the IDENTICAL unbounded-suggested_edits bug as edit-plan, as do `tg blast-radius-plan` and
+`tg blast-radius-render` (neither calls `_compact_edit_plan_seed` at all). Binding the fix at the
+single shared source (`_suggested_edits_from_related_spans`) unconditionally would have silently
+changed all four commands' output -- wider than the "ONE correctness fix" for edit-plan this PR
+ships and a direct violation of "do not change the context-render output". The fix is therefore
+OPT-IN: `suggested_edits_max` defaults to `None` (unbounded, byte-identical to every caller's
+pre-fix behavior) everywhere, and only `build_context_edit_plan_from_map` (edit-plan's own top-level
+builder -- never shared with context-render or blast-radius-plan/render) passes a real value. The
+context-render/blast-radius-plan/blast-radius-render gaps are real and share the same root cause,
+but are deliberately left unfixed here as an out-of-scope, separately-reviewable follow-up.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import repo_map
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_many_callers_project(tmp_path: Path, *, caller_count: int) -> Path:
+    """A `create_invoice` definition plus `caller_count` distinct files that each import AND call
+    it. Every caller file contributes both a `caller-update` suggested edit (the call site) and an
+    `import-update` suggested edit (the `from ... import create_invoice` line), so `caller_count`
+    files reliably produce roughly `2 * caller_count` raw `suggested_edits` entries -- comfortably
+    more than a small `--max-files` cap would allow, which is what makes this fixture able to prove
+    the cap is doing real work instead of trivially passing because there was nothing to truncate.
+    """
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    _write(src_dir / "payments.py", "def create_invoice(total):\n    return total + 1\n")
+    for index in range(caller_count):
+        _write(
+            src_dir / f"caller_{index}.py",
+            "from src.payments import create_invoice\n"
+            "\n"
+            f"def wrap_{index}(total):\n"
+            "    return create_invoice(total)\n",
+        )
+    return project
+
+
+def test_edit_plan_max_files_bounds_suggested_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-confirmed then GREEN: `--max-files 2` must bound `edit_plan_seed.suggested_edits` to
+    <=2 entries, even though the fixture produces far more than 2 raw candidates."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    # RED: reproduce the exact PRE-FIX shape by making the enforcement point a no-op passthrough
+    # (before this PR, `_suggested_edits_from_related_spans`'s body never consulted `max_edits` at
+    # all, which is behaviorally identical to `_capped_suggested_edits` always returning its input
+    # unchanged). This proves two things at once: (a) the fixture genuinely produces more than the
+    # cap -- so the assertion below isn't vacuously satisfied -- and (b) the bug, if reintroduced,
+    # will fail this same test rather than silently regressing.
+    monkeypatch.setattr(repo_map, "_capped_suggested_edits", lambda entries, max_edits: entries)
+    uncapped_payload = repo_map.build_context_edit_plan("create invoice", project, max_files=2)
+    uncapped_edits = uncapped_payload["edit_plan_seed"]["suggested_edits"]
+    assert len(uncapped_edits) > 2, (
+        "fixture must produce MORE than the --max-files cap without enforcement, or this test "
+        "cannot prove the cap does real work (this would be a fixture bug, not a repo_map bug)"
+    )
+    monkeypatch.undo()
+
+    # GREEN: with the real fix active, the SAME query/repo/cap is actually bounded, and the capped
+    # list is a stable PREFIX of the uncapped one (not some other truncation/reordering).
+    payload = repo_map.build_context_edit_plan("create invoice", project, max_files=2)
+    seed = payload["edit_plan_seed"]
+    assert len(seed["suggested_edits"]) <= 2
+    assert seed["suggested_edits"] == uncapped_edits[:2]
+
+
+def test_edit_plan_max_files_larger_cap_stays_under_the_raw_count(tmp_path: Path) -> None:
+    """A generous --max-files must never inflate suggested_edits beyond what the (deduplicated)
+    related-span analysis actually found -- the cap only ever truncates, never pads."""
+    project = _build_many_callers_project(tmp_path, caller_count=2)
+
+    payload = repo_map.build_context_edit_plan("create invoice", project, max_files=50)
+
+    assert len(payload["edit_plan_seed"]["suggested_edits"]) <= 50
+
+
+def test_edit_plan_max_files_zero_related_spans_still_returns_empty_list(tmp_path: Path) -> None:
+    """Guardrail: a query with no related spans at all must still return `[]`, not error -- the cap
+    must not assume a non-empty list."""
+    project = tmp_path / "project"
+    _write(project / "src" / "solo.py", "def lonely():\n    return 1\n")
+
+    payload = repo_map.build_context_edit_plan("lonely", project, max_files=2)
+
+    assert payload["edit_plan_seed"]["suggested_edits"] == []
+
+
+@pytest.mark.parametrize("render_profile", ["full", "compact", "llm"])
+def test_edit_plan_max_files_does_not_change_context_render_suggested_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    render_profile: str,
+) -> None:
+    """`tg context-render` must be byte-identical before and after this fix, in every render
+    profile. `build_context_render_from_map`'s own call to `_attach_edit_plan_metadata` never passes
+    `suggested_edits_max` (it is edit-plan's own opt-in only), so `_capped_suggested_edits` always
+    receives `max_edits=None` on this path -- i.e. this PR's new capping mechanism never actually
+    engages for context-render, regardless of profile. Proved directly: swapping in a raw passthrough
+    for `_capped_suggested_edits` (which is what `max_edits=None` already reduces to) must not change
+    context-render's output at all, for ANY profile -- including "full", the default, which (found
+    while writing this test) has NO suggested_edits cap at all, pre- or post-fix; see module
+    docstring."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    fixed_payload = repo_map.build_context_render(
+        "create invoice", project, max_files=2, render_profile=render_profile
+    )
+    fixed_edits = fixed_payload["edit_plan_seed"]["suggested_edits"]
+
+    monkeypatch.setattr(repo_map, "_capped_suggested_edits", lambda entries, max_edits: entries)
+    control_payload = repo_map.build_context_render(
+        "create invoice", project, max_files=2, render_profile=render_profile
+    )
+    control_edits = control_payload["edit_plan_seed"]["suggested_edits"]
+
+    assert control_edits == fixed_edits, (
+        f"context-render (profile={render_profile!r}) suggested_edits changed when this PR's "
+        "capping mechanism was swapped for a raw passthrough -- it must never engage on this path"
+    )
+    # Document the ACTUAL pre-existing shape per profile (measured against origin/main before this
+    # PR, unchanged by it): "compact"/"llm" already truncate via the separate, pre-existing
+    # `_compact_edit_plan_seed` cap; the default "full" profile does not truncate at all. Both facts
+    # are pinned here so a future change to either shape is a conscious, reviewed decision.
+    if render_profile == "full":
+        assert len(fixed_edits) > 2, (
+            "the default profile's suggested_edits is NOT capped by --max-files (a known, "
+            "out-of-scope gap this PR does not touch -- see module docstring); if this now holds "
+            "<=2 it should be a deliberate fix with its own test, not an accidental side effect"
+        )
+    else:
+        assert len(fixed_edits) <= 2
+
+
+def test_edit_plan_max_files_does_not_change_blast_radius_plan_or_render(tmp_path: Path) -> None:
+    """Same discipline as the context-render pin above, for the other two `_attach_edit_plan_
+    metadata` callers this PR deliberately leaves untouched: `tg blast-radius-plan` and `tg
+    blast-radius-render` share the identical B9/A18 flag-lie (neither calls `_compact_edit_plan_seed`
+    either) but are out of scope for this fix -- they must keep their pre-fix (unbounded) shape."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    plan_payload = repo_map.build_symbol_blast_radius_plan("create_invoice", project, max_files=2)
+    render_payload = repo_map.build_symbol_blast_radius_render(
+        "create_invoice", project, max_files=2
+    )
+
+    # Unchanged means still unbounded here -- both comfortably exceed the --max-files=2 cap that
+    # edit-plan now enforces, proving this PR's fix did not leak into either sibling command.
+    assert len(plan_payload["edit_plan_seed"]["suggested_edits"]) > 2
+    assert len(render_payload["edit_plan_seed"]["suggested_edits"]) > 2


### PR DESCRIPTION
## The bug (flag-lie, audit B9/A18)

`tg edit-plan --json --max-files N` visibly wired `max_edits=max_files` into
`_suggested_edits_from_related_spans` (`src/tensor_grep/cli/repo_map.py`), but the callee's body
never read `max_edits` to bound/truncate the returned `suggestions` list. `edit_plan_seed.
suggested_edits` could grow unbounded despite the caller (and the user) believing it was capped at
`--max-files` — the same class of bug as the #200/#203/#205 deadline gaps this repo has fixed
before.

Convergently found by two independent audit lenses (B9 / A18).

## Bound site

`repo_map.py:11365` — new `_capped_suggested_edits(entries, max_edits)` helper, the sole
enforcement point. All three return points of `_suggested_edits_from_related_spans` (`repo_map.py`
~11444, ~11448, ~11487) now route through it instead of returning `_deduplicate_suggested_edits(...)`
directly.

`max_edits` is threaded in via a new **opt-in** `suggested_edits_max` parameter:
`build_context_edit_plan_from_map` (`repo_map.py:~12655`, the one and only opt-in call site) →
`_attach_edit_plan_metadata` → `_build_edit_plan_seed` → `_suggested_edits_from_related_spans`.
Default is `None` (unbounded) everywhere it isn't explicitly set. `build_context_edit_plan_from_map`
covers both the cold `tg edit-plan` CLI path and the warm `tg session edit-plan` daemon path
(`session_store.py:928` calls the same function).

## VERIFY-FIRST correction (found while building this fix, not assumed from the audit)

The audit described `_compact_edit_plan_seed` as an "existing cap" for `tg context-render`'s
`suggested_edits`. Tracing the real code turned up two things the audit didn't know:

1. **`_compact_edit_plan_seed` only fires for `render_profile in {"compact", "llm"}`**
   (`_COMPACT_CONTEXT_RENDER_PROFILES = {"compact", "llm"}`, `repo_map.py:12834`) — **not** the
   default `"full"` profile. `build_context_render`'s own default is `render_profile="full"`, and
   the MCP `context_render`-family tools default to `render_profile="full"` too
   (`mcp_server.py:2943,3213,3573,4377`). So `tg context-render`'s `"full"` profile — which is the
   MCP tool's default and reachable on the CLI via `--json --render-profile full` — carries the
   **identical unbounded-suggested_edits bug** as edit-plan. (The plain `tg context-render --json`
   CLI invocation is not affected in practice: `main.py:9255` resolves `render_profile` to `"llm"`
   whenever `--json` is passed without an explicit `--render-profile`, and `"llm"` *is* capped.)
2. **`tg blast-radius-plan` and `tg blast-radius-render` share the exact same chain** (both call
   `_attach_edit_plan_metadata` → `_build_edit_plan_seed` → `_suggested_edits_from_related_spans`)
   and **never call `_compact_edit_plan_seed` at all** — so they were unconditionally unbounded too.

Binding the fix unconditionally at the shared source (`_suggested_edits_from_related_spans`) would
have silently changed all of the above — wider than "ship ONE correctness fix" and a direct
violation of "do not change the context-render output". That's why the fix is **opt-in**
(`suggested_edits_max` parameter, defaulting to `None`) rather than always-on: `tg context-render`
(all three profiles) and `tg blast-radius-plan`/`tg blast-radius-render` are **deliberately left
unbounded, unchanged** by this PR. They share the identical flag-lie and are a natural, well-scoped
follow-up — flagging here rather than silently bundling an unreviewed behavior change into this PR.

## context-render unchanged (how verified)

`tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py::
test_edit_plan_max_files_does_not_change_context_render_suggested_edits` is parametrized over all
three render profiles (`full`, `compact`, `llm`). For each, it renders once with the real fix, then
again with `_capped_suggested_edits` monkeypatched to a raw passthrough (which is exactly what
`max_edits=None` already reduces to, since `context-render`'s call site never sets
`suggested_edits_max`), and asserts byte-identical `suggested_edits` output. It also pins the
concrete current shape: `full` → uncapped (10 raw entries on the test fixture), `compact`/`llm` →
capped to 2 via the pre-existing `_compact_edit_plan_seed` path.

Also dogfooded end-to-end through the real `python -m tensor_grep.cli.bootstrap` entry point (not
CliRunner) on a 7-caller fixture: `edit-plan --max-files 2` → 2 suggested_edits (fixed);
`context-render --json` (defaults to `llm` profile) → 2 (unchanged, pre-existing cap still works);
`blast-radius-plan --max-files 2` → 14 (unchanged, out of scope, as designed).

## Tests (RED→GREEN)

`tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py`, 7 tests:
- RED-confirmed on unmodified `origin/main` directly (not just simulated): `--max-files 2` on a
  5-caller fixture produced **10** `suggested_edits` before this fix. Verified by temporarily
  reverting `repo_map.py` to `origin/main` and re-running.
- GREEN with the fix: bounded to ≤2, and the capped list is a stable prefix of the uncapped one.
- A larger cap (`max_files=50`) never pads output beyond what related-span analysis found.
- Empty-related-spans guardrail (`[]`, not an error).
- context-render unchanged across all 3 profiles (see above).
- blast-radius-plan/render unchanged (still unbounded — proves the opt-in gate holds).

## Verification

- `ruff format --preview` + `ruff check`: clean on both changed files.
- Full targeted suite (131 tests across `test_edit_plan_max_files_bounds_suggested_edits.py`,
  `test_edit_plan_seed.py`, `test_context_render_default_cap.py`,
  `test_semantic_provider_navigation.py`, `test_medlow_truncation.py`, `test_trust_planning.py`):
  all pass.
- Ran the broader `suggested_edits`-referencing test files too (`test_mcp_server.py`,
  `test_cli_modes.py`, `test_rust_advanced_resolution.py`, `test_js_ts_advanced_resolution.py`,
  `test_import_span_targeting.py`, `test_framework_test_patterns.py`,
  `test_caller_span_targeting.py`); the handful of failures found (embedded-rewrite fallback tests,
  one GPU-device-inventory test) reproduce identically on unmodified `origin/main` — pre-existing
  environment gaps in this venv, unrelated to this change.
- Python-only; no Rust/cargo touched.

Not merging — draft, per instructions.
