### PR TITLE
fix(importers): deterministic likely-first bounded scan so partial coverage finds real importers

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -15987,6 +15987,91 @@ def _confirm_import_edges(
     return edges
 
 
+_REVERSE_IMPORTER_TIER_SAME_ANCESTRY = 0
+_REVERSE_IMPORTER_TIER_SAME_PROJECT = 1
+_REVERSE_IMPORTER_TIER_SAME_LANGUAGE = 2
+_REVERSE_IMPORTER_TIER_OTHER = 3
+
+
+def _tier_reverse_importer_candidates(
+    candidates: set[str],
+    target_file: str,
+) -> list[str]:
+    """Proximity-tiered reverse-import candidate ordering (dogfood flap: v1.81.15 PASS ->
+    v1.81.17 INCOMPLETE "0 importers @ 330/1035 files scanned" on a 50k-file WSL multi-repo
+    workspace). Orders the reverse-import PREFILTER candidates by proximity to TARGET before
+    ``build_file_importers_from_map`` applies
+    its ``CALLER_SCAN_FILE_CEILING``/``--deadline`` slice, instead of the plain lexicographic
+    path sort this replaces.
+
+    ``_reverse_importers``'s alias prefilter is DELIBERATELY broad -- ``_module_aliases_for_path``
+    keys purely on a file's basename/near-basename (e.g. every ``utils.py`` in a 40-repo
+    workspace collides on the "utils" alias), relying on the per-candidate
+    ``_confirm_import_edges`` CONFIRM step to separate real edges from same-named-but-unrelated
+    noise. On a huge multi-repo ROOT this prefilter can legitimately balloon to 1000+ candidates
+    for one target file, the overwhelming majority from OTHER repos. A plain
+    ``sorted(reverse_map.get(target_file, set()))`` then buckets that list by absolute-path
+    string, i.e. effectively by REPO NAME alphabetically -- nothing about it favors TARGET's own
+    repo. When the ceiling/deadline slice below cuts the list short (a large ROOT + a
+    --deadline, or the default CLI --deadline-less path racing wall-clock variance on a slow
+    WSL /mnt/c mount), a target file whose own repo happens to sort late is entirely capable of
+    having ALL of its real (same-repo) importers stranded past the cut line, reporting "0
+    importers" while the scan is still honestly stamped incomplete -- exactly the reported flap.
+
+    A real importer of FILE is overwhelmingly within FILE's own repo/package, so reordering the
+    SAME candidate set (never dropping or adding members) into four proximity tiers, closest
+    first, makes a partial scan cover the highest-yield subset first:
+
+      0. same directory as FILE, or one of FILE's ancestor directories up to (and including) its
+         inferred project root (``_infer_project_root`` -- the nearest ``.git``/``pyproject.toml``/
+         ``package.json``/``Cargo.toml``/``tsconfig.json`` marker) -- the files most likely to hold
+         a real same-package edge (a parent ``__init__.py``, a sibling module).
+      1. elsewhere inside the same project root.
+      2. outside the project root, but the same language (file suffix) as FILE.
+      3. everything else.
+
+    Within a tier, candidates sort by path string for full determinism, independent of the
+    upstream set/dict iteration order. This is a pure REORDERING of the same candidate
+    membership -- an unbounded/complete scan (no ceiling or deadline hit) still confirms every
+    candidate exactly as before and returns the identical found-set;
+    ``build_file_importers_from_map`` re-sorts ``edges`` by ``(file, line)`` before returning, so
+    the tiering here never changes output order, only which candidates survive a partial cut.
+    """
+    target_path = Path(target_file)
+    target_dir = target_path.parent
+    project_root = _infer_project_root(target_path)
+    ancestor_dirs: set[Path] = set()
+    current = target_dir
+    while True:
+        try:
+            ancestor_dirs.add(current.resolve())
+        except OSError:
+            ancestor_dirs.add(current)
+        if current == project_root:
+            break
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    target_suffix = target_path.suffix.lower()
+
+    def _tier(candidate: str) -> int:
+        candidate_path = Path(candidate)
+        try:
+            resolved_candidate = candidate_path.resolve()
+        except OSError:
+            resolved_candidate = candidate_path
+        if resolved_candidate.parent in ancestor_dirs:
+            return _REVERSE_IMPORTER_TIER_SAME_ANCESTRY
+        if _path_is_relative_to(candidate_path, project_root):
+            return _REVERSE_IMPORTER_TIER_SAME_PROJECT
+        if candidate_path.suffix.lower() == target_suffix:
+            return _REVERSE_IMPORTER_TIER_SAME_LANGUAGE
+        return _REVERSE_IMPORTER_TIER_OTHER
+
+    return sorted(candidates, key=lambda candidate: (_tier(candidate), candidate))
+
+
 def build_file_importers_from_map(
     repo_map: dict[str, Any],
     file_path: str | Path,
@@ -16050,7 +16135,13 @@ def build_file_importers_from_map(
     reverse_map = _reverse_importers(
         all_files, imports_by_file, include_directory_index_aliases=True
     )
-    prefiltered = sorted(reverse_map.get(target_file, set()))
+    # Proximity-tiered, not a plain lexicographic path sort (dogfood flap fix) -- see
+    # _tier_reverse_importer_candidates for why a bare alphabetical order strands a target
+    # repo's real importers on a large multi-repo ROOT once the ceiling/deadline slice below
+    # cuts the candidate list short.
+    prefiltered = _tier_reverse_importer_candidates(
+        reverse_map.get(target_file, set()), target_file
+    )
 
     ceiling_hit = len(prefiltered) > CALLER_SCAN_FILE_CEILING
     bounded_candidates = prefiltered[:CALLER_SCAN_FILE_CEILING]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -16054,6 +16054,21 @@ def _tier_reverse_importer_candidates(
             break
         current = parent
     target_suffix = target_path.suffix.lower()
+    # Opus-gate nit (PR #670, same class as the #639 precedent at :1149): _tier runs once per
+    # candidate via sorted() below, and for every non-same-ancestry candidate (the majority on a
+    # large multi-repo ROOT) used to pay ~3 filesystem syscalls -- its own
+    # candidate_path.resolve(), a SECOND resolve of that identical path inside
+    # _path_is_relative_to, and a resolve of project_root inside _path_is_relative_to repeated on
+    # EVERY call despite being invariant across the whole sort. This runs over the FULL
+    # prefiltered set (not ceiling-bounded) BEFORE the deadline-gated confirm loop, so on a slow
+    # filesystem a short --deadline could be consumed by tiering itself. Resolve project_root
+    # exactly ONCE here; _tier below reuses the already-resolved resolved_candidate directly via
+    # relative_to instead of calling _path_is_relative_to (which would re-resolve both sides
+    # again) -- net one resolve per candidate, zero per-candidate project-root resolves.
+    try:
+        project_root_resolved = project_root.resolve()
+    except OSError:
+        project_root_resolved = project_root
 
     def _tier(candidate: str) -> int:
         candidate_path = Path(candidate)
@@ -16063,8 +16078,11 @@ def _tier_reverse_importer_candidates(
             resolved_candidate = candidate_path
         if resolved_candidate.parent in ancestor_dirs:
             return _REVERSE_IMPORTER_TIER_SAME_ANCESTRY
-        if _path_is_relative_to(candidate_path, project_root):
+        try:
+            resolved_candidate.relative_to(project_root_resolved)
             return _REVERSE_IMPORTER_TIER_SAME_PROJECT
+        except ValueError:
+            pass
         if candidate_path.suffix.lower() == target_suffix:
             return _REVERSE_IMPORTER_TIER_SAME_LANGUAGE
         return _REVERSE_IMPORTER_TIER_OTHER

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 from typer.testing import CliRunner
@@ -1727,3 +1728,227 @@ def test_build_file_imports_sys_path_insert_here_alias_resolves(tmp_path: Path) 
     entry = next(current for current in payload["imports"] if current["module"] == "aliasmod")
     assert entry["resolved"] == str(lib_mod.resolve())
     assert entry["external"] is False
+
+
+# ---------------------------------------------------------------------------------------------
+# Proximity-tiered reverse-import candidate ordering. Dogfood flap (v1.81.15 PASS
+# -> v1.81.17 INCOMPLETE "0 importers @ 330/1035 files scanned" on a 50k-file WSL multi-repo
+# workspace) traced to `build_file_importers_from_map` slicing its CALLER_SCAN_FILE_CEILING /
+# --deadline budget off a PLAIN lexicographic path sort (`sorted(reverse_map.get(target_file,
+# set()))`), which buckets candidates by absolute-path string -- i.e. by REPO NAME alphabetically
+# on a multi-repo ROOT -- with zero preference for TARGET's own repo. `_tier_reverse_importer_candidates`
+# replaces that with a 4-tier proximity order (same dir/ancestor dirs < rest of project < other
+# project same language < everything else) so a partial scan covers the highest-yield candidates
+# first, while an unbounded scan still finds the identical result set.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_tier_reverse_importer_candidates_orders_by_proximity(tmp_path: Path) -> None:
+    """Direct unit coverage of the 4 tiers: same-dir/ancestor-dir (0) < rest of same project (1)
+    < other project, same language (2) < everything else (3); stable path sort within a tier."""
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    pkg = proj / "src" / "pkg"
+    pkg.mkdir(parents=True)
+    target = pkg / "target.py"
+    target.write_text("", encoding="utf-8")
+
+    sibling = pkg / "sibling.py"  # tier 0: same directory as target
+    sibling.write_text("", encoding="utf-8")
+    top_level_sibling = proj / "src" / "top_level_sibling.py"  # tier 0: target's ancestor dir
+    top_level_sibling.write_text("", encoding="utf-8")
+    same_project_elsewhere = proj / "tests" / "test_target.py"  # tier 1: same project, NOT an
+    same_project_elsewhere.parent.mkdir(parents=True)  # ancestor of target's own directory
+    same_project_elsewhere.write_text("", encoding="utf-8")
+    other_repo_same_language = tmp_path / "other_proj" / "other.py"  # tier 2: other repo, .py
+    other_repo_same_language.parent.mkdir(parents=True)
+    other_repo_same_language.write_text("", encoding="utf-8")
+    other_repo_other_language = tmp_path / "other_proj" / "notes.md"  # tier 3: other repo, .md
+    other_repo_other_language.write_text("", encoding="utf-8")
+
+    candidates = {
+        str(sibling.resolve()),
+        str(top_level_sibling.resolve()),
+        str(same_project_elsewhere.resolve()),
+        str(other_repo_same_language.resolve()),
+        str(other_repo_other_language.resolve()),
+    }
+
+    ordered = repo_map._tier_reverse_importer_candidates(candidates, str(target))
+
+    assert set(ordered[:2]) == {str(sibling.resolve()), str(top_level_sibling.resolve())}
+    assert ordered[2] == str(same_project_elsewhere.resolve())
+    assert ordered[3] == str(other_repo_same_language.resolve())
+    assert ordered[4] == str(other_repo_other_language.resolve())
+
+
+def test_tier_reverse_importer_candidates_is_deterministic(tmp_path: Path) -> None:
+    """Two calls over the same candidate MEMBERSHIP produce byte-identical output -- guaranteed
+    by construction (the function always ends in a full `sorted(..., key=(tier, path))`, a total
+    order with no ties beyond the path string itself), but pinned here as an explicit regression
+    guard against a future change that stops fully sorting the result."""
+    proj = tmp_path / "proj"
+    (proj / ".git").mkdir(parents=True)
+    target = proj / "target.py"
+    target.write_text("", encoding="utf-8")
+    paths: list[str] = []
+    for idx in range(30):
+        current = proj / f"file_{idx:02d}.py"
+        current.write_text("", encoding="utf-8")
+        paths.append(str(current.resolve()))
+
+    first = repo_map._tier_reverse_importer_candidates(set(paths), str(target))
+    second = repo_map._tier_reverse_importer_candidates(set(paths), str(target))
+
+    assert first == second
+    assert first == sorted(paths)  # all same-project here -- collapses to a plain path sort
+
+
+def _build_synthetic_multi_repo_workspace(
+    tmp_path: Path,
+    *,
+    decoy_repo_count: int = 36,
+    decoy_files_per_repo: int = 10,
+) -> dict[str, Any]:
+    """A ~40-repo/few-hundred-file synthetic ROOT for the importers ceiling-bounded-scan
+    coverage: `decoy_repo_count` unrelated repos, each with several files that ALIAS-prefilter
+    match the target via a plain `import helpers` (the real `_reverse_importers` prefilter keys
+    on basename only -- see `_module_aliases_for_path` -- so this is exactly the kind of
+    same-named-but-unrelated noise a huge multi-repo ROOT produces), one importer reached only
+    from a DISTANT repo via a sys.path hack, and the target's own small repo with 3 real
+    importers (one same-directory, two elsewhere in the same project). Decoy repo names
+    ("repo_00".."repo_NN") are chosen to sort BEFORE the target repo name ("zzz_target_repo") in
+    plain lexicographic order, so a pre-fix plain-alphabetical candidate sort exhausts a partial
+    budget entirely on decoys before ever reaching a real importer -- reproducing the reported
+    flap deterministically."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    target_repo = workspace / "zzz_target_repo"
+    (target_repo / ".git").mkdir(parents=True)
+    pkg = target_repo / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target_file = pkg / "helpers.py"
+    target_file.write_text("def foo():\n    return 1\n", encoding="utf-8")
+
+    same_dir_importer = pkg / "main.py"  # tier 0
+    same_dir_importer.write_text("import pkg.helpers\n", encoding="utf-8")
+
+    sub = pkg / "sub"
+    sub.mkdir()
+    (sub / "__init__.py").write_text("", encoding="utf-8")
+    nested_importer = sub / "consumer.py"  # tier 1 (not an ancestor dir of target's own dir)
+    nested_importer.write_text("from pkg.helpers import foo\n", encoding="utf-8")
+
+    other = target_repo / "other"
+    other.mkdir()
+    sibling_importer = other / "another_consumer.py"  # tier 1 (sibling subtree, same project)
+    sibling_importer.write_text("import pkg.helpers\n", encoding="utf-8")
+
+    same_repo_importers = {
+        str(same_dir_importer.resolve()),
+        str(nested_importer.resolve()),
+        str(sibling_importer.resolve()),
+    }
+
+    decoy_repo_dirs = []
+    for repo_idx in range(decoy_repo_count):
+        repo_dir = workspace / f"repo_{repo_idx:02d}"
+        repo_dir.mkdir()
+        decoy_repo_dirs.append(repo_dir)
+        for file_idx in range(decoy_files_per_repo):
+            decoy = repo_dir / f"decoy_{file_idx:02d}.py"
+            # Aliases to "helpers" (target's basename) via _module_aliases_for_path, so this
+            # file enters the reverse-import PREFILTER -- but nothing at any of ITS OWN
+            # candidate roots is a real `helpers.py`, so it never CONFIRMS as a real edge.
+            decoy.write_text("import helpers\n", encoding="utf-8")
+
+    distant_importer = decoy_repo_dirs[0] / "distant_consumer.py"
+    # Only a statically-resolvable sys.path hack lets an import from a SIBLING repo resolve --
+    # the natural "ancestor directory up to repo root" search (_python_candidate_roots) never
+    # crosses a repo boundary on its own.
+    distant_importer.write_text(
+        "import sys, os\n"
+        'sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "zzz_target_repo", "pkg"))\n'
+        "from helpers import foo\n",
+        encoding="utf-8",
+    )
+
+    total_candidates = decoy_repo_count * decoy_files_per_repo + 1 + len(same_repo_importers)
+    return {
+        "workspace": workspace,
+        "target_file": target_file,
+        "same_repo_importers": same_repo_importers,
+        "distant_importer": str(distant_importer.resolve()),
+        "total_candidates": total_candidates,
+    }
+
+
+def test_build_file_importers_ceiling_bounded_scan_finds_same_repo_importers_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end proof: on a ~40-repo/few-hundred-file ROOT, a CALLER_SCAN_FILE_CEILING
+    bounded to ~30% of the prefiltered candidates still finds all 3 real same-repo importers
+    (proximity-tiered first) and honestly stamps the result incomplete -- the exact shape of the
+    "0 importers @ 330/1035 files scanned" dogfood flap, now with the real importers surviving
+    the cut instead of being stranded behind alphabetically-earlier decoy repos."""
+    fixture = _build_synthetic_multi_repo_workspace(tmp_path)
+    budget = max(1, int(fixture["total_candidates"] * 0.3))
+    monkeypatch.setattr(repo_map, "CALLER_SCAN_FILE_CEILING", budget)
+
+    payload = repo_map.build_file_importers(fixture["target_file"], fixture["workspace"])
+
+    assert payload["result_incomplete"] is True
+    caller_scan_limit = payload["caller_scan_limit"]
+    assert caller_scan_limit["possibly_truncated"] is True
+    assert caller_scan_limit["files_total"] == fixture["total_candidates"]
+    importer_files = set(payload["importer_files"])
+    assert fixture["same_repo_importers"] <= importer_files
+
+
+def test_build_file_importers_ceiling_bounded_scan_misses_importers_without_tiering(
+    tmp_path: Path,
+) -> None:
+    """Regression guard / causal proof for the fix above: simulate the PRE-FIX plain
+    lexicographic order (what `prefiltered = sorted(reverse_map.get(target_file, set()))` used
+    to do) over the IDENTICAL candidate set and budget -- the 3 same-repo importers, whose repo
+    name ("zzz_target_repo") sorts AFTER all decoy repo names ("repo_00".."repo_35"), are
+    entirely stranded past the cut line. This is the exact reported dogfood flap this fix closes."""
+    fixture = _build_synthetic_multi_repo_workspace(tmp_path)
+    budget = max(1, int(fixture["total_candidates"] * 0.3))
+
+    rmap = repo_map.build_repo_map(fixture["workspace"])
+    all_files = [str(current) for current in rmap.get("files", [])]
+    imports_by_file = {
+        str(current["file"]): list(
+            dict.fromkeys(str(name) for name in current.get("imports", []) if name)
+        )
+        for current in rmap.get("imports", [])
+    }
+    reverse_map = repo_map._reverse_importers(
+        all_files, imports_by_file, include_directory_index_aliases=True
+    )
+    target_str = str(fixture["target_file"].resolve())
+    pre_fix_order = sorted(reverse_map.get(target_str, set()))
+    assert len(pre_fix_order) == fixture["total_candidates"]
+    pre_fix_bounded = set(pre_fix_order[:budget])
+
+    assert fixture["same_repo_importers"].isdisjoint(pre_fix_bounded)
+
+
+def test_build_file_importers_unbounded_result_set_unaffected_by_tiering(tmp_path: Path) -> None:
+    """Regression guard: when nothing is truncated (no ceiling/deadline hit), the tiered
+    candidate order is a pure REORDERING of the exact same membership -- the found result set
+    must equal what the OLD plain lexicographic order would ALSO find, since every candidate
+    gets confirmed either way and `build_file_importers_from_map` re-sorts `edges` by
+    (file, line) before returning."""
+    fixture = _build_synthetic_multi_repo_workspace(tmp_path)
+    assert fixture["total_candidates"] < repo_map.CALLER_SCAN_FILE_CEILING  # no ceiling hit here
+
+    payload = repo_map.build_file_importers(fixture["target_file"], fixture["workspace"])
+
+    assert payload.get("result_incomplete") is not True
+    importer_files = set(payload["importer_files"])
+    expected = fixture["same_repo_importers"] | {fixture["distant_importer"]}
+    assert importer_files == expected


### PR DESCRIPTION
## Dogfood signal

`tg importers FILE ROOT` with ROOT = the whole multi-project workspace flapped across two
consecutive CEO dogfood reports on a 50k-file WSL `/mnt/c` multi-repo workspace: PASS on
v1.81.15, then INCOMPLETE `"0 importers @ 330/1035 files scanned"` on v1.81.17.

## Verify-first verdict: hypothesis CONFIRMED, with citations

Traced the reverse-import path in `src/tensor_grep/cli/repo_map.py`:

- **(a) Order today**: `build_file_importers_from_map` (pre-fix, `repo_map.py:16053`) built its
  candidate list via `prefiltered = sorted(reverse_map.get(target_file, set()))` -- a plain
  lexicographic sort of absolute path strings. This IS deterministic given a stable input file
  universe (not literally "arbitrary" as the working hypothesis phrased it), but on a multi-repo
  ROOT it buckets candidates by **repo name alphabetically** (the repo directory name is a
  shared path prefix), with nothing that favors the target file's own repo.
- **(b) Prioritization toward target's own repo/directory**: **confirmed absent**. Nothing in
  `build_file_importers_from_map` or `_reverse_importers` (`repo_map.py:7591`) considers
  TARGET's location when ordering candidates.
- **(c) Partial-coverage stamping**: unchanged by this fix. Ceiling-hit stamps
  `_mark_result_incomplete(..., caller_scan_limit={"possibly_truncated": True, "ceiling":
  CALLER_SCAN_FILE_CEILING, "files_total": len(prefiltered)})` (`repo_map.py:16092-16100`
  pre-fix numbering); a deadline hit mid-scan stamps `payload["deadline_limit"] =
  {"deadline_exceeded": True, "importer_candidates_scanned": scanned_count,
  "importer_candidates_total": len(bounded_candidates)}` (`repo_map.py:16101-16107` pre-fix
  numbering) -- this second shape is exactly the reported `"330/1035"` (scanned/total-bounded).

**Why the candidate list can legitimately balloon to 1000+ for one file** (this is by design,
not a bug to fix here): `_reverse_importers`' alias prefilter keys on `_module_aliases_for_path`
(`repo_map.py:7465`), which aliases purely on a file's **basename** (`current.stem.lower()`),
not its full path. On a large multi-repo ROOT, any file elsewhere named the same as (or
importing a module textually matching) TARGET's basename becomes a PREFILTER candidate; the
per-candidate `_confirm_import_edges` step is what turns "maybe imports it" into a confirmed
edge. This is deliberate recall-over-precision at the prefilter layer (see the
`include_directory_index_aliases=True` note at `repo_map.py:16044-16049`), so a target file with
a common basename can easily prefilter to 1000+ candidates on a 40-repo workspace, the
overwhelming majority from unrelated repos.

**Net causal chain**: broad basename-based prefilter (by design) + zero proximity awareness in
the ordering (the bug) + a ceiling/deadline cut (by design, needed for scale honesty) = a target
repo that sorts late alphabetically can have ALL of its real importers stranded past the cut
line, reporting `"0 importers"` while still honestly stamped incomplete. This is not a
regression in the ceiling/deadline machinery itself -- it is the ORDER fed into it that was
wrong.

**Residual/adjacent, explicitly out of scope for this fix**: `build_repo_map`'s own file walk
(`_iter_repo_files`, `repo_map.py:985`) shares the *same* `deadline_monotonic` as the importers
confirm-loop (`build_file_importers`, `repo_map.py:16153-16167` pre-fix numbering passes one
shared deadline into both `build_repo_map` and `build_file_importers_from_map`), and when
`--max-repo-files` bounds the walk it uses a fairness-oriented round-robin bucket scheme across
ROOT's immediate child directories (`repo_map.py:1006-1070`) rather than a straight walk. On an
extreme ROOT (dozens of repos, one of them very large) this could independently limit how much
of a large individual repo even enters the map before the importers scan ever starts. This is a
pre-existing, deliberate design (breadth-fairness across a multi-repo ROOT, task #52-era), not
something this PR's citations pin as the proximate cause of the two specific reported runs, and
changing it is out of scope for a proximity-ordering fix -- flagging for the gate as a possible
follow-up if further dogfooding shows the flap persists after this fix ships.

## The fix

`_tier_reverse_importer_candidates` (new, `src/tensor_grep/cli/repo_map.py`, inserted directly
before `build_file_importers_from_map`) replaces the plain sort with a 4-tier proximity order,
closest first:

0. Same directory as FILE, or one of FILE's ancestor directories up to (and including) its
   inferred project root -- reusing the **existing** `_infer_project_root` helper
   (`repo_map.py:15721`, already used by the forward `tg imports` path for the identical
   nearest-`.git`/`pyproject.toml`/`package.json`/`Cargo.toml`/`tsconfig.json` marker walk, so
   this fix adds zero new marker-detection logic).
1. Elsewhere inside the same project root.
2. Outside the project root, but the same language (file suffix) as FILE.
3. Everything else.

Within a tier, candidates sort by path string -- a total order (tier, path) with no ties, so the
result is fully deterministic regardless of upstream set/dict iteration order. `prefiltered` in
`build_file_importers_from_map` now calls this helper instead of a bare `sorted(...)`; nothing
else in the ceiling/deadline slicing or the honesty stamping changed.

**Unbounded-scan invariant preserved by construction**: this is a pure reordering of the same
candidate membership -- no candidate is added or dropped. When nothing is truncated, every
candidate still gets confirmed and `build_file_importers_from_map` already re-sorts `edges` by
`(file, line)` before returning (`repo_map.py:16067` pre-fix numbering, unchanged), so the found
result set and its output order are unaffected by this fix. Proven directly by
`test_build_file_importers_unbounded_result_set_unaffected_by_tiering`.

## TDD: synthetic ~40-repo / 364-candidate workspace

Built entirely under `tmp_path` (no `--gpu`, no real workspace touched): 36 decoy repos (`repo_00`
.. `repo_35`, 10 files each, each a one-line `import helpers` that prefilter-matches but never
confirms), a target repo `zzz_target_repo` (deliberately sorts AFTER every decoy repo name
alphabetically) with 3 real importers (one same-directory, two elsewhere in the same project),
and 1 importer reached only from a decoy repo via a `sys.path.insert` hack (the only way a
Python import legitimately crosses a repo boundary in this resolver). Total prefiltered
candidates: 364.

| Scenario | Budget | Same-repo importers found | Distant importer found | Stamped incomplete |
|---|---|---|---|---|
| Pre-fix order (simulated directly against `_reverse_importers`' output) | 30% (110/364) | **0 of 3** | n/a | n/a (simulated slice) |
| This fix, `CALLER_SCAN_FILE_CEILING` monkeypatched to 30% | 110/364 | **3 of 3** | not required at this budget | yes (`result_incomplete`, `caller_scan_limit.possibly_truncated`) |
| This fix, unbounded (default ceiling, 364 < 2000) | 364/364 | 3 of 3 | **yes** (1 of 1) | no |

Determinism: two calls over the same candidate membership return byte-identical output (pinned
by `test_tier_reverse_importer_candidates_is_deterministic`; guaranteed by construction since
the function always ends in a full `sorted(..., key=(tier, path))`).

New tests (`tests/unit/test_file_deps.py`):
- `test_tier_reverse_importer_candidates_orders_by_proximity` -- direct 4-tier boundary test.
- `test_tier_reverse_importer_candidates_is_deterministic`
- `test_build_file_importers_ceiling_bounded_scan_finds_same_repo_importers_first` -- end-to-end,
  30% budget.
- `test_build_file_importers_ceiling_bounded_scan_misses_importers_without_tiering` -- causal
  regression guard: proves the OLD plain-alphabetical order really would strand all 3 same-repo
  importers at the identical budget.
- `test_build_file_importers_unbounded_result_set_unaffected_by_tiering` -- found-set parity.

All 5 pass in ~9s standalone. Full existing coverage
(`tests/unit/test_file_deps.py` + `test_cap_fix_chokepoint.py` + `test_repo_map_graph.py`, the
files that exercise `build_file_importers*`/`_reverse_importers`/the `CALLER_SCAN_FILE_CEILING`
chokepoint) still green with this fix in place -- see PR comment / CI for the final combined
count.

## Verification

- `ruff check .` -- clean (whole repo).
- `ruff format --preview --check .` -- the 2 files this PR touches are clean; 4 PRE-EXISTING,
  UNRELATED `.md` files elsewhere in the repo (`docs/architecture.md`,
  `docs/planning/PROJECT_PLAN.md`, `docs/plans/backlog-100/cluster-124-evidence-signing.md`,
  `docs/plans/design-tensor-grep-2026-04-29_01-45-34.md`) already fail this check on a clean
  `origin/main` checkout with zero edits -- matches this repo's known "whole-repo ruff-format
  gap" issue (markdown code-fence formatting), unrelated to this change and out of scope here.
- Import sanity: `tensor_grep.cli.main`/`repo_map`/`bootstrap` import cleanly; `"importers"` still
  present in `KNOWN_COMMANDS`.
- No Rust/FFI surface touched -- pure Python change in `repo_map.py`, no `cargo`/`maturin`
  needed to verify (CPU-safe shared-server constraint honored).

## Anything unsure for the gate

1. The residual/adjacent map-build-walk mechanism noted above (shared deadline + round-robin
   bucket fairness) was **not** reproduced live against a real 50k-file workspace (CPU-safe rule
   forbids running against the real `C:/dev/projects` tree from this session) -- it's cited from
   reading `_iter_repo_files`/`build_file_importers`, not from a live repro of the two specific
   flap runs. If a further dogfood after this ships still shows an occasional flap, that's the
   next place to look.
2. `test_build_file_importers_ceiling_bounded_scan_finds_same_repo_importers_first` does not
   assert anything about whether the distant importer is ALSO found at the 30% budget (only that
   it's found unbounded) -- deliberately loose per the task spec, since its tier-2 position
   relative to ~360 same-tier decoys isn't pinned by design.
