### PR TITLE
feat(imports): resolve literal dynamic imports (import_module/__import__) with dynamic:true

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1695,18 +1695,67 @@ def _is_python_dynamic_import_call(node: ast.Call) -> bool:
     )
 
 
+def _python_dynamic_import_call_is_relative(node: ast.Call) -> bool:
+    """True when a ``__import__(...)`` call is unambiguously or possibly RELATIVE via its
+    ``level`` argument (5th positional, or the ``level=`` keyword) -- ``__import__``'s own
+    relative-import marker is this integer, separate from ``import_module``'s leading-dot
+    module-string convention (the caller checks that with a plain ``.startswith(".")`` on the
+    literal module name instead, since ``import_module`` has no ``level`` parameter at all --
+    this always returns ``False`` for an ``import_module``/bare-``import_module`` call, harmlessly).
+
+    A non-literal ``level`` value (a variable, an expression) can't be proven to be the safe
+    default of ``0``, so it is conservatively treated as relative too -- the same "can't prove
+    it's safe" fail-closed posture as every other honesty check in this module (e.g. the
+    non-literal-argument case just above, or the #152 sys.path-hack idiom matcher).
+    """
+    level_arg: ast.expr | None = None
+    if len(node.args) >= 5:
+        level_arg = node.args[4]
+    else:
+        for keyword in node.keywords:
+            if keyword.arg == "level":
+                level_arg = keyword.value
+                break
+    if level_arg is None:
+        return False
+    if isinstance(level_arg, ast.Constant) and isinstance(level_arg.value, int):
+        return level_arg.value != 0
+    return True  # non-literal level -- can't prove it's 0, fail closed (treat as relative)
+
+
 def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
     """Raw per-call dynamic-import entries: one dict per ``__import__``/``import_module``/
     ``importlib.import_module`` call anywhere in ``tree``, shaped like the static entries
     ``_python_imports_with_lines`` emits (``module``, ``line``, ``level``) plus the two #93 SUB-1
-    markers -- ``dynamic`` (always ``True`` here) and ``dynamic_unresolved`` (``True`` when the
-    first argument isn't a static string literal, e.g. a variable or an f-string).
+    markers -- ``dynamic`` (always ``True`` here) and ``dynamic_unresolved`` (``True`` when there
+    is no static-string-literal target to resolve at all -- the first argument isn't a literal,
+    e.g. a variable or an f-string -- OR when the literal names a RELATIVE import this slice
+    deliberately does not attempt to resolve, see below).
 
-    Fails CLOSED on the unresolved case: ``module`` is ``""`` rather than a guessed name --
-    asserting a fabricated edge for an import whose target we can't actually read would be a
-    precision regression in a moat feature (see ``_resolve_raw_import_entry`` /
+    Fails CLOSED on the non-literal-argument case: ``module`` is ``""`` rather than a guessed
+    name -- asserting a fabricated edge for an import whose target we can't actually read would
+    be a precision regression in a moat feature (see ``_resolve_raw_import_entry`` /
     ``_confirm_import_edges``, which both skip resolution entirely when ``dynamic_unresolved``
     is set).
+
+    Also fails CLOSED on a RELATIVE literal -- a leading-dot ``import_module(".sibling",
+    package=...)`` module string, or an ``__import__(name, ..., level=N)`` call with a nonzero
+    (or non-literal, unprovable) ``level`` (``_python_dynamic_import_call_is_relative`` above --
+    scope slice #6, the tractable dynamic-import LITERAL slice). Both forms carry a real literal
+    name, kept here (unlike the non-literal case, ``module`` is NOT blanked to ``""`` -- nothing
+    is fabricated, the literal text is exactly what the source says), but the downstream absolute
+    resolver (``_python_module_candidates``) must never see it: its ``_python_module_parts``
+    splitter drops a leading empty component from ``".sibling".split(".")``, so an unguarded
+    relative literal would silently be searched for as if it were the ABSOLUTE module "sibling" --
+    a PROVEN false-edge risk (a same-named-but-unrelated top-level file can exist anywhere in the
+    search roots) not merely a theoretical one. Resolving the relative form correctly needs a
+    second, chained lookup (resolve the ``package``/enclosing-package argument to a directory
+    FIRST, only then walk it by the relative level) that this slice does not build -- out of scope
+    per the "no false edges, missing is fine" contract; a future slice can add it. ``package``
+    itself is never read here (a non-literal ``package`` -- the overwhelmingly common real-world
+    shape, ``package=__name__``/``package=__package__`` -- couldn't be resolved statically anyway,
+    and even a literal ``package`` string is left for that future slice), so this is a pure
+    detect-and-refuse guard on the ``module``/``level`` shape alone.
     """
     entries: list[dict[str, Any]] = []
     for node in ast.walk(tree):
