### PR TITLE
test(search): many-fixed-pattern dedup guard at scale (+ root-cause finding of the latent native AC dedup over-count)

### DIFF
--- a/tests/e2e/test_multi_pattern_native.py
+++ b/tests/e2e/test_multi_pattern_native.py
@@ -231,6 +231,81 @@ def test_multi_pattern_golden_parity_pattern_file_deterministic_cpu_backend(
     ]
 
 
+# --- many-fixed-pattern scale: rg-parity dedup must hold at a REALISTIC pattern count, ---
+# not just N=2 (docs/gpu_crossover.md's documented ~2.3x-21x tg-vs-rg gap on 100-pattern ---
+# multi-literal search was profiled to this exact `_combine_multi_patterns` call; this pins ---
+# the CORRECTNESS side of that same code path at the SAME scale so a future performance fix ---
+# cannot silently regress it). ------------------------------------------------------------
+
+
+def test_many_fixed_patterns_dedupe_overlapping_lines_at_scale(
+    env: dict[str, str], tmp_path: Path
+) -> None:
+    """Regression/characterization test for the many-fixed-string CPU search path
+    (docs/gpu_crossover.md: 100 fixed patterns, rg=0.105s vs tg-CPU=2.220s, ~21x).
+
+    The existing tests above pin the OR-combine dedup contract
+    (`_combine_multi_patterns`, cli/main.py) at N=2 patterns
+    (`test_multi_e_native_reports_both_match_line_once` /
+    `test_multi_pattern_golden_parity_pattern_file_deterministic_cpu_backend`); this test
+    pins the SAME rg-parity "reported once, never once per matching pattern" contract at
+    a REALISTIC pattern count (100, matching the CEO benchmark's own scale) with TWO
+    distinct overlap widths (one line hit by exactly 2 patterns, one line hit by exactly
+    3), which a naive performance fix could regress if it swapped in the ALREADY-SHIPPED
+    but currently-buggy native AhoCorasick multi-pattern fast path
+    (`native_search.rs::run_native_fixed_multi_pattern_search` /
+    `collect_fixed_multi_pattern_line_matches`) as-is instead of via this Python
+    combine-into-one-alternation-regex path -- that native fast path emits ONE match
+    record per (line, matching-pattern) pair rather than per line, over-counting
+    `total_matches` whenever 2+ patterns hit the same line. Verified directly against the
+    published `tg` binary: a 2-line/2-pattern-overlap fixture
+    (`tg search -F --cpu --json -e A -e B overlap.txt`) reports `total_matches: 3`
+    instead of the rg-correct `2`. This is exactly why `bootstrap.py`'s
+    `_can_delegate_to_native_tg_search` and `cli/main.py`'s
+    `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS` both deliberately refuse to delegate
+    ANY `-e`/`-f` search to the native binary (see the audit #69 comments at both sites)
+    -- this test's own combine-in-Python path is the CORRECT side of that trade-off; any
+    future fix that reuses the native/AC engine (for speed) MUST fix its per-line dedup
+    first, and this test must stay green throughout.
+    """
+    root = tmp_path / "many-pattern"
+    root.mkdir()
+    (root / "corpus.txt").write_text(
+        "line A has NEEDLE_01 only\n"
+        "line B has NEEDLE_02 only\n"
+        "line C has NEEDLE_01 and NEEDLE_02 together\n"
+        "line D has NEEDLE_03 and NEEDLE_04 and NEEDLE_05 together\n"
+        "line E has no needles at all\n",
+        encoding="utf-8",
+    )
+
+    real_needles = [f"NEEDLE_{i:02d}" for i in range(1, 6)]  # 5 patterns that DO match
+    absent_patterns = [f"ABSENT_{i:03d}_XYZQ" for i in range(95)]  # padding to 100 total
+    patterns = real_needles + absent_patterns
+    assert len(patterns) == 100
+
+    (tmp_path / "patterns.txt").write_text("\n".join(patterns) + "\n", encoding="utf-8")
+
+    result = _tg(
+        ["-F", "--cpu", "--json", "-f", "../patterns.txt", "."],
+        cwd=root,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    # rg parity: 4 LINES matched (A, B, C, D) -- never one row per (line, pattern) pair.
+    # Line C matches 2 of the 100 patterns; line D matches 3. Neither may be double- or
+    # triple-counted, and none of the 95 absent patterns may contribute a phantom match.
+    assert payload["total_matches"] == 4
+    assert sorted(match["text"] for match in payload["matches"]) == [
+        "line A has NEEDLE_01 only",
+        "line B has NEEDLE_02 only",
+        "line C has NEEDLE_01 and NEEDLE_02 together",
+        "line D has NEEDLE_03 and NEEDLE_04 and NEEDLE_05 together",
+    ]
+
+
 # --- -F multi-literal: each -e is re.escape'd, never interpreted as regex. --------------
 
 


### PR DESCRIPTION
## Summary

Investigated the CEO-research finding at `docs/gpu_crossover.md:9-10`: 100 fixed-string
patterns over 1GB, no-match `rg=0.169s` vs `tg-CPU=0.394s` (2.3x); mixed 100-pattern/
2665-match `rg=0.105s` vs `tg-CPU=2.220s` (~21x).

**This is not an oversight -- it is a documented, deliberate correctness-over-speed
tradeoff that has not been fully closed out.** The Rust core already has a working
`aho-corasick`-based multi-pattern fast path. It is deliberately not used by the
Python-driven CPU search path because it has its own known bug, and using it would
silently return wrong match counts. This PR does not change runtime behavior; it adds
one regression test that pins the current correct (but slow) behavior at a realistic
100-pattern scale, and the PR description below is the full root-cause writeup plus a
fix plan for a follow-up.

## Root cause chain (cited)

1. **Python collapses N fixed patterns into ONE non-literal alternation regex and
   clears `fixed_strings`:** `src/tensor_grep/cli/main.py:4737-4752`
   (`_combine_multi_patterns`) builds `(?:(?:esc1)|(?:esc2)|...|(?:escN))`; invoked and
   `fixed_strings` cleared to `False` at `:7494-7497` (the `-e`xN path) and `:7710-7711`
   (the `-f` file-sourced path).
2. **This forces the single-pattern-only Rust FFI down the general-regex path.**
   `rust_core/src/lib.rs:159-172` (`RustBackend.search`, the only PyO3-exposed search
   method) takes one `pattern: &str` -- there is no multi-pattern entry point at all.
   `src/tensor_grep/backends/rust_backend.py:311-317` and
   `src/tensor_grep/backends/cpu_backend.py:390-408` both forward
   `fixed_strings=config.fixed_strings` (now `False`) straight through.
3. **On the Rust side, `backend_cpu.rs::search_with_paths`
   (`rust_core/src/backend_cpu.rs:35-99`) has exactly two paths:** a `memchr::memmem`
   ultra-fast single-literal substring scan (`fixed_strings && !ignore_case`, lines
   46-67), or `regex::bytes::RegexBuilder` -- the general regex engine (lines 70-78)
   for everything else, including our N-branch alternation. No Aho-Corasick code
   exists in this file at all.
4. **The `aho-corasick` dependency (`Cargo.toml:19`) IS used, correctly, for exactly
   this case -- but only in `rust_core/src/native_search.rs:746-797`**
   (`run_native_fixed_multi_pattern_search`), gated on `fixed_strings=True &&
   patterns.len()>1` (`:799-818`), and wired only into the standalone binary's own
   argv dispatch (`main.rs`) -- never exposed through the PyO3 `#[pymodule] rust_core`
   surface (`lib.rs:349-361`) that `CPUBackend`/`RustCoreBackend` call into.
5. **That native AC fast path has an independently-reproduced, already-documented
   correctness bug**, which is why it is not wired to Python:
   `collect_fixed_multi_pattern_line_matches` (`native_search.rs:854-881`) emits ONE
   match record per (line, matching-pattern) pair instead of one per line. Repro
   against the published `tg` v1.91.0 binary:
   `tg search -F --cpu --json -e NEEDLE_000 -e NEEDLE_001 overlap.txt` (a 2-line file
   where line 2 matches BOTH patterns) reports `"total_matches":3`, where `rg`'s
   equivalent reports the correct `2`.
6. **This is exactly why the team already blocks native delegation for `-e`/`-f`.**
   `src/tensor_grep/cli/bootstrap.py:470-483` (`_can_delegate_to_native_tg_search`'s
   `unsupported_flags`) and `cli/main.py`'s
   `_NATIVE_TG_DELEGATION_DEFAULT_REQUIRED_FIELDS` (`:1877-1879`, `regexp`/
   `file_patterns`) both explicitly refuse `-e`/`-f` delegation, with an inline
   comment citing this exact bug ("multiple -e patterns are not deduplicated when a
   single line matches more than one") plus a second, more severe one ("a -f pattern
   file is silently never read at all"). `tests/unit/test_cli_bootstrap.py:1769-1787`
   (`test_multi_pattern_e_f_do_not_delegate_to_native_binary`) pins this refusal.

Net: the slow, general-regex Python path is not a bug nobody noticed -- it is the
side the team chose because the fast side is currently wrong. The real fix is to fix
`native_search.rs`'s per-line dedup (and re-verify the `-f`-file-read claim against
current code), then either lift the delegation refusal or expose a new
dedup-correct multi-pattern PyO3 method for Python-embedded callers (MCP server,
no-native-binary installs) to use directly.

## Reproduction + profiling (bounded, CPU-safe workload)

355KB synthetic corpus (4000 lines), 100 fixed-string patterns (no-match set; mixed
set = 20 real "needle" literals + 80 absent, ~1460 matching lines). Full repro scripts
were run from a scratch directory, not included in this PR.

**Isolated backend-call scaling (bypasses CLI/process overhead, `RustCoreBackend`
direct call, corpus size held fixed, pattern count varied):**

| patterns (k) | no_match median | mixed median | mixed total_matches |
|---:|---:|---:|---:|
| 1   | 1.395 ms | 1.209 ms | 99 |
| 20  | 2.213 ms | 6.098 ms | 1460 |
| 60  | 3.479 ms | 8.999 ms | 1460 |
| 100 | 4.459 ms | 8.203 ms | 1460 |

Real, non-flat growth with pattern count at fixed corpus size and fixed match count
(mixed patterns beyond k=20 add zero new matches yet still cost more) -- this is the
general-regex-engine-vs-true-multi-literal-automaton gap the aho-corasick fast path
exists to close. One alternate theory was ruled out: flat `pat|pat|...` vs the current
nested `(?:...)|(?:...)` grouping showed no measurable difference (7.577ms vs
7.588ms), so the fix is not a pattern-construction tweak -- it needs a real
multi-literal automaton reachable from Python.

**Full end-to-end (Python CLI path, `--cpu --json`, same bounded corpus):** roughly
20-27x slower than `rg -F -e ... -e ...` on the mixed-pattern scenario, closely
matching the doc's own ~21x figure at 1GB scale.

## What this PR actually contains

Test-only. `tests/e2e/test_multi_pattern_native.py`:
`test_many_fixed_patterns_dedupe_overlapping_lines_at_scale` -- 100 fixed patterns (5
real matching a corpus with 2-way and 3-way per-line overlaps, plus 95 padding),
asserting `total_matches == 4` (one per matched line, never one per matching pattern).
Passes today (18/18 in the file). Sanity-checked as discriminating: re-running the
identical fixture through the native AC path (`-e`x100 against the standalone
`tg.exe`) reports `total_matches: 7` (1+1+2+3, the known dedup bug), confirming this
test would catch a regression if a future performance fix wired in the native path
without first fixing its dedup.

No `src/tensor_grep` changes. `ruff check` / `ruff format --check --preview` clean on
the touched file.

## Suggested follow-up (not in this PR -- cross-language, needs Rust compilation to validate)

1. Fix `collect_fixed_multi_pattern_line_matches` (`native_search.rs:854-881`) to emit
   one match per line (not per (line, pattern_id)); apply the same fix to the
   per-pattern-loop fallback in `main.rs::collect_native_multi_pattern_matches`
   (`:6985-7030`), which has the identical non-dedup gap for the non-`-F` regex
   multi-pattern case.
2. Fresh repro of the "-f pattern file silently never read" claim against current
   `main.rs` (my own quick repro of `-f` this session actually routed through a Python
   sidecar and returned correct results -- the exact trigger condition needs
   re-verification before assuming it is unchanged).
3. Once (1)-(2) are fixed and covered by (ideally) the golden-parity tests in
   `tests/e2e/test_multi_pattern_native.py` re-run against the standalone binary (not
   just `TG_DISABLE_NATIVE_TG=1`), lift the `-e`/`-f` exclusions in both
   `bootstrap.py:480-483` and `cli/main.py`'s refuse-tuple, and/or expose a new
   PyO3-bound multi-pattern method so Python-embedded callers (no native binary
   installed, MCP server) benefit too.

Load-bearing search backend surface -- flagging for independent Opus gate per project
convention even though this PR itself only adds a test.

Generated with Claude Code
