### PR TITLE
test(retrieval): measure the shipped dense-weight config + ndcg regression floor

### DIFF
--- a/benchmarks/eval_late_rerank_quality.py
+++ b/benchmarks/eval_late_rerank_quality.py
@@ -14,13 +14,24 @@ mean_reciprocal_rank_at_k, ndcg_at_k) -- no new metric is invented here (verific
 Correction #7: golden labels are relevant-FILE sets; scoring is file-granularity, matching this
 repo's existing ``eval_bm25_quality.py`` precedent).
 
-Arms: ``bm25`` (always scored), ``dense``/``rrf``/``rrf+maxsim`` (scored when their leg is
-available, else SKIPPED with a loud, specific reason -- never silently degraded into a vacuous
-comparison), ``find``/``find+stack`` (ALWAYS skipped this wave -- ``tg find`` is Wave 2c/Wave 3,
-not built yet; reported as ``skipped: awaiting-wave-2``). A comparison/verdict is REFUSED
+Arms: ``bm25`` (always scored), ``dense``/``rrf``/``rrf_shipped``/``rrf+maxsim`` (scored when their
+leg is available, else SKIPPED with a loud, specific reason -- never silently degraded into a
+vacuous comparison), ``find``/``find+stack`` (ALWAYS skipped -- see
+:data:`SKIP_FIND_ARM_NOT_WIRED`: ``tg find``'s own CLI/MCP pipeline is built and shipped
+(v1.77.0/v1.78.0, docs/BACKLOG.md #189's "tg find campaign" history), this harness has simply never
+been wired to invoke it end-to-end as a scored arm). A comparison/verdict is REFUSED
 (``GoldenSetError``) whenever either side of the pair is not ``scored`` (E1's "never a vacuous
 comparison" discipline generalized to the arm-skip mechanism, per the review ledger's WAVE 1 E1/E4
 items and plan Correction #2).
+
+``rrf_shipped`` (accuracy-leg regression protection, added after the dense-weight flip -- #191/#634
+-- landed in production and shipped live in v1.93.2): the SAME bm25+dense RRF fusion as ``rrf``,
+but weighted with :data:`SHIPPED_DENSE_WEIGHT` -- the value ``tg find`` actually uses by default
+for a multi-word NL query once ``TG_FIND_DENSE_WEIGHT`` is unset (``cli/main.py``'s
+``_find_dense_weight``). Before this arm existed, the harness could only ever measure the OLD 1:1
+fusion (``rrf``, kept exactly as-is below as a clearly-labeled comparison baseline, never removed)
+-- meaning the shipped behavior itself had zero regression protection. See
+:func:`run_rrf_arm`'s own docstring for the byte-identical-at-default-weight contract.
 
 The 4 mandatory must-fixes from the adversarial review (tg_find_review_ledger.md, "WAVE 1"):
 
@@ -56,6 +67,13 @@ Usage (always via ``uv run --no-sync``, this repo's convention):
 Exit 0 on success (including "every arm skipped but ran cleanly"); exit 1 on a loud config/oracle
 error (missing corpus, malformed golden set, non-deterministic --runs); exit 2 is not used here
 (this is a benchmarks script, not a `tg` command -- no rg-parity exit-code contract applies).
+
+Regression protection: ``tests/eval/test_retrieval_quality_regression.py`` asserts the
+``rrf_shipped`` arm's ndcg@10 stays above a floor on the committed golden set -- opt-in, ``eval``
+marker (excluded from the default ``-m "not eval"`` CI sweep, no CI workflow currently installs
+the `semantic` extra + fetches the model). Run it explicitly:
+
+    uv run --no-sync pytest tests/eval/test_retrieval_quality_regression.py -m eval -v -s
 """
 
 from __future__ import annotations
@@ -102,10 +120,34 @@ DEFAULT_TOP_KS: tuple[int, ...] = (5, 10)
 # name is a private module constant of reranker.py, not part of its public contract.
 DEFAULT_POOL_K = 50
 
-# find/find+stack depend on Wave 2c (the tg find pipeline) and Wave 3 (the CPU rank stack), which
-# are not built yet -- see docs/BACKLOG.md #189 and tg_find_plan.md Sec.3 WAVE 2/3. Reported as an
-# explicit, permanent skip stub this wave; never silently omitted from the arm list.
-SKIP_AWAITING_WAVE2 = "skipped: awaiting-wave-2 (tg find pipeline not built yet)"
+# Accuracy-leg regression protection (2026-07-22): mirrors cli/main.py's
+# `_FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT` (main.py ~:4171) -- the `dense_weight` `tg find` actually
+# passes to `rank_chunks` for a genuinely multi-word NL query once `TG_FIND_DENSE_WEIGHT` is
+# unset, since the #191/#634 dense-weight flip went live (shipped in v1.93.2). Every golden query
+# in this harness's corpus is multi-word NL (see the module docstring's "NL 40-query set"), so this
+# one weight reproduces the shipped default across the whole set. A fresh LOCAL constant, not an
+# import, for the exact reason `DEFAULT_POOL_K` above is one: `_FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT`
+# is a private module constant of `cli/main.py`, not part of its public contract -- and importing
+# it would drag a ~17k-line Typer CLI module (with its own heavyweight dataclass/typer import
+# surface) into a benchmarks script that needs exactly one float. If `cli/main.py`'s shipped
+# default ever changes, update this constant to match and re-run the golden-set report to confirm
+# the new number, rather than importing across the module boundary.
+SHIPPED_DENSE_WEIGHT = 5.0
+
+# STALE-CLAIM FIX (accuracy-leg blind-spot audit, 2026-07-22): this constant used to read
+# "awaiting-wave-2 (tg find pipeline not built yet)" -- true when this harness was first written
+# (Wave 1, #625) but FALSE since v1.77.0: `tg find`'s CLI pipeline shipped that release (Wave
+# 2b/2c, #626) and its MCP tool followed in v1.78.0 (Wave 2d, #627) -- see docs/BACKLOG.md #189's
+# "tg find campaign" history. find/find+stack are still skipped below, but for the HONEST reason:
+# nobody has wired THIS golden-set harness to invoke the real `tg find` pipeline end-to-end and
+# score its output yet -- a distinct, not-yet-scheduled integration task, not a missing dependency.
+# Reported as an explicit, permanent skip stub until that wiring lands; never silently omitted from
+# the arm list.
+SKIP_FIND_ARM_NOT_WIRED = (
+    "skipped: tg find's CLI/MCP pipeline is built and shipped (v1.77.0/v1.78.0) -- this harness "
+    "has not been wired to invoke it end-to-end as a scored arm yet (a separate integration task, "
+    "not a missing dependency)"
+)
 
 _METRIC_NAMES: tuple[str, ...] = (
     "recall@5",
@@ -363,16 +405,36 @@ def run_rrf_arm(
     top_ks: tuple[int, ...],
     bm25_index: Bm25Index,
     dense_index: DenseIndex,
+    *,
+    dense_weight: float = 1.0,
+    name: str = "rrf",
 ) -> ArmResult:
+    """Fuse the bm25 + dense leg via plain RRF -- mirrors ``rank_chunks``'s own fusion step
+    (reranker.py:258-267), minus the late-rerank/path-channel extras this harness either scores
+    separately (``rrf+maxsim``) or never exercises (the ``TG_RRF_CHANNELS`` path channel).
+
+    ``dense_weight`` (accuracy-leg regression protection): a per-leg RRF weight, identical in
+    meaning to ``rank_chunks``'s own parameter of the same name. ``dense_weight=1.0`` (the
+    default, and every call site that predates this parameter) is a BYTE-IDENTICAL no-op:
+    ``reciprocal_rank_fusion`` is called with ``weights=None`` exactly as before, so the original
+    unweighted ``rrf`` arm this function has always produced is unchanged by this parameter's
+    existence. A non-default value builds ``weights=[1.0, dense_weight]``, the same two-entry
+    shape ``rank_chunks`` builds internally for the identical reason.
+
+    ``name`` lets a caller build a second, differently-weighted ``ArmResult`` from this same
+    function without a second copy-pasted implementation (see ``build_report``'s ``rrf_shipped``);
+    the returned ``ArmResult`` is otherwise identical in shape to the un-parameterized original.
+    """
     per_query: dict[str, dict[str, float]] = {}
     total = max(1, len(chunks))
+    weights: list[float] | None = [1.0, dense_weight] if dense_weight != 1.0 else None
     for query in queries:
         bm25_ranking = [i for i, _score in bm25_index.query(query.query, top_k=total)]
         dense_ranking = [i for i, _score in dense_index.query(query.query, top_k=total)]
-        fused = reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K)
+        fused = reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K, weights=weights)
         ranked_files = _dedupe_ranked_files(fused, chunks, corpus_dir)
         per_query[query.id] = _score_ranking(ranked_files, query.relevant_files, top_ks)
-    return ArmResult(name="rrf", status="scored", per_query=per_query)
+    return ArmResult(name=name, status="scored", per_query=per_query)
 
 
 def build_late_reranker() -> tuple[LateReranker | None, str | None]:
@@ -398,8 +460,18 @@ def run_rrf_maxsim_arm(
     late_reranker: LateReranker,
     *,
     pool_k: int = DEFAULT_POOL_K,
+    dense_weight: float = 1.0,
 ) -> ArmResult:
     """Composes the SAME leg functions ``rrf`` uses, then MaxSim-reranks the fused head.
+
+    ``dense_weight`` (accuracy-leg regression protection): threaded through for the same reason,
+    and with the same byte-identical-at-1.0 contract, as :func:`run_rrf_arm` above -- it closes
+    the identical latent no-weights gap in this arm's own ``reciprocal_rank_fusion`` call.
+    ``build_report`` does not currently build a weighted ``rrf+maxsim`` variant by default: the
+    unweighted arm already scores BELOW bm25 on this golden set (ndcg@10 0.068 vs 0.109 -- see the
+    optimization queue's KILL LIST item F8.4, "late-rerank... twice-confirmed dead at the current
+    model tier"), so a second maxsim variant is not a useful regression signal yet. The parameter
+    exists so a future caller can measure a weighted maxsim arm without another signature change.
 
     Deliberately does NOT call ``reranker.rerank_hybrid`` -- that function operates over
     ``SearchResult.matches`` (grep-hit reordering) and wraps its late-interaction splice in a
@@ -411,10 +483,11 @@ def run_rrf_maxsim_arm(
     """
     per_query: dict[str, dict[str, float]] = {}
     total = max(1, len(chunks))
+    weights: list[float] | None = [1.0, dense_weight] if dense_weight != 1.0 else None
     for query in queries:
         bm25_ranking = [i for i, _score in bm25_index.query(query.query, top_k=total)]
         dense_ranking = [i for i, _score in dense_index.query(query.query, top_k=total)]
-        fused = reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K)
+        fused = reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K, weights=weights)
         head = fused[:pool_k]
         tail = fused[pool_k:]
         if head:
@@ -577,10 +650,10 @@ def build_report(
     ``*_override`` parameters exist ONLY for tests (dependency injection mirroring
     ``test_search_semantic_rerank.py``'s ``_stub_dense_clean``/``_FakeDenseModel`` and
     ``test_reranker_hybrid.py``'s ``_FixedVectorModel`` conventions) -- they let a test exercise
-    the "dense/rrf/rrf+maxsim actually SCORED" path deterministically without the `semantic`/
-    `rerank` extras or a fetched model being present in CI. When both are ``None`` (the default,
-    used by the real CLI), availability is probed for real via :func:`build_dense_index` /
-    :func:`build_late_reranker`.
+    the "dense/rrf/rrf_shipped/rrf+maxsim actually SCORED" path deterministically without the
+    `semantic`/`rerank` extras or a fetched model being present in CI. When both are ``None``
+    (the default, used by the real CLI), availability is probed for real via
+    :func:`build_dense_index` / :func:`build_late_reranker`.
     """
     corpus_files = load_corpus_files(corpus_dir)
     chunks: list[Chunk] = []
@@ -601,10 +674,25 @@ def build_report(
     if dense_index is None:
         arms["dense"] = skipped_arm("dense", dense_reason or "dense leg unavailable")
         arms["rrf"] = skipped_arm("rrf", f"dense leg unavailable: {dense_reason}")
+        arms["rrf_shipped"] = skipped_arm("rrf_shipped", f"dense leg unavailable: {dense_reason}")
         arms["rrf+maxsim"] = skipped_arm("rrf+maxsim", f"dense leg unavailable: {dense_reason}")
     else:
         arms["dense"] = run_dense_arm(chunks, corpus_dir, queries, top_ks, dense_index)
         arms["rrf"] = run_rrf_arm(chunks, corpus_dir, queries, top_ks, bm25_index, dense_index)
+        # Accuracy-leg regression protection: the SAME rrf fusion, weighted to match what `tg
+        # find` actually ships by default (SHIPPED_DENSE_WEIGHT) -- this is the arm
+        # tests/eval/test_retrieval_quality_regression.py's ndcg@10 floor measures. `rrf` above is
+        # untouched (still the old 1:1 comparison baseline), so this is purely additive.
+        arms["rrf_shipped"] = run_rrf_arm(
+            chunks,
+            corpus_dir,
+            queries,
+            top_ks,
+            bm25_index,
+            dense_index,
+            dense_weight=SHIPPED_DENSE_WEIGHT,
+            name="rrf_shipped",
+        )
 
         if late_reranker_override is not None:
             late_reranker, late_reason = late_reranker_override, None
@@ -629,10 +717,12 @@ def build_report(
                 pool_k=pool_k,
             )
 
-    # find/find+stack: ALWAYS skipped this wave (Wave 2c/Wave 3 not built) -- never silently
-    # omitted from the arm list.
-    arms["find"] = skipped_arm("find", SKIP_AWAITING_WAVE2)
-    arms["find+stack"] = skipped_arm("find+stack", SKIP_AWAITING_WAVE2)
+    # find/find+stack: `tg find`'s own CLI/MCP pipeline is built and shipped (v1.77.0/v1.78.0);
+    # this harness just has not been wired to invoke it end-to-end as a scored arm -- see
+    # SKIP_FIND_ARM_NOT_WIRED's own comment for the full history. Never silently omitted from the
+    # arm list.
+    arms["find"] = skipped_arm("find", SKIP_FIND_ARM_NOT_WIRED)
+    arms["find+stack"] = skipped_arm("find+stack", SKIP_FIND_ARM_NOT_WIRED)
 
     return Report(
         corpus_dir=str(corpus_dir),
@@ -667,9 +757,9 @@ def render_report(report: Report, top_ks: tuple[int, ...]) -> str:
             lines.append(f"  {name:12} scored")
         else:
             # `arm.reason` may already carry its own "skipped: ..." framing (e.g. find/find+stack's
-            # SKIP_AWAITING_WAVE2) or a bare unavailability message (e.g. dense's dense_available()
-            # reason) -- a single "--" separator reads cleanly either way, unlike wrapping every
-            # reason in a second, possibly-redundant "skipped (...)".
+            # SKIP_FIND_ARM_NOT_WIRED) or a bare unavailability message (e.g. dense's
+            # dense_available() reason) -- a single "--" separator reads cleanly either way,
+            # unlike wrapping every reason in a second, possibly-redundant "skipped (...)".
             lines.append(f"  {name:12} skipped -- {arm.reason}")
     lines.append("")
 

--- a/tests/eval/test_retrieval_quality_regression.py
+++ b/tests/eval/test_retrieval_quality_regression.py
@@ -1,0 +1,125 @@
+"""Accuracy-leg regression protection (#7): the ndcg@10 floor for `tg find`'s SHIPPED
+dense-weight config (the #191/#634 flip, live in production since v1.93.2).
+
+WHY THIS EXISTS: the dense-weight flip that lifted `tg find`'s NL ndcg@10 from 0.3047 to 0.4466
+(recall@10 0.55 -> 0.80) shipped straight to production with ZERO regression protection --
+``benchmarks/eval_late_rerank_quality.py``'s own ``run_rrf_arm`` called RRF with no weights (the
+OLD 1:1 pre-flip fusion) until this same change added the ``rrf_shipped`` arm (see that module's
+``SHIPPED_DENSE_WEIGHT`` constant and ``run_rrf_arm``'s ``dense_weight`` parameter). This test is
+the actual regression gate: it fails loudly if a future refactor silently reverts the shipped
+weighting back toward 1:1 fusion.
+
+Requires the REAL ``semantic`` extra (``model2vec`` + a fetched dense model at
+``~/.tensor-grep/models/potion-code-16M`` or ``TG_SEMANTIC_MODEL_DIR``) -- SKIPPED (not failed)
+when unavailable, mirroring ``build_dense_index``'s own graceful-degrade contract. No CI workflow
+currently installs the ``semantic`` extra + fetches the model (``ci.yml`` installs ``[dev,ast]``
+only; ``benchmark.yml`` installs ``[dev,ast]`` (+ optionally ``[bench,nlp]`` for the UNRELATED GPU
+suite) -- neither pulls in ``model2vec`` or fetches ``potion-code-16M``), so wiring this into any
+existing workflow would mean adding a brand-new network-dependent install step, not reusing a
+cheap existing slot. Per this campaign's own low-risk/benchmarks-only scoping for #7, this stays
+OPT-IN-LOCAL: ``eval`` marker, excluded from the default ``-m "not eval"`` CI sweep
+(``pyproject.toml``'s ``markers``), same discipline as ``tests/eval/test_agent_accuracy.py``.
+
+Run explicitly (mirrors that file's own documented invocation):
+
+    uv run --no-sync pytest tests/eval/test_retrieval_quality_regression.py -m eval -v -s
+
+Bidirectional-oracle proof (the corrupted-weight side of this gate, PR-body evidence): the SAME
+measurement, forced back to the pre-#7/pre-flip 1:1 fusion, must FAIL this floor --
+
+    TG_EVAL_FLOOR_DENSE_WEIGHT=1.0 uv run --no-sync pytest \\
+        tests/eval/test_retrieval_quality_regression.py -m eval -v -s
+
+FLOOR JUSTIFICATION: measured ndcg@10 at the shipped weight (5.0) is 0.4466; at the corrupted
+weight (1.0, the old fusion) it is 0.3047 -- a 0.1419 gap between "healthy" and "silently
+reverted". The harness is proven BYTE-DETERMINISTIC across repeated in-process runs against the
+real model + real corpus (``test_three_runs_identical`` /
+``test_build_report_is_deterministic_across_repeated_calls`` in
+``tests/unit/test_eval_late_rerank_quality.py``, 3/3 byte-identical), so there is effectively zero
+run-to-run NOISE to absorb -- the floor below is sized for margin against FUTURE incidental drift
+(a golden-set/corpus edit, a ``model2vec`` version bump subtly shifting embeddings), not run
+noise. 0.40 sits ~0.047 below the measured 0.4466 (room for that incidental drift) while remaining
+~0.095 *above* the corrupted value -- more than 2x the margin on the low side -- so it cannot
+accidentally pass a silent reversion to 1:1 fusion.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = [pytest.mark.eval, pytest.mark.slow]
+
+# Safely below the measured 0.4466 (see module docstring's FLOOR JUSTIFICATION) -- must be
+# cleared by tg find's shipped dense-weight config on the committed 40-query NL golden set.
+_NDCG10_FLOOR = 0.40
+
+
+def _load_eval_module() -> ModuleType:
+    """Mirrors ``tests/unit/test_eval_late_rerank_quality.py``'s own loader (this repo's
+    established pattern for testing a ``benchmarks/*.py`` script that is not part of the
+    installed ``tensor_grep`` package under ``--import-mode=importlib``)."""
+    root = Path(__file__).resolve().parents[2]
+    spec = importlib.util.spec_from_file_location(
+        "eval_late_rerank_quality", root / "benchmarks" / "eval_late_rerank_quality.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_shipped_dense_weight_config_meets_ndcg10_floor() -> None:
+    """Measures the REAL ``rrf`` arm (bm25 + dense fused via RRF) on the committed 40-query
+    golden set at the SHIPPED weight and asserts ndcg@10 clears the regression floor.
+
+    ``TG_EVAL_FLOOR_DENSE_WEIGHT`` (test-only escape hatch, read ONLY by this test -- never by any
+    production code) lets this exact assertion be re-run against a DIFFERENT weight for the
+    bidirectional-oracle proof without a second copy of this test; see the module docstring's
+    invocation examples. Defaults to ``SHIPPED_DENSE_WEIGHT`` (what actually ships).
+    """
+    mod = _load_eval_module()
+
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)
+    corpus_files = mod.load_corpus_files(mod.DEFAULT_CORPUS_DIR)
+    chunks = []
+    for path in corpus_files:
+        chunks.extend(mod.chunk_file(path))
+
+    dense_index, reason = mod.build_dense_index(chunks)
+    if dense_index is None:
+        pytest.skip(
+            "dense leg unavailable -- cannot measure the real shipped-config ndcg@10 (run "
+            f"`tg install-dense`, or pip install 'tensor-grep[semantic]' and fetch the model): "
+            f"{reason}"
+        )
+
+    weight = float(os.environ.get("TG_EVAL_FLOOR_DENSE_WEIGHT", mod.SHIPPED_DENSE_WEIGHT))
+    bm25_index = mod.Bm25Index(chunks)
+    arm = mod.run_rrf_arm(
+        chunks,
+        mod.DEFAULT_CORPUS_DIR,
+        queries,
+        (10,),
+        bm25_index,
+        dense_index,
+        dense_weight=weight,
+        name="rrf_floor_check",
+    )
+    assert arm.status == "scored"
+    ndcg10 = arm.mean("ndcg@10")
+
+    print(f"\nrrf ndcg@10={ndcg10:.4f} at dense_weight={weight} (floor={_NDCG10_FLOOR})")
+    assert ndcg10 >= _NDCG10_FLOOR, (
+        f"rrf ndcg@10={ndcg10:.4f} at dense_weight={weight} fell below the regression floor "
+        f"{_NDCG10_FLOOR} on the {len(queries)}-query golden set -- the accuracy-leg dense-weight "
+        "flip (#191/#634, shipped in v1.93.2) may have silently regressed. See this module's "
+        "docstring for the bidirectional-oracle proof (TG_EVAL_FLOOR_DENSE_WEIGHT=1.0 must FAIL "
+        "this same assertion) and the floor's justification."
+    )

--- a/tests/unit/test_eval_late_rerank_quality.py
+++ b/tests/unit/test_eval_late_rerank_quality.py
@@ -280,11 +280,12 @@ def test_arm_skipped_vs_scored_distinct() -> None:
     assert report.arms["bm25"].status == "scored"
     assert report.arms["dense"].status == "scored"
     assert report.arms["rrf"].status == "scored"
+    assert report.arms["rrf_shipped"].status == "scored"
     assert report.arms["rrf+maxsim"].status == "scored"
     assert report.arms["find"].status == "skipped"
-    assert report.arms["find"].reason == mod.SKIP_AWAITING_WAVE2
+    assert report.arms["find"].reason == mod.SKIP_FIND_ARM_NOT_WIRED
     assert report.arms["find+stack"].status == "skipped"
-    assert report.arms["find+stack"].reason == mod.SKIP_AWAITING_WAVE2
+    assert report.arms["find+stack"].reason == mod.SKIP_FIND_ARM_NOT_WIRED
 
     # a paired comparison across two SCORED arms works and covers every query exactly once...
     comparison = mod.paired_comparison(report.arms["bm25"], report.arms["dense"], "ndcg@10")
@@ -299,16 +300,31 @@ def test_arm_skipped_vs_scored_distinct() -> None:
 
 
 def test_dense_rrf_and_maxsim_skip_cleanly_without_the_optional_extras() -> None:
-    """In THIS environment (CI installs only [dev], per test_retrieval_dense.py's own
-    docstring), model2vec/onnxruntime are not installed -- dense/rrf/rrf+maxsim must degrade to
-    a clean, specific SKIPPED status, never crash and never silently score as though they ran."""
+    """When the dense leg is unavailable (CI installs only [dev], per test_retrieval_dense.py's
+    own docstring) -- dense/rrf/rrf_shipped/rrf+maxsim must degrade to a clean, specific SKIPPED
+    status, never crash and never silently score as though they ran.
+
+    ``dense_reason_override`` FORCES this scenario explicitly rather than relying on the ambient
+    environment actually lacking `model2vec`/a fetched model: a semantic-enabled dev venv (e.g. a
+    local `[semantic]` install with the model already fetched) would otherwise silently make this
+    assertion false and this test would incorrectly fail on a perfectly healthy machine -- proven
+    empirically while building the `rrf_shipped` arm (a semantic-enabled venv scored every leg
+    here before this override was added). Mirrors `test_corpus_hardness_bm25_near_floor`'s own
+    `dense_reason_override` usage above for the identical reason.
+    """
     mod = _load_eval_module()
     queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:2]
 
-    report = mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10))
+    report = mod.build_report(
+        queries,
+        mod.DEFAULT_CORPUS_DIR,
+        (5, 10),
+        dense_reason_override="test: dense leg forced off to verify the skip-cleanly contract "
+        "regardless of the ambient environment's installed extras",
+    )
 
     assert report.arms["bm25"].status == "scored"
-    for name in ("dense", "rrf", "rrf+maxsim"):
+    for name in ("dense", "rrf", "rrf_shipped", "rrf+maxsim"):
         arm = report.arms[name]
         assert arm.status == "skipped"
         assert arm.reason  # a specific, human-readable reason, never a bare None/empty string
@@ -318,12 +334,168 @@ def test_render_report_never_prints_a_verdict_over_skipped_arms() -> None:
     mod = _load_eval_module()
     queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:2]
 
-    report = mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10))
+    # Forced off for the same reason as test_dense_rrf_and_maxsim_skip_cleanly_without_the_
+    # optional_extras above: this test's premise ("only bm25 scores") must hold on ANY machine,
+    # not just one that happens to lack the `semantic` extra.
+    report = mod.build_report(
+        queries,
+        mod.DEFAULT_CORPUS_DIR,
+        (5, 10),
+        dense_reason_override="test: dense leg forced off so only bm25 is scored",
+    )
     text = mod.render_report(report, (5, 10))
 
     assert "not computed" in text  # only bm25 is scored -> no >=2-arm verdict is possible
     assert "find" in text
-    assert mod.SKIP_AWAITING_WAVE2 in text
+    assert mod.SKIP_FIND_ARM_NOT_WIRED in text
+
+
+# ---------------------------------------------------------------------------------------
+# Accuracy-leg regression protection (#7): dense_weight threading through run_rrf_arm /
+# run_rrf_maxsim_arm is a BYTE-IDENTICAL no-op at the default (every call site that predates #7),
+# and the new `rrf_shipped` arm is wired to the documented SHIPPED_DENSE_WEIGHT constant, not an
+# independently-drifting number. Pinned by spying on the real `reciprocal_rank_fusion` (mirrors
+# `test_oracle_bidirectional_catches_a_broken_metric`'s own module-attribute monkeypatch style
+# above) -- this pins the WIRING CONTRACT directly instead of depending on corpus-specific RRF
+# arithmetic, which is already covered end-to-end by test_retrieval_fusion.py's own
+# test_weights_changes_fused_order_in_expected_direction. The real ndcg@10 NUMBERS this wiring
+# produces on the full golden set (0.4466 at SHIPPED_DENSE_WEIGHT, requiring the real `semantic`
+# extra + a fetched model) are the separate regression FLOOR in
+# tests/eval/test_retrieval_quality_regression.py (opt-in, `eval` marker).
+# ---------------------------------------------------------------------------------------
+
+
+def test_run_rrf_arm_dense_weight_wiring_contract() -> None:
+    """dense_weight=1.0 (the default, and every pre-#7 call site) must call
+    `reciprocal_rank_fusion` with weights=None -- byte-identical to the function's original,
+    unparameterized behavior. A non-default value must build weights=[1.0, dense_weight], the
+    same two-entry shape `rank_chunks` (the production caller) builds internally."""
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:2]
+    # A small corpus slice keeps this test fast -- only the wiring is under test, not the numbers.
+    corpus_files = mod.load_corpus_files(mod.DEFAULT_CORPUS_DIR)[:3]
+    chunks = []
+    for path in corpus_files:
+        chunks.extend(mod.chunk_file(path))
+    bm25_index = mod.Bm25Index(chunks)
+    dense_index = mod.DenseIndex(chunks, _FakeDenseModel())
+
+    seen_weights: list[list[float] | None] = []
+    original_fusion = mod.reciprocal_rank_fusion
+
+    def _spy_fusion(
+        rankings: list[list[int]], *, k: int = mod.DEFAULT_K, weights: list[float] | None = None
+    ) -> list[int]:
+        seen_weights.append(weights)
+        return original_fusion(rankings, k=k, weights=weights)  # type: ignore[no-any-return]
+
+    try:
+        mod.reciprocal_rank_fusion = _spy_fusion  # type: ignore[attr-defined]
+        mod.run_rrf_arm(chunks, mod.DEFAULT_CORPUS_DIR, queries, (10,), bm25_index, dense_index)
+        assert seen_weights == [None] * len(queries), (
+            f"default dense_weight=1.0 must pass weights=None, got {seen_weights}"
+        )
+
+        seen_weights.clear()
+        mod.run_rrf_arm(
+            chunks,
+            mod.DEFAULT_CORPUS_DIR,
+            queries,
+            (10,),
+            bm25_index,
+            dense_index,
+            dense_weight=mod.SHIPPED_DENSE_WEIGHT,
+            name="rrf_shipped",
+        )
+    finally:
+        mod.reciprocal_rank_fusion = original_fusion  # type: ignore[attr-defined]
+
+    assert seen_weights == [[1.0, mod.SHIPPED_DENSE_WEIGHT]] * len(queries), (
+        f"dense_weight={mod.SHIPPED_DENSE_WEIGHT} must pass "
+        f"weights=[1.0, {mod.SHIPPED_DENSE_WEIGHT}], got {seen_weights}"
+    )
+
+
+def test_run_rrf_maxsim_arm_dense_weight_wiring_contract() -> None:
+    """The identical wiring contract as run_rrf_arm above, for run_rrf_maxsim_arm's OWN
+    `reciprocal_rank_fusion` call -- a separate call site with the same latent no-weights gap
+    before #7."""
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:2]
+    corpus_files = mod.load_corpus_files(mod.DEFAULT_CORPUS_DIR)[:3]
+    chunks = []
+    for path in corpus_files:
+        chunks.extend(mod.chunk_file(path))
+    bm25_index = mod.Bm25Index(chunks)
+    dense_index = mod.DenseIndex(chunks, _FakeDenseModel())
+    late_reranker = mod.LateReranker(encode=_fake_late_encode)
+
+    seen_weights: list[list[float] | None] = []
+    original_fusion = mod.reciprocal_rank_fusion
+
+    def _spy_fusion(
+        rankings: list[list[int]], *, k: int = mod.DEFAULT_K, weights: list[float] | None = None
+    ) -> list[int]:
+        seen_weights.append(weights)
+        return original_fusion(rankings, k=k, weights=weights)  # type: ignore[no-any-return]
+
+    try:
+        mod.reciprocal_rank_fusion = _spy_fusion  # type: ignore[attr-defined]
+        mod.run_rrf_maxsim_arm(
+            chunks, mod.DEFAULT_CORPUS_DIR, queries, (10,), bm25_index, dense_index, late_reranker
+        )
+        assert seen_weights == [None] * len(queries), (
+            f"default dense_weight=1.0 must pass weights=None, got {seen_weights}"
+        )
+
+        seen_weights.clear()
+        mod.run_rrf_maxsim_arm(
+            chunks,
+            mod.DEFAULT_CORPUS_DIR,
+            queries,
+            (10,),
+            bm25_index,
+            dense_index,
+            late_reranker,
+            dense_weight=3.0,
+        )
+    finally:
+        mod.reciprocal_rank_fusion = original_fusion  # type: ignore[attr-defined]
+
+    assert seen_weights == [[1.0, 3.0]] * len(queries), (
+        f"dense_weight=3.0 must pass weights=[1.0, 3.0], got {seen_weights}"
+    )
+
+
+def test_build_report_rrf_shipped_matches_direct_call_at_shipped_weight() -> None:
+    """`build_report`'s `rrf_shipped` arm must be EXACTLY what calling `run_rrf_arm(...,
+    dense_weight=SHIPPED_DENSE_WEIGHT)` produces on the same corpus -- no second, independently
+    drifting weight value hardcoded inside build_report."""
+    mod = _load_eval_module()
+    queries = mod.load_golden_queries(mod.DEFAULT_GOLDEN_PATH)[:6]
+    corpus_files = mod.load_corpus_files(mod.DEFAULT_CORPUS_DIR)
+    chunks = []
+    for path in corpus_files:
+        chunks.extend(mod.chunk_file(path))
+    dense_index = mod.DenseIndex(chunks, _FakeDenseModel())
+    bm25_index = mod.Bm25Index(chunks)
+
+    report = mod.build_report(
+        queries, mod.DEFAULT_CORPUS_DIR, (5, 10), dense_index_override=dense_index
+    )
+    direct = mod.run_rrf_arm(
+        chunks,
+        mod.DEFAULT_CORPUS_DIR,
+        queries,
+        (5, 10),
+        bm25_index,
+        dense_index,
+        dense_weight=mod.SHIPPED_DENSE_WEIGHT,
+        name="rrf_shipped",
+    )
+
+    assert report.arms["rrf_shipped"].status == "scored"
+    assert report.arms["rrf_shipped"].per_query == direct.per_query
 
 
 # ---------------------------------------------------------------------------------------

--- a/tests/unit/test_eval_late_rerank_quality.py
+++ b/tests/unit/test_eval_late_rerank_quality.py
@@ -521,3 +521,19 @@ def test_build_report_is_deterministic_across_repeated_calls() -> None:
     second = mod.render_report(mod.build_report(queries, mod.DEFAULT_CORPUS_DIR, (5, 10)), (5, 10))
 
     assert first == second
+
+
+def test_shipped_dense_weight_mirror_matches_the_real_cli_default() -> None:
+    """Drift pin (item-#7 fold): the harness deliberately mirrors the CLI's private
+    default as a local ``SHIPPED_DENSE_WEIGHT`` constant instead of importing across the
+    benchmarks/cli boundary. That is the right layering -- but an UN-PINNED mirror recreates
+    the exact blind spot this harness change closes: if ``tg find``'s shipped default ever
+    moves, the regression floor would silently keep measuring the old weight. This test is
+    the sync contract: change one, change both (and re-derive the floor)."""
+    from tensor_grep.cli.main import _FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT
+
+    assert _load_eval_module().SHIPPED_DENSE_WEIGHT == _FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT, (
+        "benchmarks/eval_late_rerank_quality.SHIPPED_DENSE_WEIGHT no longer matches "
+        "cli/main._FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT -- update the mirror AND re-derive "
+        "the ndcg regression floor in tests/eval/test_retrieval_quality_regression.py"
+    )


### PR DESCRIPTION
## Summary

Implements RANKED-QUEUE ITEM #7 of the +10% campaign: the shipped v1.93.2 dense-weight flip
(#191/#634, NL ndcg@10 0.3047->0.4466) had ZERO regression protection. This PR closes that gap
with benchmarks/tests-only infra -- no production source touched.

- **Thread `dense_weight`** through `run_rrf_arm`/`run_rrf_maxsim_arm` in
  `benchmarks/eval_late_rerank_quality.py` (byte-identical no-op at the default 1.0 -- every
  pre-existing call site is unaffected). Adds a fresh local `SHIPPED_DENSE_WEIGHT = 5.0` constant
  mirroring `cli/main.py`'s private `_FIND_DENSE_WEIGHT_ADAPTIVE_DEFAULT` (not imported, per the
  same "fresh local constant" precedent `DEFAULT_POOL_K` already sets for `reranker.py`'s private
  pool-size constant -- avoids dragging the ~17k-line CLI module into a benchmarks script).
- **New `rrf_shipped` arm** in `build_report`: the same bm25+dense RRF fusion as `rrf`, weighted to
  match what `tg find` actually ships. `rrf` itself is untouched (kept as the old 1:1 comparison
  baseline, clearly labeled).
- **New opt-in regression floor**: `tests/eval/test_retrieval_quality_regression.py`, `eval`
  marker (excluded from the default `-m "not eval"` CI sweep -- same discipline as
  `tests/eval/test_agent_accuracy.py`), asserts `ndcg@10 >= 0.40` on the committed 40-query golden
  set at the shipped weight.
- **Fixed the stale skip message**: `find`/`find+stack` used to claim "tg find pipeline not built
  yet" -- false since v1.77.0 (`tg find`'s CLI shipped that release, MCP followed in v1.78.0; see
  docs/BACKLOG.md #189). Renamed `SKIP_AWAITING_WAVE2` to `SKIP_FIND_ARM_NOT_WIRED` with an honest
  message: the pipeline exists, this harness just hasn't been wired to invoke it end-to-end yet.
- Hardened 2 pre-existing tests in `tests/unit/test_eval_late_rerank_quality.py` that silently
  assumed the ambient environment lacks `model2vec` (discovered while building this PR in a
  semantic-enabled venv) with explicit `dense_reason_override=...`, and added 4 new tests pinning
  the `dense_weight` wiring contract plus the `rrf_shipped`/`SHIPPED_DENSE_WEIGHT` consistency.

## The three blind-spot verifications (file:line, all confirmed true at HEAD 4e471cc / v1.93.2)

**(a) `run_rrf_arm` called RRF with no weights.** Confirmed --
`benchmarks/eval_late_rerank_quality.py` (pre-PR, line 372) called
`reciprocal_rank_fusion([bm25_ranking, dense_ranking], k=DEFAULT_K)` with no `weights=`,
reproducing only the OLD pre-flip 1:1 fusion. Independently re-measured before touching any code:
`rrf` ndcg@10 = **0.3047** (byte-identical to the ranked-queue's own number) on the real 40-query
golden set plus the real fetched dense model.

**(b) The `find` arm is unconditionally stubbed, stale since v1.77.0.** Confirmed --
`SKIP_AWAITING_WAVE2 = "skipped: awaiting-wave-2 (tg find pipeline not built yet)"` (pre-PR, line
108) is FALSE: `docs/BACKLOG.md` records `tg find`'s CLI (Wave 2b/2c, #626) shipping in v1.77.0 and
its MCP tool (Wave 2d, #627) in v1.78.0. **Decision: kept the arms skipped, did NOT force a real
`tg find` scoring integration** -- item #7's own text never claims the *harness-wiring* machinery
exists (only that the *pipeline* itself exists), the item's "Implementation" bullet scopes this as
"benchmarks-only patch + a CI job... LOW risk", and actually invoking `tg find`'s CLI pipeline
end-to-end inside this chunk-granularity harness (different chunking/corpus-scoping assumptions,
budget truncation, `MatchLine` vs `Chunk` shapes) is a real, separate integration task -- forcing
it here would be scope creep on a task explicitly bounded to "results-identical infra". Fixed the
lie instead of the scope: renamed to `SKIP_FIND_ARM_NOT_WIRED` with an honest reason.

**(c) Nothing in `.github/workflows/` invokes this harness.** Confirmed -- grepping
`eval_late_rerank_quality` across `.github/workflows/` returns zero hits; `benchmark.yml` is a
weekly-cron, speed-only suite (`run_benchmarks.py`/`run_ast_benchmarks.py`/`run_gpu_benchmarks.py`,
throughput smoke); `ci.yml` explicitly excludes the `eval` marker from its main sweep
(`pytest tests -v --tb=short -m "not eval"`, ci.yml line 413) and nothing else runs `tests/eval/`.

## Floor rationale (0.40)

Independently re-measured, byte-identical to the ranked-queue's prediction: shipped weight (5.0)
ndcg@10 = **0.4466**; corrupted/old weight (1.0) ndcg@10 = **0.3047** (recall@10 0.5500 to 0.8000,
+0.25 -- also byte-identical to the historical claim). The harness is proven BYTE-DETERMINISTIC
against the real model and real corpus (`test_three_runs_identical` /
`test_build_report_is_deterministic_across_repeated_calls`, 3/3 identical, re-verified in this
PR's own venv), so there is effectively **zero run-to-run noise** to absorb -- 0.40 is sized for
margin against FUTURE incidental drift (a golden-set edit, a `model2vec` version bump), not noise:
it sits about 0.047 below the measured 0.4466 while remaining about 0.095 (2x the margin) *above*
the corrupted value, so it cannot accidentally pass a silent reversion to 1:1 fusion.

## Bidirectional oracle proof

PASS at the shipped weight (5.0, the default):

```
tests/eval/test_retrieval_quality_regression.py::test_shipped_dense_weight_config_meets_ndcg10_floor
rrf ndcg@10=0.4466 at dense_weight=5.0 (floor=0.4)
PASSED
============================== 1 passed in 3.02s ==============================
```

FAIL at the corrupted weight (1.0, forced via the test-only `TG_EVAL_FLOOR_DENSE_WEIGHT` escape
hatch -- read ONLY by this test, never by production code):

```
TG_EVAL_FLOOR_DENSE_WEIGHT=1.0 pytest tests/eval/test_retrieval_quality_regression.py -v -s
tests/eval/test_retrieval_quality_regression.py::test_shipped_dense_weight_config_meets_ndcg10_floor
rrf ndcg@10=0.3047 at dense_weight=1.0 (floor=0.4)
FAILED
E   AssertionError: rrf ndcg@10=0.3047 at dense_weight=1.0 fell below the regression floor 0.4 ...
E   assert 0.3046733520524516 >= 0.4
============================== 1 failed in 3.61s ==============================
```

## CI wiring decision: opt-in-local, NOT wired into any workflow

No existing workflow is a cheap slot: `ci.yml` excludes `eval` from its main sweep and nothing
else runs `tests/eval/`; `benchmark.yml` (the only scheduled workflow) installs `[dev,ast]` only,
no `semantic` extra, no dense-model fetch. Wiring this in would mean adding a brand new,
unmeasured CI capability (install `model2vec` and fetch/verify a 63MB model over the network) with
zero existing affordability evidence, which the task explicitly says not to do without evidence.
Left opt-in-local instead, documented in both the harness's own docstring and the new test file's
docstring/invocation instructions (mirrors `tests/eval/test_agent_accuracy.py`'s existing "run
explicitly with `pytest tests/eval -m eval -v -s`" convention).

## Verification

- `ruff check` + `ruff format --check --preview`: clean on all 3 touched/new files.
- `mypy` (strict): clean on `benchmarks/eval_late_rerank_quality.py` and the new
  `tests/eval/test_retrieval_quality_regression.py`. `tests/unit/test_eval_late_rerank_quality.py`
  carries 2 PRE-EXISTING `attr-defined` errors on `mod.ndcg_at_k` (independently verified present
  on the unmodified file at `origin/main`; `tests/` is outside CI's `mypy src/tensor_grep` gate) --
  the 4 new `mod.reciprocal_rank_fusion` call sites use the identical established pattern with
  explicit `# type: ignore[attr-defined]`, adding zero new mypy errors.
- `tests/unit/test_eval_late_rerank_quality.py`: 20/20 pass (2 were pre-existing environment-
  fragile failures in a semantic-enabled venv -- independently reproduced on the file BEFORE any
  edit, then hardened with explicit `dense_reason_override=...`).
- `tests/eval/test_retrieval_quality_regression.py`: verified both directions above.
- Combined run of both files together: 21/21 pass.
- Confirmed via `--collect-only -m "not eval"` that the new floor test is correctly EXCLUDED (3
  deselected = 2 in `test_agent_accuracy.py` + 1 new, matching exactly).
- No production source touched: the PR diff touches only `benchmarks/eval_late_rerank_quality.py`,
  `tests/unit/test_eval_late_rerank_quality.py` (modified), and
  `tests/eval/test_retrieval_quality_regression.py` (new).

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check --preview` clean
- [x] `mypy` clean (zero new errors vs baseline)
- [x] New floor test demonstrated red (corrupted weight) then green (shipped weight)
- [x] All existing + new unit tests green (21/21)
- [x] No production source (main.py/repo_map.py/agent_capsule.py) touched

Generated with [Claude Code](https://claude.com/claude-code)
