### PR TITLE
fix(gpu): detect a bare-named WSL front-door shim as cross-domain (#171 GPU-P0-1 follow-up)

### DIFF
--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -378,16 +378,94 @@ def native_binary_targets_windows(binary: Path | str) -> bool:
     return str(binary).lower().endswith(".exe")
 
 
+# GPU-P0-1 follow-up (2026-07-21 CEO WSL dogfood, gotcontext-saddle): `native_binary_targets_windows()`
+# is keyed on the `.exe` suffix of the resolved candidate ITSELF, which is correct for a raw
+# binary but blind to the bare-named (`tg`, no extension) POSIX shim that BOTH managed installers
+# generate for WSL/git-bash/MSYS shells: `scripts/install.sh`'s staged `bin/tg` heredoc (copied via
+# `cp "$INSTALL_DIR/bin/tg" "$SHIM_PATH"` into every `SHIM_DIRS` entry, install.sh:395-401) and
+# `scripts/install.ps1`'s `$frontdoorBashContent` (`Write-BashFile -Path $stagingFrontdoorBashPath`
+# for the original `.tensor-grep/bin/tg`, then a byte-identical copy into every `$shimDirs` entry
+# via `Write-BashFile -Path $bashShimPath -Value $frontdoorBashContent`, install.ps1:837-852). Both
+# shims detect WSL via their own `/proc/version` "microsoft" check and then `exec` the real
+# `tg.exe` -- but the SHIM itself, not the `.exe` it delegates to, is what
+# `resolve_native_tg_binary()` returns on a WSL/Linux host (it looks for a literal `tg`, no
+# extension: `binary_name = "tg.exe" if sys.platform.startswith("win") else "tg"` above). The
+# `.exe`-suffix check alone therefore reads this shim as same-domain, so the doctor/agent probes
+# hand it an untranslated `/tmp/...` path; the shim's real Windows-target child process can't open
+# it and returns the native binary's own structured `path_not_found` -- which the doctor then
+# reports as the honest-LOOKING but WRONG `failed_probe_path` (same-domain bucket) instead of
+# `failed_path_bridging`/`path_domain_mismatch` (verified live: `tg doctor --json` under WSL
+# resolved a `~/bin/tg`-class shim (bash script, no `.exe`) that internally `exec`s `tg.exe`).
+#
+# Two independent signals below, both filesystem-observable from the shim's own resolved path:
+#   1. `_native_frontdoor_metadata_targets_windows()` -- the sibling `tg-native-metadata.json`
+#      written next to the ORIGINAL front door (`.tensor-grep/bin/tg-native-metadata.json`).
+#   2. `_sibling_native_windows_binary_exists()` -- a co-located `tg.exe`. This is the one that
+#      actually catches the live repro: install.ps1's `Copy-Item -LiteralPath $nativeFrontdoorPath
+#      -Destination $exeShimPath` (line 841) copies a REAL `tg.exe` into every `$shimDirs` entry
+#      alongside the bash shim, but does NOT copy `tg-native-metadata.json` there (only the
+#      original `.tensor-grep/bin/` gets it) -- so a shim resolved via `~/bin/tg` or
+#      `~/.local/bin/tg` (the common case; these, not `.tensor-grep/bin/`, are what installer
+#      wiring puts on `$PATH`) has signal 2 but NOT signal 1. Confirmed empirically: on the CEO's
+#      WSL dogfood box, `resolve_native_tg_binary()` resolved exactly such a shimDir copy, and
+#      re-running the doctor probe logic against it post-fix (signal 2 present, signal 1 absent)
+#      correctly flips `is_cross_domain_native_binary()` to True and the translated path opens
+#      cleanly via the real `tg.exe`. Keeping signal 1 too: it survives a `tg.exe` later being
+#      deleted out from under an otherwise-intact managed install (the shim's own fallback branch
+#      then execs the managed venv's Windows-side `python.exe`, still cross-domain).
+def _native_frontdoor_metadata_targets_windows(binary: Path | str) -> bool:
+    """True when the sibling `tg-native-metadata.json` records a Windows-target asset.
+
+    Reads `asset_name` (written by the installer next to whatever front-door entry point it
+    creates: `tg-windows-amd64-{cpu,nvidia}.exe` vs `tg-linux-amd64-{cpu,nvidia}`/`tg-macos-amd64-
+    cpu`) via the existing `native_frontdoor_metadata_path()`/`_read_native_frontdoor_metadata()`
+    helpers. Fails closed to False on any miss -- no metadata file, unreadable, malformed, or no
+    `asset_name` field -- so this can only ever ADD a cross-domain detection, never remove one.
+    """
+    try:
+        binary_path = binary if isinstance(binary, Path) else Path(binary)
+    except TypeError:
+        return False
+    metadata = _read_native_frontdoor_metadata(binary_path)
+    asset_name = metadata.get("native_frontdoor_asset_name")
+    return isinstance(asset_name, str) and asset_name.lower().endswith(".exe")
+
+
+def _sibling_native_windows_binary_exists(binary: Path | str) -> bool:
+    """True when a `<name>.exe` file exists alongside `binary` in the same directory.
+
+    Both managed installers place a real copy of the native `tg.exe` in the SAME directory as the
+    bare-named POSIX shim that `exec`s it (install.ps1:841's `Copy-Item ... -Destination
+    $exeShimPath`; install.sh's `STAGING_NATIVE_BINARY`/shim both live under the same staged
+    `bin/`), so this is a filesystem-observable signal independent of whether install-time metadata
+    happens to be co-located too (it usually is NOT for the distributed shim-dir copies -- see the
+    module comment above). Fails closed to False when `binary` has no name component or the sibling
+    does not exist, so this can only ever ADD a cross-domain detection, never remove one.
+    """
+    try:
+        binary_path = binary if isinstance(binary, Path) else Path(binary)
+    except TypeError:
+        return False
+    name = binary_path.name
+    if not name:
+        return False
+    return (binary_path.parent / f"{name}.exe").is_file()
+
+
 def is_cross_domain_native_binary(binary: Path | str | None) -> bool:
     """True when the host is Linux/WSL but the resolved native `tg` binary targets Windows.
 
-    Requires ALL THREE: a Linux host (`sys.platform`), a genuine WSL signal (`is_wsl_host()`),
-    and a Windows-shaped binary path (`native_binary_targets_windows()`). Dropping the WSL-signal
-    check would false-positive on any bare Linux CI runner whose test fixtures happen to use a
-    `.exe`-suffixed name for unrelated reasons; dropping the platform check would be redundant but
-    harmless. The downstream `wslpath` lookup also fails closed (returns None) when unavailable,
-    so even a false positive here degrades to the honest `path_domain_mismatch` status rather than
-    a silently wrong argv.
+    Requires a Linux host (`sys.platform`), a genuine WSL signal (`is_wsl_host()`), and a
+    Windows-shaped target -- the resolved path itself carrying the `.exe` suffix
+    (`native_binary_targets_windows()`), OR either of two install-time signals for the bare-named
+    POSIX shim case documented above: its sibling metadata naming a Windows asset
+    (`_native_frontdoor_metadata_targets_windows()`) or a co-located `tg.exe` on disk
+    (`_sibling_native_windows_binary_exists()`). Dropping the WSL-signal check would
+    false-positive on any bare Linux CI runner whose test fixtures happen to use a `.exe`-suffixed
+    name for unrelated reasons; dropping the platform check would be redundant but harmless. The
+    downstream `wslpath` lookup also fails closed (returns None) when unavailable, so even a false
+    positive here degrades to the honest `path_domain_mismatch` status rather than a silently wrong
+    argv.
     """
     if binary is None:
         return False
@@ -395,7 +473,11 @@ def is_cross_domain_native_binary(binary: Path | str | None) -> bool:
         return False
     if not is_wsl_host():
         return False
-    return native_binary_targets_windows(binary)
+    return (
+        native_binary_targets_windows(binary)
+        or _native_frontdoor_metadata_targets_windows(binary)
+        or _sibling_native_windows_binary_exists(binary)
+    )
 
 
 def translate_path_for_windows_binary(

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -136,10 +136,18 @@ def native_frontdoor_metadata_path(native_binary: Path) -> Path:
 def _read_native_frontdoor_metadata(native_binary: Path) -> dict[str, str]:
     metadata_path = native_frontdoor_metadata_path(native_binary)
     try:
+        # Bounded + fail-closed (gate NIT-2 on #704): this reader now also runs on the agent
+        # GPU-evidence path via is_cross_domain_native_binary, so a corrupt sidecar file must
+        # degrade to "invalid", never propagate. UnicodeDecodeError is a ValueError (NOT an
+        # OSError, and json.JSONDecodeError is itself a ValueError subclass), so catching
+        # (OSError, ValueError) covers unreadable, non-UTF8, and malformed-JSON uniformly.
+        # The size cap keeps a bogus multi-GB file from stalling a diagnostic probe.
+        if metadata_path.stat().st_size > 1_048_576:
+            return {"native_frontdoor_metadata_status": "invalid"}
         raw = json.loads(metadata_path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {}
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
         return {"native_frontdoor_metadata_status": "invalid"}
     if not isinstance(raw, dict):
         return {"native_frontdoor_metadata_status": "invalid"}

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -631,6 +631,120 @@ class TestNativeBinaryTargetsWindows:
         )
 
 
+class TestNativeFrontdoorMetadataTargetsWindows:
+    """2026-07-21 CEO WSL dogfood: both installers generate a bare-named (`tg`, no `.exe`) POSIX
+    shim that internally `exec`s the real `tg.exe` -- the extension-only check can't see through
+    it, so this second signal reads the sibling `tg-native-metadata.json` instead."""
+
+    def test_true_when_sibling_metadata_names_a_windows_asset(self, tmp_path):
+        shim = tmp_path / ".tensor-grep" / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({
+                "artifact": "tensor_grep_native_frontdoor_metadata",
+                "asset_flavor": "cpu",
+                "requested_asset_flavor": "cpu",
+                "asset_name": "tg-windows-amd64-cpu.exe",
+                "version": "1.92.1",
+            }),
+            encoding="utf-8",
+        )
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is True
+
+    def test_true_is_case_insensitive_on_exe_suffix(self, tmp_path):
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({"asset_name": "tg-windows-amd64-nvidia.EXE"}), encoding="utf-8"
+        )
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is True
+
+    def test_false_when_sibling_metadata_names_a_linux_asset(self, tmp_path):
+        """The install.sh flow run natively under WSL: a genuine Linux `tg-native` asset next to
+        the shim. Must NOT be flagged cross-domain -- that would translate a same-domain ELF's
+        `/tmp` path to a UNC path it cannot open, breaking a working config."""
+        shim = tmp_path / ".tensor-grep" / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({"asset_name": "tg-linux-amd64-cpu"}), encoding="utf-8"
+        )
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is False
+
+    def test_false_when_no_sibling_metadata_file_exists(self, tmp_path):
+        in_tree_dev_binary = tmp_path / "rust_core" / "target" / "release" / "tg"
+        in_tree_dev_binary.parent.mkdir(parents=True, exist_ok=True)
+        in_tree_dev_binary.write_text("elf\n", encoding="utf-8")
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(in_tree_dev_binary) is False
+
+    def test_false_when_metadata_is_malformed_json(self, tmp_path):
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text("{not json", encoding="utf-8")
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is False
+
+    def test_false_when_asset_name_field_missing(self, tmp_path):
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({"artifact": "tensor_grep_native_frontdoor_metadata"}), encoding="utf-8"
+        )
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is False
+
+    def test_accepts_str_path_not_just_path_object(self, tmp_path):
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({"asset_name": "tg-windows-amd64-cpu.exe"}), encoding="utf-8"
+        )
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(str(shim)) is True
+
+
+class TestSiblingNativeWindowsBinaryExists:
+    """2026-07-21 CEO WSL dogfood: the signal that actually catches the live repro -- the
+    distributed shim-dir copies (`~/bin/tg`, `~/.local/bin/tg`) that installer wiring puts on
+    `$PATH` carry a co-located `tg.exe` but NOT a copy of `tg-native-metadata.json`."""
+
+    def test_true_when_exe_sibling_exists(self, tmp_path):
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg.exe").write_bytes(b"MZ fake pe\n")
+
+        assert runtime_paths._sibling_native_windows_binary_exists(shim) is True
+
+    def test_false_when_no_exe_sibling(self, tmp_path):
+        elf = tmp_path / "rust_core" / "target" / "release" / "tg"
+        elf.parent.mkdir(parents=True, exist_ok=True)
+        elf.write_text("elf\n", encoding="utf-8")
+
+        assert runtime_paths._sibling_native_windows_binary_exists(elf) is False
+
+    def test_false_on_nonexistent_directory(self, tmp_path):
+        missing = tmp_path / "does-not-exist" / "tg"
+        assert runtime_paths._sibling_native_windows_binary_exists(missing) is False
+
+    def test_accepts_str_path_not_just_path_object(self, tmp_path):
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg.exe").write_bytes(b"MZ fake pe\n")
+
+        assert runtime_paths._sibling_native_windows_binary_exists(str(shim)) is True
+
+
 class TestIsWslHost:
     def test_true_when_wsl_distro_name_set(self, monkeypatch):
         monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
