### PR TITLE
fix(agent): thread --deadline through the warm call-site-evidence branch

### DIFF
--- a/src/tensor_grep/cli/agent_capsule.py
+++ b/src/tensor_grep/cli/agent_capsule.py
@@ -826,11 +826,24 @@ def _collect_capsule_call_site_evidence_from_map(
     include_blast_radius: bool,
     max_files: int,
     seed_confidence: float,
+    deadline_monotonic: float | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
     """Task #108 (Tier-2 daemon moat) map-based sibling of ``_collect_capsule_call_site_evidence``:
     identical gating + evidence shape, but resolves the blast radius against an already-built
     ``rm`` (e.g. the warm session daemon's cached map) via ``build_symbol_blast_radius_from_map``
     instead of re-scanning through the cold ``build_symbol_blast_radius`` wrapper.
+
+    ``deadline_monotonic`` (SLA-honesty fix, +10% campaign #5): this warm branch used to call
+    ``build_symbol_blast_radius_from_map`` with no deadline at all -- structurally unbounded even
+    though the caller (``build_agent_capsule_from_map``) already has an in-scope
+    ``deadline_monotonic`` it threads into every OTHER sibling stage (context-render, DAR outbound
+    deps, vendored-subtree detection). The cold sibling above already threads its own
+    ``deadline_monotonic`` into the FS-backed ``build_symbol_blast_radius`` (converted to a
+    relative ``deadline_seconds`` there, since that is the shape ITS callee accepts); this warm
+    callee, ``build_symbol_blast_radius_from_map``, already accepts ``deadline_monotonic`` directly
+    (repo_map.py) and threads it into its own defs/callers/impact sub-calls, so no conversion is
+    needed here -- a straight pass-through. ``None`` (the default, and every existing caller's
+    behavior before this fix) is byte-identical to the pre-fix call.
 
     TRAP A (audit #107 class): the cold wrapper transparently retries a truncated no_match via
     ``_literal_symbol_seed_files`` (see ``build_symbol_blast_radius``); the map-based lookup here
@@ -890,6 +903,7 @@ def _collect_capsule_call_site_evidence_from_map(
             rm,
             target_symbol,
             max_depth=1,
+            deadline_monotonic=deadline_monotonic,
         )
         radius_payload = repo_map._apply_blast_radius_output_limits(
             radius_payload,
@@ -3281,6 +3295,10 @@ def build_agent_capsule_from_map(
     else:
         # WARM/DAEMON path: rescue-less _from_map collector (single cached map, no second scan);
         # on a truncated no_match it flags daemon_unreliable so the client falls back to cold.
+        # SLA-honesty fix (+10% campaign #5): thread the SAME in-scope deadline_monotonic this
+        # function's other sibling stages already receive (cold branch above, DAR outbound deps
+        # below) -- previously dropped here, leaving this branch's build_symbol_blast_radius_from_
+        # map call structurally unbounded even under an explicit --deadline.
         related_call_sites, call_site_evidence, call_site_evidence_daemon_unreliable = (
             _collect_capsule_call_site_evidence_from_map(
                 query,
@@ -3289,6 +3307,7 @@ def build_agent_capsule_from_map(
                 include_blast_radius=include_blast_radius,
                 max_files=max_files,
                 seed_confidence=primary_target_seed_confidence,
+                deadline_monotonic=deadline_monotonic,
             )
         )
     # F4: verified call-site evidence is only available NOW (after the collection above), so the

--- a/tests/unit/test_cli_deadline_coverage_gaps.py
+++ b/tests/unit/test_cli_deadline_coverage_gaps.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 from typer.testing import CliRunner
@@ -613,3 +614,145 @@ def test_build_context_edit_plan_from_map_threads_deadline_into_edit_plan_metada
     )
 
     assert recorded.get("deadline_monotonic") == sentinel_deadline, recorded
+
+
+# ==================================================================================================
+# Item 6 (+10% campaign, ranked-queue #5): `tg agent`'s WARM/DAEMON call-site-evidence collector,
+# `_collect_capsule_call_site_evidence_from_map` (agent_capsule.py), had NO `deadline_monotonic`
+# parameter at all -- its own `build_symbol_blast_radius_from_map` call (repo_map.py, itself already
+# deadline-aware and internally deadline-gated since the #691/#222 BFS-bounding wave) was reached
+# with no deadline, making the DEFAULT branch of `build_agent_capsule_from_map`
+# (`_rescue_call_site_evidence=False`, taken by every warm/daemon `tg agent`/`tg prepare` call --
+# `session_store.py`'s "agent" command handler) run this scan structurally unbounded regardless of
+# `--deadline`. The cold sibling (`_collect_capsule_call_site_evidence`, covered by Item 3 above)
+# already threads its own deadline correctly; this closes the warm sibling's gap. Purely additive:
+# `deadline_monotonic` defaults to `None`, identical in effect to every pre-fix caller (none of
+# which could pass it at all, since the parameter did not exist).
+# ==================================================================================================
+
+
+def _write_ambiguous_symbol_fixture(tmp_path: Path, *, padding_files: int) -> None:
+    """Two files define the SAME top-level symbol name ("helper") -- the one shape that forces
+    `_preferred_definition_files`' own deadline-checked loop (repo_map.py) to actually iterate; with
+    a single definition file it early-returns before ever consulting the deadline. `padding_files`
+    extra tiny modules pad out the repo-map file universe that loop iterates, so an injected
+    per-file delay (see the budget test below) accumulates into a measurable, controllable total."""
+    (tmp_path / "helper.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "helper_dup.py").write_text("def helper():\n    return 2\n", encoding="utf-8")
+    for i in range(padding_files):
+        (tmp_path / f"pad_{i}.py").write_text(f"PAD_{i} = {i}\n", encoding="utf-8")
+
+
+def test_warm_call_site_evidence_respects_deadline_budget(tmp_path: Path, monkeypatch) -> None:
+    """Part (a): with the fix, a tight deadline bounds the ACTUAL wall clock of
+    `_collect_capsule_call_site_evidence_from_map`, not just the flags it returns. Deterministic --
+    no wall-clock racing against real scan cost: an artificial per-file delay is injected into
+    `_file_imports_symbol_from_definition` (the innermost call inside `_preferred_definition_files`'
+    own deadline-checked loop), so the fully-unbounded total (40 padding files x up to 2 definition
+    candidates x 0.01s <= 0.8s) is far larger than the budget, and the bounded total must stay close
+    to it instead. RED pre-fix: this call would raise TypeError (no such parameter existed) --
+    proving the seam itself, not just its timing, was previously absent."""
+    _write_ambiguous_symbol_fixture(tmp_path, padding_files=40)
+    original = repo_map._file_imports_symbol_from_definition
+
+    def _slow_check(*args, **kwargs):
+        time.sleep(0.01)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "_file_imports_symbol_from_definition", _slow_check)
+
+    rm = repo_map.build_repo_map(str(tmp_path))
+    target = {"symbol": "helper", "confidence": 0.9}
+    deadline = time.monotonic() + 0.15
+
+    start = time.monotonic()
+    agent_capsule._collect_capsule_call_site_evidence_from_map(
+        "helper",
+        rm,
+        target,
+        include_blast_radius=True,
+        max_files=3,
+        seed_confidence=0.9,
+        deadline_monotonic=deadline,
+    )
+    elapsed = time.monotonic() - start
+
+    # Budget (0.15s) + generous slack for scheduler jitter -- comfortably below the ~0.8s the
+    # fully-unbounded loop would take if the deadline were silently dropped (the pre-fix bug).
+    assert elapsed < 0.6, f"elapsed={elapsed:.3f}s -- deadline was not threaded into the warm scan"
+
+
+def test_warm_call_site_evidence_reports_partial_honestly_on_deadline(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Part (b): an ALREADY-EXPIRED shared deadline must make the collected evidence dict report
+    partial=True / deadline_limit.deadline_exceeded=True honestly (not silently succeed), mirroring
+    Item 4's `test_collect_capsule_call_site_evidence_propagates_inner_partial_signal` for the cold
+    sibling. Deterministic: the deadline is already in the past when the collector is entered, so
+    `_preferred_definition_files`' very first loop iteration trips the deadline check -- no
+    sleeping, no timing assertions."""
+    _write_ambiguous_symbol_fixture(tmp_path, padding_files=5)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    target = {"symbol": "helper", "confidence": 0.9}
+    already_expired = time.monotonic() - 5.0
+
+    _related, evidence, _unreliable = agent_capsule._collect_capsule_call_site_evidence_from_map(
+        "helper",
+        rm,
+        target,
+        include_blast_radius=True,
+        max_files=3,
+        seed_confidence=0.9,
+        deadline_monotonic=already_expired,
+    )
+
+    assert evidence.get("partial") is True, evidence
+    assert evidence.get("deadline_limit", {}).get("deadline_exceeded") is True, evidence
+
+
+def test_warm_call_site_evidence_deadline_none_is_byte_identical_noop(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Part (c): the new `deadline_monotonic` parameter defaults to `None`, and passing `None`
+    explicitly must be indistinguishable from every pre-fix caller (which could not pass it at all,
+    since the parameter did not exist -- the callee's OWN default was already `None` either way).
+    Pins BOTH the exact kwarg `build_symbol_blast_radius_from_map` receives AND the full returned
+    payload, proving the two call shapes (omit the kwarg vs pass `deadline_monotonic=None`) are
+    byte-identical."""
+    _write_helper_and_caller(tmp_path)
+    rm = repo_map.build_repo_map(str(tmp_path))
+    target = {"symbol": "helper", "confidence": 0.9}
+    recorded: list[Any] = []
+    original = repo_map.build_symbol_blast_radius_from_map
+
+    def _spy(*args, **kwargs):
+        recorded.append(kwargs.get("deadline_monotonic", "<absent>"))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(agent_capsule.repo_map, "build_symbol_blast_radius_from_map", _spy)
+
+    omitted = agent_capsule._collect_capsule_call_site_evidence_from_map(
+        "helper",
+        rm,
+        target,
+        include_blast_radius=True,
+        max_files=3,
+        seed_confidence=0.9,
+    )
+    explicit_none = agent_capsule._collect_capsule_call_site_evidence_from_map(
+        "helper",
+        rm,
+        target,
+        include_blast_radius=True,
+        max_files=3,
+        seed_confidence=0.9,
+        deadline_monotonic=None,
+    )
+
+    assert recorded == [None, None], recorded
+    assert omitted == explicit_none, (omitted, explicit_none)
+    related, evidence, unreliable = omitted
+    assert evidence["status"] == "collected"
+    assert evidence["symbol"] == "helper"
+    assert unreliable is False
+    assert related and Path(related[0]["file"]).name == "caller.py", related


### PR DESCRIPTION
## Summary

Ranked-queue item #5 of the +10% campaign: closes the agent-capsule **warm-path deadline
hole** — an SLA-honesty fix restoring a currently-VOID `--deadline` guarantee on the
default branch. Purely additive; nothing else touched.

## Seam verification (file:line, all confirmed against the real code at HEAD)

- `_collect_capsule_call_site_evidence_from_map` (`agent_capsule.py:821-950`, pre-fix) had
  **no `deadline_monotonic` parameter**, so its `build_symbol_blast_radius_from_map` call
  (`agent_capsule.py:889-893`, pre-fix) ran with **no deadline at all** — even though that
  callee (`repo_map.py:17438-17446`) already accepts `deadline_monotonic` and threads it
  internally into its own defs/callers/impact/`_preferred_definition_files`/reverse-import-graph
  sub-calls (deadline-gated since the #691/#222 BFS-bounding wave).
- The dispatcher `build_agent_capsule_from_map` (`agent_capsule.py:2750-2766`) has
  `deadline_monotonic` in scope for its whole body (never reassigned) and threads it into
  every sibling stage — the cold rescue branch (line 3278), DAR outbound-deps (~line 3350) —
  but **dropped it specifically at the warm call-site-evidence call** (lines 3284-3293,
  pre-fix).
- `_rescue_call_site_evidence` defaults `False` (`agent_capsule.py:2765`) — confirmed the
  warm/`_from_map` branch (lines 3281-3293) is genuinely the **default**, taken by every
  caller that doesn't explicitly request the cold rescue path. `build_agent_capsule` (the
  cold, direct wrapper `tg agent`/`tg prepare` use) explicitly passes
  `_rescue_call_site_evidence=True` (line 2746); the only caller left at the default is
  `session_store.py`'s `"agent"` command handler (line 1457) — i.e. every real warm
  session-daemon `tg agent` request.
- Cold sibling `_collect_capsule_call_site_evidence` (line 715-818) already threads its own
  `deadline_monotonic` (line 724) — the pattern this PR copies. One nuance: the cold
  sibling **converts** absolute→relative `deadline_seconds` for its FS-backed callee
  (`build_symbol_blast_radius`, which takes `deadline_seconds`); the warm callee
  (`build_symbol_blast_radius_from_map`) already accepts `deadline_monotonic` **directly**,
  so this fix is a straight pass-through, no conversion.
- Trigger condition (`_target_symbol_was_explicitly_requested` + `seed_confidence >= 0.75`,
  lines 868/877) confirmed unchanged — this fix only affects what happens **after** that
  gate already passed.

## The fix

Purely additive, 19 insertions / 0 deletions in `agent_capsule.py`:
1. `deadline_monotonic: float | None = None` added to
   `_collect_capsule_call_site_evidence_from_map`'s signature.
2. Forwarded verbatim into the `build_symbol_blast_radius_from_map(...)` call.
3. Passed at the one warm call site inside `build_agent_capsule_from_map`
   (`deadline_monotonic=deadline_monotonic`, the same in-scope value every sibling stage
   already receives).

## The None-noop proof

`None` is the default, and — since the parameter did not exist before this PR — it is the
**only** shape every pre-fix caller could ever produce. `test_warm_call_site_evidence_
deadline_none_is_byte_identical_noop` spies on `build_symbol_blast_radius_from_map` and
asserts it receives `deadline_monotonic=None` whether the new kwarg is omitted entirely or
passed explicitly as `None`, and that the two call shapes return an **identical** 3-tuple
payload (pinned, not just type-checked) — the two existing direct callers of this function
in `tests/unit/test_orient_agent_daemon.py` (lines 148, 169, 677) all use keyword-only args
with no `deadline_monotonic`, so they're unaffected by construction (new keyword-only param,
default `None`).

## Tests (TDD, RED-verified)

`tests/unit/test_cli_deadline_coverage_gaps.py`, new "Item 6" section, mirroring the
cold-path "Item 3" suite:
- `test_warm_call_site_evidence_respects_deadline_budget` — part (a): a tight deadline
  bounds the **actual wall clock**, not just the flags. Deterministic (no wall-clock
  racing): injects a per-file delay into `_file_imports_symbol_from_definition` (inside
  `_preferred_definition_files`'s own already-deadline-checked loop, entered via a
  duplicate-symbol-name fixture), so the fully-unbounded total (~0.8s) is far above the
  budget (0.15s) and the bounded run must stay well under it.
- `test_warm_call_site_evidence_reports_partial_honestly_on_deadline` — part (b): an
  already-expired deadline makes `call_site_evidence.partial` /
  `deadline_limit.deadline_exceeded` report honestly. No sleeping, no timing assertions.
- `test_warm_call_site_evidence_deadline_none_is_byte_identical_noop` — part (c): the
  None-noop proof above.

**Verified RED-before-GREEN directly** (not just by inspection): stashed only the
production-code change, keeping the tests, confirmed all 3 new tests fail with
`TypeError: _collect_capsule_call_site_evidence_from_map() got an unexpected keyword
argument 'deadline_monotonic'` — then restored the fix and confirmed all 3 pass. Full
`test_cli_deadline_coverage_gaps.py` suite: 39/39 passed post-fix.

## A/B receipt

3 reps each, medians. Pinned `tg-pinned` clone (v1.93.2 / `4e471cc`, the same base this
worktree branched from), `build_repo_map` scans 552 files. Query
`"build_agent_capsule_from_map"` — a real, single-definition, explicit top-level symbol
(this file, line 2750) — with a 5.0s budget mirroring `--deadline 5`.
`_rescue_call_site_evidence` left at its real default (`False`, the warm branch);
`build_repo_map` itself excluded from the timed region (matches how a real warm daemon
amortizes it across many requests — the daemon holds one cached map across requests, never
rebuilding per-request).

| metric | before | after | delta |
|---|---:|---:|---:|
| total capsule wall (`build_agent_capsule_from_map`) | 13.890s | 6.594s | -52.5% |
| evidence-stage wall (isolated, the code this PR changes) | 8.141s | 1.282s | -84.3% |
| `call_site_evidence.partial` | `null` (never set) | `True` | now honest |
| `call_site_evidence.returned_call_sites` | 6 (ran to full completion, ignoring the deadline) | 0 (honestly truncated within budget) | n/a |

Before/after individual reps and the isolation methodology are in the commit message; raw
JSON lives in the campaign scratchpad (`opt10/item5_ab_before.json`,
`opt10/item5_ab_after.json`), not part of this diff.

**Honesty note on the residual ~1.3-6.6s** (why "after" isn't flush against 5.0s): the
capsule's pre-evidence-stage work (context-render/ranking, ~5.3-5.6s on this corpus in both
before/after runs) is untouched by this fix — a separate, already-tracked concern
(ranked-queue items #1-#3). This fix bounds exactly the piece it targets: the evidence-stage
isolated wall time (8.14s to 1.28s), which is the part that was structurally unbounded before.

**Why not a literal `tg agent ... --deadline 5` subprocess repro:** verified
`main.py:9524-9539` — the `agent` CLI command only attempts daemon routing
(`_maybe_agent_via_running_daemon`) when `effective_deadline is None`; an explicit
`--deadline` always takes the cold path (`_rescue_call_site_evidence=True`), which never
reaches the code this PR changes. The warm branch is reached only via a running session
daemon, whose own dispatch (`session_store.py:1456`) anchors its own fixed default budget
(`WARM_DAEMON_DEFAULT_DEADLINE_SECONDS = 60.0`, `session_store.py:77`) rather than the
caller's `--deadline` value — threading a CLI `--deadline` all the way into the daemon
request is the separate, not-yet-built "W1" warm-tier queue item, out of scope here. The A/B
receipt above drives the exact function `session_store.py` calls, with an explicit 5s
budget, to isolate this fix's effect precisely — the same approach this codebase's own
existing daemon unit tests (`test_orient_agent_daemon.py`) already use for this seam.

## Verification

- `ruff check` — clean (scoped + whole-repo).
- `ruff format --check --preview` — clean on both touched files (whole-repo run surfaces 4
  pre-existing unrelated `.md` fence-formatting drifts, not touched by this PR and not in
  `git status` — a known pre-existing condition, unrelated).
- `mypy src/tensor_grep` — `Success: no issues found in 81 source files`.
- New tests (3) — green, RED-before-GREEN verified via git-stash.
- `tests/unit/test_cli_deadline_coverage_gaps.py` — 39/39 passed.
- Full targeted gate (deadline-coverage + deadline-flag + deadline-frontdoor-anchor +
  orient-agent-daemon + session-daemon-default-deadline + all 9
  `test_agent_capsule_*.py` + agent-deadline/vendored-subtree/ignore/suggested-scope/
  workspace-root suites) — **338/338 passed**.
- `tensor_grep.__file__` verified resolving into this worktree (not a stale shared venv)
  before trusting any result.
- CPU-safe: no cargo/rustc/maturin; venv + `PYTHONPATH`; no `tests/e2e/test_routing_parity.py`;
  all runs bounded and serial.

## Review ask

Additive + contract-restoring, but flagging for a **light independent review** per the
campaign's own discipline — the crux to check: (1) the `None`-default byte-identity claim
(a build-agent-self-gating-its-own-work conflict of interest), and (2) confirm no
cold-branch (`_rescue_call_site_evidence=True`) behavior changed (it shouldn't have — the
cold branch's own `deadline_monotonic` threading at line 3278 is untouched by this diff).

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
