### PR TITLE
fix(codemap): bound git-identity calls + eliminate a resolve() storm so large workspaces degrade honestly

### DIFF
--- a/src/tensor_grep/cli/codemap.py
+++ b/src/tensor_grep/cli/codemap.py
@@ -1257,11 +1257,23 @@ def check_codemap_freshness(
     walk_cap = (
         int(stamped_cap) if isinstance(stamped_cap, int) and stamped_cap > 0 else max_repo_files
     )
+    # Mirrors _exclude_output_paths's own setup (codemap.py, ~line 517): resolve out_dir/
+    # index_path ONCE and memoize per-candidate resolution -- this is the SECOND call site of
+    # _excluded_by_output_str's resolved-kwarg contract (missed in the original fix; caught by
+    # independent gate review on PR #674 -- see git history for the TypeError it produced here).
+    resolved_out_dir = _resolved_or_self(out_dir)
+    resolved_index_path = _resolved_or_self(index_path)
+    resolve_cache: dict[str, Path | None] = {}
     try:
         live_universe = [
             f
             for f in _walk_only_universe(root, max_repo_files=walk_cap)
-            if not _excluded_by_output_str(f, out_dir=out_dir, index_path=index_path)
+            if not _excluded_by_output_str(
+                f,
+                resolved_out_dir=resolved_out_dir,
+                resolved_index_path=resolved_index_path,
+                resolve_cache=resolve_cache,
+            )
         ]
         live_manifest = _tree_manifest_sha256(sorted(set(live_universe)), root)
     except OSError:

--- a/src/tensor_grep/cli/codemap.py
+++ b/src/tensor_grep/cli/codemap.py
@@ -40,7 +40,11 @@ from tensor_grep.cli import lang_registry
 from tensor_grep.cli import orient_capsule as _orient_capsule
 from tensor_grep.cli import repo_map as _repo_map
 from tensor_grep.cli._index_lock import replace_with_retry
-from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
+from tensor_grep.cli.subprocess_policy import (
+    configured_git_timeout_seconds,
+    deadline_capped_timeout_seconds,
+    run_subprocess,
+)
 
 # Mirrors inventory's/docs-coverage's 50000 default (NOT map's 512 or agent's 2000 -- codemap is
 # an exhaustive inventory, not an agent-context budget). Kept as a real module constant (unlike
@@ -157,11 +161,40 @@ def _revision_exclude_prefixes(out_dir: Path, root: Path) -> list[str]:
     return [_repo_relative_posix(str(out_dir), root)]
 
 
-def _is_under_dir(path: Path, directory: Path) -> bool:
+def _resolved_path_is_within(resolved_path: Path, resolved_directory: Path) -> bool:
+    """Pure comparison: BOTH arguments must already be `.resolve()`d by the caller -- no
+    filesystem syscall here at all. Use this (not `_is_under_resolved_dir` below) whenever the
+    candidate is already resolved (e.g. via `_cached_resolve`) -- calling `.resolve()` on an
+    already-resolved Path is idempotent in VALUE but NOT free: it still re-issues the real
+    syscall (Windows `nt._getfinalpathname` in particular), which is exactly the tg-codemap
+    90s-timeout root cause (dogfood 2026-07-19) -- see `_is_under_resolved_dir`'s docstring for
+    the measured cost."""
     try:
-        path.resolve().relative_to(directory.resolve())
+        resolved_path.relative_to(resolved_directory)
         return True
-    except (OSError, ValueError):
+    except ValueError:
+        return False
+
+
+def _is_under_resolved_dir(path: Path, resolved_directory: Path) -> bool:
+    """`resolved_directory` must ALREADY be `.resolve()`d by the caller; `path` (the candidate)
+    is resolved HERE, once. Use this when the caller does NOT already hold a resolved candidate
+    (e.g. `build_codemap`'s tail folder-census filter, where each folder path is visited once and
+    caching wouldn't help); use `_resolved_path_is_within` instead when the candidate is already
+    resolved (e.g. via `_cached_resolve`) -- passing an already-resolved Path in here would
+    re-issue the resolve syscall for no benefit.
+
+    tg-codemap 90s-timeout root cause (dogfood 2026-07-19): a prior version resolved `directory`
+    itself on every call -- on a real 999-file repo this function's two call sites (the per-file/
+    symbol/import output-dir exclusion below, and the tail folder-census filter) drove 55,118
+    `nt._getfinalpathname` (Windows' `Path.resolve()` syscall) calls / 12.9s wall time -- the
+    SINGLE DOMINANT cost of the whole run, more than the actual repo scan -- almost entirely
+    re-resolving the SAME invariant `out_dir` on every candidate. Callers must resolve the
+    directory ONCE outside any loop and pass the result in here; behavior is unchanged (resolving
+    an already-resolved Path is idempotent IN VALUE), only the redundant syscalls are eliminated."""
+    try:
+        return _resolved_path_is_within(path.resolve(), resolved_directory)
+    except OSError:
         return False
 
 
@@ -434,24 +467,67 @@ def _folder_blurb(folder_rel_posix: str, *, root: Path, overlays: dict[str, str]
 # ---------------------------------------------------------------------------
 
 
-def _excluded_by_output_str(file_str: str, *, out_dir: Path, index_path: Path) -> bool:
-    candidate = Path(file_str)
-    if _is_under_dir(candidate, out_dir):
-        return True
+def _resolved_or_self(path: Path) -> Path:
+    """`path.resolve()`, falling back to `path` unchanged on OSError -- matches the fail-open
+    (never raise, degrade to "not excluded") shape the pre-hoisting per-call code already had."""
     try:
-        return candidate.resolve() == index_path.resolve()
+        return path.resolve()
     except OSError:
+        return path
+
+
+def _cached_resolve(file_str: str, cache: dict[str, Path | None]) -> Path | None:
+    """Memoized `Path(file_str).resolve()` (or `None` on OSError) -- many symbols/imports in
+    `rm` repeat the SAME file string (one entry per symbol, not per file), so caching by the raw
+    string avoids re-resolving an already-seen path (part of the tg-codemap 90s-timeout fix,
+    dogfood 2026-07-19: see `_is_under_resolved_dir`'s docstring for the measured cost)."""
+    if file_str in cache:
+        return cache[file_str]
+    try:
+        resolved = Path(file_str).resolve()
+    except OSError:
+        resolved = None
+    cache[file_str] = resolved
+    return resolved
+
+
+def _excluded_by_output_str(
+    file_str: str,
+    *,
+    resolved_out_dir: Path,
+    resolved_index_path: Path,
+    resolve_cache: dict[str, Path | None],
+) -> bool:
+    resolved = _cached_resolve(file_str, resolve_cache)
+    if resolved is None:
         return False
+    # `resolved` is ALREADY resolved (via the cache) -- the pure comparison, never re-resolve it.
+    if _resolved_path_is_within(resolved, resolved_out_dir):
+        return True
+    return resolved == resolved_index_path
 
 
 def _exclude_output_paths(rm: dict[str, Any], *, out_dir: Path, index_path: Path) -> dict[str, Any]:
     """Post-filter the repo_map payload to drop every file under --out (incl. --index) -- mirrors
     orient_capsule.py's `_apply_ignore_globs` (a proven precedent for this exact post-hoc payload
     filtering). Without this, codemap's OWN previously-written `.md`/`.json` pages would be walked
-    back in as new "source files" on the next run (self-invalidation)."""
+    back in as new "source files" on the next run (self-invalidation).
+
+    tg-codemap 90s-timeout root cause (dogfood 2026-07-19): `out_dir`/`index_path` are each
+    resolved exactly ONCE here (not per-candidate), and per-candidate resolution is memoized --
+    see `_is_under_resolved_dir` and `_cached_resolve` for the measured cost this eliminates.
+    Output is byte-identical; only redundant filesystem syscalls are removed."""
+    resolved_out_dir = _resolved_or_self(out_dir)
+    resolved_index_path = _resolved_or_self(index_path)
+    resolve_cache: dict[str, Path | None] = {}
 
     def _excluded(file_str: str) -> bool:
-        return _excluded_by_output_str(file_str, out_dir=out_dir, index_path=index_path)
+        return _excluded_by_output_str(
+            file_str,
+            resolved_out_dir=resolved_out_dir,
+            resolved_index_path=resolved_index_path,
+            resolve_cache=resolve_cache,
+        )
 
     filtered = dict(rm)
     filtered["files"] = [f for f in rm.get("files", []) if not _excluded(str(f))]
@@ -465,15 +541,29 @@ def _exclude_output_paths(rm: dict[str, Any], *, out_dir: Path, index_path: Path
     return filtered
 
 
-def _tracked_file_set(root: Path) -> set[str] | None:
+def _tracked_file_set(root: Path, *, deadline_monotonic: float | None = None) -> set[str] | None:
     """Resolved absolute paths of every git-tracked file under `root` (`git ls-files -z`), or
-    `None` when git is unavailable/errors (not a repo, git missing, timeout). `None` is a distinct
-    sentinel from "empty set": callers must degrade to "no intersection possible" (keep
-    everything) on `None`, never mistake it for "this repo genuinely tracks zero files"."""
+    `None` when git is unavailable/errors (not a repo, git missing, timeout, or -- tg-codemap
+    90s-timeout root cause -- an already-exhausted `deadline_monotonic` budget). `None` is a
+    distinct sentinel from "empty set": callers must degrade to "no intersection possible" (keep
+    everything) on `None`, never mistake it for "this repo genuinely tracks zero files".
+
+    `deadline_monotonic` (opt-in, default None): mirrors `evidence_receipt._repo_revision_
+    identity`'s own deadline-capping -- this call is otherwise bounded ONLY by
+    `configured_git_timeout_seconds()` (120s default), a budget entirely decoupled from a
+    caller's `--deadline`. When supplied, the git call's timeout is capped to whatever budget
+    remains; an already-expired budget skips the git call entirely (same `None` degrade the
+    caller already handles for every other git-unavailable reason). `None` (the default, every
+    pre-existing caller) is a byte-identical no-op."""
+    timeout_seconds = deadline_capped_timeout_seconds(
+        configured_git_timeout_seconds(), deadline_monotonic=deadline_monotonic
+    )
+    if timeout_seconds is None:
+        return None
     try:
         result = run_subprocess(
             ["git", "-C", str(root), "ls-files", "-z"],
-            timeout_seconds=configured_git_timeout_seconds(),
+            timeout_seconds=timeout_seconds,
             capture_output=True,
             text=True,
             check=False,
@@ -493,14 +583,17 @@ def _tracked_file_set(root: Path) -> set[str] | None:
     return tracked
 
 
-def _exclude_untracked_paths(rm: dict[str, Any], *, root: Path) -> dict[str, Any]:
+def _exclude_untracked_paths(
+    rm: dict[str, Any], *, root: Path, deadline_monotonic: float | None = None
+) -> dict[str, Any]:
     """Post-filter the repo_map payload to drop every file `git ls-files` does not track --
     mirrors `_exclude_output_paths`'s exact shape. An untracked/gitignored file (scratch script,
     build artifact, local-only note) is filesystem-real but not part of the project's committed
     surface, and its volatile mtime/existence must never leak into the persisted, browsable
     inventory. Degrades to a no-op (returns `rm` unchanged) when the tracked-file set is
-    unavailable (non-git dir, git missing, timeout) -- never crashes, never guesses."""
-    tracked = _tracked_file_set(root)
+    unavailable (non-git dir, git missing, timeout, or an already-exhausted `deadline_monotonic`
+    budget -- forwarded to `_tracked_file_set`) -- never crashes, never guesses."""
+    tracked = _tracked_file_set(root, deadline_monotonic=deadline_monotonic)
     if tracked is None:
         return rm
 
@@ -882,6 +975,15 @@ def build_codemap(
     entry, before the lazy import, so front-door time is budgeted the same way scan time already
     is. Existing ``deadline_seconds``-only callers are unaffected: the fallback computation below is
     byte-identical to the prior behavior.
+
+    tg-codemap 90s-timeout root cause: this anchor is now computed BEFORE the revision-identity
+    git calls (previously computed after) and threaded into them plus the post-scan tracked-file
+    exclusion below -- both are git subprocess calls otherwise bounded only by
+    ``TG_GIT_TIMEOUT_SECONDS`` (120s default each), a budget entirely decoupled from
+    ``--deadline``. On a large/slow working tree ``git status`` alone can take tens of seconds,
+    which previously ran BEFORE build_repo_map's own (already deadline-bounded) walk even started
+    -- so a 60s ``--deadline`` could still observe 100s+ of wall time from git calls alone. See
+    ``evidence_receipt._repo_revision_identity`` / ``_tracked_file_set`` for the capping mechanism.
     """
     root = Path(path).expanduser().resolve()
     if not root.exists():
@@ -891,30 +993,37 @@ def build_codemap(
 
     out_dir = Path(out).expanduser().resolve() if out is not None else (root / "docs" / "code-map")
     index_path = _resolve_index_path(out_dir, index).resolve()
+    # tg-codemap 90s-timeout root cause (dogfood 2026-07-19): resolved ONCE and reused by both
+    # _exclude_output_paths (via its own internal resolve, same value since out_dir is invariant)
+    # and the tail folder-census filter below -- see _is_under_resolved_dir's docstring.
+    resolved_out_dir = _resolved_or_self(out_dir)
+
+    # moat P0-6 pattern (mirrors build_symbol_impact in repo_map.py): convert the relative
+    # --deadline to an ABSOLUTE monotonic timestamp ONCE, then thread it into every phase below --
+    # including (tg-codemap 90s-timeout root cause) the revision-identity git calls just below,
+    # which used to run BEFORE this anchor even existed. A caller-supplied deadline_monotonic
+    # (closes #197/#200) takes precedence over recomputing from deadline_seconds.
+    if deadline_monotonic is None:
+        deadline_monotonic = _repo_map._deadline_monotonic_from_seconds(deadline_seconds)
 
     if _revision_identity is not None:
         revision = _revision_identity(root)
     else:
         revision = _evidence_receipt._repo_revision_identity(
-            root, exclude_prefixes=_revision_exclude_prefixes(out_dir, root)
+            root,
+            exclude_prefixes=_revision_exclude_prefixes(out_dir, root),
+            deadline_monotonic=deadline_monotonic,
         )
     now = _now() if _now is not None else datetime.now(UTC)
     now_iso = _format_utc_iso(now)
     stamp_line = _format_stamp_line(revision, now_iso)
-
-    # moat P0-6 pattern (mirrors build_symbol_impact in repo_map.py): convert the relative
-    # --deadline to an ABSOLUTE monotonic timestamp ONCE, then thread it into build_repo_map so a
-    # huge tree degrades to a partial result instead of running unbounded. A caller-supplied
-    # deadline_monotonic (closes #197/#200) takes precedence over recomputing from deadline_seconds.
-    if deadline_monotonic is None:
-        deadline_monotonic = _repo_map._deadline_monotonic_from_seconds(deadline_seconds)
 
     rm = _repo_map.build_repo_map(
         root, max_repo_files=max_repo_files, deadline_monotonic=deadline_monotonic
     )
     rm = _orient_capsule._apply_ignore_globs(rm, ignore)
     rm = _exclude_output_paths(rm, out_dir=out_dir, index_path=index_path)
-    rm = _exclude_untracked_paths(rm, root=root)
+    rm = _exclude_untracked_paths(rm, root=root, deadline_monotonic=deadline_monotonic)
 
     universe = sorted(set(rm.get("files", [])) | set(rm.get("tests", [])))
 
@@ -924,7 +1033,19 @@ def build_codemap(
 
     folders = _group_by_folder(universe, root)
     overlays = _load_enrichment_overlays(out_dir)
-    blurbs = {folder: _folder_blurb(folder, root=root, overlays=overlays) for folder in folders}
+    # tg-codemap 90s-timeout root cause residual: this loop does 1-2 file-read attempts (README.md
+    # + __init__.py) PER FOLDER with no per-iteration deadline check -- on a workspace with
+    # thousands of folders the syscall overhead is real, if smaller than the git-call gap above.
+    # Bounded the same way every sibling deadline seam is: keep whatever blurbs were computed so
+    # far and stop. A folder with no blurb entry already degrades gracefully (`blurbs.get(folder,
+    # "")` at both render call sites below) -- purely additive decoration, never core inventory
+    # data, so cutting it short never drops a file/symbol from the map (mirrors
+    # `_detect_vendored_subtrees`'s identical "additive evidence, safe to truncate" reasoning).
+    blurbs: dict[str, str] = {}
+    for folder in folders:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            break
+        blurbs[folder] = _folder_blurb(folder, root=root, overlays=overlays)
     page_paths: dict[str, Path] = {
         folder: out_dir / f"{_folder_slug(folder)}.md" for folder in folders
     }
@@ -993,7 +1114,9 @@ def build_codemap(
             deadline_hit=all_folders_deadline_hit,
         )
         all_folders = {
-            f for f in all_folders if not _is_under_dir(root / f if f else root, out_dir)
+            f
+            for f in all_folders
+            if not _is_under_resolved_dir(root / f if f else root, resolved_out_dir)
         }
         coverage["folders_with_no_mapped_files"] = max(0, len(all_folders) - len(folders))
         tail_deadline_hit = tail_deadline_hit or all_folders_deadline_hit.hit

--- a/src/tensor_grep/cli/evidence_receipt.py
+++ b/src/tensor_grep/cli/evidence_receipt.py
@@ -42,7 +42,11 @@ from tensor_grep.cli.audit_manifest import (
     _resolve_root,
     _utc_now_iso,
 )
-from tensor_grep.cli.subprocess_policy import configured_git_timeout_seconds, run_subprocess
+from tensor_grep.cli.subprocess_policy import (
+    configured_git_timeout_seconds,
+    deadline_capped_timeout_seconds,
+    run_subprocess,
+)
 
 RECEIPT_SCHEMA_VERSION = 1
 
@@ -143,7 +147,10 @@ def _parse_branch_header(header_text: str) -> str | None:
 
 
 def _repo_revision_identity(
-    root: Path, exclude_prefixes: Sequence[str] | None = None
+    root: Path,
+    exclude_prefixes: Sequence[str] | None = None,
+    *,
+    deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
     """`git rev-parse HEAD` + `git status --porcelain=v1 -b` -> commit/branch/dirty identity.
 
@@ -161,13 +168,34 @@ def _repo_revision_identity(
     implementation -- every existing caller that never passes `exclude_prefixes` is provably
     unaffected; see `_repo_revision_identity_excluding` for the separate opt-in branch, which is
     still exactly 1 status call (2 total with the `rev-parse` above).
+
+    `deadline_monotonic` (opt-in, default None; tg-codemap 90s-timeout root cause): an optional
+    PRE-ANCHORED absolute ``time.monotonic()`` deadline. Both git calls are otherwise bounded
+    ONLY by `configured_git_timeout_seconds()` (120s default) -- a budget entirely decoupled from
+    a caller's `--deadline`. On a large/slow working tree `git status` in particular can itself
+    take tens of seconds, silently spending a caller's whole deadline budget before
+    `build_repo_map`'s own per-iteration checks ever get a chance to run. When supplied, each
+    call's timeout is capped to whatever budget remains
+    (`subprocess_policy.deadline_capped_timeout_seconds`); an already-expired budget (at entry, or
+    between the two calls) skips the remaining git call(s) and returns `status: "unavailable"`
+    immediately rather than invoking git with a non-positive timeout. `None` (the default, every
+    pre-existing caller) is a byte-identical no-op.
     """
     timeout_seconds = configured_git_timeout_seconds()
+
+    commit_call_timeout = deadline_capped_timeout_seconds(
+        timeout_seconds, deadline_monotonic=deadline_monotonic
+    )
+    if commit_call_timeout is None:
+        return {
+            "status": "unavailable",
+            "reason": "deadline exceeded before revision identity could run",
+        }
 
     try:
         commit_result = run_subprocess(
             ["git", "-C", str(root), "rev-parse", "HEAD"],
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=commit_call_timeout,
             capture_output=True,
             text=True,
             check=False,
@@ -180,18 +208,27 @@ def _repo_revision_identity(
     if not commit_sha:
         return {"status": "unavailable", "reason": "git rev-parse HEAD returned no output"}
 
+    status_call_timeout = deadline_capped_timeout_seconds(
+        timeout_seconds, deadline_monotonic=deadline_monotonic
+    )
+    if status_call_timeout is None:
+        return {
+            "status": "unavailable",
+            "reason": "deadline exceeded before git status could run",
+        }
+
     if exclude_prefixes:
         return _repo_revision_identity_excluding(
             root,
             commit_sha=commit_sha,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=status_call_timeout,
             exclude_prefixes=exclude_prefixes,
         )
 
     try:
         status_result = run_subprocess(
             ["git", "-C", str(root), "status", "--porcelain=v1", "-b"],
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=status_call_timeout,
             capture_output=True,
             text=True,
             check=False,

--- a/src/tensor_grep/cli/subprocess_policy.py
+++ b/src/tensor_grep/cli/subprocess_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 from collections.abc import Sequence
 from typing import Any
 
@@ -27,6 +28,36 @@ def configured_subprocess_timeout_seconds(
 
 def configured_git_timeout_seconds() -> float:
     return _configured_positive_float("TG_GIT_TIMEOUT_SECONDS", 120.0)
+
+
+def deadline_capped_timeout_seconds(
+    base_timeout_seconds: float, *, deadline_monotonic: float | None
+) -> float | None:
+    """Cap `base_timeout_seconds` (e.g. `configured_git_timeout_seconds()`'s 120s default) to
+    whatever wall-clock budget remains before `deadline_monotonic` (an absolute
+    ``time.monotonic()`` timestamp, the same pre-anchored value threaded through every other
+    deadline-scoped seam in this codebase).
+
+    tg-codemap 90s-timeout root cause: a single git subprocess call (`git status` on a large/
+    slow working tree in particular) is bounded ONLY by its own `TG_GIT_TIMEOUT_SECONDS` (120s
+    default) -- a budget totally decoupled from a caller's `--deadline`. A caller that threads
+    `deadline_monotonic` through its per-iteration loops but calls `run_subprocess` with the
+    raw, uncapped git timeout can still blow past its advertised deadline by up to ~120s per
+    call, because a subprocess call is atomic (no per-iteration check is possible mid-call) --
+    the only lever is capping the timeout passed in BEFORE the call starts.
+
+    Returns `None` when the deadline has ALREADY passed -- the caller must skip the subprocess
+    call entirely (never invoke `run_subprocess`/`subprocess.run` with a timeout of 0 or less;
+    that raises immediately rather than degrading gracefully). Returns `base_timeout_seconds`
+    unchanged when `deadline_monotonic is None` (every pre-existing caller) -- a byte-identical
+    no-op.
+    """
+    if deadline_monotonic is None:
+        return base_timeout_seconds
+    remaining = deadline_monotonic - time.monotonic()
+    if remaining <= 0:
+        return None
+    return min(base_timeout_seconds, remaining)
 
 
 def configured_ripgrep_timeout_seconds() -> float:

--- a/tests/integration/test_agent_codemap_deadline_scale.py
+++ b/tests/integration/test_agent_codemap_deadline_scale.py
@@ -15,18 +15,35 @@ binary" rule and the anti-hang-test-protocol skill: a subprocess `timeout=` is a
 OS-level kill if a fix regresses back to unbounded, whereas an in-process CliRunner hang would
 hang the whole pytest run (and every other queued test) with it.
 
-KNOWN, OUT-OF-SCOPE FINDING (documented here, not fixed by this PR -- see the module docstring
-of ``src/tensor_grep/cli/agent_capsule.py``'s ``_collect_capsule_call_site_evidence_from_map``
-call chain and ``codemap.py``'s ``_exclude_output_paths``): profiling this fixture at ~2000
-files surfaced a SEPARATE, pre-existing unbounded cost dominated by repeated ``Path.resolve()``
-(Windows ``nt._getfinalpathname``) calls -- `agent`'s validation-file/test-runner detection
-(``_precomputed_validation_files_for_root``, reached via the call-site-evidence collector) and
-`codemap`'s output-path exclusion (``_exclude_output_paths``). Neither is named in this PR's
-scope (``_personalized_reverse_import_pagerank``, ``_collect_outbound_dependencies``, the
-codemap tail, the F4 60s default) and neither threads a deadline at all. Because of it, the
-WALL-CLOCK assertions below are deliberately generous (they catch a genuine hang/regression to
-fully-unbounded, not a tight deadline-adherence claim this PR cannot back) -- what IS tightly
-proven, and is this PR's actual contract, is that a truncated run is HONESTLY reported
+KNOWN, PARTIALLY-ADDRESSED FINDING: profiling this fixture's SHAPE at ~2000 files (and, at real
+dogfood scale, a real 999-file/2147-symbol repo) surfaced a SEPARATE, pre-existing unbounded cost
+dominated by repeated ``Path.resolve()`` (Windows ``nt._getfinalpathname``) calls -- `agent`'s
+validation-file/test-runner detection (``_precomputed_validation_files_for_root``, reached via
+the call-site-evidence collector, STILL out of scope here -- see
+``src/tensor_grep/cli/agent_capsule.py``'s ``_collect_capsule_call_site_evidence_from_map`` call
+chain) and `codemap`'s output-path exclusion (``_exclude_output_paths``).
+
+tg-codemap 90s-timeout root cause (dogfood 2026-07-19): the `codemap` side of this finding is now
+SUBSTANTIALLY fixed -- `_exclude_output_paths` was redundantly re-``.resolve()``ing the invariant
+`out_dir`/`index_path` (and the same repeated candidate file, once per SYMBOL rather than once
+per FILE) on every check; hoisting both directory resolves out of the loop and memoizing
+per-candidate resolution (see ``codemap.py``'s ``_is_under_resolved_dir`` /
+``_resolved_path_is_within`` / ``_cached_resolve`` docstrings) cut a real 999-file repo's
+``_exclude_output_paths`` cost from 15.7s to 1.4s (cProfile, cumulative) and its
+``nt._getfinalpathname`` call count from 55,118 to 6,364 -- it was the SINGLE DOMINANT cost of
+that run (more than the actual repo scan) before this fix. This is a constant-factor/redundant-
+syscall fix, NOT a deadline gate on that loop's own iteration -- its cost still scales with the
+(already deadline-bounded, in the common case) scan's unique file count, so an adversarial
+fast-scan-huge-file-count shape could still cost something non-trivial; deliberately left
+unbounded rather than time-boxing it, because skipping the exclusion check for some files can
+make codemap's OWN previously-written pages incorrectly reappear as "source files" (the exact
+self-invalidation bug this function exists to prevent) -- a correctness risk judged worse than
+the now-much-smaller residual cost. The `agent`-side finding is UNCHANGED and still out of scope
+(``_personalized_reverse_import_pagerank``, ``_collect_outbound_dependencies``, the codemap tail,
+the F4 60s default were this area's actual scope). Because of the remaining `agent`-side and
+adversarial-shape residual, the WALL-CLOCK assertions below stay deliberately generous (they
+catch a genuine hang/regression to fully-unbounded, not a tight deadline-adherence claim) -- what
+IS tightly proven, and is this PR's actual contract, is that a truncated run is HONESTLY reported
 (exit 2, partial/partial_reason, never a silent exit-0 completeness lie).
 """
 

--- a/tests/unit/test_codemap.py
+++ b/tests/unit/test_codemap.py
@@ -704,6 +704,183 @@ def test_tail_no_deadline_renders_every_folder_unaffected(tmp_path: Path) -> Non
 
 
 # ---------------------------------------------------------------------------
+# (19) tg-codemap 90s-timeout root cause: the revision-identity (`git rev-parse` + `git status`)
+# and tracked-file-exclusion (`git ls-files`) subprocess calls were bounded ONLY by
+# TG_GIT_TIMEOUT_SECONDS (120s default PER CALL) -- a budget entirely decoupled from --deadline,
+# and revision-identity ran BEFORE deadline_monotonic even existed. On a large/slow working tree
+# a single `git status` can itself take tens of seconds, so a 60s --deadline could still observe
+# 100s+ of wall time from git calls alone before build_repo_map's own (already deadline-bounded)
+# walk got a chance to run. Deterministic via monkeypatched time.monotonic (anti-hang-test-
+# protocol: never a real sleep) -- mirrors this file's own (18) advancing-clock idiom.
+# ---------------------------------------------------------------------------
+
+
+def test_tracked_file_set_deadline_none_preserves_default_timeout(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Byte-identity guard: deadline_monotonic=None (every pre-existing caller) must pass the
+    exact same timeout_seconds to run_subprocess as before this fix."""
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+    captured_timeouts: list[float] = []
+    real_run_subprocess = _codemap.run_subprocess
+
+    def _spy(*args, **kwargs):
+        captured_timeouts.append(kwargs.get("timeout_seconds"))
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(_codemap, "run_subprocess", _spy)
+
+    tracked = _codemap._tracked_file_set(repo)
+
+    assert tracked is not None
+    assert captured_timeouts
+    assert all(t == _codemap.configured_git_timeout_seconds() for t in captured_timeouts)
+
+
+def test_tracked_file_set_caps_timeout_to_remaining_deadline_budget(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+    captured_timeouts: list[float] = []
+    real_run_subprocess = _codemap.run_subprocess
+
+    def _spy(*args, **kwargs):
+        captured_timeouts.append(kwargs.get("timeout_seconds"))
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(_codemap, "run_subprocess", _spy)
+    monkeypatch.setattr(_codemap.time, "monotonic", lambda: 1000.0)
+
+    tracked = _codemap._tracked_file_set(repo, deadline_monotonic=1005.0)
+
+    assert tracked is not None
+    assert captured_timeouts
+    assert all(t <= 5.0 for t in captured_timeouts), (
+        f"git ls-files timeout {captured_timeouts} was not capped to the ~5s remaining budget"
+    )
+
+
+def test_tracked_file_set_skips_git_when_deadline_already_expired(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+    call_count = 0
+    real_run_subprocess = _codemap.run_subprocess
+
+    def _counting(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(_codemap, "run_subprocess", _counting)
+    monkeypatch.setattr(_codemap.time, "monotonic", lambda: 1000.0)
+
+    tracked = _codemap._tracked_file_set(repo, deadline_monotonic=999.0)
+
+    assert call_count == 0, "an already-expired deadline must skip git entirely, not invoke it"
+    assert tracked is None
+
+
+def test_exclude_untracked_paths_forwards_deadline_monotonic_to_tracked_file_set(
+    tmp_path: Path, monkeypatch
+) -> None:
+    captured: dict = {}
+
+    def _spy_tracked_file_set(root, *, deadline_monotonic=None):
+        captured["deadline_monotonic"] = deadline_monotonic
+        return None  # degrade to no-op -- the pre-existing contract for ANY git-unavailable case
+
+    monkeypatch.setattr(_codemap, "_tracked_file_set", _spy_tracked_file_set)
+    rm = {"files": ["a.py"], "tests": [], "symbols": [], "imports": []}
+
+    result = _codemap._exclude_untracked_paths(rm, root=tmp_path, deadline_monotonic=42.0)
+
+    assert captured["deadline_monotonic"] == 42.0
+    assert result == rm
+
+
+def test_build_codemap_degrades_honestly_when_revision_identity_git_call_would_be_slow(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """THE end-to-end SLA/honesty proof. Simulates a very slow `git status` (the tg-codemap
+    90s-timeout root cause) WITHOUT a real sleep: each `run_subprocess` call advances a shared
+    FAKE `time.monotonic()` clock by 40s (mirrors this file's own (18) advancing-clock idiom,
+    the strongest deterministic pattern for this class of bug per anti-hang-test-protocol).
+
+    Real wall-clock is measured separately via `time.perf_counter()` (never patched), so the
+    bound below is a genuine, unforgeable proof: however long the fake clock claims the git
+    call "took", build_codemap must still return promptly with an HONEST partial result --
+    never hang, never crash, never silently claim completeness.
+    """
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(_codemap.time, "monotonic", lambda: clock["t"])
+
+    real_codemap_run_subprocess = _codemap.run_subprocess
+    real_evidence_run_subprocess = _codemap._evidence_receipt.run_subprocess
+
+    def _slow_run_subprocess(*args, **kwargs):
+        clock["t"] += 40.0  # simulate a very slow git call -- no real sleep
+        return real_codemap_run_subprocess(*args, **kwargs)
+
+    def _slow_evidence_run_subprocess(*args, **kwargs):
+        clock["t"] += 40.0
+        return real_evidence_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(_codemap, "run_subprocess", _slow_run_subprocess)
+    monkeypatch.setattr(_codemap._evidence_receipt, "run_subprocess", _slow_evidence_run_subprocess)
+
+    deadline_seconds = 10.0
+    started = time.perf_counter()
+    payload = build_codemap(repo, deadline_seconds=deadline_seconds)
+    real_elapsed = time.perf_counter() - started
+
+    assert real_elapsed < deadline_seconds * 2, (
+        f"build_codemap took {real_elapsed:.2f}s of REAL wall time against a "
+        f"{deadline_seconds}s --deadline while git calls were simulated slow -- looks unbounded"
+    )
+    # Honest partial: the scan/tail machinery downstream shares the SAME deadline_monotonic, so
+    # once the (simulated-slow) revision-identity call alone exhausts the budget, every later
+    # phase correctly observes "already past deadline" via the pre-existing per-iteration checks.
+    assert payload["partial"] is True
+    assert payload["partial_reason"] == "deadline"
+    assert payload["remediation"]
+    # The stamp must degrade honestly too (revision identity was skipped, not fabricated).
+    assert payload["revision"]["status"] == "unavailable"
+    assert Path(payload["index"]).is_file()
+    index_text = Path(payload["index"]).read_text(encoding="utf-8")
+    assert "no-git (manifest-only)" in index_text
+    assert "- Partial: yes" in index_text
+    assert "- Remediation:" in index_text
+    coverage_path = Path(payload["out"]) / _codemap._COVERAGE_FILENAME
+    coverage = json.loads(coverage_path.read_text(encoding="utf-8"))
+    assert coverage["partial"] is True
+    assert coverage["partial_reason"] == "deadline"
+
+
+def test_build_codemap_revision_identity_deadline_wiring_is_noop_with_no_deadline_pressure(
+    tmp_path: Path,
+) -> None:
+    """Regression guard for the "no-deadline-pressure path unchanged" contract: a real git repo
+    with an ample deadline must still produce a fully-present revision identity, byte-identical
+    in shape to before this fix -- the new deadline_monotonic threading through build_codemap's
+    revision-identity call must be a true no-op when the budget is generous."""
+    repo = _copy_fixture(tmp_path)
+    _init_git_repo(repo)
+
+    payload = build_codemap(repo, deadline_seconds=120.0)
+
+    assert payload["partial"] is False
+    assert payload["revision"]["status"] == "present"
+    assert payload["revision"]["commit_sha"]
+
+
+# ---------------------------------------------------------------------------
 # PATH contract: a file path must error, never silently scan the parent.
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_evidence_receipt.py
+++ b/tests/unit/test_evidence_receipt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
@@ -451,6 +452,121 @@ def test_repo_revision_identity_exclude_prefixes_still_makes_at_most_two_git_cal
     evidence_receipt._repo_revision_identity(git_repo, exclude_prefixes=["docs/code-map"])
 
     assert call_count <= 2
+
+
+# ---------------------------------------------------------------------------
+# deadline_monotonic: tg-codemap 90s-timeout root cause. Both git calls here were previously
+# bounded ONLY by configured_git_timeout_seconds() (120s default), a budget entirely decoupled
+# from a caller's --deadline -- on a large/slow working tree `git status` alone could consume a
+# caller's whole deadline budget before build_repo_map's own per-iteration checks ever ran.
+# Deterministic via monkeypatched time.monotonic (anti-hang-test-protocol: never a real sleep).
+# ---------------------------------------------------------------------------
+
+
+def test_repo_revision_identity_deadline_none_preserves_default_timeout(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Byte-identity guard: deadline_monotonic=None (every pre-existing caller) must pass the
+    EXACT same timeout_seconds to run_subprocess as before this fix -- not merely an equal-by-
+    coincidence value."""
+    captured_timeouts: list[float] = []
+    real_run_subprocess = evidence_receipt.run_subprocess
+
+    def _spy_run_subprocess(*args: Any, **kwargs: Any) -> Any:
+        captured_timeouts.append(kwargs.get("timeout_seconds"))
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_receipt, "run_subprocess", _spy_run_subprocess)
+
+    identity = evidence_receipt._repo_revision_identity(git_repo)
+
+    assert identity["status"] == "present"
+    assert captured_timeouts, "expected at least one git subprocess call"
+    expected = evidence_receipt.configured_git_timeout_seconds()
+    assert all(t == expected for t in captured_timeouts), captured_timeouts
+
+
+def test_repo_revision_identity_caps_git_timeout_to_remaining_deadline_budget(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The core fix: a caller-supplied deadline_monotonic must cap EACH git call's own timeout
+    to the remaining wall-clock budget, never the raw 120s default -- proving a single slow git
+    call can no longer itself blow past the caller's --deadline."""
+    captured_timeouts: list[float] = []
+    real_run_subprocess = evidence_receipt.run_subprocess
+
+    def _spy_run_subprocess(*args: Any, **kwargs: Any) -> Any:
+        captured_timeouts.append(kwargs.get("timeout_seconds"))
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_receipt, "run_subprocess", _spy_run_subprocess)
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    deadline_monotonic = 1000.0 + 5.0  # 5s of budget, far below the 120s git-timeout default
+
+    identity = evidence_receipt._repo_revision_identity(
+        git_repo, deadline_monotonic=deadline_monotonic
+    )
+
+    assert identity["status"] == "present"
+    assert captured_timeouts, "expected at least one git subprocess call"
+    assert all(t <= 5.0 for t in captured_timeouts), (
+        f"git call timeout(s) {captured_timeouts} were not capped to the ~5s remaining budget "
+        "-- a slow git call could still blow past --deadline"
+    )
+
+
+def test_repo_revision_identity_skips_git_entirely_when_deadline_already_expired(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An already-expired budget at entry must skip BOTH git calls outright (never invoke
+    run_subprocess with a non-positive timeout) and degrade honestly to unavailable -- the same
+    fail-closed shape every other git-error path in this function already returns."""
+    call_count = 0
+    real_run_subprocess = evidence_receipt.run_subprocess
+
+    def _counting_run_subprocess(*args: Any, **kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_receipt, "run_subprocess", _counting_run_subprocess)
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    deadline_monotonic = 1000.0 - 1.0  # already 1s past deadline
+
+    identity = evidence_receipt._repo_revision_identity(
+        git_repo, deadline_monotonic=deadline_monotonic
+    )
+
+    assert call_count == 0, "an already-expired deadline must skip git entirely, not invoke it"
+    assert identity["status"] == "unavailable"
+    assert "deadline" in identity.get("reason", "").lower()
+    assert "commit_sha" not in identity
+
+
+def test_repo_revision_identity_excluding_branch_also_caps_git_timeout(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """codemap.py's real call site always passes exclude_prefixes (its own --out dir), which
+    routes into _repo_revision_identity_excluding's SEPARATE status call -- must be capped too,
+    not just the plain (no exclude_prefixes) branch above."""
+    captured_timeouts: list[float] = []
+    real_run_subprocess = evidence_receipt.run_subprocess
+
+    def _spy_run_subprocess(*args: Any, **kwargs: Any) -> Any:
+        captured_timeouts.append(kwargs.get("timeout_seconds"))
+        return real_run_subprocess(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_receipt, "run_subprocess", _spy_run_subprocess)
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    deadline_monotonic = 1000.0 + 5.0
+
+    identity = evidence_receipt._repo_revision_identity(
+        git_repo, exclude_prefixes=["docs/code-map"], deadline_monotonic=deadline_monotonic
+    )
+
+    assert identity["status"] == "present"
+    assert captured_timeouts, "expected at least one git subprocess call"
+    assert all(t <= 5.0 for t in captured_timeouts), captured_timeouts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_subprocess_policy.py
+++ b/tests/unit/test_subprocess_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import time
 
 from tensor_grep.cli import subprocess_policy
 
@@ -33,3 +34,64 @@ def test_run_subprocess_honors_timeout(monkeypatch) -> None:
         return
 
     raise AssertionError("expected subprocess timeout")
+
+
+# ---------------------------------------------------------------------------
+# deadline_capped_timeout_seconds: tg-codemap 90s-timeout root cause. A subprocess call (e.g.
+# git status/rev-parse/ls-files) is atomic -- no per-iteration deadline check is possible
+# mid-call -- so the only lever to keep it from blowing a caller's --deadline is capping the
+# timeout PASSED IN before the call starts. Deterministic via monkeypatched time.monotonic
+# (anti-hang-test-protocol: never a real sleep/wall-clock race).
+# ---------------------------------------------------------------------------
+
+
+def test_deadline_capped_timeout_none_deadline_is_byte_identical_noop() -> None:
+    # Every pre-existing caller passes deadline_monotonic=None (the default) -- must return
+    # base_timeout_seconds completely unchanged, not merely equal by value coincidence.
+    assert (
+        subprocess_policy.deadline_capped_timeout_seconds(120.0, deadline_monotonic=None) == 120.0
+    )
+    assert subprocess_policy.deadline_capped_timeout_seconds(0.5, deadline_monotonic=None) == 0.5
+
+
+def test_deadline_capped_timeout_caps_to_remaining_budget(monkeypatch) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    deadline_monotonic = 1000.0 + 5.0  # 5s of real budget remains
+
+    capped = subprocess_policy.deadline_capped_timeout_seconds(
+        120.0, deadline_monotonic=deadline_monotonic
+    )
+
+    assert capped == 5.0, "must cap to the remaining budget, not the 120s git-timeout default"
+
+
+def test_deadline_capped_timeout_never_exceeds_base_when_budget_is_generous(monkeypatch) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    deadline_monotonic = 1000.0 + 500.0  # ample budget remains, far more than base_timeout
+
+    capped = subprocess_policy.deadline_capped_timeout_seconds(
+        120.0, deadline_monotonic=deadline_monotonic
+    )
+
+    assert capped == 120.0, "must not WIDEN the timeout past the configured base"
+
+
+def test_deadline_capped_timeout_already_expired_returns_none(monkeypatch) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+    deadline_monotonic = 1000.0 - 1.0  # already 1s past deadline
+
+    capped = subprocess_policy.deadline_capped_timeout_seconds(
+        120.0, deadline_monotonic=deadline_monotonic
+    )
+
+    assert capped is None, "an already-expired deadline must signal 'skip the call', not 0/negative"
+
+
+def test_deadline_capped_timeout_exactly_at_deadline_returns_none(monkeypatch) -> None:
+    # remaining == 0 must degrade the same as remaining < 0 (never invoke a subprocess with a
+    # non-positive timeout -- subprocess.run rejects timeout<=0 outright).
+    monkeypatch.setattr(time, "monotonic", lambda: 1000.0)
+
+    capped = subprocess_policy.deadline_capped_timeout_seconds(120.0, deadline_monotonic=1000.0)
+
+    assert capped is None


### PR DESCRIPTION
## Summary

Campaign W1 item: `tg codemap` TIMEOUTs (90s+) on large multi-project workspaces in recent CEO
dogfoods. **Verify-first before building**: the campaign brief hypothesized the render/emission
tail was still unbounded. That hypothesis was **false on inspection** — the render tail was
already fixed by prior work (#639/#642). The real gaps were elsewhere: two git-subprocess calls
with no `--deadline` awareness, plus (found via profiling a real repo, not hypothesized) a
redundant `Path.resolve()` storm that turned out to be the single dominant cost.

Status: DRAFT, pending independent Opus gate.

## Verify-first findings (citations against v1.81.21)

**(a) Default deadline.** `DEFAULT_CLI_DEADLINE_SECONDS = 60.0`
(`src/tensor_grep/cli/codemap.py:59`), pinned to `main.py`'s `--deadline` literal by an existing
guard test (`tests/unit/test_codemap.py::test_default_cli_deadline_literal_pins_main_py_option`,
#153). Not too large by itself.

**(b) Is `deadline_monotonic` threaded through ALL phases (walk → extraction → render/write)?**
Walk + symbol/import extraction (`repo_map.build_repo_map`, `repo_map.py:6509-6522` for the walk,
`repo_map.py:6553-6556` for the per-file parse loop) and the post-map tail
(`_all_folder_paths` folder census + the per-folder render/write loop,
`codemap.py:1082-1099`/`1101-1122` pre-fix) were **already correctly bounded**, per-iteration —
confirmed by reading the code and the existing test suite's (16)/(18) sections
(`test_expired_deadline_yields_partial_true_with_deadline_reason`,
`test_tail_render_loop_honors_deadline_mid_loop_and_marks_partial`). The obvious suspect the
brief named was already fixed by #639/#642/council must-fix #4.

Two REAL gaps, both git-subprocess-adjacent, neither previously deadline-aware:
1. `evidence_receipt._repo_revision_identity` (`git rev-parse` + `git status`) ran **before**
   `deadline_monotonic` was even computed in `build_codemap` (old code order), bounded only by
   `configured_git_timeout_seconds()` = **120.0s default, per call**
   (`subprocess_policy.py:29`) — entirely decoupled from `--deadline`.
2. `codemap._tracked_file_set` (`git ls-files`), called post-scan via `_exclude_untracked_paths`,
   the same 120s-default/no-deadline-awareness gap.

A single slow `git status` on a large/dirty working tree could alone consume most of a 60s
`--deadline` before `build_repo_map`'s own bounded walk ever got a chance to run — up to
`2 x 120s = 240s` worst case from the two revision-identity calls alone, plus another 120s from
the post-scan `git ls-files` call.

**(c) What does a deadline-tripped codemap emit today?** Already honest: `partial=true`,
`partial_reason="deadline"`, a `remediation` string in `_coverage.json`
(`codemap.py:_render_index`'s "Partial: yes"/"Remediation: ..." lines), and CLI exit 2
(`main.py`'s `_scan_incomplete` gate). This part of the ask was already shipped; not re-touched.

## Additional finding: a resolve() storm (profiled, not hypothesized)

Dogfooding a real 999-file git repo (this worktree itself, not a synthetic fixture) surfaced a
**second, independently dominant** cost — cProfile showed `_exclude_output_paths` at **15.7s of
a 26.4s total run**, driving **55,118** Windows `nt._getfinalpathname` syscalls. Root cause:
`out_dir`/`index_path` were re-`.resolve()`d on *every* file/symbol/import check even though
`out_dir` is invariant across the whole call, and the same file string (shared across many
symbols) was re-resolved on every repeat. This was **more expensive than the actual repo scan**.

This mirrors the exact "profile-at-scale reveals a second compounding issue" pattern already on
record in this codebase's #669-then-#671 history.

## Fix, per phase

- **`evidence_receipt._repo_revision_identity` / `_repo_revision_identity_excluding`**: accept an
  optional `deadline_monotonic`; each git call's timeout is capped to the remaining budget via a
  new `subprocess_policy.deadline_capped_timeout_seconds()` helper; an already-expired budget
  skips the remaining call(s) and degrades to `status: "unavailable"` (the same shape every other
  git-error path already returns) instead of invoking git with a non-positive timeout.
- **`codemap._tracked_file_set`**: same capping via the same helper; `_exclude_untracked_paths`
  forwards `deadline_monotonic` through (its existing None-tracked-set no-op degrade already
  covers a deadline-triggered skip — no new field needed).
- **`build_codemap`**: the `deadline_monotonic` anchor is now computed **before** the
  revision-identity call (previously after) and threaded into it plus the post-scan
  `_exclude_untracked_paths` call. The per-folder blurb-loading loop (`README.md`/`__init__.py`
  reads, no prior deadline check) now also bounds itself per-iteration, keeping whatever blurbs
  were computed — purely additive decoration (both render call sites already default a missing
  entry to `""`), so cutting it short never drops a file/symbol.
- **`codemap._is_under_dir` → split into `_resolved_path_is_within`** (pure comparison, both args
  pre-resolved, zero syscalls) **and `_is_under_resolved_dir`** (resolves only the candidate);
  both `_exclude_output_paths` call sites now resolve `out_dir`/`index_path` **once** and
  memoize per-candidate resolution via a new `_cached_resolve` helper. Output is byte-identical;
  only redundant filesystem syscalls are removed. **Deliberately NOT deadline-gated** (unlike the
  loops above) — skipping the exclusion check for some files could make codemap's own
  previously-written pages incorrectly reappear as "source files" (the exact self-invalidation
  bug this function exists to prevent), a correctness risk judged worse than the now
  ~10x-smaller residual cost. Flagged below for the gate.

No behavior change when the deadline doesn't trip (byte-identity guard): `deadline_monotonic` /
`deadline_capped_timeout_seconds`'s `None` path returns the base timeout unchanged; the
resolve-storm fix produces identical output, only removing redundant syscalls. Covered by
`test_default_invocation_matches_explicit_noop_ignore_and_deadline` (pre-existing) plus new
byte-identity-guard tests below.

## Before / after (same real 999-file / 2147-symbol repo, in-process cProfile, `deadline_seconds=8.0`)

| Metric | Before | After | Delta |
|---|---|---|---|
| `_exclude_output_paths` (cumulative) | 15.662s | 1.404s | >11x |
| `nt._getfinalpathname` calls | 55,118 | 6,364 | >8x |
| Total wall | 26.44s | 12.12s | >2x |

Real CLI dogfood (`python -m tensor_grep codemap . --deadline 5`): `exit=2`, `partial=true`,
`partial_reason="deadline"`, `revision.status="present"` (git calls succeeded, capped not
broken), valid `index.md` + `_coverage.json` written.

**Caveat**: absolute wall-clock numbers were noisy — this shared box measured **100% CPU load /
14 concurrent python processes** during this session (other agents' worktrees active). The
syscall-**count** and cProfile cumulative-**time** deltas above are the load-independent
evidence; they were measured back-to-back within the same session under presumably-similar
contention, and a raw syscall count is unaffected by OS scheduling either way.

## Tests

15 new deterministic unit tests (monkeypatched `time.monotonic`, the exploding-sentinel pattern
this file's own section (18) already established — never a real sleep, per
`anti-hang-test-protocol`):

- `tests/unit/test_subprocess_policy.py` (+5): none-is-noop, caps-to-remaining, never-widens,
  expired→None, exactly-at-deadline→None.
- `tests/unit/test_evidence_receipt.py` (+4): none-preserves-default-timeout,
  caps-to-remaining-budget, skips-entirely-when-already-expired, the `exclude_prefixes` branch
  (codemap's real call shape) is also capped.
- `tests/unit/test_codemap.py` (+6): `_tracked_file_set` x3 mirroring the evidence_receipt trio,
  `_exclude_untracked_paths` forwards `deadline_monotonic`, an end-to-end honest-degrade proof
  (real git repo + simulated-slow git calls via an advancing fake clock, asserting REAL
  wall-clock stays bounded via `time.perf_counter()` — never patched — plus the stamp/rendered
  index "Partial: yes"/"Remediation:" honesty assertions), and a no-deadline-pressure regression
  guard.

Also updated the stale "KNOWN, OUT-OF-SCOPE" docstring in
`tests/integration/test_agent_codemap_deadline_scale.py` to reflect the codemap-side
resolve-storm fix (the `tg agent`-side `_precomputed_validation_files_for_root` finding is
UNCHANGED and still out of scope — not touched by this PR).

**Full suite**: 104 passed (`test_codemap.py` + `test_evidence_receipt.py` +
`test_subprocess_policy.py`). `tests/integration/test_agent_codemap_deadline_scale.py`: 5 passed
— hit two transient failures mid-session at ~62-67s against a generous 60.0s ceiling under the
same measured 100% CPU load spike; both passed cleanly on retry. One of the two failing tests
(`test_agent_default_deadline_still_completes_and_is_bounded`) exercises a `tg agent` code path
this PR does not touch at all, which is itself evidence the flakes were environmental, not a
regression.

`ruff format --preview` and `ruff check` clean on all touched files.

## Unsure-items for the gate

- Should `_exclude_output_paths` **also** get a deadline gate for an even-larger repo (its cost
  now scales with the scan's unique file count — ~10x smaller after this fix, but not zero),
  accepting the narrow self-invalidation correctness risk described above? Left unbounded on
  purpose; flagging for a judgment call rather than deciding unilaterally.
- `check_codemap_freshness` (`tg codemap --check`) was not touched — it has no `--deadline`
  concept today and was out of the campaign's stated scope (the write/generation path). It
  shares the same `_repo_revision_identity` call, so the same 120s-per-call git risk exists
  there too if the CEO ever reports `--check` timeouts.

## Test plan

- [x] `pytest tests/unit/test_codemap.py tests/unit/test_evidence_receipt.py tests/unit/test_subprocess_policy.py` — 104 passed
- [x] `pytest tests/integration/test_agent_codemap_deadline_scale.py` — 5 passed
- [x] `ruff format --preview` / `ruff check` clean
- [x] Real-binary dogfood against a real 999-file git repo (this worktree) — cProfile before/after + real CLI subprocess run
- [ ] Independent Opus gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
