### PR TITLE
fix(search,gpu): gate-findings close-out (probe parity, cost pin, which-resolution, citation)

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -5,6 +5,7 @@ import json
 import keyword
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import time
@@ -1506,7 +1507,24 @@ def _summarize_agent_gpu_json_result(
 
 def _agent_gpu_tg_command() -> str:
     native_tg = resolve_native_tg_binary()
-    return str(native_tg) if native_tg is not None else "tg"
+    if native_tg is not None:
+        return str(native_tg)
+    # #704 gate CRUX-4: falling straight through to the bare string "tg" here handed
+    # `subprocess.run` an UN-checked PATH lookup -- `resolve_native_tg_binary()` (above)
+    # deliberately filters out e.g. a Python console-script shim
+    # (`_looks_like_python_scripts_launcher`) and enforces a version match, but a bare "tg"
+    # bypasses all of that vetting AND is invisible to the cross-domain classifier below: a
+    # relative name has no directory component, so `is_cross_domain_native_binary()`'s
+    # sibling-`.exe`/metadata checks (`runtime_paths.py`) resolve against the CWD instead of
+    # wherever the shell would actually have found "tg". Pre-resolving via `shutil.which`
+    # gives an explicit absolute path that the SAME `is_cross_domain_native_binary(tg_command)`
+    # gate the call site already applies (`_agent_gpu_evidence`, below) can classify correctly
+    # -- no separate gate call needed here. If nothing resolves at all, preserve the prior
+    # behavior exactly: return the bare name rather than raising, so the probe still degrades
+    # to its existing honest failure path (`_run_agent_gpu_json_command`'s `OSError` handler
+    # turns the resulting spawn failure into a `status: "failed"` result, never a crash).
+    which_tg = shutil.which("tg")
+    return which_tg if which_tg is not None else "tg"
 
 
 def _native_gpu_route_rejection(payload: dict[str, Any]) -> str | None:

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -774,10 +774,19 @@ def _search_paths_include_vendored_root(paths: list[str]) -> bool:
 # one-level `iterdir()` probe like the vendored/workspace guards above -- there is no shallow
 # signal for "this tree is huge"; the walk itself is the only honest measurement, same approach
 # as cli/main.py's `_implicit_glob_search_walk_exceeds_ceiling`. Mirrors `--hidden`/
-# `--no-ignore*` flags into the probe config (conservatively: ANY no-ignore-family flag widens
-# the probe to `no_ignore=True`, the most inclusive walk `DirectoryScanner` supports) so this
-# probe does not UNDER-count relative to the real invocation and let an oversized
-# `--hidden`/`--no-ignore` walk slip through as "under ceiling".
+# `--no-ignore*` flags into the probe config by forwarding each raw flag to its OWN
+# `SearchConfig` field -- the same shape `_implicit_glob_search_walk_exceeds_ceiling` gets for
+# free from its already-Typer-parsed `config` argument (`dataclasses.replace(config, ...)`,
+# main.py). #702 gate NIT-1: an earlier version of this probe collapsed every flag in
+# `_SEARCH_NO_IGNORE_FLAGS` onto the single `no_ignore` field -- but `DirectoryScanner` only
+# actually disables `.gitignore` loading when `no_ignore`/`no_ignore_vcs`/`no_ignore_files` is
+# set (`_load_ignore_spec`, `io/directory_scanner.py:154`); `--no-ignore-dot`/`-exclude`/
+# `-global`/`-parent` are no-ops for this scanner's single ignore mechanism. Collapsing them all
+# onto `no_ignore` OVER-widened the probe (a latency-only over-count, not a correctness bug --
+# it could only make the guard refuse MORE often, never less), but drifted from the sibling's
+# field-exact behavior; passing each flag to its own field restores parity and still never
+# UNDER-counts relative to the real invocation (each flag maps 1:1 to the field the real,
+# Typer-parsed `SearchConfig` would carry for that same raw argv).
 def _search_paths_include_oversized_implicit_root(paths: list[str], search_args: list[str]) -> bool:
     from tensor_grep.core.config import SearchConfig
     from tensor_grep.io.directory_scanner import (
@@ -787,7 +796,13 @@ def _search_paths_include_oversized_implicit_root(paths: list[str], search_args:
 
     probe_config = SearchConfig(
         hidden=any(arg in _SEARCH_HIDDEN_FLAGS for arg in search_args),
-        no_ignore=any(arg in _SEARCH_NO_IGNORE_FLAGS for arg in search_args),
+        no_ignore="--no-ignore" in search_args,
+        no_ignore_dot="--no-ignore-dot" in search_args,
+        no_ignore_exclude="--no-ignore-exclude" in search_args,
+        no_ignore_files="--no-ignore-files" in search_args,
+        no_ignore_global="--no-ignore-global" in search_args,
+        no_ignore_parent="--no-ignore-parent" in search_args,
+        no_ignore_vcs="--no-ignore-vcs" in search_args,
     )
     count = 0
     for raw_path in paths:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -10425,7 +10425,7 @@ def _build_prepare_payload(
             except Exception as exc:
                 # Advisory coordination hook: a claim failure must never fail prepare's primary
                 # read (mirrors ledger_store.submit_claim's own "NEVER blocks" contract one level
-                # up -- see ledger_store.py:445-461).
+                # up -- see ledger_store.py:591-597, submit_claim's docstring).
                 claim_hook["error"] = str(exc)
             else:
                 claim_hook["submitted"] = True

--- a/tests/unit/test_agent_capsule_gpu_probe.py
+++ b/tests/unit/test_agent_capsule_gpu_probe.py
@@ -272,3 +272,64 @@ def test_agent_gpu_evidence_timeout_env_override_honored(monkeypatch, tmp_path):
     )
 
     assert captured_kwargs[0]["timeout"] == pytest.approx(12.5)
+
+
+# #704 gate CRUX-4: `_agent_gpu_tg_command()`'s bare-"tg" fallback (when `resolve_native_tg_binary()`
+# finds nothing) used to hand `subprocess.run` an un-checked PATH lookup, invisible to
+# `is_cross_domain_native_binary()`'s sibling-`.exe`/metadata classification (a relative name has no
+# directory component for those checks to inspect). These tests exercise `_agent_gpu_tg_command()`
+# directly rather than the full `_agent_gpu_evidence()` flow, mirroring the direct-unit-test style
+# already used for the collaborator helpers in tests/unit/test_runtime_paths.py.
+
+
+def test_agent_gpu_tg_command_uses_resolved_binary_when_available(monkeypatch):
+    """Baseline (unaffected by this fix): a resolved native binary is returned as-is."""
+    monkeypatch.setattr(
+        agent_capsule, "resolve_native_tg_binary", lambda: Path("/mnt/c/fake/tg.exe")
+    )
+    assert agent_capsule._agent_gpu_tg_command() == str(Path("/mnt/c/fake/tg.exe"))
+
+
+def test_agent_gpu_tg_command_resolves_via_shutil_which_when_unresolved(monkeypatch):
+    """When `resolve_native_tg_binary()` finds nothing but a `tg` IS on PATH, the fallback must
+    return the ABSOLUTE resolved path (so the existing `is_cross_domain_native_binary()` gate at
+    the call site can classify the real location), not the bare, un-checked string "tg"."""
+    monkeypatch.setattr(agent_capsule, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(agent_capsule.shutil, "which", lambda name: "/usr/local/bin/tg")
+
+    assert agent_capsule._agent_gpu_tg_command() == "/usr/local/bin/tg"
+
+
+def test_agent_gpu_tg_command_degrades_honestly_when_nothing_resolves(monkeypatch):
+    """When neither `resolve_native_tg_binary()` nor `shutil.which("tg")` find anything, the
+    function must still return a plain string rather than raise, so the probe falls through to
+    its existing honest failure path: `_run_agent_gpu_json_command`'s `OSError` handler turns the
+    resulting spawn failure into a `status: "failed"` result instead of crashing the capsule."""
+    monkeypatch.setattr(agent_capsule, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(agent_capsule.shutil, "which", lambda name: None)
+
+    assert agent_capsule._agent_gpu_tg_command() == "tg"
+
+
+def test_agent_gpu_evidence_classifies_shutil_which_result_cross_domain(monkeypatch, tmp_path):
+    """End-to-end (through `_agent_gpu_evidence`, not just the helper): a `shutil.which`-resolved
+    fallback binary must reach the SAME `is_cross_domain_native_binary()` gate a resolved native
+    binary would, proving the call site needs no separate handling for this path."""
+    monkeypatch.setattr(agent_capsule, "resolve_native_tg_binary", lambda: None)
+    monkeypatch.setattr(agent_capsule.shutil, "which", lambda name: "/mnt/c/fake/tg")
+
+    seen_binaries: list[str] = []
+
+    def _fake_is_cross_domain(binary):
+        seen_binaries.append(str(binary))
+        return True
+
+    monkeypatch.setattr(agent_capsule, "is_cross_domain_native_binary", _fake_is_cross_domain)
+    monkeypatch.setattr(agent_capsule, "translate_path_for_windows_binary", lambda _path: None)
+
+    result = agent_capsule._agent_gpu_evidence(
+        query="", path=str(tmp_path), gpu_device_ids=[0], max_files=5, timeout_s=5.0
+    )
+
+    assert seen_binaries == ["/mnt/c/fake/tg"]
+    assert result["status"] == "path_domain_mismatch"

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -141,6 +141,105 @@ def test_oversized_implicit_root_probe_widens_for_no_ignore_flag(tmp_path: Path)
     )
 
 
+@pytest.fixture(scope="module")
+def _gitignored_heavy_tree(tmp_path_factory):
+    """Shared fixture for the no-ignore-family parity tests below: a repo root whose
+    `.gitignore` hides a subdirectory containing more than `IMPLICIT_SEARCH_WALK_FILE_CEILING`
+    files. Built ONCE (module-scoped) and only ever READ by the parametrized cases below -- 7
+    independent 1500+-file trees would multiply this suite's I/O for no benefit."""
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = tmp_path_factory.mktemp("gitignored_heavy_tree")
+    (root / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    ignored_dir = root / "ignored"
+    ignored_dir.mkdir()
+    for index in range(IMPLICIT_SEARCH_WALK_FILE_CEILING + 10):
+        (ignored_dir / f"mod_{index}.py").write_text("x\n", encoding="utf-8")
+    return root
+
+
+@pytest.mark.parametrize(
+    ("flag", "field_name", "expected_widens"),
+    [
+        ("--no-ignore", "no_ignore", True),
+        ("--no-ignore-vcs", "no_ignore_vcs", True),
+        ("--no-ignore-files", "no_ignore_files", True),
+        ("--no-ignore-dot", "no_ignore_dot", False),
+        ("--no-ignore-exclude", "no_ignore_exclude", False),
+        ("--no-ignore-global", "no_ignore_global", False),
+        ("--no-ignore-parent", "no_ignore_parent", False),
+    ],
+)
+def test_oversized_implicit_root_probe_matches_sibling_per_no_ignore_field(
+    _gitignored_heavy_tree: Path, flag: str, field_name: str, expected_widens: bool
+) -> None:
+    """#702 gate NIT-1: bootstrap's front-door probe must mirror cli/main.py's
+    `_implicit_glob_search_walk_exceeds_ceiling` field-for-field, not collapse every
+    `--no-ignore*` flag onto a single `no_ignore=True`. `DirectoryScanner._load_ignore_spec`
+    (`io/directory_scanner.py:154`) only disables `.gitignore` for `no_ignore`/`no_ignore_vcs`/
+    `no_ignore_files` -- `--no-ignore-dot`/`-exclude`/`-global`/`-parent` are no-ops for this
+    scanner's single ignore mechanism, so they must NOT flip the probe, exactly like they don't
+    flip the sibling (which gets its `SearchConfig` for free from real Typer parsing rather than
+    hand-building one from raw argv)."""
+    from tensor_grep.core.config import SearchConfig
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = _gitignored_heavy_tree
+    bootstrap_result = bootstrap._search_paths_include_oversized_implicit_root(
+        [str(root)], ["pat", flag]
+    )
+    sibling_config = SearchConfig(**{field_name: True})
+    sibling_result = cli_main._implicit_glob_search_walk_exceeds_ceiling(
+        [str(root)], sibling_config, IMPLICIT_SEARCH_WALK_FILE_CEILING
+    )
+
+    assert bootstrap_result is expected_widens, (
+        f"{flag} widened={bootstrap_result}, expected {expected_widens}"
+    )
+    assert bootstrap_result == sibling_result, (
+        f"{flag}: bootstrap probe ({bootstrap_result}) diverged from cli/main.py's sibling "
+        f"probe ({sibling_result}) -- the two front doors disagree"
+    )
+
+
+def test_oversized_implicit_root_probe_stops_short_of_full_walk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#702 gate NIT-2: pin the short-circuit's COST, not just its boolean outcome -- the probe
+    must stop consuming `DirectoryScanner.walk()` the moment its own running count exceeds
+    `IMPLICIT_SEARCH_WALK_FILE_CEILING`, rather than draining a full walk and counting after the
+    fact. Fakes `os.walk` (instead of writing a real multi-thousand-entry tree to disk) so this
+    is a deterministic structural assertion, not a wall-clock floor: a mutable counter records
+    how many synthetic directories the walk actually produced before the probe returned, and the
+    assertion is that it stayed at exactly ceiling+1 -- far short of the fabricated tree's full
+    (10x-ceiling) size."""
+    from tensor_grep.io import directory_scanner as ds_module
+    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    root = tmp_path / "hugerepo"
+    root.mkdir()
+
+    total_synthetic_dirs = IMPLICIT_SEARCH_WALK_FILE_CEILING * 10
+    produced = {"count": 0}
+
+    def _fake_os_walk(_top, *_args, **_kwargs):
+        for index in range(total_synthetic_dirs):
+            produced["count"] += 1
+            yield (str(root / f"d{index}"), [], [f"f{index}.py"])
+
+    monkeypatch.setattr(ds_module.os, "walk", _fake_os_walk)
+
+    assert bootstrap._search_paths_include_oversized_implicit_root([str(root)], ["pat"]) is True
+    # The probe returns True the instant its running count exceeds the ceiling -- it must not
+    # have pulled anywhere near the full fabricated tree (10x the ceiling).
+    expected_pulled = IMPLICIT_SEARCH_WALK_FILE_CEILING + 1
+    assert produced["count"] == expected_pulled, (
+        f"probe pulled {produced['count']} entries from the walk before short-circuiting; "
+        f"expected exactly ceiling+1 ({expected_pulled}), proving the bound is real, not a "
+        "post-hoc count-then-truncate"
+    )
+
+
 def test_typer_app_commands_match_source_of_truth() -> None:
     typer_commands = set()
     for cmd in app.registered_commands:


### PR DESCRIPTION
## Summary

Close-out batch for three (four, counting a trivial citation fix) LOW-class, mechanical
follow-ups the independent Opus gates banked on the just-merged campaign PRs #702/#704/#705
(all live in v1.93.0, `docs/BACKLOG.md`'s "Banked follow-ups (PR comments)" line). The queue is
empty, so per the #182 precedent this is the close-out rather than letting the findings rot. A
fourth banked item (the scoring-prefilter `dynamic_unresolved` fuzzy-match guard from #703's
gate) is explicitly OUT of scope here -- it needs its own slice with a pinned blast-radius
ranking test designed first.

## Item 1 -- #702 gate NIT-1: no-ignore-family probe parity

**Gate finding:** `src/tensor_grep/cli/bootstrap.py`'s `_search_paths_include_oversized_implicit_root`
(the bootstrap front-door walk-ceiling probe added by #702) collapsed every flag in
`_SEARCH_NO_IGNORE_FLAGS` (all 7: `--no-ignore`, `--no-ignore-dot`, `--no-ignore-exclude`,
`--no-ignore-files`, `--no-ignore-global`, `--no-ignore-parent`, `--no-ignore-vcs`) onto a
single `SearchConfig(no_ignore=True)` (old `bootstrap.py:790`), while the sibling probe
`cli/main.py::_implicit_glob_search_walk_exceeds_ceiling` (`main.py:5150`) gets the real,
Typer-parsed `SearchConfig` for free and forwards each field untouched
(`dataclasses.replace(config, glob=None, iglob=None, file_type=None, type_not=None)`,
`main.py:5157`).

**Verified against real code:** `DirectoryScanner._load_ignore_spec`
(`src/tensor_grep/io/directory_scanner.py:154`) only disables `.gitignore` loading for
`self.config.no_ignore or self.config.no_ignore_vcs or self.config.no_ignore_files` --
`no_ignore_dot`/`no_ignore_exclude`/`no_ignore_global`/`no_ignore_parent`
(`core/config.py:69-81`) are not consulted anywhere in `DirectoryScanner`
(`_load_ignore_spec:154`, `_should_descend_dir:224`). So the pre-fix probe would widen (and
thus over-refuse) on `--no-ignore-dot` alone, which is a latency-only divergence from the real
invocation (never a correctness bug -- it could only refuse MORE often, never silently
under-count), but it drifted from the sibling's field-exact behavior.

**Fix:** `bootstrap.py`'s `probe_config` (`_search_paths_include_oversized_implicit_root`,
def now at `bootstrap.py:790`, the 7-field construction at `:799-805`) now sets each
`SearchConfig` field from its own matching raw flag (`"--no-ignore-dot" in search_args`, etc.)
instead of the blanket `any(... for arg in _SEARCH_NO_IGNORE_FLAGS)`, mirroring exactly what
real Typer parsing would produce for that argv (`main.py:6874-6910`'s per-flag `typer.Option`
definitions, `main.py:7392-7402`'s 1:1 forward into `SearchConfig`).

**Test (TDD, observed RED against pre-fix code, restored via stash then re-verified GREEN):**
`tests/unit/test_cli_bootstrap.py::test_oversized_implicit_root_probe_matches_sibling_per_no_ignore_field`
-- parametrized across all 7 flags, asserts (a) the expected widen/no-widen outcome and (b)
direct parity against `cli_main._implicit_glob_search_walk_exceeds_ceiling` on the identical
fixture (a `.gitignore`-hidden subdirectory with `CEILING+10` files). Pre-fix: the 4 no-op
flags (`--no-ignore-dot`/`-exclude`/`-global`/`-parent`) failed (wrongly widened); the 3 real
flags already passed.

## Item 2 -- #702 gate NIT-2: bounded-probe cost pin

**Gate finding:** no test pinned that the probe's `count > IMPLICIT_SEARCH_WALK_FILE_CEILING`
short-circuit (`bootstrap.py`, inside `_search_paths_include_oversized_implicit_root`) actually
stops consuming the walk at ceiling+1, as opposed to draining the whole generator and counting
after the fact.

**Test (structural, not wall-clock):**
`tests/unit/test_cli_bootstrap.py::test_oversized_implicit_root_probe_stops_short_of_full_walk`.
Fakes `directory_scanner.os.walk` with a generator that increments a mutable counter on every
resumption before fabricating a synthetic `(root, dirs, files)` tuple (one file each, no real
disk I/O for the bulk of the tree -- only the base dir is real, so `Path.exists()` passes). The
fake tree is `IMPLICIT_SEARCH_WALK_FILE_CEILING * 10` entries; the assertion is that the probe
pulled **exactly** `ceiling + 1` entries before returning `True`, proving `os.walk` itself was
never resumed past the short-circuit point (not merely that the boolean outcome was correct).
This passed even against the pre-Item-1-fix code (NIT-2 is an existing-behavior coverage gap,
not a bug -- confirmed via the same stash-and-rerun check used for Item 1).

## Item 3 -- #704 gate CRUX-4: `_agent_gpu_tg_command` bare-"tg" fallback

**Gate finding:** `src/tensor_grep/cli/agent_capsule.py:1507-1509` (pre-fix, cited by the task) --
`_agent_gpu_tg_command()` returned the bare string `"tg"` whenever `resolve_native_tg_binary()`
returned `None`, handing `subprocess.run` an un-checked PATH lookup. #704's own PR body flagged
this exact gap at merge time as an "unconfirmed... residual risk" it deliberately left
unaddressed pending a `shutil.which`-based fix.

**Verified against real code:** `resolve_native_tg_binary()`
(`src/tensor_grep/cli/runtime_paths.py:269`) deliberately filters out e.g. a Python
console-script shim (`_looks_like_python_scripts_launcher`) and enforces a version match before
returning a candidate -- a bare `"tg"` fallback threw all of that vetting away. Separately, the
bare name is also a dead end for `is_cross_domain_native_binary()`
(`runtime_paths.py:463-488`): a relative name has no directory component, so its
`_sibling_native_windows_binary_exists` / `_native_frontdoor_metadata_targets_windows` checks
resolve against the CWD instead of wherever the shell would actually have found `"tg"`. The call
site (`_agent_gpu_evidence`, `agent_capsule.py:1567` def, `:1586` call, `:1599`
`cross_domain = is_cross_domain_native_binary(tg_command)`) already applies that gate uniformly
to whatever `_agent_gpu_tg_command()` returns, so the call site needs no separate change --
fixing the helper's return value is sufficient (confirmed by
`test_agent_gpu_evidence_classifies_shutil_which_result_cross_domain` below, which exercises the
full `_agent_gpu_evidence` path, not just the helper).

**Fix:** `_agent_gpu_tg_command()` now pre-resolves via `shutil.which("tg")` when
`resolve_native_tg_binary()` returns `None`: if found, returns the absolute resolved path (now
classifiable by the existing cross-domain gate); if not found either, returns the bare `"tg"`
exactly as before -- `_run_agent_gpu_json_command`'s existing `OSError` handler
(`agent_capsule.py:1388-1396`) already turns that spawn failure into an honest
`status: "failed"` result rather than a crash, so the "nothing resolves" degrade path is
unchanged.

**Tests (TDD, observed RED against pre-fix code for the 3 shutil-dependent cases; the baseline
case correctly passed both before and after):**
- `test_agent_gpu_tg_command_uses_resolved_binary_when_available` -- baseline, unaffected.
- `test_agent_gpu_tg_command_resolves_via_shutil_which_when_unresolved` -- which-returns-path ->
  absolute path used.
- `test_agent_gpu_tg_command_degrades_honestly_when_nothing_resolves` -- which-returns-None ->
  honest degrade (bare `"tg"`), no crash.
- `test_agent_gpu_evidence_classifies_shutil_which_result_cross_domain` -- end-to-end through
  `_agent_gpu_evidence`, proving the resolved fallback path reaches the same cross-domain gate a
  resolved native binary would.

## Item 4 -- #705/#706 region: stale citation

**Finding (flagged by the #706 builder):** `src/tensor_grep/cli/main.py` (inside
`_build_prepare_payload`, the claim-hook error path) cited `ledger_store.py:445-461` for
`submit_claim`'s "NEVER blocks" contract. That target moved when #706 restructured
`ledger_store.py`; the real docstring is now at `ledger_store.py:591-597`
(`def submit_claim(...)` at `:581`, docstring opens `:591`, the "NEVER blocks" paragraph itself
at `:593-597`) -- verified by reading the current file, not the stale line numbers.

**Fix:** citation at `main.py:10428` updated to `ledger_store.py:591-597, submit_claim's
docstring` (comment text only, no behavior change). Confirmed no other file in the repo still
references the stale `ledger_store.py:445-461` line range (`grep -r` clean).

## Verification

- `ruff check .` -- clean (repo-wide).
- `ruff format --check --preview .` -- clean on all 5 touched files; 4 PRE-EXISTING unrelated
  `docs/*.md` formatting drifts confirmed present on the unmodified baseline too (not introduced
  by this PR, out of scope here).
- `mypy src/tensor_grep` -- clean, 81 source files.
- New/targeted tests green: `tests/unit/test_cli_bootstrap.py` (105 passed, 1 pre-existing skip),
  `tests/unit/test_agent_capsule_gpu_probe.py` (12 passed).
- TDD red-phase confirmed for the 3 behavior-changing fixes (Items 1 and 3) via a scoped
  `git stash` of just the source fix (tests kept), re-run, then `git stash pop` to restore.
- Collateral regression sweep green: `test_runtime_paths.py`, `test_device_detect.py`,
  `test_ledger_store.py`, `test_ledger_cli.py`, `test_ledger_concurrency.py`,
  `test_evidence_bundle_atomic_write.py`, `tests/integration/test_prepare_oneshot_cuj.py`,
  `test_bootstrap_fast_path_imports.py`, and the full `test_cli_modes.py` (526 passed, 1
  PRE-EXISTING unrelated failure -- `test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`,
  confirmed identical on the unmodified baseline via the same stash technique; gated on
  `sys.platform.startswith("linux")`, always False on this native-Windows run, matching #704's own
  PR body which already documented this exact pre-existing failure).
- Registration-completeness gate (`tensor_grep.core.registration_check`) -- 3/3 groups, unaffected
  (no new command/flag).
- CPU-SAFE: Python-only throughout; did not touch `rust_core/`, did not invoke
  cargo/rustc/maturin, did not run `tests/e2e/test_routing_parity.py`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
