### PR TITLE
fix(lsp): negotiate + advertise client position encoding (wire up dead audit-B13 path)

### DIFF
--- a/src/tensor_grep/cli/lsp_server.py
+++ b/src/tensor_grep/cli/lsp_server.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from urllib.parse import unquote, urlparse
 
 from lsprotocol.types import (
+    INITIALIZE,
     TEXT_DOCUMENT_DEFINITION,
     TEXT_DOCUMENT_DID_CHANGE,
     TEXT_DOCUMENT_DID_CLOSE,
@@ -25,6 +26,7 @@ from lsprotocol.types import (
     DidSaveTextDocumentParams,
     DocumentSymbol,
     DocumentSymbolParams,
+    InitializeParams,
     Location,
     OptionalVersionedTextDocumentIdentifier,
     Position,
@@ -60,9 +62,10 @@ class TensorGrepLSPServer(LanguageServer):  # type: ignore
         self.repo_map_cache: OrderedDict[str, dict[str, Any]] = OrderedDict()
         self.provider_mode = "native"
         self.external_providers = ExternalLSPProviderManager()
-        # audit B13: position encoding negotiated with the client.
-        # "utf-16" is the LSP default; we upgrade to "utf-8" when the client
-        # advertises support so that column values are codepoint offsets.
+        # audit B13: position encoding negotiated with the client, mirrored from
+        # pygls' own ``ls.workspace.position_encoding`` once INITIALIZE runs (see
+        # the ``initialize`` feature handler + ``_negotiate_position_encoding``
+        # below). "utf-16" is the LSP default and stays in effect until then.
         self._position_encoding: str = "utf-16"
 
 
@@ -240,11 +243,36 @@ def _codepoint_col_to_utf16(line_text: str, cp_col: int) -> int:
     return utf16_units
 
 
+def _utf8_col_to_codepoint(line_text: str, utf8_col: int) -> int:
+    """Convert a UTF-8 byte-offset column to a Unicode codepoint (str index) offset.
+
+    audit B13: a client that negotiates ``positionEncoding: "utf-8"`` sends
+    ``character`` as a count of UTF-8 code *units* (bytes) — a single codepoint
+    is 1-4 UTF-8 bytes, so (unlike UTF-32) a UTF-8 offset is NOT already a
+    codepoint index and needs the same kind of conversion as UTF-16.
+    """
+    cp = 0
+    utf8_units = 0
+    for ch in line_text:
+        if utf8_units >= utf8_col:
+            break
+        utf8_units += len(ch.encode("utf-8"))
+        cp += 1
+    return cp
+
+
+def _codepoint_col_to_utf8(line_text: str, cp_col: int) -> int:
+    """Convert a codepoint (str index) column offset to UTF-8 byte units."""
+    return len(line_text[:cp_col].encode("utf-8"))
+
+
 def _to_cp_col(ls: TensorGrepLSPServer, line_text: str, col: int) -> int:
     """Convert *col* from the client's position encoding to a codepoint index."""
     if ls._position_encoding == "utf-16":
         return _utf16_col_to_codepoint(line_text, col)
-    # "utf-8" or "utf-32" (codepoints) — Python str indexing is already correct.
+    if ls._position_encoding == "utf-8":
+        return _utf8_col_to_codepoint(line_text, col)
+    # "utf-32" — already a codepoint count; Python str indexing is correct as-is.
     return col
 
 
@@ -252,6 +280,8 @@ def _from_cp_col(ls: TensorGrepLSPServer, line_text: str, cp_col: int) -> int:
     """Convert a codepoint column index to the client's position encoding."""
     if ls._position_encoding == "utf-16":
         return _codepoint_col_to_utf16(line_text, cp_col)
+    if ls._position_encoding == "utf-8":
+        return _codepoint_col_to_utf8(line_text, cp_col)
     return cp_col
 
 
@@ -898,23 +928,60 @@ def workspace_symbol(
     return _workspace_symbols(ls, params.query, path_hint=path_hint)
 
 
-def _negotiate_position_encoding(
-    ls: TensorGrepLSPServer, client_capabilities: dict[str, Any]
-) -> None:
-    """Inspect client capabilities and choose the best position encoding (audit B13).
+@server.feature(INITIALIZE)  # type: ignore
+def initialize(ls: TensorGrepLSPServer, params: InitializeParams) -> None:
+    """Synchronize our column-conversion encoding with the client (audit B13).
 
-    pygls calls the initialize handler before this module's handler runs, so we
-    hook into ``run_lsp`` / the initialize notification to read capabilities.
-    This function is called from the initialize response path.
+    ``@server.feature(INITIALIZE)`` is pygls' documented extension point for
+    the ``initialize`` request. pygls' own built-in handling
+    (``LanguageServerProtocol.lsp_initialize``) negotiates the position
+    encoding and builds ``ls.workspace`` with it *before* invoking this
+    handler, and finalises + returns the ``InitializeResult`` only *after*
+    this handler returns — see ``_negotiate_position_encoding`` for why
+    ``params`` itself is not re-inspected here.
     """
-    general = client_capabilities.get("general") or {}
-    supported = general.get("positionEncodings") or []
-    if "utf-8" in supported:
-        ls._position_encoding = "utf-8"
-    elif "utf-32" in supported:
-        ls._position_encoding = "utf-32"
-    else:
-        ls._position_encoding = "utf-16"
+    _negotiate_position_encoding(ls)
+
+
+def _negotiate_position_encoding(ls: TensorGrepLSPServer) -> None:
+    """Adopt the position encoding pygls negotiated for this session (audit B13).
+
+    Previously dead code: nothing called this function, so ``ls._position_encoding``
+    stayed at its "utf-16" default forever, and the column-conversion helpers
+    (``_to_cp_col`` / ``_from_cp_col``) silently mis-converted columns for any
+    client that negotiated "utf-8" or "utf-32" on a line with non-ASCII text
+    before the target column.
+
+    pygls (>=1.1.0; confirmed against both pygls==2.0.1, the version pinned in
+    uv.lock, and pygls==2.1.1) already negotiates the encoding itself inside
+    ``LanguageServerProtocol.lsp_initialize``
+    — see ``pygls.capabilities.ServerCapabilitiesBuilder.choose_position_encoding``
+    — by walking the client's ``general.positionEncodings`` *in the client's own
+    preference order* and picking the first one pygls also supports (utf-8,
+    utf-16, or utf-32), defaulting to "utf-16" when the capability is absent or
+    empty. That negotiated value is what pygls both (a) uses to construct
+    ``ls.workspace`` before any user ``INITIALIZE`` handler runs, and (b)
+    unconditionally reports back to the client as
+    ``InitializeResult.capabilities.positionEncoding`` — fixed at negotiation
+    time, before a user ``INITIALIZE`` handler is even invoked, so nothing a
+    user handler does can change what gets reported.
+
+    We therefore mirror ``ls.workspace.position_encoding`` — the exact value
+    pygls will report — onto ``ls._position_encoding`` instead of re-deriving
+    our own answer from the raw client capabilities a second time. A second,
+    independent negotiation algorithm could disagree with pygls' own choice
+    (e.g. by not respecting the client's preference order the way pygls does)
+    and silently reintroduce the very client/server encoding mismatch this fix
+    is meant to close.
+    """
+    try:
+        encoding = ls.workspace.position_encoding
+    except RuntimeError:
+        # Defensive only: pygls always creates ls.workspace before invoking a
+        # user INITIALIZE handler, so this is unreachable via the real
+        # initialize dispatch. Guards a direct/out-of-band call.
+        encoding = None
+    ls._position_encoding = encoding if encoding else "utf-16"
 
 
 def run_lsp() -> None:

--- a/tests/unit/test_lsp_server.py
+++ b/tests/unit/test_lsp_server.py
@@ -8,10 +8,15 @@ pytest.importorskip("lsprotocol.types")
 pytest.importorskip("pygls.lsp.server")
 
 from lsprotocol.types import (
+    ClientCapabilities,
     DefinitionParams,
     DidOpenTextDocumentParams,
     DocumentSymbolParams,
+    GeneralClientCapabilities,
+    InitializeParams,
+    InitializeResult,
     Position,
+    PositionEncodingKind,
     PrepareRenameParams,
     ReferenceContext,
     ReferenceParams,
@@ -27,6 +32,7 @@ from tensor_grep.cli.lsp_server import (
     definition,
     did_open,
     document_symbol,
+    initialize,
     prepare_rename,
     references,
     rename,
@@ -48,6 +54,29 @@ def _open_document(server: TensorGrepLSPServer, path: Path, language_id: str) ->
         ),
     )
     return uri
+
+
+def _drive_initialize(server: TensorGrepLSPServer, params: InitializeParams) -> InitializeResult:
+    """Pump pygls' generator-based ``lsp_initialize`` protocol method the same way
+    ``pygls.protocol.json_rpc.JsonRPCProtocol._run_generator`` does over real
+    transport (send each yielded handler's return value back into the generator
+    until it raises ``StopIteration``), without needing a live client/asyncio
+    event loop.
+
+    This drives pygls' REAL initialize path -- including pygls' own
+    position-encoding negotiation and (if registered on *this* server
+    instance) the ``@server.feature(INITIALIZE)`` handler under test -- so it
+    is the only way to observe the actual ``InitializeResult`` pygls would
+    send back to a client (audit B13 regression coverage).
+    """
+    gen = server.protocol.lsp_initialize(params)
+    send_value = None
+    while True:
+        try:
+            handler, args, kwargs = gen.send(send_value)
+        except StopIteration as stop:
+            return stop.value  # type: ignore[no-any-return]
+        send_value = handler(*(args or ()), **(kwargs or {}))
 
 
 def test_lsp_definition_and_references_for_python_symbol(tmp_path: Path) -> None:
@@ -562,3 +591,207 @@ def test_lsp_external_rename_uses_provider_workspace_edit(tmp_path: Path, monkey
     assert edit is not None
     assert edit.document_changes is not None
     assert edit.document_changes[0].edits[0].new_text == "issue_invoice"
+
+
+# --- audit B13: position encoding negotiation (previously dead code) --------------
+
+
+@pytest.mark.parametrize(
+    ("position_encodings", "expected_encoding"),
+    [
+        pytest.param(
+            [PositionEncodingKind.Utf8, PositionEncodingKind.Utf16],
+            "utf-8",
+            id="client_prefers_utf8",
+        ),
+        pytest.param(
+            [PositionEncodingKind.Utf16, PositionEncodingKind.Utf8],
+            "utf-16",
+            id="client_prefers_utf16_over_utf8",
+        ),
+        pytest.param([PositionEncodingKind.Utf32], "utf-32", id="utf32_only"),
+        pytest.param([PositionEncodingKind.Utf16], "utf-16", id="utf16_only"),
+        pytest.param([], "utf-16", id="empty_list_defaults_utf16"),
+        pytest.param(None, "utf-16", id="missing_general_capability_defaults_utf16"),
+    ],
+)
+def test_lsp_initialize_negotiates_and_reports_position_encoding(
+    position_encodings: list[PositionEncodingKind] | None,
+    expected_encoding: str,
+) -> None:
+    """audit B13 regression: on origin/main, ``_negotiate_position_encoding`` was
+    dead code (zero call sites) so ``ls._position_encoding`` stayed stuck at
+    "utf-16" no matter what the client advertised. The fix registers
+    ``initialize`` as a real ``@server.feature(INITIALIZE)`` handler, which
+    must (a) set ``ls._position_encoding`` to the value pygls itself negotiated
+    from ``general.positionEncodings`` (respecting the client's *own*
+    preference order -- "client_prefers_utf16_over_utf8" would have picked
+    "utf-8" under the old dead code's order-blind ``if "utf-8" in supported``
+    check, which is exactly the kind of second, disagreeing negotiation this
+    fix avoids), and (b) that the SAME value is what the server actually
+    reports back in ``InitializeResult.capabilities.positionEncoding`` -- the
+    only thing a real client trusts. Absent/empty capabilities must preserve
+    today's "utf-16" default (no behavior change for existing clients).
+    """
+    server = TensorGrepLSPServer("test", "v1")
+    server.feature(lsp_module.INITIALIZE)(initialize)
+    general = (
+        None
+        if position_encodings is None
+        else GeneralClientCapabilities(position_encodings=position_encodings)
+    )
+    params = InitializeParams(
+        capabilities=ClientCapabilities(general=general),
+        process_id=None,
+        root_uri=None,
+    )
+
+    result = _drive_initialize(server, params)
+
+    assert server._position_encoding == expected_encoding
+    assert result.capabilities.position_encoding == expected_encoding
+
+
+def _utf16_units(text: str) -> int:
+    return len(text.encode("utf-16-le")) // 2
+
+
+def _utf8_units(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    [
+        pytest.param("utf-16", id="utf-16"),
+        pytest.param("utf-8", id="utf-8"),
+        pytest.param("utf-32", id="utf-32"),
+    ],
+)
+def test_lsp_column_conversion_correct_under_each_encoding_for_non_ascii_prefix(
+    tmp_path: Path, encoding: str
+) -> None:
+    """audit B13 behavioral regression: a line with a non-ASCII (astral -- i.e. a
+    UTF-16 surrogate pair AND a 4-byte UTF-8 sequence) character before the
+    target symbol must resolve to the CORRECT symbol and round-trip to the
+    CORRECT wire column under every negotiated encoding, not just "utf-16".
+
+    On origin/main this already passed for "utf-16" (the only encoding the
+    dead negotiation ever produced) but was silently WRONG for "utf-8":
+    ``_to_cp_col``/``_from_cp_col`` treated any non-"utf-16" encoding as
+    "already codepoints", which only holds for utf-32 (fixed-width, 1 unit per
+    codepoint) -- UTF-8 is a *variable-width* byte encoding (1-4 bytes per
+    codepoint), so that passthrough silently mis-converted utf-8 columns on
+    any non-ASCII line, exactly the "wrong columns on definitions/references/
+    rename" bug this fix closes.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
+    module_path = tmp_path / "module.py"
+    # U+1F600 is beyond the Basic Multilingual Plane: 1 codepoint, 2 UTF-16
+    # code units (surrogate pair), 4 UTF-8 bytes, 1 UTF-32 code unit -- so
+    # codepoint/utf-16/utf-8 wire columns for anything after it all diverge.
+    prefix = "\U0001f600"
+    symbol = "create_invoice"
+    line = f"{prefix}{symbol}(3)\n"
+    module_path.write_text(line, encoding="utf-8")
+
+    cp_col = len(prefix)
+    wire_columns = {"utf-16": _utf16_units(prefix), "utf-8": _utf8_units(prefix), "utf-32": cp_col}
+    assert wire_columns == {"utf-16": 2, "utf-8": 4, "utf-32": 1}  # sanity-check the fixture
+
+    server = TensorGrepLSPServer("test", "v1")
+    server._position_encoding = encoding
+    uri = _open_document(server, module_path, "python")
+
+    prepared = prepare_rename(
+        server,
+        PrepareRenameParams(
+            text_document=TextDocumentIdentifier(uri=uri),
+            position=Position(line=0, character=wire_columns[encoding]),
+        ),
+    )
+
+    assert prepared is not None
+    assert prepared.placeholder == symbol
+    assert prepared.range.start.character == wire_columns[encoding]
+    assert prepared.range.end.character == wire_columns[encoding] + len(symbol)
+
+
+def test_lsp_same_position_yields_different_wire_columns_per_encoding(tmp_path: Path) -> None:
+    """audit B13: proves the negotiated encoding actually CHANGES the conversion
+    result (not merely that each encoding independently "works" in isolation).
+    The same logical symbol position must be reported at three different wire
+    column numbers depending on ``ls._position_encoding``.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
+    module_path = tmp_path / "module.py"
+    line = "\U0001f600create_invoice(3)\n"
+    module_path.write_text(line, encoding="utf-8")
+
+    reported_columns: dict[str, int] = {}
+    for encoding in ("utf-16", "utf-8", "utf-32"):
+        server = TensorGrepLSPServer("test", "v1")
+        server._position_encoding = encoding
+        uri = _open_document(server, module_path, "python")
+        prepared = prepare_rename(
+            server,
+            PrepareRenameParams(
+                text_document=TextDocumentIdentifier(uri=uri),
+                # codepoint index 1 is unambiguous under every encoding for
+                # this fixture line (see the parametrized test above) -- feed
+                # it in raw here just to pick a location; what we assert on
+                # is the OUTPUT wire column, which _from_cp_col computes.
+                position=Position(line=0, character=1),
+            ),
+        )
+        assert prepared is not None
+        reported_columns[encoding] = prepared.range.start.character
+
+    assert reported_columns == {"utf-16": 2, "utf-8": 4, "utf-32": 1}
+    assert len(set(reported_columns.values())) == 3  # all three differ
+
+
+def test_lsp_initialize_to_prepare_rename_end_to_end_utf8(tmp_path: Path) -> None:
+    """audit B13 end-to-end smoke test: negotiate utf-8 via a real ``initialize``
+    call, then prove ``prepare_rename`` actually uses the negotiated encoding
+    (not just that ``ls._position_encoding`` was set in isolation, as the
+    other tests above check separately)."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname='demo'\nversion='0.1.0'\n", encoding="utf-8"
+    )
+    module_path = tmp_path / "module.py"
+    line = "\U0001f600create_invoice(3)\n"
+    module_path.write_text(line, encoding="utf-8")
+
+    server = TensorGrepLSPServer("test", "v1")
+    server.feature(lsp_module.INITIALIZE)(initialize)
+    result = _drive_initialize(
+        server,
+        InitializeParams(
+            capabilities=ClientCapabilities(
+                general=GeneralClientCapabilities(position_encodings=[PositionEncodingKind.Utf8])
+            ),
+            process_id=None,
+            root_uri=None,
+        ),
+    )
+    assert result.capabilities.position_encoding == "utf-8"
+    assert server._position_encoding == "utf-8"
+
+    uri = _open_document(server, module_path, "python")
+    prepared = prepare_rename(
+        server,
+        PrepareRenameParams(
+            text_document=TextDocumentIdentifier(uri=uri),
+            position=Position(line=0, character=4),  # UTF-8 byte offset of 'c'
+        ),
+    )
+
+    assert prepared is not None
+    assert prepared.placeholder == "create_invoice"
+    assert prepared.range.start.character == 4
+    assert prepared.range.end.character == 4 + len("create_invoice")


### PR DESCRIPTION
## The bug (audit B13)

`_negotiate_position_encoding()` in `src/tensor_grep/cli/lsp_server.py` had **zero call sites** and its docstring falsely claimed it was "called from the initialize response path." There was also no `@server.feature(INITIALIZE)` handler at all. Consequence: `ls._position_encoding` was permanently stuck at its `"utf-16"` default, so the column-conversion helpers (`_to_cp_col`/`_from_cp_col`) always assumed UTF-16. A client that negotiated `"utf-8"` or `"utf-32"` got **wrong columns on any line containing non-ASCII text before the target column** — definitions/references/rename landing at the wrong offset.

## What I found reading the installed pygls (before writing any code)

Checked the pinned pygls: `pyproject.toml` requires `pygls>=1.3.0`, `uv.lock` pins **`pygls==2.0.1`** (my local `.venv` happened to have a newer `2.1.1` installed — I verified against **both**). `lsprotocol==2025.0.0`.

pygls's own built-in `INITIALIZE` handling (`LanguageServerProtocol.lsp_initialize`, part of pygls since **1.1.0**, Oct 2023 — well before the `>=1.3.0` floor) already does the full two-half job the task described, unconditionally, for every pygls-based server:

1. **Negotiates**: `ServerCapabilitiesBuilder.choose_position_encoding(client_capabilities)` walks the client's `general.positionEncodings` **in the client's own preference order** and returns the first one pygls also supports (utf-8/utf-16/utf-32), defaulting to `"utf-16"` if the capability is absent/empty.
2. **Builds `ls.workspace`** with that encoding *before* any user `@server.feature(INITIALIZE)` handler runs (`ls.workspace.position_encoding` / `ls.workspace.position_codec` are available at that point).
3. **Reports**: `ServerCapabilitiesBuilder.__init__` unconditionally sets `server_cap.position_encoding = position_encoding` — the *same* value from step 1 — and that's what ends up in the returned `InitializeResult.capabilities.positionEncoding`. This value is fixed **before** a user `INITIALIZE` handler is even invoked; nothing a user handler does can change what gets reported.

**This means the "report" half of the task is already done by pygls itself, automatically** — I don't set `ServerCapabilities.positionEncoding` anywhere myself; there both isn't a way to (in this pygls version) and don't need to.

## The fix (two files, no new dependencies)

1. Registered `initialize` via `@server.feature(INITIALIZE)` — pygls' documented extension point.
2. Rewrote `_negotiate_position_encoding(ls)` to **mirror `ls.workspace.position_encoding`** (the exact value pygls already negotiated and will report) onto `ls._position_encoding`, instead of re-deriving a second, independent answer from the raw client capabilities. I deliberately did *not* keep the original dict-parsing algorithm (`if "utf-8" in supported: utf-8 elif "utf-32" ...`), because it disagrees with pygls' own choice whenever a client lists more than one encoding in a non-utf8-first order — e.g. `["utf-16", "utf-8"]` (client prefers utf-16): pygls picks `"utf-16"` (respects order) but the old algorithm would have picked `"utf-8"` (order-blind, "utf-8 wins if present anywhere"). Shipping that as "the fix" would have reintroduced the exact client/server mismatch bug this PR closes, just triggered by a different client capability shape. Falls back to `"utf-16"` defensively if `ls.workspace` is ever unavailable (unreachable via the real pygls dispatch, since pygls always creates it first).
3. Fixed the now-false docstring.

## A second bug found while writing the Step-3 behavioral test

The task asked for a test proving the client-column conversion "yields the **correct** codepoint index under utf-8 vs utf-16." Writing that test surfaced a second, independent bug: `_to_cp_col`/`_from_cp_col` treated `"utf-8"` the same as `"utf-32"` — passthrough, no conversion, on the comment "codepoints — Python str indexing is already correct." That's only true for UTF-32 (fixed-width, 1 code unit per codepoint). **UTF-8 is a variable-width byte encoding (1-4 bytes per codepoint)**, so the passthrough was itself silently wrong for any non-ASCII line under a utf-8-negotiating client — i.e. even with negotiation correctly wired, utf-8 clients would still get wrong columns on non-ASCII lines, just via a different code path. Added `_utf8_col_to_codepoint`/`_codepoint_col_to_utf8`, mirroring the existing UTF-16 pair exactly. Flagging this prominently since it's outside the literal bug description — happy to split it out if you'd rather review it separately, but leaving negotiation "fixed" while this stayed broken would not have actually closed the wrong-columns-for-utf8-clients bug.

## Tests (`tests/unit/test_lsp_server.py`, all new)

Written first; confirmed **RED** against unmodified origin/main two ways: (a) `ImportError: cannot import name 'initialize'` at collection time (proves no `INITIALIZE` handler exists at all), and (b) verified the dead `_negotiate_position_encoding` truly has zero callers via `git grep -c`.

- `test_lsp_initialize_negotiates_and_reports_position_encoding` (6 parametrized cases) — drives the *real* `lsp_initialize` generator dispatch (a small helper `_drive_initialize` pumps it the same way `pygls.protocol.json_rpc.JsonRPCProtocol._run_generator` does over real transport) and asserts **both** `ls._position_encoding` **and** the returned `InitializeResult.capabilities.positionEncoding` match: client-prefers-utf8, client-prefers-utf16-over-utf8 (the order-respecting case that would have broken under the old algorithm), utf32-only, utf16-only, empty list, and missing `general` capability (last two both must preserve today's `"utf-16"` default).
- `test_lsp_column_conversion_correct_under_each_encoding_for_non_ascii_prefix` (3 parametrized cases) — a line prefixed with `U+1F600` (astral: 1 codepoint / 2 UTF-16 units / 4 UTF-8 bytes / 1 UTF-32 unit, so all three wire representations diverge) resolves to the correct symbol and round-trips to the correct wire column under each encoding, via `prepare_rename`.
- `test_lsp_same_position_yields_different_wire_columns_per_encoding` — proves the negotiated encoding actually *changes* the result (2 vs 4 vs 1), not just that each encoding independently "works" in isolation.
- `test_lsp_initialize_to_prepare_rename_end_to_end_utf8` — one composed smoke test: real `initialize(utf-8)` call, then `prepare_rename` on a non-ASCII line, correct result.

## Verification

- `tests/unit/test_lsp_server.py`: **21/21 passed** (10 pre-existing + 11 new), run foreground, verified against **both** `pygls==2.0.1` (the actual `uv.lock`-pinned version) and `pygls==2.1.1` (what happened to be in the local `.venv`) — installed the locked version into an isolated `--target` dir and re-ran via `PYTHONPATH` to be sure the fix isn't accidentally version-specific.
- Retroactively confirmed RED-then-GREEN: stashed just the `src/` fix (keeping the new tests), reran — `ImportError` (proves the tests exercise something that didn't exist pre-fix); restored the fix, reran — all green.
- Full `tests/unit/` suite (1198 tests): **exactly one failure**, `test_cli_search_warns_when_gpu_device_id_out_of_local_inventory` in `test_cli_modes.py` — unrelated to this change (GPU device-inventory CLI warning). Confirmed **pre-existing**: reproduces identically (same assertion, same exit code) with my diff fully stashed, against clean `origin/main` (`a84917d`).
- `ruff format --preview --check` and `ruff check`: clean on both changed files.
- `mypy src/tensor_grep/cli/lsp_server.py` (matches the CI gate's exact scope): clean.
- `python -c "import tensor_grep.cli.lsp_server"`: succeeds, `tensor_grep.__file__` verified resolving into this worktree (not a stale/shadowing install) throughout.
- No other file in the repo references `_negotiate_position_encoding`/`_position_encoding`/`run_lsp` outside `lsp_server.py`, its test file, and `main.py`'s `tg lsp` entry point (unchanged) — the change is fully self-contained.

## Status

**Draft PR** pending an independent Opus gate. Things I'd specifically like the gate to scrutinize:
1. The design call to make `_negotiate_position_encoding` *mirror* `ls.workspace.position_encoding` rather than re-parsing `params.capabilities` itself (see "The fix" section above for the reasoning — two independent negotiation algorithms can disagree).
2. Whether the UTF-8 conversion fix (found via the TDD process, not in the original bug report) belongs in this PR or should ship separately.
3. The `try/except RuntimeError` defensive fallback in `_negotiate_position_encoding` — confirmed unreachable via the real pygls dispatch path, included only to fail closed to today's `"utf-16"` default rather than crash if this is ever invoked out-of-band.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
