### PR TITLE
fix(search): close #105 gap -- front-door raw-rg-passthrough had no walk-ceiling guard

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -751,6 +751,56 @@ def _search_paths_include_vendored_root(paths: list[str]) -> bool:
     return False
 
 
+# Item #105 (bootstrap raw-rg-passthrough gap, CEO dogfood v1.92.x directive): neither
+# `_search_paths_include_workspace_root` above (needs >=3/>=8 independently-MARKED sibling
+# dirs) nor `_search_paths_include_vendored_root` (needs a top-level vendored dir NAME) catches
+# a plain, single, large repo root -- e.g. a flat monorepo `src/` with thousands of files, no
+# vendored subdir, and no marked siblings. That shape sailed straight into `_run_rg_passthrough`
+# (a raw `rg` subprocess spawn bounded ONLY by a wall-clock timeout --
+# `TG_RG_TIMEOUT_SECONDS`/`TG_SIDECAR_TIMEOUT_MS`, no proactive refusal) because bootstrap's fast
+# path never delegates a bare, flag-less search to the native binary by default --
+# `_can_delegate_to_native_tg_search` requires a "supported trigger" flag (`--cpu`/
+# `--force-cpu`/`--json`/`--ndjson`/`--gpu-device-ids`) and `TG_RUST_FIRST_SEARCH` is off by
+# default -- so the native binary's OWN `check_implicit_walk_ceiling`
+# (`rust_core/src/rg_passthrough.rs`, audit #100/#105/#109, verified via direct invocation to
+# refuse in ~34ms) never gets a chance to run for the common bare `tg search PATTERN` shape.
+# `cli/main.py`'s full-CLI path already refuses this shape correctly (Bug #88 fix,
+# `_should_refuse_unbounded_large_root_scan`) -- this mirror sends the SAME unscoped search
+# there instead of into an unguarded raw `rg` spawn, matching the pattern already used above for
+# the workspace-root/vendored-root guards (both of which bypass cli/main.py's Python guards
+# entirely without a front-door mirror).
+#
+# Deliberately WALKS (bounded to ceiling+1 entries, never a full-tree enumeration) rather than a
+# one-level `iterdir()` probe like the vendored/workspace guards above -- there is no shallow
+# signal for "this tree is huge"; the walk itself is the only honest measurement, same approach
+# as cli/main.py's `_implicit_glob_search_walk_exceeds_ceiling`. Mirrors `--hidden`/
+# `--no-ignore*` flags into the probe config (conservatively: ANY no-ignore-family flag widens
+# the probe to `no_ignore=True`, the most inclusive walk `DirectoryScanner` supports) so this
+# probe does not UNDER-count relative to the real invocation and let an oversized
+# `--hidden`/`--no-ignore` walk slip through as "under ceiling".
+def _search_paths_include_oversized_implicit_root(paths: list[str], search_args: list[str]) -> bool:
+    from tensor_grep.core.config import SearchConfig
+    from tensor_grep.io.directory_scanner import (
+        IMPLICIT_SEARCH_WALK_FILE_CEILING,
+        DirectoryScanner,
+    )
+
+    probe_config = SearchConfig(
+        hidden=any(arg in _SEARCH_HIDDEN_FLAGS for arg in search_args),
+        no_ignore=any(arg in _SEARCH_NO_IGNORE_FLAGS for arg in search_args),
+    )
+    count = 0
+    for raw_path in paths:
+        if not raw_path or raw_path == "-" or raw_path.startswith("-"):
+            continue
+        scanner = DirectoryScanner(probe_config)
+        for _ in scanner.walk(raw_path):
+            count += 1
+            if count > IMPLICIT_SEARCH_WALK_FILE_CEILING:
+                return True
+    return False
+
+
 def _search_args_include_unbounded_broad_scan(search_args: list[str]) -> bool:
     if "--allow-broad-generated-scan" in search_args:
         return False
