### PR TITLE
docs: pip/uvx installs the Python front door (~200ms floor); tg upgrade gets the native one (rg-parity cold search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ pip install tensor-grep
 uvx tensor-grep
 ```
 
+> **Which front door do you get?** `pip install`/`uvx tensor-grep` installs the **Python front door**;
+> a cold search pays a Python-interpreter startup tax (roughly 150-250ms) before the search itself
+> runs. The install script and npm below also set up the managed **native** `tg` binary
+> (`~/.tensor-grep/bin/tg`), which starts close to raw `rg` speed, and `tg upgrade` keeps an existing
+> native front door in sync with new releases. Either way, `rg` stays the fastest baseline for cold
+> literal search — tg's edge is agent-native context (`tg orient` / `tg callers` / `tg blast-radius` /
+> `tg find`), not raw grep speed.
+
 Supported on Windows, macOS, and Linux. See [docs/installation.md](docs/installation.md) for Homebrew, winget, and source build options.
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,6 +88,13 @@ tg --help
 
 *Note: the Python package path is the one that supports `tg update` / `tg upgrade`. It requires a configured Python environment and may need additional GPU dependencies such as `cudf` and `torch`.*
 
+**Cold-search speed.** This Python entry point pays a Python-interpreter startup tax on every cold,
+one-shot search: roughly 150-250ms before the search itself runs (tracked in
+[issue #48](https://github.com/oimiragieo/tensor-grep/issues/48)). `rg` remains the fastest baseline
+for cold literal search regardless of install channel. For a cold start close to native `rg` speed, use
+the install scripts (Option 1) or `npx`/`npm` (Option 2) above; they set up the managed **native** `tg`
+binary as the front door, and once it is installed, `tg upgrade` keeps it in sync with new releases.
+
 On Windows, the Python package installs a launcher shim under a Python `Scripts` directory. That shim is for invoking the Python CLI path, not for native delegation. Simple AST rewrite plan/apply is still available through the packaged PyO3 Rust extension. If you need native-only features such as rewrite diff, checkpoint, audit, validation, verify, or explicit MCP handoff to the standalone executable, point `TG_NATIVE_TG_BINARY` at an explicit native `tg.exe` path or use a release binary / in-tree Rust build.
 
 ## Option 5: Package Managers


### PR DESCRIPTION
## Summary

Honesty fix closing the README-headline-vs-native-front-door-ships-on-stable credibility gap (from
the native-front-door scoping): the README's headline install command is `pip install tensor-grep`,
which installs the Python console-script front door and silently pays a Python-interpreter startup
tax (roughly 150-250ms, per the real benchmark in #48) on every cold search -- while the native front
door (curl|bash / PowerShell / npm installers, `scripts/install.sh:363-376`) already ships on the
stable channel and is close to raw `rg` cold-start speed. `docs/CONTRACTS.md:73` already says stable
installs should prefer the native binary and `:86` already positions `rg` as the cold exact-text
baseline; the install-facing docs didn't say so.

- Adds a short, additive callout to README.md's `## Install` section.
- Adds a short, additive paragraph to `docs/installation.md`'s `## Option 4: Python (pip / uv)`
  section.
- No code changes; no removed/altered text; no CONTRACTS.md edit (skipped -- its existing positioning
  at :73/:86 already covers this, and that file carries ~80 pinned-substring governance assertions,
  so an edit there was not worth the risk for an optional addition).

**Does not claim tg beats rg on cold search.** Both notes end on "`rg` stays the fastest baseline for
cold literal search" / "`rg` remains the fastest baseline ... regardless of install channel" -- tg's
positioned edge is agent-native context (`tg orient` / `tg callers` / `tg blast-radius` / `tg find`),
consistent with `docs/CONTRACTS.md:86` and the existing `docs/index.md` "Product Positioning" section.

**One correction to the originating scoping premise, verified against the real code before writing:**
the scoping assumed `tg upgrade` installs the native managed front door. Tracing
`src/tensor_grep/cli/main.py`, `_managed_native_frontdoor_path()` (native front-door path resolver)
returns `None` unless `~/.tensor-grep/bin/tg.exe` (Windows) already exists as a file, or the running
interpreter is already inside `~/.tensor-grep/.venv`; `_refresh_managed_native_frontdoor()` early-returns
when that path is `None`. So `tg upgrade` only *keeps an already-installed* native front door in sync
with new releases -- it does not bootstrap one from a bare `pip install`. Both notes are worded
accordingly ("keeps an existing native front door in sync"), and point pip/uvx users at the install
script or npm as the actual bootstrap path for the native front door.

## Facts verified against `origin/main` (891610b) before writing

- `pyproject.toml:643` -- `tg = "tensor_grep.cli.bootstrap:main_entry"` (pip/uvx console-script front
  door).
- `scripts/install.sh:363-376` -- writes a `tg` launcher that `exec`s the native binary when present,
  falling back to `python -m tensor_grep`.
- `docs/CONTRACTS.md:73` -- "Stable managed install scripts should prefer the matching release-native
  CPU `tg` binary as the public front door..."
- `docs/CONTRACTS.md:86` -- "...the public positioning that `rg` remains the cold exact-text baseline
  while `ast-grep` remains the structural-search feature/performance baseline."
- `.github/workflows/ci.yml:1113` -- `build-release-native-assets` job (native assets published every
  stable release).
- Issue [#48](https://github.com/oimiragieo/tensor-grep/issues/48) -- real, dated benchmark (v1.69.3,
  Windows, best-of-6, real repo): `tg --version` (pure shim) 193ms, `tg search <literal>` (shim +
  search) 232ms, vs `rg <literal>` 22ms raw baseline; a 2026-07-17 follow-up confirms the `search` path
  specifically is still not closed. This is the basis for the "roughly 150-250ms" figure -- hedged
  rather than pinned, and the note links the live issue instead of a brittle exact number.
- `src/tensor_grep/cli/main.py` -- `_managed_native_frontdoor_path()` / `_refresh_managed_native_frontdoor()`
  (the `tg upgrade` correction above).

## Docs-governance verification (all green, real venv / global interpreter with tensor-grep + deps
installed, run from the worktree so `_REPO_ROOT`-anchored tests read the changed files)

