### PR TITLE
fix: tg defs/symbol commands scope to a FILE path instead of raising NotADirectoryError

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1470,6 +1470,26 @@ def _literal_symbol_seed_files(
     return seed_files
 
 
+def _repo_map_root_dir(repo_map: dict[str, Any]) -> Path:
+    """Directory-safe root derived from ``repo_map['path']``.
+
+    A repo map's own ``path`` field can be a FILE, not a directory -- ``tg defs/source/refs/
+    callers/impact/blast-radius <file> <symbol>`` scopes the whole map to that one file (see
+    ``build_repo_map``'s ``_envelope(root)`` call, which deliberately stamps the raw, possibly-
+    file ``root`` so the OUTPUT accurately echoes back what path was targeted). But any INTERNAL
+    consumer that needs a directory to root external tooling in -- an LSP `workspace_root` (which
+    ultimately reaches ``subprocess.Popen(cwd=...)`` in ``lsp_external_provider.py``), or a Cargo/
+    go.mod discovery walk -- must never receive that file itself: unlike ``Path.is_file()``/
+    ``.exists()`` (which pathlib silently degrades to ``False`` for a through-a-file path),
+    ``subprocess.Popen(cwd=<file>)`` is a raw OS call with no such guard and crashes with
+    ``NotADirectoryError`` (WinError 267 on Windows, ENOTDIR on POSIX) -- the CEO-dogfood-reported
+    crash on `tg defs <file> <symbol> --provider lsp/hybrid` (native is unaffected; it never reaches
+    this code). Mirrors the pre-existing ``root if root.is_dir() else root.parent`` pattern already
+    used by ``build_repo_map`` (``context_root``)."""
+    root = Path(str(repo_map["path"])).expanduser().resolve()
+    return root if root.is_dir() else root.parent
+
+
 def _repo_map_file_and_test_universe(repo_map: dict[str, Any]) -> tuple[list[Path], list[Path]]:
     """Same normalization + cross-key dedupe as ``_repo_map_file_universe`` below, but returned
     as SEPARATE (files, tests) lists so a caller can distinguish membership (F1 fix: the
@@ -1477,8 +1497,7 @@ def _repo_map_file_and_test_universe(repo_map: dict[str, Any]) -> tuple[list[Pat
     re-deriving it. ``_repo_map_file_universe`` is a thin wrapper over this and its
     source-first-then-tests concatenation order is UNCHANGED -- existing global-order
     consumers (build_context_pack_from_map, edit-plan seeding) are untouched."""
-    root = Path(str(repo_map["path"])).expanduser().resolve()
-    base = root if root.is_dir() else root.parent
+    base = _repo_map_root_dir(repo_map)
     seen: set[str] = set()
     files: list[Path] = []
     tests: list[Path] = []
@@ -3684,7 +3703,7 @@ def _build_import_graph_consumers_from_map(
 ) -> list[dict[str, Any]]:
     if not definition_files:
         return []
-    repo_root = Path(str(repo_map["path"])).resolve()
+    repo_root = _repo_map_root_dir(repo_map)
     definition_file_set = {str(current) for current in definition_files}
     files = bounded_files if bounded_files is not None else _repo_map_file_universe(repo_map)
     consumers: list[dict[str, Any]] = []
@@ -3750,7 +3769,7 @@ def _preferred_definition_files(
     deadline_monotonic: float | None = None,
     deadline_hit: _DeadlineBreakFlag | None = None,
 ) -> list[str]:
-    repo_root = Path(str(repo_map["path"])).resolve()
+    repo_root = _repo_map_root_dir(repo_map)
     definitions = [
         dict(current)
         for current in repo_map.get("symbols", [])
@@ -3796,7 +3815,7 @@ def _relevant_tests_for_symbol(
     deadline_hit: _DeadlineBreakFlag | None = None,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> list[str]:
-    repo_root = Path(str(repo_map["path"])).resolve()
+    repo_root = _repo_map_root_dir(repo_map)
     tests = [str(current) for current in repo_map.get("tests", [])]
     caller_set = set(caller_files or [])
     symbol_candidates = [symbol]
@@ -14690,7 +14709,7 @@ def build_symbol_defs_from_map(
     fallback_used = False
     if normalized_provider != "native":
         external_definitions = _external_definitions(
-            Path(str(repo_map["path"])).resolve(),
+            _repo_map_root_dir(repo_map),
             symbol,
             native_definitions,
             repo_map=repo_map,
@@ -14780,7 +14799,7 @@ def build_symbol_defs_from_map(
         fallback_used=fallback_used,
     )
     payload["provider_status"] = _provider_status_snapshot(
-        Path(str(repo_map["path"])).resolve(),
+        _repo_map_root_dir(repo_map),
         semantic_provider=normalized_provider,
         languages=_provider_languages_for_symbol(repo_map, symbol, definitions),
         fallback_used=fallback_used,
@@ -14897,7 +14916,7 @@ def build_symbol_source_from_map(
         repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
     )
     default_agreement, default_status = _default_provider_metadata(
-        Path(str(repo_map["path"])).resolve(),
+        _repo_map_root_dir(repo_map),
         repo_map,
         symbol,
         semantic_provider=semantic_provider,
@@ -15019,7 +15038,7 @@ def build_symbol_impact_from_map(
         repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
     )
     default_agreement, default_status = _default_provider_metadata(
-        Path(str(repo_map["path"])).resolve(),
+        _repo_map_root_dir(repo_map),
         repo_map,
         symbol,
         semantic_provider=semantic_provider,
@@ -15386,7 +15405,7 @@ def build_symbol_refs_from_map(
         deadline_monotonic=deadline_monotonic,
         deadline_hit=context_pack_deadline_hit,
     )
-    repo_root = Path(str(repo_map["path"])).resolve()
+    repo_root = _repo_map_root_dir(repo_map)
     refs_universe_files, refs_universe_tests = _repo_map_file_and_test_universe(repo_map)
     bounded_files, refs_ceiling_hit = _cap_caller_scan_files(
         [*refs_universe_files, *refs_universe_tests],
@@ -16180,7 +16199,7 @@ def build_symbol_callers_from_map(
         payload["coverage_summary"] = _coverage_summary(payload)
         payload["resolution_gaps"] = []
         return _attach_profiling(payload, _profiling_collector)
-    repo_root = Path(str(repo_map["path"])).resolve()
+    repo_root = _repo_map_root_dir(repo_map)
     callers_universe_files, callers_universe_tests = _repo_map_file_and_test_universe(repo_map)
     bounded_files, callers_ceiling_hit = _cap_caller_scan_files(
         [*callers_universe_files, *callers_universe_tests],
@@ -16877,7 +16896,7 @@ def build_symbol_blast_radius_from_map(
         repo_map, symbol, semantic_provider=semantic_provider, deadline_monotonic=deadline_monotonic
     )
     default_agreement, default_status = _default_provider_metadata(
-        Path(str(repo_map["path"])).resolve(),
+        _repo_map_root_dir(repo_map),
         repo_map,
         symbol,
         semantic_provider=semantic_provider,

--- a/tests/unit/test_semantic_provider_navigation.py
+++ b/tests/unit/test_semantic_provider_navigation.py
@@ -1957,3 +1957,295 @@ def test_mcp_blast_radius_render_accepts_provider_parameter(tmp_path: Path, monk
     )
 
     assert payload["semantic_provider"] == "lsp"
+
+
+# ---------------------------------------------------------------------------
+# Regression (CEO dogfood 2026-07-18): `tg defs/source/refs/callers/impact/
+# blast-radius <FILE> <SYMBOL> --provider lsp/hybrid` used to crash with
+# NotADirectoryError. Root cause: when a repo map is scoped to a single FILE
+# (not a directory), `repo_map["path"]` IS that file. Several `_external_*`
+# call sites derived `repo_root`/`workspace_root` directly from it via
+# `Path(str(repo_map["path"])).resolve()` with no directory guard. That value
+# eventually reaches `ExternalLSPClient._start_locked`'s
+# `subprocess.Popen(cwd=str(self.workspace_root), ...)`
+# (lsp_external_provider.py:500), which raises `NotADirectoryError`
+# (WinError 267 on Windows, ENOTDIR on POSIX) when `cwd` is a file rather
+# than a directory. `--provider native` (the CLI default) never reaches this
+# code, which is why the bug shipped silently -- it only reproduces under
+# `--provider lsp`/`hybrid`.
+#
+# The fix threads every such site through `_repo_map_root_dir()`, mirroring
+# the pre-existing `root if root.is_dir() else root.parent` pattern already
+# used by `build_repo_map` (`context_root`) and
+# `_repo_map_file_and_test_universe` (`base`) -- so external tooling always
+# receives a real directory, while the user-visible `path`/`definitions[].file`
+# fields are unaffected (they still report the exact file, per `_envelope`).
+# ---------------------------------------------------------------------------
+
+
+def test_repo_map_defs_file_path_with_lsp_provider_scopes_workspace_to_parent_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tg defs <file.py> <symbol> --provider lsp` must never crash with
+    NotADirectoryError. The LSP `workspace_root` passed to `get_client` must be
+    the file's PARENT directory (a real directory `subprocess.Popen(cwd=...)`
+    can chdir into), never the file itself."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+
+    class _FakeClient:
+        request_timeout_seconds = 3.0
+        initialize_timeout_seconds = 3.0
+
+        def ensure_document(self, **kwargs: object) -> None:
+            pass
+
+        def request(self, method: str, params: dict[str, object]) -> list[dict[str, object]]:
+            return []
+
+    class _FakeManager:
+        def get_client(self, *, language: str, workspace_root: Path) -> _FakeClient:
+            # The load-bearing assertion: workspace_root must be a real directory (the
+            # file's parent), never the file itself -- a file here is exactly what crashed
+            # subprocess.Popen(cwd=...) with NotADirectoryError.
+            assert workspace_root == tmp_path.resolve()
+            assert workspace_root.is_dir()
+            return _FakeClient()
+
+        def provider_status(self, *, language: str, workspace_root: Path) -> dict[str, object]:
+            assert workspace_root == tmp_path.resolve()
+            return {
+                "language": language,
+                "workspace_root": str(workspace_root),
+                "available": True,
+                "health_status": "ready",
+            }
+
+    monkeypatch.setattr(repo_map, "_EXTERNAL_LSP_PROVIDER_MANAGER", _FakeManager())
+
+    payload = repo_map.build_symbol_defs("create_invoice", module_path, semantic_provider="lsp")
+
+    assert payload["definitions"][0]["name"] == "create_invoice"
+    # The user-visible `path` field must still report the exact FILE, unaffected by the
+    # internal workspace-root directory fix.
+    assert payload["path"] == str(module_path.resolve())
+
+
+def test_repo_map_defs_file_path_symbol_not_found_with_lsp_provider_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same crash is reachable even when the symbol is absent from the file:
+    `_external_workspace_symbols` runs unconditionally before any native-match
+    check, so a bad `workspace_root` crashes regardless of whether the symbol
+    resolves."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+
+    class _FakeClient:
+        request_timeout_seconds = 3.0
+        initialize_timeout_seconds = 3.0
+
+        def ensure_document(self, **kwargs: object) -> None:
+            pass
+
+        def request(self, method: str, params: dict[str, object]) -> list[dict[str, object]]:
+            return []
+
+    class _FakeManager:
+        def get_client(self, *, language: str, workspace_root: Path) -> _FakeClient:
+            assert workspace_root.is_dir()
+            return _FakeClient()
+
+        def provider_status(self, *, language: str, workspace_root: Path) -> dict[str, object]:
+            assert workspace_root.is_dir()
+            return {
+                "language": language,
+                "workspace_root": str(workspace_root),
+                "available": True,
+                "health_status": "ready",
+            }
+
+    monkeypatch.setattr(repo_map, "_EXTERNAL_LSP_PROVIDER_MANAGER", _FakeManager())
+
+    payload = repo_map.build_symbol_defs(
+        "ThisSymbolDoesNotExist", module_path, semantic_provider="lsp"
+    )
+
+    assert payload["definitions"] == []
+
+
+def test_repo_map_defs_directory_path_with_lsp_provider_workspace_root_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: a DIRECTORY path must keep using itself (not its parent) as the
+    LSP workspace_root -- unchanged from before this fix."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+
+    class _FakeClient:
+        request_timeout_seconds = 3.0
+        initialize_timeout_seconds = 3.0
+
+        def ensure_document(self, **kwargs: object) -> None:
+            pass
+
+        def request(self, method: str, params: dict[str, object]) -> list[dict[str, object]]:
+            return []
+
+    class _FakeManager:
+        def get_client(self, *, language: str, workspace_root: Path) -> _FakeClient:
+            assert workspace_root == tmp_path.resolve()
+            return _FakeClient()
+
+        def provider_status(self, *, language: str, workspace_root: Path) -> dict[str, object]:
+            assert workspace_root == tmp_path.resolve()
+            return {
+                "language": language,
+                "workspace_root": str(workspace_root),
+                "available": True,
+                "health_status": "ready",
+            }
+
+    monkeypatch.setattr(repo_map, "_EXTERNAL_LSP_PROVIDER_MANAGER", _FakeManager())
+
+    payload = repo_map.build_symbol_defs("create_invoice", tmp_path, semantic_provider="lsp")
+
+    assert payload["definitions"][0]["name"] == "create_invoice"
+
+
+def test_repo_map_source_file_path_with_lsp_provider_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tg source <file> <symbol> --provider lsp` inherits defs' internal
+    `_external_definitions` call and used to crash identically."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+
+    captured_roots: list[Path] = []
+
+    def _fake_external_workspace_symbols(root, symbol, **kwargs):
+        captured_roots.append(root)
+        return []
+
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", _fake_external_workspace_symbols)
+
+    payload = repo_map.build_symbol_source("create_invoice", module_path, semantic_provider="lsp")
+
+    assert captured_roots, "expected _external_workspace_symbols to be invoked"
+    assert all(root.is_dir() for root in captured_roots)
+    assert payload["sources"][0]["name"] == "create_invoice"
+
+
+def test_repo_map_impact_file_path_with_lsp_provider_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tg impact <file> <symbol> --provider lsp` inherits defs' internal
+    `_external_definitions` call and used to crash identically."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+
+    captured_roots: list[Path] = []
+
+    def _fake_external_workspace_symbols(root, symbol, **kwargs):
+        captured_roots.append(root)
+        return []
+
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", _fake_external_workspace_symbols)
+
+    payload = repo_map.build_symbol_impact("create_invoice", module_path, semantic_provider="lsp")
+
+    assert captured_roots, "expected _external_workspace_symbols to be invoked"
+    assert all(root.is_dir() for root in captured_roots)
+    assert payload["definitions"][0]["name"] == "create_invoice"
+
+
+def test_repo_map_blast_radius_file_path_with_lsp_provider_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tg blast-radius <file> <symbol> --provider lsp` inherits defs' internal
+    `_external_definitions` call and used to crash identically."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text("def create_invoice() -> None:\n    return None\n", encoding="utf-8")
+
+    captured_roots: list[Path] = []
+
+    def _fake_external_workspace_symbols(root, symbol, **kwargs):
+        captured_roots.append(root)
+        return []
+
+    def _fake_external_references(root, symbol, definitions):
+        captured_roots.append(root)
+        return []
+
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", _fake_external_workspace_symbols)
+    monkeypatch.setattr(repo_map, "_external_references", _fake_external_references)
+
+    payload = repo_map.build_symbol_blast_radius(
+        "create_invoice", module_path, semantic_provider="lsp"
+    )
+
+    assert captured_roots, "expected external LSP helpers to be invoked"
+    assert all(root.is_dir() for root in captured_roots)
+    assert payload["definitions"][0]["name"] == "create_invoice"
+
+
+def test_repo_map_refs_file_path_with_lsp_provider_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tg refs <file> <symbol> --provider lsp` has its OWN independent repo_root
+    computation (distinct from defs' internal one) feeding `_external_references` --
+    must be fixed at its own site too, or this crashes even after defs itself is fixed."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text(
+        "def create_invoice() -> None:\n    return None\n\n\ncreate_invoice()\n", encoding="utf-8"
+    )
+
+    captured_roots: list[Path] = []
+
+    def _fake_external_workspace_symbols(root, symbol, **kwargs):
+        captured_roots.append(root)
+        return []
+
+    def _fake_external_references(root, symbol, definitions):
+        captured_roots.append(root)
+        return []
+
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", _fake_external_workspace_symbols)
+    monkeypatch.setattr(repo_map, "_external_references", _fake_external_references)
+
+    payload = repo_map.build_symbol_refs("create_invoice", module_path, semantic_provider="lsp")
+
+    assert captured_roots, "expected external LSP helpers to be invoked"
+    assert all(root.is_dir() for root in captured_roots)
+    assert payload["definitions"][0]["name"] == "create_invoice"
+
+
+def test_repo_map_callers_file_path_with_lsp_provider_no_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tg callers <file> <symbol> --provider lsp` has its OWN independent repo_root
+    computation (distinct from defs' internal one) feeding `_external_references` --
+    must be fixed at its own site too, or this crashes even after defs itself is fixed."""
+    module_path = tmp_path / "module.py"
+    module_path.write_text(
+        "def create_invoice() -> None:\n    return None\n\n\ncreate_invoice()\n", encoding="utf-8"
+    )
+
+    captured_roots: list[Path] = []
+
+    def _fake_external_workspace_symbols(root, symbol, **kwargs):
+        captured_roots.append(root)
+        return []
+
+    def _fake_external_references(root, symbol, definitions):
+        captured_roots.append(root)
+        return []
+
+    monkeypatch.setattr(repo_map, "_external_workspace_symbols", _fake_external_workspace_symbols)
+    monkeypatch.setattr(repo_map, "_external_references", _fake_external_references)
+
+    payload = repo_map.build_symbol_callers("create_invoice", module_path, semantic_provider="lsp")
+
+    assert captured_roots, "expected external LSP helpers to be invoked"
+    assert all(root.is_dir() for root in captured_roots)
+    assert payload["definitions"][0]["name"] == "create_invoice"


### PR DESCRIPTION
## Status: DRAFT — pending independent Opus gate

## The bug (CEO dogfood, tg 1.81.11/1.81.12)

`tg defs <FILE path> <symbol> --provider lsp` (and `--provider hybrid`) crashes:

```
NotADirectoryError: [WinError 267] The directory name is invalid
  File "...\lsp_external_provider.py", line 500, in _start_locked
    self.process = subprocess.Popen(spawn_argv, cwd=str(self.workspace_root), ...)
```

**`--provider native` (the CLI default) never reaches this code**, which is why it shipped silently. A DIRECTORY path with `--provider lsp` succeeds normally (the "structured fallback" in the bug report).

### Exact crashing op + traceback frame

`src/tensor_grep/cli/lsp_external_provider.py:500`, inside `ExternalLSPClient._start_locked`:
```python
self.process = subprocess.Popen(spawn_argv, cwd=str(self.workspace_root), ...)
```

Full chain: `main.py:10667 defs()` → `repo_map.py build_symbol_defs` → `build_symbol_defs_from_map` calls `_external_definitions(Path(str(repo_map["path"])).resolve(), ...)` — passing the **file** as `repo_root` when `defs` was scoped to a single file → `_external_definitions` → `_external_workspace_symbols` (runs **unconditionally**, before any native-match check) → `get_client(workspace_root=repo_root)` → `ExternalLSPClient._start_locked` → `subprocess.Popen(cwd=<file>)`.

### Root cause

`build_repo_map` already handles file-vs-directory correctly for its own file-walk (`_iter_repo_files`'s `if root.is_file(): return [root.resolve()]`) and for `context_root` (`root if root.is_dir() else root.parent`). But the returned `repo_map["path"]` field deliberately still stores the raw file (so output honestly echoes what was targeted — `_envelope(root)`). **Ten separate call sites** across `defs`/`source`/`refs`/`callers`/`impact`/`blast-radius` re-derived a `repo_root`/`workspace_root` straight from `Path(str(repo_map["path"])).resolve())` with no directory guard, and some of those values reach `subprocess.Popen(cwd=...)` (an LSP workspace root) — which, unlike `Path.is_file()`/`.exists()` (silently degrade to `False` for a through-a-file path), is a raw OS call with no such guard.

## The fix (scope-to-file preserved + shared root-resolution guard)

The **scope-to-file behavior was already correct** — `tg defs <file> <symbol>` already searches just that file and returns real defs (confirmed: `--provider native` never crashed). The bug is specifically that the **internal LSP workspace root** must be a directory (a real `cwd` a subprocess can chdir into), while the **user-visible `path` output field must keep reporting the exact file** (unchanged contract).

Added one helper, mirroring the pre-existing `root if root.is_dir() else root.parent` pattern `build_repo_map` already uses for `context_root`:

```python
def _repo_map_root_dir(repo_map: dict[str, Any]) -> Path:
    root = Path(str(repo_map["path"])).expanduser().resolve()
    return root if root.is_dir() else root.parent
```

Threaded through all 10 repo_root/workspace_root call sites in the symbol-command family:
- `build_symbol_defs_from_map`'s `_external_definitions` call (**the primary crash site** — shared internally by source/impact/refs/callers/blast-radius, all of which call `build_symbol_defs_from_map` first) + its `_provider_status_snapshot` call
- `build_symbol_source_from_map`, `build_symbol_impact_from_map`, `build_symbol_blast_radius_from_map`'s `_default_provider_metadata` calls
- `build_symbol_refs_from_map` and `build_symbol_callers_from_map`'s **own independent** `repo_root` (feeds `_external_references` — these do NOT go through `_external_definitions`, so fixing the primary site alone would NOT have fixed refs/callers)
- `_build_import_graph_consumers_from_map`, `_preferred_definition_files`, `_relevant_tests_for_symbol` — same bug class (Go/Rust cross-file import resolution was silently degraded, not crashed, when `repo_root` was a file; fixed for consistency, zero behavior change on directories)

**Directory-input behavior is byte-identical** (`root.is_dir()` branch unchanged) — only file-input behavior changes, and only for the better. The `path` / `definitions[].file` output fields are unaffected (`_envelope()` still reports the exact file).

**Left untouched** (different command family / explicit contract, per scope):
- `tg edit-plan`'s `_build_edit_plan_seed` repo_root — different command, out of scope.
- `build_file_importers_from_map`'s repo_root (`tg importers`) — explicitly comment-guarded ("do not 'fix' this function to resolve against cwd instead, that would silently break the session/daemon contract").

## Which symbol commands were affected + how fixed

Tested each with a FILE path + `--provider lsp`:

| Command | Crashed? | Fix |
|---|---|---|
| `defs` | Yes (primary site) | `_repo_map_root_dir()` at the `_external_definitions` call |
| `source` | Yes (inherited — calls `build_symbol_defs_from_map` internally) | Fixed transitively by the primary site + its own `_default_provider_metadata` call |
| `impact` | Yes (inherited) | Same |
| `blast-radius` | Yes (inherited) | Same |
| `refs` | Yes (inherited **+ own independent site**) | Primary site + its own `repo_root` (feeds `_external_references`) |
| `callers` | Yes (inherited **+ own independent site**) | Primary site + its own `repo_root` (feeds `_external_references`) |

One shared helper fixes all six; `refs`/`callers` needed one extra line each since they compute `repo_root` a second time for their own reference/caller scan.

## Test evidence

TDD: 8 new tests added to `tests/unit/test_semantic_provider_navigation.py`, in a clearly-commented block at the end of the file. Written first and confirmed **red** on pre-fix code:

```
7 failed, 1 passed  (only the directory-path regression guard passed pre-fix, as expected)
```

Post-fix, all **green**:

```
tests/unit/test_semantic_provider_navigation.py::test_repo_map_defs_directory_path_with_lsp_provider_workspace_root_unchanged PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_blast_radius_file_path_with_lsp_provider_no_crash PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_defs_file_path_symbol_not_found_with_lsp_provider_no_crash PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_callers_file_path_with_lsp_provider_no_crash PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_defs_file_path_with_lsp_provider_scopes_workspace_to_parent_dir PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_source_file_path_with_lsp_provider_no_crash PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_impact_file_path_with_lsp_provider_no_crash PASSED
tests/unit/test_semantic_provider_navigation.py::test_repo_map_refs_file_path_with_lsp_provider_no_crash PASSED
8 passed
```

Coverage: `defs` on a FILE containing the symbol (asserts the LSP `workspace_root` reaching `get_client` is the file's **parent directory**, not the file — the load-bearing assertion), `defs` on a FILE **not** containing the symbol (the crash reproduces here too, since `_external_workspace_symbols` runs unconditionally before any match check), a DIRECTORY path (regression guard — `workspace_root` stays the directory itself, unchanged), and one FILE-path no-crash test per sibling command.

**Real end-to-end confirmation** (not mocked — the actual CLI front door, `bootstrap.main_entry()`, real subprocess spawn):
- `tg defs <file.py> build_repo_map --provider lsp` — pre-fix: `NotADirectoryError` traceback (captured above); post-fix: `exit=0`, `definitions=1`, found.
- `tg refs <file.py> build_repo_map --provider lsp` — post-fix: `exit=0`, `references=15 files=1`, found (confirms refs' own independent fix site).

**Regressions**: full `test_semantic_provider_navigation.py` (63 tests, including 55 pre-existing) — all pass. Broader repo_map/symbol-command/MCP regression sweep (`test_answer_first_symbol_payloads`, `test_cap_fix_chokepoint`, `test_cli_deadline_flag`, `test_cli_modes`, `test_mcp_caps`, `test_mcp_contract_fixes`, `test_medlow2_main_cli`, `test_medlow2_repo_map`, `test_repo_map_partial_propagation`, `test_symbol_defs_stage_deadline_c1c2`) — 700 tests, 699 passed. The 1 failure (`test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`, unrelated to this diff — `tg search --gpu-device-ids` GPU inventory detection) was confirmed **pre-existing** by running it in an isolated worktree checked out at the parent commit (before this fix): identical failure. `tests/unit/test_lang_go.py` (15 failures) was also confirmed pre-existing/environmental (missing tree-sitter Go grammar binding in this bare-interpreter sandbox) the same way — identical 15 failures with this diff stashed out.

**ruff**: `ruff format --preview` and `ruff check` both clean on the 2 changed files (`src/tensor_grep/cli/repo_map.py`, `tests/unit/test_semantic_provider_navigation.py`).

**Import sanity**: `python -c "import tensor_grep.cli.main, tensor_grep.cli.repo_map"` succeeds.

## Directory-path regression guard (confirms no change to existing behavior)

`test_repo_map_defs_directory_path_with_lsp_provider_workspace_root_unchanged` passed on **both** pre-fix and post-fix code — the directory case was already correct and stays byte-identical.

## Note for the gate

- Branched from `origin/main` (fresh worktree via `git worktree add ... origin/main`), rebased cleanly onto `origin/main` after PR #662 (dead-code cleanup) merged mid-session — zero conflicts, exactly as anticipated.
- This diff does **not** touch the Rust extension, `main.py`, or anything outside `repo_map.py` + the one test file.
- One thing to double check independently: I applied the same helper to 3 sites (`_build_import_graph_consumers_from_map`, `_preferred_definition_files`, `_relevant_tests_for_symbol`) that were **not independently crash-reproducible** on Windows (Go's `.is_file()`-based `go.mod` lookup gracefully degrades rather than raising) but are the same conceptual bug (a file masquerading as a directory root) and are within the same symbol-command family. Flagging this as a judgment call in case the gate prefers a narrower diff limited to only the reproduced crash sites (`build_symbol_defs_from_map`, `build_symbol_refs_from_map`, `build_symbol_callers_from_map`, and their `_provider_status_snapshot`/`_default_provider_metadata` siblings).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