@@ -761,6 +811,8 @@ def _search_args_include_unbounded_broad_scan(search_args: list[str]) -> bool:
     if _search_paths_include_workspace_root(paths):
         return True
     if _search_paths_include_vendored_root(paths):
+        return True
+    if paths_defaulted and _search_paths_include_oversized_implicit_root(paths, search_args):
         return True
     return _search_args_request_unrestricted_generated_scan(
         search_args

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -47,6 +47,7 @@ from tensor_grep.io.directory_scanner import (
     BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
     BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
     BROAD_WORKSPACE_PROJECT_MARKERS,
+    IMPLICIT_SEARCH_WALK_FILE_CEILING,
     UNBOUNDED_VENDORED_ROOT_DIR_NAMES,
 )
 from tensor_grep.sidecar import DEFAULT_CLASSIFY_MAX_LINES
@@ -5057,7 +5058,12 @@ def _format_unbounded_vendored_root_scan_error(vendored_dirs: list[str]) -> str:
 # guards, which are cheap top-level probes that never see the real count). Bypassing on
 # `--glob` alone (the pre-fix `_has_generated_scan_bound` check) defeated this guard for
 # exactly the bare-`--glob`-no-PATH shape it exists to catch; see `_has_walk_scope_bound`.
-_LARGE_ROOT_SCAN_FILE_CEILING = 1500
+#
+# Item #105-parity: imported (not hardcoded) from `io/directory_scanner.py` so this ceiling and
+# `cli/bootstrap.py`'s front-door mirror `_search_paths_include_oversized_implicit_root` can
+# never drift out of sync -- the same single-source-of-truth pattern already used above for
+# `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` / `BROAD_WORKSPACE_PROJECT_MARKERS`.
+_LARGE_ROOT_SCAN_FILE_CEILING = IMPLICIT_SEARCH_WALK_FILE_CEILING
 
 
 def _should_refuse_unbounded_large_root_scan(

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -76,6 +76,21 @@ BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
 # being a workspace parent.
 BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = 8
 
+# Item #105-parity (bootstrap raw-rg-passthrough gap, CEO dogfood v1.92.x): the ceiling above
+# which an IMPLICIT-path (no explicit PATH positional) search walk must be refused rather than
+# run to completion/timeout. Neither the workspace-root guard above (needs >=3/>=8
+# independently-MARKED sibling dirs) nor the vendored-root guard (needs a top-level vendored dir
+# NAME) catches a plain, single, large repo root -- e.g. a flat monorepo `src/` with thousands of
+# files, no vendored subdir, and no marked siblings. `cli/main.py`'s `_LARGE_ROOT_SCAN_FILE_CEILING`
+# (Bug #88 fix, the full-CLI-side guard) and `cli/bootstrap.py`'s front-door mirror
+# `_search_paths_include_oversized_implicit_root` both import this single source of truth so the
+# two guards can never drift out of sync (same pattern as `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` and
+# `BROAD_WORKSPACE_PROJECT_MARKERS` above). Matches the Rust native front door's own
+# `IMPLICIT_SEARCH_WALK_FILE_CEILING` (`rust_core/src/rg_passthrough.rs`, audit #100/#105/#109) --
+# kept at the same numeric value by convention across the language boundary (a literal constant
+# cannot be shared across Python/Rust).
+IMPLICIT_SEARCH_WALK_FILE_CEILING = 1500
+
 # The Rust PyO3 directory scanner (`RustDirectoryScanner`) is NOT exported by the `rust_core`
 # extension (only `RustBackend` + functions are), so the old `from rust_core import
 # RustDirectoryScanner` always raised and this flag was permanently False — the Python walk below was

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -78,6 +78,69 @@ def test_vendored_root_guard_triggers_on_every_canonical_name(tmp_path: Path) ->
     assert bootstrap._search_paths_include_vendored_root([str(unrelated_root)]) is False
 
 
+def test_implicit_search_walk_file_ceiling_matches_source_of_truth() -> None:
+    """Item #105-parity: cli/main.py's `_LARGE_ROOT_SCAN_FILE_CEILING` and cli/bootstrap.py's
+    front-door mirror `_search_paths_include_oversized_implicit_root` must both consult the
+    SAME ceiling value (`io/directory_scanner.IMPLICIT_SEARCH_WALK_FILE_CEILING`), or the two
+    front doors (native/rg fast path vs full CLI) can disagree about whether an implicit-path
+    root is oversized -- exactly the class of drift the vendored/workspace constants above were
+    centralized to prevent."""
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    assert cli_main._LARGE_ROOT_SCAN_FILE_CEILING == IMPLICIT_SEARCH_WALK_FILE_CEILING
+    assert IMPLICIT_SEARCH_WALK_FILE_CEILING > 0
+
+
+def test_oversized_implicit_root_probe_triggers_over_ceiling_real_walk(tmp_path: Path) -> None:
+    """Item #105: bootstrap's front-door ceiling probe must fire on a REAL walk exceeding the
+    canonical ceiling -- mirrors cli/main.py's own
+    `test_implicit_glob_walk_probe_exceeds_ceiling_even_with_zero_matching_files` fixture style
+    (real files on disk, not a monkeypatched-down ceiling), so this proves the SAME real-scale
+    behavior at the bootstrap layer."""
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = tmp_path / "bigrepo"
+    root.mkdir()
+    for index in range(IMPLICIT_SEARCH_WALK_FILE_CEILING + 100):
+        (root / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+
+    assert bootstrap._search_paths_include_oversized_implicit_root([str(root)], ["pat"]) is True
+
+
+def test_oversized_implicit_root_probe_allows_small_tree(tmp_path: Path) -> None:
+    """Non-regression: a small tree well under the ceiling must not be flagged."""
+    root = tmp_path / "smallrepo"
+    root.mkdir()
+    for index in range(20):
+        (root / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+
+    assert bootstrap._search_paths_include_oversized_implicit_root([str(root)], ["pat"]) is False
+
+
+def test_oversized_implicit_root_probe_widens_for_no_ignore_flag(tmp_path: Path) -> None:
+    """The probe must not UNDER-count relative to the real invocation: files that only exist
+    because `--no-ignore` was requested must still be counted toward the ceiling, or a huge
+    `--no-ignore` walk could slip through as "under ceiling" while the real search walks far
+    more than the probe measured."""
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    ignored_dir = root / "ignored"
+    ignored_dir.mkdir()
+    for index in range(IMPLICIT_SEARCH_WALK_FILE_CEILING + 100):
+        (ignored_dir / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+
+    # Default config respects .gitignore -- the probe must NOT see the ignored files.
+    assert bootstrap._search_paths_include_oversized_implicit_root([str(root)], ["pat"]) is False
+    # `--no-ignore` widens the walk to include them -- the probe must now catch it.
+    assert (
+        bootstrap._search_paths_include_oversized_implicit_root([str(root)], ["pat", "--no-ignore"])
+        is True
+    )
+
+
 def test_typer_app_commands_match_source_of_truth() -> None:
     typer_commands = set()
     for cmd in app.registered_commands:
@@ -311,6 +374,86 @@ def test_main_entry_should_not_passthrough_single_project_root_with_top_level_ve
     bootstrap.main_entry()
 
     assert called["full_cli"] is True
+
+
+def test_main_entry_should_not_passthrough_oversized_implicit_single_project_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Item #105 (CEO dogfood v1.92.x directive): a bare, flag-less, unscoped `tg search
+    PATTERN` on a large ORDINARY single-project root -- no top-level vendored dir name, no
+    independently-marked sibling projects, so NEITHER `_search_paths_include_workspace_root`
+    NOR `_search_paths_include_vendored_root` fires -- used to sail straight into
+    `_run_rg_passthrough` (a raw `rg` subprocess spawn bounded only by a wall-clock timeout,
+    `TG_RG_TIMEOUT_SECONDS`, no proactive refusal), because `_can_delegate_to_native_tg_search`
+    requires a "supported trigger" flag (`--cpu`/`--json`/...) that a bare search never carries
+    and `TG_RUST_FIRST_SEARCH` is off by default, so the native binary's own walk-ceiling gate
+    never even ran. It must now fall through to the full CLI instead, which owns the actual
+    fast (<1s, no full-tree walk to timeout) refusal via `_should_refuse_unbounded_large_root_scan`.
+    """
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    called = {"full_cli": False}
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()  # single ordinary project marker, not a workspace parent
+    for index in range(IMPLICIT_SEARCH_WALK_FILE_CEILING + 100):
+        (root / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "needle"])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_native_tg_search",
+        lambda *_args, **_kwargs: pytest.fail("native passthrough should not run"),
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda *_args, **_kwargs: pytest.fail(
+            "rg passthrough should not run (raw rg has no walk-ceiling guard)"
+        ),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: called.__setitem__("full_cli", True))
+
+    bootstrap.main_entry()
+
+    assert called["full_cli"] is True
+
+
+def test_main_entry_should_passthrough_oversized_EXPLICIT_root_search(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Non-regression companion (Trap #3 parity): the SAME oversized single-project root, but
+    with an EXPLICIT path positional, must still take the fast native/rg path uninhibited -- an
+    explicit path is a deliberately-scoped root even when huge. Proves the new #105 guard does
+    not regress the common scoped-search case (no added latency: the probe is gated on
+    `paths_defaulted` and must never even run here)."""
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+    for index in range(IMPLICIT_SEARCH_WALK_FILE_CEILING + 100):
+        (root / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "needle", str(root)])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda binary_name, argv: seen.update({"argv": list(argv)}) or 0,
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    assert excinfo.value.code == 0
+    assert seen["argv"] == ["needle", str(root)]
 
 
 def test_main_entry_should_not_native_delegate_bare_type_filter_with_json_trigger_from_vendored_root(
@@ -798,6 +941,32 @@ def test_search_args_include_unbounded_broad_scan_refuses_bare_type_filter_from_
     assert bootstrap._search_args_include_unbounded_broad_scan(["pat", "-t", "py"]) is True
     assert bootstrap._search_args_include_unbounded_broad_scan(["pat", ".", "-t", "py"]) is False
     assert bootstrap._search_args_include_unbounded_broad_scan(["pat", "-d", "3"]) is False
+
+
+def test_search_args_include_unbounded_broad_scan_refuses_oversized_implicit_single_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Item #105: end-to-end (within bootstrap.py, no main_entry monkeypatching) proof that a
+    large ORDINARY single-project root (no vendored dir, no marked siblings) now flags as an
+    unbounded broad scan when the path is implicit, and is exempted the moment either an
+    explicit path or an explicit `--max-depth` bound is present -- same escape-hatch contract
+    as the workspace/vendored guards above."""
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+    for index in range(IMPLICIT_SEARCH_WALK_FILE_CEILING + 100):
+        (root / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+    monkeypatch.chdir(root)
+
+    assert bootstrap._search_args_include_unbounded_broad_scan(["pat"]) is True
+    assert bootstrap._search_args_include_unbounded_broad_scan(["pat", "."]) is False
+    assert bootstrap._search_args_include_unbounded_broad_scan(["pat", "-d", "3"]) is False
+    assert (
+        bootstrap._search_args_include_unbounded_broad_scan(["pat", "--allow-broad-generated-scan"])
+        is False
+    )
 
 
 def test_main_entry_should_strip_noop_rg_format_and_keep_sort_for_rg_passthrough(monkeypatch):


### PR DESCRIPTION
## Verdict

**Classification: (a) -- a REAL residual gap on an unguarded shape**, reproduced natively (Windows, no WSL involved). Hypothesis (ii) (silent empty-exit-0 on timeout) was investigated and **falsified** -- the existing timeout path is already fail-closed. Hypothesis (c) (pure WSL artifact) is **not the explanation** for this specific gap -- it reproduces on any OS whenever the shape below is hit, though WSL `/mnt/c` amplification (documented separately, `tensor-grep-wsl-mnt-c-latency-artifact-2026-07-11`) could still worsen wall-clock on top of it.

## Root cause

`bootstrap.py`'s front door has **two independent `rg`-invocation paths**:

1. Delegate to the **native `tg` binary**, which internally shells out to `rg` via `rust_core/src/rg_passthrough.rs` -- protected by `check_implicit_walk_ceiling` (audit #100/#105/#109), verified via direct invocation to refuse a 2420-file implicit-path root in **~34ms**.
2. `_run_rg_passthrough` (`bootstrap.py:1007`) -- a **raw `rg` subprocess spawn straight from Python**, bounded ONLY by a wall-clock timeout (`TG_RG_TIMEOUT_SECONDS`/`TG_SIDECAR_TIMEOUT_MS`, default 60s). **No walk-ceiling probe at all.**

Bootstrap's dispatch logic **prefers path 2 for the common, flag-less `tg search PATTERN` shape**: `_can_delegate_to_native_tg_search` (`bootstrap.py:443`) only returns `True` when a "supported trigger" flag is present (`--cpu`/`--force-cpu`/`--json`/`--ndjson`/`--gpu-device-ids`), and `TG_RUST_FIRST_SEARCH` (the opt-in that would prefer native first) is **off by default**. So a bare, unscoped `tg search PATTERN` -- the exact shape in the dogfood report -- almost never reaches the native binary's own ceiling guard; it goes straight to the unguarded raw-`rg` path whenever `rg` resolves.

This is compounded by how the native binary is actually distributed: a plain `pip install tensor-grep` does **not** install a standalone native `tg` binary (only `[project.scripts] tg = "tensor_grep.cli.bootstrap:main_entry"` -- a Python entry point; the compiled binary is a *separate* managed install via curl/npm/Homebrew/winget downloading a GitHub release asset into `~/.tensor-grep/bin/`). So `resolve_native_tg_binary()` legitimately returns `None` for a large class of real installs -- very plausible for a pip-based WSL dogfood environment -- which makes path 2 (raw rg-passthrough, unguarded) the *default* experience, not an edge case.

## Classification matrix (shape x guard x outcome, file:line)

All measured on a synthetic 2420-file single-project root (one `.git` marker only, no vendored dir name, no marked siblings -- deliberately slips past every existing guard) on native Windows NTFS, via `python -m tensor_grep search PATTERN` (the real bootstrap front door, not CliRunner).

| # | Shape | Guard that fires (file:line) | Outcome before fix | Outcome after fix |
|---|---|---|---|---|
| 1 | Marked-workspace root, unscoped | `_search_paths_include_workspace_root` (`bootstrap.py:673`, item #154) | exit 2, fast refuse | unchanged |
| 2 | Vendored top-level dir, unscoped | `_search_paths_include_vendored_root` (`bootstrap.py:735`) | exit 2, fast refuse | unchanged |
| 3 | **Plain large single-project root, unscoped, native binary resolvable** | none (native never invoked -- no supported-trigger flag) | ran raw `rg`, **0.29-3.16s, no refuse** | **exit 2, ~0.35s, fast refuse** |
| 4 | **Plain large single-project root, unscoped, native unresolvable, `rg` resolvable** | none | ran raw `rg`, **no refuse** | **exit 2, ~0.35-0.87s, fast refuse** |
| 5 | Same, native+rg both unresolvable | `_should_refuse_unbounded_large_root_scan` (`main.py`, Bug #88, already shipped) | exit 2, fast refuse (full CLI) | unchanged (still the same path) |
| 6 | Same root, short `TG_RG_TIMEOUT_SECONDS=0.001` | `_streaming_passthrough_returncode` timeout handler (`bootstrap.py:900`) | **exit 124 + honest stderr** (already fail-closed) | now refused before timeout even matters (~0.38s) |
| 7 | Same root, **explicit path** (`search PATTERN .`) | `paths_defaulted` gate (Trap #3) | ran normally, found match, ~0.29s | **unchanged** -- 0.26-0.30s across 3 repeats, zero measurable regression |
| 8 | Small tree (40 files), unscoped | ceiling probe returns False | ran normally | unchanged |
| 9 | Large tree, unscoped, explicit `--max-depth` reaching target | `max_depth` unconditional-bound gate | ran normally | unchanged |
| 10 | Native binary present + `--json`/`--cpu` trigger, unscoped, oversized | `check_native_implicit_walk_ceiling` (Rust, already shipped) | exit 2, ~34ms (direct) | unchanged |

Row 3-4 are the confirmed gap; rows 1-2, 5-6, 8-10 are non-regression / already-correct baselines re-verified during this investigation.

## Fix

- `src/tensor_grep/io/directory_scanner.py`: new `IMPLICIT_SEARCH_WALK_FILE_CEILING = 1500` -- single source of truth (same pattern as `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` / `BROAD_WORKSPACE_PROJECT_MARKERS`).
- `src/tensor_grep/cli/main.py`: `_LARGE_ROOT_SCAN_FILE_CEILING` now imports that constant instead of a separate hardcoded `1500` literal (prevents future drift between the two Python-side guards).
- `src/tensor_grep/cli/bootstrap.py`: new `_search_paths_include_oversized_implicit_root(paths, search_args)` -- a bounded walk (never more than ceiling+1 entries) via `DirectoryScanner`, mirroring `cli/main.py`'s existing `_implicit_glob_search_walk_exceeds_ceiling` (Bug #88). Wired into `_search_args_include_unbounded_broad_scan`, gated on `paths_defaulted` (implicit path only -- an explicit PATH still runs uninhibited, matching the existing Trap #3 contract). Also widens the probe to `no_ignore=True` when any `--no-ignore*` flag is present in the raw args, so it never under-counts relative to the real walk.
- When the guard fires, bootstrap defers to `_run_full_cli()`, which already owns the actual refusal message + exit 2 via `cli/main.py`'s pre-existing `_should_refuse_unbounded_large_root_scan` (verified working end-to-end before this PR -- this fix is about *reaching* that guard, not building a new one).

## Non-regression proof (measured, not assumed)

- **Scoped search (explicit path) on the identical oversized tree: unaffected.** The probe is gated on `paths_defaulted`, so it never runs for a scoped search -- 3 repeated timings post-fix: 0.301s / 0.284s / 0.287s, matching pre-fix baseline timings (0.29-0.35s) with no measurable delta.
- Small tree, unscoped: still runs normally (no over-refusal).
- `--max-depth` on an oversized implicit root: still runs normally (existing escape hatch preserved).
- `--allow-broad-generated-scan` opt-in: still bypasses the new guard.
- 85/86 existing `test_cli_bootstrap.py` tests pass (1 skip: native-binary-required lock test, no in-tree build in this environment). 522/523 `test_cli_modes.py` tests pass (1 pre-existing failure, `test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`, confirmed failing identically on unmodified `main` via `git stash` -- unrelated to this change, GPU device-inventory environment issue).
- 7 new tests added: constant-parity, probe-direct (over/under ceiling, `--no-ignore` widening), full `main_entry()` dispatch-level (oversized implicit refuses via full CLI / oversized explicit still fast-paths), and `_search_args_include_unbounded_broad_scan`-level.
- `ruff check` clean, `ruff format --check --preview` clean, `mypy` clean on all touched files.

## What did NOT change

- No new CLI flag or command (no registration-site changes needed).
- The fail-closed timeout contract (`_streaming_passthrough_returncode`, exit 124 + honest stderr) was already correct -- untouched, just re-verified.
- `prepare`/`doctor`/find-hint copy and the ledger were not touched (out of this seam).

## Flag for review

**Front-door change** (`bootstrap.py` dispatch logic) -- flagging for an independent Opus gate per house discipline.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
