### PR TITLE
test(locks): prove per-root lock independence as a contract, not a wall-clock race

### DIFF
--- a/tests/unit/test_index_lock_concurrency.py
+++ b/tests/unit/test_index_lock_concurrency.py
@@ -399,73 +399,94 @@ def test_open_session_reclaims_stale_lock_two_racing_threads(tmp_path: Path) -> 
 
 
 # --------------------------------------------------------------------------------------
-# Per-root isolation (tdd_test_legit bonus): locks are per-index-file, not global -- two
-# different roots opened concurrently must not block each other.
+# Per-root isolation (tdd_test_legit bonus): locks are per-index-file, not global --
+# holding one root's lock must never block another root's lock. Proven directly against
+# the lock primitive as a scheduler-independent CONTRACT; see the docstring below for why
+# both prior wall-clock versions (ratio, then overlap) still flaked.
 # --------------------------------------------------------------------------------------
 
 
-def test_index_lock_is_per_root_not_global(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_index_lock_is_per_root_not_global(tmp_path: Path) -> None:
+    """Per-root isolation, proven as a scheduler-independent CONTRACT instead of a
+    wall-clock timing heuristic.
+
+    History of the flake this replaces:
+      - Original: ``concurrent_elapsed < baseline_elapsed * 1.8 + 0.5`` (a wall-clock
+        RATIO). Red on the v1.81.1 release run (concurrent=0.906s vs a 0.894s ceiling --
+        pure runner jitter, not serialization).
+      - #204/#650 harden: replaced the ratio with "the two roots' write-lock hold
+        intervals must OVERLAP in wall time" -- believed jitter-immune, but it red-ed
+        AGAIN on v1.92.2 (windows-latest CI run 29873888662, loaded runner):
+            project_a=[1034.781, 1035.281] project_b=[1034.265, ...]
+        i.e. project_b's hold window had already closed before project_a's opened.
+        Overlap is STILL a wall-clock claim: on a sufficiently starved runner the OS can
+        simply fail to schedule thread B until thread A's hold has already finished, even
+        though the two per-root locks never contended on each other at all. Two
+        independent locks are not guaranteed to be *simultaneously held* under an
+        adversarial scheduler -- only guaranteed not to *block* each other. Racing the
+        scheduler to observe "simultaneous" can never be made both sharp and non-flaky.
+
+    The only scheduler-independent way to prove "per-root, not global" is to test the
+    BLOCKING behavior directly, Event-gated (never sleep-gated, so there is no timing
+    window to race):
+      1. Hold root_a's lock on a background thread until told to let go.
+      2. INDEPENDENCE: acquiring root_b's lock while root_a's is held must succeed
+         promptly (bounded timeout) -- a shared/global lockfile would instead block
+         root_b until root_a releases, which never happens inside this check, so the bug
+         now surfaces as a fast, deterministic ``IndexLockTimeoutError`` rather than a
+         hang or a scheduler-dependent timing artifact.
+      3. CONVERSE CONTROL: a second acquisition of root_a's OWN lock, while genuinely
+         held, must itself BLOCK/timeout -- proving the lock is a real mutual-exclusion
+         primitive and not a no-op that would let check 2 pass vacuously.
+    Both checks are pass/fail the instant they run; nothing needs to overlap, race, or
+    outrun the CI scheduler for either to be correct.
+
+    Concurrent-write CORRECTNESS through the real ``open_session``/``_write_index`` path
+    (lost inserts, retention, ownership-token races) is already covered by the sibling
+    tests above (``test_concurrent_open_session_no_lost_insert`` et al.); this test's only
+    job is proving the lock is keyed per-index-file rather than global, which
+    ``_index_lock.index_lock`` is the direct, minimal unit to prove it against -- using
+    the SAME ``_index_path`` production helper ``open_session`` itself calls, so a
+    routing bug that collapsed two roots onto the same lock target would still surface
+    here too.
+    """
     root_a = _make_project(tmp_path, name="project_a")
     root_b = _make_project(tmp_path, name="project_b")
+    index_a = session_store._index_path(root_a)
+    index_b = session_store._index_path(root_b)
+    assert index_a != index_b  # sanity: the two roots really do map to different lock targets
 
-    orig_write_index = session_store._write_index
+    holder_ready = threading.Event()
+    release_holder = threading.Event()
+    holder_errors: list[BaseException] = []
 
-    # Record the write-lock hold interval per root so we can assert the two
-    # concurrent writes OVERLAP in time -- a causal, jitter-immune proof that
-    # per-root locks did not serialize. The previous wall-clock RATIO assertion
-    # (concurrent < baseline*1.8 + 0.5) flaked on contended CI runners: the
-    # v1.81.1 release run saw concurrent=0.906s vs a 0.894s ceiling, pure runner
-    # jitter, not serialization -- and the jitter even exceeded 2x baseline, so no
-    # ratio bound stays both sharp AND non-flaky. Overlap is unaffected by absolute
-    # timing: two per-root locks held at the same instant overlap no matter how
-    # slow the runner is, while a shared/global lockfile forces one write to wait
-    # for the other to release -> zero overlap -> the assertion still fails.
-    HOLD_SECONDS = 0.5
-    intervals: dict[str, tuple[float, float]] = {}
-    intervals_lock = threading.Lock()
+    def hold_root_a() -> None:
+        try:
+            with _index_lock.index_lock(index_a):
+                holder_ready.set()
+                # Bounded: never hang the suite even if the main thread's asserts raise
+                # before reaching the `finally: release_holder.set()` below (index_lock's
+                # own 12s acquire timeout is the ultimate backstop regardless).
+                release_holder.wait(timeout=10.0)
+        except BaseException as exc:  # surface into the main thread, not a silent thread death
+            holder_errors.append(exc)
 
-    def slow_write_index(r: Path, recs: list) -> None:
-        enter = time.monotonic()
-        time.sleep(HOLD_SECONDS)
-        leave = time.monotonic()
-        with intervals_lock:
-            intervals[r.name] = (enter, leave)
-        return orig_write_index(r, recs)
+    holder = threading.Thread(target=hold_root_a)
+    holder.start()
+    try:
+        assert holder_ready.wait(timeout=5.0), "root_a holder thread never acquired its lock"
 
-    monkeypatch.setattr(session_store, "_write_index", slow_write_index)
+        # (2) Independence.
+        with _index_lock.index_lock(index_b, timeout_s=2.0):
+            pass  # success == root_b was NOT blocked by root_a's held lock
 
-    results: dict[str, session_store.SessionOpenResult] = {}
-    # Release both threads together so thread-start skew is not a flake vector. The
-    # barrier is BEFORE open_session, not inside the locked write, so a hypothetical
-    # global lock still serializes (one thread blocks on lock acquisition) instead
-    # of deadlocking the barrier. timeout guards against an anti-hang stall.
-    ready = threading.Barrier(2)
+        # (3) Converse control -- proves the lock is real, not a no-op.
+        with pytest.raises(_index_lock.IndexLockTimeoutError):
+            with _index_lock.index_lock(index_a, timeout_s=0.3, stale_after_s=60.0):
+                pass
+    finally:
+        release_holder.set()
+        holder.join(timeout=15.0)  # generous headroom past index_lock's own 12s acquire ceiling
 
-    def worker(key: str, root: Path) -> None:
-        ready.wait(timeout=10)
-        results[key] = session_store.open_session(str(root))
-
-    threads = [
-        threading.Thread(target=worker, args=("a", root_a)),
-        threading.Thread(target=worker, args=("b", root_b)),
-    ]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    # Two DIFFERENT roots must not serialize against each other's lock: their
-    # write-lock hold intervals must OVERLAP. A shared/global lockfile would make
-    # one write wait for the other to release (a_leave <= b_enter, or vice versa)
-    # -> no overlap -> this assertion fails, catching the regression.
-    assert "project_a" in intervals and "project_b" in intervals, (
-        f"expected one slowed write per root; got {sorted(intervals)}"
-    )
-    a_enter, a_leave = intervals["project_a"]
-    b_enter, b_leave = intervals["project_b"]
-    assert a_enter < b_leave and b_enter < a_leave, (
-        "per-root locks serialized (write-hold intervals did not overlap): "
-        f"project_a=[{a_enter:.3f}, {a_leave:.3f}] project_b=[{b_enter:.3f}, {b_leave:.3f}]"
-    )
-    assert results["a"].session_id in {r.session_id for r in session_store._load_index(root_a)}
-    assert results["b"].session_id in {r.session_id for r in session_store._load_index(root_b)}
+    assert not holder.is_alive(), "root_a holder thread did not exit after release"
+    assert not holder_errors, f"root_a holder thread raised: {holder_errors!r}"


### PR DESCRIPTION
## Summary

`test_index_lock_is_per_root_not_global` has now red-ed CI **twice** on loaded
windows-latest runners:

- **v1.81.1 release run**: the original assertion
  `concurrent_elapsed < baseline_elapsed * 1.8 + 0.5` (a wall-clock RATIO) tripped at
  `concurrent=0.906s` vs a `0.894s` ceiling — pure runner jitter, not serialization.
- **#204 / PR #650** (this repo's prior harden): replaced the ratio with "the two roots'
  write-lock hold intervals must OVERLAP in wall time," believed jitter-immune (and
  recorded in `docs/BACKLOG.md`/`CHANGELOG.md` as one of "two recurring release-flakes
  permanently killed"). It **red-ed again today** on **v1.92.2, CI run
  [29873888662](https://github.com/oimiragieo/tensor-grep/actions/runs/29873888662)**:
  `AssertionError: per-root locks serialized (write-hold intervals did not overlap):
  project_a=[1034.781, 1035.281] project_b=[1034.265, ...]` (1 failed / 2649 passed).

## Why #204's overlap invariant was still insufficient

Overlap is *still* a wall-clock claim. Two per-root locks being genuinely independent
only guarantees neither **blocks** the other — it does not guarantee the OS schedules
both threads into their monkeypatched-slow write at the same instant. On a sufficiently
starved/loaded runner, thread B can simply not get scheduled until thread A's 0.5s hold
has already finished, even though the two locks never contended on each other at all. No
wall-clock window — ratio or overlap — can be made both sharp and immune to an
adversarial scheduler, because the property under test (lock independence) does not
imply the property being measured (simultaneous wall-clock execution).

## New design: assert the contract, not a timing artifact

Rewrote the test to prove independence + mutual exclusion directly against
`_index_lock.index_lock`, using `threading.Event` handshakes (never sleeps, so there is
no timing window to race):

1. A background thread acquires `root_a`'s lock (via `_index_lock.index_lock` directly,
   on the same `session_store._index_path` production helper `open_session` uses
   internally) and holds it until told to let go.
2. **Independence**: the main thread acquires `root_b`'s lock with a short (2.0s)
   timeout while `root_a`'s is held. Success proves `root_b` was never blocked by
   `root_a` — a shared/global lockfile would instead block until `root_a` releases
   (which never happens inside this check), turning the bug into a fast, deterministic
   `IndexLockTimeoutError` instead of a scheduler-dependent artifact.
3. **Converse control**: a second acquisition of `root_a`'s own lock, while genuinely
   held, must itself block/timeout (0.3s) — proves the lock is a real mutual-exclusion
   primitive, not a no-op that would let check 2 pass vacuously.

Both checks are pass/fail the instant they run; nothing needs to overlap, race, or
outrun the CI scheduler for either to be correct.

Concurrent-write *correctness* through the real `open_session`/`_write_index` path (lost
inserts, retention, ownership-token races) stays covered by the sibling tests already in
this file (`test_concurrent_open_session_no_lost_insert` et al.) — this test's sole job,
proving the lock is keyed per-index-file rather than global, is now proven directly
against the lock primitive instead of indirectly through `open_session`'s full pipeline,
which removes the extra timing surface that pipeline was adding without adding any
coverage of its own.

Test-only change — no shipped code touched.

## Verification

- **Red-phase sanity check**: temporarily forced `_lock_path_for` to return one fixed
  path regardless of input (simulating a global lock), confirmed the test fails fast
  (2.72s, `IndexLockTimeoutError` at the independence check), then reverted and
  reconfirmed green — proves the new test actually detects the regression it guards
  against, not just passes vacuously.
- **20/20** passes in a fresh-process loop (~1.4s/run, dominated by interpreter startup,
  not the test body).
- **10/10** passes with 4 self-bounded CPU-busy processes running concurrently (modest
  artificial load on a shared box, not full saturation) to emulate a loaded runner
  (~1.55s/run avg — only mild slowdown from the load, no flakes, no hangs).
- Whole file: **13/13** passing.
- `ruff check`, `ruff format --check --preview`, and `mypy` all pass on the file. mypy's
  9 pre-existing findings are all above the diff's line-399 hunk boundary, in untouched
  sibling test functions (not introduced by this change).

## Test plan

- [x] `pytest tests/unit/test_index_lock_concurrency.py::test_index_lock_is_per_root_not_global -v` — pass
- [x] 20x stability loop (fresh process each run) — 20/20 pass
- [x] 10x stability loop under artificial CPU load — 10/10 pass
- [x] Full file `pytest tests/unit/test_index_lock_concurrency.py -v` — 13/13 pass
- [x] Red-phase check: injected a simulated global-lock bug, confirmed the test fails fast and correctly; reverted
- [x] `ruff check` / `ruff format --check --preview` / `mypy` on the file — all clean (no new findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)