@@ -754,6 +868,56 @@ class TestIsCrossDomainNativeBinary:
         monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
         linux_elf_on_mount = Path("/mnt/c/dev/tensor-grep/rust_core/target/release/tg")
         assert runtime_paths.is_cross_domain_native_binary(linux_elf_on_mount) is False
+
+    def test_true_on_bare_shim_via_sibling_windows_metadata(self, monkeypatch, tmp_path):
+        """2026-07-21 CEO WSL dogfood repro: `resolve_native_tg_binary()` returns the managed
+        installer's bare-named (`tg`, no `.exe`) POSIX shim, which internally `exec`s the real
+        `tg.exe`. The `.exe`-suffix check alone misses this; the sibling metadata signal must
+        catch it so the doctor/agent probes translate the path instead of reporting the
+        misleading same-domain `failed_probe_path`."""
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        shim = tmp_path / ".tensor-grep" / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({"asset_name": "tg-windows-amd64-cpu.exe"}), encoding="utf-8"
+        )
+
+        assert runtime_paths.is_cross_domain_native_binary(shim) is True
+
+    def test_false_on_bare_shim_via_sibling_linux_metadata(self, monkeypatch, tmp_path):
+        """The install.sh flow run natively under WSL installs a genuine Linux `tg-native` asset
+        next to the same bare-named shim shape -- must stay same-domain."""
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        shim = tmp_path / ".tensor-grep" / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_text(
+            json.dumps({"asset_name": "tg-linux-amd64-cpu"}), encoding="utf-8"
+        )
+
+        assert runtime_paths.is_cross_domain_native_binary(shim) is False
+
+    def test_true_on_shim_dir_copy_with_no_metadata_only_exe_sibling(self, monkeypatch, tmp_path):
+        """The LIVE repro shape: `resolve_native_tg_binary()` resolved a shim-dir copy
+        (`~/bin/tg`-class path, not the original `.tensor-grep/bin/tg`) that installer wiring
+        actually puts on `$PATH`. `scripts/install.ps1`'s `$shimDirs` loop copies a real `tg.exe`
+        next to each shim copy (line 841) but does NOT copy `tg-native-metadata.json` there (only
+        the original front-door directory gets it) -- so this case has NO metadata signal and must
+        be caught by the co-located `.exe` alone."""
+        monkeypatch.setattr(runtime_paths.sys, "platform", "linux")
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+        shim = tmp_path / "home" / "user" / ".local" / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg.exe").write_bytes(b"MZ fake pe\n")
+        # No tg-native-metadata.json in this directory -- confirms the .exe-sibling signal alone
+        # (not the metadata signal) is what makes this detect as cross-domain.
+        assert not (shim.parent / "tg-native-metadata.json").exists()
+
+        assert runtime_paths.is_cross_domain_native_binary(shim) is True
 
 
 class TestTranslatePathForWindowsBinary:

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -691,6 +691,29 @@ class TestNativeFrontdoorMetadataTargetsWindows:
 
         assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is False
 
