### PR TITLE
feat(prepare): capsule --out + dogfood UX honesty batch

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -1984,10 +1984,32 @@ def _doctor_installed_version() -> str:
     return _cli_package_version()
 
 
+def _doctor_session_daemon_autostart_status() -> str:
+    """v1.92.1 dogfood item 5: human-readable autostart posture for a STOPPED daemon.
+
+    `session_daemon.running: false` on a cold box (nothing has ever warmed a daemon for this
+    root) reads as broken even though the Tier-1 fast path
+    (`_session_daemon_autostart_enabled`, defined further below in this module) will spin one up
+    transparently, non-blocking, on the very next defs/impact/refs/callers/blast-radius call.
+    Reuses that SAME gate function -- the one the real autostart dispatch actually checks -- so
+    this string can never drift from the runtime behavior it describes into a new lie of its
+    own (e.g. claiming "on-first-use" while an operator has explicitly disabled autostart).
+    """
+    if _session_daemon_autostart_enabled():
+        return "on-first-use (not yet warmed)"
+    return "disabled (TG_SESSION_DAEMON_AUTOSTART is off, or CI was detected)"
+
+
 def _doctor_session_daemon_status(path: str) -> dict[str, Any]:
     from tensor_grep.cli.session_daemon import get_session_daemon_status
 
-    return get_session_daemon_status(path)
+    status = get_session_daemon_status(path)
+    if not status.get("running"):
+        # Additive-only field, present only in the not-running state -- mirrors the
+        # conditional `install_hint` precedent (_doctor_ast_grep_status/_doctor_dense_model_
+        # status below) rather than always emitting a field that is meaningless once warm.
+        status["autostart"] = _doctor_session_daemon_autostart_status()
+    return status
 
 
 def _upgrade_running_session_daemon_snapshot(path: str = ".") -> dict[str, Any] | None:
@@ -4026,8 +4048,16 @@ def _apply_semantic_rerank(all_results: "SearchResult", pattern: str) -> "Search
             model = load_dense_model(default_model_dir())
             dense_index = DenseIndex(chunks, model)
         except DenseUnavailableError as exc:
-            all_results.rank_fallback_reason = str(exc)
-            sys.stderr.write(f"tg: {exc}\n")
+            # v1.92.1 dogfood item 3: rewrite the raw module-CLI fetch hint into the friendly
+            # `tg install-dense` one-shot -- mirrors `tg find`'s identical treatment below
+            # (`_friendly_dense_unavailable_message`); previously only `tg find` got this, so
+            # `tg search --semantic`'s "model not fetched" degrade still showed the raw
+            # `python -m tensor_grep.core.retrieval_dense --fetch` command. A no-op for any
+            # DenseUnavailableError that doesn't carry the raw hint (e.g. a malformed-shape
+            # message never mentions fetch).
+            message = _friendly_dense_unavailable_message(exc)
+            all_results.rank_fallback_reason = message
+            sys.stderr.write(f"tg: {message}\n")
         # BackendExecutionError (e.g. a corrupt model directory) deliberately propagates: that is
         # an unrecoverable fault the CLI boundary must catch and exit on (F4), not degrade here.
 
@@ -10392,6 +10422,19 @@ def _build_prepare_payload(
                     "claim": submitted["claim"],
                     "overlaps": submitted["overlaps"],
                 }
