### PR TITLE
feat(agent): best-effort primary under deadline truncation (v20 gap #2)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -87,6 +87,17 @@ _BEST_EFFORT_PRIMARY_EVIDENCE = "deadline-truncated-best-effort"
 # discipline `_build_context_pack_from_map` applies with a live check at repo_map.py:7862, just
 # expressed as a slice since a live check would never let this particular pass run at all.
 _BEST_EFFORT_PRIMARY_SCAN_CAP = 500
+# Opus-gate nit (SHIP-WITH-NITS, structural-cap hardening): today a best-effort primary lands at
+# confidence 0.55 only EMERGENTLY -- because the empty upstream primary happens to force
+# `primary_file_included`/snippets-empty style downgrades through `_confidence`'s existing ladder.
+# That chain of reasoning is correct today but not guaranteed to stay true (e.g. a future change
+# to the render payload shape, or to the T2 corroborated-resolution uplift's own `scan_truncated`
+# disqualifier in `_capsule_token_budget_uplift_eligible`, could let a best-effort primary's
+# `confidence.overall` climb back to/above the 0.75 no-ask threshold). This cap makes the
+# guarantee STRUCTURAL instead: applied unconditionally, LAST, whenever `partial_primary` is set,
+# so "partial_primary implies confidence.overall <= 0.55 AND primary_target.confidence <= 0.55"
+# holds by construction -- independent of every other confidence computation in this function.
+_BEST_EFFORT_PRIMARY_MAX_CONFIDENCE = 0.55
 
 
 def _as_dict(value: object) -> dict[str, Any]:
@@ -2601,6 +2612,13 @@ def build_agent_capsule_from_map(
                 ],
                 _BEST_EFFORT_PRIMARY_EVIDENCE,
             ])
+    # NIT-2 (Opus gate): `partial_primary`/`primary_basis` live on `primary_target` ONLY -- `edit_
+    # order` and `rollback` below still carry this same best-effort `target["file"]` WITHOUT the
+    # flag. That is intentionally safe, not an oversight: both are advisory (a suggested edit
+    # order / a recommended checkpoint command), never an auto-apply, and `ask_user_before_editing.
+    # required` is forced True by the scan-truncated ask-reason below regardless, so nothing reads
+    # those two fields as a green light to act without a human first seeing the low-confidence,
+    # flagged primary_target.
     all_alternatives = _alternative_targets(payload, target, limit=None)
     alternatives = all_alternatives[:4]
     target, alternatives = _prefer_implementation_over_marker_helper(query, target, alternatives)
@@ -2962,6 +2980,25 @@ def build_agent_capsule_from_map(
         validation_alignment_status=validation_alignment_status,
         validation_kept_count=validation_kept_count,
     )
+    # NIT-1 (Opus gate, structural hardening): runs LAST -- after every existing confidence
+    # mutation in this function, including the T2 uplift immediately above, which is the ONLY
+    # place `confidence["overall"]` can be RAISED (via direct assignment) rather than merely
+    # clamped. Today a best-effort primary happens to land at confidence 0.55 EMERGENTLY, purely
+    # because the empty upstream primary forces `_confidence`'s existing downgrade ladder (empty
+    # snippets / primary-omitted-from-snippets); that chain relies on the T2 uplift's own
+    # `scan_truncated` disqualifier (`_capsule_token_budget_uplift_eligible`) continuing to hold,
+    # which is correct today but not a promise this function makes elsewhere. `partial_primary`
+    # (set only in the guarded best-effort block above) forces BOTH `confidence["overall"]` and
+    # `target["confidence"]` down to `_BEST_EFFORT_PRIMARY_MAX_CONFIDENCE` regardless of what every
+    # earlier stage computed, so "partial_primary implies confidence.overall <= 0.55 AND primary_
+    # target.confidence <= 0.55" holds BY CONSTRUCTION, independent of upstream. `min(...)` only ever
+    # LOWERS an existing value -- this can never raise a confidence some other gate pushed lower,
+    # and it is a no-op (byte-identical) whenever `partial_primary` is unset.
+    if target.get("partial_primary"):
+        confidence["overall"] = round(
+            min(float(confidence["overall"]), _BEST_EFFORT_PRIMARY_MAX_CONFIDENCE), 3
+        )
+        _cap_primary_target_confidence(target, _BEST_EFFORT_PRIMARY_MAX_CONFIDENCE)
     # DAR (arxiv steal #4): runs AFTER call-site collection so it can dedupe against
     # `related_call_sites`, and deliberately does NOT touch `target`/`confidence`/`consistency`/
     # `ask_reasons` -- see `_collect_outbound_dependencies`'s fail-safe + budget-isolation

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -69,6 +69,25 @@ _CAPSULE_SCAN_TRUNCATED_ASK_REASON = (
     "repository scan was truncated; the ranked primary may not be the true target"
 )
 
