### PR TITLE
feat(agent-capsule): CodeAnchor-style inline caller/fan-in annotation (experimental, opt-in)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -1899,6 +1899,205 @@ def _build_snippets(
     return snippets, omitted, used_tokens
 
 
+# CodeAnchor steal (arXiv 2606.26979, "How Much Static Structure Do Code Agents Need?"): render a
+# lightweight caller/fan-in fact as an INLINE plain-text comment near the primary target's
+# definition, inside the rendered source excerpt itself, rather than requiring a separate tool
+# call -- the paper's own finding is that this ambient placement (not a structured sibling field)
+# is what drove +3.4pp Pass@1 and halved run-to-run variance, and it directly targets the
+# cross-paper "agents skip the graph tool 58% of the time" adoption gap (CodeCompass 2602.20048).
+#
+# SCOPE (verify-plan-against-code finding): this capsule already collects verified call-site
+# evidence for the PRIMARY target ONLY (`_collect_capsule_call_site_evidence[_from_map]`, gated on
+# confidence>=0.75 + an explicitly-requested symbol) via a real blast-radius scan the capsule pays
+# for regardless of this feature. Annotating that one already-evidenced snippet is therefore a pure
+# RENDERING-layer change -- no new graph computation. Annotating every OTHER rendered snippet would
+# need a fresh per-symbol blast-radius scan this function does not already run, which is exactly
+# the "big new per-symbol computation" this feature deliberately does NOT attempt; scope stays
+# primary-target-only rather than forcing that cost.
+_CAPSULE_INLINE_CALLER_ANNOTATION_ENV = "TG_CAPSULE_INLINE_CALLERS"
+_CAPSULE_INLINE_CALLER_ANNOTATION_TOP_LIMIT = 2
+
+
+def _capsule_inline_caller_annotation_enabled() -> bool:
+    """Opt-in flag (default OFF). Same polarity as `_capsule_outbound_dependencies_enabled`, for a
+    stronger reason than DAR's "pending a measured golden-set win": this feature MUTATES an
+    EXISTING field's byte content (`snippets[i]["source"]`, `["line_map"]`, `["token_estimate"]`)
+    rather than only adding new sibling keys, so a default-on flip would silently change output
+    shape for every existing consumer/test on this repo. Enable via `TG_CAPSULE_INLINE_CALLERS` in
+    {"1", "true", "yes", "on"} (case-insensitive).
+    """
+    raw = os.environ.get(_CAPSULE_INLINE_CALLER_ANNOTATION_ENV)
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _inline_annotation_comment_prefix(file_path: str) -> str | None:
+    """Line-comment token for the primary snippet's language, or None to skip annotation entirely
+    on a language this renderer does not confidently recognize -- fail-closed: never guess wrong on
+    comment syntax and risk corrupting the excerpt's copy-usability. Deliberately mirrors the exact
+    suffix sets `repo_map._render_source_block`/`repo_map._is_comment_line` already use for
+    comment-aware rendering, so "languages this feature understands" cannot drift from "languages
+    the renderer already strips comments for" into a second, independently-maintained list.
+    """
+    suffix = Path(file_path).suffix
+    if suffix == ".py":
+        return "#"
+    if suffix in repo_map._JS_TS_SUFFIXES or suffix in repo_map._RUST_SUFFIXES:
+        return "//"
+    return None
+
+
+def _top_caller_symbol_names(
+    rm: dict[str, Any],
+    related_call_sites: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[str]:
+    """Resolve each call site's ENCLOSING function/method name via the already-built `rm`'s
+    per-file symbol table (`repo_map._enclosing_symbol_for_line` -- the same helper
+    `_related_spans_from_blast_radius` already uses for the edit-plan-seed's related spans), an
+    in-memory lookup against data the capsule already holds, not a new file scan. Never fabricates
+    a name: a call site whose enclosing symbol cannot be resolved (a module-level call, or a
+    language gap) is silently skipped rather than guessed. Deduplicated, order-preserving, capped
+    at `limit` so the rendered fact stays a single short line.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for site in related_call_sites:
+        if len(names) >= limit:
+            break
+        file_path = str(site.get("file") or "")
+        if not file_path:
+            continue
+        try:
+            line = int(site.get("line") or 0)
+        except (TypeError, ValueError):
+            continue
+        if line <= 0:
+            continue
+        enclosing = repo_map._enclosing_symbol_for_line(rm, file_path, line)
+        if not enclosing:
+            continue
+        name = str(enclosing.get("name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def _build_inline_caller_annotation_text(
+    comment_prefix: str,
+    call_site_evidence: dict[str, Any],
+    top_names: list[str],
+) -> str | None:
+    """Compact caller/fan-in fact, ~1 line: an INVERSE-only (who-calls-me) fact -- per the
+    CodeAnchor paper's own finding that forward-edge annotations add tokens without the
+    reliability win, this deliberately never renders callees/imports, only callers. Returns None
+    when `call_site_evidence` was never actually collected (status "disabled"/"skipped"/"error") --
+    honest absence, never a fabricated "callers=0" for a symbol nobody looked up.
+    """
+    status = call_site_evidence.get("status")
+    if status not in ("collected", "collected_no_call_sites"):
+        return None
+    returned = int(call_site_evidence.get("returned_call_sites", 0) or 0)
+    omitted = int(call_site_evidence.get("omitted_call_sites", 0) or 0)
+    truncated = omitted > 0 or bool(call_site_evidence.get("partial"))
+    count_text = f"{returned}+" if truncated else str(returned)
+    if top_names:
+        fact = f"callers={count_text} (top: {', '.join(top_names)})"
+    else:
+        fact = f"callers={count_text}"
+    return f"{comment_prefix} tg: {fact}"
+
+
+def _apply_inline_caller_annotation(
+    snippets: list[dict[str, Any]],
+    target: dict[str, Any],
+    call_site_evidence: dict[str, Any],
+    related_call_sites: list[dict[str, Any]],
+    rm: dict[str, Any],
+    *,
+    max_tokens: int | None,
+    used_tokens: int,
+) -> None:
+    """Prepend a one-line inline structural annotation to the PRIMARY target's rendered snippet --
+    the definition an agent is actually about to edit, which is the one snippet this capsule
+    already has verified call-site evidence for. Mutates the matching snippet dict in place; a
+    no-op (returns without touching anything) whenever the feature is off, the data was never
+    collected, the language is unrecognized, or the annotation would blow the caller's own
+    `max_tokens` ceiling.
+
+    ORDERING CONTRACT (enforced by the caller in `build_agent_capsule_from_map`, not here): this
+    must run AFTER `_collect_outbound_dependencies` (DAR). DAR resolves callee line numbers as
+    `start_line + offset` into the primary snippet's OWN rendered source
+    (`_outbound_dependency_call_tokens`); prepending a line to that source before DAR runs would
+    shift every subsequent line off by one in DAR's own arithmetic. Running last avoids that
+    entirely -- DAR always sees the unmodified snippet.
+
+    `line_map` uses the SAME "unknown/synthetic line -> None" convention `_expanded_line_map`
+    already emits for a truncated/unmapped rendered line (not a new shape), so a consumer that
+    already tolerates `line: None` there tolerates it here too.
+    """
+    if not snippets or not _capsule_inline_caller_annotation_enabled():
+        return
+    target_file = str(target.get("file") or "")
+    target_symbol = str(target.get("symbol") or "")
+    if not target_file or not target_symbol:
+        return
+    primary_snippet = next(
+        (
+            snippet
+            for snippet in snippets
+            if str(snippet.get("file") or "") == target_file
+            and str(snippet.get("symbol") or "") == target_symbol
+        ),
+        None,
+    )
+    if primary_snippet is None:
+        return
+    comment_prefix = _inline_annotation_comment_prefix(target_file)
+    if comment_prefix is None:
+        return
+    top_names = _top_caller_symbol_names(
+        rm, related_call_sites, limit=_CAPSULE_INLINE_CALLER_ANNOTATION_TOP_LIMIT
+    )
+    annotation_line = _build_inline_caller_annotation_text(
+        comment_prefix, call_site_evidence, top_names
+    )
+    if annotation_line is None:
+        return
+    annotation_token_estimate = repo_map._estimate_tokens(annotation_line)
+    if max_tokens is not None and used_tokens + annotation_token_estimate > max_tokens:
+        # Fail closed on the token budget: never silently exceed a caller-requested --max-tokens
+        # ceiling just to squeeze in an annotation. The snippet still renders, unmodified.
+        return
+    original_source = str(primary_snippet.get("source") or "")
+    primary_snippet["source"] = (
+        f"{annotation_line}\n{original_source}" if original_source else annotation_line
+    )
+    raw_line_map = primary_snippet.get("line_map")
+    expanded_line_map = raw_line_map if isinstance(raw_line_map, list) else []
+    primary_snippet["line_map"] = [
+        {"line": None, "text": annotation_line},
+        *expanded_line_map,
+    ]
+    primary_snippet["token_estimate"] = (
+        int(primary_snippet.get("token_estimate", 0) or 0) + annotation_token_estimate
+    )
+    primary_snippet["inline_structural_annotation"] = {
+        "applied": True,
+        "kind": "callers",
+        "callers_returned": int(call_site_evidence.get("returned_call_sites", 0) or 0),
+        "callers_truncated": bool(
+            int(call_site_evidence.get("omitted_call_sites", 0) or 0) > 0
+            or call_site_evidence.get("partial")
+        ),
+        "top_callers": top_names,
+    }
+
+
 def _follow_up_reads(
     payload: dict[str, Any],
     omitted_sources: list[dict[str, Any]],
@@ -3125,6 +3324,18 @@ def build_agent_capsule_from_map(
         preview_token_budget=outbound_dependency_preview_budget,
         deadline_monotonic=deadline_monotonic,
         deadline_hit=outbound_dependencies_deadline_hit,
+    )
+    # CodeAnchor inline structural annotation (arXiv 2606.26979): MUST run after DAR above, not
+    # before -- see `_apply_inline_caller_annotation`'s ordering-contract docstring. Mutates the
+    # primary snippet only, and only when `TG_CAPSULE_INLINE_CALLERS` opts in.
+    _apply_inline_caller_annotation(
+        snippets,
+        target,
+        call_site_evidence,
+        related_call_sites,
+        rm,
+        max_tokens=max_tokens,
+        used_tokens=used_tokens,
     )
     rollback_ref = _command_ref(["tg", "checkpoint", "create", resolved_path])
     route_rationale: list[dict[str, Any]] = [

--- a/tests/unit/test_agent_capsule_inline_caller_annotation.py
+++ b/tests/unit/test_agent_capsule_inline_caller_annotation.py
@@ -1,0 +1,604 @@
+"""CodeAnchor-style inline structural annotation (arXiv 2606.26979, "How Much Static Structure Do
+Code Agents Need?"): the `tg agent` capsule renders a compact caller/fan-in fact as a plain-text
+comment INSIDE the primary target's rendered source excerpt, ambient to the code an agent already
+reads, instead of requiring a separate tool call. The paper's own reported win was +3.4pp Pass@1
+and halved run-to-run variance from exactly this ambient placement (not a structured sibling
+field), and it targets the cross-paper "agents skip the graph tool 58% of the time" adoption gap
+(CodeCompass 2602.20048).
+
+SCOPE (verify-plan-against-code finding, see `agent_capsule._apply_inline_caller_annotation`'s
+docstring): this capsule already collects verified call-site evidence for the PRIMARY target ONLY
+(`_collect_capsule_call_site_evidence[_from_map]`, gated on confidence>=0.75 + an
+explicitly-requested symbol) via a blast-radius scan the capsule pays for regardless of this
+feature. Annotating that one already-evidenced snippet is a pure rendering-layer change; every
+other rendered snippet is deliberately left unannotated rather than paying for a fresh per-symbol
+blast-radius scan this function does not already run.
+
+THE TRAP these tests guard against: DAR (`_collect_outbound_dependencies`) resolves call-token line
+numbers as `start_line + offset` into the PRIMARY snippet's own rendered `source`
+(`agent_capsule._outbound_dependency_call_tokens`). Prepending the annotation line before DAR runs
+would shift every subsequent line off by one in DAR's own arithmetic -- `test_inline_caller_
+annotation_runs_after_dar_ordering_contract` pins the fix (annotate strictly after DAR) as an
+ordering contract, not an implementation detail.
+
+Most tests here build REAL on-disk fixture projects and drive the full `build_agent_capsule`
+pipeline (real repo scan, real blast-radius call-site evidence, real `_enclosing_symbol_for_line`
+resolution) -- the same "prove it against real data" discipline `test_agent_capsule_outbound_deps.py`
+uses for DAR. A handful of pure-function tests exercise the small rendering helpers directly for
+determinism (language-comment mapping, annotation text variants, multi-snippet targeting).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tensor_grep.cli import agent_capsule
+
+_TARGET_SYMBOL = "target_fn"
+_CALLER_SYMBOL = "process_incoming_request"
+
+
+def _write_project_with_one_caller(tmp_path: Path) -> dict[str, Path]:
+    project = tmp_path / "workspace"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    handler = project / "handler.py"
+    handler.write_text(
+        f"def {_TARGET_SYMBOL}(payload):\n    return payload\n",
+        encoding="utf-8",
+    )
+    caller = project / "caller.py"
+    caller.write_text(
+        f"from handler import {_TARGET_SYMBOL}\n\n\n"
+        f"def {_CALLER_SYMBOL}(payload):\n    return {_TARGET_SYMBOL}(payload)\n",
+        encoding="utf-8",
+    )
+    return {"project": project, "handler": handler, "caller": caller}
+
+
+def _write_project_with_uncalled_leaf(tmp_path: Path) -> dict[str, Path]:
+    project = tmp_path / "workspace"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    handler = project / "handler.py"
+    handler.write_text(
+        "def unreferenced_leaf_fn(payload):\n    return payload\n",
+        encoding="utf-8",
+    )
+    return {"project": project, "handler": handler}
+
+
+# ---------------------------------------------------------------------------------------------
+# (1) Opt-in flag: defaults OFF, toggled by TG_CAPSULE_INLINE_CALLERS.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_defaults_off_when_env_unset() -> None:
+    saved = os.environ.pop("TG_CAPSULE_INLINE_CALLERS", None)
+    try:
+        assert agent_capsule._capsule_inline_caller_annotation_enabled() is False
+        os.environ["TG_CAPSULE_INLINE_CALLERS"] = "1"
+        assert agent_capsule._capsule_inline_caller_annotation_enabled() is True
+        os.environ["TG_CAPSULE_INLINE_CALLERS"] = "0"
+        assert agent_capsule._capsule_inline_caller_annotation_enabled() is False
+    finally:
+        if saved is None:
+            os.environ.pop("TG_CAPSULE_INLINE_CALLERS", None)
+        else:
+            os.environ["TG_CAPSULE_INLINE_CALLERS"] = saved
+
+
+def test_inline_caller_annotation_absent_by_default_leaves_source_untouched(
+    tmp_path: Path,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+    os.environ.pop("TG_CAPSULE_INLINE_CALLERS", None)
+
+    payload = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+
+    snippet = payload["snippets"][0]
+    assert snippet["source"] == f"def {_TARGET_SYMBOL}(payload):\n    return payload\n"
+    assert "inline_structural_annotation" not in snippet
+
+
+# ---------------------------------------------------------------------------------------------
+# (2) Real end-to-end: one real caller -> honest count + resolved top-caller name.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_renders_count_and_top_caller_for_real_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+
+    payload = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+
+    assert payload["call_site_evidence"]["status"] == "collected"
+    snippet = payload["snippets"][0]
+    expected_annotation = f"# tg: callers=1 (top: {_CALLER_SYMBOL})"
+    assert snippet["source"] == (
+        f"{expected_annotation}\ndef {_TARGET_SYMBOL}(payload):\n    return payload\n"
+    )
+    # The real code stays byte-identical AFTER the one prepended comment line -- copy-usability
+    # is preserved, the fact lives strictly in a comment, never inside the code.
+    assert snippet["source"].split("\n", 1)[1] == (
+        f"def {_TARGET_SYMBOL}(payload):\n    return payload\n"
+    )
+
+    line_map = snippet["line_map"]
+    assert line_map[0] == {"line": None, "text": expected_annotation}
+    assert line_map[1]["line"] == 1
+    assert line_map[2]["line"] == 2
+
+    annotation = snippet["inline_structural_annotation"]
+    assert annotation == {
+        "applied": True,
+        "kind": "callers",
+        "callers_returned": 1,
+        "callers_truncated": False,
+        "top_callers": [_CALLER_SYMBOL],
+    }
+
+    # Token accounting stays honest: the snippet's own token_estimate grows by exactly the
+    # annotation line's own estimate (never silently absorbed/ignored).
+    base_source = f"def {_TARGET_SYMBOL}(payload):\n    return payload\n"
+    from tensor_grep.cli import repo_map
+
+    assert snippet["token_estimate"] == repo_map._estimate_tokens(
+        base_source
+    ) + repo_map._estimate_tokens(expected_annotation)
+
+
+def test_inline_caller_annotation_cli_json_round_trips(tmp_path: Path) -> None:
+    """The feature must survive a real --json serialization (the JSON contract stays intact --
+    additive metadata, not a shape break)."""
+    paths = _write_project_with_one_caller(tmp_path)
+    os.environ["TG_CAPSULE_INLINE_CALLERS"] = "1"
+    try:
+        payload = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+        encoded = json.dumps(payload)
+        decoded = json.loads(encoded)
+        assert decoded["snippets"][0]["inline_structural_annotation"]["callers_returned"] == 1
+        assert decoded["snippets"][0]["line_map"][0]["line"] is None
+    finally:
+        os.environ.pop("TG_CAPSULE_INLINE_CALLERS", None)
+
+
+# ---------------------------------------------------------------------------------------------
+# (3) Real end-to-end: a genuinely uncalled symbol -> honest "callers=0", never fabricated.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_renders_honest_zero_when_no_callers_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_uncalled_leaf(tmp_path)
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+
+    payload = agent_capsule.build_agent_capsule("unreferenced_leaf_fn", paths["project"])
+
+    assert payload["call_site_evidence"]["status"] == "collected_no_call_sites"
+    snippet = payload["snippets"][0]
+    assert snippet["source"].startswith("# tg: callers=0\n")
+    assert snippet["inline_structural_annotation"]["callers_returned"] == 0
+    assert snippet["inline_structural_annotation"]["top_callers"] == []
+
+
+# ---------------------------------------------------------------------------------------------
+# (4) Graceful absence: evidence never collected -> no annotation, no fabricated "callers=0".
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_absent_when_call_site_evidence_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+
+    payload = agent_capsule.build_agent_capsule(
+        _TARGET_SYMBOL,
+        paths["project"],
+        include_blast_radius=False,
+    )
+
+    assert payload["call_site_evidence"]["status"] == "disabled"
+    snippet = payload["snippets"][0]
+    assert snippet["source"] == f"def {_TARGET_SYMBOL}(payload):\n    return payload\n"
+    assert "inline_structural_annotation" not in snippet
+
+
+# ---------------------------------------------------------------------------------------------
+# (5) Token budget: fail closed rather than silently exceed --max-tokens.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_fails_closed_on_tight_token_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+    from tensor_grep.cli import repo_map
+
+    base_source = f"def {_TARGET_SYMBOL}(payload):\n    return payload\n"
+    exact_fit_tokens = repo_map._estimate_tokens(base_source)
+
+    payload = agent_capsule.build_agent_capsule(
+        _TARGET_SYMBOL,
+        paths["project"],
+        max_tokens=exact_fit_tokens,
+    )
+
+    assert payload["call_site_evidence"]["status"] == "collected"
+    snippet = payload["snippets"][0]
+    # The base snippet still fits and renders -- only the annotation is dropped, never the code.
+    assert snippet["source"] == base_source
+    assert "inline_structural_annotation" not in snippet
+
+
+def test_inline_caller_annotation_fits_when_budget_has_room(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+
+    payload = agent_capsule.build_agent_capsule(
+        _TARGET_SYMBOL,
+        paths["project"],
+        max_tokens=200,
+    )
+
+    snippet = payload["snippets"][0]
+    assert snippet["source"].startswith("# tg: callers=1")
+    assert snippet["inline_structural_annotation"]["applied"] is True
+
+
+# ---------------------------------------------------------------------------------------------
+# (6) Kill switch: explicit off-values match the unset-env baseline byte-for-byte.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_kill_switch_matches_default_off_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+    os.environ.pop("TG_CAPSULE_INLINE_CALLERS", None)
+    payload_unset = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+
+    for off_value in ("0", "false", "False", "no", "off", ""):
+        monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", off_value)
+        payload_off = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+        assert json.dumps(payload_off, sort_keys=True) == json.dumps(
+            payload_unset, sort_keys=True
+        ), off_value
+
+
+# ---------------------------------------------------------------------------------------------
+# (7) Isolation: never mutates confidence/consistency/ask-user/related_call_sites state.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_never_mutates_confidence_or_consistency_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _write_project_with_one_caller(tmp_path)
+
+    os.environ.pop("TG_CAPSULE_INLINE_CALLERS", None)
+    payload_off = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+    payload_on = agent_capsule.build_agent_capsule(_TARGET_SYMBOL, paths["project"])
+
+    assert payload_on["snippets"][0]["source"] != payload_off["snippets"][0]["source"]
+    assert payload_on["confidence"] == payload_off["confidence"]
+    assert payload_on["ask_user_before_editing"] == payload_off["ask_user_before_editing"]
+    assert payload_on["context_consistency"] == payload_off["context_consistency"]
+    assert payload_on["primary_target"] == payload_off["primary_target"]
+    assert payload_on["related_call_sites"] == payload_off["related_call_sites"]
+    assert payload_on["call_site_evidence"] == payload_off["call_site_evidence"]
+
+
+# ---------------------------------------------------------------------------------------------
+# (8) Ordering contract: MUST run after DAR, so DAR's own line arithmetic over the primary
+# snippet's source is never disturbed by the prepended annotation line.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_inline_caller_annotation_runs_after_dar_ordering_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+
+    call_order: list[str] = []
+    original_dar = agent_capsule._collect_outbound_dependencies
+    original_annotate = agent_capsule._apply_inline_caller_annotation
+
+    def _spy_dar(*args: Any, **kwargs: Any) -> Any:
+        call_order.append("dar")
+        return original_dar(*args, **kwargs)
+
+    def _spy_annotate(*args: Any, **kwargs: Any) -> Any:
+        call_order.append("annotate")
+        return original_annotate(*args, **kwargs)
+
+    monkeypatch.setattr(agent_capsule, "_collect_outbound_dependencies", _spy_dar)
+    monkeypatch.setattr(agent_capsule, "_apply_inline_caller_annotation", _spy_annotate)
+
+    agent_capsule.build_agent_capsule("f", str(tmp_path))
+
+    assert call_order == ["dar", "annotate"]
+
+
+def test_dar_call_token_line_numbers_would_shift_if_annotation_ran_first() -> None:
+    """Documents the MECHANISM the ordering contract above guards against: DAR's own tokenizer
+    computes each call token's absolute line as `start_line + offset`-within-`source`. Prepending
+    a line to `source` before this runs shifts every subsequent line off by one."""
+    base_source = "def f():\n    return g()\n"
+    start_line = 10
+    tokens_unannotated = agent_capsule._outbound_dependency_call_tokens(base_source, start_line)
+    assert ("g", 11) in tokens_unannotated
+
+    annotated_source = "# tg: callers=1 (top: caller)\n" + base_source
+    tokens_if_annotated_first = agent_capsule._outbound_dependency_call_tokens(
+        annotated_source, start_line
+    )
+    # Off by one -- exactly the corruption the ordering contract prevents.
+    assert ("g", 12) in tokens_if_annotated_first
+    assert ("g", 11) not in tokens_if_annotated_first
+
+
+# ---------------------------------------------------------------------------------------------
+# (9) Direct helper tests: comment-prefix language mapping (fail-closed on unknown languages).
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("file_name", "expected_prefix"),
+    [
+        ("mod.py", "#"),
+        ("mod.js", "//"),
+        ("mod.jsx", "//"),
+        ("mod.ts", "//"),
+        ("mod.tsx", "//"),
+        ("mod.mjs", "//"),
+        ("mod.cjs", "//"),
+        ("mod.rs", "//"),
+        ("mod.go", None),
+        ("mod.md", None),
+        ("mod.json", None),
+        ("mod.txt", None),
+        ("mod", None),
+    ],
+)
+def test_inline_annotation_comment_prefix_by_language(
+    file_name: str, expected_prefix: str | None
+) -> None:
+    assert agent_capsule._inline_annotation_comment_prefix(f"/repo/{file_name}") == expected_prefix
+
+
+# ---------------------------------------------------------------------------------------------
+# (10) Direct helper tests: annotation text variants (never fabricates on non-collected status).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_inline_caller_annotation_text_collected_with_names() -> None:
+    evidence = {"status": "collected", "returned_call_sites": 2, "omitted_call_sites": 0}
+    text = agent_capsule._build_inline_caller_annotation_text("#", evidence, ["foo", "bar"])
+    assert text == "# tg: callers=2 (top: foo, bar)"
+
+
+def test_build_inline_caller_annotation_text_collected_truncated() -> None:
+    evidence = {"status": "collected", "returned_call_sites": 8, "omitted_call_sites": 3}
+    text = agent_capsule._build_inline_caller_annotation_text("//", evidence, ["foo"])
+    assert text == "// tg: callers=8+ (top: foo)"
+
+
+def test_build_inline_caller_annotation_text_collected_no_names() -> None:
+    evidence = {"status": "collected", "returned_call_sites": 1, "omitted_call_sites": 0}
+    text = agent_capsule._build_inline_caller_annotation_text("#", evidence, [])
+    assert text == "# tg: callers=1"
+
+
+def test_build_inline_caller_annotation_text_zero_callers() -> None:
+    evidence = {
+        "status": "collected_no_call_sites",
+        "returned_call_sites": 0,
+        "omitted_call_sites": 0,
+    }
+    text = agent_capsule._build_inline_caller_annotation_text("#", evidence, [])
+    assert text == "# tg: callers=0"
+
+
+@pytest.mark.parametrize("status", ["skipped", "disabled", "error"])
+def test_build_inline_caller_annotation_text_none_when_not_collected(status: str) -> None:
+    evidence = {"status": status}
+    assert agent_capsule._build_inline_caller_annotation_text("#", evidence, ["foo"]) is None
+
+
+def test_build_inline_caller_annotation_text_partial_forces_truncated_marker() -> None:
+    evidence = {
+        "status": "collected",
+        "returned_call_sites": 1,
+        "omitted_call_sites": 0,
+        "partial": True,
+    }
+    text = agent_capsule._build_inline_caller_annotation_text("#", evidence, [])
+    assert text == "# tg: callers=1+"
+
+
+# ---------------------------------------------------------------------------------------------
+# (11) Direct helper tests: top-caller name resolution (dedupe, cap, skip-unresolved).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_top_caller_symbol_names_dedupes_caps_and_skips_unresolved() -> None:
+    rm = {
+        "symbols": [
+            {
+                "file": "/repo/caller.py",
+                "name": "outer_a",
+                "kind": "function",
+                "start_line": 1,
+                "end_line": 5,
+            },
+            {
+                "file": "/repo/caller.py",
+                "name": "outer_b",
+                "kind": "function",
+                "start_line": 10,
+                "end_line": 15,
+            },
+        ],
+    }
+    related_call_sites = [
+        {"file": "/repo/caller.py", "line": 3},  # -> outer_a
+        {"file": "/repo/caller.py", "line": 4},  # -> outer_a again (dedupe)
+        {"file": "/repo/caller.py", "line": 12},  # -> outer_b
+        {"file": "/repo/caller.py", "line": 999},  # unresolved (no enclosing symbol) -> skipped
+        {"file": "/repo/unknown.py", "line": 1},  # unresolved file -> skipped
+    ]
+
+    names = agent_capsule._top_caller_symbol_names(rm, related_call_sites, limit=2)
+
+    assert names == ["outer_a", "outer_b"]
+
+
+def test_top_caller_symbol_names_respects_limit() -> None:
+    rm = {
+        "symbols": [
+            {
+                "file": "/repo/caller.py",
+                "name": f"outer_{index}",
+                "kind": "function",
+                "start_line": index * 10,
+                "end_line": index * 10 + 5,
+            }
+            for index in range(5)
+        ],
+    }
+    related_call_sites = [{"file": "/repo/caller.py", "line": index * 10 + 2} for index in range(5)]
+
+    names = agent_capsule._top_caller_symbol_names(rm, related_call_sites, limit=2)
+
+    assert len(names) == 2
+
+
+# ---------------------------------------------------------------------------------------------
+# (12) Direct helper tests: `_apply_inline_caller_annotation` targets ONLY the matching primary
+# snippet among several, and is a no-op on every documented fail-safe path.
+# ---------------------------------------------------------------------------------------------
+
+
+def _make_snippet(*, file: str, symbol: str, source: str) -> dict[str, Any]:
+    return {
+        "file": file,
+        "symbol": symbol,
+        "start_line": 1,
+        "end_line": max(1, len(source.splitlines())),
+        "source": source,
+        "line_map": [
+            {"line": index + 1, "text": line} for index, line in enumerate(source.splitlines())
+        ],
+        "token_estimate": 5,
+        "evidence": ["parser-backed", "heuristic"],
+    }
+
+
+def test_apply_inline_caller_annotation_only_touches_matching_primary_snippet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+    primary = _make_snippet(
+        file="/repo/primary.py", symbol="primary_fn", source="def primary_fn():\n    pass\n"
+    )
+    other = _make_snippet(
+        file="/repo/other.py", symbol="other_fn", source="def other_fn():\n    pass\n"
+    )
+    other_source_before = other["source"]
+    target = {"file": "/repo/primary.py", "symbol": "primary_fn"}
+    call_site_evidence = {"status": "collected", "returned_call_sites": 1, "omitted_call_sites": 0}
+    related_call_sites = [{"file": "/repo/caller.py", "line": 3}]
+    rm: dict[str, Any] = {"symbols": []}
+
+    agent_capsule._apply_inline_caller_annotation(
+        [primary, other],
+        target,
+        call_site_evidence,
+        related_call_sites,
+        rm,
+        max_tokens=None,
+        used_tokens=0,
+    )
+
+    assert primary["source"].startswith("# tg: callers=1")
+    assert primary["inline_structural_annotation"]["applied"] is True
+    assert other["source"] == other_source_before
+    assert "inline_structural_annotation" not in other
+
+
+def test_apply_inline_caller_annotation_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TG_CAPSULE_INLINE_CALLERS", raising=False)
+    primary = _make_snippet(
+        file="/repo/primary.py", symbol="primary_fn", source="def primary_fn():\n    pass\n"
+    )
+    source_before = primary["source"]
+    target = {"file": "/repo/primary.py", "symbol": "primary_fn"}
+    call_site_evidence = {"status": "collected", "returned_call_sites": 1, "omitted_call_sites": 0}
+
+    agent_capsule._apply_inline_caller_annotation(
+        [primary],
+        target,
+        call_site_evidence,
+        [],
+        {"symbols": []},
+        max_tokens=None,
+        used_tokens=0,
+    )
+
+    assert primary["source"] == source_before
+    assert "inline_structural_annotation" not in primary
+
+
+def test_apply_inline_caller_annotation_noop_when_no_snippet_matches_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TG_CAPSULE_INLINE_CALLERS", "1")
+    other = _make_snippet(
+        file="/repo/other.py", symbol="other_fn", source="def other_fn():\n    pass\n"
+    )
+    source_before = other["source"]
+    target = {"file": "/repo/primary.py", "symbol": "primary_fn"}  # not in snippets
+    call_site_evidence = {"status": "collected", "returned_call_sites": 1, "omitted_call_sites": 0}
+
+    agent_capsule._apply_inline_caller_annotation(
+        [other],
+        target,
+        call_site_evidence,
+        [],
+        {"symbols": []},
+        max_tokens=None,
+        used_tokens=0,
+    )
+
+    assert other["source"] == source_before
+    assert "inline_structural_annotation" not in other


### PR DESCRIPTION
## Summary

Competitor-research steal: CodeAnchor (arXiv 2606.26979, "How Much Static Structure Do Code
Agents Need?") reports that rendering lightweight caller/fan-in facts as **inline plain-text
comments near definitions** (instead of requiring a separate graph tool call) gave **+3.4pp
Pass@1** and **halved run-to-run variance** at ~10% more tokens. It also targets the cross-paper
"agents skip the graph tool 58% of the time" adoption gap (CodeCompass 2602.20048).

- Adds `# tg: callers=N (top: foo, bar)` as the **first line** of the `tg agent` capsule's
  **primary target's** rendered source excerpt (`snippets[0]["source"]`), when
  `TG_CAPSULE_INLINE_CALLERS=1` (default OFF).
- Honest by construction: renders `callers=0` when the blast-radius scan genuinely found zero
  callers (a real, verified fact), and renders **nothing** when call-site evidence was never
  collected (query didn't explicitly request the symbol, confidence < 0.75, or
  `include_blast_radius=False`) -- never a fabricated count.
- Fails closed on the caller's own `--max-tokens` ceiling rather than silently exceeding it.
- Additive metadata: `snippets[i]["inline_structural_annotation"]` (`applied`, `callers_returned`,
  `callers_truncated`, `top_callers`) so `--json` consumers get the same fact structurally without
  text-scraping.

## verify-plan-against-code finding (the crux)

The capsule already collects verified call-site evidence for the **primary target only**
(`_collect_capsule_call_site_evidence[_from_map]` in `src/tensor_grep/cli/agent_capsule.py:807`
/ `:919`, gated on confidence >= 0.75 + an explicitly-requested symbol) via a blast-radius scan
(`repo_map.build_symbol_blast_radius[_from_map]`) it pays for **regardless of this feature**.
Annotating that one already-evidenced snippet is therefore a pure **rendering-layer** change --
no new graph computation. Enclosing-caller names are resolved via the already-built repo map's
symbol table (`repo_map._enclosing_symbol_for_line`, `repo_map.py:10817` -- the same helper
`_related_spans_from_blast_radius` already uses), an in-memory lookup, not a new file scan.

Every *other* rendered snippet (non-primary context sources) is deliberately left unannotated:
that would require a fresh per-symbol blast-radius scan the capsule does not already run, which
is exactly the "big new per-symbol computation" this feature does NOT attempt. Scope is
primary-target-only by design, not an oversight.

## Render seam (file:line)

- Render point: `_build_snippets` (`src/tensor_grep/cli/agent_capsule.py:1770`) builds
  `snippets[i]["source"]` from `repo_map._render_source_block`'s output.
- New annotation step: `_apply_inline_caller_annotation`
  (`src/tensor_grep/cli/agent_capsule.py:2039`), called from `build_agent_capsule_from_map`
  right after `_collect_outbound_dependencies` (DAR) and before `rollback_ref`/final result
  assembly (`src/tensor_grep/cli/agent_capsule.py:3238`).
- **Ordering contract (load-bearing):** must run strictly *after* DAR. DAR resolves call-token
  line numbers as `start_line + offset` into the primary snippet's own rendered `source`
  (`_outbound_dependency_call_tokens`, `agent_capsule.py:963`); prepending the annotation line
  before DAR runs would shift every subsequent line off by one in DAR's own arithmetic.
  Regression-pinned by `test_inline_caller_annotation_runs_after_dar_ordering_contract` (plus a
  companion test that documents the exact off-by-one mechanism this ordering avoids).

## Token-cost delta (measured on real code, not a toy fixture)

On a real 44-line function from this repo (`_build_snippets` itself): **+15 tokens (2.8% of that
snippet's own token budget)** for one resolved real caller name. (The paper's own reported
average was ~10%; tg's format is more compact and this function is larger than average, so the
fixed per-annotation overhead amortizes better here -- expect a higher percentage on very small
functions.)

## Verdict

Cleanly buildable, additive, safe -- shipped **opt-in / default-OFF** (`TG_CAPSULE_INLINE_CALLERS`),
matching the same polarity `_capsule_outbound_dependencies_enabled` (DAR) already uses in this
file, for a stronger reason than DAR's "pending a measured win": this feature mutates an
*existing* field's byte content (`snippets[i]["source"]`), not just new sibling keys, so a
default-on flip would silently change output shape for every existing consumer/test. Flip to
default-on only after a measured golden-set/dogfood win, per this repo's own idea-lifecycle
discipline.

**Load-bearing (changes capsule output shape) -- needs the independent Opus gate before merge**,
per this repo's change-control discipline. Crux to verify: token-budget respected, JSON contract
additive-only, source excerpt stays byte-identical after the one prepended comment line (copy-usable).

## Test plan

- [x] 38 new tests in `tests/unit/test_agent_capsule_inline_caller_annotation.py`: default-off
      byte-identical output: real end-to-end rendering (real repo scan, real blast-radius, real
      `_enclosing_symbol_for_line` resolution) + honest zero-callers case + evidence-not-collected
      graceful absence + token-budget fail-closed + kill-switch parity + confidence/consistency
      isolation + the DAR-ordering contract + direct unit coverage of each helper (language
      mapping, text variants, name dedup/cap, multi-snippet targeting).
- [x] Existing `tests/unit/test_agent_capsule_*.py` (78 tests) + agent/deadline/orient-adjacent
      slice (344 tests) + governance/contract-adjacent slice (185 tests) all still pass unmodified
      (feature is a no-op by default).
- [x] `ruff check` clean (touched files + whole repo).
- [x] `ruff format --check --preview` clean.
- [x] `mypy --strict` clean across all 81 files in `src/tensor_grep`.
- [ ] Independent Opus gate (load-bearing capsule output-shape change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)