### PR TITLE
perf(repo-map): O(k) source truncation via running length (byte-identical)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -8856,15 +8856,23 @@ def _render_context_parts(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return parts
 
 
+def _estimate_tokens_for_len(length: int) -> int:
+    """The SINGLE source of the chars->tokens estimate. `_estimate_tokens` (the text-taking
+    wrapper) and `_truncate_source_text_to_budget`'s running-length fast path MUST both go
+    through here -- a duplicated formula would let the truncation loop silently desync from
+    the budget check if the estimate ever changes."""
+    if length <= 0:
+        return 0
+    return max(1, math.ceil(length / 3.5))
+
+
 def _estimate_tokens(
     text: str,
     *,
     _profiling_collector: _ProfileCollector | None = None,
 ) -> int:
     with _profiling_phase(_profiling_collector, "token_estimation"):
-        if not text:
-            return 0
-        return max(1, math.ceil(len(text) / 3.5))
+        return _estimate_tokens_for_len(len(text))
 
 
 def _line_map_for_budgeted_lines(
@@ -8951,10 +8959,8 @@ def _truncate_source_text_to_budget(
     def _within_budget_for_len(candidate_len: int) -> bool:
         if max_chars is not None and candidate_len > max_chars:
             return False
-        if max_tokens is not None:
-            estimated_tokens = 0 if candidate_len <= 0 else max(1, math.ceil(candidate_len / 3.5))
-            if estimated_tokens > max_tokens:
-                return False
+        if max_tokens is not None and _estimate_tokens_for_len(candidate_len) > max_tokens:
+            return False
         return True
 
     lines = text.splitlines(keepends=True)

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -8936,21 +8936,39 @@ def _truncate_source_text_to_budget(
         line_count = len(text.splitlines())
         return text, list(range(1, line_count + 1)), False
 
+    # perf (O(k^2) -> O(k)): `_source_text_within_budget` (and the `_estimate_tokens` it calls) is
+    # a PURE function of `len(text)` -- `_estimate_tokens` is `max(1, ceil(len(text)/3.5))` (0 for
+    # an empty string) and never reads text content, only `len(text)`, `max_tokens`, `max_chars`
+    # (see the two functions right above this one). The two loops below used to rebuild the FULL
+    # candidate string on every iteration just to hand it to that length-only check
+    # (`"".join([*selected_lines, line])`, and the same shape rebuilding `candidate_lines` in the
+    # tail-rescue loop) -- each rebuild is O(current total length), making the loops O(k^2) on a
+    # k-line file. `_within_budget_for_len` reproduces the identical pass/fail decision from a
+    # running integer length instead, so `selected_lines`/`selected_indexes`/the final joined text
+    # come out byte-identical while both loops become O(k) (see
+    # tests/unit/test_token_budget.py::test_truncate_*_is_byte_identical for the pinned-output
+    # regression coverage, captured from this function before the rewrite).
+    def _within_budget_for_len(candidate_len: int) -> bool:
+        if max_chars is not None and candidate_len > max_chars:
+            return False
+        if max_tokens is not None:
+            estimated_tokens = 0 if candidate_len <= 0 else max(1, math.ceil(candidate_len / 3.5))
+            if estimated_tokens > max_tokens:
+                return False
+        return True
+
     lines = text.splitlines(keepends=True)
     selected_lines: list[str] = []
     selected_indexes: list[int] = []
+    running_len = 0
 
     for index, line in enumerate(lines, start=1):
-        candidate = "".join([*selected_lines, line])
-        if not _source_text_within_budget(
-            candidate,
-            max_tokens=max_tokens,
-            max_chars=max_chars,
-            _profiling_collector=_profiling_collector,
-        ):
+        candidate_len = running_len + len(line)
+        if not _within_budget_for_len(candidate_len):
             break
         selected_lines.append(line)
         selected_indexes.append(index)
+        running_len = candidate_len
 
     tail_line: tuple[int, str] | None = None
     for index in range(len(lines), 0, -1):
@@ -8961,32 +8979,23 @@ def _truncate_source_text_to_budget(
             break
 
     if tail_line is not None and tail_line[0] not in selected_indexes:
+        tail_text = tail_line[1]
+        tail_len = len(tail_text)
         last_selected = max(selected_indexes, default=0)
         omitted_between = max(0, tail_line[0] - last_selected - 1)
         marker = f"# ... {omitted_between} lines omitted by source budget ...\n"
-        candidate_lines = [*selected_lines, marker, tail_line[1]]
-        candidate_indexes = [*selected_indexes, 0, tail_line[0]]
-        while selected_lines and not _source_text_within_budget(
-            "".join(candidate_lines),
-            max_tokens=max_tokens,
-            max_chars=max_chars,
-            _profiling_collector=_profiling_collector,
-        ):
-            selected_lines.pop()
+        candidate_len = running_len + len(marker) + tail_len
+        while selected_lines and not _within_budget_for_len(candidate_len):
+            popped = selected_lines.pop()
             selected_indexes.pop()
+            running_len -= len(popped)
             last_selected = max(selected_indexes, default=0)
             omitted_between = max(0, tail_line[0] - last_selected - 1)
             marker = f"# ... {omitted_between} lines omitted by source budget ...\n"
-            candidate_lines = [*selected_lines, marker, tail_line[1]]
-            candidate_indexes = [*selected_indexes, 0, tail_line[0]]
-        if _source_text_within_budget(
-            "".join(candidate_lines),
-            max_tokens=max_tokens,
-            max_chars=max_chars,
-            _profiling_collector=_profiling_collector,
-        ):
-            selected_lines = candidate_lines
-            selected_indexes = candidate_indexes
+            candidate_len = running_len + len(marker) + tail_len
+        if _within_budget_for_len(candidate_len):
+            selected_lines = [*selected_lines, marker, tail_text]
+            selected_indexes = [*selected_indexes, 0, tail_line[0]]
 
     if not selected_lines and lines:
         chunk = lines[0]

--- a/tests/unit/test_token_budget.py
+++ b/tests/unit/test_token_budget.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -1012,3 +1013,190 @@ def test_cli_session_context_render_accepts_max_tokens_and_model(tmp_path: Path)
     assert payload["max_tokens"] == 48
     assert payload["model"] == "gpt-test"
     _assert_within_budget(payload, 48)
+
+
+# --- perf campaign #1: O(k^2) source-truncation rebuild -> O(k) running length -------------------
+#
+# `_truncate_source_text_to_budget` used to rebuild the whole candidate string on every line
+# (`"".join([*selected_lines, line])`) just to hand it to `_source_text_within_budget`, which only
+# ever reads `len(text)` -- an O(k) loop doing O(current-length) work per iteration, i.e. O(k^2)
+# overall, with the same shape in the tail-rescue loop. The fix replaces the string-rebuild with a
+# running integer length. These tests pin the EXACT (byte-identical) output of the unmodified
+# function on 3+ realistic inputs -- captured from the real (pre-fix) implementation -- so the
+# rewrite can be checked against them: green before, green after, or the two are not behaviorally
+# equivalent and the PR must stop and report the divergence.
+
+
+def _large_synthetic_source(function_count: int, lines_per_function: int) -> str:
+    """Deterministic large multi-function synthetic source: many small functions, each ending in a
+    `return` line -- shaped like this repo's own large modules (repo_map.py/main.py) without
+    depending on their live content, which would churn the pinned hash on unrelated edits.
+    """
+    parts: list[str] = []
+    for fn_index in range(function_count):
+        parts.append(f"def helper_function_{fn_index:05d}(value):\n")
+        for line_index in range(lines_per_function):
+            parts.append(f"    step_{line_index} = value + {fn_index} + {line_index}\n")
+        parts.append(f"    return step_{lines_per_function - 1}\n")
+        parts.append("\n")
+    return "".join(parts)
+
+
+def _tail_rescue_source(filler_count: int) -> str:
+    return (
+        "def build_payload():\n"
+        "    payload = {\n"
+        + "".join(f"        'field_{index:05d}': {index},\n" for index in range(filler_count))
+        + "    }\n"
+        "    raise RuntimeError('boom')\n"
+    )
+
+
+def test_truncate_no_truncation_case_is_byte_identical_to_pinned_golden() -> None:
+    text = (
+        "def add_totals(values):\n"
+        "    total = 0\n"
+        "    for value in values:\n"
+        "        total += value\n"
+        "    return total\n"
+    )
+
+    truncated, selected_indexes, was_truncated = repo_map._truncate_source_text_to_budget(
+        text,
+        max_tokens=10_000,
+        max_chars=None,
+    )
+
+    assert was_truncated is False
+    assert truncated == text
+    assert selected_indexes == [1, 2, 3, 4, 5]
+    assert (
+        hashlib.sha256(truncated.encode("utf-8")).hexdigest()
+        == "11c508bd37d3bcfed7d71adf072fb2f2288deea653aba1e25a6eb553b4e9ea08"
+    )
+
+
+def test_truncate_tail_rescue_with_pops_is_byte_identical_to_pinned_golden() -> None:
+    text = _tail_rescue_source(300)
+
+    truncated, selected_indexes, was_truncated = repo_map._truncate_source_text_to_budget(
+        text,
+        max_tokens=60,
+        max_chars=None,
+    )
+
+    assert was_truncated is True
+    assert selected_indexes == [1, 2, 3, 4, 5, 0, 304]
+    assert len(truncated) == 190
+    assert (
+        hashlib.sha256(truncated.encode("utf-8")).hexdigest()
+        == "a539cbd75bb6c6c7198077e3b5929940b7c85c5b809a8fdd9f59878062c58d30"
+    )
+
+
+def test_truncate_tail_rescue_pops_down_to_marker_and_tail_is_byte_identical() -> None:
+    text = _tail_rescue_source(300)
+
+    truncated, selected_indexes, was_truncated = repo_map._truncate_source_text_to_budget(
+        text,
+        max_tokens=24,
+        max_chars=None,
+    )
+
+    assert was_truncated is True
+    assert selected_indexes == [0, 304]
+    assert len(truncated) == 75
+    assert (
+        hashlib.sha256(truncated.encode("utf-8")).hexdigest()
+        == "139cdd360f744d148afd092e18fc8b422d5ef34295dad3cc680db83aad950ffb"
+    )
+
+
+def test_truncate_large_file_default_16000_token_budget_is_byte_identical() -> None:
+    text = _large_synthetic_source(function_count=1000, lines_per_function=8)
+    assert len(text.splitlines()) == 11_000  # sanity: matches the pinned capture below
+
+    truncated, selected_indexes, was_truncated = repo_map._truncate_source_text_to_budget(
+        text,
+        max_tokens=16_000,
+        max_chars=None,
+    )
+
+    assert was_truncated is True
+    assert len(truncated) == 55_990
+    assert len(selected_indexes) == 2194
+    assert selected_indexes[:5] == [1, 2, 3, 4, 5]
+    assert selected_indexes[-5:] == [2190, 2191, 2192, 0, 10999]
+    assert (
+        hashlib.sha256(truncated.encode("utf-8")).hexdigest()
+        == "4be53b46493acd231dd83a05c2838a192e6b4907a45cad3ad7af45839f7f19b4"
+    )
+
+
+def test_truncate_large_file_raised_60000_token_budget_is_byte_identical() -> None:
+    text = _large_synthetic_source(function_count=1000, lines_per_function=8)
+
+    truncated, selected_indexes, was_truncated = repo_map._truncate_source_text_to_budget(
+        text,
+        max_tokens=60_000,
+        max_chars=None,
+    )
+
+    assert was_truncated is True
+    assert len(truncated) == 209_977
+    assert len(selected_indexes) == 8137
+    assert selected_indexes[:5] == [1, 2, 3, 4, 5]
+    assert selected_indexes[-5:] == [8133, 8134, 8135, 0, 10999]
+    assert (
+        hashlib.sha256(truncated.encode("utf-8")).hexdigest()
+        == "f9c937012d96bd76fbeb0fa121b2cb675ae17e3547ade35e19bba90e1c640846"
+    )
+
+
+def test_truncate_large_file_does_not_call_budget_check_proportionally_to_line_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structural (non-flaky) perf-sanity check for the O(k^2) fix.
+
+    The OLD implementation called the real `_source_text_within_budget` (and therefore
+    `_estimate_tokens`) once per surviving line inside the main truncation loop -- 2194 times for
+    this exact 11,000-line/16000-token case (see the golden test above) -- each call handed a
+    freshly `"".join(...)`-rebuilt candidate string, which is what made it O(k^2). The fixed
+    implementation tracks a running integer length via a local closure instead, so it must call the
+    module-level `_source_text_within_budget` at most a small constant number of times (just the
+    single upfront "does the whole text already fit" check), independent of the file's line count.
+    A wall-clock bound would be a flaky floor on a shared box (anti-hang-test-protocol); a call-count
+    bound is deterministic regardless of machine speed.
+    """
+    call_count = 0
+    real_within_budget = repo_map._source_text_within_budget
+
+    def _counting_within_budget(
+        text: str,
+        *,
+        max_tokens: int | None,
+        max_chars: int | None,
+        _profiling_collector: object | None = None,
+    ) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return real_within_budget(
+            text,
+            max_tokens=max_tokens,
+            max_chars=max_chars,
+            _profiling_collector=_profiling_collector,  # type: ignore[arg-type]
+        )
+
+    monkeypatch.setattr(repo_map, "_source_text_within_budget", _counting_within_budget)
+
+    text = _large_synthetic_source(function_count=1000, lines_per_function=8)
+    assert len(text.splitlines()) == 11_000
+
+    repo_map._truncate_source_text_to_budget(text, max_tokens=16_000, max_chars=None)
+
+    assert call_count <= 5, (
+        f"_source_text_within_budget was called {call_count} times while truncating an "
+        "11,000-line file at a 16000-token budget (2194 lines survive) -- expected a small "
+        "constant independent of line count, not one call per surviving line (O(k) rebuild "
+        "regression?)."
+    )


### PR DESCRIPTION
## Summary

Ranked-queue item #1: kill the O(k^2) source-truncation rebuild in
`_truncate_source_text_to_budget` (`repo_map.py`). **Results-identical perf** — byte-identical
output is the whole contract, proven below.

## Mechanism (verified against HEAD, file:line)

`_truncate_source_text_to_budget` (`src/tensor_grep/cli/repo_map.py:8923-9008` at HEAD) rebuilt
the whole candidate string on **every line** of its main loop —
`candidate = "".join([*selected_lines, line])` (`:8944`) — just to hand it to
`_source_text_within_budget`, an O(k) loop doing O(current-total-length) work per iteration, i.e.
O(k²) on a k-line file. The tail-rescue loop (`:8967-8981`) rebuilt `"".join(candidate_lines)` on
every pop with the identical shape.

**Equivalence proof (verify-first, before writing any code):** `_source_text_within_budget`
(`:8902`) and the `_estimate_tokens` it calls (`:8859`, `max(1, ceil(len(text)/3.5))`, `0` for an
empty string) are **pure functions of `len(text)`** — neither reads text content, only
`len(text)`/`max_tokens`/`max_chars`. The only side channel is `_profiling_phase`
(`_ProfilePhase.__enter__`/`__exit__`, lines ~410-432), which is a pure wall-clock timing recorder
with **zero effect on any returned value** — confirmed by reading its `__enter__`/`__exit__` and by
grepping the whole test suite for `token_estimation` (the phase name `_estimate_tokens` records
under): it has **zero test coverage on call count**, so the rewrite's incidental reduction in
`token_estimation` phase calls (an untested, diagnostic-only side effect of removing the redundant
budget checks) is not a behavior change in the sense this PR's contract cares about.

This equivalence is what makes a running-integer-length rewrite behavior-preserving: a local
`_within_budget_for_len(candidate_len: int) -> bool` closure reproduces the identical pass/fail
decision from a running integer length instead of a rebuilt string. Both loops became O(k);
separator/marker lengths (`# ... N lines omitted...`) are accounted for exactly so the running
total always equals `len("".join(...))`.

## TDD proof

**(a) Golden byte-identical pin** — 5 tests in `tests/unit/test_token_budget.py`, each asserting
sha256 + length + `selected_indexes` against values **captured from the unmodified function**
(confirmed green before the rewrite, still green after):
- no-truncation case (early-return path, untouched by this PR)
- tail-rescue with several pops (`max_tokens=60` on a 304-line fixture)
- tail-rescue popping all the way down to marker+tail only (`max_tokens=24`)
- synthetic 11,000-line / 284,120-char "large file" (many small functions, matches this repo's own
  16.9k/18.3k-line worst case in shape) at the **16000-token default**
- the same large file at a **raised 60000-token budget**

**(b) Structural perf-sanity test (non-flaky)** — spies on `_source_text_within_budget` via
`monkeypatch` and asserts it is called at most a small constant number of times regardless of line
count (no wall-clock floor, per anti-hang-test-protocol). **RED on the unmodified function**
(2200 calls — proportional to the 2194 lines that survive the budget) → **GREEN after the fix**
(O(1) calls: just the single upfront "does the whole text already fit" check).

All 44 tests in `test_token_budget.py` pass, plus 219 tests across the repo_map/context/profiling
suites (`test_profiling_harness.py`, `test_profiling_cli_mcp.py`,
`test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py`,
`test_context_render_default_cap.py`, `test_context_token_budget.py`,
`test_mcp_context_default_cap.py`, `test_medlow2_repo_map.py`,
`test_refs_context_pack_deadline_205.py`, `test_repo_map_binary_detection.py`,
`test_repo_map_cache.py`, `test_repo_map_deadline.py`, `test_repo_map_graph.py`,
`test_repo_map_lexical_ranking.py`, `test_repo_map_partial_propagation.py`,
`test_repo_map_spans.py`, `test_repo_map_targets.py`), plus all `test_agent_capsule_*.py` suites
and `test_cli_bootstrap.py`.

A broader `tests/unit` sweep (2300+ tests across two runs) surfaced exactly 3 failures, **all
confirmed pre-existing and unrelated**:
- `test_cli_modes.py::test_search_generate_help_lists_only_supported_generators` and
  `test_cli_bootstrap.py::test_root_help_should_surface_current_agent_gpu_launcher_and_validation_
  contracts` (shell-completion / root-help-text assertions, nothing to do with `repo_map.py`) —
  both reproduce **identically on the unmodified pre-fix source tree under the same test
  ordering**, and both pass cleanly in isolation: order-dependent/environment-sensitive flakiness
  in those two large CLI-surface files.
- `test_cpu_backend.py::TestCPUBackend::test_should_includeAfterContext_when_dashA_isProvided` —
  `ModuleNotFoundError: No module named 'tensor_grep.rust_core'`. An environment fact, not a code
  issue: this worktree's shared venv has no compiled Rust extension (correctly — this PR never ran
  cargo/rustc/maturin, per the CPU-SAFE constraint), and the same failure reproduces identically on
  the unmodified old snapshot.

None of the three touch `repo_map.py`, `_truncate_source_text_to_budget`, or any context/repo_map
rendering path.

## MEASURE

### Micro-benchmark (function-level, old snapshot vs fixed, real files from the pinned tg v1.93.2
clone, `<opt10>/corpora/tg-pinned`)

5 reps each, median reported, byte-identical output verified (sha256 + length match on every row):

| file | lines | max_tokens | old (median) | new (median) | speedup |
|---|---|---|---|---|---|
| agent_capsule.py | 3,604 | 16000 | 26.00ms | 1.29ms | **20.2x** |
| agent_capsule.py | 3,604 | 60000 | 0.54ms | 0.57ms | 0.9x (no truncation either way — early-return path) |
| main.py | 16,897 | 16000 | 16.73ms | 4.76ms | **3.5x** |
| main.py | 16,897 | 60000 | 354.15ms | 5.57ms | **63.6x** |
| repo_map.py | 18,270 | 16000 | 33.43ms | 3.47ms | **9.6x** |
| repo_map.py | 18,270 | 60000 | 457.99ms | 7.25ms | **63.1x** |

Matches the queue item's predicted order of magnitude (8.5x/84x) — repo_map.py at the default
budget lands at 9.6x (predicted 8.5x) and at the raised budget lands at 63.1x (predicted 83.7x;
same order of magnitude, file-content-dependent).

### End-to-end A/B (`tg context-render` / `tg context`, source-tree PYTHONPATH before/after,
pinned tg-v1.93.2 corpus (1011 files) as target, `TG_SESSION_DAEMON_AUTOSTART=0` so every rep is
genuinely cold)

**Verify-first finding on the queue item's own "Cells:" line:** `tg context` (`build_context_pack`)
does **not** reach `_truncate_source_text_to_budget` at all — traced its full call path
(`build_context_pack` → `build_context_pack_from_map` → `_apply_context_token_budget`, which only
shrinks the ranked **file count**, never renders per-symbol source text) and confirmed
`_apply_source_output_budget`/`_truncate_source_text_to_budget` have exactly one call site each,
both inside `build_context_render_from_map` (only reached by `context-render`, `route-test`, and
`agent_capsule.py:2858`'s `build_context_render_from_map` call — never by plain `context`). Ran
`tg context` anyway per the literal instruction (below) for an honest, complete comparison.

**E1 — `context-render`, default (1 source, 16000-token budget), 5 cold reps:**

| | old | new |
|---|---|---|
| reps (s) | 24.17, 24.75, 24.16, 21.47, 21.18 | 22.51, 22.11, 22.28, 20.18, 20.22 |
| median | 24.16s | 22.11s |
| min/max | 21.18s / 24.75s | 20.18s / 22.51s |

Median delta 2.05s (8.5% faster) but **smaller than old's own 3.56s rep-to-rep spread — per this
campaign's noise-band rule, reported as within-noise, not claimed as a confirmed E2E win.** This is
the expected, honest result: a single-source cold `context-render` call is dominated by the
cold `build_repo_map` scan of a 1011-file repo (~20s+), which this PR does not touch — the fixed
function itself costs single-digit milliseconds even on this repo's own largest files (see the
micro-benchmark), so its share of a ~22-24s total is small. **Full end-to-end stdout is
byte-identical between old and new** (44,599 bytes each, confirmed via direct diff of a captured
rep) — the strongest possible proof that the fix changed nothing observable end-to-end.

**E2/E3 — `context-render --max-files 10 --max-sources 10` (amplify truncation's share), at 16000
and 60000 tokens:** designed to pull in more large-source renders per call. Unexpected but
honestly-reported finding: **both old AND new hit the 30s subprocess timeout** on every rep at this
setting (old: 6/6 reps timed out; new: 1/1 sampled rep also timed out before the cell was cut
short to avoid burning more wall time on a non-informative repeat). This means a *different*,
larger cost — almost certainly per-file source **extraction** across 10 files (`build_symbol_
source_from_map`/AST re-parse), not the truncation function this PR targets — already dominates at
`max-sources=10` regardless of this fix. Out of scope for item #1; flagged here as a possible
separate future queue candidate, not something this PR attempts to fix.

**E4 — plain `context` (literal task instruction), 2 reps:** old 19.90s/16.90s (median 18.40s), new
15.05s/14.23s (median 14.64s). Consistent with the verify-first trace: `context` never calls the
changed function, so this delta is box-load noise on a shared machine, not attributable to the fix
— included for completeness per the literal instruction, not as evidence of a win.

## CPU-SAFE / scope

No cargo/rustc/maturin anywhere in this PR. All verification via the shared
`C:/dev/projects/tensor-grep/.venv` + `PYTHONPATH` (confirmed `tensor_grep.__file__` resolves into
this worktree, not a stale venv shadow, before trusting any red/green). `tests/e2e/test_routing_
parity.py` was never invoked (it self-compiles Rust). Scope: exactly the two files below.

## Files changed

- `src/tensor_grep/cli/repo_map.py` — the rewrite (`_truncate_source_text_to_budget`, ~8923-9017)
- `tests/unit/test_token_budget.py` — 6 new tests (5 golden-pin + 1 structural perf-sanity)

## Delivery checklist

- [x] `ruff check` — clean
- [x] `ruff format --check --preview` — clean
- [x] `mypy src/tensor_grep` — clean (81 source files)
- [x] `tests/unit/test_token_budget.py` — 44/44 green
- [x] repo_map/context/profiling suites — 219/219 green
- [x] agent_capsule + cli_bootstrap suites — green
- [x] broader `tests/unit` sweep — clean except 3 confirmed-pre-existing, unrelated flakes
- [x] byte-identical proof — golden pins + micro-benchmark hash equality, zero divergence found