- `tests/unit/test_public_docs_governance.py` + `tests/unit/test_skill_index_sync.py` -- 47 passed
- `tests/unit/test_harness_api_docs.py` -- 8 passed (includes the live-MCP-tool-registry cross-check)
- `tests/unit/test_enterprise_docs_governance.py` + `tests/unit/test_harness_cookbook.py` -- 17 passed
- `tests/unit/test_release_assets_validation.py` -- 145 passed
- `python scripts/validate_release_assets.py` (the real CI release-readiness gate, run directly against
  the actual repo docs) -- `Release/package assets validation passed.` This is the gate carrying the
  banned-positioning check (`"faster than rg"`, `"GPU-ready"`, etc.) -- confirmed clean.
- Broader safety net -- every other test file in `tests/unit/` that references `README.md` or
  `docs/installation.md` (`test_agent_readiness_script`, `test_checkpoint_cli`, `test_codemap*`,
  `test_docs_coverage`, `test_dogfood_cli`, `test_evidence_receipt`, `test_inventory`,
  `test_issue_intake_governance`, `test_issue_triage`, `test_orient_central_excludes_docs`,
  `test_repo_hygiene_script`, `test_review_bundle_evidence_receipts`, `test_stamp_release_assets`,
  `test_validation_commands`) -- 389 passed
- `ruff format --preview --check README.md docs/installation.md` -- `2 files already formatted`
- `git diff --check` -- clean (no whitespace errors)
- No `.py` files touched, so mypy is not applicable.

## Release intent

`docs:` prefix -- no-release per `CONTRIBUTING.md`'s conventional-commit table. Confirmed the local
commit and PR title both use it.

## Test plan

- [x] Docs-governance suite green (see above)
- [x] `scripts/validate_release_assets.py` green against the real README/installation docs
- [x] `ruff format --preview --check` clean on both changed files
- [x] Manual read-through for overclaiming language (no "faster than rg", no GPU claims, no beats-rg
      claim)
- [ ] CEO / light gate: quick read of the claims for honesty (requested light-gate step; not a code
      review since this is docs-only and already governance-validated)

Not merging -- opening as draft per instructions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