@@ -1719,12 +1768,17 @@ def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
             and isinstance(node.args[0].value, str)
         ):
             literal_module = node.args[0].value
+        dynamic_unresolved = literal_module is None
+        if literal_module is not None and (
+            literal_module.startswith(".") or _python_dynamic_import_call_is_relative(node)
+        ):
+            dynamic_unresolved = True
         entries.append({
             "module": literal_module or "",
             "line": int(node.lineno),
             "level": 0,
             "dynamic": True,
-            "dynamic_unresolved": literal_module is None,
+            "dynamic_unresolved": dynamic_unresolved,
         })
     return entries
 

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -1731,6 +1731,376 @@ def test_build_file_imports_sys_path_insert_here_alias_resolves(tmp_path: Path) 
 
 
 # ---------------------------------------------------------------------------------------------
+# CEO dogfood feature 6 -- the dynamic-import LITERAL slice. The base recall (#93 SUB-1, block
+# above) already turns a literal `importlib.import_module("x")` / bare `import_module("x")` /
+# `__import__("x")` call into a resolvable edge with `dynamic: true`. This block closes three
+# real gaps found by re-verifying that base feature against the ACTUAL code (not just reading
+# it): two are PROVEN FALSE-EDGE bugs (relative-form literals silently mis-resolved as absolute),
+# fixed in `_python_dynamic_import_entries`/`_python_dynamic_import_call_is_relative`; the rest
+# are regression-lock coverage for behavior that was already correct by composition (the dynamic
+# entries flow through the exact same `_resolve_raw_import_entry`/`_confirm_import_edges` ->
+# `_python_module_candidates` path as static imports) but had no dedicated test.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_build_file_imports_relative_import_module_literal_stays_external_no_false_edge(
+    tmp_path: Path,
+) -> None:
+    """The false-edge bug this slice fixes: `import_module(".sibling", package="pkg.subpkg")`
+    is a RELATIVE literal (leading dot). Naively resolving it through the absolute-module path
+    (`_python_module_parts` strips the leading empty component from `".sibling".split(".")`)
+    would search for it as if it were the ABSOLUTE module "sibling" -- proven here by planting an
+    UNRELATED top-level `sibling.py` decoy that must NEVER be reported as this call's target.
+    `package` is a literal string too, but this slice does not attempt the chained
+    package-to-directory resolution that would be needed to resolve it correctly -- it must fail
+    closed (external/unresolved), not guess."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    subpkg = pkg / "subpkg"
+    subpkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (subpkg / "__init__.py").write_text("", encoding="utf-8")
+    decoy = project / "sibling.py"
+    decoy.write_text("DECOY = True\n", encoding="utf-8")
+    consumer = subpkg / "loader.py"
+    consumer.write_text(
+        "from importlib import import_module\n\n"
+        "def load():\n"
+        '    return import_module(".sibling", package="pkg.subpkg")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [current for current in payload["imports"] if current.get("dynamic")]
+    assert len(dynamic_entries) == 1
+    entry = dynamic_entries[0]
+    assert entry["module"] == ".sibling"  # the literal text, not fabricated/blanked
+    assert entry["dynamic_unresolved"] is True
+    assert entry["resolved"] is None
+    assert entry["resolved"] != str(decoy.resolve())
+    assert str(decoy.resolve()) not in payload["resolved_files"]
+
+
+def test_build_file_importers_relative_import_module_literal_asserts_no_edge(
+    tmp_path: Path,
+) -> None:
+    """Reverse direction of the same false-edge bug: `tg importers` on the decoy file must NOT
+    report `loader.py` as a confirmed importer just because its relative dynamic literal shares a
+    bare name with the decoy."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    subpkg = pkg / "subpkg"
+    subpkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (subpkg / "__init__.py").write_text("", encoding="utf-8")
+    decoy = project / "sibling.py"
+    decoy.write_text("DECOY = True\n", encoding="utf-8")
+    consumer = subpkg / "loader.py"
+    consumer.write_text(
+        "from importlib import import_module\n\n"
+        "def load():\n"
+        '    return import_module(".sibling", package="pkg.subpkg")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_importers(decoy, project)
+
+    assert payload["importer_files"] == []
+    assert str(consumer.resolve()) not in payload["importer_files"]
+
+
+def test_build_file_imports_dunder_import_explicit_level_keyword_stays_external(
+    tmp_path: Path,
+) -> None:
+    """`__import__`'s relative marker is its `level` INTEGER argument, not a leading dot in the
+    name -- `__import__("sibling", level=1)` is relative even though `"sibling"` itself has no
+    dot. Same false-edge risk as the `import_module` case above if `level` is ignored: proven via
+    the same unrelated-decoy-file pattern."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    subpkg = pkg / "subpkg"
+    subpkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (subpkg / "__init__.py").write_text("", encoding="utf-8")
+    decoy = project / "sibling.py"
+    decoy.write_text("DECOY = True\n", encoding="utf-8")
+    consumer = subpkg / "loader.py"
+    consumer.write_text(
+        'def load():\n    return __import__("sibling", level=1)\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [current for current in payload["imports"] if current.get("dynamic")]
+    assert len(dynamic_entries) == 1
+    entry = dynamic_entries[0]
+    assert entry["dynamic_unresolved"] is True
+    assert entry["resolved"] is None
+    assert entry["resolved"] != str(decoy.resolve())
+
+
+def test_build_file_imports_dunder_import_explicit_level_positional_stays_external(
+    tmp_path: Path,
+) -> None:
+    """Same as above, but `level` passed as the 5th POSITIONAL argument
+    (`__import__(name, globals, locals, fromlist, level)`) -- the full stdlib call shape."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    subpkg = pkg / "subpkg"
+    subpkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (subpkg / "__init__.py").write_text("", encoding="utf-8")
+    decoy = project / "sibling.py"
+    decoy.write_text("DECOY = True\n", encoding="utf-8")
+    consumer = subpkg / "loader.py"
+    consumer.write_text(
+        'def load():\n    return __import__("sibling", globals(), locals(), [], 1)\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    dynamic_entries = [current for current in payload["imports"] if current.get("dynamic")]
+    assert len(dynamic_entries) == 1
+    entry = dynamic_entries[0]
+    assert entry["dynamic_unresolved"] is True
+    assert entry["resolved"] is None
+    assert entry["resolved"] != str(decoy.resolve())
+
+
+def test_build_file_imports_dunder_import_explicit_level_zero_still_resolves(
+    tmp_path: Path,
+) -> None:
+    """Regression guard: an explicit but ZERO `level=0` keyword is still the safe absolute case
+    (Python's own default) -- must not be swept into the relative fail-closed path just because a
+    `level` keyword is textually present."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text(
+        'mod = __import__("pkg.helpers", level=0)\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "pkg.helpers")
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+    assert entry["resolved"] == str(target.resolve())
+
+
+def test_build_file_imports_dynamic_import_resolves_through_sys_path_insert_root(
+    tmp_path: Path,
+) -> None:
+    """Composition with #152: a module ONLY reachable via a `sys.path.insert` hack must still
+    resolve when reached through `importlib.import_module(...)` instead of a static `from x
+    import y` -- both raw-entry shapes (`_python_imports_with_lines`'s static loop and its
+    `_python_dynamic_import_entries` extension) feed the SAME `_resolve_raw_import_entry` ->
+    `_python_module_candidates` resolver, which tries the sys-path-hacked roots first."""
+    project = tmp_path / "project"
+    lib_dir = project / "lib"
+    lib_dir.mkdir(parents=True)
+    mymod_path = lib_dir / "mymod.py"
+    mymod_path.write_text("def x():\n    return 1\n", encoding="utf-8")
+    app_py = project / "app.py"
+    app_py.write_text(
+        "import sys, os, importlib\n"
+        'sys.path.insert(0, os.path.join(os.path.dirname(__file__), "lib"))\n'
+        "def load():\n"
+        '    return importlib.import_module("mymod")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(app_py)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "mymod")
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+    assert entry["resolved"] == str(mymod_path.resolve())
+    assert entry["external"] is False
+    assert entry["provenance"] == ["sys-path-insert"]
+
+
+def test_build_file_importers_dynamic_import_finds_importer_through_sys_path_insert_root(
+    tmp_path: Path,
+) -> None:
+    """Reverse direction of the composition-with-#152 test above: `tg importers` must find the
+    sys.path-hacking consumer as a confirmed importer via its DYNAMIC `import_module(...)` call,
+    with the sys-path-hack provenance honestly reported on the edge (mirrors the static #155 fix
+    at `test_build_file_importers_finds_sys_path_insert_hacked_importer`)."""
+    project = tmp_path / "project"
+    lib_dir = project / "lib"
+    lib_dir.mkdir(parents=True)
+    mymod_path = lib_dir / "mymod.py"
+    mymod_path.write_text("def x():\n    return 1\n", encoding="utf-8")
+    app_py = project / "app.py"
+    app_py.write_text(
+        "import sys, os, importlib\n"
+        'sys.path.insert(0, os.path.join(os.path.dirname(__file__), "lib"))\n'
+        "def load():\n"
+        '    return importlib.import_module("mymod")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_importers(mymod_path, project)
+
+    assert str(app_py.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(app_py.resolve())
+    )
+    assert edge["dynamic"] is True
+    assert edge["dynamic_unresolved"] is False
+    assert edge["module"] == "mymod"
+    assert edge["path_provenance"] == "sys-path-insert"
+
+
+def test_build_file_importers_recalls_bare_import_module_call(tmp_path: Path) -> None:
+    """Reverse-direction coverage for the bare `from importlib import import_module` alias form
+    -- the forward side already covers this
+    (`test_build_file_imports_detects_bare_import_module_call`); the reverse side had no
+    dedicated test (only the `importlib.import_module` attribute form did, via
+    `test_build_file_importers_recalls_dynamic_importlib_import_module`)."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text(
+        "from importlib import import_module\n\n"
+        "def load():\n"
+        '    return import_module("pkg.helpers")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(consumer.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(consumer.resolve())
+    )
+    assert edge["dynamic"] is True
+    assert edge["dynamic_unresolved"] is False
+    assert edge["module"] == "pkg.helpers"
+
+
+def test_build_file_importers_recalls_dunder_import_to_local_file(tmp_path: Path) -> None:
+    """Reverse-direction coverage for `__import__(...)` resolving to a LOCAL repo file -- the
+    existing `__import__` reverse test only exercised the JS `import(...)` call form; the
+    existing Python `__import__` test only exercised the forward direction against a stdlib name
+    (`json`, always external)."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text('mod = __import__("pkg.helpers")\n', encoding="utf-8")
+
+    payload = repo_map.build_file_importers(target, project)
+
+    assert str(consumer.resolve()) in set(payload["importer_files"])
+    edge = next(
+        current for current in payload["importers"] if current["file"] == str(consumer.resolve())
+    )
+    assert edge["dynamic"] is True
+    assert edge["dynamic_unresolved"] is False
+    assert edge["module"] == "pkg.helpers"
+
+
+def test_build_file_imports_detects_dynamic_import_nested_in_conditional_inside_function(
+    tmp_path: Path,
+) -> None:
+    """Deeper-nesting recall: a dynamic-import call two scopes down (function -> if -> try), not
+    just directly in a function body like the other fixtures in this file -- `ast.walk` visits
+    every depth uniformly, this locks that in explicitly."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text(
+        "import importlib\n\n"
+        "def load(flag):\n"
+        "    if flag:\n"
+        "        try:\n"
+        '            return importlib.import_module("pkg.helpers")\n'
+        "        except ImportError:\n"
+        "            return None\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "pkg.helpers")
+    assert entry["dynamic"] is True
+    assert entry["resolved"] == str(target.resolve())
+    assert entry["line"] == 6
+
+
+def test_build_file_imports_detects_dynamic_import_at_module_top_level(tmp_path: Path) -> None:
+    """Opposite extreme from the nested fixtures: a dynamic-import call with NO function wrapper
+    at all, directly at module scope -- `ast.walk` doesn't require nesting either."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    target = pkg / "helpers.py"
+    target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "loader.py"
+    consumer.write_text(
+        'import importlib\nmod = importlib.import_module("pkg.helpers")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "pkg.helpers")
+    assert entry["dynamic"] is True
+    assert entry["resolved"] == str(target.resolve())
+    assert entry["line"] == 2
+
+
+def test_build_file_imports_unresolvable_dynamic_literal_stays_external(tmp_path: Path) -> None:
+    """A literal (resolvable-in-principle) module name that simply doesn't exist anywhere in the
+    search roots must be honestly `external`, decoupled from the existing dunder-import test's
+    stdlib-name ambiguity (`json` is external partly because it's a real stdlib module tg doesn't
+    special-case -- this uses a name that is definitely not any real package)."""
+    project = tmp_path / "project"
+    project.mkdir()
+    consumer = project / "app.py"
+    consumer.write_text(
+        "import importlib\n"
+        'mod = importlib.import_module("totally.nonexistent.repo_local_module")\n',
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(
+        current
+        for current in payload["imports"]
+        if current["module"] == "totally.nonexistent.repo_local_module"
+    )
+    assert entry["dynamic"] is True
+    assert entry["dynamic_unresolved"] is False
+    assert entry["external"] is True
+    assert entry["resolved"] is None
+    assert "totally.nonexistent.repo_local_module" in payload["external_modules"]
+
+
+# ---------------------------------------------------------------------------------------------
 # Proximity-tiered reverse-import candidate ordering. Dogfood flap (v1.81.15 PASS
 # -> v1.81.17 INCOMPLETE "0 importers @ 330/1035 files scanned" on a 50k-file WSL multi-repo
 # workspace) traced to `build_file_importers_from_map` slicing its CALLER_SCAN_FILE_CEILING /


### PR DESCRIPTION
## Summary

CEO dogfood feature 6: dynamic-import / string-dispatch coverage beyond `sys.path.insert`. Scope, strictly: `importlib.import_module("literal.string")` and `__import__("literal.string")` calls with a **string-literal** argument become resolvable edges in `tg imports` (forward) and `tg importers` (reverse), flagged `dynamic: true`. Non-literal args (variables, f-strings, concatenation) stay honestly external/unresolved. String-dispatch tables / entry-points are out of scope (a later slice).

## What was already there vs. what this PR actually changes

Verify-plan-against-code turned up that the base feature **already shipped** in #504 (`fix(repo_map): dynamic-import recall in imports/importers`, audit #93 SUB-1):

- `_python_dynamic_import_entries` (`src/tensor_grep/cli/repo_map.py:1726`, called from `_is_python_dynamic_import_call` at `:1678`) already recognizes all 3 call shapes -- `importlib.import_module(...)`, bare `import_module(...)` (from `from importlib import import_module`), and `__import__(...)` -- via `ast.walk` (whole-tree, so it already catches calls nested in a function/conditional/try, the #563 fix -- `fix(imports): resolve nested (function/conditional-scoped) imports in tg imports/importers`).
- It already feeds **both** directions through the exact same downstream resolver static imports use: `_python_imports_with_lines` (forward, `tg imports`, `repo_map.py:5943`) and `_python_imports_and_symbols` (reverse alias-graph prefilter, `tg importers`, `repo_map.py:1988`) both call it, and both flow into `_resolve_raw_import_entry` (`:16077`, forward) / `_confirm_import_edges` (`:16240`, reverse CONFIRM step) -> `_python_module_candidates` (`:6378`) -- the SAME machinery `sys.path.insert` roots (#152) already compose through automatically.
- The `dynamic`/`dynamic_unresolved` markers are already additive-only (a static entry omits both keys entirely -- see the existing `test_build_file_imports_static_require_unaffected_by_dynamic_detection` payload-bloat guard), so no JSON contract change was needed here either.
- 11 pre-existing tests in `tests/unit/test_file_deps.py` already covered: literal `import_module` resolving (both call shapes), `__import__` literal, non-literal -> unresolved (both directions), and the reverse "never assert an edge for an unresolved dynamic import" precision guard.

**So this PR is a bug-fix + regression-lock PR, not a from-scratch build.** Re-verifying the shipped feature against *real execution* (reproduced directly against `build_file_imports`/`build_file_importers` before writing any fix) surfaced two provable false-edge bugs:

1. `import_module(".sibling", package="pkg.subpkg")` -- a **relative** literal (leading dot) -- resolved to an **unrelated top-level `sibling.py`** file. Root cause: `_python_module_parts` does `module_name.split(".")` then filters empty strings, so `".sibling"` silently becomes `["sibling"]` and gets searched for as the **absolute** module `sibling` -- a same-named-but-unrelated top-level file can (and in the repro, does) satisfy that search.
2. `__import__("sibling", level=1)` (both the `level=` keyword form and the 5-positional-arg stdlib form `__import__(name, globals, locals, fromlist, level)`) -- same false-edge shape, because the old `_python_dynamic_import_entries` hardcoded `"level": 0` on every raw entry regardless of an explicit nonzero `level` argument (`__import__`'s own relative-import marker, distinct from `import_module`'s leading-dot convention).

Both were live in **already-shipped code** -- this is a real precision bug, not a hypothetical.

## The fix

`_python_dynamic_import_entries` (`repo_map.py:1726`) is the single upstream point of truth both `tg imports` and `tg importers` consume. A new helper, `_python_dynamic_import_call_is_relative` (`:1698`), detects an explicit non-zero-or-non-literal `level` on `__import__`; combined with a `literal_module.startswith(".")` check, both relative-literal shapes now set `dynamic_unresolved = True` on the raw entry -- **reusing the existing, already-tested unresolved-skip logic** in `_resolve_raw_import_entry` and `_confirm_import_edges` (both already `continue`/short-circuit on `dynamic_unresolved`), rather than adding new branches downstream. The literal text itself is kept (not blanked to `""` like the genuinely-non-literal case -- nothing is fabricated), so it surfaces honestly in the `unresolved` summary list.

Deliberately **out of scope**: resolving the relative-with-literal-`package` form correctly needs a second, chained lookup (resolve `package` to a directory first, then walk it by the relative level) -- real work, its own risk surface, and the overwhelmingly common real shape (`package=__name__`/`package=__package__`) is a `Name` node anyway, not resolvable statically without a much bigger file-path->module-name reverse-resolution feature. Per the task's own scope note ("relative-with-package only if... the resolution machinery supports it -- otherwise leave external") and the crux below, this slice fails closed instead.

**Crux -- no false edges:** a wrong resolved edge is worse than a missing one. Every new/changed path here can only ever *narrow* `dynamic_unresolved` from `False`->`True` (never fabricate a new resolution); the two bug-fix tests below are decoy-file proofs, not just shape assertions.

## Tests (`tests/unit/test_file_deps.py`, 12 new, TDD-first)

Bug-fix proofs (each plants an unrelated top-level `sibling.py` decoy and asserts it is never the resolved target):
- `test_build_file_imports_relative_import_module_literal_stays_external_no_false_edge` / `test_build_file_importers_relative_import_module_literal_asserts_no_edge` (forward + reverse)
- `test_build_file_imports_dunder_import_explicit_level_keyword_stays_external` / `..._positional_stays_external` (both `__import__` level shapes)
- `test_build_file_imports_dunder_import_explicit_level_zero_still_resolves` (regression guard: a *present-but-zero* `level=0` must still resolve normally)

Regression-lock coverage for behavior that was already correct by composition, but had no dedicated test (confirmed via direct pre-fix repro that these already passed):
- `test_build_file_imports_dynamic_import_resolves_through_sys_path_insert_root` / `test_build_file_importers_dynamic_import_finds_importer_through_sys_path_insert_root` -- composition with #152, both directions, asserts `provenance == ["sys-path-insert"]` / `path_provenance == "sys-path-insert"`
- `test_build_file_importers_recalls_bare_import_module_call` / `test_build_file_importers_recalls_dunder_import_to_local_file` -- reverse-side coverage the existing suite was missing for the bare-alias and `__import__`-to-local-file shapes
- `test_build_file_imports_detects_dynamic_import_nested_in_conditional_inside_function` (2-level nesting: function -> if -> try) / `..._at_module_top_level` (no function wrapper at all)
- `test_build_file_imports_unresolvable_dynamic_literal_stays_external` -- a definitely-nonexistent name, decoupled from the existing `__import__("json")` test's stdlib-name ambiguity

## Verification

- `ruff check` / `ruff format --check --preview` -- clean (one preview-formatter quote-style fix applied to my own new fixtures).
- `mypy src/tensor_grep/cli/repo_map.py` -- clean (fixed one real `str | None` narrowing gap it caught: `literal_module.startswith(".")` needed an explicit `is not None` check, not the separate `dynamic_unresolved` bool).
- `tests/unit/test_file_deps.py` -- 85/85 passed (73 pre-existing + 12 new).
- Broader regression net (not the full ~5.5k-test suite -- CPU-safe scoping): 329 additional tests across `test_agent_capsule_*`, `test_orient_*`, `test_caller_span_targeting`, `test_impact_callers_shared_map`, `test_repo_map_*`, `test_import_root`, `test_import_span_targeting`, `test_blast_radius_mermaid` -- all green. (`_python_dynamic_import_entries` has exactly 2 callers in the whole tree, confirmed via grep, so this is the real blast radius.)
- **Dogfooded the real published `tg` CLI end-to-end** (not just CliRunner -- bootstrap front door, `.venv`'s installed `tg.exe` with `PYTHONPATH` pointed at this worktree, confirmed via `tensor_grep.__file__`): `tg imports loader.py --json` shows `dogfood_pkg.helpers` resolved with `dynamic: true` and `.sibling` honestly `dynamic_unresolved: true` (`external: false`, `resolved: null`, listed in `unresolved`); `tg importers sibling.py <clean-root> --json` on the decoy returns `importer_count: 0` on a **complete, non-truncated** scan (`scanned_files: 4`, `possibly_truncated: false`) -- exit 1, genuine not-found, not a truncation artifact.

## Load-bearing flag

This changes `tg imports`/`tg importers` **output membership** (a relative dynamic-import literal that previously resolved -- wrongly -- now correctly reports unresolved). Per house policy this is flagged for an **independent Opus gate** before merge; the build agent's own verification above is a hypothesis, not a self-certified pass.

Generated with [Claude Code](https://claude.com/claude-code)
