### PR TITLE
fix(agent-capsule): down-weight thin CLI-dispatcher wrappers in primary-target ranking (#250)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -337,6 +337,84 @@ def _prefer_implementation_over_marker_helper(
     return implementation, demoted
 
 
+def _cli_dispatcher_implementation_candidate(
+    primary_target: dict[str, Any],
+    alternatives: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Task #250: return the alternative a thin CLI-dispatcher primary target provably calls
+    through to, or ``None`` if the primary is not a provable pass-through.
+
+    Conservative by design: a bare "primary lives under cli/" is NOT enough on its own --
+    `cli/main.py` is the CORRECT target for plenty of tasks (e.g. "add a --flag to tg search",
+    where the flag registration itself lives in that Typer command's own signature). This only
+    fires when BOTH:
+
+      1. the primary symbol is decorated as a Typer/Click command (``@x.command(...)``) -- the
+         structural signature of a dispatcher, not a guess from its name or lexical score; and
+      2. the primary symbol's OWN body (``_thin_cli_dispatcher_call_targets`` -- a bounded,
+         already-selected span, not a new scan) contains a direct call to a SPECIFIC alternative
+         candidate's symbol, defined in a DIFFERENT file -- i.e. the dispatcher hands off to that
+         exact implementation.
+
+    Real repro (task #250): ``tg prepare`` resolving "fix the ledger claim TTL logic" to
+    ``cli/main.py``'s ``ledger_claim`` (a ``@ledger_app.command("claim")`` dispatcher whose body
+    is a single call to ``ledger_store.submit_claim(...)``) instead of the real implementation in
+    ``cli/ledger_store.py``, purely because ``ledger_claim`` happens to lexically match both
+    query words at once. This helper recognizes that shape and prefers the callee.
+    """
+    file_path = str(primary_target.get("file") or "")
+    symbol_name = str(primary_target.get("symbol") or "")
+    if not file_path or not symbol_name:
+        return None
+    if str(primary_target.get("kind") or "") not in {"function", "method"}:
+        return None
+
+    candidates = [
+        alternative
+        for alternative in alternatives
+        if str(alternative.get("symbol") or "")
+        and str(alternative.get("file") or "") not in ("", file_path)
+        and str(alternative.get("kind") or "") in {"function", "method"}
+    ]
+    if not candidates:
+        return None
+
+    line = primary_target.get("line")
+    expected_line: int | None = None
+    if isinstance(line, int):
+        expected_line = line
+    elif isinstance(line, str) and line.isdigit():
+        expected_line = int(line)
+    called_names = repo_map._thin_cli_dispatcher_call_targets(
+        file_path, symbol_name, expected_line=expected_line
+    )
+    if not called_names:
+        return None
+
+    matched = [candidate for candidate in candidates if str(candidate["symbol"]) in called_names]
+    if not matched:
+        return None
+    matched.sort(key=lambda candidate: _numeric_confidence(candidate.get("confidence"), 0.0))
+    return matched[-1]
+
+
+def _prefer_implementation_over_cli_dispatcher_helper(
+    primary_target: dict[str, Any],
+    alternatives: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Analogous to `_prefer_implementation_over_marker_helper` above (task #250): when the
+    primary target is a provable thin CLI-dispatcher call-through
+    (`_cli_dispatcher_implementation_candidate`), swap it with the specific implementation
+    alternative it calls -- the dispatcher becomes a (still-surfaced) alternative instead of
+    silently disappearing, so the same tie/ambiguity signals still apply downstream."""
+    implementation = _cli_dispatcher_implementation_candidate(primary_target, alternatives)
+    if implementation is None:
+        return primary_target, alternatives
+    demoted = [alternative for alternative in alternatives if alternative is not implementation]
+    demoted.insert(0, primary_target)
+    return implementation, demoted
+
+
 def _dedupe(values: list[str]) -> list[str]:
     return list(dict.fromkeys(values))
 
@@ -2014,10 +2092,12 @@ def _capsule_confidence_and_ask_without_render(
     scan_truncated = _capsule_scan_incomplete(payload)
     # Build target + alternatives EXACTLY as `build_agent_capsule_from_map` does (agent_capsule.py:
     # `target = _primary_target(...)` -> `_alternative_targets(...)[:4]` ->
-    # `_prefer_implementation_over_marker_helper`), so tie/marker detection sees the same inputs.
+    # `_prefer_implementation_over_marker_helper` -> `_prefer_implementation_over_cli_dispatcher_
+    # helper`), so tie/marker/dispatcher detection sees the same inputs.
     target = _primary_target(payload)
     alternatives = _alternative_targets(payload, target, limit=None)[:4]
     target, alternatives = _prefer_implementation_over_marker_helper(query, target, alternatives)
+    target, alternatives = _prefer_implementation_over_cli_dispatcher_helper(target, alternatives)
 
     edit_plan_seed = _as_dict(payload.get("edit_plan_seed"))
     validation_plan = _as_list_of_dicts(edit_plan_seed.get("validation_plan"))
@@ -2638,6 +2718,7 @@ def build_agent_capsule_from_map(
     all_alternatives = _alternative_targets(payload, target, limit=None)
     alternatives = all_alternatives[:4]
     target, alternatives = _prefer_implementation_over_marker_helper(query, target, alternatives)
+    target, alternatives = _prefer_implementation_over_cli_dispatcher_helper(target, alternatives)
     # T2: capture the RAW pre-cap seed confidence now, before any of this function's own trust/
     # tie/budget caps mutate `target["confidence"]` in place -- `_collect_capsule_call_site_evidence`
     # must gate on this seed value, not the post-cap one, or a capped target could never earn the

--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -341,17 +341,26 @@ def _cli_dispatcher_implementation_candidate(
     primary_target: dict[str, Any],
     alternatives: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """Task #250: return the alternative a thin CLI-dispatcher primary target provably calls
-    through to, or ``None`` if the primary is not a provable pass-through.
+    """Task #250: return the alternative a GENUINELY THIN CLI-dispatcher primary target provably
+    calls through to, or ``None`` if the primary is not a provable thin pass-through.
 
     Conservative by design: a bare "primary lives under cli/" is NOT enough on its own --
     `cli/main.py` is the CORRECT target for plenty of tasks (e.g. "add a --flag to tg search",
     where the flag registration itself lives in that Typer command's own signature). This only
-    fires when BOTH:
+    fires when ALL THREE hold (all three are checked inside
+    ``repo_map._thin_cli_dispatcher_call_targets``, gate NIT-1 on #693):
 
       1. the primary symbol is decorated as a Typer/Click command (``@x.command(...)``) -- the
-         structural signature of a dispatcher, not a guess from its name or lexical score; and
-      2. the primary symbol's OWN body (``_thin_cli_dispatcher_call_targets`` -- a bounded,
+         structural signature of a dispatcher, not a guess from its name or lexical score;
+      2. the primary symbol is STRUCTURALLY small -- at most
+         ``repo_map._THIN_DISPATCHER_MAX_BODY_STATEMENTS`` top-level body statements (docstring
+         excluded) and at most ``repo_map._THIN_DISPATCHER_MAX_CALL_TARGETS`` distinct callee
+         names. Decoration alone is NOT sufficient: an independent review found
+         ``search_command`` (the real, ~1500-line implementation of ``tg search`` in
+         ``cli/main.py``) is ALSO a ``.command``-decorated function that calls dozens of names --
+         without this size gate, the swap's safety would be an EMERGENT property of which names
+         happen to rank as alternatives, not a real structural guarantee; and
+      3. the primary symbol's OWN body (``_thin_cli_dispatcher_call_targets`` -- a bounded,
          already-selected span, not a new scan) contains a direct call to a SPECIFIC alternative
          candidate's symbol, defined in a DIFFERENT file -- i.e. the dispatcher hands off to that
          exact implementation.

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -6935,20 +6935,42 @@ def _is_cli_command_module_path(file_path: str) -> bool:
     return "cli" in parts
 
 
+# Task #250 gate NIT-1: a REAL thinness gate, not just "decorated as a command + calls
+# something" -- an independent Opus review on #693 found that shape alone is an EMERGENT ranking
+# property, not a structural guarantee: `search_command` (cli/main.py, the real ~1500-line
+# implementation of `tg search` itself) is ALSO a `.command`-decorated function that calls dozens
+# of other names, and would be treated identically to a genuine one-line passthrough if any one of
+# its many callees ever happened to surface as a top-4 alternative for some query. The swap must
+# only fire on a function that is STRUCTURALLY small, not merely "decorated + calls the right
+# name". Calibrated against the two known genuine dispatcher shapes in this repo -- `ledger_claim`
+# (10 top-level body statements, 14 distinct callee names, docstring excluded from both counts) and
+# `ledger_release` (6 / 10) -- versus the one known fat command, `search_command` (89 / 104). Both
+# real dispatchers sit at or under 15 on each axis; `search_command` sits 6-10x over. 20 leaves
+# roughly 2x headroom above the largest observed genuine dispatcher on each axis while staying far
+# below any real implementation function measured in this repo.
+_THIN_DISPATCHER_MAX_BODY_STATEMENTS = 20
+_THIN_DISPATCHER_MAX_CALL_TARGETS = 20
+
+
 def _thin_cli_dispatcher_call_targets(
     file_path: str, symbol_name: str, *, expected_line: int | None = None
 ) -> set[str] | None:
-    """Task #250: does ``symbol_name`` (defined in ``file_path``) look like a thin Typer/Click
-    command dispatcher -- decorated with a ``.command(...)`` registration -- and if so, what
-    names does its body call?
+    """Task #250: does ``symbol_name`` (defined in ``file_path``) look like a GENUINELY THIN
+    Typer/Click command dispatcher -- decorated with a ``.command(...)`` registration AND small
+    enough on both axes below to be structurally a passthrough, not a real implementation -- and
+    if so, what names does its body call?
 
-    Returns ``None`` when the file can't be parsed, the symbol isn't a function/method, or it is
-    NOT decorated as a command -- i.e. not provably a dispatcher, so the caller must leave the
-    primary target alone (this is what protects a genuine ``cli/main.py`` target, e.g. "add a
-    --flag to tg search", from ever being demoted). Returns the -- possibly empty -- set of names
-    the body calls otherwise; the caller intersects this against alternative-candidate symbol
-    names to find the SPECIFIC implementation a dispatcher hands off to (e.g. ``ledger_claim``'s
-    body calling ``ledger_store.submit_claim(...)``).
+    Returns ``None`` when the file can't be parsed, the symbol isn't a function/method, it is NOT
+    decorated as a command, OR it exceeds ``_THIN_DISPATCHER_MAX_BODY_STATEMENTS`` top-level body
+    statements (docstring excluded) or ``_THIN_DISPATCHER_MAX_CALL_TARGETS`` distinct callee
+    names -- i.e. not provably a THIN dispatcher, so the caller must leave the primary target
+    alone. This is what protects a genuine ``cli/main.py`` target, e.g. ``search_command`` (see
+    the constants' docstring above) or "add a --flag to tg search", from ever being demoted: a
+    big command is rejected here regardless of whether one of its many callees happens to match an
+    alternative candidate's name. Returns the -- possibly empty -- set of names the (small) body
+    calls otherwise; the caller intersects this against alternative-candidate symbol names to find
+    the SPECIFIC implementation a dispatcher hands off to (e.g. ``ledger_claim``'s body calling
+    ``ledger_store.submit_claim(...)``).
 
     Reuses ``_read_source_text_cached``/``_cached_ast_parse`` (both content-addressed -- a cache
     HIT, not a re-read/re-parse, for a file already scanned earlier in this same process) and
@@ -6984,6 +7006,15 @@ def _thin_cli_dispatcher_call_targets(
     if "command" not in decorator_names:
         return None
 
+    # Structural thinness gate (NIT-1): count top-level body statements, excluding a leading
+    # docstring (boilerplate that scales with how well-documented a command is, not with its
+    # implementation size) so a thoroughly-documented thin dispatcher isn't unfairly penalized.
+    body = match.body
+    if body and ast.get_docstring(match, clean=False) is not None:
+        body = body[1:]
+    if len(body) > _THIN_DISPATCHER_MAX_BODY_STATEMENTS:
+        return None
+
     called_names: set[str] = set()
     for call_node in ast.walk(match):
         if not isinstance(call_node, ast.Call):
@@ -6993,6 +7024,8 @@ def _thin_cli_dispatcher_call_targets(
             called_names.add(func.id)
         elif isinstance(func, ast.Attribute):
             called_names.add(func.attr)
+    if len(called_names) > _THIN_DISPATCHER_MAX_CALL_TARGETS:
+        return None
     return called_names
 
 

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -6918,6 +6918,84 @@ def _symbol_span_length(symbol: dict[str, Any]) -> int:
     return max(1, end_line - start_line + 1)
 
 
+def _is_cli_command_module_path(file_path: str) -> bool:
+    """No-I/O, path-only check: does ``file_path`` live under a ``cli/`` package? Necessary but
+    NOT sufficient for "thin CLI dispatcher" (task #250) -- see
+    ``_thin_cli_dispatcher_call_targets``, which additionally requires the specific symbol to
+    carry a Typer/Click ``.command(...)`` registration decorator AND a provable call-through
+    before a ``cli/`` symbol is ever treated as a pass-through wrapper rather than genuine logic
+    (e.g. ``tg search``'s own flag-parsing in ``cli/main.py`` IS the real implementation for "add
+    a --flag to tg search" and must never be demoted by this check)."""
+    if not file_path.lower().endswith(".py"):
+        return False
+    try:
+        parts = {part.lower() for part in Path(file_path).parts}
+    except (OSError, ValueError):
+        return False
+    return "cli" in parts
+
+
+def _thin_cli_dispatcher_call_targets(
+    file_path: str, symbol_name: str, *, expected_line: int | None = None
+) -> set[str] | None:
+    """Task #250: does ``symbol_name`` (defined in ``file_path``) look like a thin Typer/Click
+    command dispatcher -- decorated with a ``.command(...)`` registration -- and if so, what
+    names does its body call?
+
+    Returns ``None`` when the file can't be parsed, the symbol isn't a function/method, or it is
+    NOT decorated as a command -- i.e. not provably a dispatcher, so the caller must leave the
+    primary target alone (this is what protects a genuine ``cli/main.py`` target, e.g. "add a
+    --flag to tg search", from ever being demoted). Returns the -- possibly empty -- set of names
+    the body calls otherwise; the caller intersects this against alternative-candidate symbol
+    names to find the SPECIFIC implementation a dispatcher hands off to (e.g. ``ledger_claim``'s
+    body calling ``ledger_store.submit_claim(...)``).
+
+    Reuses ``_read_source_text_cached``/``_cached_ast_parse`` (both content-addressed -- a cache
+    HIT, not a re-read/re-parse, for a file already scanned earlier in this same process) and
+    bounds the walk to the ONE matched function's own subtree: a structural re-check of a symbol
+    already selected as the primary-target candidate, not a new repo-wide scan.
+    """
+    if not _is_cli_command_module_path(file_path):
+        return None
+    try:
+        source = _read_source_text_cached(file_path)
+        tree = _cached_ast_parse(source)
+    except (OSError, SyntaxError, UnicodeDecodeError, ValueError, RecursionError):
+        return None
+
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == symbol_name
+    ]
+    if not matches:
+        return None
+    if len(matches) > 1 and expected_line is not None:
+        matches.sort(key=lambda node: abs(node.lineno - expected_line))
+    match = matches[0]
+
+    decorator_names: set[str] = set()
+    for decorator in match.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Attribute):
+            decorator_names.add(target.attr)
+        elif isinstance(target, ast.Name):
+            decorator_names.add(target.id)
+    if "command" not in decorator_names:
+        return None
+
+    called_names: set[str] = set()
+    for call_node in ast.walk(match):
+        if not isinstance(call_node, ast.Call):
+            continue
+        func = call_node.func
+        if isinstance(func, ast.Name):
+            called_names.add(func.id)
+        elif isinstance(func, ast.Attribute):
+            called_names.add(func.attr)
+    return called_names
+
+
 def _symbol_rank_key(symbol: dict[str, Any]) -> tuple[int, int, int, int, str, int, str]:
     if bool(symbol.get("exact_query_match")):
         query_match_rank = 0

--- a/tests/eval/test_agent_accuracy.py
+++ b/tests/eval/test_agent_accuracy.py
@@ -21,10 +21,10 @@ Design notes (each choice was verified empirically against the real binary, not 
   ``--ignore`` globs, and is also faster (a real 60s-class deadline never gets close to tripping).
 - A GENEROUS fixed ``--deadline`` (60s -- ``tg prepare``'s own documented cold-path default, see
   ``DEFAULT_AGENT_CLI_DEADLINE_SECONDS`` in ``agent_capsule.py``) so a normal run always completes
-  without truncation; the slowest of the 15 tasks measured ~14s against this same repo during
-  development, so 60s leaves wide margin for a slower CI runner. Truncation flakiness would be a
-  correctness bug in THIS test, not a signal about capsule accuracy, so a truncated task fails
-  loudly (see ``_run_tg_prepare``) instead of being silently scored.
+  without truncation; the slowest of the golden-set tasks measured ~14s against this same repo
+  during development, so 60s leaves wide margin for a slower CI runner. Truncation flakiness
+  would be a correctness bug in THIS test, not a signal about capsule accuracy, so a truncated
+  task fails loudly (see ``_run_tg_prepare``) instead of being silently scored.
 - HIT = the expected file is ``primary_target.file`` OR appears anywhere in
   ``alternative_targets`` (which ``agent_capsule.py``'s own ``_alternative_targets(..., limit=
   None)[:4]`` caps at <=4 entries -- there is no arbitrary extra "top-N" window here, this is
@@ -42,9 +42,9 @@ itself needs revisiting.
 
 Marked ``eval`` + ``slow`` (opt-in / isolable from the flaky-sensitive main suite -- see
 ``pyproject.toml``'s ``markers`` and the CI workflow's ``-m "not eval"`` exclusion on the main
-``test-python`` job): this suite makes 15 real subprocess calls against the live ranking pipeline,
-which is exactly the kind of test whose failure should never silently mask unrelated unit-test
-failures via ``pytest``'s repo-wide ``-x`` fail-fast. Run explicitly with
+``test-python`` job): this suite makes one real subprocess call per ``GOLDEN_SET`` entry against
+the live ranking pipeline, which is exactly the kind of test whose failure should never silently
+mask unrelated unit-test failures via ``pytest``'s repo-wide ``-x`` fail-fast. Run explicitly with
 ``pytest tests/eval -m eval -v -s``.
 """
 
@@ -76,11 +76,15 @@ _SUBPROCESS_TIMEOUT_S = 150.0
 
 # Observed baseline on origin/main (v1.91.0-era capsule ranking, measured on Windows during
 # development of this gate): 15/15 golden tasks resolved via primary_target alone (no alternative-
-# window fallback needed). The floor deliberately leaves 3 tasks of slack -- well beyond the 0
-# actually observed -- so a different OS's filesystem walk order or one benign ranking tweak does
-# not red this gate; a real capsule-ranking regression (several tasks losing their file at once)
-# still will. If you re-baseline this gate, record the new observed score and date here.
-_ACCURACY_FLOOR_HITS = 12
+# window fallback needed). Re-baselined (task #250, same day): a 16th task ("fix the ledger claim
+# TTL logic") was added back after fixing the thin-CLI-dispatcher ranking bug it had originally
+# exposed (see agent_capsule._prefer_implementation_over_cli_dispatcher_helper) -- now 16/16, with
+# the original 15 unchanged (byte-identical primary_target file per task). The floor deliberately
+# leaves 3 tasks of slack -- well beyond the 0 actually observed -- so a different OS's filesystem
+# walk order or one benign ranking tweak does not red this gate; a real capsule-ranking regression
+# (several tasks losing their file at once) still will. If you re-baseline this gate, record the
+# new observed score and date here.
+_ACCURACY_FLOOR_HITS = 13
 
 # Each entry: a task phrased the way an engineer would file it, and the small set of files a
 # competent engineer would consider correct. Every (task, file) pair below was verified two ways
@@ -198,6 +202,21 @@ GOLDEN_SET: list[dict[str, Any]] = [
             "forward it to ripgrep, AND the flag's actual typer.Option lives on the `search` "
             "command in main.py. A competent engineer touches both; this task exercises that this "
             "eval's scoring correctly treats either as a hit rather than forcing a single answer."
+        ),
+    },
+    {
+        "task": "fix the ledger claim TTL logic",
+        "expected_files": ["cli/ledger_store.py"],
+        "notes": (
+            "task #250: this task was DROPPED from the original golden set because it exposed a "
+            "real ranking bug -- `ledger_claim`, the thin `@ledger_app.command('claim')` Typer "
+            "dispatcher in cli/main.py, exact-lexically-matched both substantive query words "
+            "('ledger' + 'claim') at once and outranked the real implementation. ledger_store.py "
+            "owns the actual TTL logic (_DEFAULT_TTL_SECONDS/_TTL_ENV/_configured_ttl_seconds) "
+            "and the ClaimRecord.ttl_seconds field; ledger_claim's body is a single call-through "
+            "to ledger_store.submit_claim. Fixed by down-weighting a provable thin CLI-dispatcher "
+            "call-through against the implementation module it calls "
+            "(agent_capsule._prefer_implementation_over_cli_dispatcher_helper)."
         ),
     },
 ]

--- a/tests/unit/test_agent_capsule_hardcases.py
+++ b/tests/unit/test_agent_capsule_hardcases.py
@@ -484,6 +484,48 @@ def test_prefer_implementation_no_swap_when_alternative_lives_in_same_file(tmp_p
     assert alternatives == [same_file_alternative]
 
 
+def test_prefer_implementation_no_swap_for_fat_command_even_if_a_callee_matches(tmp_path):
+    """Gate NIT-1 on #693: the exact fragility the independent review flagged -- a fat
+    `.command`-decorated function (the `search_command` shape: many top-level statements, many
+    distinct callees) must NOT be demoted just because one of its callees happens to match an
+    alternative candidate's symbol name. Without the structural thinness gate in
+    `repo_map._thin_cli_dispatcher_call_targets`, this synthetic 50-call command would swap;
+    with it, it must not."""
+    from tensor_grep.cli.agent_capsule import _prefer_implementation_over_cli_dispatcher_helper
+
+    cli_dir = tmp_path / "src" / "tensor_grep" / "cli"
+    cli_dir.mkdir(parents=True)
+    main_path = cli_dir / "main.py"
+    # 50 top-level statements, each calling a distinct helper -- one of them (helper_17) matches
+    # the alternative candidate's symbol name below, exactly like `search_command` could plausibly
+    # call something matching a ranked alternative for some future query.
+    body_lines = "\n".join(f"    helper_{i}(path)" for i in range(50))
+    main_path.write_text(
+        f"@app.command()\ndef search_command(path):\n{body_lines}\n", encoding="utf-8"
+    )
+    impl_path = cli_dir / "cpu_backend.py"
+    impl_path.write_text("def helper_17(path):\n    return path\n", encoding="utf-8")
+
+    primary_target = {
+        "file": str(main_path),
+        "symbol": "search_command",
+        "kind": "function",
+        "line": 2,
+        "confidence": 0.75,
+    }
+    alternative = {
+        "file": str(impl_path),
+        "symbol": "helper_17",
+        "kind": "function",
+        "confidence": 0.75,
+    }
+    primary, alternatives = _prefer_implementation_over_cli_dispatcher_helper(
+        primary_target, [alternative]
+    )
+    assert primary["symbol"] == "search_command"
+    assert alternatives == [alternative]
+
+
 def test_agent_capsule_prefers_ledger_store_implementation_over_dispatcher(tmp_path):
     """End-to-end (full capsule pipeline, not just the isolated helper): the exact #250 repro
     shape, scoped to a synthetic project so it is corpus-size-independent."""

--- a/tests/unit/test_agent_capsule_hardcases.py
+++ b/tests/unit/test_agent_capsule_hardcases.py
@@ -368,6 +368,158 @@ def test_prefer_implementation_no_swap_when_no_implementation_candidate():
     assert alternatives == [other_marker]
 
 
+# --- #250: thin CLI-dispatcher ranking weakness -----------------------------
+# `tg prepare src/tensor_grep "fix the ledger claim TTL logic"` resolved `primary_target` to
+# `cli/main.py`'s `ledger_claim` Typer dispatcher (an exact-symbol-name match on the query's two
+# substantive words) instead of the real implementation in `cli/ledger_store.py`. These tests
+# cover the down-weight helper directly; the golden-set regression coverage lives in
+# tests/eval/test_agent_accuracy.py.
+
+
+def _write_ledger_dispatcher_fixture(tmp_path, *, decorated: bool, calls_through: bool):
+    from tensor_grep.cli.agent_capsule import _prefer_implementation_over_cli_dispatcher_helper
+
+    cli_dir = tmp_path / "src" / "tensor_grep" / "cli"
+    cli_dir.mkdir(parents=True)
+    decorator = "@ledger_app.command('claim')\n" if decorated else ""
+    call_line = (
+        "    return ledger_store.submit_claim(path)\n"
+        if calls_through
+        else "    return {'claim_id': 'x'}\n"
+    )
+    main_path = cli_dir / "main.py"
+    main_path.write_text(
+        f"from tensor_grep.cli import ledger_store\n\n{decorator}def ledger_claim(path):\n{call_line}",
+        encoding="utf-8",
+    )
+    store_path = cli_dir / "ledger_store.py"
+    store_path.write_text(
+        "def submit_claim(path):\n    return {'claim_id': path}\n",
+        encoding="utf-8",
+    )
+    primary_target = {
+        "file": str(main_path),
+        "symbol": "ledger_claim",
+        "kind": "function",
+        "line": 3 if decorated else 2,
+        "confidence": 0.75,
+    }
+    alternative = {
+        "file": str(store_path),
+        "symbol": "submit_claim",
+        "kind": "function",
+        "confidence": 0.75,
+    }
+    return _prefer_implementation_over_cli_dispatcher_helper, primary_target, alternative
+
+
+def test_prefer_implementation_over_cli_dispatcher_swaps_thin_wrapper(tmp_path):
+    """The reported #250 shape: a `.command`-decorated dispatcher whose body is a single
+    call-through to the real implementation must be demoted below that implementation."""
+    swap, primary_target, alternative = _write_ledger_dispatcher_fixture(
+        tmp_path, decorated=True, calls_through=True
+    )
+    primary, alternatives = swap(primary_target, [alternative])
+    assert primary["symbol"] == "submit_claim"
+    assert primary["file"] == alternative["file"]
+    assert alternatives[0]["symbol"] == "ledger_claim"
+
+
+def test_prefer_implementation_no_swap_when_cli_primary_is_genuine_target(tmp_path):
+    """The crux guard (task #250): a `.command`-decorated `cli/main.py` function that does NOT
+    call through to the alternative (i.e. it holds real logic of its own, like `tg search`'s own
+    flag handling) must NOT be demoted -- this is what keeps "add a --flag to tg search"-style
+    tasks resolving to cli/main.py correctly."""
+    swap, primary_target, alternative = _write_ledger_dispatcher_fixture(
+        tmp_path, decorated=True, calls_through=False
+    )
+    primary, alternatives = swap(primary_target, [alternative])
+    assert primary["symbol"] == "ledger_claim"
+    assert alternatives == [alternative]
+
+
+def test_prefer_implementation_no_swap_when_no_command_decorator(tmp_path):
+    """A plain (non-Typer-command) function that happens to call another module's function is
+    not provably a dispatcher -- the decorator, not the call alone, is the gating signal."""
+    swap, primary_target, alternative = _write_ledger_dispatcher_fixture(
+        tmp_path, decorated=False, calls_through=True
+    )
+    primary, alternatives = swap(primary_target, [alternative])
+    assert primary["symbol"] == "ledger_claim"
+    assert alternatives == [alternative]
+
+
+def test_prefer_implementation_no_swap_when_alternative_lives_in_same_file(tmp_path):
+    from tensor_grep.cli.agent_capsule import _prefer_implementation_over_cli_dispatcher_helper
+
+    cli_dir = tmp_path / "src" / "tensor_grep" / "cli"
+    cli_dir.mkdir(parents=True)
+    main_path = cli_dir / "main.py"
+    main_path.write_text(
+        "@ledger_app.command('claim')\n"
+        "def ledger_claim(path):\n"
+        "    return _submit(path)\n\n"
+        "def _submit(path):\n"
+        "    return {'claim_id': path}\n",
+        encoding="utf-8",
+    )
+    # Same-file "alternative" must never be treated as a cross-module implementation candidate.
+    same_file_alternative = {
+        "file": str(main_path),
+        "symbol": "_submit",
+        "kind": "function",
+        "confidence": 0.75,
+    }
+    primary_target = {
+        "file": str(main_path),
+        "symbol": "ledger_claim",
+        "kind": "function",
+        "line": 2,
+        "confidence": 0.75,
+    }
+    primary, alternatives = _prefer_implementation_over_cli_dispatcher_helper(
+        primary_target, [same_file_alternative]
+    )
+    assert primary["symbol"] == "ledger_claim"
+    assert alternatives == [same_file_alternative]
+
+
+def test_agent_capsule_prefers_ledger_store_implementation_over_dispatcher(tmp_path):
+    """End-to-end (full capsule pipeline, not just the isolated helper): the exact #250 repro
+    shape, scoped to a synthetic project so it is corpus-size-independent."""
+    project = tmp_path / "workspace"
+    cli_dir = project / "src" / "tensor_grep" / "cli"
+    cli_dir.mkdir(parents=True)
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (cli_dir / "main.py").write_text(
+        "from tensor_grep.cli import ledger_store\n\n"
+        "@ledger_app.command('claim')\n"
+        "def ledger_claim(path, ttl=None):\n"
+        '    """Claim TTL in seconds."""\n'
+        "    return ledger_store.submit_claim(path, ttl_seconds=ttl)\n",
+        encoding="utf-8",
+    )
+    (cli_dir / "ledger_store.py").write_text(
+        "_DEFAULT_TTL_SECONDS = 900\n\n\n"
+        "def _configured_ttl_seconds(explicit):\n"
+        "    return explicit or _DEFAULT_TTL_SECONDS\n\n\n"
+        "def submit_claim(path, ttl_seconds=None):\n"
+        "    resolved_ttl = _configured_ttl_seconds(ttl_seconds)\n"
+        "    return {'path': path, 'ttl_seconds': resolved_ttl}\n\n\n"
+        "def release_claim(claim_id):\n"
+        "    return {'claim_id': claim_id, 'released': True}\n",
+        encoding="utf-8",
+    )
+
+    payload = _agent_payload(project, "fix the ledger claim TTL logic")
+
+    assert payload["primary_target"]["file"] == str((cli_dir / "ledger_store.py").resolve())
+    assert payload["primary_target"]["symbol"] in {"submit_claim", "_configured_ttl_seconds"}
+
+
 def test_agent_capsule_prefers_ripgrep_resolver_for_binary_resolution_query(tmp_path):
     project = tmp_path / "workspace"
     cli_src = project / "src" / "tensor_grep" / "cli"

--- a/tests/unit/test_repo_map_targets.py
+++ b/tests/unit/test_repo_map_targets.py
@@ -194,6 +194,59 @@ def test_symbol_name_exact_match_requires_full_query_or_distinctive_token() -> N
     )
 
 
+# --- #250: thin CLI-dispatcher call-through detection -----------------------
+# (down-weighting a thin Typer/Click command wrapper vs. the implementation it calls through to;
+# see agent_capsule.py's `_cli_dispatcher_implementation_candidate`, which consumes this signal)
+
+
+def test_thin_cli_dispatcher_call_targets_detects_command_call_through(tmp_path: Path) -> None:
+    main_path = tmp_path / "src" / "tensor_grep" / "cli" / "main.py"
+    main_path.parent.mkdir(parents=True, exist_ok=True)
+    main_path.write_text(
+        "from tensor_grep.cli import ledger_store\n\n"
+        "@ledger_app.command('claim')\n"
+        "def ledger_claim(path):\n"
+        "    result = ledger_store.submit_claim(path)\n"
+        "    return result\n",
+        encoding="utf-8",
+    )
+    called = repo_map._thin_cli_dispatcher_call_targets(str(main_path), "ledger_claim")
+    assert called is not None
+    assert "submit_claim" in called
+
+
+def test_thin_cli_dispatcher_call_targets_none_without_command_decorator(tmp_path: Path) -> None:
+    # Mirrors a genuine `cli/main.py` implementation (e.g. `tg search`'s own flag handling): a
+    # plain, undecorated function that also happens to call another module's function must NOT
+    # be treated as a dispatcher -- the decorator is the load-bearing signal, not the call alone.
+    main_path = tmp_path / "src" / "tensor_grep" / "cli" / "main.py"
+    main_path.parent.mkdir(parents=True, exist_ok=True)
+    main_path.write_text(
+        "from tensor_grep.cli import ledger_store\n\n"
+        "def search(path):\n"
+        "    return ledger_store.submit_claim(path)\n",
+        encoding="utf-8",
+    )
+    assert repo_map._thin_cli_dispatcher_call_targets(str(main_path), "search") is None
+
+
+def test_thin_cli_dispatcher_call_targets_none_outside_cli_module(tmp_path: Path) -> None:
+    module_path = tmp_path / "src" / "tensor_grep" / "core" / "ledger_store.py"
+    module_path.parent.mkdir(parents=True, exist_ok=True)
+    module_path.write_text(
+        "@ledger_app.command('claim')\ndef ledger_claim(path):\n    return submit_claim(path)\n",
+        encoding="utf-8",
+    )
+    assert repo_map._thin_cli_dispatcher_call_targets(str(module_path), "ledger_claim") is None
+
+
+def test_thin_cli_dispatcher_call_targets_none_when_symbol_missing(tmp_path: Path) -> None:
+    main_path = tmp_path / "src" / "tensor_grep" / "cli" / "main.py"
+    main_path.parent.mkdir(parents=True, exist_ok=True)
+    main_path.write_text("def other():\n    return 1\n", encoding="utf-8")
+    assert repo_map._thin_cli_dispatcher_call_targets(str(main_path), "ledger_claim") is None
+
+
 def test_context_render_and_edit_plan_prefer_multi_term_symbol_over_common_word(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_repo_map_targets.py
+++ b/tests/unit/test_repo_map_targets.py
@@ -247,6 +247,42 @@ def test_thin_cli_dispatcher_call_targets_none_when_symbol_missing(tmp_path: Pat
     assert repo_map._thin_cli_dispatcher_call_targets(str(main_path), "ledger_claim") is None
 
 
+def test_thin_cli_dispatcher_call_targets_none_for_fat_command(tmp_path: Path) -> None:
+    """Gate NIT-1 on #693: a `.command`-decorated function that is NOT structurally thin (a real
+    implementation with many top-level statements and many distinct callees -- the
+    `search_command` shape the independent review flagged) must be rejected even though it DOES
+    call a name that could match some alternative candidate. Decoration + a call-through alone is
+    not enough; the thinness gate must fire independently of which names happen to be called."""
+    main_path = tmp_path / "src" / "tensor_grep" / "cli" / "main.py"
+    main_path.parent.mkdir(parents=True, exist_ok=True)
+    # 50 distinct top-level statements, each calling a distinct helper name -- comfortably over
+    # both _THIN_DISPATCHER_MAX_BODY_STATEMENTS and _THIN_DISPATCHER_MAX_CALL_TARGETS (20 each).
+    # One of the fifty (helper_17) is deliberately named to match a plausible alternative symbol,
+    # proving the rejection is NOT simply "no calls matched".
+    body_lines = "\n".join(f"    helper_{i}(path)" for i in range(50))
+    main_path.write_text(
+        f"@app.command()\ndef search_command(path):\n{body_lines}\n",
+        encoding="utf-8",
+    )
+    assert repo_map._thin_cli_dispatcher_call_targets(str(main_path), "search_command") is None
+
+
+def test_thin_cli_dispatcher_call_targets_none_for_many_distinct_callees_even_if_few_statements(
+    tmp_path: Path,
+) -> None:
+    """The call-target-count axis alone must also reject a fat command, independent of the
+    statement-count axis: one top-level statement that fans out to 30 distinct calls (e.g. a
+    single chained/nested expression) is still NOT a thin passthrough."""
+    main_path = tmp_path / "src" / "tensor_grep" / "cli" / "main.py"
+    main_path.parent.mkdir(parents=True, exist_ok=True)
+    calls = " + ".join(f"helper_{i}(path)" for i in range(30))
+    main_path.write_text(
+        f"@app.command()\ndef search_command(path):\n    return {calls}\n",
+        encoding="utf-8",
+    )
+    assert repo_map._thin_cli_dispatcher_call_targets(str(main_path), "search_command") is None
+
+
 def test_context_render_and_edit_plan_prefer_multi_term_symbol_over_common_word(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

`tg prepare src/tensor_grep "fix the ledger claim TTL logic"` resolved `primary_target` to
`cli/main.py`'s `ledger_claim` -- a `@ledger_app.command("claim")` Typer dispatcher that is a
single call-through to `ledger_store.submit_claim(...)` -- instead of the real implementation in
`cli/ledger_store.py` (which owns `_DEFAULT_TTL_SECONDS`/`_TTL_ENV`/`_configured_ttl_seconds` and
`ClaimRecord.ttl_seconds`). Root cause: `ledger_claim`'s name is a literal concatenation of the
query's two substantive words ("ledger" + "claim"), so `repo_map._score_symbol`'s
`covered_query_match` bonus (embedded +2 in the score, +24 at the file-score level, plus top-rank
bucket precedence in `_symbol_rank_key`) let the dispatcher outrank the implementation even though
`ledger_store.py` scored higher on every other signal (path, import, source, graph-centrality).

## Fix

A conservative, structural down-weight applied **after** ranking -- not a change to the scorer
itself (which stays untouched, so nothing else shifts):

- `repo_map._thin_cli_dispatcher_call_targets` (`repo_map.py:6938`, gated by
  `_is_cli_command_module_path` at `repo_map.py:6921`) reuses the already-cached AST parse of the
  primary target's own file to check whether the symbol is **(a)** decorated as a Typer/Click
  command (`.command(...)`) and **(b)** whether its body calls a specific alternative candidate
  directly. No new repo-wide scan -- one bounded re-check of a symbol already selected as primary.
- Only when **both** hold does `agent_capsule._prefer_implementation_over_cli_dispatcher_helper`
  (`agent_capsule.py:401`, via `_cli_dispatcher_implementation_candidate` at
  `agent_capsule.py:340`) swap it with that alternative -- mirroring the existing
  `_prefer_implementation_over_marker_helper` pattern already in this file. The dispatcher is
  demoted to an alternative, never dropped, so downstream tie/ambiguity signals still apply.
- Wired into both capsule-shaping call sites (`agent_capsule.py:2100`, `:2721`), right after the
  marker-helper swap, so `tg prepare`, `tg agent`, and `tg edit-plan` all see the fix identically.

The crux guard: a bare "primary lives under `cli/`" is deliberately **not** enough --
`cli/main.py` is the correct target for plenty of tasks (e.g. "add a --flag to tg search", where
the flag registration itself lives in that Typer command's signature). The swap only fires when
the primary is **provably** a thin pass-through (decorator + call-through both present), never on
lexical score or file location alone.

## Validation -- the accuracy-gate numbers (`tests/eval/test_agent_accuracy.py`)

| Run | Golden set | Result |
|---|---|---|
| BEFORE (baseline, no fix) | original 15 tasks | **15/15** |
| AFTER (fix applied) | same 15 tasks | **15/15** -- byte-identical `primary_target.file` per task, including "add a new --flag to tg search" still resolving to `cli/bootstrap.py` |
| AFTER (fix applied) | 16 tasks ("fix the ledger claim TTL logic" added back) | **16/16** -- the previously-dropped task now resolves to `cli/ledger_store.py` |

The 16th task was dropped from the original golden set (PR #690) specifically because of this bug;
it's added back here now that it hits. Floor bumped `12 -> 13` to preserve the documented "3 tasks
of slack" policy against the new 16-task baseline.

## Test plan

- [x] `ruff check .` -- clean
- [x] `ruff format --check --preview .` -- clean
- [x] `mypy src/tensor_grep` -- clean (81 files)
- [x] New unit tests: 4 in `tests/unit/test_repo_map_targets.py` (AST-level detector: command-call-through,
      no-decorator, outside-cli, symbol-missing) + 6 in `tests/unit/test_agent_capsule_hardcases.py`
      (swap helper, including the crux guard that a genuinely-implementing `cli/main.py` primary is
      NOT demoted, plus a full synthetic end-to-end capsule repro) -- all passing
- [x] `tests/integration/test_prepare_oneshot_cuj.py` -- 9/9 passing
- [x] `tests/eval -m eval -v -s` (the accuracy gate) -- before AND after, see table above
- [x] Broader regression sweep (~900 tests across agent_capsule/repo_map/codemap/edit_plan/context/cli_modes):
      4 pre-existing failures in `test_cli_modes.py` (terminal-width-dependent `--help` rendering)
      reproduce **identically** on origin/main with this diff stashed out -- confirmed unrelated to
      this change (same failures, same messages, with or without the fix)

## Gate note

LOAD-BEARING: `primary_target` ranking is core capsule value (per `AGENTS.md`/`CLAUDE.md`
change-control discipline). This needs an **independent Opus gate** before merge to verify it does
not regress the golden set or shift other `primary_target`s -- not self-gated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>