+    def test_false_when_metadata_is_not_utf8(self, tmp_path):
+        """Gate NIT-2 on #704: a non-UTF8 sidecar must fail CLOSED (invalid), never raise.
+
+        UnicodeDecodeError is a ValueError, not an OSError -- the pre-fix except tuple let it
+        propagate through is_cross_domain_native_binary into the GPU probes.
+        """
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        (shim.parent / "tg-native-metadata.json").write_bytes(b"\xff\xfe{invalid\x00utf8}")
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is False
+
+    def test_false_when_metadata_is_oversized(self, tmp_path):
+        """Gate NIT-2 on #704: a bogus multi-MB sidecar is refused before the read (bounded)."""
+        shim = tmp_path / "bin" / "tg"
+        shim.parent.mkdir(parents=True, exist_ok=True)
+        shim.write_text("#!/usr/bin/env bash\nexec true\n", encoding="utf-8")
+        oversized = b'{"asset_name": "' + b"a" * 1_100_000 + b'"}'
+        (shim.parent / "tg-native-metadata.json").write_bytes(oversized)
+
+        assert runtime_paths._native_frontdoor_metadata_targets_windows(shim) is False
+
     def test_false_when_asset_name_field_missing(self, tmp_path):
         shim = tmp_path / "bin" / "tg"
         shim.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Verdict

