### PR TITLE
fix(lsp): name the exact rustup component-add remediation + tighten pygls floor to >=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -596,7 +596,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "pyarrow>=23.0.1"]
 gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "pygls>=1.3.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "pygls>=2.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -2125,6 +2125,92 @@ def _doctor_apply_lsp_workspace_warnings(
     return [_doctor_downgrade_lsp_workspace_proof(provider) for provider in providers]
 
 
+_DOCTOR_RUST_ANALYZER_MISSING_COMPONENT_TOOLCHAIN_RE = re.compile(r"toolchain '([^']+)'")
+
+
+def _doctor_lsp_missing_rust_analyzer_component_lines(stderr_lines: list[str]) -> list[str]:
+    """Return stderr lines matching rustup's missing-component proxy fingerprint.
+
+    When the ``rust-analyzer`` rustup component is not installed for the active toolchain,
+    the rustup proxy binary at ``~/.cargo/bin/rust-analyzer`` still spawns successfully (the
+    process starts), but immediately exits, printing e.g. ``error: unknown binary
+    'rust-analyzer' in toolchain '1.96.0-x86_64-pc-windows-msvc'`` to stderr. Requiring BOTH
+    markers keeps this narrow: it must not fire on other rust-analyzer stderr noise that
+    happens to mention "toolchain" or "binary" alone.
+    """
+    matches: list[str] = []
+    for raw in stderr_lines:
+        line = str(raw)
+        lowered = line.lower()
+        if "unknown binary" in lowered and "rust-analyzer" in lowered:
+            matches.append(line)
+    return matches
+
+
+def _doctor_rust_analyzer_missing_component_remediation(stderr_lines: list[str]) -> str | None:
+    """Return the exact ``rustup component add`` remediation, or None when rustup's missing-
+    component fingerprint (see ``_doctor_lsp_missing_rust_analyzer_component_lines``) is absent
+    from ``stderr_lines``. The toolchain, when parseable from the matched line, is threaded into
+    ``--toolchain`` so the remediation is copy-pasteable as-is; otherwise this falls back to the
+    plain (no-toolchain) form rather than emitting a broken ``--toolchain`` with no value.
+    """
+    matches = _doctor_lsp_missing_rust_analyzer_component_lines(stderr_lines)
+    if not matches:
+        return None
+    toolchain: str | None = None
+    for line in matches:
+        found = _DOCTOR_RUST_ANALYZER_MISSING_COMPONENT_TOOLCHAIN_RE.search(line)
+        if found:
+            toolchain = found.group(1)
+            break
+    command = (
+        f"rustup component add rust-analyzer --toolchain {toolchain}"
+        if toolchain
+        else "rustup component add rust-analyzer"
+    )
+    return (
+        f"Missing rustup component: run `{command}` "
+        "(or `tg lsp-setup --include-toolchain-providers` to let tensor-grep manage it)."
+    )
+
+
+def _doctor_apply_lsp_rust_analyzer_remediation(provider: dict[str, Any]) -> dict[str, Any]:
+    """Append the rustup component-add remediation to a rust provider's surfaced guidance when
+    its stderr matches the missing-component fingerprint. Narrow by design: only
+    ``language == "rust"`` and only this one fingerprint are touched -- every other language and
+    every other error shape passes through unchanged (this must never become a generic error
+    rewriter)."""
+    if str(provider.get("language", "")).strip().lower() != "rust":
+        return provider
+    stderr_lines = [
+        str(item)
+        for item in (
+            list(provider.get("stderr_tail") or [])
+            + list(provider.get("provider_recent_stderr") or [])
+            + [provider.get("last_error")]
+        )
+        if item
+    ]
+    remediation = _doctor_rust_analyzer_missing_component_remediation(stderr_lines)
+    if remediation is None:
+        return provider
+    updated = dict(provider)
+    existing_reason = str(updated.get("not_lsp_proof_reason") or "").strip()
+    if remediation in existing_reason:
+        return updated  # already applied -- idempotent, avoids duplicate text on repeat calls
+    updated["not_lsp_proof_reason"] = (
+        f"{existing_reason} {remediation}" if existing_reason else remediation
+    )
+    updated["lsp_missing_component_remediation"] = remediation
+    return updated
+
+
+def _doctor_apply_lsp_missing_component_remediation(
+    providers: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [_doctor_apply_lsp_rust_analyzer_remediation(provider) for provider in providers]
+
+
 def _doctor_lsp_providers_by_language(
     providers: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
@@ -3290,8 +3376,8 @@ def _build_doctor_payload(
         "session_daemon": _doctor_session_daemon_status(str(root)),
     }
     if with_lsp:
-        lsp_providers = _doctor_apply_lsp_workspace_warnings(
-            _doctor_lsp_provider_statuses(str(root))
+        lsp_providers = _doctor_apply_lsp_missing_component_remediation(
+            _doctor_apply_lsp_workspace_warnings(_doctor_lsp_provider_statuses(str(root)))
         )
         lsp_providers_by_language = _doctor_lsp_providers_by_language(lsp_providers)
         payload["lsp"] = {

--- a/tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py
+++ b/tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py
@@ -34,7 +34,14 @@ from pathlib import Path
 
 import pytest
 
-from tensor_grep.cli import repo_map
+from tensor_grep.cli import repo_map, session_daemon
+from tests.unit.test_symbol_daemon_autostart import (
+    _autostart_env,
+    _cli_json,
+    _probe_fake_for,
+    _real_daemon,
+    _serve,
+)
 
 
 def _write(path: Path, content: str) -> None:
@@ -214,3 +221,54 @@ def test_zero_related_spans_still_returns_empty_list(tmp_path: Path, build) -> N
     payload = build(project)
 
     assert payload["edit_plan_seed"]["suggested_edits"] == []
+
+
+# ---------------------------------------------------------------------------------------------
+# Warm-daemon parity (gate nit from the #666 review): #666 threaded `suggested_edits_max=
+# max_files` into `build_context_render_from_map` ITSELF (not the cold `build_context_render`
+# wrapper), specifically so the cap would apply on both routes -- but every test above only ever
+# drives it through the cold wrapper. `tg context-render` is also served by the warm session
+# daemon (session_store.py's `context_render` command handler calls `build_context_render_from_map`
+# directly against an already-cached repo_map, bypassing `build_context_render`'s own
+# `build_repo_map` call entirely), so this proves the cap holds on that real code path too, not
+# just when reached cold. Mirrors the real-spawned-daemon harness
+# `test_orient_agent_daemon.py` established for orient/agent (itself reusing
+# `test_symbol_daemon_autostart.py`'s `_real_daemon`/`_serve`/`_probe_fake_for`/`_autostart_env`/
+# `_cli_json` fixtures for the same warm-vs-cold parity contract).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_context_render_warm_daemon_bounds_suggested_edits_same_as_cold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = _build_many_callers_project(tmp_path, caller_count=5)
+    render_args = [
+        "context-render",
+        str(project),
+        "create invoice",
+        "--max-files",
+        "2",
+        "--render-profile",
+        "full",
+        "--json",
+    ]
+
+    cold_payload = _cli_json(render_args)
+    cold_edits = cold_payload["edit_plan_seed"]["suggested_edits"]
+    assert len(cold_edits) <= 2, "cold route must already bound suggested_edits (see #666)"
+
+    server = _real_daemon(project)
+    _serve(server)
+    try:
+        monkeypatch.setattr(session_daemon, "_probe_daemon", _probe_fake_for(server, "test-token"))
+        _autostart_env(monkeypatch, enabled=True)
+        warm_payload = _cli_json(render_args)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    # Confirms the request actually went through the warm/daemon route, not a silent cold fallback.
+    assert warm_payload["routing_reason"] == "session-context-render"
+    warm_edits = warm_payload["edit_plan_seed"]["suggested_edits"]
+    assert len(warm_edits) <= 2
+    assert warm_edits == cold_edits

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -26,8 +26,11 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from tensor_grep.cli.main import (
+    _doctor_apply_lsp_missing_component_remediation,
+    _doctor_apply_lsp_rust_analyzer_remediation,
     _doctor_apply_lsp_workspace_warnings,
     _doctor_downgrade_lsp_workspace_proof,
+    _doctor_rust_analyzer_missing_component_remediation,
     _should_refuse_unbounded_workspace_root_scan,
     app,
 )
@@ -191,6 +194,121 @@ def test_m10_lsp_proof_preserved_without_workspace_error() -> None:
     # A provider that was never lsp_proof stays untouched.
     assert result[1]["lsp_proof"] is False
     assert "workspace_warning" not in result[1]
+
+
+# ---------------------------------------------------------------------------
+# Actionable rust-analyzer error - name the exact rustup component-add
+# remediation when a rust provider's stderr matches rustup's "missing
+# component" proxy fingerprint (real repro: rustup's rust-analyzer proxy
+# binary spawns, then immediately exits with "unknown binary 'rust-analyzer'
+# in toolchain '<toolchain>'" when the component was never installed for the
+# active toolchain). Narrow by design: only language == rust and only this
+# ONE fingerprint are touched -- every other language and every other error
+# shape must pass through unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_rust_analyzer_missing_component_remediation_names_the_toolchain() -> None:
+    stderr_lines = [
+        "stdout: some other provider noise",
+        "error: unknown binary 'rust-analyzer' in toolchain '1.96.0-x86_64-pc-windows-msvc'",
+    ]
+    remediation = _doctor_rust_analyzer_missing_component_remediation(stderr_lines)
+    assert remediation is not None
+    assert (
+        "rustup component add rust-analyzer --toolchain 1.96.0-x86_64-pc-windows-msvc"
+        in remediation
+    )
+    assert "tg lsp-setup --include-toolchain-providers" in remediation
+
+
+def test_rust_analyzer_missing_component_remediation_falls_back_without_toolchain() -> None:
+    # The fingerprint markers are present but no quoted toolchain string follows -- must fall
+    # back to the plain command instead of emitting a broken `--toolchain` with no value.
+    stderr_lines = ["error: unknown binary 'rust-analyzer' -- no toolchain reported"]
+    remediation = _doctor_rust_analyzer_missing_component_remediation(stderr_lines)
+    assert remediation is not None
+    assert "rustup component add rust-analyzer" in remediation
+    assert "--toolchain" not in remediation
+
+
+def test_rust_analyzer_missing_component_remediation_absent_when_fingerprint_missing() -> None:
+    stderr_lines = ["some unrelated crash", "thread 'main' panicked at src/main.rs:10"]
+    assert _doctor_rust_analyzer_missing_component_remediation(stderr_lines) is None
+    assert _doctor_rust_analyzer_missing_component_remediation([]) is None
+
+
+def test_doctor_appends_rust_analyzer_remediation_to_not_lsp_proof_reason() -> None:
+    unhealthy = {
+        "language": "rust",
+        "available": True,
+        "health_status": "unhealthy",
+        "lsp_proof": False,
+        "not_lsp_proof_reason": "Provider semantic health probe failed or timed out.",
+        "stderr_tail": [
+            "error: unknown binary 'rust-analyzer' in toolchain '1.96.0-x86_64-pc-windows-msvc'",
+        ],
+    }
+    out = _doctor_apply_lsp_rust_analyzer_remediation(unhealthy)
+    assert (
+        "rustup component add rust-analyzer --toolchain 1.96.0-x86_64-pc-windows-msvc"
+        in out["not_lsp_proof_reason"]
+    )
+    # The original generic reason text is preserved, not replaced.
+    assert "Provider semantic health probe failed or timed out." in out["not_lsp_proof_reason"]
+    # Original dict is not mutated.
+    assert (
+        unhealthy["not_lsp_proof_reason"] == "Provider semantic health probe failed or timed out."
+    )
+
+
+def test_doctor_rust_analyzer_remediation_narrow_to_rust_language() -> None:
+    non_rust = {
+        "language": "python",
+        "health_status": "unhealthy",
+        "not_lsp_proof_reason": "Provider semantic health probe failed or timed out.",
+        "stderr_tail": [
+            "error: unknown binary 'rust-analyzer' in toolchain '1.96.0-x86_64-pc-windows-msvc'",
+        ],
+    }
+    out = _doctor_apply_lsp_rust_analyzer_remediation(non_rust)
+    assert out is non_rust
+    assert out["not_lsp_proof_reason"] == "Provider semantic health probe failed or timed out."
+
+
+def test_doctor_rust_analyzer_remediation_narrow_to_the_exact_fingerprint() -> None:
+    generic_rust_error = {
+        "language": "rust",
+        "health_status": "unhealthy",
+        "not_lsp_proof_reason": "Provider semantic health probe failed or timed out.",
+        "stderr_tail": ["thread 'main' panicked at src/main.rs:10: index out of bounds"],
+    }
+    out = _doctor_apply_lsp_rust_analyzer_remediation(generic_rust_error)
+    assert out["not_lsp_proof_reason"] == "Provider semantic health probe failed or timed out."
+
+
+def test_doctor_apply_lsp_missing_component_remediation_over_provider_list() -> None:
+    providers = [
+        {
+            "language": "rust",
+            "health_status": "unhealthy",
+            "not_lsp_proof_reason": "Provider semantic health probe failed or timed out.",
+            "stderr_tail": [
+                "error: unknown binary 'rust-analyzer' in toolchain '1.96.0-x86_64-pc-windows-msvc'",
+            ],
+        },
+        {
+            "language": "python",
+            "health_status": "unhealthy",
+            "not_lsp_proof_reason": "Provider semantic health probe failed or timed out.",
+            "stderr_tail": [],
+        },
+    ]
+    result = _doctor_apply_lsp_missing_component_remediation(providers)
+    assert "rustup component add rust-analyzer" in result[0]["not_lsp_proof_reason"]
+    assert (
+        result[1]["not_lsp_proof_reason"] == "Provider semantic health probe failed or timed out."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -41,6 +41,18 @@ def test_ast_dev_bench_extras_include_tree_sitter_go_for_path_a_stage1() -> None
         assert "tree-sitter-go" in deps[extra_name], f"tree-sitter-go missing from [{extra_name}]"
 
 
+def test_ast_extra_pins_pygls_floor_matching_lsp_server_import() -> None:
+    # cli/lsp_server.py imports `from pygls.lsp.server import LanguageServer`, a module path
+    # that exists only in pygls 2.x (pygls 1.x has no `pygls.lsp.server` module at all -- its
+    # LanguageServer lives at `pygls.server`). The `ast` extra's pygls floor must match what the
+    # code actually requires, or `pip install "tensor-grep[ast]"` can resolve a pygls 1.x that
+    # ImportErrors the moment `tg lsp` runs (found by the #663 Opus gate).
+    deps = _optional_dependencies()["ast"]
+
+    assert "pygls>=2.0" in deps
+    assert "pygls>=1.3.0" not in deps
+
+
 def test_semantic_extra_should_pin_model2vec_and_numpy_no_torch() -> None:
     deps = _optional_dependencies()["semantic"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4211,7 +4211,7 @@ requires-dist = [
     { name = "pathspec", specifier = ">=1.0.4" },
     { name = "psutil", marker = "extra == 'dev'" },
     { name = "pyarrow", marker = "extra == 'gpu'", specifier = ">=23.0.1" },
-    { name = "pygls", marker = "extra == 'ast'", specifier = ">=1.3.0" },
+    { name = "pygls", marker = "extra == 'ast'", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'bench'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },


### PR DESCRIPTION
## Summary

Three small LOW-polish TDD items, batched into one PR (pending independent Opus gate).

### 1. Actionable rust-analyzer error (the main item)

Real-repro context: on a Rust repo where the rustup COMPONENT is missing, spawning
rust-analyzer fails with `unknown binary 'rust-analyzer' in toolchain
'1.96.0-x86_64-pc-windows-msvc'` and tg already correctly reports unhealthy
(`health_status: unhealthy`, `lsp_proof: false`) -- but the user had to figure out the fix
themselves.

Hooked in at `src/tensor_grep/cli/main.py`, in the `tg doctor --with-lsp` payload-construction
pipeline (`_build_doctor_payload`), mirroring the existing M10 `_doctor_downgrade_lsp_workspace_proof`
/ `_doctor_apply_lsp_workspace_warnings` pattern rather than touching the shared
`lsp_external_provider.py` status-assembly code that every LSP consumer (doctor, repo_map
navigation, mcp_server, agent_capsule) goes through -- narrower blast radius, same precedent
shape, and the real-repro symptom (`health_status`/`lsp_proof` fields) is exactly what `tg
doctor` already reports.

New functions (`src/tensor_grep/cli/main.py`):
- `_doctor_lsp_missing_rust_analyzer_component_lines` -- returns stderr lines matching BOTH
  `"unknown binary"` and `"rust-analyzer"` (case-insensitive substrings).
- `_doctor_rust_analyzer_missing_component_remediation` -- parses the toolchain out of
  `toolchain '...'` when present and returns the exact remediation string, or `None` when the
  fingerprint is absent.
- `_doctor_apply_lsp_rust_analyzer_remediation` -- narrow gate: only `language == "rust"`;
  appends the remediation to the provider's existing `not_lsp_proof_reason` (never replaces it)
  and stamps an additive `lsp_missing_component_remediation` field. Non-rust providers and
  non-matching rust errors pass through byte-identical (even the same dict identity for the
  non-rust case).
- `_doctor_apply_lsp_missing_component_remediation` -- list wrapper, composed into
  `_build_doctor_payload`'s `with_lsp` branch alongside the existing workspace-warning pass.

**Before/after message example** (`not_lsp_proof_reason`, both JSON and the `tg doctor` text
renderer read this same field):

```
BEFORE: Provider semantic health probe failed or timed out.

AFTER:  Provider semantic health probe failed or timed out. Missing rustup component: run
        `rustup component add rust-analyzer --toolchain 1.96.0-x86_64-pc-windows-msvc` (or
        `tg lsp-setup --include-toolchain-providers` to let tensor-grep manage it).
```

Falls back to the plain `rustup component add rust-analyzer` (no `--toolchain`) when the
toolchain string isn't parseable from the matched line.

**Narrowness**: gated on `language == "rust"` AND both fingerprint substrings present. A
non-rust provider, or a rust provider with a different/generic error, is returned completely
unchanged (tests assert this, including dict identity for the non-rust case).

### 2. pygls floor

`pyproject.toml`'s `ast` extra still floored `pygls>=1.3.0`, but `cli/lsp_server.py` hard-imports
`from pygls.lsp.server import LanguageServer` -- a module path that exists only in pygls 2.x
(found by the #663 Opus gate). Tightened to `pygls>=2.0`. `uv.lock`'s `requires-dist` metadata
line updated to match (text-only edit -- the locked `pygls==2.0.1` already satisfies `>=2.0`, so
no re-resolution/`uv lock` run was needed or attempted, keeping this CPU-safe/no-cargo).

Added a governance test (`tests/unit/test_pyproject_dependencies.py`) pinning the new floor and
asserting the old `pygls>=1.3.0` string is gone.

### 3. Warm-daemon parity test (test-only, from the #666 gate nits)

PR #666 threaded `suggested_edits_max=max_files` into `build_context_render_from_map` ITSELF
(not the cold `build_context_render` wrapper), specifically so the `suggested_edits` cap would
hold on both the cold CLI route and the warm/session-daemon route (`session_store.py`'s
`context_render` command handler calls `build_context_render_from_map` directly against an
already-cached repo_map). #666's own test file only ever exercised the cold wrapper.

Added one regression test,
`test_context_render_warm_daemon_bounds_suggested_edits_same_as_cold`, in
`tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py`. It drives
`tg context-render --max-files 2 --render-profile full --json` through a REAL spawned session
daemon (reusing `test_symbol_daemon_autostart.py`'s `_real_daemon`/`_serve`/`_probe_fake_for`/
`_autostart_env`/`_cli_json` harness -- the same pattern `test_orient_agent_daemon.py` already
established for orient/agent's warm-vs-cold parity) and asserts the warm route's
`suggested_edits` is `<=2` and byte-identical to the cold route's.

Sanity-checked this test is not vacuous: temporarily reverted the #666 fix locally
(`suggested_edits_max=None`), confirmed the new test goes RED (`10 <= 2` assertion failure on
the cold side too, since both routes share the function), then reverted back to GREEN and
confirmed `git diff` on `repo_map.py` is empty (no accidental change shipped).

## Test evidence

```
$ pytest tests/unit/test_lsp_external_provider.py tests/unit/test_lsp_external_provider_hardening.py \
         tests/unit/test_pyproject_dependencies.py \
         tests/unit/test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py \
         tests/unit/test_medlow_main_cli.py tests/unit/test_symbol_daemon_autostart.py \
         tests/unit/test_orient_agent_daemon.py
138 passed
```

Also ran, scoped to the doctor/lsp surface in the large `test_cli_modes.py` suite (unaffected,
sanity-only): `-k doctor` 53 passed, `-k lsp` 19 passed.

`ruff check` + `ruff format --preview` clean on all touched files.
`python -c "import tensor_grep.cli.lsp_external_provider"` succeeds.
`python -c "import tensor_grep.cli.main"` succeeds.
`mypy src/tensor_grep/cli/main.py` -- Success, no issues.

## For the gate

- Item 1's hook point is `cli/main.py` (doctor payload construction), not
  `lsp_external_provider.py` -- a deliberate choice (narrower blast radius, matches the
  real-repro's `tg doctor` symptom, mirrors the existing M10 precedent exactly). Flagging in
  case the gate expected the other location per the dispatch brief's "likely
  lsp_external_provider.py" guess.
- The fingerprint match also scans `last_error` in addition to `stderr_tail` /
  `provider_recent_stderr`, as a robustness fallback (the dispatch brief's "or the spawn fails
  with the toolchain string present" alternate-detection wording) -- still gated on the same
  narrow `"unknown binary" + "rust-analyzer"` substring pair, no broader matching added.
- `uv.lock` was hand-edited (one specifier string) rather than regenerated via `uv lock`/`uv
  sync`, to avoid any risk of invoking maturin's metadata hook (which could reach for
  cargo/rustc) on this CPU-safe shared box. The locked `pygls==2.0.1` already satisfies the new
  `>=2.0` floor, so this is purely a drift-prevention text fix, not a real re-resolution.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
