### PR TITLE
chore(cleanup): remove 11 provably-dead private symbols (repo_map/main/agent_capsule/directory_scanner) (#210)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -408,12 +408,6 @@ def _capsule_trust_checks(
     }
 
 
-def _validation_plan_has_targeted_primary_evidence(
-    validation_plan: list[dict[str, Any]],
-) -> bool:
-    return bool(_targeted_validation_evidence(validation_plan))
-
-
 def _targeted_validation_evidence(validation_plan: list[dict[str, Any]]) -> list[str]:
     evidence: list[str] = []
     for step in validation_plan:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -565,11 +565,6 @@ def _native_frontdoor_asset_candidates() -> list[_NativeFrontdoorAssetCandidate]
     return candidates
 
 
-def _native_frontdoor_asset_name() -> str | None:
-    candidates = _native_frontdoor_asset_candidates()
-    return candidates[0].asset_name if candidates else None
-
-
 def _native_frontdoor_download_candidates(
     version: str,
 ) -> list[tuple[_NativeFrontdoorAssetCandidate, str]]:
@@ -581,13 +576,6 @@ def _native_frontdoor_download_candidates(
         )
         for candidate in _native_frontdoor_asset_candidates()
     ]
-
-
-def _native_frontdoor_download_url(version: str) -> str | None:
-    candidates = _native_frontdoor_download_candidates(version)
-    if not candidates:
-        return None
-    return candidates[0][1]
 
 
 def _managed_native_frontdoor_path_from_env() -> Path | None:
@@ -1036,17 +1024,6 @@ def _windows_python_scripts_tensor_grep_package_version(
     if not owns_launcher:
         return None
     return version or "installed"
-
-
-def _windows_stale_tensor_grep_python_launchers(
-    expected_version: str,
-    native_path: Path,
-) -> list[_WindowsStalePythonLauncher]:
-    stale_launchers, _unowned_launchers = _windows_tensor_grep_python_launcher_scan(
-        expected_version,
-        native_path,
-    )
-    return stale_launchers
 
 
 def _windows_tensor_grep_python_launcher_scan(
@@ -5444,20 +5421,6 @@ def _load_sg_project_config(config_path: str | None) -> dict[str, object]:
     }
 
 
-def _iter_yaml_files(base_dir: Path, rel_dirs: list[str]) -> list[Path]:
-    candidates: list[Path] = []
-    for rel_dir in rel_dirs:
-        target = (base_dir / rel_dir).resolve()
-        if target.is_file() and target.suffix.lower() in {".yml", ".yaml"}:
-            candidates.append(target)
-            continue
-        if not target.is_dir():
-            continue
-        candidates.extend(sorted(target.rglob("*.yml")))
-        candidates.extend(sorted(target.rglob("*.yaml")))
-    return sorted(set(candidates))
-
-
 def _extract_rule_pattern(rule_data: dict[str, object]) -> str | None:
     direct = rule_data.get("pattern")
     if isinstance(direct, str) and direct.strip():
@@ -5470,46 +5433,6 @@ def _extract_rule_pattern(rule_data: dict[str, object]) -> str | None:
             return nested.strip()
 
     return None
-
-
-def _load_rule_specs(project_cfg: dict[str, object]) -> list[dict[str, str]]:
-    from tensor_grep.backends.ast_backend import normalize_ast_language
-
-    root_dir = cast(Path, project_cfg["root_dir"])
-    rule_dirs = cast(list[str], project_cfg["rule_dirs"])
-    default_language = cast(str, project_cfg["language"])
-
-    specs: list[dict[str, str]] = []
-    for rule_file in _iter_yaml_files(root_dir, rule_dirs):
-        payload = _load_yaml_dict(rule_file)
-
-        raw_rules = payload.get("rules")
-        if isinstance(raw_rules, list):
-            for idx, item in enumerate(raw_rules):
-                if not isinstance(item, dict):
-                    continue
-                pattern = _extract_rule_pattern(item)
-                if not pattern:
-                    continue
-                specs.append({
-                    "id": str(item.get("id") or f"{rule_file.stem}-{idx + 1}"),
-                    "pattern": pattern,
-                    "language": normalize_ast_language(
-                        item.get("language") or payload.get("language") or default_language
-                    ),
-                })
-            continue
-
-        pattern = _extract_rule_pattern(payload)
-        if not pattern:
-            continue
-        specs.append({
-            "id": str(payload.get("id") or rule_file.stem),
-            "pattern": pattern,
-            "language": normalize_ast_language(str(payload.get("language") or default_language)),
-        })
-
-    return specs
 
 
 def _load_inline_rule_specs(
@@ -5617,15 +5540,6 @@ def _filter_ast_rule_specs(
     except re.error as exc:
         raise ValueError(f"Invalid --filter regex: {exc}") from exc
     return [rule for rule in rules if compiled.search(str(rule.get("id", "")))]
-
-
-def _suffix_for_language(language: str) -> str:
-    normalized = language.lower()
-    if normalized in {"js", "javascript"}:
-        return ".js"
-    if normalized in {"ts", "typescript"}:
-        return ".ts"
-    return ".py"
 
 
 def _build_rulesets_payload() -> dict[str, object]:
@@ -6494,113 +6408,6 @@ def _run_ast_scan_payload(
         suppression_justification=suppression_justification,
     )
     return payload
-
-
-def _search_ast_test_snippets_with_wrapper(
-    backend: object,
-    *,
-    root_dir: Path,
-    case_cfg: "SearchConfig",
-    pattern: str,
-    language: str,
-    snippets: list[str],
-) -> list[bool]:
-    if not snippets:
-        return []
-
-    suffix = _suffix_for_language(language)
-    with TemporaryDirectory(prefix=".tg_rule_test_batch_", dir=root_dir) as temp_dir:
-        temp_root = Path(temp_dir)
-        snippet_paths: list[Path] = []
-        for index, snippet in enumerate(snippets):
-            snippet_path = temp_root / f"case_{index}{suffix}"
-            snippet_path.write_text(snippet, encoding="utf-8")
-            snippet_paths.append(snippet_path)
-
-        result = cast(Any, backend).search_many(
-            [str(temp_root)],
-            pattern,
-            config=case_cfg,
-        )
-
-        def _resolve_match_path(raw_path: str) -> Path:
-            candidate = Path(raw_path)
-            if candidate.is_absolute():
-                return candidate.resolve()
-            return (temp_root / candidate).resolve()
-
-        matched_paths = {_resolve_match_path(path) for path in result.matched_file_paths}
-        matched_paths.update(
-            _resolve_match_path(match.file) for match in result.matches if match.file
-        )
-        return [snippet_path.resolve() in matched_paths for snippet_path in snippet_paths]
-
-
-def _evaluate_ast_test_case_with_wrapper(
-    backend: object,
-    *,
-    root_dir: Path,
-    case_cfg: "SearchConfig",
-    pattern: str,
-    language: str,
-    valid_snippets: list[str],
-    invalid_snippets: list[str],
-) -> list[tuple[str, bool, bool]]:
-    snippets = [*valid_snippets, *invalid_snippets]
-    if not snippets:
-        return []
-
-    match_results = _search_ast_test_snippets_with_wrapper(
-        backend,
-        root_dir=root_dir,
-        case_cfg=case_cfg,
-        pattern=pattern,
-        language=language,
-        snippets=snippets,
-    )
-    expected_matches = [False] * len(valid_snippets) + [True] * len(invalid_snippets)
-    return list(zip(snippets, expected_matches, match_results, strict=True))
-
-
-def _evaluate_grouped_ast_test_cases_with_wrapper(
-    *,
-    failures: list[str],
-    grouped_cases: dict[
-        tuple[int, str, str],
-        dict[str, object],
-    ],
-) -> None:
-    for batch in grouped_cases.values():
-        backend = batch["backend"]
-        root_dir = cast(Path, batch["root_dir"])
-        case_cfg = cast("SearchConfig", batch["case_cfg"])
-        pattern = cast(str, batch["pattern"])
-        language = cast(str, batch["language"])
-        items = cast(list[tuple[str, str, bool]], batch["items"])
-        snippets = [snippet for _, snippet, _ in items]
-        try:
-            match_results = _search_ast_test_snippets_with_wrapper(
-                backend,
-                root_dir=root_dir,
-                case_cfg=case_cfg,
-                pattern=pattern,
-                language=language,
-                snippets=snippets,
-            )
-        except Exception as exc:
-            for case_key, _, _ in items:
-                failures.append(f"{case_key}: backend error: {exc}")
-            continue
-
-        for (case_key, snippet, expected_match), has_match in zip(
-            items, match_results, strict=True
-        ):
-            if has_match != expected_match:
-                expectation = "match" if expected_match else "no match"
-                failures.append(
-                    f"{case_key}: expected {expectation}, got "
-                    f"{'match' if has_match else 'no match'} for snippet {snippet!r}"
-                )
 
 
 def _describe_ast_backend_mode(backend_name: str) -> str:

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -2811,30 +2811,6 @@ def _rust_module_tree_for_entry(
     return module_tree
 
 
-def _rust_module_path_for_definition(
-    definition_path: Path,
-    entry_path: Path,
-) -> tuple[str, ...] | None:
-    normalized_definition = definition_path.expanduser().resolve()
-    normalized_entry = entry_path.expanduser().resolve()
-    if normalized_definition == normalized_entry:
-        return ()
-    try:
-        relative_path = normalized_definition.relative_to(normalized_entry.parent)
-    except ValueError:
-        return None
-    if relative_path.suffix != ".rs":
-        return None
-    parts = list(relative_path.parts)
-    if parts[-1] in {"lib.rs", "main.rs"}:
-        return ()
-    if parts[-1] == "mod.rs":
-        parts = parts[:-1]
-    else:
-        parts[-1] = Path(parts[-1]).stem
-    return tuple(part for part in parts if part)
-
-
 def _rust_workspace_entry_for_crate(
     crate_name: str,
     repo_root: Path | str | None = None,
@@ -7707,26 +7683,6 @@ def _personalized_reverse_import_pagerank(
         return {current: rank for current, rank in ranks.items() if rank > 0.0}
 
 
-def _dependency_ranked_files(
-    ranked_files: list[str],
-    all_files: list[str],
-    imports_by_file: dict[str, list[str]],
-) -> list[str]:
-    if not ranked_files:
-        return []
-
-    boosted: list[tuple[int, str]] = []
-    distances = _reverse_import_distances(ranked_files, all_files, imports_by_file)
-    for current, depth in distances.items():
-        bonus = max(1, 5 - depth)
-        boosted.append((bonus, current))
-
-    boosted.sort(key=lambda item: (-item[0], item[1]))
-    for _, current in boosted:
-        ranked_files.append(current)
-    return ranked_files
-
-
 def _test_import_bonus(
     test_path: str,
     source_tokens: set[str],
@@ -9554,13 +9510,6 @@ def _relative_validation_path(path: Path, repo_root: Path) -> str:
         return path.resolve().relative_to(repo_root).as_posix()
     except ValueError:
         return path.name
-
-
-def _append_unique_command(commands: list[str], command: str, seen: set[str]) -> None:
-    if command in seen:
-        return
-    seen.add(command)
-    commands.append(command)
 
 
 def _shell_safe_arg(value: str) -> str:

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -205,11 +205,6 @@ class DirectoryScanner:
                 decision = result.include
         return bool(decision)
 
-    def _requires_python_guardrails(self, base_path: Path) -> bool:
-        if self.config.no_ignore or self.config.no_ignore_files:
-            return False
-        return base_path.name.lower() in {".claude", *(_GENERATED_DIR_NAMES)}
-
     def _should_descend_dir(self, base_path: Path, root: Path, directory: str) -> bool:
         if self.config.no_ignore or self.config.no_ignore_files:
             return True


### PR DESCRIPTION
## Summary

Conservative, evidence-backed dead-code cleanup across `src/tensor_grep/cli/repo_map.py`, `cli/main.py`, `cli/agent_capsule.py`, and `io/directory_scanner.py`. **255 lines removed, 0 added, 4 files touched.** No CLI-facing surface changed; no test changed; no behavior change.

This is a **DRAFT PR** pending the independent adversarial Opus gate per the repo's Backlog Campaign discipline. Under-removal was preferred throughout — see the KEPT section below for items that looked dead but were deliberately left alone.

## Method

1. Started from the task's 11 static-scan seed candidates, but **triaged every one individually against the real code** rather than trusting the scan — result: **10 of 11 seeds were false positives** (see KEPT table).
2. Since the seed list was mostly noise, ran my own sweep: two independent zero-reference scanners over all of `src/` + `tests/` + `docs/*.md`/`*.toml`/`*.json`/`*.yml` — a full regex re-scan and a single-pass identifier-frequency tokenizer — cross-validated to **identical results** (13 candidates).
3. Every candidate manually verified against: dispatch tables (`LanguageSpec` callable fields), stdlib callback contracts (`urlretrieve` reporthook), Python protocol methods (`__exit__`), parametrized-test pins, and git history (to find *why* each became dead, not just *that* it's dead).
4. Applied removals, then **re-ran both scanners** on the result — zero new dead symbols in the 4 target files, confirming no orphans were left behind by the cascaded removals.

## Kill-list (11 symbols removed, 14 rows below — 3 are cascaded orphans found while removing their sole caller)

| Symbol | File:Line (pre-edit) | Evidence | LOC |
|---|---|---|---|
| `_rust_module_path_for_definition` | `repo_map.py:2814` | Zero references anywhere in repo (2 independent scans + direct grep) | 22 |
| `_dependency_ranked_files` | `repo_map.py:7710` | Zero references; its callee `_reverse_import_distances` independently alive via 3 other call sites | 17 |
| `_append_unique_command` | `repo_map.py:9559` | Zero references anywhere in repo | 5 |
| `_native_frontdoor_asset_name` | `main.py:568` | Zero references; superseded by the nvidia/cpu multi-candidate fallback (`_native_frontdoor_asset_candidates`) | 4 |
| `_native_frontdoor_download_url` | `main.py:586` | Zero references; superseded by `_native_frontdoor_download_candidates` (multi-candidate) | 5 |
| `_windows_stale_tensor_grep_python_launchers` | `main.py:1041` | Zero references. Distinct from the similarly-named, live `_remove_windows_stale_tensor_grep_python_launchers` (called at :1418/:1807, tested in `test_cli_modes.py`) — that function calls the shared scan helper directly instead of through this wrapper | 9 |
| `_iter_yaml_files` | `main.py:5447` | Only caller was the also-dead `_load_rule_specs` (below). `ast_workflows.py` has its own independent, live `_iter_yaml_files` (:369) — different module, no collision | 12 |
| `_load_rule_specs` | `main.py:5475` | Zero references. `tg scan`'s sgconfig path calls `ast_workflows._load_ast_project_data` → `_load_rule_specs_and_meta`, a full independent reimplementation. This function predates that refactor | 38 |
| `_suffix_for_language` | `main.py:5622` (pre-cascade) | Only caller was the also-dead `_search_ast_test_snippets_with_wrapper`. `ast_workflows.py` has its own independent, live `_suffix_for_language` (:397, called at :444/:1480) | 7 |
| `_search_ast_test_snippets_with_wrapper` | `main.py:6499` (pre-cascade) | Only callers were the two `_evaluate_*_with_wrapper` functions below (both dead). `ast_workflows.py`'s `tg test` path (~:1400-1500) has its own independent, live test-case evaluator that never calls this chain | 38 |
| `_evaluate_ast_test_case_with_wrapper` | `main.py:6539` (pre-cascade) | Zero external references | 24 |
| `_evaluate_grouped_ast_test_cases_with_wrapper` | `main.py:6565` (pre-cascade) | Zero external references | 40 |
| `_validation_plan_has_targeted_primary_evidence` | `agent_capsule.py:411` | Zero references. Boolean wrapper over `_targeted_validation_evidence`; current live callers (`:1956`, `:2573`) call `_targeted_validation_evidence` directly and use the returned list, not this wrapper | 4 |
| `_requires_python_guardrails` | `directory_scanner.py:208` | Zero references. Git history proof: its only call site was the `RustDirectoryScanner` fast-path branch, which commit `e527eae` (PR #308, "drop dead scanner path") deleted — `RustDirectoryScanner` was never actually exported by `rust_core`, so `HAS_RUST_SCANNER` was permanently `False` and that branch was already unreachable. #308 removed the branch but missed this now-orphaned helper | 4 |

**Total: 255 lines removed across 4 files.**

## KEPT (looks dead but isn't)

| Symbol | File | Why kept |
|---|---|---|
| `__exit__`'s `exc`/`exc_type`/`tb` params | `repo_map.py:421` | Python context-manager protocol requires this exact signature even when unused (hard KEEP-LIST rule) |
| `_python_file_imports_symbol_from_definition`'s `file_path`/`repo_root` | `repo_map.py:3284` | `LanguageSpec.file_imports_symbol_from_definition` (`lang_registry.py:59`) is a `Callable[[Path, str, str, str, Path\|str\|None], bool]` — the dispatcher (`_file_imports_symbol_from_definition`, `repo_map.py:3404`) calls every language's implementation with this exact uniform positional signature. Python's impl doesn't need these two, but the dispatch contract does |
| `_python_references_and_calls_for_registry`'s `repo_root` | `repo_map.py:5664` | Same dispatch-table reason — `LanguageSpec.references_and_calls` type alias requires `(Path, str, Path\|str\|None)` |
| `_python_provider_alias_calls_for_registry`'s `repo_root` | `repo_map.py:5674` | Same dispatch-table reason |
| `_python_import_update_target_for_registry`'s `repo_root` | `repo_map.py:5680` | Same dispatch-table reason (`ImportUpdateTarget` type alias) |
| `_suggested_edits_from_related_spans`'s `max_edits` | `repo_map.py:11388` | **Seed was stale** — #661 (this branch's parent commit) fixed the "flag-lie" this seed described. `max_edits` is now genuinely threaded into `_capped_suggested_edits` at all 3 return points. Verified by reading the current function body, not the seed's claim |
| `_enforce_byte_cap`'s `total_size` | `main.py:651` | `urllib.request.urlretrieve`'s `reporthook` callback contract requires exactly `(block_number, read_size, total_size)` — stdlib API shape, not ours to change |
| `imports` command's `--deadline` option | `main.py:11198` | `typer.Option` — a CLI-facing contract change is explicitly out of scope per the task. The command currently ignores the flag it accepts (a real "flag-lie"), but removing/fixing that is a behavior change, not a dead-code removal. Flagging for follow-up #212, not touching |
| `_classify_native_rewrite_failure`'s `returncode` | `mcp_server.py:840` | Unused in the function body (classification is purely `stderr`-signature-based), but pinned by a parametrized unit test (`test_mcp_plan_bound_apply.py::test_classify_native_rewrite_failure`) that calls it with the exact keyword. Kept per the under-removal bias rather than touching a test file for a few bytes of savings |
| `_definition_confidence_score`'s `symbol` | `repo_map.py:14590` | Unused in the function body, but called **positionally** (`_definition_confidence_score(defn, "run")`) by 4 pinned unit tests in `test_medlow2_repo_map.py`. The task's own rule explicitly flags "called positionally" as a reason to keep. Kept |
| `_GO_DEF_NODE_KINDS` | `lang_go.py:117` | Zero references (Go's `LanguageSpec.def_node_kinds` registration at `repo_map.py:5773` duplicates the same 5 values as an inline literal instead of referencing this constant). However its own comment explicitly states it is "used only for documentation/introspection parity with the other LanguageSpec entries" — clearly intentional, not accidental. Flagging for awareness, not removing |
| `_negotiate_position_encoding` | `lsp_server.py:901` | Zero references — but this is an **incomplete feature**, not cruft. Introduced by commit `29ac86b` ("audit B13") with a docstring stating it needs to be hooked into pygls's `INITIALIZE` lifecycle event ("This function is called from the initialize response path") — that hook was never added, then or since. The LSP server has silently defaulted to `utf-16` position encoding regardless of client capabilities since introduction. Removing this would delete correct, audit-tagged logic that a future fix only needs to *wire up*, not rewrite. **Recommend a follow-up issue** to either finish wiring it (one `@server.feature(INITIALIZE)` handler) or formally retire it — that's a product decision, not a dead-code call |

## Test results

All run in the foreground (not backgrounded), against the worktree source (verified `tensor_grep.__file__` resolves into the worktree before trusting any result — the documented stale-venv trap).

- **Targeted (all 4 changed modules + their direct test files):** 978 passed, 2 skipped, 0 failed.
  - `repo_map.py`-related (14 files): 230 passed
  - `main.py`-related (6 files + `test_cli_modes.py`): 110 + 515 = 625 passed
  - `agent_capsule.py` + `directory_scanner.py` (10 files): 91 passed
  - `mcp_server.py` sanity (untouched file, confirms KEPT items still work): 32 passed, 2 skipped
- **Full `tests/unit/` sweep** (superset, for extra confidence beyond the task's literal scope): **4931 passed**, 21 skipped, 12 failed, 1 deselected.
  - The 1 deselected test (`test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`) and all 12 failures were individually confirmed **pre-existing and unrelated** to this PR:
    - The GPU-device test fails identically via `git stash` + rerun against the clean, unmodified `origin/main` baseline in this environment.
    - All 12 full-suite failures trace to exactly 3 missing optional/native dependencies in this shared dev venv: the uncompiled `tensor_grep.rust_core` PyO3 extension (7 failures — this venv has no native build, and the CPU-safe rule for this task explicitly forbids running `cargo`/`rustc`/`maturin` to build one; CI compiles Rust separately), `model2vec` (2 failures), and `onnxruntime` (3 failures). None touch `repo_map.py`, `main.py`, `agent_capsule.py`, or `directory_scanner.py`.
- **ruff:** `ruff format --preview --check` and `ruff check` both clean on all 4 changed files.
- **Sanity import:** `python -c "import tensor_grep.cli.main, tensor_grep.cli.repo_map, tensor_grep.cli.mcp_server, tensor_grep.cli.agent_capsule"` succeeds.
- **Post-edit dead-symbol re-scan:** both scanners re-run against the edited tree — zero remaining dead symbols in the 4 target files (confirms the 3 cascaded orphans were fully cleaned up, not partially).

## For the Opus gate to focus on

- The 3 cascaded removals (`_iter_yaml_files`, `_suffix_for_language`, `_search_ast_test_snippets_with_wrapper`) — each was independently verified dead, but they were found *while* removing their sole caller rather than in the original sweep. Worth a second look.
- The two KEPT-but-zero-reference items (`_GO_DEF_NODE_KINDS`, `_negotiate_position_encoding`) — I judged these as "intentional/incomplete" rather than "dead," which is a judgment call. If the gate disagrees, both are cheap to remove in a follow-up.
- I did not attempt to fix the `imports --deadline` flag-lie or wire up `_negotiate_position_encoding` — both are real findings but out of scope for a pure dead-code removal; flagging them here so they don't get lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
