### PR TITLE
docs(enterprise): review-bundle evidence-gate CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ It ships as a native CLI on Windows, macOS, and Linux — no server required for
 - **`tg rulesets`** — built-in security and compliance AST rule packs.
 - **`tg audit`** — audit-verify / audit-history / audit-diff with signed manifest digests and semantic diff.
 - **`tg classify`** — log and code classification. Default path is local deterministic heuristics; set `TENSOR_GREP_CLASSIFY_PROVIDER=cybert` to opt into the CyBERT/Triton path.
-- **`tg review-bundle`** — produce enterprise review bundles.
+- **`tg review-bundle`** — produce enterprise review bundles. See [docs/enterprise_review_bundle_ci.md](docs/enterprise_review_bundle_ci.md) for a turnkey CI PR-gate recipe.
 
 ### Edit safety & audit
 - **`tg checkpoint create/list/undo`** — create, list, and undo edit checkpoints before applying rewrites.
@@ -181,6 +181,7 @@ tg dogfood
 | [docs/installation.md](docs/installation.md) | Supported install paths |
 | [docs/EXPERIMENTAL.md](docs/EXPERIMENTAL.md) | Opt-in and hidden features outside the stable surface |
 | [docs/CONTRACTS.md](docs/CONTRACTS.md) | Compatibility guarantees for configs, caches, and outputs |
+| [docs/enterprise_review_bundle_ci.md](docs/enterprise_review_bundle_ci.md) | Turnkey CI PR-gate recipe: signed evidence receipts -> review bundle -> fail-closed verify |
 | [docs/CI_PIPELINE.md](docs/CI_PIPELINE.md) | CI, release, audit, and dependency-maintenance automation |
 | [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) | Supported platforms, runtimes, and distribution channels |
 | [docs/HOTFIX_PROCEDURE.md](docs/HOTFIX_PROCEDURE.md) | Patch, rollback, and verification process |

