### PR TITLE
fix(security): uniform symlink-refusal + atomic-rename hardening across the JSON/key/audit-manifest writers (C4/#659 residual)

### DIFF
--- a/src/tensor_grep/cli/_index_lock.py
+++ b/src/tensor_grep/cli/_index_lock.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 import os
 import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 _POLL_S = 0.02
@@ -42,6 +44,102 @@ def replace_with_retry(
             if attempt == attempts - 1:
                 raise
             time.sleep(delay_s)
+
+
+def atomic_write_bytes(path: Path, data: bytes, *, mode: int | None = None) -> None:
+    """Write ``data`` to ``path`` atomically, refusing to write through a pre-existing symlink.
+
+    The ONE shared hardening baseline (audit C4 / CWE-59, PR #659; uniformized across every
+    sibling writer by task #211) for every JSON/key/manifest writer in the ``cli`` package: an
+    ``is_symlink()`` refusal precheck on the PRE-resolve destination, a same-directory temp file,
+    POSIX ``O_CREAT|O_EXCL`` plus ``O_NOFOLLOW`` where the platform has it, an ``fsync`` of the
+    written bytes before the rename, and :func:`replace_with_retry` (``os.replace``) to publish.
+
+    Why the precheck AND the rename-based swap: ``os.replace`` never dereferences a destination
+    symlink -- POSIX ``rename()`` atomically replaces the link ENTRY itself, never the file it
+    points to -- so this function can never be tricked into corrupting an arbitrary symlink
+    TARGET through the publish step alone. But without the precheck it would still silently
+    destroy a pre-existing symlink at the destination with no signal that something unexpected was
+    already there; refusing outright is the same fail-closed posture
+    ``evidence_signing._write_private_key_atomic`` has always taken (the original C4 fix), now
+    uniform across every sibling writer instead of copy-pasted (or, in three sites, MISSING)
+    per-module.
+
+    ``O_NOFOLLOW`` is a documented no-op on Windows (``getattr(os, "O_NOFOLLOW", 0)`` mirrors both
+    cpython's own ``tempfile`` module and this codebase's established
+    ``main._write_json_refuse_symlink`` idiom) -- it is belt-and-suspenders defense-in-depth
+    against a symlink swapped in at the randomly-named temp path itself (astronomically unlikely,
+    since the name includes a fresh ``uuid4``), not the cross-platform guard. The cross-platform
+    guard is the precheck + same-directory-temp + rename shape, which holds identically on POSIX
+    and Windows -- do NOT treat ``O_NOFOLLOW`` alone as sufficient hardening on this codebase's
+    primary (Windows) development platform.
+
+    Callers that first ``.expanduser().resolve()`` a caller-supplied path MUST check
+    ``is_symlink()`` on the PRE-resolve path themselves before calling this function (mirrors
+    ``evidence_signing.generate_keypair``) -- ``.resolve()`` follows symlinks, so by the time a
+    resolved path reaches here the symlink-ness of the ORIGINAL destination is already lost. This
+    function's own check remains as defense-in-depth against a symlink planted directly at an
+    already-resolved leaf path (the common case for internal callers that never round-trip through
+    a caller-supplied string) and against the narrow TOCTOU window between an outer check and this
+    call.
+
+    ``mode``, when given, is applied to the temp file at creation (honoring the umask) and
+    re-asserted with ``os.chmod`` afterward for determinism (in case the umask stripped a bit);
+    when ``None`` the temp file is created at the same effective permissions plain ``open()``
+    would use (``0o666`` masked by umask).
+
+    Raises ``OSError`` if ``path`` is already a symlink; propagates any other write/rename failure
+    (Backend Fail-Closed Contract -- never a silent partial write).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise OSError(f"Refusing to write through a symlink: {path}")
+    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    create_mode = 0o666 if mode is None else mode
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(tmp_path, flags, create_mode)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            # M6: fsync the data before the rename so a crash can never publish a truncated
+            # file (mirrors session_store._write_json_atomic, audit I5).
+            os.fsync(handle.fileno())
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)  # don't leave a partial temp behind
+        raise
+    if mode is not None:
+        # O_CREAT honors the umask, so the created mode is never broader than `mode`; force the
+        # exact requested bits for determinism (in case the umask stripped an owner bit).
+        try:
+            os.chmod(tmp_path, mode)
+        except OSError:
+            pass
+    replace_with_retry(tmp_path, path)
+    # Best-effort durability of the rename itself; directory fsync is a no-op or unsupported on
+    # Windows, so failures here are non-fatal.
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
+def atomic_write_json(path: Path, payload: Any, *, mode: int | None = None) -> None:
+    """``json.dumps(payload, indent=2)`` convenience wrapper over :func:`atomic_write_bytes`.
+
+    Shared by every caller whose serialization is exactly ``json.dumps(payload, indent=2)`` (no
+    ``sort_keys``, no trailing newline) -- currently ``session_store``/``checkpoint_store``/
+    ``audit_manifest``'s index/metadata writers. A caller with different serialization (e.g.
+    ``dogfood``'s ``sort_keys=True`` + trailing newline) calls :func:`atomic_write_bytes` directly
+    with its own precomputed bytes instead, so its on-disk output stays byte-for-byte unchanged.
+    """
+    atomic_write_bytes(path, json.dumps(payload, indent=2).encode("utf-8"), mode=mode)
 
 
 def _lock_path_for(index_path: Path) -> Path:

--- a/src/tensor_grep/cli/audit_manifest.py
+++ b/src/tensor_grep/cli/audit_manifest.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from tensor_grep.cli._index_lock import atomic_write_json
+
 _AUDIT_INDEX_VERSION = 1
 _TG_DIRNAME = ".tensor-grep"
 _AUDIT_SUBDIR = "audit"
@@ -519,15 +521,19 @@ def _history_sort_key(entry: dict[str, Any]) -> tuple[datetime, str, str]:
 
 
 def _write_history_index(root: Path, entries: list[dict[str, Any]]) -> None:
+    # audit C4/#659 residual (task #211): this was a bare `write_text` -- no symlink precheck, no
+    # atomic temp+rename, no fsync -- even though it persists the tamper-evident audit-history
+    # index (.tensor-grep/audit/index.json) that record_audit_manifest/list_audit_history build
+    # the manifest chain from. Route through the same shared C4 baseline every other session/
+    # evidence/checkpoint writer uses; `mkdir` is now handled inside the shared helper.
     index_path = _history_index_path(root)
-    index_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "version": _AUDIT_INDEX_VERSION,
         "schema_version": _AUDIT_INDEX_VERSION,
         "manifests": sorted(entries, key=_history_sort_key, reverse=True),
         "updated_at": _utc_now_iso(),
     }
-    index_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    atomic_write_json(index_path, payload)
 
 
 def _load_history_index(root: Path) -> list[dict[str, Any]] | None:

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from tensor_grep.cli._index_lock import index_lock, replace_with_retry
+from tensor_grep.cli._index_lock import atomic_write_json, index_lock
 from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
 
 _CHECKPOINT_VERSION = 1
@@ -97,28 +97,15 @@ def _is_generated_discovery_dir(path: Path) -> bool:
 
 
 def _write_json_atomic(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
-    with open(tmp_path, "w", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, indent=2))
-        handle.flush()
-        # fsync the data before the rename so a crash can never publish a truncated
-        # index/metadata that would leave the agent's rollback safety net unable to
-        # find the checkpoint while edits stay applied (audit I5).
-        os.fsync(handle.fileno())
-    replace_with_retry(tmp_path, path)
-    # Best-effort durability of the rename itself; directory fsync is a no-op or
-    # unsupported on Windows, so failures here are non-fatal.
-    try:
-        dir_fd = os.open(str(path.parent), os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(dir_fd)
-    except OSError:
-        pass
-    finally:
-        os.close(dir_fd)
+    """Write ``payload`` as pretty JSON to ``path`` atomically, refusing a pre-existing symlink.
+
+    Thin wrapper over the shared C4/#659 hardening baseline (`_index_lock.atomic_write_json`).
+    This module's own copy of the atomic-write pattern predated the C4 fix and never gained the
+    `is_symlink()` precheck `session_store`/`evidence_signing` already carry (task #211 residual)
+    -- routing through the shared helper closes that gap uniformly instead of re-patching a third
+    copy of the same pattern in place.
+    """
+    atomic_write_json(path, payload)
 
 
 def _resolve_within_root(root: Path, root_resolved: Path, rel_path: str) -> Path:

--- a/src/tensor_grep/cli/dogfood.py
+++ b/src/tensor_grep/cli/dogfood.py
@@ -10,6 +10,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
+from tensor_grep.cli._index_lock import atomic_write_bytes
 from tensor_grep.cli.progress import ProgressReporter
 
 ARTIFACT_TAIL_LINE_LIMIT = 20
@@ -57,10 +58,13 @@ def _bounded_tail_lines(
 
 
 def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(f"{path.name}.tmp")
-    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    tmp_path.replace(path)
+    # audit C4/#659 residual (task #211): this had no symlink precheck, no fsync, and used a
+    # PREDICTABLE (non-random) temp filename -- route through the shared C4 baseline
+    # (`_index_lock.atomic_write_bytes`) instead of re-patching a fourth copy of the same gap in
+    # place. The exact serialization (sort_keys=True + trailing newline) is preserved
+    # byte-for-byte; only the write mechanics (atomicity/symlink-safety) change.
+    data = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    atomic_write_bytes(path, data)
 
 
 def _read_json_object(path: Path) -> dict[str, Any] | None:

--- a/src/tensor_grep/cli/evidence_signing.py
+++ b/src/tensor_grep/cli/evidence_signing.py
@@ -47,7 +47,7 @@ from cryptography.hazmat.primitives.serialization import (
     PublicFormat,
 )
 
-from tensor_grep.cli._index_lock import replace_with_retry
+from tensor_grep.cli._index_lock import atomic_write_bytes
 from tensor_grep.cli.audit_manifest import _utc_now_iso
 
 ALGORITHM = "ed25519"
@@ -202,7 +202,10 @@ def _write_private_key_atomic(path: Path, raw_private_bytes: bytes, *, force: bo
     # Refuse to write THROUGH a pre-existing symlink at the target path regardless of --force: a
     # symlink there could redirect the private key material somewhere the caller does not expect
     # (write-side symlink-attack class; see AGENTS.md "Symlink-follow disclosure", the read-side
-    # sibling of this same concern).
+    # sibling of this same concern). `atomic_write_bytes` repeats this same check internally
+    # (defense-in-depth against the outer-check/write TOCTOU window), but this explicit check
+    # stays here so the caller-visible exception on the common path is EvidenceSigningError, not
+    # the shared helper's generic OSError.
     if path.is_symlink():
         raise EvidenceSigningError(f"Refusing to write a signing key through a symlink: {path}")
     if path.exists() and not force:
@@ -210,24 +213,11 @@ def _write_private_key_atomic(path: Path, raw_private_bytes: bytes, *, force: bo
             f"Signing key already exists: {path} (pass --force to overwrite)"
         )
 
-    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
-    # audit S3 / atomic-write-permission-window pattern (session_store._write_json_atomic): create
-    # the temp AT 0600 from byte one via os.open(O_CREAT|O_EXCL) so the private key is never
-    # briefly world-readable, and O_EXCL refuses to follow a pre-existing temp/symlink.
-    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        with os.fdopen(fd, "wb") as handle:
-            handle.write(raw_private_bytes)
-            handle.flush()
-            os.fsync(handle.fileno())
-    except BaseException:
-        tmp_path.unlink(missing_ok=True)
-        raise
-    try:
-        os.chmod(tmp_path, 0o600)
-    except OSError:
-        pass
-    replace_with_retry(tmp_path, path)
+    # audit S3 / round-3 / task #211 (uniform-onofollow-211): create+publish via the shared
+    # C4/#659 hardening baseline (`_index_lock.atomic_write_bytes` -- 0600 from byte one via
+    # os.open(O_CREAT|O_EXCL[|O_NOFOLLOW]), fsync before the rename, os.replace) instead of a
+    # hand-rolled copy of the same pattern.
+    atomic_write_bytes(path, raw_private_bytes, mode=0o600)
 
 
 def generate_keypair(out_path: str | Path, *, force: bool = False) -> dict[str, str]:
@@ -254,11 +244,16 @@ def generate_keypair(out_path: str | Path, *, force: bool = False) -> dict[str, 
     pub_b64 = public_key_b64(private_key)
     key_id = key_id_from_public_b64(pub_b64)
     pub_path = resolved.with_name(resolved.name + ".pub")
-    pub_path.write_text(pub_b64 + "\n", encoding="utf-8")
-    try:
-        os.chmod(pub_path, 0o644)
-    except OSError:
-        pass
+    # audit C4/#659 residual (task #211): this sibling write had NO symlink precheck, no
+    # atomicity, and no fsync at all (a bare write_text) even though it is a signing artifact
+    # emitted alongside the already-hardened private key. Mirror `_write_private_key_atomic`'s own
+    # precheck-then-shared-helper shape (so a refused attempt here raises the same
+    # EvidenceSigningError type as every other failure mode in this module) and route the actual
+    # write through the same shared baseline. Public-key material is not secret, but the
+    # write-through-symlink / partial-write-on-crash risk classes apply just the same.
+    if pub_path.is_symlink():
+        raise EvidenceSigningError(f"Refusing to write a signing key through a symlink: {pub_path}")
+    atomic_write_bytes(pub_path, (pub_b64 + "\n").encode("utf-8"), mode=0o644)
 
     return {
         "private_key_path": str(resolved),

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -238,6 +238,16 @@ def _write_daemon_metadata_windows(path: Path, payload: dict[str, Any]) -> None:
     the file rather than being recomputed from the parent.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
+    # audit C4/#659 residual (task #211): this Windows-specific copy of the atomic-write pattern
+    # (needed so the ACL lockdown below can run between temp-file creation and the token write --
+    # see the docstring above) never gained the is_symlink() precheck session_store.
+    # _write_json_atomic and evidence_signing._write_private_key_atomic already carry. Add it here
+    # too so a pre-existing symlink at daemon.json is refused instead of silently replaced. POSIX
+    # O_NOFOLLOW is a no-op on Windows (this function only ever runs on win32, per the caller's
+    # `sys.platform == "win32"` guard), so this precheck is the ONLY defense available on this
+    # code path; O_EXCL on the temp-file open below still applies as usual.
+    if path.is_symlink():
+        raise OSError(f"Refusing to write through a symlink: {path}")
     tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
     data = json.dumps(payload, indent=2)
     fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _DAEMON_METADATA_MODE)

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -14,7 +14,7 @@ from time import monotonic
 from typing import Any, TextIO, cast
 from uuid import uuid4
 
-from tensor_grep.cli._index_lock import index_lock, replace_with_retry
+from tensor_grep.cli._index_lock import atomic_write_json, index_lock
 from tensor_grep.cli.agent_capsule import build_agent_capsule_from_map
 from tensor_grep.cli.orient_capsule import build_orient_capsule_from_map
 from tensor_grep.cli.repo_map import (
@@ -422,68 +422,17 @@ def _load_index(root: Path) -> list[SessionRecord]:
 
 
 def _write_json_atomic(path: Path, payload: Any, *, mode: int | None = None) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # audit C4 / CWE-59: refuse to write THROUGH a pre-existing symlink at the destination --
-    # mirrors evidence_signing._write_private_key_atomic's guard. Without this, `os.replace`
-    # below would not corrupt the symlink's TARGET (POSIX rename() atomically replaces the link
-    # entry itself, not what it points to) but it would still silently destroy the caller's
-    # symlink with no signal that something unexpected was already at the destination -- refusing
-    # outright is the same fail-closed posture the private-key writer already takes. Every caller
-    # of this shared helper (session payloads/index, the daemon token + metrics files, and, via
-    # the C4 fix, the evidence-receipt and review-bundle CLI/MCP writers) gets the same
-    # protection. Callers that first `.expanduser().resolve()` a caller-supplied path MUST check
-    # `is_symlink()` on the pre-resolve path themselves (mirrors evidence_signing.generate_keypair)
-    # -- `.resolve()` follows symlinks, so by the time a resolved path reaches this function the
-    # symlink-ness of the ORIGINAL destination is already lost; this check remains as
-    # defense-in-depth against a symlink planted directly at an already-resolved leaf path (e.g.
-    # the session/daemon internal callers below, which never round-trip through a caller-supplied
-    # string) and against the narrow TOCTOU window between an outer check and this call.
-    if path.is_symlink():
-        raise OSError(f"Refusing to write through a symlink: {path}")
-    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
-    data = json.dumps(payload, indent=2)
-    if mode is not None:
-        # audit S3 + round-3: create the temp AT the restrictive mode via os.open(O_CREAT|O_EXCL)
-        # so a sensitive file (e.g. the 0600 daemon token) is never briefly world-readable in the
-        # window between write and chmod. O_EXCL also refuses to follow a pre-existing temp/symlink.
-        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(data)
-                handle.flush()
-                # M6: fsync the data before the rename so a crash can never publish a
-                # truncated session index/payload (mirrors checkpoint_store._write_json_atomic,
-                # audit I5).
-                os.fsync(handle.fileno())
-        except BaseException:
-            tmp_path.unlink(missing_ok=True)  # don't leave a partial temp behind
-            raise
-        # O_CREAT honors the umask, so the created mode is never broader than `mode`; force the
-        # exact requested bits for determinism (in case the umask stripped an owner bit).
-        try:
-            os.chmod(tmp_path, mode)
-        except OSError:
-            pass
-    else:
-        with open(tmp_path, "w", encoding="utf-8") as handle:
-            handle.write(data)
-            handle.flush()
-            # M6: fsync the data before the rename so a crash can never publish a truncated
-            # session index/payload (mirrors checkpoint_store._write_json_atomic, audit I5).
-            os.fsync(handle.fileno())
-    replace_with_retry(tmp_path, path)
-    # Best-effort durability of the rename itself; directory fsync is a no-op or unsupported
-    # on Windows, so failures here are non-fatal.
-    try:
-        dir_fd = os.open(str(path.parent), os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(dir_fd)
-    except OSError:
-        pass
-    finally:
-        os.close(dir_fd)
+    """Write ``payload`` as pretty JSON to ``path`` atomically, refusing a pre-existing symlink.
+
+    Thin wrapper over the shared C4/#659 hardening baseline
+    (`_index_lock.atomic_write_json`/`atomic_write_bytes` -- see those docstrings for the full
+    precheck + same-dir-temp + fsync + os.replace (+ POSIX O_EXCL|O_NOFOLLOW) rationale). Every
+    caller of this function (session payloads/index, the daemon token + metrics files via
+    session_daemon, and, via the C4 fix, the evidence-receipt and review-bundle CLI/MCP writers)
+    gets the same protection, uniformized (task #211) across every sibling writer in the `cli`
+    package instead of being re-implemented per module.
+    """
+    atomic_write_json(path, payload, mode=mode)
 
 
 def _write_index(root: Path, records: list[SessionRecord]) -> None:

--- a/tests/unit/test_checkpoint_containment.py
+++ b/tests/unit/test_checkpoint_containment.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -492,3 +494,101 @@ def test_undo_still_restores_normal_nested_snapshot_after_source_containment_fix
     result = checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
     assert result.restored_files == 1
     assert nested.read_text(encoding="utf-8") == "deep-original\n"
+
+
+# ---------------------------------------------------------------------------
+# audit C4/#659 residual (task #211): checkpoint_store._write_json_atomic never gained the
+# is_symlink() refusal precheck session_store/evidence_signing already carry -- it predates the
+# C4 fix and was left as its own, un-hardened copy of the same atomic-write pattern (same-dir
+# temp + fsync + os.replace, but no symlink check at all). Before this fix, a pre-existing
+# symlink at metadata.json / index.json / the discovery cache would have been SILENTLY replaced
+# by a real file (os.replace on POSIX swaps the link entry itself, never corrupting the symlink's
+# TARGET, but destroying the symlink with no signal) -- now routed through the shared
+# `_index_lock.atomic_write_json` helper so it fails closed like every sibling writer.
+# ---------------------------------------------------------------------------
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+
+
+def test_write_json_atomic_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    link_path = tmp_path / "link.json"
+    _symlink_or_skip(link_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        checkpoint_store._write_json_atomic(link_path, {"attacker": "payload"})
+
+    # The refused attempt must leave the symlink -- and its target's content -- untouched.
+    assert link_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}
+
+
+def test_write_json_atomic_normal_write_still_succeeds(tmp_path: Path) -> None:
+    dest = tmp_path / "index.json"
+
+    checkpoint_store._write_json_atomic(dest, [{"checkpoint_id": "ckpt-1"}])
+
+    assert json.loads(dest.read_text(encoding="utf-8")) == [{"checkpoint_id": "ckpt-1"}]
+
+
+def test_write_json_atomic_overwrite_of_a_regular_file_still_succeeds(tmp_path: Path) -> None:
+    """A regular (non-symlink) pre-existing file at the destination must still be overwritable --
+    the new guard targets symlinks specifically, not "anything already there"."""
+    dest = tmp_path / "metadata.json"
+    dest.write_text('{"old": true}', encoding="utf-8")
+
+    checkpoint_store._write_json_atomic(dest, {"new": True})
+
+    assert json.loads(dest.read_text(encoding="utf-8")) == {"new": True}
+
+
+def test_create_checkpoint_refuses_when_metadata_path_is_a_pre_existing_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end proof through the real ``create_checkpoint`` entry point (not just the isolated
+    writer): if a symlink is already planted at the checkpoint's metadata.json destination, the
+    create must fail the WHOLE checkpoint closed and never disclose/corrupt the symlink's real
+    (out-of-tree) target -- the exact gap this module's un-hardened copy of the atomic-write
+    pattern had before it was routed through the shared C4 baseline.
+
+    The checkpoint id embeds ``datetime.now(UTC)`` + a random ``uuid4`` hex, so both are pinned
+    here to make the resulting metadata path predictable/plantable in advance, with no race
+    against the real call's own clock/uuid reads.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / "file.txt").write_text("hello\n", encoding="utf-8")
+
+    fixed_now = datetime(2026, 1, 1, tzinfo=UTC)
+    fixed_uuid = uuid.UUID("deadbeef-0000-4000-8000-000000000000")
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(checkpoint_store, "datetime", _FixedDatetime)
+    monkeypatch.setattr(checkpoint_store, "uuid4", lambda: fixed_uuid)
+
+    checkpoint_id = f"ckpt-{fixed_now.strftime('%Y%m%d%H%M%S')}-{fixed_uuid.hex[:8]}"
+    metadata_path = checkpoint_store._metadata_path(root, checkpoint_id)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    real_target = tmp_path / "outside_secret.json"
+    real_target.write_text('{"do-not-touch": true}', encoding="utf-8")
+    _symlink_or_skip(metadata_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        checkpoint_store.create_checkpoint(str(root))
+
+    # The real target OUTSIDE the checkpoint tree is never disclosed/corrupted.
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"do-not-touch": True}
+    # The existing BaseException cleanup (audit #125a) still fires correctly for this NEW failure
+    # mode: no orphaned partial checkpoint directory is left behind (shutil.rmtree unlinks the
+    # symlink ENTRY it encounters as part of that cleanup; it never follows it into the target).
+    assert not metadata_path.parent.exists()

--- a/tests/unit/test_dogfood_cli.py
+++ b/tests/unit/test_dogfood_cli.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from tensor_grep.cli import dogfood as dogfood_module
@@ -360,3 +361,49 @@ def test_dogfood_rejects_non_positive_progress_interval(tmp_path: Path) -> None:
 
     assert result.exit_code == 2
     assert "progress interval must be greater than 0" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# task #211 (C4/#659 residual): dogfood._write_json_atomic had NO symlink precheck, no fsync,
+# and used a PREDICTABLE (non-random) temp filename, unlike every other ``_write_json_atomic``
+# sibling in the `cli` package. Now routed through the same shared `_index_lock.atomic_write_bytes`
+# helper -- serialization (sort_keys=True + trailing newline) stays byte-for-byte unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_write_json_atomic_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    link_path = tmp_path / "link.json"
+    try:
+        link_path.symlink_to(real_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported / not privileged on this platform")
+
+    with pytest.raises(OSError, match="symlink"):
+        dogfood_module._write_json_atomic(link_path, {"attacker": "payload"})
+
+    assert link_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}
+
+
+def test_write_json_atomic_normal_write_preserves_exact_serialization(tmp_path: Path) -> None:
+    """Sort-keys + trailing-newline serialization must stay byte-for-byte unchanged by the
+    atomic-write-mechanics refactor."""
+    dest = tmp_path / "dogfood.json"
+
+    dogfood_module._write_json_atomic(dest, {"b": 2, "a": 1})
+
+    assert (
+        dest.read_text(encoding="utf-8")
+        == json.dumps({"b": 2, "a": 1}, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def test_write_json_atomic_overwrite_of_a_regular_file_still_succeeds(tmp_path: Path) -> None:
+    dest = tmp_path / "dogfood.json"
+    dest.write_text('{"old": true}', encoding="utf-8")
+
+    dogfood_module._write_json_atomic(dest, {"new": True})
+
+    assert json.loads(dest.read_text(encoding="utf-8")) == {"new": True}

--- a/tests/unit/test_evidence_bundle_atomic_write.py
+++ b/tests/unit/test_evidence_bundle_atomic_write.py
@@ -272,3 +272,69 @@ def test_write_json_atomic_overwrite_of_a_regular_file_still_succeeds(tmp_path: 
     session_store._write_json_atomic(dest, {"new": True})
 
     assert json.loads(dest.read_text(encoding="utf-8")) == {"new": True}
+
+
+# ---------------------------------------------------------------------------
+# 5. task #211 (the C4/#659 residual this file's name predates): audit_manifest.
+#    _write_history_index was a bare `write_text` -- no symlink refusal, no atomic temp+rename,
+#    no fsync at all -- even though it persists the tamper-evident audit-history index
+#    (.tensor-grep/audit/index.json) that record_audit_manifest/list_audit_history build the
+#    manifest chain from. Now routed through the same shared `_index_lock.atomic_write_json`
+#    helper as every other writer covered by this file.
+# ---------------------------------------------------------------------------
+
+
+def test_write_history_index_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    history_dir = root / ".tensor-grep" / "audit"
+    history_dir.mkdir(parents=True)
+    link_path = history_dir / "index.json"
+    _symlink_or_skip(link_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        audit_manifest._write_history_index(root, [])
+
+    assert link_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}
+
+
+def test_write_history_index_normal_write_still_succeeds(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    entry = {
+        "manifest_sha256": "a" * 64,
+        "kind": "rewrite-audit-manifest",
+        "created_at": "2026-01-01T00:00:00Z",
+        "file_path": str(root / "manifest.json"),
+        "previous_manifest_sha256": None,
+    }
+
+    audit_manifest._write_history_index(root, [entry])
+
+    index_path = root / ".tensor-grep" / "audit" / "index.json"
+    on_disk = json.loads(index_path.read_text(encoding="utf-8"))
+    assert on_disk["manifests"] == [entry]
+
+
+def test_record_audit_manifest_refuses_when_history_index_is_a_pre_existing_symlink(
+    tmp_path: Path,
+) -> None:
+    """End-to-end proof through the real ``record_audit_manifest`` entry point (reached from
+    ``verify_audit_manifest`` on every successful verification, main.py's `tg run
+    --audit-manifest`, and `tg audit record`): a pre-existing symlink at
+    .tensor-grep/audit/index.json must fail the write closed instead of silently replacing it."""
+    project = _make_project(tmp_path)
+    manifest_path = project / ".tensor-grep" / "audit" / "manifest.json"
+    manifest = _write_audit_manifest(manifest_path, project_root=project)
+
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    index_path = project / ".tensor-grep" / "audit" / "index.json"
+    _symlink_or_skip(index_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        audit_manifest.record_audit_manifest(manifest_path, manifest=manifest)
+
+    assert index_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}

--- a/tests/unit/test_evidence_signing.py
+++ b/tests/unit/test_evidence_signing.py
@@ -273,24 +273,36 @@ def test_verify_with_malformed_trusted_key_entry_never_matches_and_never_crashes
 def test_generate_keypair_creates_the_temp_at_a_restrictive_mode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Cross-platform (works on Windows too): confirm the temp is created via os.open with a mode
-    that grants no group/other bits, mirroring session_store's own atomic-write-permission-window
-    regression test -- never create-world-readable-then-chmod."""
+    """Cross-platform (works on Windows too): confirm the PRIVATE KEY temp is created via
+    os.open with a mode that grants no group/other bits, mirroring session_store's own
+    atomic-write-permission-window regression test -- never create-world-readable-then-chmod.
+
+    The sibling ``.pub`` file (also routed through the shared atomic-write helper as of the
+    uniform-onofollow-211 hardening pass, task #211) is deliberately created at a WIDER 0o644
+    mode -- it is public key material, not a secret -- so this spy records ``(path, mode)`` pairs
+    and asserts the private-key temp specifically (identified by its ``.pub.`` -free temp name),
+    rather than blanket-asserting over every ``os.open`` call `generate_keypair` makes.
+    """
     key_path = tmp_path / "key"
-    created_modes: list[int] = []
+    created: list[tuple[str, int]] = []
     real_open = os.open
 
     def _spy_open(path: Any, flags: int, mode: int = 0o777, *args: Any, **kwargs: Any) -> int:
         if flags & os.O_CREAT:
-            created_modes.append(mode)
+            created.append((str(path), mode))
         return real_open(path, flags, mode, *args, **kwargs)
 
     monkeypatch.setattr(evidence_signing.os, "open", _spy_open)
 
     evidence_signing.generate_keypair(key_path)
 
-    assert created_modes, "the private key temp must be created via os.open(O_CREAT, mode)"
-    assert all((mode & 0o077) == 0 for mode in created_modes)
+    key_modes = [mode for path, mode in created if ".pub." not in path]
+    pub_modes = [mode for path, mode in created if ".pub." in path]
+    assert key_modes, "the private key temp must be created via os.open(O_CREAT, mode)"
+    assert all((mode & 0o077) == 0 for mode in key_modes)
+    # The .pub sibling is intentionally NOT restrictive -- it is public material.
+    assert pub_modes, "the .pub temp must also be created via os.open(O_CREAT, mode)"
+    assert all(mode == 0o644 for mode in pub_modes)
 
 
 def test_generate_keypair_final_mode_is_0600_on_posix(tmp_path: Path) -> None:
@@ -342,6 +354,30 @@ def test_generate_keypair_refuses_to_write_through_a_symlink_even_with_force(
 
     # the symlink's target must be untouched by the refused attempt
     assert link_path.is_symlink()
+
+
+def test_generate_keypair_refuses_to_write_the_pub_file_through_a_symlink(
+    tmp_path: Path,
+) -> None:
+    """task #211 (C4/#659 residual): the ``.pub`` sibling write had NO symlink precheck at all
+    before this fix (a bare ``write_text``) -- unlike the private key it sits beside. Exercise it
+    specifically: the PRIVATE key destination is fresh (no force needed), but the ``.pub``
+    sibling path is pre-symlinked."""
+    key_path = tmp_path / "key"
+    real_target = tmp_path / "real_target.pub"
+    real_target.write_text("do-not-touch-me", encoding="utf-8")
+    pub_link = tmp_path / "key.pub"
+    try:
+        pub_link.symlink_to(real_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported / not privileged on this platform")
+
+    with pytest.raises(evidence_signing.EvidenceSigningError, match="symlink"):
+        evidence_signing.generate_keypair(key_path)
+
+    # the symlink's target must be untouched by the refused attempt
+    assert pub_link.is_symlink()
+    assert real_target.read_text(encoding="utf-8") == "do-not-touch-me"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_index_lock.py
+++ b/tests/unit/test_index_lock.py
@@ -10,10 +10,14 @@ fresh-but-dead lock would NEVER be reclaimed within the wait window -- every wai
 
 from __future__ import annotations
 
+import json
 import os
 import threading
 import time
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from tensor_grep.cli import _index_lock
 
@@ -280,3 +284,157 @@ def test_repeated_acquire_release_hammer_windows(tmp_path: Path) -> None:
             assert lock_path.exists()
             assert _index_lock._token_for_lock(lock_path) is not None
         assert not lock_path.exists(), f"orphaned lockfile after cycle {i}"
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_bytes / atomic_write_json: the shared C4/#659 hardening baseline (task #211)
+# uniformized across session_store / checkpoint_store / evidence_signing / audit_manifest /
+# session_daemon / dogfood's atomic writers. Direct unit coverage of the shared primitive lives
+# here; each sibling module's own test suite covers the thin delegation from its call site.
+# ---------------------------------------------------------------------------
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported / not privileged on this platform")
+
+
+def test_atomic_write_bytes_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real.txt"
+    real_target.write_bytes(b"do-not-touch-me")
+    link_path = tmp_path / "link.json"
+    _symlink_or_skip(link_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        _index_lock.atomic_write_bytes(link_path, b'{"attacker": "payload"}')
+
+    # The refused attempt must leave the symlink -- and its target's content -- untouched.
+    assert link_path.is_symlink()
+    assert real_target.read_bytes() == b"do-not-touch-me"
+
+
+def test_atomic_write_bytes_normal_write_succeeds_and_leaves_no_temp_behind(
+    tmp_path: Path,
+) -> None:
+    dest = tmp_path / "payload.bin"
+
+    _index_lock.atomic_write_bytes(dest, b"hello world")
+
+    assert dest.read_bytes() == b"hello world"
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def test_atomic_write_bytes_overwrite_of_a_regular_file_still_succeeds(tmp_path: Path) -> None:
+    """A regular (non-symlink) pre-existing file at the destination must still be overwritable --
+    the guard targets symlinks specifically, not "anything already there"."""
+    dest = tmp_path / "existing.bin"
+    dest.write_bytes(b"old")
+
+    _index_lock.atomic_write_bytes(dest, b"new")
+
+    assert dest.read_bytes() == b"new"
+
+
+def test_atomic_write_bytes_creates_missing_parent_directories(tmp_path: Path) -> None:
+    dest = tmp_path / "nested" / "dir" / "payload.bin"
+
+    _index_lock.atomic_write_bytes(dest, b"hi")
+
+    assert dest.read_bytes() == b"hi"
+
+
+def test_atomic_write_bytes_temp_open_uses_o_creat_o_excl_and_o_nofollow_where_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Belt-and-suspenders defense-in-depth: the temp file open must always request O_EXCL, and
+    O_NOFOLLOW whenever the platform defines it -- a documented no-op on Windows (see the
+    docstring on ``atomic_write_bytes``); the cross-platform guard is the symlink precheck
+    tested above, not this flag."""
+    captured_flags: list[int] = []
+    real_open = os.open
+
+    def _spy_open(path: Any, flags: int, mode: int = 0o777, *args: Any, **kwargs: Any) -> int:
+        captured_flags.append(flags)
+        return real_open(path, flags, mode, *args, **kwargs)
+
+    monkeypatch.setattr(_index_lock.os, "open", _spy_open)
+
+    _index_lock.atomic_write_bytes(tmp_path / "flagged.bin", b"data")
+
+    assert captured_flags, "the temp file must be created via os.open"
+    flags = captured_flags[0]
+    assert flags & os.O_CREAT
+    assert flags & os.O_EXCL
+    expected_nofollow = getattr(os, "O_NOFOLLOW", 0)
+    assert (flags & expected_nofollow) == expected_nofollow
+
+
+def test_atomic_write_bytes_applies_and_reasserts_the_requested_mode(tmp_path: Path) -> None:
+    if os.name != "posix":
+        pytest.skip("POSIX permission bits are only meaningful on POSIX")
+    dest = tmp_path / "secret.bin"
+
+    _index_lock.atomic_write_bytes(dest, b"s3cr3t", mode=0o600)
+
+    assert (dest.stat().st_mode & 0o777) == 0o600
+
+
+def test_atomic_write_bytes_default_mode_matches_plain_open(tmp_path: Path) -> None:
+    """``mode=None`` must behave like plain ``open()`` -- 0o666 masked by umask -- not silently
+    narrow (or widen) an existing caller's permissions relative to the pre-refactor behavior."""
+    if os.name != "posix":
+        pytest.skip("POSIX permission bits are only meaningful on POSIX")
+    dest_default = tmp_path / "default.bin"
+    dest_plain_open = tmp_path / "plain_open.bin"
+
+    _index_lock.atomic_write_bytes(dest_default, b"data")
+    with open(dest_plain_open, "wb") as handle:
+        handle.write(b"data")
+
+    assert (dest_default.stat().st_mode & 0o777) == (dest_plain_open.stat().st_mode & 0o777)
+
+
+def test_atomic_write_bytes_crash_before_fsync_leaves_destination_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Proves the write genuinely goes through the fsync'd temp-then-rename path: a crash before
+    fsync completes must never publish a truncated/partial file over a valid pre-existing one
+    (patching ``os.fsync`` has no effect on a bare, non-atomic write, which never calls it)."""
+    dest = tmp_path / "existing.json"
+    dest.write_bytes(b'{"stale": "pre-existing-valid-json"}')
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated crash before fsync completes")
+
+    monkeypatch.setattr(_index_lock.os, "fsync", _boom)
+
+    with pytest.raises(OSError):
+        _index_lock.atomic_write_bytes(dest, b'{"new": "should-never-land"}')
+
+    assert dest.read_bytes() == b'{"stale": "pre-existing-valid-json"}'
+    assert list(tmp_path.glob(".*.tmp")) == []  # no partial temp left behind either
+
+
+def test_atomic_write_json_serializes_with_indent_2(tmp_path: Path) -> None:
+    """Pin the exact serialization contract every JSON-shaped sibling (session_store /
+    checkpoint_store / audit_manifest) relies on staying byte-for-byte unchanged."""
+    dest = tmp_path / "payload.json"
+
+    _index_lock.atomic_write_json(dest, {"b": 2, "a": 1})
+
+    assert dest.read_text(encoding="utf-8") == json.dumps({"b": 2, "a": 1}, indent=2)
+
+
+def test_atomic_write_json_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    link_path = tmp_path / "link.json"
+    _symlink_or_skip(link_path, real_target)
+
+    with pytest.raises(OSError, match="symlink"):
+        _index_lock.atomic_write_json(link_path, {"attacker": "payload"})
+
+    assert link_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -3233,16 +3233,22 @@ def test_session_blast_radius_render_reuses_cached_repo_map(tmp_path: Path) -> N
 def test_session_open_fsyncs_payload_before_atomic_replace(tmp_path: Path, monkeypatch) -> None:
     """M6: session_store's atomic writer must fsync the payload data before the atomic
     rename, mirroring checkpoint_store's fix (audit I5) -- otherwise a power-loss between
-    the write and the page-cache flush can publish a truncated index.json/session payload."""
-    from tensor_grep.cli import session_store
+    the write and the page-cache flush can publish a truncated index.json/session payload.
+
+    task #211: the write/fsync/rename mechanics now live in the shared
+    ``_index_lock.atomic_write_bytes`` helper (``session_store._write_json_atomic`` is a thin
+    delegator as of the uniform-onofollow-211 hardening pass) -- patch the fsync/replace call
+    sites there, where the real work now happens, instead of on ``session_store`` directly.
+    """
+    from tensor_grep.cli import _index_lock, session_store
 
     project = tmp_path / "project"
     project.mkdir()
     (project / "sample.py").write_text("value = 1\n", encoding="utf-8")
 
     call_order: list[str] = []
-    real_fsync = session_store.os.fsync
-    real_replace = session_store.replace_with_retry
+    real_fsync = _index_lock.os.fsync
+    real_replace = _index_lock.replace_with_retry
 
     def spy_fsync(fd):
         call_order.append("fsync")
@@ -3252,8 +3258,8 @@ def test_session_open_fsyncs_payload_before_atomic_replace(tmp_path: Path, monke
         call_order.append("replace")
         return real_replace(src, dst, **kwargs)
 
-    monkeypatch.setattr(session_store.os, "fsync", spy_fsync)
-    monkeypatch.setattr(session_store, "replace_with_retry", spy_replace)
+    monkeypatch.setattr(_index_lock.os, "fsync", spy_fsync)
+    monkeypatch.setattr(_index_lock, "replace_with_retry", spy_replace)
 
     session_store.open_session(str(project))
 

--- a/tests/unit/test_session_daemon_security.py
+++ b/tests/unit/test_session_daemon_security.py
@@ -295,6 +295,35 @@ def test_write_daemon_metadata_windows_cleans_up_temp_on_lock_failure(
     assert leftover == [], f"a partial/unlocked temp file was left behind: {leftover}"
 
 
+def test_write_daemon_metadata_windows_refuses_a_pre_existing_symlink(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """task #211 (C4/#659 residual): this Windows-specific copy of the atomic-write pattern
+    (needed so the ACL lockdown can run between temp-file creation and the token write) never
+    gained the is_symlink() precheck session_store._write_json_atomic /
+    evidence_signing._write_private_key_atomic already carry. A pre-existing symlink at
+    daemon.json -- which carries the IPC token -- must now be refused instead of silently
+    replaced (POSIX O_NOFOLLOW is a no-op on Windows, so this precheck is the only defense
+    available on this code path)."""
+    monkeypatch.setattr(session_daemon.sys, "platform", "win32")
+    root = tmp_path.resolve()
+
+    real_target = tmp_path / "real.json"
+    real_target.write_text('{"untouched": true}', encoding="utf-8")
+    metadata_path = session_daemon._daemon_metadata_path(root)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        metadata_path.symlink_to(real_target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation requires privilege on this platform")
+
+    with pytest.raises(OSError, match="symlink"):
+        session_daemon._write_daemon_metadata(root, {"token": "sekret", "version": 1})
+
+    assert metadata_path.is_symlink()
+    assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}
+
+
 def test_restrict_windows_file_is_noop_off_windows(tmp_path: Path, monkeypatch) -> None:
     called: list[object] = []
     monkeypatch.setattr(session_daemon.subprocess, "run", lambda *a, **k: called.append(a))


### PR DESCRIPTION
## Summary

The C4/#659 gate (already on `main`) hardened the evidence-bundle atomic write against a CWE-59
symlink attack with a **precheck + same-dir-temp + fsync + `os.replace`** pattern, and established
that `O_NOFOLLOW` is a **no-op on Windows** — the real cross-platform guard is the precheck +
same-dir-temp + rename shape, not the flag. This PR is the residual task: uniform-ize that exact
pattern across every sibling atomic writer in `cli/`, closing the gaps a fresh sweep found instead
of copy-pasting a fourth/fifth near-identical implementation.

**Approach**: one new shared primitive, `_index_lock.atomic_write_bytes` (+ a
`atomic_write_json` convenience wrapper for the common `json.dumps(payload, indent=2)` shape).
`_index_lock.py` already had zero internal-package imports and already hosted `replace_with_retry`
(used by all these siblings), so it's a safe, non-circular home. Every touched writer now
delegates to it; **no writer's serialization/output changed, only the write mechanics**
(atomicity + symlink-safety).

## Per-writer status

| Writer | Before this PR | After |
|---|---|---|
| `session_store._write_json_atomic` | Already had precheck+same-dir-temp+fsync+replace (the original C4 site). Gap: `O_NOFOLLOW` missing entirely; the `mode=None` branch used plain `open()` (no `O_EXCL` either). | Delegates to the shared helper — both branches now get `O_EXCL`\|`O_NOFOLLOW`(POSIX) uniformly. |
| `evidence_signing._write_private_key_atomic` | Already had precheck+same-dir-temp+`O_EXCL`+fsync+replace. Gap: `O_NOFOLLOW` missing. | Delegates to the shared helper (`mode=0o600`); its own precheck stays in front so the caller-visible exception is still `EvidenceSigningError`, not the helper's generic `OSError`. |
| `evidence_signing.generate_keypair`'s `.pub` sibling write | **Bare `write_text`** — no precheck, no atomicity, no fsync at all. | Own precheck (mirrors the private-key writer, so it raises `EvidenceSigningError` too) + delegates to the shared helper (`mode=0o644`). |
| `checkpoint_store._write_json_atomic` | **No `is_symlink()` precheck at all** — the biggest gap of the four named targets. Had same-dir-temp+fsync+replace but a pre-existing symlink at `metadata.json`/`index.json`/the discovery cache was silently *replaced* (not corrupted-through, but destroyed with no signal). | Delegates to the shared helper — gains the precheck + `O_EXCL`\|`O_NOFOLLOW`. |
| `audit_manifest._write_history_index` | **Bare `write_text`** — no precheck, no atomic temp+rename, no fsync at all — for the tamper-evident `.tensor-grep/audit/index.json` history chain. (`create_review_bundle`'s own `output_path` write was *already* hardened via `session_store._write_json_atomic` + its own precheck — left untouched, it transitively picks up the `O_NOFOLLOW` upgrade.) | Delegates to the shared helper. |
| `session_daemon._write_daemon_metadata_windows` | Not one of the 4 named targets, but found during the sweep: this Windows-specific copy of the pattern (needed so the ACL lockdown can run *between* temp-file creation and the token write — a separate, already-hardened concern, audit #81/#13) never gained the precheck. Carries the daemon's IPC secret token. | Added the precheck directly (kept **out** of the shared helper — routing it through would break the create-then-lock-then-write ordering the ACL fix depends on). `O_NOFOLLOW` doesn't apply here (Windows-only call site by construction). |
| `dogfood._write_json_atomic` | A **fourth** near-identical `_write_json_atomic` (found via the "any other sibling" sweep) — no precheck, no fsync, no `O_EXCL`, and a *predictable* (non-`uuid4`) temp filename. | Delegates to the shared helper via `atomic_write_bytes` (its serialization — `sort_keys=True` + trailing newline — differs from the common shape, so it stays outside `atomic_write_json` and passes its own precomputed bytes). |

**Left untouched, flagged for the gate**: `codemap.py::_atomic_write_text` (generates
`docs/code-map/*` pages) has the same missing-precheck shape, but it's a different risk class —
repo-documentation generation, not part of the session/evidence/checkpoint/audit trust chain the
C4 fix protects — so it was kept out of scope to keep this diff tight. `main.py`'s
`_write_json_refuse_symlink` (ruleset baseline/suppressions) was **not** touched — it already has
its own precheck + `O_NOFOLLOW` (in fact it's the codebase's existing reference for the
`getattr(os, "O_NOFOLLOW", 0)` idiom, cited in the new shared helper's docstring) and isn't part
of this writer family. The Rust-side `write_audit_manifest` TOCTOU is the separate,
already-tracked #110 — Python-side only per the task.

## Why not naive `O_NOFOLLOW`

`O_NOFOLLOW` is a documented no-op on Windows — verified empirically in this session (`hasattr(os,
"O_NOFOLLOW")` is `False` on this box). Relying on it alone would give false confidence on this
repo's primary dev platform. The uniform baseline is **`is_symlink()` refusal precheck (pre-resolve)
+ same-directory temp + fsync + `os.replace`**, which holds identically cross-platform, with
`O_CREAT|O_EXCL|O_NOFOLLOW` (`getattr`-guarded) on the temp file as POSIX-only
belt-and-suspenders on top.

## Testing

TDD throughout — a symlink-refusal test per newly-hardened writer, asserting the pre-existing
symlink is refused (`OSError`, or `EvidenceSigningError` at the two evidence-signing sites) and
its *target* is left untouched, plus a normal-write sanity test and (where relevant) an
overwrite-of-a-regular-file test. Two are genuine end-to-end tests through the *public* entry
point rather than the raw writer (`checkpoint_store.create_checkpoint`,
`audit_manifest.record_audit_manifest`), using a deterministic clock/uuid monkeypatch to avoid
any timing race. The shared primitive itself (`atomic_write_bytes`/`atomic_write_json`) has direct
unit coverage in `test_index_lock.py`: symlink refusal, normal write, overwrite-of-regular-file,
parent-dir creation, `O_CREAT`/`O_EXCL`/`O_NOFOLLOW` flag assertion (spied), mode
apply+reassert, default-mode-matches-`open()`, and a crash-before-fsync atomicity proof
(monkeypatched `os.fsync`, mirroring the existing C4 regression test's technique).

One pre-existing test (`test_session_cli.py::test_session_open_fsyncs_payload_before_atomic_replace`)
monkeypatched `session_store.replace_with_retry` directly; since the real write now happens inside
`_index_lock.atomic_write_bytes`, that patch point no longer intercepts anything (a per-module
`from X import name` binding, unlike the shared `os` module singleton the same test's `fsync` patch
relies on) — retargeted to patch `_index_lock.replace_with_retry` instead, same assertions,
verified passing. `test_evidence_signing.py`'s existing `os.open`-restrictive-mode spy test now
also observes the *new* `.pub` file's `os.open` call — rescoped to assert the private-key temp
(`0o600`, no group/other bits) and the `.pub` temp (`0o644`) separately, since blanket-asserting
"every `os.open` call is restrictive" is no longer the intended contract now the `.pub` write is
correctly *less* restrictive (it's public material).

**Results**:
- Ruff format (`--preview`) + ruff check: clean on all 14 touched files.
- `python -c "import ..."` sanity import: all 7 touched modules + `main`/`mcp_server` import cleanly.
- Targeted test files (14 touched + siblings): 261 passed, 4 skipped (POSIX-only, correctly
  skipped on this Windows box), 0 failed.
- Full regression sweep — every test file in `tests/unit/` that references any of the 7 touched
  modules (78 files, ~3000 tests): **2969 passed, 7 skipped, 5 deselected, 0 failed.** The 5
  deselected are pre-existing failures **unrelated to this change** — verified individually by
  `git stash`-ing this diff and re-running each on the clean `origin/main` (eae8ea9) baseline,
  where they fail identically: 4 in `test_mcp_server.py` (a `rewrite_plan`/`rewrite_apply`
  "embedded fallback when native binary is missing" cluster — this worktree has no compiled
  native `tg` binary, per the CPU-safe build rule) and 1 in `test_cli_modes.py` (a GPU
  device-inventory test, environment-dependent).
- Real-binary sanity: `tg --version` (via bootstrap) succeeds; `checkpoint create --json` and
  `evidence keygen --json` both exercise the changed write paths end-to-end through the real
  Typer CLI app with exit code 0 (including confirming the `.pub` file is written correctly).

## Confirmation

No output/return-value/behavior change for any writer's success path — only the write mechanics
(atomicity + symlink-safety) changed. On the fail-closed refusal path, a pre-existing symlink at
any of these destinations is now refused instead of silently replaced/destroyed (a deliberate,
intended fail-closed tightening — the whole point of this task).

Draft pending the independent Opus gate.