+                # v1.92.1 dogfood item 6: `ledger_store.resolve_agent_id` falls back to the
+                # literal "anonymous" (CONTRACTS.md section 9 "agent_id resolution"; also
+                # ledger_store._DEFAULT_AGENT_ID, not imported here to stay decoupled from that
+                # module's private surface) whenever neither TG_LEDGER_AGENT_ID nor
+                # TG_EVIDENCE_AGENT_ID is set -- `prepare` has no --agent-id flag of its own, so
+                # that env-var pair is the only way a caller sets identity through this path.
+                # Read the ACTUAL recorded value back off the submitted claim (never re-derive
+                # the resolution rule here) so this hint can never drift from what was really
+                # written to the ledger. Additive-only field, present only in the anonymous
+                # case -- mirrors the conditional install_hint/autostart precedent elsewhere in
+                # this module.
+                if str(submitted["claim"].get("agent_id") or "") == "anonymous":
+                    claim_hook["agent_id_hint"] = "set TG_LEDGER_AGENT_ID for a stable identity"
 
     evidence_ref = _command_ref([
         "tg",
@@ -10491,6 +10534,15 @@ def prepare(
     json_output: bool = typer.Option(
         True, "--json/--text", help="Emit machine-readable JSON output (default)."
     ),
+    out: str | None = typer.Option(
+        None,
+        "--out",
+        help=(
+            "Also persist the full capsule JSON to FILE, byte-identical to the --json stdout "
+            "payload regardless of --text, so `tg evidence emit --capsule FILE` can reuse it "
+            "without a manual save. Refuses to write through a pre-existing symlink."
+        ),
+    ),
 ) -> None:
     """One-call edit-readiness capsule: primary target, confidence, a callers/blast-radius
     floor, validation commands, and claim/evidence coordination hooks -- the single call meant
@@ -10549,6 +10601,37 @@ def prepare(
         typer.echo(f"claim_submitted={bool(claim_hook.get('submitted'))}")
         if payload.get("partial"):
             typer.echo(f"partial=true partial_reason={payload.get('partial_reason')}")
+
+    if out is not None:
+        # v1.92.1 dogfood feature 4: persist the FULL capsule JSON regardless of --text, so the
+        # file always works with `tg evidence emit --capsule FILE` (a text-mode summary would
+        # not). Written AFTER stdout above (never before) -- mirrors this command's own
+        # "output-before-exit" contract: an --out failure must not hide the payload that was
+        # already computed. Reuses the house atomic-write helper
+        # (_index_lock.atomic_write_json via session_store._write_json_atomic) with the exact
+        # same symlink-precheck-then-resolve shape `tg evidence emit --out` uses
+        # (main.py's evidence_emit, "audit C4 / CWE-59") rather than a bare open().write().
+        from tensor_grep.cli.session_store import _write_json_atomic
+
+        try:
+            # C4/CWE-59: check for a symlink BEFORE `.resolve()` -- resolving first would
+            # follow the symlink to its real target and make `is_symlink()` on the result
+            # always False, silently defeating `_write_json_atomic`'s own symlink guard. This
+            # also refuses a DANGLING symlink (a broken target still makes `is_symlink()` True
+            # regardless of whether the target exists). A destination that is an existing
+            # directory is refused too, via the OSError `atomic_write_bytes`'s own
+            # `os.replace` raises when a file cannot replace a directory -- caught by the same
+            # `except OSError` below, never a raw traceback.
+            expanded_out = Path(out).expanduser()
+            if expanded_out.is_symlink():
+                raise OSError(
+                    f"Refusing to write the prepare capsule through a symlink: {expanded_out}"
+                )
+            resolved_out = expanded_out.resolve()
+            _write_json_atomic(resolved_out, payload)
+        except OSError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
 
     if _scan_incomplete(payload):
         raise typer.Exit(2)

--- a/src/tensor_grep/core/retrieval_dense.py
+++ b/src/tensor_grep/core/retrieval_dense.py
@@ -71,9 +71,14 @@ def dense_available() -> tuple[bool, str | None]:
     try:
         import model2vec  # noqa: F401
     except ImportError as exc:
+        # v1.92.1 dogfood item 3 (UX/honesty batch): lead with the one-shot `tg install-dense`
+        # command (CEO#7) -- the pip extra stays as a parenthetical alternative for a caller who
+        # wants to script the install directly. Keep both "model2vec not installed" and
+        # "tensor-grep[semantic]" verbatim in the message: pinned by
+        # test_retrieval_dense.py::test_false_when_model2vec_missing.
         return False, (
             "semantic ranking unavailable: model2vec not installed -- "
-            f"pip install 'tensor-grep[semantic]' ({exc})"
+            f"run `tg install-dense` (or pip install 'tensor-grep[semantic]') ({exc})"
         )
     try:
         import numpy  # noqa: F401

--- a/tests/integration/test_prepare_oneshot_cuj.py
+++ b/tests/integration/test_prepare_oneshot_cuj.py
@@ -300,6 +300,93 @@ def test_prepare_claim_flag_submits(billing_repo: Path) -> None:
     assert (billing_repo / ".tensor-grep" / "ledger").exists()
 
 
+def test_prepare_claim_anonymous_agent_id_gets_hint(
+    billing_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Item 3 (v1.92.1 dogfood UX/honesty batch): a --claim submitted with the ledger's
+    anonymous default (neither TG_LEDGER_AGENT_ID nor TG_EVIDENCE_AGENT_ID set) must
+    self-diagnose via an additive agent_id_hint field, instead of silently recording an
+    untraceable identity with no signal to the caller that it happened."""
+    monkeypatch.delenv("TG_LEDGER_AGENT_ID", raising=False)
+    monkeypatch.delenv("TG_EVIDENCE_AGENT_ID", raising=False)
+
+    result = _run_tg(
+        ["prepare", str(billing_repo), "calculate_late_fee", "--claim", "--json"],
+        cwd=billing_repo,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    claim = payload["coordination"]["claim"]
+    assert claim.get("submitted") is True, claim
+    assert claim["result"]["claim"]["agent_id"] == "anonymous", claim
+    assert claim.get("agent_id_hint") == "set TG_LEDGER_AGENT_ID for a stable identity", claim
+
+
+def test_prepare_claim_explicit_agent_id_env_has_no_hint(
+    billing_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sibling negative control: once TG_LEDGER_AGENT_ID is set, the resulting claim must carry
+    that identity verbatim and NEVER the agent_id_hint (which would be a false "you forgot to
+    set an identity" nag for an operator who already did)."""
+    monkeypatch.setenv("TG_LEDGER_AGENT_ID", "ci-worker-7")
+
+    result = _run_tg(
+        ["prepare", str(billing_repo), "calculate_late_fee", "--claim", "--json"],
+        cwd=billing_repo,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    claim = payload["coordination"]["claim"]
+    assert claim.get("submitted") is True, claim
+    assert claim["result"]["claim"]["agent_id"] == "ci-worker-7", claim
+    assert "agent_id_hint" not in claim, claim
+
+
+def test_prepare_out_writes_full_capsule_json_matching_stdout(
+    billing_repo: Path, tmp_path: Path
+) -> None:
+    """Item 4 (v1.92.1 dogfood UX/honesty batch): --out persists the FULL capsule JSON so `tg
+    evidence emit --capsule FILE` can reuse it without a manual save. The file's JSON content
+    must match the --json stdout payload exactly (same json.dumps(..., indent=2) serialization,
+    reusing the house atomic-write helper -- session_store._write_json_atomic /
+    _index_lock.atomic_write_json -- rather than a bare write); stdout itself is unchanged."""
+    out_path = tmp_path / "capsule.json"
+    result = _run_tg(
+        ["prepare", str(billing_repo), "calculate_late_fee", "--out", str(out_path), "--json"],
+        cwd=billing_repo,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert out_path.exists(), "tg prepare --out must create the file"
+
+    stdout_payload = json.loads(result.stdout)
+    assert stdout_payload["primary_target"]["symbol"] == "calculate_late_fee", stdout_payload
+    file_payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert file_payload == stdout_payload
+    # `_write_json_atomic`/`atomic_write_json` serializes with json.dumps(payload, indent=2) and
+    # no trailing newline (the same shape `tg evidence emit --out` already produces) -- confirm
+    # the on-disk bytes match that exact serialization, not just the round-tripped dict.
+    assert out_path.read_text(encoding="utf-8") == json.dumps(stdout_payload, indent=2)
+
+
+def test_prepare_out_persists_full_json_even_in_text_mode(
+    billing_repo: Path, tmp_path: Path
+) -> None:
+    """--out must persist the FULL JSON capsule even when stdout renders the --text summary --
+    the whole point is a reusable capsule.json for `tg evidence emit --capsule`, not a copy of
+    whatever stdout happened to show; --text's own stdout stays exactly as before (additive)."""
+    out_path = tmp_path / "capsule_text_mode.json"
+    result = _run_tg(
+        ["prepare", str(billing_repo), "calculate_late_fee", "--out", str(out_path), "--text"],
+        cwd=billing_repo,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "primary=" in result.stdout, result.stdout  # text-mode stdout unaffected
+
+    file_payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert file_payload["primary_target"]["symbol"] == "calculate_late_fee", file_payload
+    assert file_payload["blast_radius_floor"]["callers_count"] >= 1, file_payload
+
+
 def test_prepare_exits_2_on_truncation(large_billing_repo: Path) -> None:
     """Test 5: a tiny --deadline must truncate the (padded) scan, exit 2, and still print the
     full honest JSON -- never a silent exit 0 that reads as a complete result."""

--- a/tests/integration/test_semantic_search_flag.py
+++ b/tests/integration/test_semantic_search_flag.py
@@ -84,6 +84,35 @@ def test_search_semantic_zero_matches_still_probes_availability(
     assert "semantic ranking unavailable" in result.stderr
 
 
+def test_search_semantic_not_fetched_uses_friendly_install_dense_hint(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """v1.92.1 dogfood item 3 (install-hint alignment): `tg search --semantic`'s "model not
+    fetched" degrade (extra installed, but `default_model_dir()` does not exist) must show the
+    friendly `tg install-dense` one-shot -- matching `tg find`'s existing
+    `_friendly_dense_unavailable_message` treatment -- not the raw
+    `python -m tensor_grep.core.retrieval_dense --fetch` module-CLI command. Regression guard for
+    the gap where only `tg find` got the friendly rewrite and `tg search --semantic` did not."""
+    monkeypatch.setattr("tensor_grep.core.retrieval_dense.dense_available", lambda: (True, None))
+    monkeypatch.setattr(
+        "tensor_grep.core.retrieval_dense.default_model_dir",
+        lambda: tmp_path / "does-not-exist-model-dir",
+    )
+
+    sample = tmp_path / "sample.py"
+    sample.write_text("def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["search", "--semantic", "--json", "invoice", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    reason = payload.get("rank_fallback_reason")
+    assert reason is not None
+    assert "tg install-dense" in reason, reason
+    assert "python -m tensor_grep.core.retrieval_dense --fetch" not in reason, reason
+    assert "tg install-dense" in result.stderr, result.stderr
+
+
 def test_search_semantic_query_time_dim_mismatch_degrades_to_bm25(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -2092,6 +2092,94 @@ def test_doctor_json_no_lsp_keeps_empty_schema_compatibility(monkeypatch, tmp_pa
     assert payload["lsp_providers"] == {}
 
 
+# ---------------------------------------------------------------------------------------------
+# v1.92.1 dogfood item 5 (cold-doctor daemon honesty): `session_daemon.running: false` on a cold
+# box (no daemon has ever been started) reads as broken even though the Tier-1 fast path will
+# autostart one transparently on the next symbol-command call. `autostart` is an additive JSON
+# field, present only when `running` is falsy, mirroring the conditional `install_hint` style
+# already used by `_doctor_ast_grep_status`/`_doctor_dense_model_status`.
+# ---------------------------------------------------------------------------------------------
+
+
+def test_doctor_session_daemon_autostart_status_reflects_the_live_gate(monkeypatch) -> None:
+    """The pure status-string function must reuse `_session_daemon_autostart_enabled` (the SAME
+    gate the real Tier-1 fast path checks) rather than re-deriving its own copy of the rule."""
+    monkeypatch.setattr(cli_main, "_session_daemon_autostart_enabled", lambda: True)
+    assert cli_main._doctor_session_daemon_autostart_status() == "on-first-use (not yet warmed)"
+
+    monkeypatch.setattr(cli_main, "_session_daemon_autostart_enabled", lambda: False)
+    disabled = cli_main._doctor_session_daemon_autostart_status()
+    assert "disabled" in disabled
+    assert disabled != "on-first-use (not yet warmed)"
+
+
+def test_doctor_session_daemon_status_adds_autostart_hint_when_stopped(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """`_doctor_session_daemon_status` (the real wrapper, unpatched) must enrich a stopped-daemon
+    status with `autostart` -- patch the INNER `get_session_daemon_status` (not the wrapper
+    itself) so the new enrichment logic actually executes."""
+    monkeypatch.setattr(
+        "tensor_grep.cli.session_daemon.get_session_daemon_status",
+        lambda path: {"version": 1, "root": path, "discovered": False, "running": False},
+    )
+    monkeypatch.setattr(cli_main, "_session_daemon_autostart_enabled", lambda: True)
+
+    status = cli_main._doctor_session_daemon_status(str(tmp_path))
+
+    assert status["running"] is False
+    assert status["autostart"] == "on-first-use (not yet warmed)"
+
+
+def test_doctor_session_daemon_status_omits_autostart_hint_when_running(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A WARM daemon must not carry a meaningless `autostart` hint -- additive-only, conditional
+    on the not-running state (mirrors the `install_hint` precedent's own conditional-add style)."""
+    monkeypatch.setattr(
+        "tensor_grep.cli.session_daemon.get_session_daemon_status",
+        lambda path: {
+            "version": 1,
+            "root": path,
+            "discovered": False,
+            "running": True,
+            "host": "127.0.0.1",
+            "port": 43123,
+            "pid": 9001,
+            "started_at": "2026-07-21T00:00:00Z",
+        },
+    )
+
+    status = cli_main._doctor_session_daemon_status(str(tmp_path))
+
+    assert status["running"] is True
+    assert "autostart" not in status
+
+
+def test_doctor_json_reports_cold_daemon_autostart_hint(monkeypatch, tmp_path: Path) -> None:
+    """End-to-end through `tg doctor --json`: a cold box's `session_daemon.running: false` must
+    come with the additive `autostart` field, without touching any other doctor field."""
+    monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
+    monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(
+        "tensor_grep.cli.session_daemon.get_session_daemon_status",
+        lambda path: {"version": 1, "root": path, "discovered": False, "running": False},
+    )
+    monkeypatch.setattr("tensor_grep.cli.main._session_daemon_autostart_enabled", lambda: True)
+
+    result = CliRunner().invoke(app, ["doctor", str(tmp_path), "--json", "--no-lsp"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["session_daemon"]["running"] is False
+    assert payload["session_daemon"]["autostart"] == "on-first-use (not yet warmed)"
+    # Additive-only: doctor's own top-level schema_version must NOT need a bump for a nested,
+    # conditionally-present diagnostic field (CONTRACTS.md section 5: "Individual diagnostic
+    # fields may grow as new probes are added").
+    assert payload["schema_version"] == 2
+    assert payload["doctor_schema_version"] == 2
+
+
 def test_doctor_text_reports_ast_grep_availability(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("tensor_grep.cli.main._doctor_installed_version", lambda: "9.9.9")
     monkeypatch.setattr("tensor_grep.cli.main.resolve_native_tg_binary", lambda: None)

--- a/tests/unit/test_evidence_bundle_atomic_write.py
+++ b/tests/unit/test_evidence_bundle_atomic_write.py
@@ -12,6 +12,11 @@ symlink's TARGET (CWE-59); a crash/kill mid-write had no atomic fallback and cou
 truncated receipt/bundle. Both sites now route through the same hardened
 ``session_store._write_json_atomic`` helper already used for session/daemon state, extended
 here with a symlink-refusal guard mirroring ``evidence_signing._write_private_key_atomic``.
+
+Section 6 (v1.92.1 dogfood feature 4) adds ``tg prepare --out <path>`` -- a NEW writer, not a
+retrofit -- which opted into the exact same ``session_store._write_json_atomic`` symlink-guard
+shape from the start rather than a bare ``open().write()``. Its tests mirror the ``evidence
+emit --out`` cases above (section 1) so a third writer never regresses the C4 contract either.
 """
 
 from __future__ import annotations
@@ -338,3 +343,95 @@ def test_record_audit_manifest_refuses_when_history_index_is_a_pre_existing_syml
 
     assert index_path.is_symlink()
     assert json.loads(real_target.read_text(encoding="utf-8")) == {"untouched": True}
+
+
+# ---------------------------------------------------------------------------
+# 6. v1.92.1 dogfood feature 4: `tg prepare --out <path>` -- a THIRD writer opting into the same
+#    C4-hardened `_write_json_atomic` contract from inception. Mirrors section 1's evidence-emit
+#    symlink cases, plus a dangling-symlink and a directory-destination case (`tg prepare --out`
+#    must refuse both cleanly, never a raw traceback, per the dogfood batch's explicit ask).
+# ---------------------------------------------------------------------------
+
+
+def _make_prepare_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "prepare_repo"
+    repo.mkdir()
+    (repo / "sample.py").write_text(
+        "def make_invoice(invoice_id):\n    return invoice_id\n", encoding="utf-8"
+    )
+    return repo
+
+
+def test_prepare_out_refuses_to_write_through_a_symlink(tmp_path: Path) -> None:
+    real_target = tmp_path / "real_target.txt"
+    real_target.write_text("do-not-touch-me", encoding="utf-8")
+    link_path = tmp_path / "capsule.json"
+    _symlink_or_skip(link_path, real_target)
+
+    repo = _make_prepare_repo(tmp_path)
+
+    result = CliRunner().invoke(
+        app, ["prepare", str(repo), "make_invoice", "--out", str(link_path), "--json"]
+    )
+
+    assert result.exit_code == 1, result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "symlink" in result.output.lower()
+    assert real_target.read_text(encoding="utf-8") == "do-not-touch-me"
+    assert link_path.is_symlink()
+
+
+def test_prepare_out_refuses_a_dangling_symlink_too(tmp_path: Path) -> None:
+    """A symlink whose TARGET does not exist is still a symlink -- `Path.is_symlink()` is True
+    regardless of target existence -- so the guard must refuse a dangling link exactly like a
+    live one, and must never create the missing target as a side effect of the refused write."""
+    missing_target = tmp_path / "does-not-exist.json"
+    link_path = tmp_path / "dangling_capsule.json"
+    _symlink_or_skip(link_path, missing_target)
+
+    repo = _make_prepare_repo(tmp_path)
+
+    result = CliRunner().invoke(
+        app, ["prepare", str(repo), "make_invoice", "--out", str(link_path), "--json"]
+    )
+
+    assert result.exit_code == 1, result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "symlink" in result.output.lower()
+    assert not missing_target.exists()
+    assert link_path.is_symlink()
+
+
+def test_prepare_out_refuses_a_directory_destination(tmp_path: Path) -> None:
+    """A --out path that IS an existing directory must fail cleanly (no raw traceback, no
+    replacing/writing into the directory) -- `os.replace` cannot swap a file in for a directory,
+    and that OSError must surface through the same fail-closed `except OSError` handling as the
+    symlink cases, not escape as an unhandled exception."""
+    dir_path = tmp_path / "capsule_is_a_dir"
+    dir_path.mkdir()
+    (dir_path / "sentinel.txt").write_text("do-not-touch-me", encoding="utf-8")
+
+    repo = _make_prepare_repo(tmp_path)
+
+    result = CliRunner().invoke(
+        app, ["prepare", str(repo), "make_invoice", "--out", str(dir_path), "--json"]
+    )
+
+    assert result.exit_code != 0, result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert dir_path.is_dir()
+    assert (dir_path / "sentinel.txt").read_text(encoding="utf-8") == "do-not-touch-me"
+
+
+def test_prepare_out_writes_a_valid_complete_json_file(tmp_path: Path) -> None:
+    repo = _make_prepare_repo(tmp_path)
+    output_path = tmp_path / "capsule.json"
+
+    result = CliRunner().invoke(
+        app, ["prepare", str(repo), "make_invoice", "--out", str(output_path), "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
+    assert on_disk["primary_target"]["symbol"] == "make_invoice"
+    assert on_disk == json.loads(result.output)

--- a/tests/unit/test_retrieval_dense.py
+++ b/tests/unit/test_retrieval_dense.py
@@ -74,6 +74,11 @@ class TestDenseAvailable:
         assert reason is not None
         assert "model2vec not installed" in reason
         assert "tensor-grep[semantic]" in reason
+        # v1.92.1 dogfood item 3 (install-hint alignment): `tg install-dense` must be the
+        # PRIMARY hint now, ahead of the pip-extra parenthetical -- CEO dogfood flagged the old
+        # message for still only mentioning `pip install 'tensor-grep[semantic]'`.
+        assert "tg install-dense" in reason
+        assert reason.index("tg install-dense") < reason.index("tensor-grep[semantic]"), reason
 
     @pytest.mark.skipif(
         not dense_available()[0],


### PR DESCRIPTION
## Summary

CEO v1.92.1 dogfood UX/honesty batch -- four small, related, additive items in one PR. Orchestrator will review the diff before un-draft (no full Opus gate requested; nothing here flagged as risky).

### 1. Install-hint alignment (dogfood item 3)
- `src/tensor_grep/core/retrieval_dense.py:74-81` (`dense_available()`): the "model2vec not installed" message now leads with `tg install-dense` and keeps `pip install 'tensor-grep[semantic]'` as a parenthetical alternative. This message flows verbatim into `rank_fallback_reason` from 3 call sites (`main.py:3906`, `3971`, `4382` via `_set_semantic_rank_fallback_reason`/`_apply_semantic_rerank`/`tg find`), so fixing it at the source fixes all three.
- `src/tensor_grep/cli/main.py` (`_apply_semantic_rerank`, `~4028-4058`): `tg search --semantic`'s "model not fetched" degrade (a `DenseUnavailableError` from `load_dense_model`) now also runs through `_friendly_dense_unavailable_message` -- previously only `tg find`'s equivalent path (`main.py:4384-4391`) got that rewrite, so `tg search --semantic` still showed the raw `python -m tensor_grep.core.retrieval_dense --fetch` module-CLI command. Now both search surfaces are consistent.
- Copy-only: no error classes or exit codes changed. Swept `mcp_server.py`/`agent_capsule.py`/`prepare` for any independent dense/semantic hint construction -- none found (MCP reuses `_set_semantic_rank_fallback_reason`; `prepare`'s only "semantic" hits are the unrelated LSP `semantic_provider` flag).

### 2. Cold-doctor daemon honesty (dogfood item 5)
- `src/tensor_grep/cli/main.py` (`_doctor_session_daemon_status`, `~1987-2009`): additive `autostart` field on the `session_daemon` doctor block, present **only** when `running` is falsy (mirrors the conditional `install_hint` precedent used by `_doctor_ast_grep_status`/`_doctor_dense_model_status`).
- New `_doctor_session_daemon_autostart_status()` reuses `_session_daemon_autostart_enabled()` -- the exact gate the real Tier-1 autostart fast path checks (`main.py:8824`) -- so the string can never drift into a NEW lie (e.g. claiming "on-first-use" while an operator explicitly disabled autostart via `TG_SESSION_DAEMON_AUTOSTART=0`).
- Values: `"on-first-use (not yet warmed)"` when armed, `"disabled (TG_SESSION_DAEMON_AUTOSTART is off, or CI was detected)"` otherwise.
- JSON-only by design: text-mode's `session_daemon:` rendering (`main.py:3611-3619`) is untouched -- it never reads the new key, so text output is byte-identical to before.
- No `doctor_schema_version` bump: CONTRACTS.md section 5 explicitly allows individual diagnostic fields to grow without a version bump ("Individual diagnostic fields may grow as new probes are added").

### 3. prepare --claim anonymous agent_id (dogfood item 6)
- `src/tensor_grep/cli/main.py` (`_build_prepare_payload`, `~10420-10435`): after a successful `--claim` submission, if the recorded `agent_id` came back as the ledger's literal `"anonymous"` default (CONTRACTS.md section 9; `ledger_store._DEFAULT_AGENT_ID`, not imported -- kept decoupled from that module's private surface per the hard constraint), `coordination.claim` gains an additive `agent_id_hint: "set TG_LEDGER_AGENT_ID for a stable identity"`.
- Reads the hint condition off the **actual returned** `submitted["claim"]["agent_id"]` rather than re-deriving `ledger_store`'s resolution rule, so it can never drift from what was really written.
- `ledger_store.py` and all `tg ledger` CLI commands are completely untouched (verified via `git diff --stat`) -- this is prepare-side output only, per the hard constraint.

### 4. `tg prepare --out FILE` (feature 4)
- New `--out` Typer option on `prepare` (`main.py`, prepare signature + body). Persists the **full** capsule JSON to FILE, byte-identical to the `--json` stdout serialization (same `payload` dict, same `_write_json_atomic`/`atomic_write_json` -> `json.dumps(payload, indent=2)` call shape), regardless of `--text` -- so a `--text --out capsule.json` run still gets a real, parseable capsule file for `tg evidence emit --capsule FILE`.
- Reuses the house atomic-write helper: `session_store._write_json_atomic` (thin wrapper over `_index_lock.atomic_write_json`) -- never a bare `open().write()`.
- Mirrors `tg evidence emit --out`'s exact symlink-precheck-then-resolve shape (`main.py`'s `evidence_emit`, audit C4/CWE-59): `is_symlink()` checked **before** `.resolve()` (resolving first would follow the symlink and make the check always False), refusing both a live-target symlink and a **dangling** one (`is_symlink()` is True regardless of target existence). A directory at the destination fails cleanly too, via the `OSError` `os.replace` raises when a file can't replace a directory -- caught by the same `except OSError`, never a raw traceback.
- Written **after** stdout (never before) -- mirrors `prepare`'s own pre-existing "output-before-exit" contract (the full payload is always shown before any non-zero exit). A write failure exits 1, independent of the pre-existing exit-2 truncation check.
- **Front-door registration checked**: `tg prepare` is a `trailing_var_arg` catch-all passthrough in the native Rust front door (`rust_core/src/main.rs:1174-1179`, `Commands::Prepare { args } => handle_python_passthrough("prepare", args)`) -- confirmed zero Rust-side changes needed for a new Python-only flag. No `bootstrap.py` special-casing for `prepare` (grep: no matches). No MCP tool exposes `prepare` yet (grep: no matches). The Typer signature is the only registration site.

## Test plan
- [x] `ruff check .` -- clean (whole repo)
- [x] `ruff format --preview --check src/ tests/` -- clean (the 4 unformatted `.md` files under `docs/` are pre-existing, untouched drift -- confirmed absent from this PR's diff)
- [x] `mypy src/tensor_grep` -- `Success: no issues found in 81 source files`
- [x] New/updated tests, one per item, TDD (red before the fix, green after):
  - Item 1: `tests/unit/test_retrieval_dense.py::TestDenseAvailable::test_false_when_model2vec_missing` (extended) + new `tests/integration/test_semantic_search_flag.py::test_search_semantic_not_fetched_uses_friendly_install_dense_hint`
  - Item 2: 4 new tests in `tests/unit/test_cli_modes.py` (pure-function branches, wrapper enrichment when stopped/running, end-to-end `doctor --json`)
  - Item 3: 2 new real-binary tests in `tests/integration/test_prepare_oneshot_cuj.py` (anonymous hint present / explicit-env hint absent)
  - Item 4: 2 new real-binary tests (byte-identical JSON, `--text` mode) in `test_prepare_oneshot_cuj.py` + 4 new CliRunner tests in `tests/unit/test_evidence_bundle_atomic_write.py` (symlink, dangling symlink, directory destination, valid write)
- [x] 594 targeted tests pass across all touched areas (semantic/dense, doctor, prepare, evidence atomic-write, plus the newly-merged lock test file) -- 2 skipped (expected, documented), 4 deselected as **pre-existing, unrelated** environment gaps (see below)
- [x] 199 governance/docs contract tests pass unchanged (no pinned doctor/prepare JSON shape violated)
- [x] Dogfooded live via `python -m tensor_grep` (real module entry point, not CliRunner) for all four items, including `prepare --claim --out` together producing a correct `agent_id_hint` + capsule file
- [x] ASCII-only verified (`grep -P '[^\x00-\x7F]'` over the full diff: zero matches)
- [x] Never ran `tests/e2e/test_routing_parity.py`; never touched `ledger_store.py`, ledger CLI commands, or `bootstrap.py` (all confirmed via `git diff --stat`)

### Pre-existing, unrelated findings (not fixed here, out of scope)
- `tests/unit/test_retrieval_dense.py::TestRealFetchedModel` (2 tests) and `tests/integration/test_semantic_search_flag.py::test_search_semantic_with_real_model_engages_dense_leg`: this worktree's `.venv` lacks the `model2vec` package while a stale fetched model directory exists on disk from a prior session (`~/.tensor-grep/models/potion-code-16M`) -- the skip-guards check only directory existence, not package importability. Neither `load_dense_model` nor these skip guards are touched by this PR.
- `tests/unit/test_cli_modes.py::test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`: fails in isolation too, unrelated to anything GPU/device-detect in this diff (confirmed via `git diff --stat` -- zero overlap).
- 4 `.md` files under `docs/` fail whole-repo `ruff format --preview --check .` -- pre-existing drift (matches the documented "whole-repo ruff-format gap" project memory), absent from this PR's diff.

Generated with Claude Code