**(b) — a real, reproduced sibling path the #184/#594 (`GPU-P0-1`) fix missed.**
Not a recurrence of the original bug, and not honest-but-misread behavior: `wslpath`
translation genuinely fixes it, live-verified end to end on the reporting box.

## Probe-path map

Every place a filesystem path crosses from a WSL Python process to a resolved native `tg`
binary, and whether it goes through translation:

| Call site | Resolves binary via | Cross-domain gate | Status before this PR |
| --- | --- | --- | --- |
| `tg doctor` GPU probe — `_doctor_gpu_search_runtime_probe` (`src/tensor_grep/cli/main.py:2882-2925`) | `resolve_native_tg_binary()` (always a resolved `Path`, never a bare string) | `is_cross_domain_native_binary()` (`runtime_paths.py:2907`) | **Missed** the bare-named shim case |
| Agent GPU evidence — `_agent_gpu_evidence` (`src/tensor_grep/cli/agent_capsule.py:1549-1690`) | `_agent_gpu_tg_command()` -> `resolve_native_tg_binary()`, falls back to bare `"tg"` only if unresolved | `is_cross_domain_native_binary()` (`agent_capsule.py:1581`) | **Missed** the same shim case (same shared helper) |
| `tg calibrate` (`main.py:8197`) | `resolve_native_tg_binary()`, inherited stdio, no filesystem path argument passed | n/a | Not this bug class -- no Python-side path crosses the boundary |
| `tg devices` (`main.py:8204-8241`) | N/A -- pure Python `DeviceDetector`/`collect_device_inventory()`, no subprocess to a native binary at all | n/a | Not this bug class |

