### PR TITLE
fix: context-render/blast-radius-plan/blast-radius-render --max-files now bounds suggested_edits (broader B9/#661 flag-lie, #212)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -11340,14 +11340,21 @@ def _capped_suggested_edits(
     --max-files N`` grew ``suggested_edits`` unbounded despite the flag's documented meaning.
 
     ``max_edits`` is threaded in from ``_build_edit_plan_seed``'s ``suggested_edits_max`` parameter,
-    which defaults to ``None`` and is OPT-IN per caller (see that parameter's docstring): only
-    ``tg edit-plan``'s own builder (``build_context_edit_plan_from_map``) currently passes a real
-    value. ``tg context-render`` (own separate, pre-existing downstream cap via
-    ``_compact_edit_plan_seed``, but only for the compact/llm render profiles -- the default "full"
-    profile has no cap at all) and ``tg blast-radius-plan``/``tg blast-radius-render`` (no cap at
-    all) carry the identical flag-lie this function fixes, but stay on the ``None`` default and are
-    deliberately left unbounded -- out of scope for this PR; see
-    ``tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py`` for the pins proving so."""
+    which defaults to ``None`` and is OPT-IN per caller (see that parameter's docstring).
+    ``tg edit-plan``'s own builder (``build_context_edit_plan_from_map``, audit B9/A18) was the
+    first to pass a real value. Audit #212 (a follow-up to B9/#661) found the identical flag-lie in
+    three sibling callers and closed it the same way: ``tg context-render`` (own separate,
+    pre-existing downstream cap via ``_compact_edit_plan_seed``, but only for the compact/llm render
+    profiles -- the default "full" profile had no cap at all) and ``tg blast-radius-plan``/``tg
+    blast-radius-render`` (no cap at all, in any profile) now ALSO opt in, passing their own
+    ``--max-files`` value through ``build_context_render_from_map``/``build_symbol_blast_radius_
+    plan_from_map``/``build_symbol_blast_radius_render_from_map`` respectively. See
+    ``tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py`` and
+    ``tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py`` for the
+    pins proving so. Any FUTURE caller of ``_build_edit_plan_seed``/``_attach_edit_plan_metadata``
+    that does not explicitly pass ``suggested_edits_max`` still gets the unbounded, pre-fix
+    behavior -- the low-level default stays ``None`` on purpose so a not-yet-written caller is never
+    silently capped."""
     if max_edits is None:
         return entries
     return entries[:max_edits]
@@ -12110,14 +12117,16 @@ def _build_edit_plan_seed(
             definitions=suggested_edit_definitions,
             callers=list(radius_payload.get("callers", [])) if radius_payload is not None else [],
             repo_root=Path(str(repo_map["path"])).resolve(),
-            # Opt-in only (audit B9/A18 fix scope): `suggested_edits_max` defaults to `None`
-            # (unbounded, byte-identical to every caller's pre-fix behavior) unless the caller of
-            # `_build_edit_plan_seed` explicitly requests a bound. Only `tg edit-plan`'s own builder
-            # (`build_context_edit_plan_from_map`) opts in today -- `tg context-render` (which has
-            # its own separate, pre-existing downstream cap for the compact/llm profiles only -- see
-            # `_compact_edit_plan_seed`) and `tg blast-radius-plan`/`tg blast-radius-render` (which
-            # have no cap at all) are deliberately left unchanged; they share the identical flag-lie
-            # this fix closes but are out of scope for this PR.
+            # Opt-in only (audit B9/A18 fix scope, broadened by #212): `suggested_edits_max` defaults
+            # to `None` (unbounded, byte-identical to every UNNAMED caller's pre-fix behavior) unless
+            # the caller of `_build_edit_plan_seed` explicitly requests a bound. `tg edit-plan`'s own
+            # builder (`build_context_edit_plan_from_map`) opted in first (B9/A18); `tg context-render`
+            # (which also has its own separate, pre-existing downstream cap for the compact/llm
+            # profiles only -- see `_compact_edit_plan_seed` -- but none for the default "full"
+            # profile) and `tg blast-radius-plan`/`tg blast-radius-render` (which had no cap at all,
+            # in any profile) now ALSO opt in (#212, a follow-up to B9/#661), each passing its own
+            # `--max-files` value through `_attach_edit_plan_metadata`. Any future caller that omits
+            # `suggested_edits_max` still gets the unbounded pre-fix shape.
             max_edits=suggested_edits_max,
         ),
         "dependency_trust": dependency_trust,
@@ -13608,6 +13617,15 @@ def build_context_render_from_map(
             semantic_provider=semantic_provider,
             deadline_monotonic=deadline_monotonic,
             _profiling_collector=collector,
+            # #212 (broader B9/#661 flag-lie): the "full" render profile (the default for text
+            # output, and explicitly selectable for --json) has no downstream cap on suggested_edits
+            # at all -- _compact_context_render_payload's _compact_edit_plan_seed truncation only
+            # runs for render_profile in {"compact", "llm"} (see that function's own guard). Opting
+            # into the SAME suggested_edits_max mechanism build_context_edit_plan_from_map already
+            # uses closes the gap for "full" while being a provable no-op for "compact"/"llm" --
+            # _compact_edit_plan_seed's OWN [:max_files] truncation downstream already reduces those
+            # profiles to <=max_files, so bounding at the source produces the identical final list.
+            suggested_edits_max=max_files,
         )
     else:
         payload = _attach_lightweight_navigation_metadata(
@@ -17432,6 +17450,12 @@ def build_symbol_blast_radius_plan_from_map(
         # bound the build_symbol_blast_radius_from_map call above.
         deadline_monotonic=deadline_monotonic,
         _profiling_collector=_profiling_collector,
+        # #212 (broader B9/#661 flag-lie): `tg blast-radius-plan` has NO downstream compaction step
+        # at all (unlike context-render), so before this, edit_plan_seed.suggested_edits was
+        # unconditionally unbounded regardless of --max-files -- dogfooded on tensor-grep's own repo
+        # (SearchConfig, 80 files): --max-files 1 returned files=[1] but suggested_edits spanning 8
+        # distinct files. Opt into the same mechanism build_context_edit_plan_from_map already uses.
+        suggested_edits_max=normalized_max_files,
     )
     return _attach_profiling(payload, _profiling_collector)
 
@@ -17625,6 +17649,13 @@ def build_symbol_blast_radius_render_from_map(
         # dropped deadline_monotonic entirely.
         deadline_monotonic=deadline_monotonic,
         _profiling_collector=collector,
+        # #212 (broader B9/#661 flag-lie): `tg blast-radius-render` has NO downstream compaction
+        # step either, in ANY render_profile, so before this, edit_plan_seed.suggested_edits was
+        # unconditionally unbounded regardless of --max-files -- dogfooded on tensor-grep's own repo
+        # (SearchConfig, 80 files): --max-files 1 returned files=[1] but suggested_edits spanning 40
+        # distinct files (identical 73-entry count as --max-files 50 -- zero bounding effect at all).
+        # Opt into the same mechanism build_context_edit_plan_from_map already uses.
+        suggested_edits_max=max_files,
     )
     # task #203: fold this function's OWN source-lookup loop deadline signal into partial --
     # `dict(radius_payload)` above already copied forward any partial/deadline_limit that

--- a/tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py
+++ b/tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py
@@ -1,0 +1,216 @@
+"""Audit #212, a follow-up to B9/#661: B9 fixed `tg edit-plan --json --max-files N` silently
+ignoring `max_edits` when bounding `edit_plan_seed.suggested_edits` (repo_map.py's
+`_capped_suggested_edits`), but its own test file
+(`test_edit_plan_max_files_bounds_suggested_edits.py`) explicitly documented -- and pinned with a
+"must not change" regression test -- that three sibling commands carried the IDENTICAL flag-lie and
+were deliberately left unfixed as out of scope: `tg context-render`'s default "full" render profile
+(the "compact"/"llm" profiles already had their own separate, pre-existing cap via
+`_compact_edit_plan_seed`), `tg blast-radius-plan`, and `tg blast-radius-render` (neither of the
+latter two has any downstream compaction step at all, in any profile).
+
+VERIFIED REAL before fixing (not assumed from the audit): dogfooded directly against tensor-grep's
+own `src/tensor_grep` tree (80 files, symbol `SearchConfig`) using the real Python builders.
+`blast-radius-render --max-files 1` returned `files=[1 file]` (correctly bounded) but
+`edit_plan_seed.suggested_edits` had 73 entries spanning 40 DISTINCT files -- byte-identical counts
+to `--max-files 50` (55 related_spans / 73 suggested_edits in both cases), i.e. `--max-files` had
+literally zero effect on this field. `blast-radius-plan --max-files 1` similarly returned 25
+suggested_edits across 8 distinct files. `context-render --render-profile full --max-files 1`
+returned 5 suggested_edits across 3 distinct files (`compact`/`llm` profiles were already correctly
+bounded to 1 by their own separate cap).
+
+Fixed the same disciplined way B9 did: each builder now opts into the ALREADY-EXISTING
+`suggested_edits_max` parameter on `_attach_edit_plan_metadata`/`_build_edit_plan_seed` (which still
+defaults to `None` -- unbounded -- for any caller that does not explicitly pass it), by threading its
+own `--max-files` value through. No new CLI flags, no change to the low-level opt-in default.
+
+This file proves the fix with the SAME RED/GREEN methodology
+`test_edit_plan_max_files_bounds_suggested_edits.py` established for edit-plan itself: a fixture that
+provably produces MORE raw suggested_edits than the cap (so the assertion isn't vacuous), a RED check
+via monkeypatching `_capped_suggested_edits` to a raw passthrough (reproducing the exact pre-fix
+shape), and a GREEN check that the real fix truncates to a stable PREFIX of the uncapped list.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli import repo_map
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_many_callers_project(tmp_path: Path, *, caller_count: int) -> Path:
+    """Same fixture shape as `test_edit_plan_max_files_bounds_suggested_edits.py`'s own helper: a
+    `create_invoice` definition plus `caller_count` distinct files that each import AND call it, so
+    `caller_count` files reliably produce roughly `2 * caller_count` raw `suggested_edits` entries --
+    comfortably more than a small `--max-files` cap, proving the cap does real truncation work."""
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    _write(src_dir / "payments.py", "def create_invoice(total):\n    return total + 1\n")
+    for index in range(caller_count):
+        _write(
+            src_dir / f"caller_{index}.py",
+            "from src.payments import create_invoice\n"
+            "\n"
+            f"def wrap_{index}(total):\n"
+            "    return create_invoice(total)\n",
+        )
+    return project
+
+
+def test_context_render_full_profile_max_files_bounds_suggested_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-confirmed then GREEN, for `render_profile="full"` (the default for text output, and
+    explicitly selectable for --json): `--max-files 2` must now bound
+    `edit_plan_seed.suggested_edits` to <=2 entries, matching edit-plan's own already-fixed
+    behavior."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    monkeypatch.setattr(repo_map, "_capped_suggested_edits", lambda entries, max_edits: entries)
+    uncapped_payload = repo_map.build_context_render(
+        "create invoice", project, max_files=2, render_profile="full"
+    )
+    uncapped_edits = uncapped_payload["edit_plan_seed"]["suggested_edits"]
+    assert len(uncapped_edits) > 2, (
+        "fixture must produce MORE than the --max-files cap without enforcement, or this test "
+        "cannot prove the cap does real work"
+    )
+    monkeypatch.undo()
+
+    payload = repo_map.build_context_render(
+        "create invoice", project, max_files=2, render_profile="full"
+    )
+    seed = payload["edit_plan_seed"]
+    assert len(seed["suggested_edits"]) <= 2
+    assert seed["suggested_edits"] == uncapped_edits[:2]
+
+
+def test_blast_radius_plan_max_files_bounds_suggested_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-confirmed then GREEN for `tg blast-radius-plan`, which (unlike context-render) has no
+    downstream compaction step at all -- before this fix, suggested_edits was unconditionally
+    unbounded regardless of profile."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    monkeypatch.setattr(repo_map, "_capped_suggested_edits", lambda entries, max_edits: entries)
+    uncapped_payload = repo_map.build_symbol_blast_radius_plan(
+        "create_invoice", project, max_files=2
+    )
+    uncapped_edits = uncapped_payload["edit_plan_seed"]["suggested_edits"]
+    assert len(uncapped_edits) > 2, (
+        "fixture must produce MORE than the --max-files cap without enforcement, or this test "
+        "cannot prove the cap does real work"
+    )
+    monkeypatch.undo()
+
+    payload = repo_map.build_symbol_blast_radius_plan("create_invoice", project, max_files=2)
+    seed = payload["edit_plan_seed"]
+    assert len(seed["suggested_edits"]) <= 2
+    assert seed["suggested_edits"] == uncapped_edits[:2]
+
+
+def test_blast_radius_render_max_files_bounds_suggested_edits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED-confirmed then GREEN for `tg blast-radius-render`, the starkest case dogfooded against
+    tensor-grep's own repo: `--max-files 1` vs `--max-files 50` produced byte-IDENTICAL
+    suggested_edits counts pre-fix (zero bounding effect whatsoever)."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    monkeypatch.setattr(repo_map, "_capped_suggested_edits", lambda entries, max_edits: entries)
+    uncapped_payload = repo_map.build_symbol_blast_radius_render(
+        "create_invoice", project, max_files=2
+    )
+    uncapped_edits = uncapped_payload["edit_plan_seed"]["suggested_edits"]
+    assert len(uncapped_edits) > 2, (
+        "fixture must produce MORE than the --max-files cap without enforcement, or this test "
+        "cannot prove the cap does real work"
+    )
+    monkeypatch.undo()
+
+    payload = repo_map.build_symbol_blast_radius_render("create_invoice", project, max_files=2)
+    seed = payload["edit_plan_seed"]
+    assert len(seed["suggested_edits"]) <= 2
+    assert seed["suggested_edits"] == uncapped_edits[:2]
+
+
+@pytest.mark.parametrize("render_profile", ["compact", "llm"])
+def test_context_render_compact_and_llm_profiles_stay_prefix_stable(
+    tmp_path: Path,
+    render_profile: str,
+) -> None:
+    """ "compact"/"llm" profiles now apply the bound TWICE (once at the source via
+    `suggested_edits_max`, once more downstream via `_compact_edit_plan_seed`'s own pre-existing
+    `[:max_files]` truncation) -- both truncations agree on the same prefix, so this must be a
+    provable no-op: the doubly-truncated result equals the singly-truncated (source-only) one."""
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+
+    doubly_truncated = repo_map.build_context_render(
+        "create invoice", project, max_files=2, render_profile=render_profile
+    )["edit_plan_seed"]["suggested_edits"]
+
+    full_profile_edits = repo_map.build_context_render(
+        "create invoice", project, max_files=2, render_profile="full"
+    )["edit_plan_seed"]["suggested_edits"]
+
+    assert len(doubly_truncated) <= 2
+    assert doubly_truncated == full_profile_edits
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda project: repo_map.build_context_render(
+            "create invoice", project, max_files=50, render_profile="full"
+        ),
+        lambda project: repo_map.build_symbol_blast_radius_plan(
+            "create_invoice", project, max_files=50
+        ),
+        lambda project: repo_map.build_symbol_blast_radius_render(
+            "create_invoice", project, max_files=50
+        ),
+    ],
+    ids=["context-render-full", "blast-radius-plan", "blast-radius-render"],
+)
+def test_larger_cap_stays_under_the_raw_count(tmp_path: Path, build) -> None:
+    """A generous --max-files must never inflate suggested_edits beyond what the (deduplicated)
+    related-span analysis actually found -- the cap only ever truncates, never pads. Mirrors
+    `test_edit_plan_max_files_bounds_suggested_edits.py`'s own guard of the same name for
+    edit-plan."""
+    project = _build_many_callers_project(tmp_path, caller_count=2)
+
+    payload = build(project)
+
+    assert len(payload["edit_plan_seed"]["suggested_edits"]) <= 50
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda project: repo_map.build_context_render(
+            "lonely", project, max_files=2, render_profile="full"
+        ),
+        lambda project: repo_map.build_symbol_blast_radius_plan("lonely", project, max_files=2),
+        lambda project: repo_map.build_symbol_blast_radius_render("lonely", project, max_files=2),
+    ],
+    ids=["context-render-full", "blast-radius-plan", "blast-radius-render"],
+)
+def test_zero_related_spans_still_returns_empty_list(tmp_path: Path, build) -> None:
+    """Guardrail: a query/symbol with no related spans at all must still return `[]`, not error --
+    the cap must not assume a non-empty list. Mirrors
+    `test_edit_plan_max_files_bounds_suggested_edits.py`'s own guard of the same name for
+    edit-plan."""
+    project = tmp_path / "project"
+    _write(project / "src" / "solo.py", "def lonely():\n    return 1\n")
+
+    payload = build(project)
+
+    assert payload["edit_plan_seed"]["suggested_edits"] == []

--- a/tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py
+++ b/tests/unit/test_edit_plan_max_files_bounds_suggested_edits.py
@@ -22,6 +22,17 @@ pre-fix behavior) everywhere, and only `build_context_edit_plan_from_map` (edit-
 builder -- never shared with context-render or blast-radius-plan/render) passes a real value. The
 context-render/blast-radius-plan/blast-radius-render gaps are real and share the same root cause,
 but are deliberately left unfixed here as an out-of-scope, separately-reviewable follow-up.
+
+RESOLVED by #212 (a follow-up audit to this one): dogfooding on tensor-grep's own repo confirmed the
+gap was real and user-visible (`--max-files 1` on `blast-radius-render` returned `files=[1]` but
+`suggested_edits` spanning 40 distinct files -- byte-identical to `--max-files 50`, i.e. zero
+bounding effect). `build_context_render_from_map`, `build_symbol_blast_radius_plan_from_map`, and
+`build_symbol_blast_radius_render_from_map` now ALL opt in too, each passing its own `--max-files`
+value as `suggested_edits_max`. The two tests below that used to pin the unbounded shape as
+"must not change" were updated in place to pin the now-bounded shape instead; see
+`tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py` for the
+RED/GREEN proof (mirroring this file's own `test_edit_plan_max_files_bounds_suggested_edits`
+methodology) that the fix does real work on all three sibling commands.
 """
 
 from pathlib import Path
@@ -111,56 +122,40 @@ def test_edit_plan_max_files_zero_related_spans_still_returns_empty_list(tmp_pat
 
 
 @pytest.mark.parametrize("render_profile", ["full", "compact", "llm"])
-def test_edit_plan_max_files_does_not_change_context_render_suggested_edits(
+def test_edit_plan_max_files_now_bounds_context_render_suggested_edits_in_every_profile(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     render_profile: str,
 ) -> None:
-    """`tg context-render` must be byte-identical before and after this fix, in every render
-    profile. `build_context_render_from_map`'s own call to `_attach_edit_plan_metadata` never passes
-    `suggested_edits_max` (it is edit-plan's own opt-in only), so `_capped_suggested_edits` always
-    receives `max_edits=None` on this path -- i.e. this PR's new capping mechanism never actually
-    engages for context-render, regardless of profile. Proved directly: swapping in a raw passthrough
-    for `_capped_suggested_edits` (which is what `max_edits=None` already reduces to) must not change
-    context-render's output at all, for ANY profile -- including "full", the default, which (found
-    while writing this test) has NO suggested_edits cap at all, pre- or post-fix; see module
-    docstring."""
+    """UPDATED by #212 (was `..._does_not_change_context_render_suggested_edits`, which pinned the
+    OLD unbounded "full"-profile shape as "must not change"): `build_context_render_from_map` now
+    opts into `suggested_edits_max` too (passing its own `--max-files` value), closing the gap for
+    "full" -- the default profile, and the one this test previously proved had NO cap at all, pre-
+    or post-B9. "compact"/"llm" are unaffected in practice (they already truncated to the same bound
+    one step downstream via `_compact_edit_plan_seed`) but are asserted here too so all three
+    profiles are pinned to the same invariant going forward. See
+    `test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py` for the RED/GREEN
+    proof that this bound does real truncation work (not vacuously satisfied)."""
     project = _build_many_callers_project(tmp_path, caller_count=5)
 
-    fixed_payload = repo_map.build_context_render(
+    payload = repo_map.build_context_render(
         "create invoice", project, max_files=2, render_profile=render_profile
     )
-    fixed_edits = fixed_payload["edit_plan_seed"]["suggested_edits"]
 
-    monkeypatch.setattr(repo_map, "_capped_suggested_edits", lambda entries, max_edits: entries)
-    control_payload = repo_map.build_context_render(
-        "create invoice", project, max_files=2, render_profile=render_profile
+    assert len(payload["edit_plan_seed"]["suggested_edits"]) <= 2, (
+        f"context-render (profile={render_profile!r}) suggested_edits must now be bounded by "
+        "--max-files in every profile (#212 closed the 'full'-profile gap this test used to pin "
+        "as deliberately out of scope)"
     )
-    control_edits = control_payload["edit_plan_seed"]["suggested_edits"]
-
-    assert control_edits == fixed_edits, (
-        f"context-render (profile={render_profile!r}) suggested_edits changed when this PR's "
-        "capping mechanism was swapped for a raw passthrough -- it must never engage on this path"
-    )
-    # Document the ACTUAL pre-existing shape per profile (measured against origin/main before this
-    # PR, unchanged by it): "compact"/"llm" already truncate via the separate, pre-existing
-    # `_compact_edit_plan_seed` cap; the default "full" profile does not truncate at all. Both facts
-    # are pinned here so a future change to either shape is a conscious, reviewed decision.
-    if render_profile == "full":
-        assert len(fixed_edits) > 2, (
-            "the default profile's suggested_edits is NOT capped by --max-files (a known, "
-            "out-of-scope gap this PR does not touch -- see module docstring); if this now holds "
-            "<=2 it should be a deliberate fix with its own test, not an accidental side effect"
-        )
-    else:
-        assert len(fixed_edits) <= 2
 
 
-def test_edit_plan_max_files_does_not_change_blast_radius_plan_or_render(tmp_path: Path) -> None:
-    """Same discipline as the context-render pin above, for the other two `_attach_edit_plan_
-    metadata` callers this PR deliberately leaves untouched: `tg blast-radius-plan` and `tg
-    blast-radius-render` share the identical B9/A18 flag-lie (neither calls `_compact_edit_plan_seed`
-    either) but are out of scope for this fix -- they must keep their pre-fix (unbounded) shape."""
+def test_edit_plan_max_files_now_bounds_blast_radius_plan_and_render(tmp_path: Path) -> None:
+    """UPDATED by #212 (was `..._does_not_change_blast_radius_plan_or_render`, which pinned the OLD
+    unbounded shape as "must not change"): `build_symbol_blast_radius_plan_from_map` and
+    `build_symbol_blast_radius_render_from_map` now ALSO opt into `suggested_edits_max`, each
+    passing its own `--max-files` value -- the same fix `build_context_edit_plan_from_map` (B9/A18)
+    and `build_context_render_from_map` (#212, above) already ship. See
+    `test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py` for the RED/GREEN
+    proof that this bound does real truncation work (not vacuously satisfied)."""
     project = _build_many_callers_project(tmp_path, caller_count=5)
 
     plan_payload = repo_map.build_symbol_blast_radius_plan("create_invoice", project, max_files=2)
@@ -168,7 +163,5 @@ def test_edit_plan_max_files_does_not_change_blast_radius_plan_or_render(tmp_pat
         "create_invoice", project, max_files=2
     )
 
-    # Unchanged means still unbounded here -- both comfortably exceed the --max-files=2 cap that
-    # edit-plan now enforces, proving this PR's fix did not leak into either sibling command.
-    assert len(plan_payload["edit_plan_seed"]["suggested_edits"]) > 2
-    assert len(render_payload["edit_plan_seed"]["suggested_edits"]) > 2
+    assert len(plan_payload["edit_plan_seed"]["suggested_edits"]) <= 2
+    assert len(render_payload["edit_plan_seed"]["suggested_edits"]) <= 2


### PR DESCRIPTION
## Summary

VERIFY-FIRST task for #212, a follow-up to B9/#661. Hypothesis: `tg context-render` and
`tg blast-radius-plan`/`blast-radius-render` advertise a `--max-files` cap flag but silently
ignore it for `edit_plan_seed.suggested_edits`, the same class of bug B9/#661 fixed for
`tg edit-plan`.

**Verdict: REAL, confirmed for all three commands** before writing any fix.

### Verification (before touching code)

1. **Source-level**: B9's own docstrings already documented the exact gap.
   `_capped_suggested_edits`'s docstring (repo_map.py) said context-render's "compact"/"llm"
   profiles get a downstream cap via `_compact_edit_plan_seed`, but the default **"full"
   profile has no cap at all**, and blast-radius-plan/render (which never call
   `_compact_edit_plan_seed`) have **no cap at all, in any profile**. All three were marked
   "deliberately left unbounded -- out of scope" for B9's PR.
2. **CLI contract**: all three commands DO advertise `--max-files` (typer help text:
   "Maximum files to include in the render bundle" / "...in the plan"), default 3.
3. **Live dogfood** (Python builders called directly against tensor-grep's own
   `src/tensor_grep`, 80 files, symbol `SearchConfig`):

   | command | `--max-files` | `files` | `suggested_edits` | distinct files touched |
   |---|---|---|---|---|
   | blast-radius-render | 1 | `[1]` | 73 | 40 |
   | blast-radius-render | 50 | `[42]` | 73 (**identical**) | 40 |
   | blast-radius-plan | 1 | `[1]` | 25 | 8 |
   | context-render (full) | 1 | `[1]` | 5 | 3 |

   `blast-radius-render` is the starkest case: `--max-files` has **zero** measurable effect
   on `suggested_edits` -- 1 vs 50 produce byte-identical counts.

## Fix

Mirrors B9's own opt-in pattern exactly -- no new CLI flags, no change to the low-level
`suggested_edits_max: int | None = None` default (any future/unnamed caller still gets the
unbounded pre-fix shape). Three builders now thread their own already-existing `--max-files`
value into `_attach_edit_plan_metadata`'s existing `suggested_edits_max` parameter:

- `build_context_render_from_map` -> `suggested_edits_max=max_files` (closes the "full"
  profile gap; "compact"/"llm" already truncated to the same bound one step downstream via
  `_compact_edit_plan_seed`, so this is a **provable no-op** for those two profiles -- see
  `test_context_render_compact_and_llm_profiles_stay_prefix_stable`).
- `build_symbol_blast_radius_plan_from_map` -> `suggested_edits_max=normalized_max_files`.
- `build_symbol_blast_radius_render_from_map` -> `suggested_edits_max=max_files`.

`related_spans` (the raw input to `suggested_edits`) is intentionally left unbounded,
matching edit-plan's own already-shipped B9 fix, which also never capped `related_spans` --
staying symbol-scoped to exactly what B9 capped.

## Before / after (dogfood re-run post-fix)

| command | `--max-files` | `suggested_edits` before | `suggested_edits` after |
|---|---|---|---|
| context-render (full) | 1 / 50 | 5 / 73 | 1 / 50 |
| blast-radius-plan | 1 / 50 | 25 / 73 | 1 / 50 |
| blast-radius-render | 1 / 50 | 73 / 73 | 1 / 50 |

## Tests

- Updated the two B9 regression tests in
  `test_edit_plan_max_files_bounds_suggested_edits.py` that pinned the OLD unbounded shape
  as "must not change" -- they now pin the corrected bounded shape (renamed
  `..._now_bounds_context_render_suggested_edits_in_every_profile` /
  `..._now_bounds_blast_radius_plan_and_render`).
- New file `test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py`:
  RED/GREEN proof per command (monkeypatch `_capped_suggested_edits` to a raw passthrough to
  confirm the fixture produces more than the cap, then confirm the real fix truncates to a
  stable prefix), a larger-cap-never-inflates guard, a zero-related-spans guard, and the
  compact/llm double-truncation no-op check -- all parametrized across the three commands
  where practical.
- `18 passed` on the two files combined.
- Full regression sweep: every test file in the repo that references
  `build_context_render*`/`build_symbol_blast_radius_plan*`/`build_symbol_blast_radius_render*`
  / `context-render` / `blast-radius-plan` / `blast-radius-render` was run foreground and
  passes (agent_capsule, cli_deadline, cli_modes, mcp_server, mcp_caps, session/daemon,
  repo_map spans/targets/deadline/lexical-ranking, edit_plan_seed, blast_radius perf/mermaid,
  trust_planning, validation_commands, token_budget, semantic_provider_navigation,
  bakeoff/benchmark/profiling harnesses, agent_readiness/success, js/ts/rust advanced
  resolution, caller/import span targeting). A handful of pre-existing failures were found
  (AST rewrite/apply "embedded fallback" tests in `test_mcp_server.py`, and a GPU-inventory
  test in `test_cli_modes.py`) -- confirmed via `git stash` that all of them fail identically
  on unmodified origin/main code, unrelated to this diff (different subsystem: AST
  rewrite/apply native-binary resolution and local GPU device inventory, neither touched by
  this fix).
- `ruff format --preview` and `ruff check` clean on all three changed files.
- Import sanity confirmed (`tensor_grep.__file__` resolves into the worktree, `cli.main`/
  `cli.repo_map`/`cli.mcp_server` import cleanly).

## Scope discipline

- No CLI flag added or removed; `--max-files` was already registered and documented on all
  three commands.
- No change to the low-level opt-in default (`suggested_edits_max=None` everywhere except
  the four now-named callers).
- `related_spans` deliberately left unbounded, matching edit-plan's own precedent.
- Diff is symbol-scoped: 3 keyword-argument additions at existing call sites, plus docstring/
  comment updates so the "deliberately out of scope" notes B9 left behind don't mislead a
  future reader, plus the test updates described above.

Draft pending the independent Opus gate per this repo's Backend Fail-Closed / change-control
discipline (load-bearing repo_map.py surface).

## Test plan

- [x] `ruff format --preview` clean
- [x] `ruff check` clean
- [x] New + updated unit tests pass (18/18)
- [x] Broad regression sweep across every test file referencing the touched builders/commands
- [x] Live dogfood before AND after the fix, on tensor-grep's own repo
- [ ] Independent Opus gate review