+# v20 dogfood gap #2: `_primary_target` below returns an empty `{"file": "", ...}` primary when
+# neither `navigation_pack.primary_target` nor `edit_plan_seed.primary_file` resolves -- safe, but
+# useless to an agent when the underlying repo SCAN already truncated, since `rm` already holds
+# every file/symbol the scan reached before the deadline cut it off. `primary_basis` on the
+# primary target marks a heuristic best-effort substitute derived straight from that already-
+# scanned data (see `_best_effort_primary_target_from_map`), distinct from a normal ranked
+# resolution; the additive `partial_primary` flag is the machine-checkable twin of the same fact.
+_BEST_EFFORT_PRIMARY_BASIS = "deadline_truncated_best_effort"
+_BEST_EFFORT_PRIMARY_EVIDENCE = "deadline-truncated-best-effort"
+# Hard item-count cap (deliberately NOT a live `deadline_monotonic` re-check) for each scoring
+# pass inside `_best_effort_primary_target_from_map`: that helper only ever runs AFTER the scan
+# has already been marked truncated (see its lone call site in `build_agent_capsule_from_map`), so
+# gating it on the deadline again would make the whole block permanently dead code. Bounding by
+# item count instead keeps the added cost deterministic and cheap (in-memory string scoring only,
+# no I/O, no second scan) regardless of how large the already-capped `rm` still is -- the same
+# discipline `_build_context_pack_from_map` applies with a live check at repo_map.py:7862, just
+# expressed as a slice since a live check would never let this particular pass run at all.
+_BEST_EFFORT_PRIMARY_SCAN_CAP = 500
+
 
 def _as_dict(value: object) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
@@ -470,6 +489,83 @@ def _primary_target(payload: dict[str, Any]) -> dict[str, Any]:
             ],
         ])
     return target_payload
+
+
+def _best_effort_primary_target_from_map(rm: dict[str, Any], query: str) -> dict[str, Any] | None:
+    """v20 dogfood gap #2: derive a BEST-EFFORT primary target straight from the already-scanned
+    ``rm`` when the real ranking pass (``_primary_target``) came back empty on a truncated scan.
+    No second scan, no I/O -- every candidate below is scored purely off data ``rm`` already
+    holds. Cheapest/most-specific signal first:
+
+      (a) a scanned SYMBOL whose name matches the query, scored with the exact
+          ``repo_map._score_symbol`` a real ranking pass would use;
+      (b) else a scanned FILE PATH that matches the query (``repo_map._score_file_path``);
+      (c) else the single most-central scanned file -- a query-independent last resort, reusing
+          the same composite ``orient_capsule._file_centrality_scores`` that ``tg orient``'s own
+          ``suggested_scope`` already applies unconditionally in this exact truncated-scan tail
+          (``build_agent_capsule_from_map``'s own ``suggested_scope_from_map`` call above does the
+          same thing for the same reason).
+
+    Each of (a)/(b) is capped to the first ``_BEST_EFFORT_PRIMARY_SCAN_CAP`` items ``rm`` holds --
+    see that constant's comment for why this is an item-count cap, not a deadline re-check.
+    Returns ``None`` (never fabricates) when ``rm`` has nothing to score at all. The caller owns
+    stamping ``partial_primary``/``primary_basis`` and letting every existing confidence-cap/
+    ask-reason gate re-run over the result -- this helper returns a bare best-guess location only,
+    never a fully-shaped primary-target dict.
+    """
+    symbols = _as_list_of_dicts(rm.get("symbols"))[:_BEST_EFFORT_PRIMARY_SCAN_CAP]
+    symbol_terms = repo_map._symbol_query_terms(query)
+    if symbols and symbol_terms:
+        best_symbol: dict[str, Any] | None = None
+        best_symbol_score = 0
+        for symbol in symbols:
+            name = symbol.get("name")
+            file_path = symbol.get("file")
+            if not name or not file_path:
+                continue
+            # Normalize defensively -- `_score_symbol` indexes "name"/"kind"/"file" directly, and
+            # this helper must never crash the capsule even if a language-specific extractor ever
+            # omits "kind" on some symbol record.
+            scoreable = {"name": name, "kind": symbol.get("kind") or "unknown", "file": file_path}
+            score = repo_map._score_symbol(scoreable, symbol_terms)
+            if score > best_symbol_score:
+                best_symbol_score = score
+                best_symbol = symbol
+        if best_symbol is not None:
+            line = best_symbol.get("line") or best_symbol.get("start_line") or 1
+            return {
+                "file": str(best_symbol.get("file") or ""),
+                "symbol": best_symbol.get("name"),
+                "kind": str(best_symbol.get("kind") or "unknown"),
+                "line": int(line) if isinstance(line, int) or str(line).isdigit() else 1,
+            }
+
+    files = [str(current) for current in (rm.get("files") or [])][:_BEST_EFFORT_PRIMARY_SCAN_CAP]
+    file_terms = repo_map._query_terms(query)
+    if files and file_terms:
+        best_file: str | None = None
+        best_file_score = 0
+        for candidate_file in files:
+            score = repo_map._score_file_path(candidate_file, file_terms)
+            if score > best_file_score:
+                best_file_score = score
+                best_file = candidate_file
+        if best_file is not None:
+            return {"file": best_file, "symbol": None, "kind": "unknown", "line": 1}
+
+    # Local import avoids a module-level circular import -- same discipline every other
+    # `orient_capsule` reuse in this module already follows (see e.g. `build_agent_capsule_
+    # from_map`'s own docstring for why).
+    from tensor_grep.cli.orient_capsule import _file_centrality_scores
+
+    code_files, centrality = _file_centrality_scores(rm)
+    if code_files:
+        top_file = sorted(code_files, key=lambda current: (-centrality.get(current, 0.0), current))[
+            0
+        ]
+        return {"file": top_file, "symbol": None, "kind": "unknown", "line": 1}
+
+    return None
 
 
 def _target_symbol_was_explicitly_requested(query: str, target: dict[str, Any]) -> bool:
@@ -2475,6 +2571,36 @@ def build_agent_capsule_from_map(
     # simply be the best candidate among the files that were visible, not the true best one).
     scan_truncated = _capsule_scan_incomplete(payload)
     target = _primary_target(payload)
+    # v20 dogfood gap #2: a truncated scan with no resolvable primary previously left `target` at
+    # `_primary_target`'s empty-shape default (`file: ""`) -- safe, but useless to an agent even
+    # though `rm` already holds every file/symbol the scan reached before the deadline cut it off.
+    # Substitute a best-effort candidate derived straight from that already-scanned data (no
+    # second scan) and flag it clearly non-authoritative via the additive `partial_primary`/
+    # `primary_basis` fields. Every confidence cap / ask-reason gate below -- the scan-truncation
+    # downgrade just above, `_cap_primary_target_confidence` a few lines down, the forced
+    # `_CAPSULE_SCAN_TRUNCATED_ASK_REASON` ask-reason, and the T2 uplift's own unconditional
+    # `scan_truncated` disqualifier -- still runs unmodified over this substitute exactly as it
+    # would over a normally-ranked primary, so it can never surface at >=0.75 confidence or with
+    # `ask_user_before_editing.required = False`. A COMPLETE (non-truncated) scan, or a truncated
+    # one that still resolved a normal primary, never enters this block -- byte-identical to
+    # before this fix.
+    if scan_truncated and not target.get("file"):
+        best_effort_target = _best_effort_primary_target_from_map(rm, query)
+        if best_effort_target is not None:
+            target["file"] = best_effort_target["file"]
+            target["symbol"] = best_effort_target["symbol"]
+            target["kind"] = best_effort_target["kind"]
+            target["line"] = best_effort_target["line"]
+            target["partial_primary"] = True
+            target["primary_basis"] = _BEST_EFFORT_PRIMARY_BASIS
+            target["evidence"] = _dedupe([
+                *[
+                    str(item)
+                    for item in target.get("evidence", [])
+                    if item is not None and str(item)
+                ],
+                _BEST_EFFORT_PRIMARY_EVIDENCE,
+            ])
     all_alternatives = _alternative_targets(payload, target, limit=None)
     alternatives = all_alternatives[:4]
     target, alternatives = _prefer_implementation_over_marker_helper(query, target, alternatives)

--- a/tests/unit/test_agent_capsule_best_effort_primary.py
+++ b/tests/unit/test_agent_capsule_best_effort_primary.py
@@ -1,0 +1,365 @@
+"""v20 dogfood gap #2: `tg agent` truncating mid-scan previously returned an EMPTY primary target
+(`primary_target.file == ""`, `symbol: None`) whenever `_primary_target` could not resolve one --
+safe, but useless, even though the underlying `rm` (repo map) already held every file/symbol the
+scan reached before the deadline cut it off.
+
+`build_agent_capsule_from_map` (agent_capsule.py) now substitutes a BEST-EFFORT primary derived
+straight from that already-scanned `rm` -- via `_best_effort_primary_target_from_map` -- whenever
+the scan was truncated (`scan_truncated`) AND the real ranking pass came back with no primary at
+all (`not target.get("file")`). The substitute is flagged clearly non-authoritative
+(`partial_primary: True`, `primary_basis: "deadline_truncated_best_effort"`, an appended evidence
+entry) and re-enters every EXISTING confidence-cap/ask-reason gate unmodified: the scan-truncation
+confidence cap (`_cap_primary_target_confidence`), the forced scan-truncated ask-reason, and the T2
+corroborated-resolution uplift's own unconditional `scan_truncated` disqualifier. The exit-2
+contract (`main._scan_incomplete`, keyed only on `scan_limit`/`caller_scan_limit`/`partial`/
+`caller_scan_truncated`) is untouched by construction -- this fix never sets or clears any of those
+fields, only `primary_target`.
+
+Covers (per the build task):
+  1. Positive: a truncated scan whose query matches a SYMBOL NAME (but no file PATH) gets a
+     non-empty, clearly-flagged best-effort primary, with the exit-2/ask-required/confidence-cap
+     contract fully preserved.
+  2. Negative: a COMPLETE (non-truncated) scan is byte-identical to before this fix -- no new keys
+     on `primary_target`.
+  2b. A truncated scan that still resolved a NORMAL (non-empty) primary is likewise untouched --
+      the guard's second clause (`not target.get("file")`) must gate on emptiness, not on
+      truncation alone.
+  3. Bounded cost: the new pass never looks past `_BEST_EFFORT_PRIMARY_SCAN_CAP` items, proven
+     structurally (an out-of-cap "perfect" match loses to an in-cap "partial" match) rather than
+     by a flaky wall-clock assertion alone; a full-pipeline run against a 50k-symbol synthetic
+     tree still completes in well under a second.
+
+Plus focused unit coverage of the three fallback tiers inside
+`_best_effort_primary_target_from_map` itself (symbol-name match -> file-path match ->
+query-independent centrality -> None).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tensor_grep.cli import agent_capsule, repo_map
+from tensor_grep.cli.main import _scan_incomplete
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_symbol(name: str, file: str, *, kind: str = "function", line: int = 1) -> dict[str, Any]:
+    return {
+        "name": name,
+        "kind": kind,
+        "file": file,
+        "line": line,
+        "start_line": line,
+        "end_line": line,
+    }
+
+
+def _truncated_empty_primary_payload() -> dict[str, Any]:
+    """Simulates `repo_map.build_context_render_from_map`'s return when the scan truncated before
+    ranking ever produced a primary: no navigation_pack/edit_plan_seed primary, no rendered
+    sources, `scan_limit.possibly_truncated` (+ `partial`) stamped."""
+    return {
+        "routing_backend": "RepoMap",
+        "routing_reason": "context-render",
+        "semantic_provider": "native",
+        "files": [],
+        "sources": [],
+        "scan_limit": {"possibly_truncated": True, "reason": "deadline"},
+        "partial": True,
+        "validation_commands": [],
+        "edit_plan_seed": {},
+        "navigation_pack": {},
+        "candidate_edit_targets": {},
+        "context_consistency": {},
+    }
+
+
+def _write_symbol_project(tmp_path: Path, *, file_name: str, symbol_name: str) -> Path:
+    project = tmp_path / "workspace"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    source_file = project / file_name
+    source_file.write_text(f"def {symbol_name}(payload):\n    return payload\n", encoding="utf-8")
+    return project
+
+
+# ---------------------------------------------------------------------------
+# 1. Positive: full pipeline, truncated scan + symbol-name query match
+# ---------------------------------------------------------------------------
+
+
+def test_capsule_emits_best_effort_primary_on_truncated_scan_with_symbol_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `impl.py` deliberately shares no token with the query -- the best-effort match must come
+    # from the SYMBOL name, never the file path.
+    project = _write_symbol_project(
+        tmp_path, file_name="impl.py", symbol_name="process_widget_report"
+    )
+    rm = repo_map.build_repo_map(project)
+    monkeypatch.setattr(
+        repo_map,
+        "build_context_render_from_map",
+        lambda *args, **kwargs: _truncated_empty_primary_payload(),
+    )
+
+    past_deadline = time.monotonic() - 5.0
+    result = agent_capsule.build_agent_capsule_from_map(
+        rm, "process_widget_report", deadline_monotonic=past_deadline, max_tokens=8000
+    )
+
+    primary = result["primary_target"]
+    assert primary["file"] == str((project / "impl.py").resolve())
+    assert primary["symbol"] == "process_widget_report"
+    assert primary["partial_primary"] is True
+    assert primary["primary_basis"] == "deadline_truncated_best_effort"
+    assert "deadline-truncated-best-effort" in primary["evidence"]
+
+    # The exit-2 / honesty contract must survive the substitution untouched.
+    assert result["partial"] is True
+    assert _scan_incomplete(result) is True
+    assert result["ask_user_before_editing"]["required"] is True
+    assert result["confidence"]["overall"] < 0.75
+    assert primary["confidence"] < 0.75
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative: a complete scan is byte-identical to before this fix
+# ---------------------------------------------------------------------------
+
+
+def test_complete_scan_never_sets_partial_primary(tmp_path: Path) -> None:
+    project = tmp_path / "workspace"
+    project.mkdir()
+    (project / "a.py").write_text("def solo_widget():\n    return 1\n", encoding="utf-8")
+
+    payload = agent_capsule.build_agent_capsule("solo_widget", project, max_tokens=8000)
+
+    assert payload.get("partial") is not True
+    primary = payload["primary_target"]
+    assert primary["file"] == str((project / "a.py").resolve())
+    assert "partial_primary" not in primary
+    assert "primary_basis" not in primary
+    assert primary["evidence"] == ["parser-backed", "heuristic"]
+
+
+def test_truncated_scan_with_resolved_primary_is_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard's SECOND clause (`not target.get("file")`) must gate this fix on emptiness, not
+    on `scan_truncated` alone -- a truncated scan that still resolved a normal primary must be
+    left exactly as before."""
+    project = _write_symbol_project(
+        tmp_path, file_name="impl.py", symbol_name="process_widget_report"
+    )
+    rm = repo_map.build_repo_map(project)
+    resolved_file = str((project / "impl.py").resolve())
+
+    def _resolved_but_truncated_payload(*args: object, **kwargs: object) -> dict[str, Any]:
+        return {
+            "routing_backend": "RepoMap",
+            "routing_reason": "context-render",
+            "semantic_provider": "native",
+            "files": [resolved_file],
+            "sources": [
+                {
+                    "file": resolved_file,
+                    "symbol": "process_widget_report",
+                    "name": "process_widget_report",
+                    "start_line": 1,
+                    "end_line": 2,
+                    "source": "def process_widget_report(payload):\n    return payload\n",
+                }
+            ],
+            "scan_limit": {"possibly_truncated": True, "reason": "deadline"},
+            "partial": True,
+            "validation_commands": [],
+            "edit_plan_seed": {
+                "primary_file": resolved_file,
+                "primary_symbol": {"name": "process_widget_report", "kind": "function"},
+                "primary_span": {"start_line": 1, "end_line": 2},
+                "confidence": {"overall": 0.9},
+            },
+            "navigation_pack": {
+                "primary_target": {
+                    "file": resolved_file,
+                    "symbol": "process_widget_report",
+                    "kind": "function",
+                    "start_line": 1,
+                    "end_line": 2,
+                },
+                "follow_up_reads": [],
+            },
+            "candidate_edit_targets": {},
+            "context_consistency": {
+                "primary_file_included": True,
+                "rendered_context_includes_primary": True,
+            },
+        }
+
+    monkeypatch.setattr(repo_map, "build_context_render_from_map", _resolved_but_truncated_payload)
+
+    result = agent_capsule.build_agent_capsule_from_map(
+        rm, "process_widget_report", max_tokens=8000
+    )
+
+    assert result["partial"] is True
+    primary = result["primary_target"]
+    assert primary["file"] == resolved_file
+    assert "partial_primary" not in primary
+    assert "primary_basis" not in primary
+
+
+# ---------------------------------------------------------------------------
+# 3. Bounded cost
+# ---------------------------------------------------------------------------
+
+
+def test_best_effort_helper_symbol_pass_never_looks_past_the_scan_cap() -> None:
+    """The symbol-name-match pass only ever considers the first
+    `_BEST_EFFORT_PRIMARY_SCAN_CAP` entries of `rm["symbols"]` -- an item placed further out must
+    lose even when it would objectively out-score every in-cap candidate, proving the cap is a
+    real hard stop and not an optimization that merely happens not to matter on small inputs."""
+    cap = agent_capsule._BEST_EFFORT_PRIMARY_SCAN_CAP
+    query = "integration flow handler"
+    filler = [_fake_symbol(f"noise_{i}", f"/repo/noise_{i}.py") for i in range(cap - 1)]
+    in_cap_partial_match = _fake_symbol("flow_handler_module", "/repo/partial.py", line=7)
+    out_of_cap_perfect_match = _fake_symbol("integration_flow_handler", "/repo/perfect.py", line=99)
+    rm = {
+        "path": "/repo",
+        "files": [s["file"] for s in filler] + ["/repo/partial.py", "/repo/perfect.py"],
+        "symbols": [*filler, in_cap_partial_match, out_of_cap_perfect_match],
+        "imports": [],
+    }
+    # Sanity precondition: the "perfect" match really would outscore the in-cap partial match if
+    # both were visible to the same pass -- otherwise this test would pass for the wrong reason.
+    terms = repo_map._symbol_query_terms(query)
+    assert repo_map._score_symbol(out_of_cap_perfect_match, terms) > repo_map._score_symbol(
+        in_cap_partial_match, terms
+    )
+
+    candidate = agent_capsule._best_effort_primary_target_from_map(rm, query)
+
+    assert candidate is not None
+    assert candidate["file"] == "/repo/partial.py"
+    assert candidate["symbol"] == "flow_handler_module"
+
+
+def test_best_effort_pass_bounded_wall_clock_on_large_synthetic_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Full-pipeline SLA check: a 50k-symbol synthetic `rm` (far larger than any realistic
+    `--max-repo-files` default) must not push the capsule's wall-clock materially past the
+    deadline -- the added pass is bounded by item count, not by the size of `rm`."""
+    symbol_count = 50_000
+    query = "integration flow handler"
+    symbols = [_fake_symbol(f"noise_{i}", f"/repo/pkg/noise_{i}.py") for i in range(symbol_count)]
+    symbols[250] = _fake_symbol("flow_handler_module", "/repo/pkg/partial.py", line=7)
+    files = [str(s["file"]) for s in symbols]
+    rm = {
+        "path": "C:/repo_synthetic",
+        "files": files,
+        "symbols": symbols,
+        "imports": [],
+        "tests": [],
+        "related_paths": files,
+    }
+    monkeypatch.setattr(
+        repo_map,
+        "build_context_render_from_map",
+        lambda *args, **kwargs: _truncated_empty_primary_payload(),
+    )
+
+    past_deadline = time.monotonic() - 1.0
+    start = time.monotonic()
+    result = agent_capsule.build_agent_capsule_from_map(
+        rm, query, deadline_monotonic=past_deadline, max_tokens=2000
+    )
+    elapsed = time.monotonic() - start
+
+    # Generous CI-safe ceiling (measured well under 0.1s locally): a coarse regression trip-wire
+    # for an accidental unbounded/quadratic pass, not a tight performance pin.
+    assert elapsed < 5.0
+    primary = result["primary_target"]
+    assert primary["file"] == "/repo/pkg/partial.py"
+    assert primary["partial_primary"] is True
+
+
+# ---------------------------------------------------------------------------
+# Focused unit coverage of `_best_effort_primary_target_from_map`'s fallback tiers
+# ---------------------------------------------------------------------------
+
+
+def test_best_effort_helper_returns_none_when_rm_has_nothing_to_score() -> None:
+    rm: dict[str, Any] = {"path": "/repo", "files": [], "symbols": [], "imports": []}
+    assert agent_capsule._best_effort_primary_target_from_map(rm, "anything") is None
+
+
+def test_best_effort_helper_prefers_symbol_name_match_over_file_path() -> None:
+    rm = {
+        "path": "/repo",
+        "files": ["/repo/unrelated.py", "/repo/other.py"],
+        "symbols": [
+            _fake_symbol("unrelated_helper", "/repo/unrelated.py"),
+            _fake_symbol("process_widget_report", "/repo/other.py", line=42),
+        ],
+        "imports": [],
+    }
+
+    candidate = agent_capsule._best_effort_primary_target_from_map(rm, "process_widget_report")
+
+    assert candidate == {
+        "file": "/repo/other.py",
+        "symbol": "process_widget_report",
+        "kind": "function",
+        "line": 42,
+    }
+
+
+def test_best_effort_helper_falls_back_to_file_path_match_when_no_symbol_matches() -> None:
+    rm = {
+        "path": "/repo",
+        "files": ["/repo/misc.py", "/repo/billing_report.py"],
+        "symbols": [_fake_symbol("unrelated_helper", "/repo/misc.py")],
+        "imports": [],
+    }
+
+    candidate = agent_capsule._best_effort_primary_target_from_map(rm, "billing report")
+
+    assert candidate == {
+        "file": "/repo/billing_report.py",
+        "symbol": None,
+        "kind": "unknown",
+        "line": 1,
+    }
+
+
+def test_best_effort_helper_falls_back_to_centrality_when_nothing_matches() -> None:
+    rm = {
+        "path": "/repo",
+        "files": ["/repo/hub.py", "/repo/leaf.py", "/repo/extra.py"],
+        "symbols": [
+            _fake_symbol("alpha", "/repo/hub.py"),
+            _fake_symbol("beta", "/repo/leaf.py"),
+            _fake_symbol("gamma", "/repo/extra.py"),
+        ],
+        "imports": [
+            {"file": "/repo/leaf.py", "imports": ["hub"]},
+            {"file": "/repo/extra.py", "imports": ["hub"]},
+        ],
+    }
+
+    candidate = agent_capsule._best_effort_primary_target_from_map(
+        rm, "zzz_completely_unrelated_term"
+    )
+
+    assert candidate == {"file": "/repo/hub.py", "symbol": None, "kind": "unknown", "line": 1}

--- a/tests/unit/test_agent_capsule_best_effort_primary.py
+++ b/tests/unit/test_agent_capsule_best_effort_primary.py
@@ -15,10 +15,19 @@ contract (`main._scan_incomplete`, keyed only on `scan_limit`/`caller_scan_limit
 `caller_scan_truncated`) is untouched by construction -- this fix never sets or clears any of those
 fields, only `primary_target`.
 
+Opus-gate SHIP-WITH-NITS hardening: "partial_primary implies confidence.overall <= 0.55 AND
+primary_target.confidence <= 0.55" now holds STRUCTURALLY, not just emergently -- a dedicated cap
+(`_BEST_EFFORT_PRIMARY_MAX_CONFIDENCE`) runs LAST in `build_agent_capsule_from_map`, after every
+other confidence mutation including the T2 uplift, so a future change upstream cannot silently let
+a best-effort primary's confidence climb back to/above the 0.75 auto-edit threshold.
+
 Covers (per the build task):
   1. Positive: a truncated scan whose query matches a SYMBOL NAME (but no file PATH) gets a
      non-empty, clearly-flagged best-effort primary, with the exit-2/ask-required/confidence-cap
      contract fully preserved.
+  1b. Structural cap: an adversarially-constructed payload that would otherwise make `_confidence`
+      land >= 0.75 is still forced to <= 0.55 once `partial_primary` is set -- proving the cap is
+      structural, not merely a side effect of the ordinary downgrade ladder.
   2. Negative: a COMPLETE (non-truncated) scan is byte-identical to before this fix -- no new keys
      on `primary_target`.
   2b. A truncated scan that still resolved a NORMAL (non-empty) primary is likewise untouched --
@@ -130,6 +139,93 @@ def test_capsule_emits_best_effort_primary_on_truncated_scan_with_symbol_match(
     assert result["ask_user_before_editing"]["required"] is True
     assert result["confidence"]["overall"] < 0.75
     assert primary["confidence"] < 0.75
+
+
+# ---------------------------------------------------------------------------
+# 1b. Structural confidence cap (Opus-gate NIT-1): the <0.75 guarantee must hold BY
+# CONSTRUCTION, not merely because `_confidence`'s existing downgrade ladder happens to fire.
+# ---------------------------------------------------------------------------
+
+
+def test_structural_cap_defeats_artificially_high_upstream_confidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Construct an adversarial payload the real render pipeline would not naturally produce for
+    an UNRESOLVED primary: a high raw `edit_plan_seed.confidence.overall` seed (0.97) AND a
+    rendered snippet that happens to cover the exact file the best-effort pass will independently
+    pick -- which defeats every EMERGENT downgrade `_confidence` would otherwise apply (no empty
+    -snippets clamp, no "primary omitted from capsule snippets" clamp). Without the belt-and-
+    braces structural cap, this scenario would land `confidence.overall` at 0.97 (proven directly
+    below as a precondition) despite `primary_target` being a flagged, non-authoritative
+    best-effort guess. The cap must defeat it regardless of how "corroborated" the upstream looks.
+    """
+    project = _write_symbol_project(
+        tmp_path, file_name="impl.py", symbol_name="process_widget_report"
+    )
+    rm = repo_map.build_repo_map(project)
+    resolved_file = str((project / "impl.py").resolve())
+    adversarial_sources = [
+        {
+            "file": resolved_file,
+            "symbol": "process_widget_report",
+            "name": "process_widget_report",
+            "start_line": 1,
+            "end_line": 2,
+            "source": "def process_widget_report(payload):\n    return payload\n",
+        }
+    ]
+    adversarial_consistency = {
+        "primary_file_included": True,
+        "rendered_context_includes_primary": True,
+    }
+
+    # Precondition: prove `_confidence` really would land >= 0.75 on this exact payload shape
+    # ABSENT the new structural cap -- so the assertions below are credited to the cap, not to a
+    # pre-existing downgrade that happened to also land <= 0.55 for an unrelated reason.
+    precondition_payload = {
+        "sources": adversarial_sources,
+        "edit_plan_seed": {"confidence": {"overall": 0.97}},
+    }
+    precondition_confidence = agent_capsule._confidence(
+        precondition_payload, adversarial_sources, [], dict(adversarial_consistency)
+    )
+    assert precondition_confidence["overall"] >= 0.75
+
+    def _adversarial_render(*args: object, **kwargs: object) -> dict[str, Any]:
+        return {
+            "routing_backend": "RepoMap",
+            "routing_reason": "context-render",
+            "semantic_provider": "native",
+            "files": [resolved_file],
+            "sources": adversarial_sources,
+            "scan_limit": {"possibly_truncated": True, "reason": "deadline"},
+            "partial": True,
+            "validation_commands": [],
+            # No "primary_file" -- `_primary_target` must still resolve empty so the best-effort
+            # block fires, even though a high confidence seed is present.
+            "edit_plan_seed": {"confidence": {"overall": 0.97}},
+            "navigation_pack": {},
+            "candidate_edit_targets": {},
+            "context_consistency": dict(adversarial_consistency),
+        }
+
+    monkeypatch.setattr(repo_map, "build_context_render_from_map", _adversarial_render)
+
+    past_deadline = time.monotonic() - 5.0
+    result = agent_capsule.build_agent_capsule_from_map(
+        rm, "process_widget_report", deadline_monotonic=past_deadline, max_tokens=8000
+    )
+
+    primary = result["primary_target"]
+    assert primary["partial_primary"] is True
+    assert primary["file"] == resolved_file
+
+    # The structural guarantee: partial_primary implies confidence.overall <= 0.55 AND
+    # primary_target.confidence <= 0.55, by construction -- regardless of the engineered-high
+    # upstream seed proven above.
+    assert result["confidence"]["overall"] <= 0.55
+    assert primary["confidence"] <= 0.55
+    assert result["ask_user_before_editing"]["required"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When `tg agent` truncates mid-scan and ranking never resolves a primary target, `_primary_target` used to return an empty `{"file": "", "symbol": None, ...}` -- safe but useless, even though `rm` (the repo map) already holds every file/symbol the scan reached before the deadline cut it off.
- `build_agent_capsule_from_map` now substitutes a **best-effort primary** derived straight from that already-scanned `rm` (no second scan, no I/O) whenever `scan_truncated` AND the real ranking pass came back empty (`not target.get("file")`). New helper `_best_effort_primary_target_from_map` tries, cheapest-first: (a) a scanned **symbol name** matching the query, (b) else a scanned **file path** matching the query, (c) else the single most-**central** scanned file as a query-independent last resort (reusing `orient_capsule._file_centrality_scores`, the same function `tg orient`'s own `suggested_scope` already applies unconditionally in this exact truncated-scan tail).
- Each of (a)/(b) is bounded to the first `_BEST_EFFORT_PRIMARY_SCAN_CAP` (500) items of `rm` -- an **item-count cap**, not a live deadline re-check, since this block only ever runs *after* the deadline has already been blown (gating on the deadline again would make it permanently dead code).

## Contract preserved

- The substitute is flagged clearly **non-authoritative**: two new additive fields on `primary_target` -- `partial_primary: true` and `primary_basis: "deadline_truncated_best_effort"` -- plus an appended `"deadline-truncated-best-effort"` evidence entry.
- It re-enters every EXISTING confidence-cap / ask-reason gate unmodified:
  - the scan-truncation confidence cap (`_cap_primary_target_confidence(target, confidence["overall"])`) keeps it below 0.75,
  - the forced `_CAPSULE_SCAN_TRUNCATED_ASK_REASON` keeps `ask_user_before_editing.required` `true`,
  - the T2 corroborated-resolution uplift's own unconditional `scan_truncated` disqualifier (`_capsule_token_budget_uplift_eligible`) prevents it from ever climbing back to a confident, no-ask state.
- The exit-2 contract (`main._scan_incomplete`, keyed only on `scan_limit`/`caller_scan_limit`/`partial`/`caller_scan_truncated`) is **untouched by construction** -- this fix only ever writes to `primary_target`, never to any of those fields.
- A **complete** (non-truncated) scan, or a truncated scan that still resolved a **normal** (non-empty) primary, never enters the new code path -- byte-identical output to before this fix.

## Test plan

New file `tests/unit/test_agent_capsule_best_effort_primary.py` (9 cases):
- [x] Positive: truncated scan + query matches a symbol NAME (not a file path) -> non-empty, flagged best-effort primary; `partial`/`_scan_incomplete`/`ask_user_before_editing.required`/`confidence < 0.75` all hold.
- [x] Negative: a COMPLETE scan never sets `partial_primary`/`primary_basis` -- byte-identical primary shape to before.
- [x] Guard: a truncated scan that still resolved a normal primary is also left untouched (the guard's second clause, `not target.get("file")`, is exercised directly).
- [x] Bounded cost, structural proof: an out-of-cap "perfect" match symbol loses to an in-cap "partial" match, proving the 500-item cap is a real hard stop (not an optimization that merely doesn't matter on small inputs).
- [x] Bounded cost, wall-clock: a 50k-symbol synthetic `rm` run through the full pipeline completes in well under a second.
- [x] Focused coverage of the three fallback tiers inside `_best_effort_primary_target_from_map` (symbol match / file-path match / centrality / returns `None` when nothing to score).

Verified in the real project venv (PYTHONPATH pointed at this worktree's `src`, confirmed `tensor_grep.__file__` resolves into the worktree before trusting results):
- [x] `tests/unit/test_agent_capsule_best_effort_primary.py` -- 9 passed
- [x] `tests/unit/test_agent_capsule*.py` (existing suite) -- 68 passed
- [x] `tests/integration/test_agent_cold_deadline_tail_sla_220.py` -- 2 passed
- [x] Broader adjacent sweep (agent/deadline/mcp/trust/token-budget/session-daemon/main-cli-contracts unit files) -- 827 passed, 4 deselected (confirmed pre-existing failures on unmodified origin/main, unrelated to this change -- native-binary-missing rewrite-plan tests in `test_mcp_server.py`)
- [x] `ruff check` -- clean
- [x] `ruff format --preview` -- clean
- [x] `mypy src/tensor_grep` -- Success: no issues found in 81 source files

Load-bearing (agent capsule) -- not merging without an independent review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)