Both affected call sites share **one** classification helper
(`is_cross_domain_native_binary` / `native_binary_targets_windows`,
`src/tensor_grep/cli/runtime_paths.py:368-459` pre-fix), so the fix lands once and covers both.

## Root cause

`native_binary_targets_windows()` keys Windows-target detection on the `.exe` suffix of the
resolved candidate alone (`runtime_paths.py:368-378`, unchanged by this PR -- its narrow,
already-tested contract is preserved). That is correct for a raw binary, but both managed
installers also generate a **bare-named (`tg`, no extension) POSIX shim** for WSL/git-bash
shells that internally `exec`s the real `tg.exe`:

- `scripts/install.sh:363-377` -- the staged `bin/tg` heredoc, copied via `cp
  "$INSTALL_DIR/bin/tg" "$SHIM_PATH"` into every `SHIM_DIRS` entry (`install.sh:395-401`).
- `scripts/install.ps1:731-750` (`$frontdoorBashContent`) -- written once to the original
  `.tensor-grep/bin/tg`, then copied **byte-identically** into every `$shimDirs` entry
  (`~/.local/bin/tg`, `~/bin/tg`) via `Write-BashFile -Path $bashShimPath -Value
  $frontdoorBashContent` (`install.ps1:837-852`).

`resolve_native_tg_binary()` looks for a literal `tg` (no extension) on a WSL/Linux host
(`binary_name = "tg.exe" if sys.platform.startswith("win") else "tg"`, `runtime_paths.py:263`)
and legitimately returns **the shim**, not the `.exe` it delegates to. The `.exe`-suffix check
alone reads the shim as same-domain, so the probes hand it an untranslated `/tmp/...` path; the
shim's real Windows-target child process can't open it and returns the native binary's own
structured `path_not_found`, which the doctor then buckets as the honest-*looking* but wrong
`failed_probe_path` (same-domain bucket) instead of `failed_path_bridging`/`path_domain_mismatch`.

I initially assumed the sibling `tg-native-metadata.json` (already-shipped infra,
`native_frontdoor_metadata_path()`) would be sufficient to see through the shim -- it catches the
*original* `.tensor-grep/bin/tg`, but **not** the copies. `install.ps1:841`'s
`Copy-Item -LiteralPath $nativeFrontdoorPath -Destination $exeShimPath` copies a real `tg.exe`
into every `$shimDirs` entry alongside the shim, but does **not** copy `tg-native-metadata.json`
there -- and the shim-dir copies (`~/bin/tg`, `~/.local/bin/tg`), not the original front-door
directory, are what installer wiring puts on `$PATH`. Confirmed this is exactly what the
reporting box hit (see receipts below), so the fix adds a second, independent signal -- a
co-located `<name>.exe` on disk -- alongside the metadata check.

## Fix

