### PR TITLE
perf(rust): intra-file parallel search for large files in CpuBackend

### DIFF
--- a/rust_core/src/backend_cpu.rs
+++ b/rust_core/src/backend_cpu.rs
@@ -1,10 +1,277 @@
-use memchr::memmem;
+use memchr::{memchr, memchr_iter, memmem};
 use memmap2::{MmapMut, MmapOptions};
 use rayon::prelude::*;
 use regex::bytes::RegexBuilder;
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
+
+/// Large-file intra-file parallel search threshold (bytes). Matches
+/// `native_search.rs::LARGE_FILE_CHUNK_THRESHOLD_BYTES` (rust_core/src/native_search.rs:28) so
+/// "large file" means the same thing across tg's native CPU search paths. Below this size a
+/// file is scanned by a single thread exactly as before (see `scan_lines_memmem`/
+/// `scan_lines_regex` below, which is the same code either way); at or above it, the file is
+/// split into line-aligned chunks and each chunk is scanned in parallel with rayon -- the same
+/// crate this module already uses for `count_file_memmem`/`count_file_regex`'s `par_split`, and
+/// the same idiom `native_search.rs::search_file_chunk_parallel` already ships for
+/// `--json`/`--count`/`--quiet` output.
+///
+/// Deliberately NOT applied to the default plain-text / `--ndjson` streaming output modes in
+/// native_search.rs: those have an explicit, tested "first match must stream well before the
+/// full scan completes" contract
+/// (rust_core/tests/test_native_search.rs::test_native_search_default_output_streams_before_search_completion
+/// and `..._ndjson_output_streams_before_search_completion`, asserting >=25ms between first byte
+/// and process exit) that a genuine multi-core speedup would put at real risk of shrinking below
+/// -- reconciling true parallelism with that streaming/incremental-output guarantee is a
+/// separate design problem, not addressed here. `search_with_paths`'s contract has no such
+/// constraint: it collects every match into a `Vec` and returns it once, so there is nothing a
+/// parallel scan could disturb except which thread does the comparing.
+const LARGE_FILE_PARALLEL_THRESHOLD_BYTES: usize = 50 * 1024 * 1024;
+
+/// One line-aligned byte range of a large file, tagged with the 1-based line number of its
+/// first line. Every boundary is snapped forward to the byte just after a `\n` (or EOF), so a
+/// chunk can never start or end mid-line: a match can never be split, duplicated, or dropped at
+/// a seam. `first_line` lets each chunk be searched independently, on any thread, in any order,
+/// while still producing globally-correct, ascending line numbers once every chunk's results
+/// are stitched back together in original (byte-ascending) order.
+#[derive(Debug, Clone, Copy)]
+struct LineAlignedChunk {
+    start: usize,
+    end: usize,
+    first_line: usize,
+}
+
+/// Split `contents` into up to `requested_chunks` contiguous, line-aligned byte ranges. Returns
+/// an empty `Vec` when there is nothing worth splitting (empty content or `requested_chunks <=
+/// 1`) -- callers must fall back to a single whole-buffer scan in that case.
+///
+/// Mirrors `native_search.rs::plan_file_chunks`/`align_chunk_end_to_newline`
+/// (rust_core/src/native_search.rs:1613-1669), independently re-implemented here because
+/// backend_cpu.rs's match/line model (`CpuMatch`) and matcher types (`memmem` / `regex::bytes`)
+/// are local to this module, not shared with the `grep-searcher`-based native front door.
+fn plan_line_aligned_chunks(contents: &[u8], requested_chunks: usize) -> Vec<LineAlignedChunk> {
+    if contents.is_empty() || requested_chunks <= 1 {
+        return Vec::new();
+    }
+
+    let target_chunk_size = contents.len().div_ceil(requested_chunks);
+    let mut chunks = Vec::new();
+    let mut start = 0usize;
+    let mut first_line = 1usize;
+
+    while start < contents.len() {
+        let tentative_end = start.saturating_add(target_chunk_size).min(contents.len());
+        let end = align_chunk_end_to_newline(contents, tentative_end);
+        if end <= start {
+            break;
+        }
+        chunks.push(LineAlignedChunk {
+            start,
+            end,
+            first_line,
+        });
+        first_line += count_newlines(&contents[start..end]);
+        start = end;
+    }
+
+    chunks
+}
+
+/// Snap `tentative_end` forward to the first byte after the next `\n`, so a chunk boundary can
+/// never land inside a line. If `tentative_end` already sits exactly at such a boundary (the
+/// preceding byte is `\n`), it is returned unchanged; if no further `\n` exists, the chunk runs
+/// to EOF.
+fn align_chunk_end_to_newline(contents: &[u8], tentative_end: usize) -> usize {
+    if tentative_end == 0 || tentative_end >= contents.len() {
+        return contents.len();
+    }
+    if contents[tentative_end - 1] == b'\n' {
+        return tentative_end;
+    }
+    match memchr(b'\n', &contents[tentative_end..]) {
+        Some(relative_offset) => tentative_end + relative_offset + 1,
+        None => contents.len(),
+    }
+}
+
+fn count_newlines(contents: &[u8]) -> usize {
+    memchr_iter(b'\n', contents).count()
+}
+
+/// Requested chunk count for intra-file parallel search: one chunk per available core. There
+/// is no override knob (backend_cpu.rs has no config struct, only plain method arguments), so
+/// this always reflects the live core count -- mirrors `native_search.rs`'s
+/// `configured_chunk_parallelism_threads` fallback when no explicit override is configured.
+fn requested_parallel_chunk_count() -> usize {
+    std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1)
+}
+
+/// Scan `contents` line-by-line for a fixed-string `pattern` (via `memmem`), producing
+/// `CpuMatch` entries numbered from `first_line_number`. This is the ONE place that decides
+/// whether a line matches: both the whole-file single-pass scan (`first_line_number == 1`, the
+/// pre-existing behavior for files under the parallel threshold) and every parallel chunk of a
+/// large file (`first_line_number` = that chunk's first line, from `plan_line_aligned_chunks`)
+/// call this same function, so the parallel path can never diverge from serial -- it is the
+/// identical per-line predicate, just fed a different byte range and line offset. Matching is
+/// already strictly per-line (a match never looks past a `\n`), so a line-aligned split of the
+/// input can never change WHICH lines match -- it only changes how many threads do the
+/// checking.
+fn scan_lines_memmem(
+    contents: &[u8],
+    pattern: &[u8],
+    invert_match: bool,
+    first_line_number: usize,
+    path: &Path,
+) -> Vec<CpuMatch> {
+    let mut results = Vec::new();
+    let mut line_num = first_line_number;
+    let mut start = 0;
+
+    for i in memchr_iter(b'\n', contents) {
+        let line_bytes = &contents[start..i];
+        let is_match = memmem::find(line_bytes, pattern).is_some();
+        let should_include = if invert_match { !is_match } else { is_match };
+        if should_include {
+            results.push(CpuMatch {
+                file: path.to_path_buf(),
+                line: line_num,
+                text: String::from_utf8_lossy(line_bytes).into_owned(),
+            });
+        }
+        start = i + 1;
+        line_num += 1;
+    }
+
+    if start < contents.len() {
+        let line_bytes = &contents[start..];
+        let is_match = memmem::find(line_bytes, pattern).is_some();
+        let should_include = if invert_match { !is_match } else { is_match };
+        if should_include {
+            results.push(CpuMatch {
+                file: path.to_path_buf(),
+                line: line_num,
+                text: String::from_utf8_lossy(line_bytes).into_owned(),
+            });
+        }
+    }
+
+    results
+}
+
+/// Regex sibling of `scan_lines_memmem` -- identical per-line, first-line-number-offset
+/// contract, so the same "chunking cannot change which lines match" argument applies.
+fn scan_lines_regex(
+    contents: &[u8],
+    re: &regex::bytes::Regex,
+    invert_match: bool,
+    first_line_number: usize,
+    path: &Path,
+) -> Vec<CpuMatch> {
+    let mut results = Vec::new();
+    let mut line_num = first_line_number;
+    let mut start = 0;
+
+    for i in memchr_iter(b'\n', contents) {
+        let line_bytes = &contents[start..i];
+        let is_match = re.is_match(line_bytes);
+        let should_include = if invert_match { !is_match } else { is_match };
+        if should_include {
+            results.push(CpuMatch {
+                file: path.to_path_buf(),
+                line: line_num,
+                text: String::from_utf8_lossy(line_bytes).into_owned(),
+            });
+        }
+        start = i + 1;
+        line_num += 1;
+    }
+
+    if start < contents.len() {
+        let line_bytes = &contents[start..];
+        let is_match = re.is_match(line_bytes);
+        let should_include = if invert_match { !is_match } else { is_match };
+        if should_include {
+            results.push(CpuMatch {
+                file: path.to_path_buf(),
+                line: line_num,
+                text: String::from_utf8_lossy(line_bytes).into_owned(),
+            });
+        }
+    }
+
+    results
+}
+
+/// Search `contents` for a fixed-string `pattern`, transparently using the large-file
+/// line-aligned parallel-chunk path when `contents` is at/above
+/// `LARGE_FILE_PARALLEL_THRESHOLD_BYTES` and more than one chunk results; otherwise (small
+/// file, single-core box, or a file with too few line breaks to usefully split) falls back to
+/// exactly the same single-pass `scan_lines_memmem` call used today. Chunk results are
+/// collected via `Vec<LineAlignedChunk>::par_iter().map(..).collect::<Vec<_>>()`: rayon
+/// guarantees a `collect()` over an `IndexedParallelIterator` (which a `Vec`'s `par_iter()`
+/// always is) reassembles results in the same order as the source, i.e. ascending
+/// `chunk.start` / ascending line order -- so flattening the per-chunk `Vec<CpuMatch>` results
+/// in that order reproduces exactly the serial scan's match order, regardless of which thread
+/// finished first.
+fn search_contents_memmem_maybe_parallel(
+    contents: &[u8],
+    pattern: &[u8],
+    invert_match: bool,
+    path: &Path,
+) -> Vec<CpuMatch> {
+    if contents.len() >= LARGE_FILE_PARALLEL_THRESHOLD_BYTES {
+        let chunks = plan_line_aligned_chunks(contents, requested_parallel_chunk_count());
+        if chunks.len() > 1 {
+            let chunk_results: Vec<Vec<CpuMatch>> = chunks
+                .par_iter()
+                .map(|chunk| {
+                    scan_lines_memmem(
+                        &contents[chunk.start..chunk.end],
+                        pattern,
+                        invert_match,
+                        chunk.first_line,
+                        path,
+                    )
+                })
+                .collect();
+            return chunk_results.into_iter().flatten().collect();
+        }
+    }
+
+    scan_lines_memmem(contents, pattern, invert_match, 1, path)
+}
+
+/// Regex sibling of `search_contents_memmem_maybe_parallel` -- identical dispatch/ordering
+/// contract.
+fn search_contents_regex_maybe_parallel(
+    contents: &[u8],
+    re: &regex::bytes::Regex,
+    invert_match: bool,
+    path: &Path,
+) -> Vec<CpuMatch> {
+    if contents.len() >= LARGE_FILE_PARALLEL_THRESHOLD_BYTES {
+        let chunks = plan_line_aligned_chunks(contents, requested_parallel_chunk_count());
+        if chunks.len() > 1 {
+            let chunk_results: Vec<Vec<CpuMatch>> = chunks
+                .par_iter()
+                .map(|chunk| {
+                    scan_lines_regex(
+                        &contents[chunk.start..chunk.end],
+                        re,
+                        invert_match,
+                        chunk.first_line,
+                        path,
+                    )
+                })
+                .collect();
+            return chunk_results.into_iter().flatten().collect();
+        }
+    }
+
+    scan_lines_regex(contents, re, invert_match, 1, path)
+}
 
 pub struct CpuBackend;
 
