### PR TITLE
feat(dense): add opt-in dense-leg compression (int8 clears gate)

### DIFF
--- a/benchmarks/eval_dense_compression_quality.py
+++ b/benchmarks/eval_dense_compression_quality.py
@@ -1,0 +1,624 @@
+"""Dense-leg compression quality/latency/footprint benchmark (tensor-grep-semantic-search-campaign,
+dense-leg compression wave).
+
+Compares the fp32 dense-leg baseline against every compression variant from
+``core/retrieval_dense.py``'s ``DenseCompressionConfig`` (int8, binary+int8-rescore,
+truncate-{128,96,64}, and the truncate+int8 combo) on the SAME realistic, vocabulary-mismatch
+golden corpus + queries already used to gate the late-rerank promotion decision
+(``benchmarks/datasets/find_golden_corpus/`` + ``benchmarks/datasets/late_rerank_golden.jsonl``,
+74 files / 40 queries across 4 categories). That corpus was purpose-built so BM25 scores near the
+floor on it (see ``eval_late_rerank_quality.py``'s E2 corpus-hardness gate) -- i.e. it is a REAL
+discriminator of dense-leg quality, unlike the toy ``eval_bm25_quality.py`` corpus which saturates
+BM25 at recall 1.0 and would prove nothing about a compression regression (campaign skill GATE 0b).
+
+For EACH variant, reports:
+
+- quality: recall@5, recall@10, ndcg@5, ndcg@10, mrr -- via ``retrieval_scoring.py``'s exact
+  functions (no reimplemented metric), scored identically across >=2 repeated runs to PROVE
+  determinism (a mismatch is a loud failure, not a warning).
+- latency: mean per-query ``DenseIndex.query`` wall-clock time (ms) for EACH repeat separately
+  (so the noise floor between runs is visible, never collapsed into a single number), plus index
+  BUILD time.
+- footprint: the REAL measured ``DenseIndex.index_nbytes`` (not an assumed theoretical
+  multiplier).
+
+An OPTIONAL ``--extra-corpus`` (e.g. this repo's own ``src/tensor_grep`` tree) additionally
+measures latency + footprint scaling at a much larger N with no golden labels required (quality is
+never claimed for that corpus -- only latency/footprint rows are emitted for it).
+
+Usage (real fetched potion-code-16M model + the `semantic` extra required; a loud, specific
+`EvalError` on either being absent -- never a silent empty comparison):
+
+    uv run --no-sync python benchmarks/eval_dense_compression_quality.py
+    uv run --no-sync python benchmarks/eval_dense_compression_quality.py --repeats 3
+    uv run --no-sync python benchmarks/eval_dense_compression_quality.py --extra-corpus src/tensor_grep/core
+
+Exit 0 when the comparison completes (regardless of which variant wins -- this is a measurement
+harness, not a gate; the promotion decision is made by a human reading the table per
+tensor-grep-semantic-search-campaign Phase 5). Exit 1 on a loud config/data error or an
+unavailable dense leg.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+DEFAULT_CORPUS_DIR = Path(__file__).resolve().parent / "datasets" / "find_golden_corpus"
+DEFAULT_GOLDEN_PATH = Path(__file__).resolve().parent / "datasets" / "late_rerank_golden.jsonl"
+DEFAULT_OUTPUT_PATH = ROOT_DIR / "artifacts" / "bench_dense_compression_quality.json"
+
+DEFAULT_TOP_KS: tuple[int, ...] = (5, 10)
+DEFAULT_REPEATS = 2
+_METRIC_NAMES: tuple[str, ...] = ("recall@5", "recall@10", "ndcg@5", "ndcg@10", "mrr")
+
+
+class EvalError(ValueError):
+    """A loud, non-silent failure -- malformed golden set, missing corpus, or an unavailable dense
+    leg. Never caught and downgraded to a warning: this harness refuses to fabricate a comparison
+    (mirrors ``eval_late_rerank_quality.py``'s ``GoldenSetError`` discipline)."""
+
+
+@dataclass(frozen=True)
+class GoldenQuery:
+    id: str
+    query: str
+    category: str
+    relevant_files: frozenset[str]
+
+
+# ---------------------------------------------------------------------------------------
+# Loading (self-contained -- deliberately does not import eval_late_rerank_quality.py, to keep
+# this script's ownership boundary independent of that campaign's harness).
+# ---------------------------------------------------------------------------------------
+
+
+def load_golden_queries(path: Path) -> list[GoldenQuery]:
+    if not path.is_file():
+        raise EvalError(f"golden query file not found: {path}")
+
+    queries: list[GoldenQuery] = []
+    seen_ids: set[str] = set()
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise EvalError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+
+        query_id = row.get("id")
+        if not query_id:
+            raise EvalError(f"{path}:{line_number}: missing required field 'id'")
+        if query_id in seen_ids:
+            raise EvalError(f"{path}:{line_number}: duplicate query id {query_id!r}")
+        seen_ids.add(query_id)
+
+        query_text = row.get("query")
+        if not query_text:
+            raise EvalError(f"{path}:{line_number} ({query_id}): missing required field 'query'")
+
+        category = row.get("category")
+        if not category:
+            raise EvalError(f"{path}:{line_number} ({query_id}): missing required field 'category'")
+
+        relevant_entries = row.get("relevant")
+        if not relevant_entries:
+            # E1 guard (mirrors eval_late_rerank_quality.py): an empty `relevant` set would let
+            # recall_at_k/ndcg_at_k's vacuous-truth branch silently score this query as a PERFECT
+            # 1.0 for every variant, forever, with no visible signal anything is wrong.
+            raise EvalError(
+                f"{path}:{line_number} ({query_id}): 'relevant' must be a non-empty list"
+            )
+
+        relevant_files = frozenset(entry["file"] for entry in relevant_entries)
+        queries.append(
+            GoldenQuery(
+                id=query_id, query=query_text, category=category, relevant_files=relevant_files
+            )
+        )
+
+    if not queries:
+        raise EvalError(f"{path}: contained zero golden queries")
+    return queries
+
+
+def load_corpus_files(corpus_dir: Path) -> list[str]:
+    if not corpus_dir.is_dir():
+        raise EvalError(f"corpus directory not found: {corpus_dir}")
+    files = sorted(str(p) for p in corpus_dir.rglob("*") if p.is_file())
+    if not files:
+        raise EvalError(f"corpus directory is empty: {corpus_dir}")
+    return files
+
+
+def _relative_posix(path_str: str, corpus_dir: Path) -> str:
+    return Path(path_str).resolve().relative_to(corpus_dir.resolve()).as_posix()
+
+
+def validate_golden_against_corpus(queries: list[GoldenQuery], corpus_dir: Path) -> None:
+    corpus_root = corpus_dir.resolve()
+    for query in queries:
+        for relevant_file in query.relevant_files:
+            if not (corpus_root / relevant_file).is_file():
+                raise EvalError(
+                    f"{query.id}: relevant file {relevant_file!r} does not exist under {corpus_dir}"
+                )
+
+
+def _dedupe_ranked_files(
+    ranked_chunk_indices: list[int], chunks: list[Any], corpus_dir: Path
+) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for chunk_index in ranked_chunk_indices:
+        rel = _relative_posix(chunks[chunk_index].file_path, corpus_dir)
+        if rel not in seen:
+            seen.add(rel)
+            ordered.append(rel)
+    return ordered
+
+
+def _score_ranking(
+    ranked_files: list[str], relevant_files: frozenset[str], top_ks: tuple[int, ...]
+) -> dict[str, float]:
+    from tensor_grep.core.retrieval_scoring import (
+        mean_reciprocal_rank_at_k,
+        ndcg_at_k,
+        recall_at_k,
+    )
+
+    metrics: dict[str, float] = {}
+    for k in top_ks:
+        metrics[f"recall@{k}"] = recall_at_k(ranked_files, relevant_files, top_k=k)
+        metrics[f"ndcg@{k}"] = ndcg_at_k(ranked_files, relevant_files, top_k=k)
+    metrics["mrr"] = mean_reciprocal_rank_at_k(ranked_files, relevant_files, top_k=max(top_ks))
+    return metrics
+
+
+# ---------------------------------------------------------------------------------------
+# Variants under comparison.
+# ---------------------------------------------------------------------------------------
+
+
+def build_variants(rescore_candidates: int) -> dict[str, Any]:
+    from tensor_grep.core.retrieval_dense import DenseCompressionConfig, DenseQuantizationMode
+
+    return {
+        "fp32_baseline": DenseCompressionConfig(),
+        "int8": DenseCompressionConfig(quantization=DenseQuantizationMode.INT8),
+        f"binary_rescore_k{rescore_candidates}": DenseCompressionConfig(
+            quantization=DenseQuantizationMode.BINARY_RESCORE,
+            rescore_candidates=rescore_candidates,
+        ),
+        "truncate_128": DenseCompressionConfig(truncate_dims=128),
+        "truncate_96": DenseCompressionConfig(truncate_dims=96),
+        "truncate_64": DenseCompressionConfig(truncate_dims=64),
+        "truncate_128_int8": DenseCompressionConfig(
+            quantization=DenseQuantizationMode.INT8, truncate_dims=128
+        ),
+    }
+
+
+def build_dense_model() -> Any:
+    """Real production probes (mirrors ``eval_late_rerank_quality.py::build_dense_index``): a
+    RECOVERABLE unavailability (extra not installed / model not fetched) raises the loud
+    :class:`EvalError` this harness uses everywhere; a genuine
+    :class:`~tensor_grep.backends.base.BackendExecutionError` is NOT caught here and propagates
+    per the Backend Fail-Closed Contract."""
+    from tensor_grep.core.retrieval_dense import (
+        DenseUnavailableError,
+        default_model_dir,
+        dense_available,
+        load_dense_model,
+    )
+
+    available, reason = dense_available()
+    if not available:
+        raise EvalError(f"dense leg unavailable: {reason}")
+    try:
+        return load_dense_model(default_model_dir())
+    except DenseUnavailableError as exc:
+        raise EvalError(f"dense leg unavailable: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------------------
+# Measurement.
+# ---------------------------------------------------------------------------------------
+
+
+@dataclass
+class VariantResult:
+    name: str
+    dim: int
+    index_nbytes: int
+    index_build_ms: float
+    per_query_metrics: dict[str, dict[str, float]] = field(default_factory=dict)
+    latency_ms_by_run: list[list[float]] = field(default_factory=list)
+    determinism_ok: bool = True
+
+    def mean_metric(self, metric: str) -> float:
+        values = [row[metric] for row in self.per_query_metrics.values()]
+        return statistics.mean(values) if values else 0.0
+
+    def mean_latency_ms(self, run_index: int) -> float:
+        return statistics.mean(self.latency_ms_by_run[run_index])
+
+
+def run_variant(
+    name: str,
+    config: Any,
+    chunks: list[Any],
+    corpus_dir: Path,
+    queries: list[GoldenQuery],
+    top_ks: tuple[int, ...],
+    model: Any,
+    *,
+    repeats: int,
+) -> VariantResult:
+    from tensor_grep.core.retrieval_dense import DenseIndex
+
+    build_start = time.perf_counter()
+    index = DenseIndex(chunks, model, compression=config)
+    build_ms = (time.perf_counter() - build_start) * 1000.0
+
+    total = max(1, len(chunks))
+    per_query_runs: list[dict[str, dict[str, float]]] = []
+    latency_runs: list[list[float]] = []
+
+    for _run in range(repeats):
+        per_query: dict[str, dict[str, float]] = {}
+        latencies: list[float] = []
+        for query in queries:
+            t0 = time.perf_counter()
+            ranked_idx = [chunk_idx for chunk_idx, _score in index.query(query.query, top_k=total)]
+            latencies.append((time.perf_counter() - t0) * 1000.0)
+            ranked_files = _dedupe_ranked_files(ranked_idx, chunks, corpus_dir)
+            per_query[query.id] = _score_ranking(ranked_files, query.relevant_files, top_ks)
+        per_query_runs.append(per_query)
+        latency_runs.append(latencies)
+
+    determinism_ok = all(run == per_query_runs[0] for run in per_query_runs[1:])
+
+    return VariantResult(
+        name=name,
+        dim=index.dim,
+        index_nbytes=index.index_nbytes,
+        index_build_ms=build_ms,
+        per_query_metrics=per_query_runs[0],
+        latency_ms_by_run=latency_runs,
+        determinism_ok=determinism_ok,
+    )
+
+
+@dataclass
+class ExtraCorpusResult:
+    name: str
+    dim: int
+    index_nbytes: int
+    index_build_ms: float
+    mean_query_latency_ms_by_run: list[float]
+
+
+def run_extra_corpus_variant(
+    name: str,
+    config: Any,
+    chunks: list[Any],
+    probe_queries: list[str],
+    model: Any,
+    *,
+    repeats: int,
+) -> ExtraCorpusResult:
+    """Latency + footprint ONLY (no golden labels) -- used for the optional ``--extra-corpus``
+    scaling check at a much larger N than the 74-file golden corpus."""
+    from tensor_grep.core.retrieval_dense import DenseIndex
+
+    build_start = time.perf_counter()
+    index = DenseIndex(chunks, model, compression=config)
+    build_ms = (time.perf_counter() - build_start) * 1000.0
+
+    total = max(1, len(chunks))
+    means: list[float] = []
+    for _run in range(repeats):
+        latencies: list[float] = []
+        for query_text in probe_queries:
+            t0 = time.perf_counter()
+            index.query(query_text, top_k=total)
+            latencies.append((time.perf_counter() - t0) * 1000.0)
+        means.append(statistics.mean(latencies))
+
+    return ExtraCorpusResult(
+        name=name,
+        dim=index.dim,
+        index_nbytes=index.index_nbytes,
+        index_build_ms=build_ms,
+        mean_query_latency_ms_by_run=means,
+    )
+
+
+# ---------------------------------------------------------------------------------------
+# Rendering.
+# ---------------------------------------------------------------------------------------
+
+
+def render_report(
+    results: dict[str, VariantResult],
+    top_ks: tuple[int, ...],
+    corpus_dir: Path,
+    file_count: int,
+    chunk_count: int,
+    query_count: int,
+    repeats: int,
+    extra: dict[str, ExtraCorpusResult] | None,
+    extra_corpus_dir: Path | None,
+) -> str:
+    lines: list[str] = []
+    lines.append("tg dense-leg compression benchmark")
+    lines.append(f"corpus: {corpus_dir} ({file_count} files, {chunk_count} chunks)")
+    lines.append(f"queries: {query_count} (vocabulary-mismatch golden set)")
+    lines.append(f"repeats: {repeats}")
+    lines.append("")
+
+    lines.append("QUALITY (mean over all queries; IDENTICAL across all repeats == deterministic)")
+    header = (
+        "  variant                " + "  ".join(f"{m:>10}" for m in _METRIC_NAMES) + "  determinism"
+    )
+    lines.append(header)
+    for name, result in results.items():
+        row = "  " + f"{name:22} "
+        row += "  ".join(f"{result.mean_metric(m):10.4f}" for m in _METRIC_NAMES)
+        row += f"  {'OK' if result.determinism_ok else 'NON-DETERMINISTIC!'}"
+        lines.append(row)
+    lines.append("")
+
+    lines.append(
+        "LATENCY (mean per-query DenseIndex.query wall-clock, ms -- one column per repeat)"
+    )
+    repeat_header = "  ".join(f"run{i + 1:>7}" for i in range(repeats))
+    lines.append(f"  variant                {repeat_header}      mean   build_ms")
+    for name, result in results.items():
+        per_run = [result.mean_latency_ms(i) for i in range(repeats)]
+        row = "  " + f"{name:22} "
+        row += "  ".join(f"{v:10.4f}" for v in per_run)
+        row += f"  {statistics.mean(per_run):8.4f}  {result.index_build_ms:9.2f}"
+        lines.append(row)
+    lines.append("")
+
+    lines.append(
+        "FOOTPRINT (DenseIndex.index_nbytes, real measured; dim = active scoring dimensionality)"
+    )
+    baseline_nbytes = results["fp32_baseline"].index_nbytes
+    for name, result in results.items():
+        ratio = baseline_nbytes / result.index_nbytes if result.index_nbytes else float("inf")
+        lines.append(
+            f"  {name:22} dim={result.dim:4d}  bytes={result.index_nbytes:10d}  "
+            f"({ratio:6.2f}x smaller than fp32_baseline)"
+        )
+    lines.append("")
+
+    lines.append(
+        "VERDICT (ndcg@10 delta vs fp32_baseline; quality gate is recall@k/ndcg@k >= baseline"
+    )
+    lines.append("         within noise floor AND a real latency/footprint win)")
+    baseline_ndcg10 = results["fp32_baseline"].mean_metric("ndcg@10")
+    baseline_recall10 = results["fp32_baseline"].mean_metric("recall@10")
+    for name, result in results.items():
+        if name == "fp32_baseline":
+            continue
+        ndcg_delta = result.mean_metric("ndcg@10") - baseline_ndcg10
+        recall_delta = result.mean_metric("recall@10") - baseline_recall10
+        lines.append(
+            f"  {name:22} ndcg@10 delta={ndcg_delta:+.4f}  recall@10 delta={recall_delta:+.4f}"
+        )
+    lines.append("")
+
+    if extra is not None and extra_corpus_dir is not None:
+        lines.append(
+            f"EXTRA CORPUS SCALING (latency/footprint only, no golden labels): {extra_corpus_dir}"
+        )
+        for name, extra_result in extra.items():
+            per_run = extra_result.mean_query_latency_ms_by_run
+            row = (
+                f"  {name:22} dim={extra_result.dim:4d}  bytes={extra_result.index_nbytes:10d}  "
+                f"latency_ms_per_run=" + ",".join(f"{v:.4f}" for v in per_run)
+            )
+            lines.append(row)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _report_to_json(
+    results: dict[str, VariantResult],
+    corpus_dir: Path,
+    file_count: int,
+    chunk_count: int,
+    queries: list[GoldenQuery],
+    top_ks: tuple[int, ...],
+    repeats: int,
+    extra: dict[str, ExtraCorpusResult] | None,
+) -> dict[str, Any]:
+    return {
+        "artifact": "bench_dense_compression_quality",
+        "suite": "eval_dense_compression_quality",
+        "generated_at_epoch_s": time.time(),
+        "environment": {
+            "platform": platform.system().lower(),
+            "machine": platform.machine().lower(),
+            "python_version": platform.python_version(),
+        },
+        "corpus": str(corpus_dir),
+        "file_count": file_count,
+        "chunk_count": chunk_count,
+        "query_count": len(queries),
+        "top_ks": list(top_ks),
+        "repeats": repeats,
+        "variants": {
+            name: {
+                "dim": result.dim,
+                "index_nbytes": result.index_nbytes,
+                "index_build_ms": round(result.index_build_ms, 4),
+                "determinism_ok": result.determinism_ok,
+                "quality": {m: round(result.mean_metric(m), 6) for m in _METRIC_NAMES},
+                "mean_latency_ms_by_run": [
+                    round(result.mean_latency_ms(i), 6) for i in range(repeats)
+                ],
+            }
+            for name, result in results.items()
+        },
+        "extra_corpus": (
+            None
+            if extra is None
+            else {
+                name: {
+                    "dim": r.dim,
+                    "index_nbytes": r.index_nbytes,
+                    "index_build_ms": round(r.index_build_ms, 4),
+                    "mean_latency_ms_by_run": [round(v, 6) for v in r.mean_query_latency_ms_by_run],
+                }
+                for name, r in extra.items()
+            }
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Dense-leg compression quality/latency/footprint benchmark."
+    )
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS_DIR)
+    parser.add_argument("--golden", type=Path, default=DEFAULT_GOLDEN_PATH)
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        action="append",
+        dest="top_ks",
+        default=None,
+        help="rank cutoff(s) to report (repeatable; default: 5 and 10)",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=DEFAULT_REPEATS,
+        help="repeat the full query loop this many times (noise-floor discipline; default 2)",
+    )
+    parser.add_argument(
+        "--rescore-candidates",
+        type=int,
+        default=50,
+        help="binary+rescore shortlist size (default 50, mirrors DenseCompressionConfig's default)",
+    )
+    parser.add_argument(
+        "--extra-corpus",
+        type=Path,
+        default=None,
+        help="OPTIONAL second corpus (e.g. a real large source tree) for a latency/footprint-only "
+        "scaling check at a much larger N -- no golden labels required or used.",
+    )
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    top_ks = tuple(args.top_ks) if args.top_ks else DEFAULT_TOP_KS
+    repeats = max(2, args.repeats)  # noise-floor discipline: never fewer than 2 repeats
+
+    try:
+        from tensor_grep.core.retrieval_chunker import chunk_file
+
+        queries = load_golden_queries(args.golden)
+        corpus_files = load_corpus_files(args.corpus)
+        validate_golden_against_corpus(queries, args.corpus)
+
+        chunks = []
+        for path in corpus_files:
+            chunks.extend(chunk_file(path))
+
+        model = build_dense_model()
+        variants = build_variants(args.rescore_candidates)
+
+        results: dict[str, VariantResult] = {}
+        for name, config in variants.items():
+            results[name] = run_variant(
+                name, config, chunks, args.corpus, queries, top_ks, model, repeats=repeats
+            )
+
+        extra_results: dict[str, ExtraCorpusResult] | None = None
+        if args.extra_corpus is not None:
+            if not args.extra_corpus.is_dir():
+                raise EvalError(f"--extra-corpus path does not exist: {args.extra_corpus}")
+            extra_files = sorted(str(p) for p in args.extra_corpus.rglob("*.py") if p.is_file())
+            if not extra_files:
+                raise EvalError(f"--extra-corpus contains no .py files: {args.extra_corpus}")
+            extra_chunks = []
+            for path in extra_files:
+                extra_chunks.extend(chunk_file(path))
+            probe_queries = [q.query for q in queries]  # reuse the same vocab-mismatch prompts
+            extra_results = {}
+            for name, config in variants.items():
+                extra_results[name] = run_extra_corpus_variant(
+                    name, config, extra_chunks, probe_queries, model, repeats=repeats
+                )
+    except EvalError as exc:
+        print(f"tg-eval: ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    report_text = render_report(
+        results,
+        top_ks,
+        args.corpus,
+        len(corpus_files),
+        len(chunks),
+        len(queries),
+        repeats,
+        extra_results,
+        args.extra_corpus,
+    )
+    print(report_text)
+
+    for name, result in results.items():
+        if not result.determinism_ok:
+            print(
+                f"tg-eval: ERROR: variant {name!r} produced non-identical quality metrics across "
+                f"{repeats} repeats (non-deterministic)",
+                file=sys.stderr,
+            )
+            return 1
+
+    payload = _report_to_json(
+        results,
+        args.corpus,
+        len(corpus_files),
+        len(chunks),
+        queries,
+        top_ks,
+        repeats,
+        extra_results,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"\nResults written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tensor_grep/core/retrieval_dense.py
+++ b/src/tensor_grep/core/retrieval_dense.py
@@ -37,6 +37,9 @@ import sys
 import tempfile
 import time
 import urllib.request
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -160,53 +163,340 @@ def _l2_normalize(matrix: np.ndarray) -> np.ndarray:
     return matrix / norms
 
 
+# ---------------------------------------------------------------------------------------------
+# Dense-leg compression (tensor-grep-semantic-search-campaign, dense-leg compression wave):
+# int8 scalar quantization, binary(1-bit)+int8-rescore, and post-hoc dim-truncation. Every lever
+# is opt-in via `DenseCompressionConfig`, default OFF (`DenseCompressionConfig()` is a no-op) --
+# see that class's docstring for the full design rationale. Learning-free, $0, deterministic; no
+# new third-party dependency (pure numpy over the SAME model2vec output this module already
+# produces).
+# ---------------------------------------------------------------------------------------------
+
+
+class DenseQuantizationMode(StrEnum):
+    """Compression mode for :class:`DenseIndex`'s scoring representation. ``NONE`` (the default)
+    is the plain fp32 matrix this module has always used -- selecting it is a byte-identical
+    no-op against the pre-compression code."""
+
+    NONE = "none"
+    INT8 = "int8"
+    BINARY_RESCORE = "binary_rescore"
+
+
+_ENV_DENSE_QUANTIZATION = "TG_SEMANTIC_DENSE_QUANTIZATION"
+_ENV_DENSE_TRUNCATE_DIMS = "TG_SEMANTIC_DENSE_TRUNCATE_DIMS"
+_ENV_DENSE_RESCORE_CANDIDATES = "TG_SEMANTIC_DENSE_RESCORE_CANDIDATES"
+_DEFAULT_RESCORE_CANDIDATES = 50
+
+
+@dataclass(frozen=True)
+class DenseCompressionConfig:
+    """Opt-in, default-OFF compression for :class:`DenseIndex`'s scoring representation.
+
+    Every existing caller that builds a ``DenseIndex`` without passing ``compression=`` gets
+    ``DenseCompressionConfig()`` -- ``quantization=NONE, truncate_dims=None`` -- which is a
+    byte-identical no-op against the fp32 path this module shipped with; nothing about default
+    behavior changes by adding this class.
+
+    Two ORTHOGONAL, freely-combinable levers (both learning-free, $0, deterministic):
+
+    - ``truncate_dims``: keep only the first N dimensions of the embedding (Model2Vec applies PCA
+      as a post-processing step, so the dims are already variance-ordered -- this is principled
+      truncation, not an arbitrary slice), then re-L2-normalize. ``None`` (default) keeps the
+      model's full dimensionality.
+    - ``quantization``: ``NONE`` (fp32, default), ``INT8`` (per-dimension symmetric int8 scalar
+      quantization; dequantized elementwise before the cosine dot product), or
+      ``BINARY_RESCORE`` (sign-bit binarization for an O(N) Hamming-distance shortlist over the
+      WHOLE corpus via packed-byte XOR + popcount, then an int8-dequantized rescore of only the
+      ``rescore_candidates`` closest candidates -- the corpus-scale matmul against every chunk is
+      never computed in this mode).
+
+    Combining ``truncate_dims`` with ``quantization=INT8`` composes both levers (truncate first,
+    then quantize the truncated vectors) -- the "best combo" candidate the campaign specifies.
+    """
+
+    quantization: DenseQuantizationMode = DenseQuantizationMode.NONE
+    truncate_dims: int | None = None
+    rescore_candidates: int = _DEFAULT_RESCORE_CANDIDATES
+
+    def __post_init__(self) -> None:
+        if self.truncate_dims is not None and self.truncate_dims <= 0:
+            raise ValueError(f"truncate_dims must be positive, got {self.truncate_dims}")
+        if self.rescore_candidates <= 0:
+            raise ValueError(f"rescore_candidates must be positive, got {self.rescore_candidates}")
+
+    @property
+    def is_noop(self) -> bool:
+        """``True`` iff this config changes nothing vs. the pre-compression fp32 behavior."""
+        return self.quantization == DenseQuantizationMode.NONE and self.truncate_dims is None
+
+    @classmethod
+    def from_env(cls) -> DenseCompressionConfig:
+        """Read the default-OFF compression knobs from the environment.
+
+        Fail-closed: an unset/blank ``TG_SEMANTIC_DENSE_QUANTIZATION`` resolves to ``NONE`` (the
+        safe, unchanged default), but a SET-and-unrecognized value raises :class:`ValueError`
+        rather than silently falling back to ``NONE`` -- a typo'd env var must never silently
+        no-op the compression the caller thought they were turning on.
+        """
+        raw_mode = os.environ.get(_ENV_DENSE_QUANTIZATION, "").strip().lower()
+        if not raw_mode:
+            quantization = DenseQuantizationMode.NONE
+        else:
+            try:
+                quantization = DenseQuantizationMode(raw_mode)
+            except ValueError:
+                valid = ", ".join(mode.value for mode in DenseQuantizationMode)
+                raise ValueError(
+                    f"{_ENV_DENSE_QUANTIZATION}={raw_mode!r} is not a recognized dense "
+                    f"quantization mode (expected one of: {valid})"
+                ) from None
+
+        raw_truncate = os.environ.get(_ENV_DENSE_TRUNCATE_DIMS, "").strip()
+        try:
+            truncate_dims = int(raw_truncate) if raw_truncate else None
+        except ValueError:
+            raise ValueError(
+                f"{_ENV_DENSE_TRUNCATE_DIMS}={raw_truncate!r} is not a valid integer"
+            ) from None
+
+        raw_candidates = os.environ.get(_ENV_DENSE_RESCORE_CANDIDATES, "").strip()
+        try:
+            rescore_candidates = (
+                int(raw_candidates) if raw_candidates else _DEFAULT_RESCORE_CANDIDATES
+            )
+        except ValueError:
+            raise ValueError(
+                f"{_ENV_DENSE_RESCORE_CANDIDATES}={raw_candidates!r} is not a valid integer"
+            ) from None
+
+        return cls(
+            quantization=quantization,
+            truncate_dims=truncate_dims,
+            rescore_candidates=rescore_candidates,
+        )
+
+
+def _truncate_and_renormalize(matrix: np.ndarray, n_dims: int) -> np.ndarray:
+    """Keep the first ``n_dims`` columns and re-L2-normalize.
+
+    Mathematically equivalent to truncating the RAW vector before its first L2-normalization (a
+    per-row positive scalar division commutes with a fixed column slice: for unit vector
+    ``n = x / ||x||``, ``truncate(n) / ||truncate(n)|| == truncate(x) / ||truncate(x)||``), so
+    this can be applied to an already-normalized matrix without changing the result versus
+    truncating pre-normalization.
+    """
+    return _l2_normalize(matrix[:, :n_dims])
+
+
+_INT8_MAX = 127
+
+
+def _quantize_int8(matrix: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Per-dimension symmetric int8 scalar quantization.
+
+    Returns ``(codes, scale)`` where ``codes`` is ``int8`` shape ``(N, D)`` and ``scale`` is
+    ``float32`` shape ``(D,)``, such that ``codes.astype(float32) * scale`` recovers ``matrix``
+    within ``+/- scale[d] / 2`` per component (the standard round-to-nearest quantization error
+    bound). A column that is exactly all-zero gets ``scale=1.0`` (never a division by zero) and
+    every code in it is exactly ``0``, so it round-trips EXACTLY, not just within a bound.
+
+    Clipping to ``[-127, 127]`` (not the full int8 range down to -128) keeps the quantization
+    symmetric around zero and is ALSO load-bearing correctness, not decoration: rounding a
+    component whose true value sits fractionally above ``127 * scale`` could otherwise produce a
+    code of ``128``, which silently WRAPS to ``-128`` on ``.astype(np.int8)`` (numpy does not
+    clip on integer-cast overflow) -- a wrong-sign corruption, not just extra error.
+    """
+    import numpy as np
+
+    absmax = np.max(np.abs(matrix), axis=0)
+    absmax = np.where(absmax == 0.0, 1.0, absmax)
+    scale = (absmax / _INT8_MAX).astype(np.float32)
+    codes = np.clip(np.round(matrix / scale), -_INT8_MAX, _INT8_MAX).astype(np.int8)
+    return codes, scale
+
+
+def _pack_binary(matrix: np.ndarray) -> np.ndarray:
+    """Sign-bit binarization (``1`` if a component is ``>= 0`` else ``0``), packed 8-per-byte via
+    ``np.packbits`` -- the compact representation the Hamming-distance shortlist scans."""
+    import numpy as np
+
+    bits = (matrix >= 0).astype(np.uint8)
+    return np.packbits(bits, axis=1)
+
+
+_POPCOUNT_BITS: tuple[int, ...] = tuple(bin(i).count("1") for i in range(256))
+
+
+@lru_cache(maxsize=1)
+def _popcount_table() -> np.ndarray:
+    """8-bit popcount lookup table, built once (numpy stays a lazy/optional import at module
+    scope -- see the module docstring's fail-closed contract -- so this cannot be a module-level
+    numpy array literal)."""
+    import numpy as np
+
+    return np.asarray(_POPCOUNT_BITS, dtype=np.uint8)
+
+
+def _hamming_distances(packed_codes: np.ndarray, query_packed: np.ndarray) -> np.ndarray:
+    """Hamming distance from every row of ``packed_codes`` to the single ``query_packed`` code,
+    via byte-wise XOR + the precomputed popcount table (no per-bit Python loop, no per-query
+    table rebuild)."""
+    import numpy as np
+
+    table = _popcount_table()
+    xor = np.bitwise_xor(packed_codes, query_packed)
+    return table[xor].sum(axis=1).astype(np.int64)
+
+
 class DenseIndex:
     """In-memory dense (cosine) index over a chunk corpus.
 
     Vectors are L2-normalized so a plain dot product IS cosine similarity. Chunk text is fed to
     the model RAW -- static embeddings tokenize internally, so this deliberately does NOT reuse
     ``retrieval_lexical.split_terms`` (that tokenizer stays the BM25 leg's alone).
+
+    ``compression`` (default ``None``, treated as ``DenseCompressionConfig()``) is an OPT-IN,
+    default-OFF experimental knob -- see :class:`DenseCompressionConfig`. Every caller in this
+    repo today omits it, and gets exactly the fp32 behavior this class has always had.
     """
 
-    def __init__(self, chunks: list[Chunk], model: Any) -> None:
+    def __init__(
+        self,
+        chunks: list[Chunk],
+        model: Any,
+        *,
+        compression: DenseCompressionConfig | None = None,
+    ) -> None:
         import numpy as np
 
         self.chunks = list(chunks)
         self.model = model
+        self.compression = compression if compression is not None else DenseCompressionConfig()
+        self._dim = 0
+        self._matrix: np.ndarray = np.zeros((0, 0), dtype=np.float32)
+        self._int8_codes: np.ndarray | None = None
+        self._int8_scale: np.ndarray | None = None
+        self._binary_codes: np.ndarray | None = None
         if not self.chunks:
-            self._matrix: np.ndarray = np.zeros((0, 0), dtype=np.float32)
             return
 
         vectors = _encode_matrix(model, [c.text for c in self.chunks])
-        self._matrix = _l2_normalize(vectors)
+        matrix = _l2_normalize(vectors)
+
+        if self.compression.truncate_dims is not None:
+            if self.compression.truncate_dims >= matrix.shape[1]:
+                raise ValueError(
+                    f"truncate_dims={self.compression.truncate_dims} must be less than the "
+                    f"model's embedding dimensionality ({matrix.shape[1]}) -- truncating to a "
+                    "value >= the full dimensionality is a no-op; omit truncate_dims instead of "
+                    "setting it to a non-reducing value"
+                )
+            matrix = _truncate_and_renormalize(matrix, self.compression.truncate_dims)
+
+        self._dim = int(matrix.shape[1])
+
+        if self.compression.quantization == DenseQuantizationMode.NONE:
+            self._matrix = matrix
+        elif self.compression.quantization == DenseQuantizationMode.INT8:
+            self._int8_codes, self._int8_scale = _quantize_int8(matrix)
+        elif self.compression.quantization == DenseQuantizationMode.BINARY_RESCORE:
+            self._binary_codes = _pack_binary(matrix)
+            self._int8_codes, self._int8_scale = _quantize_int8(matrix)
+        else:  # pragma: no cover -- exhaustive enum; defensive only.
+            raise AssertionError(
+                f"unhandled DenseQuantizationMode: {self.compression.quantization!r}"
+            )
 
     @property
     def dim(self) -> int:
-        return int(self._matrix.shape[1]) if self._matrix.size else 0
+        return self._dim
 
-    def query(self, text: str, *, top_k: int = 10) -> list[tuple[int, float]]:
-        """Rank chunks by cosine similarity to ``text``; returns ``(chunk_index, score)`` desc.
+    @property
+    def index_nbytes(self) -> int:
+        """Actual heap footprint (bytes) of the active scoring representation -- the numeric
+        arrays this instance retains, NOT ``self.chunks``/the model. A REAL measured number per
+        compression mode, not an assumed theoretical multiplier."""
+        total = int(self._matrix.nbytes)
+        if self._int8_codes is not None:
+            total += int(self._int8_codes.nbytes)
+        if self._int8_scale is not None:
+            total += int(self._int8_scale.nbytes)
+        if self._binary_codes is not None:
+            total += int(self._binary_codes.nbytes)
+        return total
 
-        Ties break by ascending chunk index (mirrors ``Bm25Index.query``), so results are fully
-        deterministic. Raises :class:`DenseUnavailableError` -- NOT a raw ``IndexError``/
-        ``ValueError`` -- if the query embedding's dimensionality does not match the index's: a
-        defensive shape check so a broken/inconsistent model degrades visibly (BM25-only) instead
-        of crashing deep inside a numpy matrix multiply.
+    def _prepare_query_vec(self, text: str) -> np.ndarray:
+        """Encode + (if configured) truncate + L2-normalize ``text`` into the SAME space the
+        index's chunk vectors live in. Raises :class:`DenseUnavailableError` on a dimensionality
+        mismatch (a broken/inconsistent model), mirroring the pre-compression check exactly.
         """
-        if not self.chunks or self._matrix.size == 0:
-            return []
-
         query_matrix = _encode_matrix(self.model, [text])
-        if query_matrix.shape[1] != self._matrix.shape[1]:
+        if self.compression.truncate_dims is not None:
+            if query_matrix.shape[1] < self.compression.truncate_dims:
+                raise DenseUnavailableError(
+                    "semantic ranking unavailable: query embedding dim "
+                    f"{query_matrix.shape[1]} is smaller than the configured truncate_dims "
+                    f"{self.compression.truncate_dims} (dim mismatch)"
+                )
+            query_matrix = query_matrix[:, : self.compression.truncate_dims]
+        if query_matrix.shape[1] != self._dim:
             raise DenseUnavailableError(
                 "semantic ranking unavailable: query embedding dim "
-                f"{query_matrix.shape[1]} does not match index dim {self._matrix.shape[1]} "
-                "(dim mismatch)"
+                f"{query_matrix.shape[1]} does not match index dim {self._dim} (dim mismatch)"
             )
-        query_vec = _l2_normalize(query_matrix)[0]
-        scores = self._matrix @ query_vec
-        ranked = sorted(enumerate(scores.tolist()), key=lambda item: (-item[1], item[0]))
-        return ranked[:top_k]
+        return _l2_normalize(query_matrix)[0]
+
+    def query(self, text: str, *, top_k: int = 10) -> list[tuple[int, float]]:
+        """Rank chunks by similarity to ``text``; returns ``(chunk_index, score)`` desc.
+
+        Ties break by ascending chunk index (mirrors ``Bm25Index.query``), so results are fully
+        deterministic regardless of ``compression`` mode. Raises :class:`DenseUnavailableError` --
+        NOT a raw ``IndexError``/``ValueError`` -- on a dimensionality mismatch: a defensive shape
+        check so a broken/inconsistent model degrades visibly (BM25-only) instead of crashing deep
+        inside a numpy matrix multiply.
+
+        ``BINARY_RESCORE`` mode returns AT MOST ``compression.rescore_candidates`` results (an
+        honest ANN-shortlist recall bound, not a bug) -- the corpus-scale similarity computation
+        against every chunk is deliberately never performed in that mode.
+        """
+        import numpy as np
+
+        if not self.chunks or self._dim == 0:
+            return []
+
+        query_vec = self._prepare_query_vec(text)
+
+        if self.compression.quantization == DenseQuantizationMode.NONE:
+            scores = self._matrix @ query_vec
+            ranked = sorted(enumerate(scores.tolist()), key=lambda item: (-item[1], item[0]))
+            return ranked[:top_k]
+
+        if self.compression.quantization == DenseQuantizationMode.INT8:
+            assert self._int8_codes is not None and self._int8_scale is not None
+            dequantized = self._int8_codes.astype(np.float32) * self._int8_scale
+            scores = dequantized @ query_vec
+            ranked = sorted(enumerate(scores.tolist()), key=lambda item: (-item[1], item[0]))
+            return ranked[:top_k]
+
+        # BINARY_RESCORE: Hamming-shortlist over the WHOLE corpus (cheap: packed-byte XOR +
+        # popcount), then an int8-dequantized rescore of only the closest `rescore_candidates` --
+        # the full-corpus fp32/int8 matmul is never computed.
+        assert self._binary_codes is not None
+        assert self._int8_codes is not None and self._int8_scale is not None
+        query_packed = _pack_binary(query_vec.reshape(1, -1))[0]
+        hamming = _hamming_distances(self._binary_codes, query_packed)
+        candidate_count = min(self.compression.rescore_candidates, len(self.chunks))
+        shortlist = sorted(range(len(hamming)), key=lambda i: (int(hamming[i]), i))[
+            :candidate_count
+        ]
+        shortlist_idx = np.asarray(shortlist, dtype=np.int64)
+        dequantized_shortlist = (
+            self._int8_codes[shortlist_idx].astype(np.float32) * self._int8_scale
+        )
+        scores = dequantized_shortlist @ query_vec
+        order = sorted(range(len(shortlist)), key=lambda i: (-float(scores[i]), shortlist[i]))
+        return [(shortlist[i], float(scores[i])) for i in order][:top_k]
 
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/unit/test_retrieval_dense_compression.py
+++ b/tests/unit/test_retrieval_dense_compression.py
@@ -1,0 +1,519 @@
+"""Tests for the dense-leg compression levers (int8 scalar quantization, binary+int8-rescore,
+post-hoc dim-truncation) -- tensor-grep-semantic-search-campaign, dense-leg compression.
+
+Every lever is opt-in via :class:`~tensor_grep.core.retrieval_dense.DenseCompressionConfig`,
+default OFF (``DenseCompressionConfig()`` is a no-op). This file proves:
+
+1. The no-op default changes nothing (existing callers, and existing tests in
+   ``test_retrieval_dense.py``, are unaffected).
+2. Config validation is loud/fail-closed (bad env value, non-positive truncate_dims/
+   rescore_candidates, truncate_dims >= the model's real dimensionality).
+3. Each compression mode is internally consistent (round-trip quality bound for int8,
+   Hamming-distance-zero-for-identical-vectors for binary, dimensionality for truncate) and
+   fully deterministic (repeat queries produce byte-identical rankings).
+4. The fail-closed dim-mismatch contract from the original ``DenseIndex.query`` still holds under
+   every compression mode.
+5. ``index_nbytes`` reports a real, measured footprint ordering (int8 < fp32; truncated fp32 <
+   full fp32), not an assumed theoretical multiplier.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import pytest
+
+from tensor_grep.core.retrieval_chunker import Chunk
+from tensor_grep.core.retrieval_dense import (
+    DenseCompressionConfig,
+    DenseIndex,
+    DenseQuantizationMode,
+    DenseUnavailableError,
+    _hamming_distances,
+    _pack_binary,
+    _quantize_int8,
+    _truncate_and_renormalize,
+)
+
+
+class _DeterministicModel:
+    """A tiny duck-typed encoder over a fixed vocabulary of hand-picked unit-ish vectors, so every
+    test in this file is fully deterministic and independent of the real (large, non-committed)
+    potion-code-16M model."""
+
+    dim = 8
+
+    # Each text maps to a fixed raw (pre-normalization) vector. Unknown text -> a zero vector
+    # (edge case some tests exercise deliberately).
+    _VOCAB: ClassVar[dict[str, list[float]]] = {
+        "alpha": [3.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        "beta": [0.0, 3.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0],
+        "gamma": [0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        "near_alpha": [2.7, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+    }
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        rows = [self._VOCAB.get(text, [0.0] * self.dim) for text in texts]
+        return np.asarray(rows, dtype=np.float32)
+
+
+def _make_chunks(names: list[str]) -> list[Chunk]:
+    return [Chunk(file_path=f"{name}.py", start_line=1, end_line=1, text=name) for name in names]
+
+
+# ---------------------------------------------------------------------------------------
+# 1. No-op default -- byte-identical to the pre-compression path.
+# ---------------------------------------------------------------------------------------
+
+
+class TestCompressionDefaultIsNoop:
+    def test_default_config_is_noop(self) -> None:
+        config = DenseCompressionConfig()
+        assert config.is_noop is True
+        assert config.quantization == DenseQuantizationMode.NONE
+        assert config.truncate_dims is None
+
+    def test_omitting_compression_kwarg_matches_explicit_default(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        implicit = DenseIndex(chunks, _DeterministicModel())
+        explicit = DenseIndex(chunks, _DeterministicModel(), compression=DenseCompressionConfig())
+
+        assert implicit.dim == explicit.dim
+        assert implicit.query("alpha") == explicit.query("alpha")
+        assert implicit.query("near_alpha") == explicit.query("near_alpha")
+
+    def test_none_mode_ranking_unchanged_from_baseline_matmul(self) -> None:
+        # Hand-verify against a direct L2-normalize + dot product, independent of DenseIndex
+        # internals, so this test would fail if compression plumbing silently altered the
+        # NONE-mode scoring path.
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        index = DenseIndex(chunks, _DeterministicModel())
+        ranked = index.query("near_alpha", top_k=3)
+
+        model = _DeterministicModel()
+        raw = model.encode([c.text for c in chunks])
+        norms = np.linalg.norm(raw, axis=1, keepdims=True)
+        normalized = raw / norms
+        query_raw = model.encode(["near_alpha"])[0]
+        query_norm = query_raw / np.linalg.norm(query_raw)
+        expected_scores = normalized @ query_norm
+        expected_ranked = sorted(
+            enumerate(expected_scores.tolist()), key=lambda item: (-item[1], item[0])
+        )
+        assert ranked == expected_ranked
+
+
+# ---------------------------------------------------------------------------------------
+# 2. Config validation -- loud, fail-closed.
+# ---------------------------------------------------------------------------------------
+
+
+class TestCompressionConfigValidation:
+    def test_negative_truncate_dims_rejected(self) -> None:
+        with pytest.raises(ValueError, match="truncate_dims"):
+            DenseCompressionConfig(truncate_dims=0)
+
+    def test_negative_rescore_candidates_rejected(self) -> None:
+        with pytest.raises(ValueError, match="rescore_candidates"):
+            DenseCompressionConfig(rescore_candidates=0)
+
+    def test_truncate_dims_at_or_above_model_dim_rejected_at_index_build(self) -> None:
+        chunks = _make_chunks(["alpha", "beta"])
+        config = DenseCompressionConfig(truncate_dims=8)  # == _DeterministicModel.dim
+        with pytest.raises(ValueError, match="truncate_dims"):
+            DenseIndex(chunks, _DeterministicModel(), compression=config)
+
+    def test_from_env_defaults_to_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_QUANTIZATION", raising=False)
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_TRUNCATE_DIMS", raising=False)
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_RESCORE_CANDIDATES", raising=False)
+        config = DenseCompressionConfig.from_env()
+        assert config.is_noop is True
+
+    def test_from_env_reads_int8(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TG_SEMANTIC_DENSE_QUANTIZATION", "int8")
+        config = DenseCompressionConfig.from_env()
+        assert config.quantization == DenseQuantizationMode.INT8
+
+    def test_from_env_reads_truncate_dims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_QUANTIZATION", raising=False)
+        monkeypatch.setenv("TG_SEMANTIC_DENSE_TRUNCATE_DIMS", "128")
+        config = DenseCompressionConfig.from_env()
+        assert config.truncate_dims == 128
+
+    def test_from_env_unrecognized_value_raises_loudly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TG_SEMANTIC_DENSE_QUANTIZATION", "banana")
+        with pytest.raises(ValueError, match="banana"):
+            DenseCompressionConfig.from_env()
+
+    def test_from_env_non_integer_truncate_dims_raises_loudly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_QUANTIZATION", raising=False)
+        monkeypatch.setenv("TG_SEMANTIC_DENSE_TRUNCATE_DIMS", "not-a-number")
+        with pytest.raises(ValueError, match="TG_SEMANTIC_DENSE_TRUNCATE_DIMS"):
+            DenseCompressionConfig.from_env()
+
+    def test_from_env_non_integer_rescore_candidates_raises_loudly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_QUANTIZATION", raising=False)
+        monkeypatch.delenv("TG_SEMANTIC_DENSE_TRUNCATE_DIMS", raising=False)
+        monkeypatch.setenv("TG_SEMANTIC_DENSE_RESCORE_CANDIDATES", "not-a-number")
+        with pytest.raises(ValueError, match="TG_SEMANTIC_DENSE_RESCORE_CANDIDATES"):
+            DenseCompressionConfig.from_env()
+
+
+# ---------------------------------------------------------------------------------------
+# 3a. int8 quantization -- round-trip bound + determinism + ranking sanity.
+# ---------------------------------------------------------------------------------------
+
+
+class TestInt8Quantization:
+    def test_round_trip_within_half_scale_bound(self) -> None:
+        rng = np.random.default_rng(1234)
+        matrix = rng.normal(size=(20, 16)).astype(np.float32)
+        codes, scale = _quantize_int8(matrix)
+        dequantized = codes.astype(np.float32) * scale
+        assert np.all(np.abs(matrix - dequantized) <= (scale / 2.0) + 1e-6)
+
+    def test_all_zero_column_round_trips_exactly(self) -> None:
+        matrix = np.zeros((5, 4), dtype=np.float32)
+        matrix[:, 1] = [1.0, -1.0, 0.5, -0.5, 0.0]
+        codes, scale = _quantize_int8(matrix)
+        assert not np.any(np.isnan(scale))
+        dequantized = codes.astype(np.float32) * scale
+        assert np.allclose(dequantized[:, 0], 0.0)
+        assert np.allclose(dequantized[:, 2], 0.0)
+        assert np.allclose(dequantized[:, 3], 0.0)
+
+    def test_codes_never_overflow_int8_range(self) -> None:
+        rng = np.random.default_rng(99)
+        matrix = rng.normal(scale=5.0, size=(50, 32)).astype(np.float32)
+        codes, _scale = _quantize_int8(matrix)
+        assert codes.dtype == np.int8
+        assert int(codes.max()) <= 127
+        assert int(codes.min()) >= -127
+
+    def test_query_is_deterministic_across_repeated_calls(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.INT8)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        first = index.query("near_alpha")
+        second = index.query("near_alpha")
+        assert first == second
+
+    def test_ranks_nearest_vector_first(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.INT8)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        ranked = index.query("near_alpha")
+        assert ranked[0][0] == 0  # "alpha" chunk index 0 is nearest to "near_alpha"
+
+    def test_dim_mismatch_still_degrades_visibly(self) -> None:
+        chunks = _make_chunks(["alpha", "beta"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.INT8)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+
+        class _WrongDimModel:
+            dim = 3
+
+            def encode(self, texts: list[str]) -> np.ndarray:
+                return np.ones((len(texts), 3), dtype=np.float32)
+
+        index.model = _WrongDimModel()
+        with pytest.raises(DenseUnavailableError, match="dim mismatch"):
+            index.query("alpha")
+
+    def test_index_nbytes_smaller_than_fp32(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma", "near_alpha"])
+        fp32_index = DenseIndex(chunks, _DeterministicModel())
+        int8_index = DenseIndex(
+            chunks,
+            _DeterministicModel(),
+            compression=DenseCompressionConfig(quantization=DenseQuantizationMode.INT8),
+        )
+        assert int8_index.index_nbytes < fp32_index.index_nbytes
+
+
+# ---------------------------------------------------------------------------------------
+# 3b. Binary + int8-rescore -- Hamming shortlist correctness + determinism.
+# ---------------------------------------------------------------------------------------
+
+
+class TestBinaryRescore:
+    def test_hamming_distance_zero_for_identical_packed_codes(self) -> None:
+        matrix = np.array([[1.0, -1.0, 0.5, -0.5]], dtype=np.float32)
+        packed = _pack_binary(matrix)
+        distances = _hamming_distances(packed, packed[0])
+        assert distances.tolist() == [0]
+
+    def test_hamming_distance_counts_differing_sign_bits(self) -> None:
+        a = np.array([[1.0, 1.0, 1.0, 1.0]], dtype=np.float32)
+        b = np.array([[-1.0, -1.0, 1.0, 1.0]], dtype=np.float32)
+        packed_a = _pack_binary(a)
+        packed_b = _pack_binary(b)
+        distances = _hamming_distances(packed_a, packed_b[0])
+        assert distances.tolist() == [2]
+
+    def test_query_is_deterministic_across_repeated_calls(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.BINARY_RESCORE)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        first = index.query("near_alpha")
+        second = index.query("near_alpha")
+        assert first == second
+
+    def test_ranks_nearest_vector_first(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.BINARY_RESCORE)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        ranked = index.query("near_alpha")
+        assert ranked[0][0] == 0
+
+    def test_result_count_bounded_by_rescore_candidates(self) -> None:
+        names = [f"chunk{i}" for i in range(20)]
+        chunks = _make_chunks(names)
+
+        class _RandomUnitModel:
+            dim = 8
+
+            def encode(self, texts: list[str]) -> np.ndarray:
+                rng = np.random.default_rng(abs(hash(tuple(texts))) % (2**31))
+                return rng.normal(size=(len(texts), 8)).astype(np.float32)
+
+        config = DenseCompressionConfig(
+            quantization=DenseQuantizationMode.BINARY_RESCORE, rescore_candidates=5
+        )
+        index = DenseIndex(chunks, _RandomUnitModel(), compression=config)
+        ranked = index.query("anything", top_k=20)
+        assert len(ranked) <= 5
+
+    def test_dim_mismatch_still_degrades_visibly(self) -> None:
+        chunks = _make_chunks(["alpha", "beta"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.BINARY_RESCORE)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+
+        class _WrongDimModel:
+            dim = 3
+
+            def encode(self, texts: list[str]) -> np.ndarray:
+                return np.ones((len(texts), 3), dtype=np.float32)
+
+        index.model = _WrongDimModel()
+        with pytest.raises(DenseUnavailableError, match="dim mismatch"):
+            index.query("alpha")
+
+    def test_index_nbytes_much_smaller_than_fp32(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma", "near_alpha"])
+        fp32_index = DenseIndex(chunks, _DeterministicModel())
+        binary_index = DenseIndex(
+            chunks,
+            _DeterministicModel(),
+            compression=DenseCompressionConfig(quantization=DenseQuantizationMode.BINARY_RESCORE),
+        )
+        assert binary_index.index_nbytes < fp32_index.index_nbytes
+
+
+# ---------------------------------------------------------------------------------------
+# 3c. Post-hoc dim-truncation -- dimensionality + math-identity + determinism.
+# ---------------------------------------------------------------------------------------
+
+
+class TestTruncation:
+    def test_truncate_and_renormalize_matches_manual_computation(self) -> None:
+        matrix = np.array([[3.0, 4.0, 0.0, 12.0]], dtype=np.float32)  # norm = 13
+        truncated = _truncate_and_renormalize(matrix, 2)  # keep [3, 4], norm=5
+        assert truncated.shape == (1, 2)
+        np.testing.assert_allclose(truncated, [[0.6, 0.8]], atol=1e-6)
+
+    def test_truncate_commutes_with_prior_l2_normalize(self) -> None:
+        # Truncating a RAW vector then normalizing must equal normalizing-then-truncating-then-
+        # renormalizing (the module's documented commutativity claim) -- verified directly here,
+        # independent of DenseIndex, on a non-trivial random vector.
+        rng = np.random.default_rng(7)
+        raw = rng.normal(size=(1, 10)).astype(np.float32)
+
+        direct = raw[:, :4] / np.linalg.norm(raw[:, :4], axis=1, keepdims=True)
+
+        normalized_first = raw / np.linalg.norm(raw, axis=1, keepdims=True)
+        via_normalize_first = _truncate_and_renormalize(normalized_first, 4)
+
+        np.testing.assert_allclose(direct, via_normalize_first, atol=1e-6)
+
+    def test_index_dim_reflects_truncation(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(truncate_dims=4)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        assert index.dim == 4
+
+    def test_query_is_deterministic_across_repeated_calls(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(truncate_dims=4)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        first = index.query("near_alpha")
+        second = index.query("near_alpha")
+        assert first == second
+
+    def test_ranks_nearest_vector_first(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(truncate_dims=4)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        ranked = index.query("near_alpha")
+        assert ranked[0][0] == 0
+
+    def test_index_nbytes_smaller_than_full_dim(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma", "near_alpha"])
+        fp32_index = DenseIndex(chunks, _DeterministicModel())
+        truncated_index = DenseIndex(
+            chunks, _DeterministicModel(), compression=DenseCompressionConfig(truncate_dims=4)
+        )
+        assert truncated_index.index_nbytes < fp32_index.index_nbytes
+
+    def test_dim_mismatch_still_degrades_visibly(self) -> None:
+        chunks = _make_chunks(["alpha", "beta"])
+        config = DenseCompressionConfig(truncate_dims=4)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+
+        class _WrongDimModel:
+            dim = 2
+
+            def encode(self, texts: list[str]) -> np.ndarray:
+                return np.ones((len(texts), 2), dtype=np.float32)
+
+        index.model = _WrongDimModel()
+        with pytest.raises(DenseUnavailableError, match="dim mismatch"):
+            index.query("alpha")
+
+
+# ---------------------------------------------------------------------------------------
+# 3d. Combo: truncate + int8 together.
+# ---------------------------------------------------------------------------------------
+
+
+class TestTruncateInt8Combo:
+    def test_combo_builds_and_queries(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma"])
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.INT8, truncate_dims=4)
+        index = DenseIndex(chunks, _DeterministicModel(), compression=config)
+        assert index.dim == 4
+        ranked = index.query("near_alpha")
+        assert ranked[0][0] == 0
+
+    def test_combo_index_nbytes_smaller_than_int8_alone(self) -> None:
+        chunks = _make_chunks(["alpha", "beta", "gamma", "near_alpha"])
+        int8_only = DenseIndex(
+            chunks,
+            _DeterministicModel(),
+            compression=DenseCompressionConfig(quantization=DenseQuantizationMode.INT8),
+        )
+        combo = DenseIndex(
+            chunks,
+            _DeterministicModel(),
+            compression=DenseCompressionConfig(
+                quantization=DenseQuantizationMode.INT8, truncate_dims=4
+            ),
+        )
+        assert combo.index_nbytes < int8_only.index_nbytes
+
+
+# ---------------------------------------------------------------------------------------
+# 4. Empty-corpus edge case under every mode -- never crashes, never a fabricated result.
+# ---------------------------------------------------------------------------------------
+
+
+class TestEmptyCorpusUnderCompression:
+    @pytest.mark.parametrize(
+        "config",
+        [
+            DenseCompressionConfig(),
+            DenseCompressionConfig(quantization=DenseQuantizationMode.INT8),
+            DenseCompressionConfig(quantization=DenseQuantizationMode.BINARY_RESCORE),
+            DenseCompressionConfig(truncate_dims=4),
+        ],
+    )
+    def test_empty_chunks_query_returns_empty(self, config: DenseCompressionConfig) -> None:
+        index = DenseIndex([], _DeterministicModel(), compression=config)
+        assert index.dim == 0
+        assert index.query("anything") == []
+
+
+# ---------------------------------------------------------------------------------------
+# 5. Real fetched model (not mocked) -- mirrors test_retrieval_dense.py's TestRealFetchedModel:
+# per the failure-archaeology mock-green trap, prove every compression mode against the ACTUAL
+# installed model2vec + fetched potion-code-16M model, not just synthetic vectors.
+# ---------------------------------------------------------------------------------------
+
+
+def _real_dense_model_dir():
+    from tensor_grep.core.retrieval_dense import default_model_dir
+
+    candidate = default_model_dir()
+    return candidate if candidate.is_dir() else None
+
+
+@pytest.mark.skipif(
+    _real_dense_model_dir() is None,
+    reason="requires the real fetched minishlab/potion-code-16M model (local dev only, not "
+    "committed; CI does not fetch it -- this test exercises the ACTUAL model + every "
+    "compression mode when present)",
+)
+class TestRealFetchedModelCompression:
+    """Exercises the ACTUAL installed model2vec + fetched potion-code-16M model under each
+    compression mode -- not a mock. Same vocab-mismatch sanity case
+    ``test_retrieval_dense.py::TestRealFetchedModel`` uses for the uncompressed leg."""
+
+    def _chunks(self) -> list[Chunk]:
+        return [
+            Chunk(
+                file_path="auth.py",
+                start_line=1,
+                end_line=2,
+                text=(
+                    "def authenticate_user(username, password):\n"
+                    "    return check_credentials(username, password)\n"
+                ),
+            ),
+            Chunk(
+                file_path="conn.py",
+                start_line=1,
+                end_line=2,
+                text="def close_connection(conn):\n    conn.dispose()\n",
+            ),
+        ]
+
+    def test_int8_ranks_vocab_mismatch_queries_correctly(self) -> None:
+        from tensor_grep.core.retrieval_dense import load_dense_model
+
+        model = load_dense_model(_real_dense_model_dir())
+        config = DenseCompressionConfig(quantization=DenseQuantizationMode.INT8)
+        index = DenseIndex(self._chunks(), model, compression=config)
+
+        assert index.query("verify login")[0][0] == 0  # authenticate_user ranks first
+        assert index.query("tear down")[0][0] == 1  # close_connection ranks first
+
+    def test_binary_rescore_ranks_vocab_mismatch_queries_correctly(self) -> None:
+        from tensor_grep.core.retrieval_dense import load_dense_model
+
+        model = load_dense_model(_real_dense_model_dir())
+        config = DenseCompressionConfig(
+            quantization=DenseQuantizationMode.BINARY_RESCORE, rescore_candidates=2
+        )
+        index = DenseIndex(self._chunks(), model, compression=config)
+
+        assert index.query("verify login")[0][0] == 0
+        assert index.query("tear down")[0][0] == 1
+
+    def test_truncate_128_ranks_vocab_mismatch_queries_correctly(self) -> None:
+        from tensor_grep.core.retrieval_dense import load_dense_model
+
+        model = load_dense_model(_real_dense_model_dir())
+        config = DenseCompressionConfig(truncate_dims=128)
+        index = DenseIndex(self._chunks(), model, compression=config)
+
+        assert index.dim == 128
+        assert index.query("verify login")[0][0] == 0
+        assert index.query("tear down")[0][0] == 1


### PR DESCRIPTION
## Summary

Per the CEO research assignment (dense-leg compression campaign), this adds three
learning-free, $0, deterministic compression levers to `DenseIndex`'s scoring
representation in `core/retrieval_dense.py`:

- **int8**: per-dimension symmetric scalar quantization, dequantized elementwise
  before the cosine dot product.
- **binary_rescore**: sign-bit binarization (`np.packbits`) for an O(N) Hamming-distance
  shortlist over the WHOLE corpus (byte-XOR + popcount lookup table), then an
  int8-dequantized rescore of only the closest `rescore_candidates` (default 50) --
  the corpus-scale matmul against every chunk is never computed in this mode.
- **truncate_dims**: post-hoc dimension truncation (Model2Vec applies PCA as a
  post-processing step, so the kept dims are the highest-variance ones), freely
  composable with int8 (the "combo" candidate).

All three are gated by a **new `DenseCompressionConfig` dataclass, default
`DenseCompressionConfig()` == a byte-identical no-op** (`quantization=NONE,
truncate_dims=None`). `DenseIndex.__init__` gained one new keyword-only parameter
(`compression: DenseCompressionConfig | None = None`); every existing 2-arg call site
(`reranker.py`, `cli/main.py`, all pre-existing tests) is untouched and behaviorally
identical -- verified by a byte-for-byte `git diff` showing `dense_available()` /
`load_dense_model()` / `default_model_dir()` unchanged. Also readable from the
environment via `DenseCompressionConfig.from_env()` (`TG_SEMANTIC_DENSE_QUANTIZATION`,
`TG_SEMANTIC_DENSE_TRUNCATE_DIMS`, `TG_SEMANTIC_DENSE_RESCORE_CANDIDATES`) -- fail-closed:
an unrecognized value raises loudly rather than silently no-opping.

**No CLI/command wiring in this PR** -- this is a library-level opt-in surface only,
per the campaign's scope. `--rank`/`--bm25`/`--semantic` semantics are unchanged.

New benchmark: `benchmarks/eval_dense_compression_quality.py`, which measures every
variant against the fp32 baseline on the SAME realistic, purpose-hardened
vocabulary-mismatch golden corpus already gating the late-rerank promotion decision
(`benchmarks/datasets/find_golden_corpus/` + `late_rerank_golden.jsonl`, 74 files / 40
queries across concept/behavior/error-message/config categories -- BM25 scores near
the floor on this corpus by construction, unlike the toy `eval_bm25_quality.py`
corpus which saturates at recall 1.0 and would prove nothing here).

## Evidence

Fp32-baseline dense-arm numbers cross-validate exactly against the existing
`eval_late_rerank_quality.py` harness's "dense" arm (recall@5=0.750, recall@10=0.900,
ndcg@10=0.6026, mrr=0.5072) -- an independent correctness check that both harnesses
compute the same thing.

### Quality (mean over 40 queries; IDENTICAL bit-for-bit across 2 independent process
runs with 2 and 3 repeats respectively -- this is a deterministic algorithm, not a
noisy one, so "noise floor" here means the delta size, not run-to-run variance)

| variant | recall@5 | recall@10 | ndcg@5 | ndcg@10 | mrr |
|---|---|---|---|---|---|
| fp32_baseline | 0.7500 | 0.9000 | 0.5532 | 0.6026 | 0.5072 |
| **int8** | 0.7500 (=) | 0.9000 (=) | 0.5564 (+.0032) | 0.6059 (+.0033) | 0.5113 (+.0041) |
| binary_rescore_k50 | 0.7500 (=) | 0.8500 (-.05) | 0.5564 (+.0032) | 0.5897 (-.0129) | 0.5047 (-.0025) |
| truncate_128 | 0.7000 (-.05) | 0.8500 (-.05) | 0.5346 (-.0186) | 0.5839 (-.0187) | 0.4997 (-.0075) |
| truncate_96 | 0.7250 (-.025) | 0.8750 (-.025) | 0.5535 (+.0003) | 0.6036 (+.0010) | 0.5179 (+.0107) |
| truncate_64 | 0.6750 (-.075) | 0.8000 (-.10) | 0.4907 (-.0625) | 0.5308 (-.0718) | 0.4443 (-.0629) |
| truncate_128_int8 (combo) | 0.7000 (-.05) | 0.8500 (-.05) | 0.5346 (-.0186) | 0.5839 (-.0187) | 0.4997 (-.0075) |

### Latency (mean per-query `DenseIndex.query` wall-clock, ms -- 74-file golden
corpus, TWO fully independent process invocations, repeats=2 and repeats=3)

| variant | run A (2x) | run B (3x) | direction vs fp32 |
|---|---|---|---|
| fp32_baseline | 0.346 / 0.371 | 0.350 / 0.399 / 0.376 | baseline |
| int8 | 0.444 / 0.429 | 0.455 / 0.460 / 0.450 | 22-27% SLOWER |
| binary_rescore_k50 | 0.506 / 0.561 | 0.513 / 0.506 / 0.508 | 41-49% SLOWER |
| truncate_128 | 0.389 / 0.396 | 0.382 / 0.400 / 0.402 | roughly flat |
| truncate_96 | 0.410 / 0.407 | 0.376 / 0.402 / 0.407 | roughly flat |
| truncate_64 | 0.389 / 0.398 | 0.399 / 0.400 / 0.385 | roughly flat |
| truncate_128_int8 (combo) | 0.416 / 0.431 | 0.406 / 0.416 / 0.430 | ~13-20% slower |

At a much larger N=3246 (this repo's own `src/tensor_grep` tree, chunked;
latency/footprint only, no gold labels -- the 2nd real corpus for this dimension):

| variant | dim | bytes | latency ms (2 repeats) | direction vs fp32 |
|---|---|---|---|---|
| fp32_baseline | 256 | 3,323,904 | 1.964 / 1.829 | baseline |
| int8 | 256 | 832,000 | 4.168 / 3.832 | ~2.1x SLOWER (gets relatively worse with N, not better) |
| binary_rescore_k50 | 256 | 935,872 | 2.388 / 2.168 | ~22% slower (down from ~45% slower at N=74 -- narrowing but NOT crossed over; unproven beyond N=3246) |
| truncate_128 | 128 | 1,661,952 | 1.750 / 1.947 | roughly flat to slightly faster |
| truncate_96 | 96 | 1,246,464 | 1.877 / 1.766 | ~4-10% faster (small real win) |
| truncate_64 | 64 | 830,976 | 1.949 / 1.705 | roughly flat |
| truncate_128_int8 (combo) | 128 | 416,000 | 2.809 / 2.767 | ~43% slower |

**Important honest finding**: int8 and binary+rescore do NOT deliver a CPU latency win
in this pure-numpy implementation -- the elementwise dequantize-on-score tax (no
BLAS/SIMD int8 GEMM path in plain numpy) costs more than the reduced memory traffic
saves. The literature's "up to 45x faster" figures require hardware int8 SIMD (e.g.
AVX512-VNNI via FAISS) this repo does not have. Only dimension truncation shows a
plausible, mechanistically-clean latency benefit (fewer FLOPs per matmul), and even
that is small (0-10%).

### Footprint (real measured `DenseIndex.index_nbytes`, exactly verified against the
byte-accounting arithmetic by hand)

| variant | dim | bytes (N=74) | vs fp32 |
|---|---|---|---|
| fp32_baseline | 256 | 75,776 | 1.00x |
| int8 | 256 | 19,968 | 3.79x smaller |
| binary_rescore_k50 | 256 | 22,336 | 3.39x smaller |
| truncate_128 | 128 | 37,888 | 2.00x smaller |
| truncate_96 | 96 | 28,416 | 2.67x smaller |
| truncate_64 | 64 | 18,944 | 4.00x smaller |
| truncate_128_int8 (combo) | 128 | 9,984 | 7.59x smaller (best) |

## Verdict (per-variant, gate = quality within noise floor of fp32 AND a real
latency/footprint win -- gate NOT weakened)

- **int8 CLEARS.** Quality: every metric ties or beats fp32 (no regression on any of
  5 metrics). Footprint: real ~3.79x reduction. Caveat that MUST travel with any
  promotion: NO latency win -- it is measurably slower (worse at larger N, not
  better). Promote ONLY as a memory/disk-footprint lever; never market as "faster."
- **truncate_96**: a genuine near-miss, NOT promoted. ndcg@10/mrr net positive but
  recall@5 and recall@10 both dip by exactly 1/40 queries; footprint (2.67x) and
  latency (small, real) are favorable. Flagged as the strongest candidate for
  validation on a second LABELED corpus before a promotion decision (only 1 golden
  corpus was available for the quality dimension in this campaign).
- **binary_rescore_k50, truncate_128, truncate_128_int8 (combo), truncate_64:
  REJECTED.** Each shows a real (not noise-level) recall@10 regression (-0.05 to
  -0.10, i.e. 2-4 of 40 queries) without a compensating clean latency win at the
  tested scale/config. Interestingly, these are the two candidates the task
  suggested as "the likely sweet spot" (int8+rescore, truncate-128) -- the
  measurement disagrees with that prior, which is exactly why this is measured
  rather than assumed.

## Test plan

- `uv run --no-sync pytest tests/unit/test_retrieval_dense_compression.py tests/unit/test_retrieval_dense.py tests/unit/test_retrieval_dense_fetch.py` -- 70 passed (37 new contract tests + 3 new real-fetched-model tests + all 28 pre-existing tests unaffected).
- `uv run --no-sync ruff check` / `ruff format --check --preview` / `mypy src/tensor_grep` (81 files) -- all clean.
- Full `tests/unit/` suite (5433 tests): 11 pre-existing failures, ALL confirmed unrelated to this diff (5 are CLI `--help` text-content-drift tests in `cli/main.py`/`cli/bootstrap.py`, files this PR never touches; 3 are `test_retrieval_late.py` failures from a missing `onnxruntime` extra I did not need to install; 2 are `test_eval_late_rerank_quality.py` tests whose own docstrings assume the `semantic` extra is ambiently absent, which I locally installed to run these benchmarks -- confirmed via `git diff` that `dense_available`/`load_dense_model`/`default_model_dir` are byte-identical to before this PR).
- Benchmark commands used (real fetched `potion-code-16M` model, not mocked):
  - `uv run --no-sync python benchmarks/eval_dense_compression_quality.py`
  - `uv run --no-sync python benchmarks/eval_dense_compression_quality.py --repeats 3`
  - `uv run --no-sync python benchmarks/eval_dense_compression_quality.py --extra-corpus src/tensor_grep`

## Needs before any default-flip

This PR ships the mechanism default-OFF only. Per tensor-grep-change-control /
tensor-grep-semantic-search-campaign Phase 5: needs an **independent Opus gate** +
explicit **change-control conscious flag-flip** before `int8` (or any variant)
becomes a default, and before any CLI/`tg find`/`tg search --semantic` wiring is
added. Never auto-merge.

Generated with Claude Code (Opus 4.8).
