### PR TITLE
feat(calibrate): structured --json skip signal on CPU-only builds (v20 GPU-honesty)

### DIFF
--- a/rust_core/src/crossover.rs
+++ b/rust_core/src/crossover.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::fmt;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -517,6 +518,41 @@ fn crossover_gpu_remediation_hint_device_not_found() -> String {
         .to_string()
 }
 
+/// Distinguishes "this build structurally cannot run GPU calibration because CUDA support
+/// isn't compiled in" from every other calibration failure (a bad device id on a
+/// cuda-enabled build, I/O errors, a failed benchmark subprocess, ...). `main.rs`'s
+/// `handle_calibrate_command` downcasts an `anyhow::Error` on this type to decide whether its
+/// `--json` flag should emit the machine-readable `calibration_status: skipped_no_cuda_build`
+/// signal -- string-matching the rendered message would work too, but a distinct error kind
+/// can't accidentally match an unrelated failure that happens to share wording. `reason` and
+/// `remediation` are kept as separate fields (rather than one pre-joined string) so the
+/// `--json` payload can expose them as two JSON fields without re-splitting formatted text.
+#[derive(Debug)]
+pub struct NoCudaBuildError {
+    pub reason: String,
+    pub remediation: String,
+}
+
+impl fmt::Display for NoCudaBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", self.reason)?;
+        write!(f, "{}", self.remediation)
+    }
+}
+
+impl std::error::Error for NoCudaBuildError {}
+
+/// Builds the `--json` skip-signal payload for `handle_calibrate_command`'s no-cuda-build
+/// path. Pulled out as a pure, allocation-only function (no `process::exit`, no I/O) so the
+/// JSON shape is unit-testable without spawning a subprocess to observe the real exit code.
+pub fn skip_signal_payload(err: &NoCudaBuildError) -> serde_json::Value {
+    serde_json::json!({
+        "calibration_status": "skipped_no_cuda_build",
+        "reason": err.reason.clone(),
+        "remediation": err.remediation.clone(),
+    })
+}
+
 fn detect_device_name(device_id: i32) -> Result<String> {
     #[cfg(feature = "cuda")]
     {
@@ -537,10 +573,11 @@ fn detect_device_name(device_id: i32) -> Result<String> {
     #[cfg(not(feature = "cuda"))]
     {
         let _ = device_id;
-        bail!(
-            "crossover calibration requires a CUDA-enabled build.\n{}",
-            crossover_gpu_remediation_hint_no_cuda_build()
-        )
+        let no_cuda_error = NoCudaBuildError {
+            reason: "crossover calibration requires a CUDA-enabled build.".to_string(),
+            remediation: crossover_gpu_remediation_hint_no_cuda_build(),
+        };
+        Err(no_cuda_error.into())
     }
 }
 
@@ -591,6 +628,61 @@ mod tests {
         assert!(
             message.contains("tg doctor"),
             "message should still point at `tg doctor` for diagnostics: {message}"
+        );
+    }
+
+    // v20 dogfood follow-up (GPU honesty / harness-misread): `tg calibrate` on a CPU-only
+    // build honestly fails closed (exit 2, see main.rs's `handle_calibrate_command`), but a
+    // dogfood harness misread that honest message as a bare FAILURE instead of a SKIP. Fix:
+    // `detect_device_name`'s no-cuda-build error must downcast to `NoCudaBuildError` (not just
+    // render matching substrings, per the prior test above) so `--json` can emit a structured
+    // `calibration_status: skipped_no_cuda_build` signal a harness can classify as SKIP. This
+    // must stay distinguishable from the cuda-enabled device-not-found `bail!` above, which is
+    // a real failure (bad device id), never a build-capability skip.
+    #[cfg(not(feature = "cuda"))]
+    #[test]
+    fn detect_device_name_without_cuda_feature_downcasts_to_no_cuda_build_error() {
+        let err = detect_device_name(0).expect_err("a non-cuda build must fail closed");
+        let no_cuda = err
+            .downcast_ref::<NoCudaBuildError>()
+            .expect("non-cuda detect_device_name failure must be a NoCudaBuildError");
+        assert_eq!(
+            no_cuda.reason,
+            "crossover calibration requires a CUDA-enabled build."
+        );
+        assert!(no_cuda.remediation.contains("not shipped in this build"));
+        assert!(no_cuda.remediation.contains("experimental"));
+
+        // Round-trip through Display must stay byte-identical to the pre-existing pinned
+        // message (the test above) -- this is what `eprintln!("{err}")` still prints when
+        // --json is not set.
+        assert_eq!(
+            err.to_string(),
+            format!("{}\n{}", no_cuda.reason, no_cuda.remediation)
+        );
+    }
+
+    // The JSON-formatting half of the same fix, isolated from `std::process::exit(2)` (which
+    // `handle_calibrate_command` calls directly and so cannot be exercised in-process without
+    // killing the test runner) -- asserts the pure payload-building helper produces the exact
+    // structured shape a dogfood harness classifies as SKIP-not-FAIL.
+    #[test]
+    fn skip_signal_payload_reports_skipped_no_cuda_build() {
+        let no_cuda = NoCudaBuildError {
+            reason: "crossover calibration requires a CUDA-enabled build.".to_string(),
+            remediation: "install a CUDA-enabled build and retry.".to_string(),
+        };
+
+        let payload = skip_signal_payload(&no_cuda);
+
+        assert_eq!(
+            payload["calibration_status"],
+            serde_json::json!("skipped_no_cuda_build")
+        );
+        assert_eq!(payload["reason"], serde_json::json!(no_cuda.reason));
+        assert_eq!(
+            payload["remediation"],
+            serde_json::json!(no_cuda.remediation)
         );
     }
 

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -28,7 +28,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tensor_grep_rs::backend_ast::{
     AstBackend, AstMatch, AstMetaVariables, BatchRewritePlan, BatchRewriteRule,
 };
-use tensor_grep_rs::crossover::{run_crossover_calibration, write_crossover_config};
+use tensor_grep_rs::crossover::{
+    run_crossover_calibration, skip_signal_payload, write_crossover_config, NoCudaBuildError,
+};
 #[cfg(feature = "cuda")]
 use tensor_grep_rs::gpu_native::{
     benchmark_cuda_graph_search_paths, benchmark_pageable_transfer_throughput,
@@ -833,7 +835,15 @@ pub struct RunArgs {
 }
 
 #[derive(Args, Debug, Clone, Default)]
-pub struct CalibrateArgs {}
+pub struct CalibrateArgs {
+    /// Emit a structured JSON result, including a machine-readable
+    /// `calibration_status: skipped_no_cuda_build` signal when this build cannot run GPU
+    /// calibration, instead of the default human-readable output. Does not change the exit
+    /// code (still 2 on the no-cuda skip, per the backend-unavailable convention) or the
+    /// success-path output (already JSON).
+    #[arg(long)]
+    pub json: bool,
+}
 
 #[derive(Args, Debug, Clone)]
 pub struct AuditVerifyArgs {
@@ -5541,15 +5551,32 @@ fn ast_test_requires_python_passthrough(args: &[String]) -> bool {
     false
 }
 
-fn handle_calibrate_command(_args: CalibrateArgs) -> anyhow::Result<()> {
+fn handle_calibrate_command(args: CalibrateArgs) -> anyhow::Result<()> {
     let executable = env::current_exe().context("failed to resolve current tg executable")?;
     match run_crossover_calibration(&executable) {
         Ok(config) => {
             write_crossover_config(&config, None)?;
+            // --json is a no-op on the success path: the config was already JSON before this
+            // flag existed, so there is nothing additive to do here.
             println!("{}", serde_json::to_string_pretty(&config)?);
             Ok(())
         }
         Err(err) => {
+            // Fail closed (exit 2) either way -- see the module-level comment above
+            // `require_ripgrep_or_exit`. `--json` only changes WHAT is printed for the one
+            // error kind a harness needs to tell apart from a genuine failure: this build
+            // structurally cannot run GPU calibration (no CUDA compiled in). Any other error
+            // (a bad device id on a cuda-enabled build, I/O, a failed benchmark subprocess,
+            // ...) is a real failure, not a skip, so it must NOT be relabeled -- it keeps the
+            // original human-readable eprintln even under --json (fail-closed honesty, no
+            // mislabeling a genuine failure as "skipped").
+            if args.json {
+                if let Some(no_cuda) = err.downcast_ref::<NoCudaBuildError>() {
+                    let payload = skip_signal_payload(no_cuda);
+                    println!("{payload}");
+                    std::process::exit(2);
+                }
+            }
             eprintln!("{err}");
             std::process::exit(2);
         }

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8103,7 +8103,16 @@ def search_command(
 
 
 @app.command()
-def calibrate() -> None:
+def calibrate(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a structured JSON result, including a machine-readable "
+        "calibration_status skip signal when GPU calibration cannot run, instead of the "
+        "default human-readable output. Forwarded to the native tg binary; does not change "
+        "the exit code.",
+    ),
+) -> None:
     """Measure CPU vs GPU crossover thresholds using the native Rust binary."""
     native_tg_binary = resolve_native_tg_binary()
     if native_tg_binary is None:
@@ -8126,6 +8135,13 @@ def calibrate() -> None:
         # capture its stderr (that would break streaming), so only THIS wrapper-owned
         # missing-binary message gets touched; the native binary's own calibrate-failure
         # remediation is Rust-owned (crossover.rs) and follows the same discipline there.
+        # v20 dogfood (GPU honesty / harness-misread, additive): a --json caller gets a
+        # structured stdout signal too, so a harness can tell "binary missing" apart from a
+        # generic exit-1 failure the same way it can now tell the Rust side's no-cuda-build
+        # skip apart from a genuine calibration failure. The human-readable stderr message
+        # below is unchanged either way (still exit 1, still the same remediation text).
+        if json_output:
+            _safe_stdout_line(json.dumps({"calibration_status": "native_binary_unavailable"}))
         typer.echo(
             "Error: native tg binary not found for calibrate command.\n"
             "Run 'tg upgrade' to install the native tg binary that calibrate requires. GPU "
@@ -8135,7 +8151,10 @@ def calibrate() -> None:
         )
         raise typer.Exit(1)
 
-    completed = subprocess.run([str(native_tg_binary), "calibrate"], check=False)
+    argv = [str(native_tg_binary), "calibrate"]
+    if json_output:
+        argv.append("--json")
+    completed = subprocess.run(argv, check=False)
     raise typer.Exit(int(completed.returncode))
 
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -16394,6 +16394,30 @@ def test_calibrate_command_delegates_to_native_tg(monkeypatch):
     assert seen == {"cmd": ["tg.exe", "calibrate"], "check": False}
 
 
+def test_calibrate_command_json_flag_forwards_to_native_tg(monkeypatch):
+    # v20 dogfood (GPU honesty / harness-misread): --json is additive -- it must not change
+    # the argv tg.exe sees other than appending "--json", and it must not swallow the native
+    # binary's real exit code (still 2 on a CPU-only no-cuda skip, per the fail-closed
+    # backend-unavailable convention pinned by crossover.rs -- KEPT, not flipped to 0).
+    seen: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 2
+
+    monkeypatch.setattr(cli_main, "resolve_native_tg_binary", lambda: Path("tg.exe"))
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, check=False: seen.update({"cmd": list(cmd), "check": check}) or _Completed(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["calibrate", "--json"])
+
+    assert result.exit_code == 2
+    assert seen == {"cmd": ["tg.exe", "calibrate", "--json"], "check": False}
+
+
 def test_main_entry_should_rewrite_raw_pattern_to_search_subcommand(monkeypatch):
 
     seen: dict[str, list[str]] = {}

--- a/tests/unit/test_medlow_main_cli.py
+++ b/tests/unit/test_medlow_main_cli.py
@@ -400,3 +400,24 @@ def test_l10_calibrate_exits_one_when_unsupported(monkeypatch) -> None:
     # A "confirm before relying on TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR=nvidia" aside dangled
     # an override that no shipped asset honors -- the same permanent dead end, asymmetric.
     assert "TENSOR_GREP_NATIVE_FRONTDOOR_FLAVOR" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# v20 dogfood follow-up - calibrate --json emits an additive structured skip signal
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_json_flag_missing_binary_emits_skip_signal(monkeypatch) -> None:
+    # Hermetic for the same reason as L10 above: force the no-native-binary branch instead of
+    # depending on whether a native tg binary happens to be on this runner.
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)
+    runner = CliRunner()
+    result = runner.invoke(app, ["calibrate", "--json"])
+
+    # --json is additive: the exit-1 "unsupported" convention (L10) is unchanged.
+    assert result.exit_code == 1, result.stdout
+    # A structured stdout line lets a harness classify this deterministically instead of
+    # parsing the human-readable remediation text.
+    assert '"calibration_status": "native_binary_unavailable"' in result.output
+    # The human-readable remediation stays present too (additive, not replaced).
+    assert "tg upgrade" in result.output


### PR DESCRIPTION
## Summary

- v20 dogfood misread: a CPU-only (no-CUDA) build's `tg calibrate` honestly fails closed
  (exit 2, "requires a CUDA-enabled build ... not shipped in this build" -- a deliberate
  fail-closed convention, see `rust_core/src/main.rs:1421`), but a dogfood harness read that
  honest message as a bare FAILURE instead of a SKIP.
- Fix: add an **additive** `--json` flag to `tg calibrate` (Rust + Python wrapper) so a
  harness can classify the no-cuda path deterministically instead of string-scraping the
  human-readable message.
- **Exit code stays 2 on the no-cuda skip -- NOT flipped to 0.** This PR only adds a
  structured stdout signal alongside the existing exit code; it does not change the
  backend-unavailable convention.

## What changed

- `rust_core/src/main.rs`: `CalibrateArgs` gains a `--json` bool flag (mirrors
  `AuditVerifyArgs`'s existing `--json` field). `handle_calibrate_command` now downcasts the
  error from `run_crossover_calibration` and, only when it is specifically the no-cuda-build
  error AND `--json` was passed, prints
  `{"calibration_status":"skipped_no_cuda_build","reason":...,"remediation":...}` to stdout
  before exiting 2. Any other failure (e.g. a bad device id on a cuda-enabled build, I/O,
  a failed benchmark subprocess) keeps the original `eprintln!` -- fail-closed honesty, never
  mislabel a genuine failure as a "skip". The success path is byte-identical under `--json`
  (it was already JSON).
- `rust_core/src/crossover.rs`: introduces `NoCudaBuildError` (a small `reason`/`remediation`
  struct implementing `std::error::Error`) so `detect_device_name`'s no-cuda-build failure is
  a distinguishable error *kind*, not just matching text -- `main.rs` downcasts on it via
  `err.downcast_ref::<NoCudaBuildError>()`. This can never be confused with the
  cuda-enabled-build "device not found" `bail!`, which is a real failure (bad device id), not
  a build-capability skip, and is compiled into a disjoint `#[cfg(feature = "cuda")]` arm.
  `skip_signal_payload()` is a pure helper (no I/O, no `process::exit`) that builds the JSON
  payload, so the shape is unit-testable without spawning a subprocess.
- `src/tensor_grep/cli/main.py`: `calibrate()` gains a `--json` option, forwarded into the
  native binary's argv (`["calibrate", "--json"]`) only when set -- the existing delegation
  test's expected argv (`["tg.exe", "calibrate"]`, no flag) stays valid unmodified. Additively,
  the missing-native-binary branch (audit L10, exit 1) now also emits a
  `{"calibration_status":"native_binary_unavailable"}` stdout line under `--json`, without
  changing its exit code or human-readable remediation text.

## Tests

- Rust (`rust_core/src/crossover.rs`, CI-validated -- see note below):
  - Extends the pre-existing message-pin test's coverage with a new test asserting
    `detect_device_name`'s no-cuda-build error downcasts to `NoCudaBuildError` with the
    expected `reason`/`remediation`, and that `Display` stays byte-identical to the old
    `bail!`-formatted message (so `eprintln!("{err}")` output is unchanged without `--json`).
  - A second test exercises `skip_signal_payload` directly for the exact JSON shape, since
    `handle_calibrate_command` calls `std::process::exit(2)` directly and can't be
    exercised in-process without killing the test runner.
- Python (`tests/unit/test_cli_modes.py`, `tests/unit/test_medlow_main_cli.py`), run locally
  against the real venv with `PYTHONPATH` pointed at this worktree's `src/` (verified
  `tensor_grep.__file__` resolves into the worktree, not the shared venv's stale install):
  - `test_calibrate_command_json_flag_forwards_to_native_tg` -- `--json` forwards into native
    argv and the native exit code (2) passes through unchanged.
  - `test_calibrate_command_delegates_to_native_tg` (pre-existing) -- unmodified, stays green.
  - `test_calibrate_json_flag_missing_binary_emits_skip_signal` -- missing-binary + `--json`
    emits the structured stdout line, exit code and remediation text unchanged.
  - `test_l10_calibrate_exits_one_when_unsupported` (pre-existing L10 regression test in the
    same file) -- unmodified, stays green.
  - Full suite: `tests/unit/test_cli_modes.py` + `tests/unit/test_medlow_main_cli.py`,
    542 passed.
  - `ruff check`, `ruff format --preview`, `mypy src/tensor_grep` -- all clean.

**The Rust half (`rust_core/src/crossover.rs`, `rust_core/src/main.rs`) is gated on CI** --
this is a CPU-safe shared box, so `cargo`/`rustc`/`maturin` were not run locally. The diff was
re-read carefully for syntax/borrow/exhaustive-match correctness (no moved values behind
shared references, `serde_json::json!` payload construction matches an existing precedent in
`main.rs`, `Display` impl avoids `clippy::write_with_newline`, tail-expression style avoids
`clippy::needless_return`, import ordering matches `rustfmt`'s two-tier lowercase-then-uppercase
convention already used elsewhere in this file). CI's `test-rust-core` and `cargo-feature-check`
jobs are the actual compile+test gate.

## Test plan

- [x] Rust unit tests added (`crossover.rs`) -- pending CI compile+run
- [x] Python unit tests added and passing locally (`test_cli_modes.py`,
      `test_medlow_main_cli.py`)
- [x] `ruff check` / `ruff format --preview` / `mypy src/tensor_grep` clean
- [ ] CI `test-rust-core` + `cargo-feature-check` (native compile, not runnable on this box)
- [ ] Human review -- do not merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
