### PR TITLE
fix(blast-radius): exclude unresolved dynamic literals from the reverse scoring prefilter

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1985,8 +1985,30 @@ def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, A
     # see `_python_dynamic_import_entries`) so a file that ONLY reaches a target dynamically is
     # still discoverable as a candidate by the reverse `tg importers` prefilter
     # (`_reverse_importers`), not just by the forward `tg imports` primitive.
+    #
+    # #703 gate NIT-1 fix: a plain `dynamic_entry["module"]` truthiness check was NOT actually
+    # equivalent to "statically resolvable" once #703 taught `_python_dynamic_import_entries` to
+    # also mark a RELATIVE literal (leading-dot `import_module(".sibling", package=...)`) or an
+    # explicit-nonzero-`level` `__import__(...)` as `dynamic_unresolved` -- unlike the original
+    # non-literal-argument case, those keep their real literal text in `module` (nothing is
+    # fabricated/blanked, see that function's docstring) rather than blanking it to `""`. So an
+    # unresolved-but-non-blank literal like `".sibling"` used to slip past this `if` into
+    # `imports`, which becomes `repo_map["imports"]` -- the alias graph `tg blast-radius`'s
+    # reverse SCORING prefilter (`_reverse_import_distances`/`_reverse_importers`) reads. A
+    # same-named-but-unrelated top-level file (`_import_alias_candidates` + the substring test in
+    # `_import_graph_bonus`) could then fuzzy-match that unresolved literal and be pulled into
+    # `affected_files`/`dependent_files` -- even though the precise `tg importers` edge
+    # (`_resolve_raw_import_entry` / `_confirm_import_edges`) already excluded it correctly, since
+    # THAT path has always skipped resolution whenever `dynamic_unresolved` is set. Requiring
+    # `not dynamic_entry["dynamic_unresolved"]` here makes this prefilter honor the exact same
+    # "no false edges, missing is fine" contract the precise resolvers already enforce -- an
+    # unresolved dynamic import (relative-literal or non-literal-argument alike) now contributes
+    # nothing to the alias graph, closing the fuzzy-match gap. Pinned by
+    # test_blast_radius_excludes_unresolved_dynamic_literal_fuzzy_match (regression-lock) and
+    # test_blast_radius_legitimate_dependent_ranking_pin (proves the legitimate reverse-scoring
+    # ranking is unaffected) in tests/unit/test_file_deps.py.
     for dynamic_entry in _python_dynamic_import_entries(tree):