@@ -122,43 +389,12 @@ impl CpuBackend {
         let file = File::open(path)?;
         let mmap = unsafe { MmapOptions::new().map(&file)? };
 
-        let mut results = Vec::new();
-        let mut line_num = 1;
-        let mut start = 0;
-
-        for (i, &byte) in mmap.iter().enumerate() {
-            if byte == b'\n' {
-                let line_bytes = &mmap[start..i];
-                let is_match = memmem::find(line_bytes, pattern).is_some();
-                let should_include = if invert_match { !is_match } else { is_match };
-
-                if should_include {
-                    results.push(CpuMatch {
-                        file: path.clone(),
-                        line: line_num,
-                        text: String::from_utf8_lossy(line_bytes).into_owned(),
-                    });
-                }
-                start = i + 1;
-                line_num += 1;
-            }
-        }
-
-        if start < mmap.len() {
-            let line_bytes = &mmap[start..];
-            let is_match = memmem::find(line_bytes, pattern).is_some();
-            let should_include = if invert_match { !is_match } else { is_match };
-
-            if should_include {
-                results.push(CpuMatch {
-                    file: path.clone(),
-                    line: line_num,
-                    text: String::from_utf8_lossy(line_bytes).into_owned(),
-                });
-            }
-        }
-
-        Ok(results)
+        Ok(search_contents_memmem_maybe_parallel(
+            &mmap[..],
+            pattern,
+            invert_match,
+            path,
+        ))
     }
 
     fn search_file_regex(
@@ -170,43 +406,12 @@ impl CpuBackend {
         let file = File::open(path)?;
         let mmap = unsafe { MmapOptions::new().map(&file)? };
 
-        let mut results = Vec::new();
-        let mut line_num = 1;
-        let mut start = 0;
-
-        for (i, &byte) in mmap.iter().enumerate() {
-            if byte == b'\n' {
-                let line_bytes = &mmap[start..i];
-                let is_match = re.is_match(line_bytes);
-                let should_include = if invert_match { !is_match } else { is_match };
-
-                if should_include {
-                    results.push(CpuMatch {
-                        file: path.clone(),
-                        line: line_num,
-                        text: String::from_utf8_lossy(line_bytes).into_owned(),
-                    });
-                }
-                start = i + 1;
-                line_num += 1;
-            }
-        }
-
-        if start < mmap.len() {
-            let line_bytes = &mmap[start..];
-            let is_match = re.is_match(line_bytes);
-            let should_include = if invert_match { !is_match } else { is_match };
-
-            if should_include {
-                results.push(CpuMatch {
-                    file: path.clone(),
-                    line: line_num,
-                    text: String::from_utf8_lossy(line_bytes).into_owned(),
-                });
-            }
-        }
-
-        Ok(results)
+        Ok(search_contents_regex_maybe_parallel(
+            &mmap[..],
+            re,
+            invert_match,
+            path,
+        ))
     }
 
     pub fn replace_in_place(
@@ -579,5 +784,360 @@ impl CpuBackend {
             .count();
 
         Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Intra-file parallel search: chunk planning + per-line scan correctness -------------
+    //
+    // These are unit tests of the private helpers (`plan_line_aligned_chunks`,
+    // `scan_lines_memmem`/`scan_lines_regex`, `search_contents_*_maybe_parallel`), so they live
+    // inline rather than in `rust_core/tests/test_search.rs` (which only sees `CpuBackend`'s
+    // public API). The crux property under test throughout: a chunked-and-reassembled scan
+    // must be BYTE-IDENTICAL to a single-pass whole-buffer scan -- same matches, same line
+    // numbers, same order, no dup/missed match at a chunk seam.
+
+    fn line_bytes(lines: &[&str]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for line in lines {
+            bytes.extend_from_slice(line.as_bytes());
+            bytes.push(b'\n');
+        }
+        bytes
+    }
+
+    #[test]
+    fn plan_line_aligned_chunks_empty_content_returns_empty() {
+        let chunks = plan_line_aligned_chunks(b"", 4);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn plan_line_aligned_chunks_single_requested_chunk_returns_empty() {
+        // requested_chunks <= 1 must signal "use the whole-buffer fallback", not a 1-item plan
+        // -- callers rely on `chunks.len() > 1` to decide whether to go parallel at all.
+        let content = line_bytes(&["a", "b", "c"]);
+        let chunks = plan_line_aligned_chunks(&content, 1);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn plan_line_aligned_chunks_boundaries_never_split_a_line() {
+        // 400 short, fixed-width lines so the target chunk size lands mid-line for most chunk
+        // counts unless the newline-snap logic in `align_chunk_end_to_newline` kicks in.
+        let lines: Vec<String> = (0..400).map(|i| format!("line-{i:04}")).collect();
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let content = line_bytes(&line_refs);
+
+        let chunks = plan_line_aligned_chunks(&content, 7);
+        assert!(chunks.len() > 1, "expected multiple chunks for this fixture");
+
+        assert_eq!(chunks[0].start, 0);
+        assert_eq!(chunks.last().unwrap().end, content.len());
+        for pair in chunks.windows(2) {
+            assert_eq!(
+                pair[0].end, pair[1].start,
+                "chunk boundaries must be contiguous: no gap, no overlap"
+            );
+        }
+        for chunk in &chunks {
+            assert!(
+                chunk.end == content.len() || content[chunk.end - 1] == b'\n',
+                "chunk end {} does not sit immediately after a newline",
+                chunk.end
+            );
+            assert!(
+                chunk.start == 0 || content[chunk.start - 1] == b'\n',
+                "chunk start {} does not sit immediately after a newline",
+                chunk.start
+            );
+            let expected_first_line = 1 + count_newlines(&content[..chunk.start]);
+            assert_eq!(chunk.first_line, expected_first_line);
+        }
+    }
+
+    #[test]
+    fn plan_line_aligned_chunks_full_coverage_across_many_chunk_counts() {
+        // Broader sweep than the single-fixture test above: variable-length lines (to stress
+        // many different alignment offsets) checked against every requested chunk count from 2
+        // to 16. For every count, the plan must cover the whole buffer exactly once with no
+        // gap, no overlap, and every boundary landing right after a newline.
+        let lines: Vec<String> = (0..777)
+            .map(|i| format!("line-{i:04}-{}", "y".repeat(i % 5)))
+            .collect();
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        let content = line_bytes(&line_refs);
+
+        for requested_chunks in 2..=16 {
+            let chunks = plan_line_aligned_chunks(&content, requested_chunks);
+            assert!(
+                !chunks.is_empty(),
+                "requested_chunks={requested_chunks} unexpectedly produced no plan"
+            );
+            assert_eq!(chunks[0].start, 0, "requested_chunks={requested_chunks}");
+            assert_eq!(
+                chunks.last().unwrap().end,
+                content.len(),
+                "requested_chunks={requested_chunks}"
+            );
+            for pair in chunks.windows(2) {
+                assert_eq!(
+                    pair[0].end, pair[1].start,
+                    "gap/overlap at requested_chunks={requested_chunks}"
+                );
+            }
+            for chunk in &chunks {
+                assert!(
+                    chunk.end == content.len() || content[chunk.end - 1] == b'\n',
+                    "boundary not newline-aligned at requested_chunks={requested_chunks}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn align_chunk_end_to_newline_snaps_forward_when_mid_line() {
+        let content = b"aaaa\nbbbb\ncccc\n";
+        // tentative_end = 2 lands inside "aaaa" -- must snap to right after the first '\n'.
+        assert_eq!(align_chunk_end_to_newline(content, 2), 5);
+    }
+
+    #[test]
+    fn align_chunk_end_to_newline_unchanged_when_already_at_boundary() {
+        let content = b"aaaa\nbbbb\ncccc\n";
+        assert_eq!(align_chunk_end_to_newline(content, 5), 5);
+    }
+
+    #[test]
+    fn align_chunk_end_to_newline_runs_to_eof_when_no_more_newlines() {
+        let content = b"aaaa\nbbbb\ncccc"; // no trailing newline
+        assert_eq!(align_chunk_end_to_newline(content, 12), content.len());
+    }
+
+    #[test]
+    fn scan_lines_memmem_chunked_matches_whole_buffer_serial_scan() {
+        // Needles placed at the very first line, the very last line, and immediately around
+        // every internal chunk boundary computed for `REQUESTED_CHUNKS` -- exactly the
+        // seam-adjacent positions a chunking bug would get wrong.
+        const LINE_BYTES: usize = 64;
+        const TOTAL_LINES: usize = 500;
+        const REQUESTED_CHUNKS: usize = 5;
+        const NEEDLE: &[u8] = b"NEEDLE";
+
+        let lines_per_chunk = TOTAL_LINES / REQUESTED_CHUNKS;
+        let needle_lines: Vec<usize> = vec![
+            1,
+            lines_per_chunk,
+            lines_per_chunk + 1,
+            lines_per_chunk * 2,
+            lines_per_chunk * 2 + 1,
+            lines_per_chunk * 3,
+            lines_per_chunk * 3 + 1,
+            lines_per_chunk * 4,
+            lines_per_chunk * 4 + 1,
+            TOTAL_LINES,
+        ];
+
+        let mut content = Vec::with_capacity(LINE_BYTES * TOTAL_LINES);
+        for line_number in 1..=TOTAL_LINES {
+            let mut line = if needle_lines.contains(&line_number) {
+                format!("L{line_number:04} NEEDLE")
+            } else {
+                format!("L{line_number:04} filler")
+            };
+            assert!(line.len() < LINE_BYTES);
+            line.push_str(&"x".repeat(LINE_BYTES - line.len() - 1));
+            line.push('\n');
+            content.extend_from_slice(line.as_bytes());
+        }
+
+        let path = Path::new("chunk-boundary-fixture.log");
+        let serial = scan_lines_memmem(&content, NEEDLE, false, 1, path);
+
+        let chunks = plan_line_aligned_chunks(&content, REQUESTED_CHUNKS);
+        assert!(chunks.len() > 1, "fixture must produce multiple chunks");
+
+        let mut parallel = Vec::new();
+        for chunk in &chunks {
+            parallel.extend(scan_lines_memmem(
+                &content[chunk.start..chunk.end],
+                NEEDLE,
+                false,
+                chunk.first_line,
+                path,
+            ));
+        }
+
+        assert_eq!(
+            serial, parallel,
+            "chunked-and-reassembled matches must be byte-identical to the whole-buffer serial scan"
+        );
+        assert_eq!(serial.len(), needle_lines.len());
+        assert_eq!(
+            serial.iter().map(|m| m.line).collect::<Vec<_>>(),
+            needle_lines
+        );
+        for matched in &serial {
+            assert!(matched.text.contains("NEEDLE"));
+        }
+    }
+
+    #[test]
+    fn scan_lines_memmem_invert_match_chunked_matches_serial() {
+        const LINE_BYTES: usize = 32;
+        const TOTAL_LINES: usize = 300;
+        const REQUESTED_CHUNKS: usize = 4;
+
+        let mut content = Vec::new();
+        for line_number in 1..=TOTAL_LINES {
+            let mut line = if line_number % 3 == 0 {
+                format!("L{line_number:04} SKIP")
+            } else {
+                format!("L{line_number:04} keep")
+            };
+            assert!(line.len() < LINE_BYTES);
+            line.push_str(&"x".repeat(LINE_BYTES - line.len() - 1));
+            line.push('\n');
+            content.extend_from_slice(line.as_bytes());
+        }
+
+        let path = Path::new("invert-fixture.log");
+        let serial = scan_lines_memmem(&content, b"SKIP", true, 1, path);
+
+        let chunks = plan_line_aligned_chunks(&content, REQUESTED_CHUNKS);
+        assert!(chunks.len() > 1, "fixture must produce multiple chunks");
+
+        let mut parallel = Vec::new();
+        for chunk in &chunks {
+            parallel.extend(scan_lines_memmem(
+                &content[chunk.start..chunk.end],
+                b"SKIP",
+                true,
+                chunk.first_line,
+                path,
+            ));
+        }
+
+        assert_eq!(serial, parallel);
+        assert_eq!(serial.len(), TOTAL_LINES - TOTAL_LINES / 3);
+    }
+
+    #[test]
+    fn scan_lines_regex_chunked_matches_serial() {
+        const LINE_BYTES: usize = 32;
+        const TOTAL_LINES: usize = 300;
+        const REQUESTED_CHUNKS: usize = 4;
+
+        let mut content = Vec::new();
+        for line_number in 1..=TOTAL_LINES {
+            let mut line = if line_number % 5 == 0 {
+                format!("L{line_number:04} ERR{line_number}")
+            } else {
+                format!("L{line_number:04} ok")
+            };
+            assert!(line.len() < LINE_BYTES);
+            line.push_str(&"x".repeat(LINE_BYTES - line.len() - 1));
+            line.push('\n');
+            content.extend_from_slice(line.as_bytes());
+        }
+
+        let re = regex::bytes::RegexBuilder::new(r"ERR\d+")
+            .build()
+            .unwrap();
+        let path = Path::new("regex-fixture.log");
+        let serial = scan_lines_regex(&content, &re, false, 1, path);
+
+        let chunks = plan_line_aligned_chunks(&content, REQUESTED_CHUNKS);
+        assert!(chunks.len() > 1, "fixture must produce multiple chunks");
+
+        let mut parallel = Vec::new();
+        for chunk in &chunks {
+            parallel.extend(scan_lines_regex(
+                &content[chunk.start..chunk.end],
+                &re,
+                false,
+                chunk.first_line,
+                path,
+            ));
+        }
+
+        assert_eq!(serial, parallel);
+        assert_eq!(serial.len(), TOTAL_LINES / 5);
+    }
+
+    #[test]
+    fn search_contents_memmem_maybe_parallel_small_buffer_matches_direct_scan() {
+        // Below LARGE_FILE_PARALLEL_THRESHOLD_BYTES: must behave exactly like calling
+        // `scan_lines_memmem` directly -- the "small files stay on the unchanged serial path"
+        // contract.
+        let content = line_bytes(&["alpha", "NEEDLE here", "beta", "NEEDLE again"]);
+        let path = Path::new("small.log");
+
+        let expected = scan_lines_memmem(&content, b"NEEDLE", false, 1, path);
+        let actual = search_contents_memmem_maybe_parallel(&content, b"NEEDLE", false, path);
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 2);
+    }
+
+    #[test]
+    fn search_contents_regex_maybe_parallel_small_buffer_matches_direct_scan() {
+        let content = line_bytes(&["alpha", "ERR42 here", "beta", "ERR7 again"]);
+        let re = regex::bytes::RegexBuilder::new(r"ERR\d+").build().unwrap();
+        let path = Path::new("small-regex.log");
+
+        let expected = scan_lines_regex(&content, &re, false, 1, path);
+        let actual = search_contents_regex_maybe_parallel(&content, &re, false, path);
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 2);
+    }
+
+    #[test]
+    fn search_contents_memmem_maybe_parallel_uses_chunking_on_a_large_buffer() {
+        // End-to-end proof at the real size threshold: build a buffer at/above
+        // LARGE_FILE_PARALLEL_THRESHOLD_BYTES, confirm the dispatcher's own chunk plan really
+        // does produce more than one chunk on this machine (otherwise this test would silently
+        // exercise only the fallback), and assert the dispatched result is identical to a
+        // direct whole-buffer scan.
+        if requested_parallel_chunk_count() < 2 {
+            return;
+        }
+
+        const LINE_BYTES: usize = 64;
+        let total_lines = (LARGE_FILE_PARALLEL_THRESHOLD_BYTES / LINE_BYTES) + 1000;
+        let mut filler_line = b"filler".to_vec();
+        filler_line.resize(LINE_BYTES - 1, b'x');
+        filler_line.push(b'\n');
+        let mut needle_line = b"NEEDLE".to_vec();
+        needle_line.resize(LINE_BYTES - 1, b'x');
+        needle_line.push(b'\n');
+        let needle_line_numbers = [1usize, total_lines / 2, total_lines];
+
+        let mut content = Vec::with_capacity(LINE_BYTES * total_lines);
+        for line_number in 1..=total_lines {
+            if needle_line_numbers.contains(&line_number) {
+                content.extend_from_slice(&needle_line);
+            } else {
+                content.extend_from_slice(&filler_line);
+            }
+        }
+        assert!(content.len() >= LARGE_FILE_PARALLEL_THRESHOLD_BYTES);
+
+        let chunks = plan_line_aligned_chunks(&content, requested_parallel_chunk_count());
+        assert!(
+            chunks.len() > 1,
+            "fixture must be large enough to actually engage chunking on this machine"
+        );
+
+        let path = Path::new("large-buffer-fixture.log");
+        let expected = scan_lines_memmem(&content, b"NEEDLE", false, 1, path);
+        let actual = search_contents_memmem_maybe_parallel(&content, b"NEEDLE", false, path);
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), needle_line_numbers.len());
     }
 }

--- a/rust_core/src/backend_cpu.rs
+++ b/rust_core/src/backend_cpu.rs
@@ -1069,6 +1069,51 @@ mod tests {
     }
 
     #[test]
+    fn scan_lines_memmem_no_match_chunked_matches_serial_empty_result() {
+        // The task's explicit "no-match" edge case: a large multi-line, multi-chunk buffer
+        // that contains the needle nowhere must produce an empty result on both the serial
+        // whole-buffer scan and every parallel chunk -- no false positive introduced by
+        // chunking, and no panic/hang on an all-empty-per-chunk result set.
+        const LINE_BYTES: usize = 40;
+        const TOTAL_LINES: usize = 400;
+        const REQUESTED_CHUNKS: usize = 6;
+
+        let mut content = Vec::new();
+        for line_number in 1..=TOTAL_LINES {
+            let mut line = format!("L{line_number:04} nothing-to-see-here");
+            assert!(line.len() < LINE_BYTES);
+            line.push_str(&"x".repeat(LINE_BYTES - line.len() - 1));
+            line.push('\n');
+            content.extend_from_slice(line.as_bytes());
+        }
+
+        let path = Path::new("no-match-fixture.log");
+        let serial = scan_lines_memmem(&content, b"NEEDLE", false, 1, path);
+        assert!(serial.is_empty(), "serial scan must find nothing");
+
+        let chunks = plan_line_aligned_chunks(&content, REQUESTED_CHUNKS);
+        assert!(chunks.len() > 1, "fixture must produce multiple chunks");
+
+        let mut parallel = Vec::new();
+        for chunk in &chunks {
+            parallel.extend(scan_lines_memmem(
+                &content[chunk.start..chunk.end],
+                b"NEEDLE",
+                false,
+                chunk.first_line,
+                path,
+            ));
+        }
+
+        assert_eq!(serial, parallel);
+        assert!(parallel.is_empty(), "no chunk may introduce a false-positive match");
+
+        // And through the real dispatcher (whichever path this machine takes):
+        let dispatched = search_contents_memmem_maybe_parallel(&content, b"NEEDLE", false, path);
+        assert!(dispatched.is_empty());
+    }
+
+    #[test]
     fn search_contents_memmem_maybe_parallel_small_buffer_matches_direct_scan() {
         // Below LARGE_FILE_PARALLEL_THRESHOLD_BYTES: must behave exactly like calling
         // `scan_lines_memmem` directly -- the "small files stay on the unchanged serial path"

--- a/rust_core/src/backend_cpu.rs
+++ b/rust_core/src/backend_cpu.rs
@@ -833,7 +833,10 @@ mod tests {
         let content = line_bytes(&line_refs);
 
         let chunks = plan_line_aligned_chunks(&content, 7);
-        assert!(chunks.len() > 1, "expected multiple chunks for this fixture");
+        assert!(
+            chunks.len() > 1,
+            "expected multiple chunks for this fixture"
+        );
 
         assert_eq!(chunks[0].start, 0);
         assert_eq!(chunks.last().unwrap().end, content.len());
@@ -1044,9 +1047,7 @@ mod tests {
             content.extend_from_slice(line.as_bytes());
         }
 
-        let re = regex::bytes::RegexBuilder::new(r"ERR\d+")
-            .build()
-            .unwrap();
+        let re = regex::bytes::RegexBuilder::new(r"ERR\d+").build().unwrap();
         let path = Path::new("regex-fixture.log");
         let serial = scan_lines_regex(&content, &re, false, 1, path);
 
@@ -1106,7 +1107,10 @@ mod tests {
         }
 
         assert_eq!(serial, parallel);
-        assert!(parallel.is_empty(), "no chunk may introduce a false-positive match");
+        assert!(
+            parallel.is_empty(),
+            "no chunk may introduce a false-positive match"
+        );
 
         // And through the real dispatcher (whichever path this machine takes):
         let dispatched = search_contents_memmem_maybe_parallel(&content, b"NEEDLE", false, path);

--- a/rust_core/tests/test_search.rs
+++ b/rust_core/tests/test_search.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use tempfile::tempdir;
 use tensor_grep_rs::backend_cpu::CpuBackend;
 
@@ -84,4 +84,65 @@ fn test_rust_cpu_backend_invert_includes_blank_lines() {
         .count_matches("alpha", file_path.to_str().unwrap(), false, true, false)
         .unwrap();
     assert_eq!(count_pos, 1);
+}
+
+#[test]
+fn test_rust_cpu_backend_large_file_engages_intra_file_parallel_search() {
+    // Public-API, real-file (not in-memory) proof that `CpuBackend::search`'s intra-file
+    // parallel chunking (backend_cpu.rs::search_contents_memmem_maybe_parallel, gated on
+    // LARGE_FILE_PARALLEL_THRESHOLD_BYTES = 50 MiB) produces exactly the matches a serial scan
+    // would: needles placed at the very first line, the very last line, and at the file's
+    // quarter/half/three-quarter marks (spread across whatever chunk boundaries this machine's
+    // core count produces), with nothing duplicated or dropped at a seam.
+    const LINE_BYTES: usize = 1024;
+    const TOTAL_LINES: usize = 56_000; // 56_000 * 1024 bytes ~= 54.7MB, over the 50MB threshold
+    const NEEDLE: &str = "NEEDLE";
+
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("large.log");
+    let file = File::create(&file_path).unwrap();
+    let mut writer = BufWriter::new(file);
+
+    let needle_lines: Vec<usize> = vec![
+        1,
+        TOTAL_LINES / 4,
+        TOTAL_LINES / 2,
+        (TOTAL_LINES * 3) / 4,
+        TOTAL_LINES,
+    ];
+
+    for line_number in 1..=TOTAL_LINES {
+        let mut line = if needle_lines.contains(&line_number) {
+            format!("L{line_number:06} {NEEDLE}")
+        } else {
+            format!("L{line_number:06} filler")
+        };
+        assert!(line.len() < LINE_BYTES);
+        line.push_str(&"x".repeat(LINE_BYTES - line.len() - 1));
+        line.push('\n');
+        writer.write_all(line.as_bytes()).unwrap();
+    }
+    writer.flush().unwrap();
+
+    let file_len = std::fs::metadata(&file_path).unwrap().len();
+    assert_eq!(file_len, (LINE_BYTES * TOTAL_LINES) as u64);
+    assert!(
+        file_len >= 50 * 1024 * 1024,
+        "fixture must actually cross the parallel threshold: {file_len} bytes"
+    );
+
+    let backend = CpuBackend::new();
+    let results = backend
+        .search(NEEDLE, file_path.to_str().unwrap(), false, true, false)
+        .unwrap();
+
+    assert_eq!(
+        results.iter().map(|(line, _)| *line).collect::<Vec<_>>(),
+        needle_lines,
+        "matched line numbers must be exactly the needle lines, in ascending order, with no \
+         duplicate or dropped match at a chunk seam"
+    );
+    for (_, text) in &results {
+        assert!(text.contains(NEEDLE), "unexpected match text: {text}");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds **intra-file parallel search** to `rust_core/src/backend_cpu.rs`'s `CpuBackend::search_file_memmem` / `search_file_regex` — the functions behind the PyO3 `RustBackend.search()` FFI method that Python's `RustCoreBackend` (`src/tensor_grep/backends/rust_backend.py`) calls into. For a single file at/above **50 MiB**, the file is split into **line-aligned byte chunks** (a chunk boundary is always snapped forward to the byte right after a `\n`, so a line can never be split across a seam) and each chunk is searched **in parallel with `rayon`**, using the exact same per-line `memmem`/regex matching logic the serial path already used.
- Below the threshold, on a single-core box, or when a file has too few line breaks to usefully split, behavior is byte-for-byte unchanged — same whole-buffer single-pass scan as before (now via `memchr_iter` instead of a manual byte loop for the newline scan, a behavior-preserving micro-improvement).
- This is the SAME idiom `native_search.rs::search_file_chunk_parallel` (already shipped, native_search.rs:1532-1611) uses for `--json`/`--count`/`--quiet` output — applied here to the *other* native CPU search implementation in this repo, which had **zero** intra-file parallelism before this change.

## Why `backend_cpu.rs`, not `native_search.rs`'s default text-output path

The task's benchmark reference (`docs/tool_comparison.md:58`, the 200MB single-file "tie" row: `tg search --no-ignore ERROR .../large_file_200mb.log`) exercises `native_search.rs`'s **default plain-text streaming path**, which routes through `NativeCpuBackend` per `docs/routing_policy.md`. I verified (file:line) that `native_search.rs` already has a proven chunk-parallel path — `FileChunkPlan`/`plan_file_chunks`/`search_file_chunk_parallel` (native_search.rs:645-1611) — but it is **deliberately gated off** for the default text and `--ndjson` modes:

```rust
// native_search.rs:1498-1522
fn should_use_chunk_parallel_search(config: &NativeSearchConfig, path: &Path) -> Result<bool> {
    if !config.parallel_large_files
        || !config.mmap
        || config.null_data
        || config.ndjson
        || (!config.json && !config.count && !config.quiet)   // <- excludes default text mode
        ...
```

That exclusion is not an oversight. `rust_core/tests/test_native_search.rs::test_native_search_default_output_streams_before_search_completion` (:771-796) and its `--ndjson` sibling (:798-829) assert the **first match must stream at least 25ms before the whole scan completes** — a real, tested, deliberate product contract (grep-like progressive output on huge files). A genuine multi-core speedup on that path would shrink total wall time toward `T/N`; on a fixture sized for that exact test, that plausibly collapses below the fixed 25ms margin — a foreseeable regression I can't verify without a local compile (CPU-safe: no cargo/rustc on this shared box). Reconciling true parallelism with that streaming/incremental-output guarantee needs a different design (e.g. stream an initial serial slice while parallelizing the remainder in the background) and is out of scope here — I did not touch it.

`backend_cpu.rs::search_with_paths` has no such contract: it's a synchronous call that collects every match into a `Vec` and returns it once, so there is nothing a parallel scan can disturb except *which thread* does the comparing — and it had no chunk-parallelism at all, making it a clean, correctness-first target that still delivers the requested mechanism (line-aligned rayon chunking, mirroring the existing idiom) on a real, previously-unparallelized path.

**Honesty note:** this PR does **not** claim to fix the `docs/tool_comparison.md:58` benchmark row — that row measures a different backend (`NativeCpuBackend`/`native_search.rs`) than the one this PR touches (`RustCoreBackend`/`backend_cpu.rs`). Confirmed via a documentation sweep (no doc anywhere asserts a cross-backend claim this PR would make stale).

## Design

- `LineAlignedChunk { start, end, first_line }` + `plan_line_aligned_chunks` (backend_cpu.rs:31-78): splits a byte buffer into up to N contiguous ranges, each boundary snapped forward to the next `\n` (or EOF) via `align_chunk_end_to_newline`.
- `scan_lines_memmem` / `scan_lines_regex` (backend_cpu.rs:111-205): the **one** per-line matching function — used both for the small-file whole-buffer scan (`first_line_number == 1`) and for every parallel chunk (`first_line_number` = that chunk's first line). The parallel path cannot diverge from serial because it's the identical predicate on a different byte range + line offset.
- `search_contents_memmem_maybe_parallel` / `_regex_maybe_parallel` (backend_cpu.rs:207-274): the dispatcher. Below 50 MiB or fewer than 2 planned chunks -> calls the whole-buffer scan directly. Otherwise -> `chunks.par_iter().map(|c| scan_lines_*(...)).collect::<Vec<Vec<CpuMatch>>>()`, then a sequential `.flatten()`.
- Threshold: `LARGE_FILE_PARALLEL_THRESHOLD_BYTES = 50 * 1024 * 1024`, chosen to exactly match `native_search.rs::LARGE_FILE_CHUNK_THRESHOLD_BYTES` (native_search.rs:28) rather than inventing a new number, so "large file" means the same thing everywhere in `tg`.
- Chunk count: one per available core (`std::thread::available_parallelism()`), same fallback policy as `native_search.rs::configured_chunk_parallelism_threads` when no override is configured. `backend_cpu.rs` has no config struct (plain method args only), so there's no override knob here.
- Multi-file directory walk in `search_with_paths` is **untouched** (still a serial `for entry in WalkDir` loop) — per "don't double-parallelize," only the per-file scan gained intra-file parallelism; a large file hit mid-walk benefits too, but the walk's own structure is unchanged.

## Correctness argument (the crux)

1. Matching was **already** strictly per-line before this change — a match never looks past a `\n`. So partitioning the file at line boundaries cannot change *which* lines match, only which thread checks them.
2. Chunk boundaries are always contiguous and newline-aligned — every byte of the file is scanned by exactly one chunk, so no line is ever duplicated or dropped at a seam. (Verified by property tests across chunk counts 2..=16, see below.)
3. `Vec<LineAlignedChunk>::par_iter().map(..)` stays an `IndexedParallelIterator` throughout (`Map<I, F>: IndexedParallelIterator` when `I: IndexedParallelIterator`, confirmed against rayon 1.12's published docs — a `Vec`'s `par_iter()` always is one). `collect()` on an indexed parallel iterator reassembles results in source order regardless of which thread finishes first, so flattening the per-chunk match vectors in chunk order reproduces the serial scan's exact match order.

## Tests

All in `rust_core/src/backend_cpu.rs`'s new `#[cfg(test)] mod tests` unless noted:

- `plan_line_aligned_chunks_{empty_content,single_requested_chunk}_returns_empty` -- degenerate-input contract.
- `plan_line_aligned_chunks_boundaries_never_split_a_line` + `..._full_coverage_across_many_chunk_counts` -- contiguity (`chunk[i].end == chunk[i+1].start`), full coverage (`chunks[0].start == 0`, `chunks.last().end == content.len()`), and newline-alignment, the second across chunk counts 2..=16 on variable-length-line content.
- `align_chunk_end_to_newline_{snaps_forward_when_mid_line,unchanged_when_already_at_boundary,runs_to_eof_when_no_more_newlines}` -- direct boundary-snapping unit tests.
- `scan_lines_memmem_chunked_matches_whole_buffer_serial_scan` / `..._invert_match_...` / `scan_lines_regex_chunked_matches_serial` -- **the crux test**: needles placed at the first line, the last line, and immediately around every internal boundary of a deterministic 5-chunk plan; asserts the chunked-and-reassembled `Vec<CpuMatch>` is `assert_eq!`-identical to a direct whole-buffer scan (memmem, regex, and inverted-match modes all covered).
- `scan_lines_memmem_no_match_chunked_matches_serial_empty_result` -- the explicit no-match edge case: a large, multi-chunk buffer containing the needle nowhere produces an empty result on the serial scan, every chunk, the reassembled result, and the real dispatcher.
- `search_contents_{memmem,regex}_maybe_parallel_small_buffer_matches_direct_scan` -- below-threshold behavior is unchanged.
- `search_contents_memmem_maybe_parallel_uses_chunking_on_a_large_buffer` -- builds an in-memory buffer at/above the real 50 MiB threshold, asserts the dispatcher's own chunk plan actually produces >1 chunk on the test machine (so the test can't silently no-op into the fallback and pass vacuously), then asserts the dispatched result equals a direct whole-buffer scan.
- `rust_core/tests/test_search.rs::test_rust_cpu_backend_large_file_engages_intra_file_parallel_search` -- the public-API, **real on-disk file** (not in-memory) end-to-end proof: writes a ~55MB file, searches it through `CpuBackend::search` (the exact FFI entry point Python calls), asserts matched line numbers are exactly the expected needle lines (first/last/quarter marks) in ascending order.

## What this PR does NOT do

- Does not touch `native_search.rs`, `session_daemon.py`, `bootstrap.py`, `repo_map.py`, or `agent_capsule.py` (out of assigned scope).
- Does not change the multi-file directory-walk dispatch in `search_with_paths`.
- Does not fix a **pre-existing, out-of-scope gap** I found while reading `native_search.rs::search_file_chunk_parallel` for context: its already-shipped `--json`/`--count` chunk-parallel path hardcodes `binary_detected: false` for files above its threshold (skips the serial path's binary-file detection entirely). Flagging for a follow-up issue; not touched here -- different file, different path, deserves its own dedicated fix + test rather than a drive-by change in this PR. (`backend_cpu.rs` itself has no binary-file detection at all, before or after this change, so there is no analogous divergence introduced here.)
- Does not add Cargo dependencies (`memchr`/`rayon`/`regex`/`memmap2`/`tempfile` were already declared).

## Verification status (CPU-safe: no local cargo/rustc/maturin)

- **Cannot compile or run `cargo test` / `cargo clippy -D warnings` / `cargo fmt --check` locally** (shared server constraint). Every claim above comes from manually tracing types, trait bounds, and coercions (`&Mmap`/`&[u8]` slicing, `&PathBuf`->`&Path` deref coercion, `Regex: Sync`, closure captures, rayon's `IndexedParallelIterator` chain) and cross-checking against **already-compiling, already-CI-green precedent in this exact crate**: `native_search.rs`'s identical `plan_file_chunks`/`search_file_chunk_parallel` pattern, and this same file's own pre-existing `count_file_memmem`/`count_file_regex` `rayon::par_split` usage.
- Confirmed no collision with `rust_core/tests/test_replace.rs`'s source-shape test (`extract_function_body` targets only `replace_file_literal`/`replace_file_regex`/`write_replacements_with_mmap`/`apply_replacements_in_place` -- none touched by this PR).
- Manually verified: brace/paren balance, no line >100 chars outside doc comments (rustfmt's stable default does not wrap comments; confirmed 3 pre-existing >100-char comment lines already in native_search.rs as precedent), every new import used, every new function called from somewhere, no dead code.
- **Timing/speedup is explicitly NOT measured or claimed here.** It is to be validated by CI (`test-rust-core` matrix across ubuntu/windows/macos x stable, and `benchmark-regression` if applicable) and the independent Opus gate, not asserted locally.

## For the gate

The crux to adversarially re-check: does the chunk-boundary math (`plan_line_aligned_chunks`/`align_chunk_end_to_newline`) truly guarantee no line is ever split, duplicated, or dropped, across every edge case (empty file, single line with no trailing newline, file byte-length exactly divisible by chunk count, file with fewer lines than requested chunks, a chunk landing exactly on an existing newline)? And does the rayon `IndexedParallelIterator`/`collect()` ordering guarantee actually hold as represented (worth an independent doc/source check, not just trusting this description)? Please also confirm CI is green on `test-rust-core` (all OSes) and `static-analysis` (fmt + clippy) before merge, since none of that could be verified locally this session.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