Two new filesystem-observable signals in `runtime_paths.py`, OR'd into
`is_cross_domain_native_binary()` alongside the existing `.exe`-suffix check:

- `_native_frontdoor_metadata_targets_windows()` -- reads the sibling `tg-native-metadata.json`'s
  `asset_name` (present next to the *original* front door).
- `_sibling_native_windows_binary_exists()` -- a co-located `<name>.exe` file. **This is the one
  that actually catches the live repro** (the distributed shim-dir copies carry the `.exe` but not
  the metadata).

Both fail closed to `False` on any miss (no metadata file, no sibling `.exe`, unreadable,
malformed), so this can only ever **add** a cross-domain detection, never remove the pre-existing
one -- no risk to the `/mnt/<drive>/`-mounted same-domain Linux ELF case the original P0-1 fix
protects (covered by existing pinned tests, re-verified green below).

## WSL repro receipts (live, on the reporting box's real WSL environment)

**Before** (unmodified code) -- real `tg doctor --json`, `search_runtime_probe` section:
```json
{
  "status": "failed_probe_path",
  "command": "/mnt/c/Users/oimir/bin/tg search --gpu-device-ids 0 --json --no-ignore -F tg doctor gpu runtime probe <doctor-gpu-probe-file>",
  "exit_code": 2,
  "native_error_kind": "path_not_found",
  "error": "GPU runtime probe failed"
}
```
`resolve_native_tg_binary()` on this box resolves `/mnt/c/Users/oimir/bin/tg` -- a bash shim (no
`.exe`) that itself `exec`s `/mnt/c/Users/oimir/.tensor-grep/bin/tg` -> `tg.exe`.

**After** (this PR's `runtime_paths.py`, run against the same real resolved shim path via
`_doctor_gpu_search_runtime_probe`):
```json
{
  "status": "unsupported",
  "command": "/mnt/c/Users/oimir/bin/tg search --gpu-device-ids 0 --json --no-ignore -F tg doctor gpu runtime probe <doctor-gpu-probe-file>",
  "exit_code": 0,
  "routing_backend": "NativeCpuBackend",
  "routing_reason": "gpu-auto-fallback-cpu",
  "sidecar_used": false,
  "native_error_kind": null,
  "error": "GPU route did not use NativeGpuBackend (routing_backend=NativeCpuBackend, sidecar_used=False)."
}
```
The path now translates and opens cleanly through the real `tg.exe` (confirmed directly too: `tg.exe
search ... "$(wslpath -w probe.log)"` returns real match JSON, exit 0). The probe now reports the
*true* reason GPU acceleration is not available on this install -- no CUDA-enabled binary, matching
`tier.installed=false` -- instead of a spurious path failure. `_agent_gpu_evidence` (agent capsule),
which shares the same `is_cross_domain_native_binary()` gate, was verified fixed the same way.

## Validation

- `pytest tests/unit/test_runtime_paths.py tests/unit/test_agent_capsule_gpu_probe.py
  tests/unit/test_device_detect.py -q` -> 95 passed, 1 skipped (real-wslpath smoke test, skipped on
  native Windows/no-wslpath -- expected)
- `ruff check` / `ruff format --check --preview` / `mypy` on both touched files -> clean
- `git diff --check` -> clean
- All pre-existing pinned `is_cross_domain_native_binary`/`native_binary_targets_windows` tests
  (same-domain `/mnt/<drive>/` ELF, bare Linux CI runner, etc.) re-verified green, unmodified

One pre-existing, unrelated failure was observed and **ruled out** as caused by this change:
`test_cli_search_warns_when_gpu_device_id_out_of_local_inventory` (`test_cli_modes.py`) fails
identically against the pristine pre-PR `runtime_paths.py` (verified via a scoped `git stash` of
just that file) -- it is gated on `sys.platform.startswith("linux")`, which is `False` on the native
Windows test run, so this PR's code is provably never reached by that test. Out of scope (bootstrap
search-flow territory), left untouched.

## Scope note

GPU surface is experimental/default-OFF; this only affects the honesty of a diagnostic status
string on WSL cross-domain installs, not the fail-closed contract or any default-path behavior.
Did not touch the theoretically-similar but **unconfirmed** bare-`"tg"`-fallback gap in
`_agent_gpu_tg_command()` (only triggers when no native binary resolves at all) -- no live evidence
it is actually hit, and fixing it would need a different mechanism (pre-resolving via
`shutil.which` before classification); flagging here as a residual risk rather than speculatively
changing it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