-        if dynamic_entry["module"]:
+        if dynamic_entry["module"] and not dynamic_entry["dynamic_unresolved"]:
             imports.append(str(dynamic_entry["module"]))
 
     imports = sorted(dict.fromkeys(imports))

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -2101,6 +2101,132 @@ def test_build_file_imports_unresolvable_dynamic_literal_stays_external(tmp_path
 
 
 # ---------------------------------------------------------------------------------------------
+# #703 gate NIT-1 (banked follow-up, independent Opus gate on PR #703 -- "SHIP-WITH-NITS"):
+# `_python_imports_and_symbols`'s prefilter emission (repo_map.py:1988, just above the false-edge
+# test block above) keys on `dynamic_entry["module"]` truthiness ALONE, ignoring
+# `dynamic_unresolved` -- so the SAME unresolved relative literal (`".sibling"`) that
+# `test_build_file_imports_relative_import_module_literal_stays_external_no_false_edge` and
+# `test_build_file_importers_relative_import_module_literal_asserts_no_edge` above prove stays
+# honestly EXTERNAL through the precise forward/reverse resolvers still lands in `imports_by_file`
+# -- the alias graph `tg blast-radius`'s reverse SCORING prefilter reads. `_import_alias_
+# candidates(".sibling")` -> `{".sibling", "sibling"}`, and the substring test inside
+# `_import_graph_bonus` (repo_map.py:~7827) then fuzzy-matches ANY top-level `sibling.py` --
+# planting the loader file into blast-radius `affected_files`/`radius_files` for a symbol DEFINED
+# in the decoy `sibling.py`, even though the precise edge (proven above) correctly excludes it.
+# `affected_files` is a deliberately broad proximity superset, not the exact edge list -- a
+# QUALITY tightening, not a correctness emergency -- but narrowing the graph can reorder
+# `dependent_files` for the LEGITIMATE dependents (repo_map.py:7916-7924), so the gate mandated a
+# ranking PIN test before the guard changes anything.
+# ---------------------------------------------------------------------------------------------
+
+
+def _build_decoy_dynamic_import_blast_radius_project(tmp_path: Path) -> dict[str, Path]:
+    """Mirrors the exact #703 decoy shape (`test_build_file_imports_relative_import_module_
+    literal_stays_external_no_false_edge` above): a top-level `sibling.py` decoy (which also
+    defines the symbol this block runs `tg blast-radius` against) plus a `pkg/subpkg/loader.py`
+    whose ONLY reference to it is the unresolved RELATIVE dynamic literal
+    `import_module(".sibling", package="pkg.subpkg")`. Adds a genuine 2-hop static importer chain
+    -- `consumer.py` calls the decoy's symbol directly (depth 1, a real caller); `chain_consumer.py`
+    calls `consumer.py`, never referencing the decoy directly (depth 2, graph-only) -- plus 2
+    bystander files with no import relationship to the decoy at all."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    subpkg = pkg / "subpkg"
+    subpkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (subpkg / "__init__.py").write_text("", encoding="utf-8")
+
+    decoy = project / "sibling.py"
+    decoy.write_text("def decoy_target():\n    return 1\n", encoding="utf-8")
+
+    loader = subpkg / "loader.py"
+    loader.write_text(
+        "from importlib import import_module\n\n"
+        "def load():\n"
+        '    return import_module(".sibling", package="pkg.subpkg")\n',
+        encoding="utf-8",
+    )
+
+    consumer = project / "consumer.py"
+    consumer.write_text(
+        "from sibling import decoy_target\n\ndef use_it():\n    return decoy_target()\n",
+        encoding="utf-8",
+    )
+
+    chain_consumer = project / "chain_consumer.py"
+    chain_consumer.write_text(
+        "from consumer import use_it\n\ndef use_it_too():\n    return use_it()\n",
+        encoding="utf-8",
+    )
+
+    bystander_one = project / "bystander_one.py"
+    bystander_one.write_text("def noop():\n    return 0\n", encoding="utf-8")
+    bystander_two = project / "bystander_two.py"
+    bystander_two.write_text("def noop_two():\n    return 0\n", encoding="utf-8")
+
+    return {
+        "project": project,
+        "decoy": decoy,
+        "loader": loader,
+        "consumer": consumer,
+        "chain_consumer": chain_consumer,
+        "bystander_one": bystander_one,
+        "bystander_two": bystander_two,
+    }
+
+
+def test_blast_radius_legitimate_dependent_ranking_pin(tmp_path: Path) -> None:
+    """THE PIN (gate NIT-1 mandated order, step 1): membership + RELATIVE order for the
+    legitimately-related files must survive the repo_map.py:1988 guard fix byte-identical --
+    narrowing the reverse-scoring graph can reorder `dependent_files` (repo_map.py:7916-7924), and
+    this test exists to CATCH that if it ever happens, not to assert what the order should be.
+    Deliberately does NOT assert anything about the decoy's fuzzy-matched loader file (present in
+    `dependent_files` on the unfixed base, between `consumer` and `chain_consumer` -- see the gate
+    finding above) -- that is `test_blast_radius_excludes_unresolved_dynamic_literal_fuzzy_match`
+    below. Must stay GREEN both before and after the guard fix; this is the pin, not a red test."""
+    paths = _build_decoy_dynamic_import_blast_radius_project(tmp_path)
+
+    payload = repo_map.build_symbol_blast_radius_render("decoy_target", paths["project"])
+
+    affected_files = set(payload["affected_files"])
+    decoy_str = str(paths["decoy"].resolve())
+    consumer_str = str(paths["consumer"].resolve())
+    chain_str = str(paths["chain_consumer"].resolve())
+    bystander_strs = {str(paths["bystander_one"].resolve()), str(paths["bystander_two"].resolve())}
+
+    # Membership: the definition + the genuine 2-hop static chain are always present; unrelated
+    # bystanders (zero import relationship to the decoy) never enter the graph at all.
+    assert {decoy_str, consumer_str, chain_str} <= affected_files
+    assert bystander_strs.isdisjoint(affected_files)
+
+    # Order: the direct depth-1 caller must rank ahead of the depth-2 transitive dependent in
+    # `dependent_files` -- a RELATIVE check (not a hardcoded literal list), because the loader's
+    # own position in this list is exactly what the guard fix is expected to remove.
+    dependent_files = list(payload["edit_plan_seed"]["dependent_files"])
+    assert consumer_str in dependent_files
+    assert chain_str in dependent_files
+    assert dependent_files.index(consumer_str) < dependent_files.index(chain_str)
+
+
+def test_blast_radius_excludes_unresolved_dynamic_literal_fuzzy_match(tmp_path: Path) -> None:
+    """THE TIGHTENING (gate NIT-1 mandated order, step 4): a file whose ONLY reference to the
+    decoy is an UNRESOLVED dynamic literal must never enter `tg blast-radius` `affected_files` (or
+    the edit-plan seed's `dependent_files`) via the reverse-scoring prefilter's fuzzy alias match
+    -- the precise `tg importers` edge already excludes it
+    (`test_build_file_importers_relative_import_module_literal_asserts_no_edge` above); this pins
+    the same honesty for the proximity-SCORING consumer. RED on the unfixed base (the loader IS
+    present, proving the gate's finding is real, not hypothetical); GREEN after the
+    repo_map.py:1988 guard fix."""
+    paths = _build_decoy_dynamic_import_blast_radius_project(tmp_path)
+
+    payload = repo_map.build_symbol_blast_radius_render("decoy_target", paths["project"])
+
+    loader_str = str(paths["loader"].resolve())
+    assert loader_str not in set(payload["affected_files"])
+    assert loader_str not in payload["edit_plan_seed"]["dependent_files"]
+
+
+# ---------------------------------------------------------------------------------------------
 # Proximity-tiered reverse-import candidate ordering. Dogfood flap (v1.81.15 PASS
 # -> v1.81.17 INCOMPLETE "0 importers @ 330/1035 files scanned" on a 50k-file WSL multi-repo
 # workspace) traced to `build_file_importers_from_map` slicing its CALLER_SCAN_FILE_CEILING /


### PR DESCRIPTION
## Summary

The last banked slice from the `tg` blast-radius dynamic-import campaign: closes **gate NIT-1**
from #703's independent Opus gate, explicitly called out as out-of-scope for #708's close-out
batch ("A fourth banked item (the scoring-prefilter `dynamic_unresolved` fuzzy-match guard from
#703's gate) is explicitly OUT of scope here -- it needs its own slice with a pinned blast-radius
ranking test designed first").

## Gate-comment lineage (PR #703)

> Independent Opus gate: **SHIP-WITH-NITS** -- all 4 cruxes empirically verified (both false-edge
> bugs reproduced RED on origin/main via decoy fixtures and confirmed GONE on this head; zero
> legitimate edges lost incl. the absolute-name + non-literal-`package` case; `dynamic_unresolved`
> honest in every tree-wide consumer; exactly 2 callers). No pre-merge fix required. **Follow-up
> banked (gate NIT-1, PRE-EXISTING and byte-identical on main -- not this PR's regression):** the
> reverse *scoring* prefilter (repo_map.py:1988) still emits the unresolved literal `".sibling"`
> into `imports_by_file`, which fuzzy-matches decoys via `_import_alias_candidates` + the
> substring test at :7827, placing the loader into blast-radius `affected_files` (a deliberately-
> broad proximity superset, so not a gate failure). Fix in its own slice: guard
> `if dynamic_entry["module"] and not dynamic_entry["dynamic_unresolved"]:` at :1988 -- REQUIRES a
> pinned blast-radius ranking test first, since narrowing the graph can reorder `dependent_files`
> (:7920).

**Root cause, verified against real code (`src/tensor_grep/cli/repo_map.py`):**
`_python_imports_and_symbols`'s dynamic-import fold-in loop (`:1988`, now `:2011` after this PR's
comment) appended `dynamic_entry["module"]` into the file's `imports` list -- which becomes
`repo_map["imports"]`, the alias graph `tg blast-radius`'s reverse SCORING prefilter
(`_reverse_import_distances` / `_reverse_importers`) reads -- whenever `module` was non-empty,
**without checking `dynamic_unresolved`**. #703 taught `_python_dynamic_import_entries`
(`repo_map.py:1726`) to keep the real literal text in `module` (never blank it) for a RELATIVE
literal (leading-dot `import_module(".sibling", package=...)`) or an explicit-nonzero-`level`
`__import__(...)` call, marking the entry `dynamic_unresolved=True` instead of resolving it --
unlike the ORIGINAL non-literal-argument case (`#93 SUB-1`), where `module` is blanked to `""`
and the truthiness check alone was already correct. So the truthiness-only check silently stopped
being sufficient once #703 shipped, and an unresolved-but-non-blank literal like `".sibling"`
started reaching the prefilter.

`_import_alias_candidates(".sibling")` normalizes to `{".sibling", "sibling"}`
(`repo_map.py:7804`), and the substring test inside `_import_graph_bonus`
(`repo_map.py:~7827`, reached via `_reverse_import_distances`'s BFS) then fuzzy-matches **any**
same-named-but-unrelated top-level `sibling.py` -- pulling its importer (a file whose *only*
reference to the decoy is that unresolved literal) into `tg blast-radius`'s `affected_files` /
`edit_plan_seed.dependent_files`, even though the precise `tg importers` edge
(`_resolve_raw_import_entry` / `_confirm_import_edges`) already excludes it correctly (that path
has always skipped resolution whenever `dynamic_unresolved` is set). `affected_files` is a
deliberately broad proximity superset, not the exact edge list, so this was a **quality
tightening**, not a correctness emergency -- exactly as the gate characterized it.

## The fix

One-line-class guard at the exact site the gate specified (`src/tensor_grep/cli/repo_map.py`,
`_python_imports_and_symbols`):

```python
for dynamic_entry in _python_dynamic_import_entries(tree):
-   if dynamic_entry["module"]:
+   if dynamic_entry["module"] and not dynamic_entry["dynamic_unresolved"]:
        imports.append(str(dynamic_entry["module"]))
```

Nothing else changed. An unresolved dynamic import (relative-literal or non-literal-argument
alike) now contributes nothing to the reverse-scoring alias graph, matching the "no false edges,
missing is fine" contract the precise resolvers already enforce.

## Mandated order followed (pin first)

1. **Pin first** -- `test_blast_radius_legitimate_dependent_ranking_pin`
   (`tests/unit/test_file_deps.py`) was written and run GREEN against the **unmodified** base
   *before* touching the guard. It asserts `affected_files` membership and the RELATIVE order of
   the legitimately-related dependents (a genuine 2-hop static chain: a direct caller at depth 1,
   a transitive dependent at depth 2) -- deliberately not asserting anything about the decoy's
   fuzzy-matched loader file, since that's exactly what the guard is expected to remove.
2. **The guard** -- the single `if` change above.
3. **Re-ran the pin** -- still GREEN, byte-identical relative order. See receipts below: the
   *only* diff between before/after is the loader dropping out; the two legitimate dependents
   (`consumer.py` before `chain_consumer.py`) keep their exact relative order in both
   `affected_files` and `edit_plan_seed.dependent_files`. **No reorder occurred** -- the gate's
   feared regression did not happen.
4. **The tightening test** -- `test_blast_radius_excludes_unresolved_dynamic_literal_fuzzy_match`
   (same file) was RED against the unmodified base (proving the bug is real, not hypothetical) and
   is GREEN after the guard.

### Pin receipts (fixture: decoy `sibling.py` defines `decoy_target`; `consumer.py` calls it
directly at depth 1; `chain_consumer.py` calls `consumer.py` at depth 2; `pkg/subpkg/loader.py`'s
*only* reference is the unresolved relative literal `import_module(".sibling",
package="pkg.subpkg")`; 2 unrelated bystander files with zero import relationship)

| Field | Before (unmodified base) | After (this PR) |
|---|---|---|
| `affected_files` | `sibling.py`, `consumer.py`, **`loader.py`**, `chain_consumer.py` (4) | `sibling.py`, `consumer.py`, `chain_consumer.py` (3) |
| `edit_plan_seed.dependent_files` | `consumer.py`, **`loader.py`**, `chain_consumer.py` (3) | `consumer.py`, `chain_consumer.py` (2) |
| `consumer.py` depth / graph_score | 1 / 0.192626 | 1 / 0.283419 |
| `chain_consumer.py` depth / graph_score | 2 / (present in `affected_files`, truncated out of the render's default `max_files=3` `file_matches` slice) | 2 / 0.240906 |
| `loader.py` | depth 1, score 2, reasons `['graph-depth']` only (never `caller`/`import-consumer`) | absent |
| Bystanders | absent | absent |

Bystanders never appear in either run (zero import relationship to the decoy at all) -- a sanity
control, not part of the bug. `consumer.py` ranks ahead of `chain_consumer.py` in
`dependent_files` in **both** runs (depth-1-before-depth-2, `"caller"` tie-break) -- the only
change is the loader's row disappearing from between them.

## Files changed

- `src/tensor_grep/cli/repo_map.py` -- the guard (`_python_imports_and_symbols`, was `:1988`) plus
  an inline comment explaining why the truthiness-only check stopped being sufficient after #703.
- `tests/unit/test_file_deps.py` -- fixture builder
  `_build_decoy_dynamic_import_blast_radius_project` (mirrors #703's own decoy shape) plus the two
  tests above.

## Validation

```
uv run ruff check .                        # All checks passed!
uv run ruff format --check --preview .     # the 2 touched files: "2 files already formatted"
                                            #   (4 OTHER files in the repo would reformat --
                                            #    pre-existing drift, unrelated to this diff,
                                            #    confirmed via `git status --porcelain` showing
                                            #    only repo_map.py + test_file_deps.py modified)
uv run mypy src/tensor_grep                # Success: no issues found in 81 source files
```

Test surface (`PYTHONPATH=<worktree>/src`, the pre-built `.venv`, no cargo/maturin):

- The 2 new tests: pin GREEN + tightening RED on the unmodified base; both GREEN after the fix.
- `tests/unit/test_file_deps.py` + `test_blast_radius_mermaid.py` +
  `test_blast_radius_render_perf.py` +
  `test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py` +
  `test_edit_plan_seed.py` + `test_edit_plan_max_files_bounds_suggested_edits.py`: **157 passed**.
- Broader regression sweep -- every `tests/unit/*.py` file that imports/exercises `repo_map`
  (73 files, callers/context/agent-capsule/import-span/graph/deadline suites included): **1881
  passed, 1 failed**. The 1 failure
  (`test_cli_modes.py::test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`) is
  **pre-existing and unrelated** -- confirmed by `git stash`-ing this diff and re-running that
  single test against the unmodified base, where it fails identically (a local GPU-device-
  inventory environment mismatch, nothing to do with `repo_map.py`'s import graph).
- `tests/e2e/test_routing_parity.py` was deliberately **not** run (it self-compiles the native
  `tg` binary via `cargo run` as its no-prebuilt-binary fallback -- out of scope for this
  Python-only, CPU-safe change).

## Flag for review

This changes blast-radius **membership** (`affected_files` narrows for files whose only relation
to the query symbol was an unresolved dynamic-import literal). Per the gate's own framing this is
a quality tightening on a deliberately-broad proximity superset, not a correctness emergency, and
the mandated pin test confirms zero reordering among legitimately-related dependents -- but please
re-review given the ranking-reorder risk the gate explicitly flagged, and Opus-gate if anything
beyond the specified one-line guard looks load-bearing.