--- a/docs/enterprise_review_bundle_ci.md
+++ b/docs/enterprise_review_bundle_ci.md
@@ -126,6 +126,30 @@ trust at all"; `--expect-key` answers "which of those trusted signers MUST actua
 in this bundle" -- an org can trust several keys while requiring this particular gate to see
 evidence from one specific one (e.g. the CI service account, not just any developer's key).
 
+## Optional: reuse findings across agents (`tg ledger`)
+
+The chain above is the minimum for a CI gate and does not depend on this. In a multi-agent
+workflow, `tg ledger record` / `tg ledger find` (`docs/CONTRACTS.md` section 10, EXPERIMENTAL
+Slice 2) add a content-addressed cache on top of it so a sibling agent can reuse evidence another
+agent already captured for the same symbol instead of recomputing it:
+
+```bash
+# Agent A: after emitting a receipt, publish it for reuse
+tg ledger record . --receipt receipt.json --artifact-kind evidence-receipt \
+  --symbol my_symbol --agent-id "$AGENT_ID" --json
+
+# Agent B: look up a fresh finding before recomputing (3-state exit: 0 = fresh hit, 1 = nothing
+# fresh, 2 = fail-closed on a corrupt index/blob -- only 0 means "safe to reuse")
+tg ledger find . --symbol my_symbol --artifact-kind evidence-receipt --fresh-only --json
+```
+
+A finding is only served when its captured revision (commit SHA + dirty-tree hash) matches the
+CURRENT repo state -- the same freshness discipline `review-bundle verify --against` applies to
+receipts, so a finding recorded against a now-stale commit is never reused as current. This is
+**advisory and never blocks**: it is a separate, explicit-invoke cache that nothing in the CI gate
+above consults automatically, not a policy lever like `--min-receipts`/`--expect-key` -- skip it
+entirely and the gate above is unaffected.
+
 ## What this gate does and does not prove
 
 - **It proves presence only when `--min-receipts >= 1` was actually passed.** Integrity checks

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@
 
 - [docs/SUPPORT_MATRIX.md](SUPPORT_MATRIX.md)
 - [docs/CONTRACTS.md](CONTRACTS.md)
+- [docs/enterprise_review_bundle_ci.md](enterprise_review_bundle_ci.md) for a turnkey evidence-receipt CI PR-gate recipe
 - [docs/HOTFIX_PROCEDURE.md](HOTFIX_PROCEDURE.md)
 - [docs/RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md)
 - [docs/CI_PIPELINE.md](CI_PIPELINE.md)

--- a/docs/multi_agent_context_plane.md
+++ b/docs/multi_agent_context_plane.md
@@ -136,9 +136,16 @@ To keep harnesses from overclaiming, be precise about the current limits:
   (`_DAEMON_RESPONSE_CACHE_STALE_DETECTION` / `_DAEMON_RESPONSE_CACHE_ADDED_FILE_DETECTION`,
   `session_daemon.py`). After creating files, run `tg session refresh` (or request
   `refresh_on_stale`) so the new files invalidate cached hits.
-- **There is no ledger, no claims/findings store, no message bus, and no agent-to-agent
-  protocol.** `tg` shares code facts through the session store and daemon cache described above,
-  and nothing more. Anything beyond that is not shipped.
+- **A ledger exists, but is EXPERIMENTAL/preview and explicit-invoke only.** `tg ledger
+  claim`/`release`/`list` (advisory, code-scoped coordination -- `ledger_app`, `main.py:278`,
+  mounted at `main.py:14161`; `submit_claim`/`release_claim`/`list_claims`,
+  `ledger_store.py:445,507,562`) and `tg ledger record`/`find` (content-addressed artifact reuse
+  -- `record_finding`/`find_findings`, `ledger_store.py:886,1023`) are real, shipped commands --
+  see `docs/CONTRACTS.md` sections 9-10 for the full contract, and
+  `docs/enterprise_review_bundle_ci.md` for how `record`/`find` compose with the evidence-receipt
+  CI gate. Still true: nothing in `tg agent`/`tg edit-plan`/the daemon consults the ledger
+  automatically (explicit-invoke only), there is no MCP tool surface for it, and it does not
+  extend into a general message bus or cross-repo lookup.
 
 ## Demand instrumentation (step 0 for a possible shared-context surface)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - CI Pipeline: CI_PIPELINE.md
     - Support Matrix: SUPPORT_MATRIX.md
     - Contracts: CONTRACTS.md
+    - Review Bundle CI Gate: enterprise_review_bundle_ci.md
     - Experimental Features: EXPERIMENTAL.md
     - Release Checklist: RELEASE_CHECKLIST.md
     - Hotfix Procedure: HOTFIX_PROCEDURE.md


### PR DESCRIPTION
## Summary

Docs-only, non-releasing (`docs:` commit -> no semantic-release version bump). Addresses the v21
dogfood finding "Ledger -> review-bundle CI: Partial -- the pieces ship but there's no turnkey
documented CI PR-gate pattern."

**Research finding worth flagging up front:** `docs/enterprise_review_bundle_ci.md` already
existed (shipped in #681, CEO#8 enterprise close-the-loop) and already covers the core ask --
the full chain (`tg evidence emit --sign` -> `tg review-bundle create --receipt` -> `tg
review-bundle verify --against/--min-receipts/--expect-key/--require-trusted`), a full GitHub
Actions recipe, the PR-head-vs-merge-commit trap, and the `--min-receipts` empty-bundle-bypass
explanation. So this PR is narrower than a from-scratch build -- it closes the two concrete gaps
that explain why the pattern still reads as "Partial":

1. **Missing optional adjunct.** The runbook didn't mention `tg ledger record`/`find`
   (content-addressed finding reuse across agents, `docs/CONTRACTS.md` section 10) at all, even
   though it's part of the CEO's listed close-the-loop surface. Added as a short "Optional: reuse
   findings across agents" section -- explicitly advisory/never-blocking, doesn't touch the core
   gate.
2. **Discoverability.** The only pointer to the runbook anywhere was one sentence buried in
   `docs/CONTRACTS.md` section 11 prose, and the file wasn't in `mkdocs.yml` nav (so it never
   shipped on the published docs site). Fixed by adding it to: `mkdocs.yml` nav (Getting Started
   -> "Review Bundle CI Gate"), `docs/index.md`'s Enterprise/Operational Docs list, README's
   Canonical docs table, and the `tg review-bundle` bullet in README's command list.

**Bonus fix (same-PR, directly load-bearing to #1 above):** `docs/multi_agent_context_plane.md`
(a published, mkdocs-nav'd "honesty" page) stated *"There is no ledger, no claims/findings
store, ... Anything beyond that is not shipped."* That's stale -- `tg ledger
claim/release/list/record/find` are real, shipped EXPERIMENTAL commands
(`docs/CONTRACTS.md` sections 9-10). Left uncorrected, it would directly contradict the ledger
section just added to the CI runbook. Corrected with `file:line` citations matching that page's
own citation-per-claim house style (`ledger_app`, `main.py:278`; `submit_claim`/`release_claim`/
`list_claims`, `ledger_store.py:445,507,562`; `record_finding`/`find_findings`,
`ledger_store.py:886,1023`) -- what's still true (no MCP surface, no automatic consult, no
message bus, no cross-repo lookup) is preserved.

## CLI surface verified

Ran `--help` against the installed `tg 1.91.0` binary (not memory/guesswork) for every flag used
in the doc: `tg evidence emit`, `tg evidence pubkey`, `tg review-bundle create`, `tg review-bundle
verify`, `tg ledger record`, `tg ledger find`. All match the doc text exactly (`--sign`,
`--against`, `--min-receipts`, `--expect-key`, `--require-trusted`, `--trusted-key`,
`--artifact-kind`, `--fresh-only`, etc.).

## Gates run (all green)

- `python -m pytest tests/unit/test_public_docs_governance.py tests/unit/test_enterprise_docs_governance.py -q` -> 58 passed
- `python scripts/validate_release_assets.py` -> passed
- `ruff format --check --preview` on all 4 edited `.md` files (both the system `ruff 0.15.17` and
  the repo's pinned `uv run ruff` toolchain) -> already formatted, both agree
- No test in `tests/` reads/pins the content of `docs/enterprise_review_bundle_ci.md` or
  `docs/multi_agent_context_plane.md` (grepped `tests/` first) -- confirmed safe to edit freely

**Pre-existing, unrelated finding (not fixed here, out of scope):** `mkdocs build --strict`
currently crashes locally on this machine (`AttributeError: 'NoneType' object has no attribute
'replace'` inside `pymdownx.highlight` -> `pygments.formatters.html.HtmlFormatter.__init__`) on
essentially any page with a fenced code block -- reproduced identically against the unmodified
`origin/main` `mkdocs.yml` (i.e., before this PR's changes), and it moves to a different
unrelated file (`architecture.md`) when the first crashing file is set aside, then restored
byte-identical. This is a local `pygments`/`pymdownx`/`mkdocs-material` version-compatibility
issue (CI installs `mkdocs-material` unpinned via `pip install mkdocs-material`, so version drift
is a known characteristic of that gate), not something this PR introduces or is responsible for
fixing -- flagging for visibility only.

## Test plan

- [x] Docs-governance pytest suites green (see above)
- [x] `validate_release_assets.py` green
- [x] `ruff format --check --preview` green on touched `.md` files (both ruff toolchains)
- [x] CLI flags dogfooded against the real installed `tg 1.91.0` binary
- [ ] CEO audit + drain (per house process -- not merging this myself)

Draft PR -- please review before merge; not auto-merging per repo autonomy policy (draft-PR-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
