### PR TITLE
fix(ranking): test-file demotion + exact word-boundary bonus on the flat symbol scorer (#254)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -614,6 +614,10 @@ def _best_effort_primary_target_from_map(rm: dict[str, Any], query: str) -> dict
     symbols = _as_list_of_dicts(rm.get("symbols"))[:_BEST_EFFORT_PRIMARY_SCAN_CAP]
     symbol_terms = repo_map._symbol_query_terms(query)
     if symbols and symbol_terms:
+        # Task #254 heuristic 2: derived from the SAME already-capped `symbols` list (never a
+        # fresh unbounded pass over `rm["symbols"]`) so this stays within the bounded-cost
+        # contract `test_best_effort_helper_symbol_pass_never_looks_past_the_scan_cap` pins.
+        non_test_definition_names = repo_map._non_test_definition_names(symbols)
         best_symbol: dict[str, Any] | None = None
         best_symbol_score = 0
         for symbol in symbols:
@@ -625,7 +629,9 @@ def _best_effort_primary_target_from_map(rm: dict[str, Any], query: str) -> dict
             # this helper must never crash the capsule even if a language-specific extractor ever
             # omits "kind" on some symbol record.
             scoreable = {"name": name, "kind": symbol.get("kind") or "unknown", "file": file_path}
-            score = repo_map._score_symbol(scoreable, symbol_terms)
+            score = repo_map._score_symbol(
+                scoreable, symbol_terms, non_test_definition_names=non_test_definition_names
+            )
             if score > best_symbol_score:
                 best_symbol_score = score
                 best_symbol = symbol

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7137,14 +7137,80 @@ def _score_file_path(path: str, terms: list[str]) -> int:
     return _score_text_terms(path_obj.name, terms) + _score_text_terms(repo_like_tail, terms)
 
 
-def _score_symbol(symbol: dict[str, Any], terms: list[str]) -> int:
+# Task #254 (Blackbird-style ranking heuristics -- the CEO deep-research #251 steal). Two small,
+# additive signals layered onto the flat, no-IDF `_score_symbol` scorer (the known-weak point
+# named in the tensor-grep-architecture-contract skill): a soft test-file demotion (heuristic 2)
+# and an exact word-boundary bonus (heuristic 3). A third candidate signal from the same research
+# pass -- "weight definitions above references" -- was investigated and found to have NO live
+# insertion point here: `payload["symbols"]` (this scorer's entire input population, traced
+# end-to-end through `_python_imports_and_symbols`/`_js_ts_parser_symbols`/`_rust_parser_symbols`/
+# `_regex_imports_and_symbols`) is ALREADY exclusively AST/regex-matched DEFINITIONS (kind in
+# {class, function, method, struct, enum, trait}). References/call-sites are produced by a
+# structurally separate pipeline (`_python_references_and_calls` and its JS/TS/Rust/regex
+# siblings) that feeds `tg refs`/`tg callers`/blast-radius and never reaches `payload["symbols"]`
+# or this scorer -- a "definitions above references" bonus here would be permanently-inert dead
+# code (it could never fire on real data), not a real signal, so it was deliberately not added.
+_TEST_SHADOW_PENALTY = 2
+
+
+def _non_test_definition_names(symbols: list[dict[str, Any]]) -> frozenset[str]:
+    """Task #254 heuristic 2 support: names with at least one definition OUTSIDE a test file.
+
+    Query-independent (a structural fact about the scanned repo, not the search terms), so a
+    caller computes this ONCE per scoring pass -- cheaply, no I/O, no re-parsing -- and reuses it
+    for every `_score_symbol` call in that pass rather than re-deriving it per symbol.
+    """
+    return frozenset(
+        str(symbol["name"])
+        for symbol in symbols
+        if symbol.get("name")
+        and symbol.get("file")
+        and not _is_test_file(Path(str(symbol["file"])))
+    )
+
+
+def _symbol_name_exact_boundary_bonus(symbol_name: str, terms: list[str]) -> int:
+    """Task #254 heuristic 3: +1 when a query term matches ``symbol_name`` as a clean,
+    word-boundary-respecting token (a member of ``split_terms(symbol_name)``) rather than only
+    through ``_score_text_terms``'s looser RAW-SUBSTRING fallback (a long term merely embedded
+    inside a longer, differently-tokenized identifier -- e.g. term "underscore" inside a name
+    like "my_underscored_value"). Standard IR signal: an exact token match is stronger evidence of
+    relevance than mere containment. Restricted to ``len(term) > 3`` to mirror
+    ``_score_text_terms``'s own threshold -- a term of length <= 3 is ALREADY boundary-only there
+    (it only ever checks ``haystack_terms``), so there is no substring laxity to correct for short
+    terms. Deliberately additive and capped at +1 total (not per matching term) to keep the delta
+    small relative to the existing scoring scale -- this refines ORDER among candidates that
+    already match; it never changes WHICH symbols match (the base credit from
+    ``_score_text_terms`` already covers both the clean-token and substring cases).
+    """
+    name_terms = set(split_terms(symbol_name))
+    return 1 if any(len(term) > 3 and term.lower() in name_terms for term in terms) else 0
+
+
+def _score_symbol(
+    symbol: dict[str, Any],
+    terms: list[str],
+    *,
+    non_test_definition_names: frozenset[str] | None = None,
+) -> int:
+    symbol_name = str(symbol["name"])
     score = (
-        _score_text_terms(str(symbol["name"]), terms) * 3
+        _score_text_terms(symbol_name, terms) * 3
         + _score_text_terms(str(symbol["kind"]), terms)
         + _score_file_path(str(symbol["file"]), terms)
     )
-    if _symbol_name_terms_cover_query(str(symbol["name"]), terms):
+    if _symbol_name_terms_cover_query(symbol_name, terms):
         score += 2
+    score += _symbol_name_exact_boundary_bonus(symbol_name, terms)
+    if (
+        non_test_definition_names is not None
+        and symbol_name in non_test_definition_names
+        and _is_test_file(Path(str(symbol["file"])))
+    ):
+        # Task #254 heuristic 2: a test-file hit sinks below a same-named non-test
+        # implementation instead of competing with it on equal footing -- floored at 0 so a
+        # borderline match is never pushed to a misleading negative score.
+        score = max(0, score - _TEST_SHADOW_PENALTY)
     return score
 
 
@@ -8047,6 +8113,9 @@ def _build_context_pack_from_map(
         symbol_terms = _symbol_query_terms(query)
         query_language_hints = _query_language_hints(query)
         all_symbols = [dict(symbol) for symbol in payload["symbols"]]
+        # Task #254 heuristic 2: computed ONCE per scoring pass (query-independent), then reused
+        # for every `_score_symbol` call below instead of re-deriving it per symbol.
+        non_test_definition_names = _non_test_definition_names(payload["symbols"])
         imports_by_file = {
             str(entry["file"]): [str(item) for item in entry["imports"]]
             for entry in payload["imports"]
@@ -8074,7 +8143,9 @@ def _build_context_pack_from_map(
                 if deadline_hit is not None:
                     deadline_hit.hit = True
                 break
-            score = _score_symbol(symbol, symbol_terms)
+            score = _score_symbol(
+                symbol, symbol_terms, non_test_definition_names=non_test_definition_names
+            )
             if score <= 0:
                 continue
             scored_symbol = dict(symbol)

--- a/tests/unit/test_agent_capsule_best_effort_primary.py
+++ b/tests/unit/test_agent_capsule_best_effort_primary.py
@@ -377,8 +377,9 @@ def test_best_effort_helper_prefers_non_test_implementation_over_same_named_test
     rm = {
         "path": "/repo",
         "files": ["/repo/src/widgets.py", "/repo/tests/test_widgets.py"],
-        # test-file entry ordered FIRST on purpose -- a `>`-only replacement means a tie would
-        # otherwise resolve to whichever candidate the loop happens to visit first.
+        # test-file entry ordered FIRST on purpose -- the pre-fix `>`-only scan is a relevance-blind
+        # tie-break that keeps the FIRST candidate in the deterministically path-sorted list, so in a
+        # flat layout where `test_widgets.py` sorts before the impl, the test symbol wrongly wins.
         "symbols": [test_symbol, impl_symbol],
         "imports": [],
     }

--- a/tests/unit/test_agent_capsule_best_effort_primary.py
+++ b/tests/unit/test_agent_capsule_best_effort_primary.py
@@ -350,6 +350,67 @@ def test_best_effort_helper_symbol_pass_never_looks_past_the_scan_cap() -> None:
     assert candidate["symbol"] == "flow_handler_module"
 
 
+# ---------------------------------------------------------------------------
+# 4. Task #254 heuristic 2: test-file shadow demotion
+# ---------------------------------------------------------------------------
+
+
+def test_best_effort_helper_prefers_non_test_implementation_over_same_named_test_symbol() -> None:
+    """Task #254 heuristic 2, end-to-end through the one live consumer of `_score_symbol` that
+    never pre-filters test files (`_best_effort_primary_target_from_map`'s symbol-name pass --
+    unlike the main context-pack loop, which drops test-file symbols outright before ranking).
+
+    Before heuristic 2, `impl_symbol` and `test_symbol` score IDENTICALLY (same name, same kind,
+    symmetric file-path credit from "widgets.py" vs "test_widgets.py" both containing "widget").
+    The scan loop only replaces `best_symbol` on a STRICT `>`, so with `test_symbol` listed first,
+    a true tie left the WRONG (test-file) symbol as the best-effort pick -- exactly the
+    incident-#302-style tie fragility this heuristic exists to break, deterministically, in favor
+    of the non-test implementation.
+    """
+    query = "process widget report"
+    impl_symbol = _fake_symbol("process_widget_report", "/repo/src/widgets.py")
+    test_symbol = _fake_symbol("process_widget_report", "/repo/tests/test_widgets.py")
+    terms = repo_map._symbol_query_terms(query)
+    # Sanity precondition: without the heuristic, this really is a tie -- otherwise the test
+    # below would pass for the wrong reason (a pre-existing, unrelated scoring difference).
+    assert repo_map._score_symbol(test_symbol, terms) == repo_map._score_symbol(impl_symbol, terms)
+    rm = {
+        "path": "/repo",
+        "files": ["/repo/src/widgets.py", "/repo/tests/test_widgets.py"],
+        # test-file entry ordered FIRST on purpose -- a `>`-only replacement means a tie would
+        # otherwise resolve to whichever candidate the loop happens to visit first.
+        "symbols": [test_symbol, impl_symbol],
+        "imports": [],
+    }
+
+    candidate = agent_capsule._best_effort_primary_target_from_map(rm, query)
+
+    assert candidate is not None
+    assert candidate["file"] == "/repo/src/widgets.py"
+
+
+def test_best_effort_helper_does_not_penalize_test_symbol_with_no_non_test_counterpart() -> None:
+    """The heuristic 2 penalty is conditional: a symbol that exists ONLY in a test file (no
+    same-named non-test implementation anywhere in the scanned map) is never demoted -- there is
+    nothing more appropriate to prefer it over."""
+    query = "assert widget invariants helper"
+    test_only_symbol = _fake_symbol(
+        "assert_widget_invariants_helper", "/repo/tests/test_widgets.py"
+    )
+    rm = {
+        "path": "/repo",
+        "files": ["/repo/tests/test_widgets.py"],
+        "symbols": [test_only_symbol],
+        "imports": [],
+    }
+
+    candidate = agent_capsule._best_effort_primary_target_from_map(rm, query)
+
+    assert candidate is not None
+    assert candidate["file"] == "/repo/tests/test_widgets.py"
+    assert candidate["symbol"] == "assert_widget_invariants_helper"
+
+
 def test_best_effort_pass_bounded_wall_clock_on_large_synthetic_tree(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_repo_map_lexical_ranking.py
+++ b/tests/unit/test_repo_map_lexical_ranking.py
@@ -151,3 +151,73 @@ def test_context_render_limits_source_sections_to_one_per_file(tmp_path: Path) -
     source_sections = [section for section in payload["sections"] if section["kind"] == "source"]
 
     assert [section["path"] for section in source_sections].count(str(module_path.resolve())) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task #254: Blackbird-style ranking heuristics on the flat `_score_symbol` scorer.
+# ---------------------------------------------------------------------------
+
+
+def test_score_symbol_exact_boundary_beats_substring_only_match() -> None:
+    """Heuristic 3: a query term that hits a symbol's name as a whole, word-boundary-respecting
+    token (a `split_terms` member) outranks the same term only appearing embedded inside a
+    longer, differently-tokenized identifier -- a raw substring hit `_score_text_terms` already
+    credits identically to a clean token match. Isolated at the `_score_symbol` level (a direct
+    call, not the full context-pack loop) so the comparison is not entangled with the outer
+    loop's separate exact/bridge/covered query-match bonuses, which key off the symbol name
+    matching the WHOLE query rather than a single term.
+
+    Before heuristic 3, both symbols scored identically (3): `_score_text_terms` grants the same
+    +1 credit whether "rank" hits `rank_symbol`'s name as a clean token or merely as a substring
+    of `rerank_value_symbol`'s "rerank". The boundary bonus breaks that tie in favor of the
+    cleaner match.
+    """
+    terms = ["rank"]
+    boundary_symbol = {"name": "rank", "kind": "function", "file": "src/module_a.py"}
+    substring_symbol = {"name": "rerank_value", "kind": "function", "file": "src/module_b.py"}
+
+    boundary_score = repo_map._score_symbol(boundary_symbol, terms)
+    substring_score = repo_map._score_symbol(substring_symbol, terms)
+
+    assert boundary_score > substring_score
+    # Pin the exact pre/post values so a future scoring-scale change can't silently make this
+    # pass for the wrong reason (e.g. an unrelated bonus swamping the boundary delta).
+    assert boundary_score == 4
+    assert substring_score == 3
+
+
+def test_score_symbol_test_file_hit_sinks_below_non_test_implementation() -> None:
+    """Heuristic 2: a same-named symbol defined in a test file scores lower than a non-test
+    implementation once a caller supplies `non_test_definition_names` (computed once per scoring
+    pass via `_non_test_definition_names`). Without that opt-in (the default, `None`), the two
+    score identically -- existing callers that have not been updated stay byte-for-byte
+    unaffected, and a test-only symbol with NO non-test counterpart is never penalized."""
+    terms = ["process", "widget", "report"]
+    impl_symbol = {"name": "process_widget_report", "kind": "function", "file": "src/widgets.py"}
+    test_symbol = {
+        "name": "process_widget_report",
+        "kind": "function",
+        "file": "tests/test_widgets.py",
+    }
+    non_test_definition_names = repo_map._non_test_definition_names([impl_symbol, test_symbol])
+    assert non_test_definition_names == frozenset({"process_widget_report"})
+
+    impl_score = repo_map._score_symbol(
+        impl_symbol, terms, non_test_definition_names=non_test_definition_names
+    )
+    test_score = repo_map._score_symbol(
+        test_symbol, terms, non_test_definition_names=non_test_definition_names
+    )
+
+    assert test_score < impl_score
+
+    # Opt-in only: a caller that does not pass `non_test_definition_names` sees no penalty at
+    # all -- the two symbols still score identically, matching pre-#254 behavior exactly.
+    assert repo_map._score_symbol(test_symbol, terms) == impl_score
+
+    # A test-file symbol with NO non-test counterpart anywhere is never penalized -- there is
+    # nothing to prefer it over.
+    test_only_names = repo_map._non_test_definition_names([test_symbol])
+    assert repo_map._score_symbol(
+        test_symbol, terms, non_test_definition_names=test_only_names
+    ) == repo_map._score_symbol(test_symbol, terms)


### PR DESCRIPTION
## Summary

Task #254 (CEO deep-research #251 Blackbird-style ranking steal, the last item in that batch).
Adds two small, additive ranking signals to `repo_map._score_symbol` -- the flat, no-IDF scorer
named as a known weak point in the `tensor-grep-architecture-contract` skill (incident #302
fragility: no IDF/term-rarity weighting, ranking can silently flip on a corpus change).

This is a loop-4 experiment: the agent-accuracy gate (`tests/eval/test_agent_accuracy.py`) is the
oracle. Result: **holds 16/16, byte-identical before/after** -- see Validation below.

## The three seams (verified against the real code, cited `file:line`)

- **`repo_map._score_symbol`** (`src/tensor_grep/cli/repo_map.py:7190`, pre-change signature
  `def _score_symbol(symbol, terms) -> int`): flat sum of `_score_text_terms(name)*3 +
  _score_text_terms(kind) + _score_file_path(file)`, plus a +2 bonus when
  `_symbol_name_terms_cover_query`. No def-vs-ref distinction, no test-file awareness, no
  boundary-vs-substring distinction.
- **Two call sites**: `repo_map._build_context_pack_from_map` (`repo_map.py:8141`, the main
  `tg prepare`/`tg agent`/`tg edit-plan`/`tg context` scoring loop) and
  `agent_capsule._best_effort_primary_target_from_map` (`agent_capsule.py:592`, the
  truncated-scan fallback pass, added by the v20 dogfood gap #2 fix).
- **`_is_test_file`** (`repo_map.py:666`) already exists and is used extensively elsewhere
  (`_promote_substantive_symbol_for_edit_seed`, the context-pack loop's own test-file
  `continue`), but was never wired into `_score_symbol` itself.

## What was implemented

- **Heuristic 2 -- test-file demotion.** `_non_test_definition_names(symbols)`
  (`repo_map.py:7156`, query-independent, computed once per scoring pass) returns the set of
  names with a definition outside a test file. `_score_symbol` now accepts an optional
  `non_test_definition_names: frozenset[str] | None = None` and subtracts `_TEST_SHADOW_PENALTY
  = 2` (floored at 0) when the symbol sits in a test file AND its name is in that set. Wired at
  both call sites.
- **Heuristic 3 -- exact word-boundary bonus.** `_symbol_name_exact_boundary_bonus`
  (`repo_map.py:7172`) adds +1 (capped, not per matching term) when a query term (len > 3, mirroring
  `_score_text_terms`'s own threshold) matches the symbol's name as a clean `split_terms` token
  rather than only via `_score_text_terms`'s looser raw-substring fallback (e.g. term
  `"underscore"` embedded inside `"my_underscored_value"`).

## Heuristic 1 -- investigated, NOT implemented (verify-plan-against-code finding)

"Weight definitions above references" has **no live insertion point** in this scorer. Traced
end-to-end: `payload["symbols"]` (this scorer's entire input population) is built exclusively by
`_python_imports_and_symbols` / `_js_ts_parser_symbols` / `_rust_parser_symbols` /
`_regex_imports_and_symbols`, which emit ONLY `kind in {class, function, method, struct, enum,
trait}` -- genuine AST/regex-matched definitions. References/call-sites (`kind in {reference,
call}`) are produced by a structurally SEPARATE pipeline (`_python_references_and_calls` and its
JS/TS/Rust/regex siblings) that feeds `tg refs` / `tg callers` / blast-radius and never merges
into `payload["symbols"]`, `ranked_symbols`, or `candidate_edit_targets["symbols"]`. A
"definitions above references" bonus inside `_score_symbol` would be **permanently-inert dead
code** -- it could never fire on real data -- so it was deliberately left out rather than shipped
as a no-op. (Also independently confirmed `tg search --rank`'s BM25 reranker, `core/reranker.py`,
is an architecturally separate scorer, not a candidate seam either.)

## Validation -- the accuracy-gate numbers (`tests/eval/test_agent_accuracy.py`)

One run before, one run after (per the CPU-safety budget -- real `tg prepare` subprocesses, ~3 min
total each):

| Run | Golden set | Result |
|---|---|---|
| BEFORE (baseline, unchanged `origin/main`) | 16 tasks | **16/16** |
| AFTER (heuristics 2+3 applied) | 16 tasks | **16/16** -- every task's `primary_target.file` is BYTE-IDENTICAL to baseline |

Expected and explained, not just observed: heuristic 2's only *live* effect is on the best-effort
fallback path (`_best_effort_primary_target_from_map`) -- the main `tg prepare` path already
excludes test-file symbols from `payload["symbols"]` **unconditionally**, before ranking, in
`_build_context_pack_from_map`'s own scoring loop (`repo_map.py:8147`, `if
_is_test_file(Path(current_path)): continue`, which runs regardless of the symbol's score). None
of the 16 golden tasks hit a truncated scan, so the fallback path (and thus heuristic 2's visible
effect) is never exercised by this gate -- a predicted, not surprising, null result on this
specific measurement. Heuristic 3 refines tie-break order among already-matching candidates; it
did not flip any of these 16 rankings (each task's winning file was already decided by a bigger
existing signal -- `exact_query_match`'s +36 file-level bonus, `covered_query_match`'s +24, or
plain non-tied lexical dominance).

## New unit tests (TDD, synthetic fixtures)

- `tests/unit/test_repo_map_lexical_ranking.py`:
  - `test_score_symbol_exact_boundary_beats_substring_only_match` -- direct `_score_symbol` call,
    pins the exact before/after scores (3 -> 4) so a future scoring-scale change can't pass for
    the wrong reason.
  - `test_score_symbol_test_file_hit_sinks_below_non_test_implementation` -- proves the penalty is
    opt-in (default `None` = no behavior change), conditional (a test-only symbol with no
    non-test counterpart is never penalized), and effective when both conditions hold.
- `tests/unit/test_agent_capsule_best_effort_primary.py`:
  - `test_best_effort_helper_prefers_non_test_implementation_over_same_named_test_symbol` --
    end-to-end through the one live consumer that never pre-filters test files; asserts a
    genuine pre-existing tie (sanity-checked in the test itself) now resolves deterministically
    to the non-test implementation instead of whichever candidate the scan happened to visit
    first (the incident-#302-style fragility this heuristic targets).
  - `test_best_effort_helper_does_not_penalize_test_symbol_with_no_non_test_counterpart`.

## Verification

- `ruff check` / `ruff format --check --preview` / `mypy src/tensor_grep` (81 files): all clean.
- 438 targeted regression tests across every `repo_map`/`agent_capsule`-adjacent unit-test file
  (`test_agent_capsule_*`, `test_blast_radius_*`, `test_edit_plan_*`, `test_orient_*`,
  `test_repo_map_*`, `test_impact_callers_shared_map.py`, `test_prepare_package_manager_release.py`,
  `test_refs_context_pack_deadline_205.py`): zero new failures.
- Rebased cleanly onto latest `main` (includes #697, an unrelated default-off rendering feature in
  `agent_capsule.py` at a disjoint line range -- verified no overlap before rebasing).

## Load-bearing -- independent Opus gate requested before un-drafting

This scorer feeds every ranked-symbol / primary-target / alternative-target surface (`tg
prepare`, `tg agent`, `tg edit-plan`, `tg context`). Per house policy (`tensor-grep-change-control`:
"never trust a self-report"), opening as **draft**. Crux for the independent reviewer: confirm the
heuristics don't destabilize non-golden rankings beyond what's shown here, and that the
tie-break behavior stays deterministic (both new signals are small, additive, and floor/cap as
documented -- no removal of any existing match, only reordering among already-matching
candidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
