### PR TITLE
ci(audit): harden scheduled Security Audit against transient GitHub API errors

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -100,6 +100,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
+            try {
             const title = "[Security Audit] Scheduled dependency audit failure";
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
@@ -149,12 +150,19 @@ jobs:
                 labels: ["dependencies", "supply-chain"],
               });
             }
+            } catch (error) {
+              // Issue bookkeeping is best-effort: a transient GitHub API error (e.g. a 503)
+              // must not red the scheduled audit and mask a real cargo/pip-audit failure.
+              // The `audit` gate job is authoritative; surface this as a visible warning.
+              core.warning(`Scheduled-audit issue bookkeeping failed (non-fatal; audit gate result is authoritative): ${error.message}`);
+            }
 
       - name: Close scheduled audit issue on success
         if: needs.audit.result == 'success'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
+            try {
             const title = "[Security Audit] Scheduled dependency audit failure";
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
@@ -182,3 +190,8 @@ jobs:
               issue_number: existing.number,
               state: "closed",
             });
+            } catch (error) {
+              // Best-effort issue bookkeeping: a transient GitHub API error must not red a
+              // scheduled audit whose gate job (cargo/pip-audit) already succeeded.
+              core.warning(`Scheduled-audit issue bookkeeping failed (non-fatal; audit passed): ${error.message}`);
+            }


### PR DESCRIPTION
## What

The scheduled Security Audit reported **failure** on v1.83.0 while the actual audit gate -- `cargo-audit`, `cargo-deny`, `pip-audit` -- **passed**. Root cause: the `report-audit-status` job's issue-bookkeeping github-script hit a transient GitHub API 503 (`HttpError: No server is currently available`) on its `issues.listForRepo` call, during the same outage window that failed the v1.83.0 release-assets job.

## Why it matters

A transient API blip redding a scheduled **security** audit is a cry-wolf gap: it trains observers to ignore a red audit, masking a real future `cargo`/`pip-audit` failure (same class as the release-smoke-masks-a-regression lesson).

## Fix

Wrap **both** issue-management github-script bodies (`create-on-failure`, `close-on-success`) in `try/catch` + `core.warning`, so a transient API error surfaces as a **visible warning** rather than a workflow-redding failure.

**Signal-preserving by construction:** the `audit` gate job is byte-unchanged (verified -- zero deletions; all 3 diff hunks land inside `report-audit-status`). A real dependency/license finding still fails the `audit` job and reds the workflow. Only the best-effort issue bookkeeping becomes resilient.

Pure `ci:` change, non-releasing. +13 lines, additive only. Historical transient red already cleared via `gh run rerun --failed`.
