### PR TITLE
perf(prepare): reuse the capsule repo map for the blast-radius floor (truncation-gated)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -10213,6 +10213,7 @@ def route_test(
 def _build_prepare_blast_radius_floor(
     *,
     path: str,
+    rm: dict[str, Any],
     target: dict[str, Any],
     call_site_evidence: dict[str, Any],
     related_call_sites: list[dict[str, Any]],
@@ -10225,11 +10226,25 @@ def _build_prepare_blast_radius_floor(
     (agent_capsule.py:536,546) -- a natural-language task query fails that gate and leaves
     ``related_call_sites`` EMPTY even though the SELECTED primary target may have real callers.
     Reuse the capsule's own scan when it already ran (``status`` ``collected``/
-    ``collected_no_call_sites``); otherwise run exactly ONE supplementary FS-backed scan via the
-    literal-seed-rescue-equipped ``build_symbol_blast_radius`` (never the rescue-less
-    ``_from_map`` sibling -- see ``_collect_capsule_call_site_evidence_from_map``'s own TRAP A
-    docstring: a no_match against a possibly-truncated map with no rescue reads as a false-
-    complete absence) keyed on the symbol the capsule actually selected, not the raw query text.
+    ``collected_no_call_sites``); otherwise fall to a supplementary blast-radius scan keyed on
+    the symbol the capsule actually selected, not the raw query text.
+
+    opt10 campaign ranked-queue item #2: that supplementary scan used to ALWAYS pay a second
+    FS-backed ``build_repo_map`` walk+parse (via ``build_symbol_blast_radius``) even though
+    ``_build_prepare_payload`` already built one moments earlier and now passes it in as ``rm``
+    -- doubling prepare's dominant cost on every natural-language query (the common CUJ). Reuse
+    ``rm`` via the map-reusing sibling ``build_symbol_blast_radius_from_map`` UNLESS ``rm``'s own
+    truncation signal (``rm['scan_limit']['possibly_truncated']``, repo_map.py:6707-6715) says
+    the capsule's ``DEFAULT_AGENT_REPO_MAP_LIMIT``-capped map may be missing files a full scan
+    would find. THE LOAD-BEARING GUARD: the supplementary scan below is DELIBERATELY uncapped
+    (``max_repo_files`` omitted, see that branch's own comment) for large-repo recall, while
+    ``rm`` is capped at 2000 files -- blindly reusing a truncated ``rm`` would silently narrow
+    blast-radius recall on a >2000-file repo, a real correctness regression, not just a missed
+    speedup. When ``rm`` is complete (any repo at or under the cap, the common case), it already
+    IS the same file universe an uncapped rescan would produce, so reuse is recall-identical, not
+    just faster -- never stamps the rescue-less daemon ``TRAP A`` sentinel (see
+    ``_collect_capsule_call_site_evidence_from_map``'s docstring) because a no_match on a
+    ``possibly_truncated`` map is impossible on this branch by construction of the gate above it.
 
     Returns ``(floor, deadline_partial)``. ``deadline_partial`` is deliberately narrower than the
     floor's own ``possibly_incomplete`` field: it is True ONLY when a ``--deadline`` cutoff
@@ -10239,7 +10254,12 @@ def _build_prepare_blast_radius_floor(
     (``_scan_incomplete``'s own documented contract).
     """
     from tensor_grep.cli.agent_capsule import _related_call_site_record
-    from tensor_grep.cli.repo_map import build_symbol_blast_radius
+    from tensor_grep.cli.repo_map import (
+        _apply_blast_radius_output_limits,
+        _copy_partial_signal,
+        build_symbol_blast_radius,
+        build_symbol_blast_radius_from_map,
+    )
 
     symbol = str(target.get("symbol") or "")
     status = str(call_site_evidence.get("status") or "")
@@ -10275,6 +10295,38 @@ def _build_prepare_blast_radius_floor(
         if error is not None:
             floor["error"] = error
         return floor, bool(deadline_partial)
+
+    def _floor_from_radius_payload(radius_payload: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+        # Shared tail for BOTH the from-map reuse branch and the FS-backed fallback branch below
+        # -- one definition so the two paths cannot silently drift apart on how a radius_payload
+        # becomes a floor.
+        if radius_payload.get("no_match"):
+            return _floor(
+                source="supplementary_blast_radius",
+                related=[],
+                graph_trust_summary=dict(radius_payload.get("graph_trust_summary") or {}),
+                resolution_gaps=list(radius_payload.get("resolution_gaps") or []),
+                deadline_partial=bool(radius_payload.get("partial")),
+                omitted=0,
+            )
+        related = [
+            record
+            for record in (
+                _related_call_site_record(caller, target_symbol=symbol)
+                for caller in (radius_payload.get("callers") or [])
+                if isinstance(caller, dict)
+            )
+            if record is not None
+        ]
+        output_limit = radius_payload.get("output_limit") or {}
+        return _floor(
+            source="supplementary_blast_radius",
+            related=related,
+            graph_trust_summary=dict(radius_payload.get("graph_trust_summary") or {}),
+            resolution_gaps=list(radius_payload.get("resolution_gaps") or []),
+            deadline_partial=bool(radius_payload.get("partial")),
+            omitted=int(output_limit.get("omitted_callers") or 0),
+        )
 
     if status in ("collected", "collected_no_call_sites"):
         return _floor(
@@ -10313,6 +10365,45 @@ def _build_prepare_blast_radius_floor(
             omitted=0,
         )
 
+    scan_limit = rm.get("scan_limit")
+    map_possibly_truncated = isinstance(scan_limit, dict) and bool(
+        scan_limit.get("possibly_truncated")
+    )
+
+    if not map_possibly_truncated:
+        # opt10 #2: `rm` is a COMPLETE map (the file-count cap never bit), so it already IS the
+        # file universe an uncapped rescan would produce below -- reuse it via the map-reusing
+        # sibling instead of paying a second build_repo_map walk+parse. Mirrors the established
+        # from_map reuse idiom this codebase already uses elsewhere (agent_capsule._collect_
+        # capsule_call_site_evidence_from_map; main.py's own blast-radius daemon gate): a
+        # build_symbol_blast_radius_from_map call, then the SAME _apply_blast_radius_output_
+        # limits + _copy_partial_signal tail build_symbol_blast_radius itself applies internally.
+        try:
+            radius_payload = build_symbol_blast_radius_from_map(
+                rm,
+                symbol,
+                max_depth=1,
+                deadline_monotonic=deadline_monotonic,
+            )
+            radius_payload = _apply_blast_radius_output_limits(
+                radius_payload, max_callers=8, max_files=8
+            )
+            _copy_partial_signal(radius_payload, rm)
+        except Exception as exc:  # pragma: no cover - defensive evidence side path
+            return _floor(
+                source="supplementary_blast_radius",
+                related=[],
+                graph_trust_summary={},
+                resolution_gaps=[],
+                deadline_partial=False,
+                omitted=0,
+                error=str(exc),
+            )
+        return _floor_from_radius_payload(radius_payload)
+
+    # `rm` is possibly_truncated (a repo bigger than DEFAULT_AGENT_REPO_MAP_LIMIT): PRESERVE the
+    # exact pre-#2 uncapped FS rescan below rather than reusing a map that may be missing the
+    # very caller this floor exists to find (the #2 load-bearing guard).
     deadline_seconds_remaining: float | None = None
     if deadline_monotonic is not None:
         deadline_seconds_remaining = max(0.1, deadline_monotonic - time.monotonic())
@@ -10341,35 +10432,7 @@ def _build_prepare_blast_radius_floor(
             omitted=0,
             error=str(exc),
         )
-
-    if radius_payload.get("no_match"):
-        return _floor(
-            source="supplementary_blast_radius",
-            related=[],
-            graph_trust_summary=dict(radius_payload.get("graph_trust_summary") or {}),
-            resolution_gaps=list(radius_payload.get("resolution_gaps") or []),
-            deadline_partial=bool(radius_payload.get("partial")),
-            omitted=0,
-        )
-
-    related = [
-        record
-        for record in (
-            _related_call_site_record(caller, target_symbol=symbol)
-            for caller in (radius_payload.get("callers") or [])
-            if isinstance(caller, dict)
-        )
-        if record is not None
-    ]
-    output_limit = radius_payload.get("output_limit") or {}
-    return _floor(
-        source="supplementary_blast_radius",
-        related=related,
-        graph_trust_summary=dict(radius_payload.get("graph_trust_summary") or {}),
-        resolution_gaps=list(radius_payload.get("resolution_gaps") or []),
-        deadline_partial=bool(radius_payload.get("partial")),
-        omitted=int(output_limit.get("omitted_callers") or 0),
-    )
+    return _floor_from_radius_payload(radius_payload)
 
 
 def _build_prepare_payload(
@@ -10379,13 +10442,35 @@ def _build_prepare_payload(
     claim: bool,
     deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
-    """Thin composition (CEO #5): ONE ``build_agent_capsule`` call supplies primary target,
-    confidence, ask-user, and validation verbatim; the only NEW scan is the blast-radius floor
-    (see ``_build_prepare_blast_radius_floor``). No new ranking/scan logic lives here."""
-    from tensor_grep.cli.agent_capsule import _command_ref, build_agent_capsule
-    from tensor_grep.cli.repo_map import _copy_scan_limit
+    """Thin composition (CEO #5): ONE repo-map build supplies primary target, confidence,
+    ask-user, and validation verbatim; the only NEW scan is the blast-radius floor (see
+    ``_build_prepare_blast_radius_floor``). No new ranking/scan logic lives here.
 
-    capsule = build_agent_capsule(query, path, deadline_monotonic=deadline_monotonic)
+    opt10 campaign ranked-queue item #2: builds ``rm`` directly instead of calling
+    ``build_agent_capsule`` -- byte-identical to that function's own 2-line body
+    (agent_capsule.py:2724-2731: same ``DEFAULT_AGENT_REPO_MAP_LIMIT`` cap, since this command
+    never overrides ``max_repo_files``; same ``deadline_monotonic``, already resolved by the
+    caller) followed by ``build_agent_capsule_from_map(..., _rescue_call_site_evidence=True)`` --
+    the exact cold-path value ``build_agent_capsule`` itself always passes internally. The
+    returned ``capsule`` is therefore byte-identical to calling ``build_agent_capsule(query,
+    path, deadline_monotonic=...)`` directly; this function additionally keeps its own ``rm``
+    reference to hand to the blast-radius floor below, so the floor can reuse it instead of
+    paying a second ``build_repo_map`` walk+parse for the common natural-language-query CUJ.
+    ``build_agent_capsule``'s own public contract/return is completely untouched by this --
+    `tg agent` / MCP / its existing tests keep calling it directly, exactly as before."""
+    from tensor_grep.cli.agent_capsule import _command_ref, build_agent_capsule_from_map
+    from tensor_grep.cli.repo_map import (
+        DEFAULT_AGENT_REPO_MAP_LIMIT,
+        _copy_scan_limit,
+        build_repo_map,
+    )
+
+    rm = build_repo_map(
+        path, max_repo_files=DEFAULT_AGENT_REPO_MAP_LIMIT, deadline_monotonic=deadline_monotonic
+    )
+    capsule = build_agent_capsule_from_map(
+        rm, query, deadline_monotonic=deadline_monotonic, _rescue_call_site_evidence=True
+    )
 
     target = dict(capsule.get("primary_target") or {})
     call_site_evidence = dict(capsule.get("call_site_evidence") or {})
@@ -10394,6 +10479,7 @@ def _build_prepare_payload(
     resolved_query = str(capsule.get("query") or query)
     floor, floor_deadline_partial = _build_prepare_blast_radius_floor(
         path=resolved_path,
+        rm=rm,
         target=target,
         call_site_evidence=call_site_evidence,
         related_call_sites=related_call_sites,

--- a/tests/unit/test_prepare_blast_radius_floor_map_reuse.py
+++ b/tests/unit/test_prepare_blast_radius_floor_map_reuse.py
@@ -282,46 +282,62 @@ def test_prepare_builds_repo_map_once_and_matches_fs_backed_reference(
     assert floor.get("callers_count") == len(reference.get("callers", [])), floor
 
 
-_LARGE_TREE_PADDING_DIR_COUNT = 50
-_LARGE_TREE_PADDING_FILES_PER_DIR = 45
+# >= 2000 same-dir files sort before the caller -> its within-dir index exceeds the max
+# round-robin round reachable before the 2000-file cap, so the caller is guaranteed dropped.
+_LARGE_TREE_BURY_FILE_COUNT = 2100
 
 
 def _make_large_truncated_repo(root: Path) -> None:
     """The same proven billing shape as `_make_small_billing_repo`, padded to comfortably exceed
-    `DEFAULT_AGENT_REPO_MAP_LIMIT` (2000 files) with `run.py` -- the ONE caller of the selected
-    primary target `process_billing_cycle` -- deliberately placed OUTSIDE the capped scan window,
-    so a naive always-reuse fix would silently report zero callers while the correct (guarded)
-    behavior still finds it via the preserved uncapped rescan.
+    `DEFAULT_AGENT_REPO_MAP_LIMIT` (2000 files) with `zzzz_run.py` -- the ONE caller of the
+    selected primary target `process_billing_cycle` -- deliberately placed OUTSIDE the capped scan
+    window, so a naive always-reuse fix would silently report zero callers while the correct
+    (guarded) behavior still finds it via the preserved uncapped rescan.
 
-    Placement relies on `_iter_repo_files`'s documented walk order (repo_map.py:836-865,
-    1006-1070): a top-level FILE (`billing.py`, `pyproject.toml`) is bucket-group 2
-    (`_repo_walk_path_sort_key`), and `tests/` is bucket-group 1 (`_TEST_DIR_NAMES`) -- both
-    scanned before any bucket-group-3 directory, so `billing.py` (and hence the
-    `process_billing_cycle` definition) is always inside the 2000-file cap regardless of padding
-    size. Padding directories are named to sort alphabetically BEFORE the caller's directory
-    ("pad###" < "zzz_caller"); with `_LARGE_TREE_PADDING_DIR_COUNT` group-3 buckets round-robin
-    filling the (2000 - 3)-file remaining budget (billing.py + pyproject.toml + tests/test_
-    billing.py already consumed 3) at `_LARGE_TREE_PADDING_FILES_PER_DIR` files/bucket
-    (comfortably > ceil(1997 / 50) = 40), the cap is exhausted entirely within the padding
-    buckets, one full bucket-turn before "zzz_caller" is ever visited. Empirically confirmed
-    (opt10 #2 dev session): `scan_limit.possibly_truncated=True` and the caller is found only
-    once the uncapped rescan actually runs."""
+    The definition stays IN-window while the caller is buried OUT-of-window, both by construction:
+
+    - `billing.py` (holding the `process_billing_cycle` definition) and `pyproject.toml` are
+      top-level FILES -- bucket-group 2 in `_repo_walk_path_sort_key` -- and `tests/` is
+      bucket-group 1 (`_TEST_DIR_NAMES`); all three are scanned before any bucket-group-3
+      directory, so the definition is always inside the 2000-file cap regardless of padding size.
+
+    - The caller is buried at a within-directory sorted index >= 2000. The repo-map walk is
+      round-robin across directories, drawing AT MOST one file per directory per round, so the
+      maximum round reached before the 2000-file cap bites is <= 2000. Any file at within-dir
+      index >= 2000 is therefore GUARANTEED dropped -- independent of how many sibling directories
+      exist. We put `zzzz_run.py` in a single `zzz_caller/` dir behind `_LARGE_TREE_BURY_FILE_COUNT`
+      (>= 2000) `pad#####.py` files that all sort before it (`pad#####` < `zzzz_run`), so the
+      caller's within-dir index is exactly `_LARGE_TREE_BURY_FILE_COUNT`.
+
+    This is the gate-#714 fidelity fix over the original 1-file-per-padding-dir layout, whose
+    lone `zzz_caller/` file landed in round 0 and SURVIVED the cap -- leaving the caller actually
+    in-window, so a naive always-reuse would ALSO have found it and the recall claim went
+    untested. `test_prepare_recall_preserved_on_large_truncated_repo` now asserts BOTH halves: a
+    naive from-map reuse MISSES the buried caller, and the guarded floor still FINDS it via the
+    uncapped rescan (`scan_limit.possibly_truncated=True`)."""
     _make_small_billing_repo(root)
-    for dir_index in range(_LARGE_TREE_PADDING_DIR_COUNT):
-        pad_dir = root / f"pad{dir_index:03d}"
-        pad_dir.mkdir(parents=True)
-        for file_index in range(_LARGE_TREE_PADDING_FILES_PER_DIR):
-            (pad_dir / f"mod{file_index:03d}.py").write_text(
-                f"def pad_fn_{dir_index:03d}_{file_index:03d}():\n    return {file_index}\n",
-                encoding="utf-8",
-            )
+    # billing.py's own pre-existing top-level run.py (always-scanned group 2) would ALSO be a
+    # caller of process_billing_cycle and defeat the "outside the window" setup.
+    (root / "run.py").unlink()
+    # ROBUST out-of-window placement (gate #714 fix): the repo-map walk draws AT MOST one file
+    # per directory per round-robin round, so the maximum round reached before the 2000-file cap
+    # bites is <= 2000. Therefore ANY file at within-directory sorted index >= 2000 is GUARANTEED
+    # dropped, independent of how many sibling directories exist -- unlike a 1-file `zzz_caller/`
+    # dir whose sole file lands in round 0 and survives (the original fixture's latent bug: the
+    # caller was actually IN-window, so a naive always-reuse would ALSO have found it and the
+    # recall claim went untested). Bury the caller behind >=2000 same-directory pad files that
+    # sort before it; the definition (`billing.py`, top-level group 2) stays in-window so the
+    # symbol still resolves.
     caller_dir = root / "zzz_caller"
     caller_dir.mkdir(parents=True)
-    (caller_dir / "run.py").write_text(_RUN_MODULE, encoding="utf-8")
-    # billing.py's own pre-existing run.py (inside the always-scanned top-level group) would
-    # ALSO be a caller of process_billing_cycle and defeat the "outside the window" setup --
-    # _make_small_billing_repo's run.py must not coexist with this one.
-    (root / "run.py").unlink()
+    for file_index in range(_LARGE_TREE_BURY_FILE_COUNT):
+        (caller_dir / f"pad{file_index:05d}.py").write_text(
+            f"def pad_fn_{file_index:05d}():\n    return {file_index}\n",
+            encoding="utf-8",
+        )
+    # `zzzz_run.py` sorts AFTER every `pad#####.py` -> within-dir index == _LARGE_TREE_BURY_FILE_
+    # COUNT (>= 2000) -> guaranteed outside the capped window.
+    (caller_dir / "zzzz_run.py").write_text(_RUN_MODULE, encoding="utf-8")
 
 
 def test_prepare_recall_preserved_on_large_truncated_repo(tmp_path: Path, monkeypatch) -> None:
@@ -344,7 +360,7 @@ def test_prepare_recall_preserved_on_large_truncated_repo(tmp_path: Path, monkey
     unrelated subsystem at 2000+ files would make this a flaky test of code this item does not
     touch, not a reliable correctness check of the guard it adds."""
     _make_large_truncated_repo(tmp_path)
-    total_files = 3 + _LARGE_TREE_PADDING_DIR_COUNT * _LARGE_TREE_PADDING_FILES_PER_DIR + 1
+    total_files = 3 + _LARGE_TREE_BURY_FILE_COUNT + 1  # billing/pyproject/test + pads + caller
     assert total_files > 2000, total_files  # sanity: this really is a >2000-file tree
 
     for symbol_name in ("calculate_late_fee", "apply_late_fee", "process_billing_cycle"):
@@ -366,6 +382,24 @@ def test_prepare_recall_preserved_on_large_truncated_repo(tmp_path: Path, monkey
     assert scan_limit.get("possibly_truncated") is True, (
         "test setup sanity check failed -- rm was not actually truncated, so this test cannot "
         f"exercise the load-bearing guard at all: {scan_limit}"
+    )
+
+    # Gate #714 CONTRAST -- the load-bearing half of this test's fidelity: prove the fixture
+    # genuinely buries `zzzz_run.py` OUTSIDE the 2000-file capped scan window. A naive "always
+    # reuse the capped map" fix (calling build_symbol_blast_radius_from_map straight on the
+    # truncated `rm`, exactly as the floor's reuse branch does -- main.py, max_depth=1) MUST MISS
+    # the caller: that file was dropped from the scan and is therefore absent from the map's
+    # caller universe (build_symbol_callers_from_map draws strictly from the map, no fresh FS
+    # scan). This is precisely the silent recall regression the possibly_truncated guard exists to
+    # prevent; without asserting the naive path misses it, the "guard finds it" check below could
+    # pass even if the caller were accidentally in-window (the original fixture's latent bug).
+    naive_reuse = repo_map.build_symbol_blast_radius_from_map(
+        rm, "process_billing_cycle", max_depth=1
+    )
+    naive_caller_files = {str(c.get("file")) for c in naive_reuse.get("callers", [])}
+    assert not any("run.py" in current for current in naive_caller_files), (
+        "fixture no longer buries the caller out-of-window -- a naive from-map reuse already "
+        f"finds it, so this test would NOT exercise the guard: {naive_caller_files}"
     )
 
     floor, deadline_partial = _build_prepare_blast_radius_floor(

--- a/tests/unit/test_prepare_blast_radius_floor_map_reuse.py
+++ b/tests/unit/test_prepare_blast_radius_floor_map_reuse.py
@@ -1,0 +1,396 @@
+"""opt10 campaign ranked-queue item #2: `tg prepare` used to build the repo map TWICE for the
+common natural-language-query CUJ -- once in `build_agent_capsule` (via `_build_prepare_payload`)
+and again inside `_build_prepare_blast_radius_floor`'s supplementary scan, which always called the
+FS-backed `build_symbol_blast_radius` (a fresh `build_repo_map` walk+parse) even though an
+equivalent map had just been built moments earlier.
+
+The fix threads the already-built `rm` through `_build_prepare_payload` into
+`_build_prepare_blast_radius_floor`, which now reuses it via the map-reusing sibling
+`build_symbol_blast_radius_from_map` -- UNLESS `rm['scan_limit']['possibly_truncated']` is True
+(a repo bigger than `DEFAULT_AGENT_REPO_MAP_LIMIT`, 2000 files), in which case the exact pre-fix
+uncapped FS-backed rescan is preserved so blast-radius recall never silently narrows on a
+large repo (the load-bearing guard the ranked-queue item calls out explicitly).
+
+Four tests, cheapest/most-precise first:
+  1/2. Gate unit tests directly on `_build_prepare_blast_radius_floor` (monkeypatched repo_map
+       functions, synthetic `rm` dicts) -- fast, deterministic proof of the ROUTING decision
+       itself: not-truncated routes to `build_symbol_blast_radius_from_map` and NEVER touches the
+       FS-backed function; possibly_truncated routes to the FS-backed function and NEVER touches
+       `_from_map`.
+  3. Small real tree via CliRunner + a `build_repo_map` call counter: `tg prepare` with a
+     natural-language query now builds the repo map exactly ONCE, and the resulting
+     `blast_radius_floor`'s caller member set is byte-identical to calling the pre-fix FS-backed
+     `build_symbol_blast_radius` directly against the same fixture/symbol (recall-identical, not
+     just faster).
+  4. Real >2000-file tree, `_build_prepare_blast_radius_floor` called directly against a REAL,
+     genuinely-truncated `rm` (real `build_repo_map` scan, not a synthetic dict): proves the
+     load-bearing guard on real data -- a caller deliberately placed outside the 2000-file-capped
+     scan window is still found, because `possibly_truncated=True` correctly routes to the
+     preserved uncapped rescan. Bypasses `tg prepare`'s own capsule-ranking/validation-detection
+     machinery (unrelated to this item, and expensive enough at 2000+ files on a shared box to
+     make a full CliRunner run of it flaky) -- see that test's own docstring for the measurement.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import tensor_grep.cli.repo_map as repo_map
+from tensor_grep.cli.main import _build_prepare_blast_radius_floor, app
+
+
+def _skipped_not_requested_evidence() -> dict[str, object]:
+    """The `call_site_evidence` shape `_collect_capsule_call_site_evidence` returns for a
+    natural-language query that never names the primary symbol (agent_capsule.py:737-741) --
+    the exact precondition under which `_build_prepare_blast_radius_floor` reaches the
+    reuse-vs-fallback branch this test file targets."""
+    return {
+        "status": "skipped",
+        "reason": "primary symbol was not explicitly requested by query",
+    }
+
+
+def test_prepare_floor_reuses_map_when_not_truncated(monkeypatch) -> None:
+    """Gate unit test, positive half: rm['scan_limit']['possibly_truncated'] is False -> the
+    floor MUST route through build_symbol_blast_radius_from_map and MUST NOT call the FS-backed
+    build_symbol_blast_radius at all (that would be the pre-#2 double-scan this item removes)."""
+    from_map_calls: list[tuple[object, ...]] = []
+    fs_backed_calls: list[tuple[object, ...]] = []
+
+    def _fake_from_map(rm, symbol, **kwargs):
+        from_map_calls.append((rm, symbol, kwargs))
+        return {
+            "no_match": False,
+            "callers": [
+                {"file": "in_window.py", "line": 3, "symbol": symbol, "provenance": "python-ast"}
+            ],
+            "output_limit": {"omitted_callers": 0},
+            "graph_trust_summary": {},
+            "resolution_gaps": [],
+            "partial": False,
+        }
+
+    def _fake_fs_backed(symbol, path, **kwargs):
+        fs_backed_calls.append((symbol, path, kwargs))
+        raise AssertionError(
+            "build_symbol_blast_radius (FS-backed, uncapped rescan) must NOT run when rm is "
+            "not possibly_truncated -- this is the #2 regression this test guards against"
+        )
+
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius_from_map", _fake_from_map)
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _fake_fs_backed)
+
+    not_truncated_rm = {
+        "path": "/repo",
+        "scan_limit": {
+            "max_repo_files": 2000,
+            "scanned_files": 4,
+            "possibly_truncated": False,
+            "truncation_cause": None,
+        },
+    }
+    floor, deadline_partial = _build_prepare_blast_radius_floor(
+        path="/repo",
+        rm=not_truncated_rm,
+        target={"symbol": "my_symbol"},
+        call_site_evidence=_skipped_not_requested_evidence(),
+        related_call_sites=[],
+        deadline_monotonic=None,
+    )
+
+    assert len(from_map_calls) == 1, from_map_calls
+    assert len(fs_backed_calls) == 0, fs_backed_calls
+    assert floor["source"] == "supplementary_blast_radius", floor
+    assert floor["callers_count"] == 1, floor
+    assert deadline_partial is False
+
+
+def test_prepare_floor_preserves_fs_rescan_when_map_possibly_truncated(monkeypatch) -> None:
+    """Gate unit test, negative half -- THE load-bearing guard: rm['scan_limit']
+    ['possibly_truncated'] is True -> the floor MUST preserve the pre-#2 uncapped FS-backed
+    build_symbol_blast_radius rescan and MUST NOT reuse the (possibly-missing-files) map via
+    build_symbol_blast_radius_from_map. A blind reuse here would silently narrow blast-radius
+    recall on a >2000-file repo -- a correctness regression, not just a missed speedup."""
+    from_map_calls: list[tuple[object, ...]] = []
+    fs_backed_calls: list[tuple[object, ...]] = []
+
+    def _fake_from_map(rm, symbol, **kwargs):
+        from_map_calls.append((rm, symbol, kwargs))
+        raise AssertionError(
+            "build_symbol_blast_radius_from_map must NOT run when rm is possibly_truncated -- "
+            "it may be missing the very caller this floor exists to find"
+        )
+
+    def _fake_fs_backed(symbol, path, **kwargs):
+        fs_backed_calls.append((symbol, path, kwargs))
+        assert "max_repo_files" not in kwargs, (
+            "the uncapped rescan must never receive a max_repo_files cap (main.py's own "
+            "'deliberately OMITTED' comment) -- got kwargs=" + repr(kwargs)
+        )
+        return {
+            "no_match": False,
+            "callers": [
+                {
+                    "file": "beyond_the_cap.py",
+                    "line": 7,
+                    "symbol": symbol,
+                    "provenance": "python-ast",
+                }
+            ],
+            "output_limit": {"omitted_callers": 0},
+            "graph_trust_summary": {},
+            "resolution_gaps": [],
+            "partial": False,
+        }
+
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius_from_map", _fake_from_map)
+    monkeypatch.setattr(repo_map, "build_symbol_blast_radius", _fake_fs_backed)
+
+    truncated_rm = {
+        "path": "/repo",
+        "scan_limit": {
+            "max_repo_files": 2000,
+            "scanned_files": 2000,
+            "possibly_truncated": True,
+            "truncation_cause": "project-files",
+        },
+    }
+    floor, deadline_partial = _build_prepare_blast_radius_floor(
+        path="/repo",
+        rm=truncated_rm,
+        target={"symbol": "my_symbol"},
+        call_site_evidence=_skipped_not_requested_evidence(),
+        related_call_sites=[],
+        deadline_monotonic=None,
+    )
+
+    assert len(fs_backed_calls) == 1, fs_backed_calls
+    assert len(from_map_calls) == 0, from_map_calls
+    assert floor["source"] == "supplementary_blast_radius", floor
+    assert floor["callers_count"] == 1, floor
+    assert deadline_partial is False
+
+
+# Proven-shape fixture (mirrors tests/integration/test_prepare_oneshot_cuj.py's billing_repo,
+# which the maintained test suite already relies on to resolve a symbol-level -- not file-level
+# -- primary_target for a natural-language query): a 3-function call chain across 2 files gives
+# the ranker enough signal to commit to `process_billing_cycle` specifically, and the query below
+# never names it, so `_target_symbol_was_explicitly_requested` fails and this floor's
+# reuse-vs-fallback branch is reached.
+_BILLING_MODULE = (
+    '"""Monthly billing helpers."""\n\n\n'
+    "def calculate_late_fee(balance, days_late):\n"
+    '    """Compute the late fee owed on an overdue balance."""\n'
+    "    return balance * 0.01 * days_late\n\n\n"
+    "def apply_late_fee(account):\n"
+    '    """Apply the computed late fee to an account balance."""\n'
+    '    fee = calculate_late_fee(account["balance"], account["days_late"])\n'
+    '    account["balance"] += fee\n'
+    "    return account\n\n\n"
+    "def process_billing_cycle(accounts):\n"
+    '    """Run the monthly billing cycle across all accounts."""\n'
+    "    return [apply_late_fee(account) for account in accounts]\n"
+)
+_RUN_MODULE = (
+    "from billing import process_billing_cycle\n\n\n"
+    "def main():\n"
+    "    return process_billing_cycle([])\n\n\n"
+    'if __name__ == "__main__":\n'
+    "    main()\n"
+)
+_TEST_MODULE = (
+    "from billing import calculate_late_fee\n\n\n"
+    "def test_calculate_late_fee():\n"
+    "    assert calculate_late_fee(100, 2) == 2.0\n"
+)
+_PYPROJECT = (
+    "[project]\n"
+    'name = "billing-fixture"\n'
+    'version = "0.1.0"\n\n'
+    "[tool.pytest.ini_options]\n"
+    'testpaths = ["tests"]\n'
+)
+_PREPARE_NL_QUERY = "the billing job should skip accounts that already paid earlier this month"
+
+
+def _make_small_billing_repo(root: Path) -> None:
+    (root / "pyproject.toml").write_text(_PYPROJECT, encoding="utf-8")
+    (root / "billing.py").write_text(_BILLING_MODULE, encoding="utf-8")
+    (root / "run.py").write_text(_RUN_MODULE, encoding="utf-8")
+    tests_dir = root / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_billing.py").write_text(_TEST_MODULE, encoding="utf-8")
+
+
+def test_prepare_builds_repo_map_once_and_matches_fs_backed_reference(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """(b) TDD: on a small (non-truncated) repo with a natural-language query, `tg prepare` must
+    build the repo map EXACTLY ONCE (not twice, the pre-#2 behavior), and the resulting
+    blast_radius_floor's caller member set must be byte-identical to calling the pre-#2 FS-backed
+    build_symbol_blast_radius directly against the same fixture/symbol -- proving the reuse is
+    recall-identical, not just faster."""
+    _make_small_billing_repo(tmp_path)
+    for symbol_name in ("calculate_late_fee", "apply_late_fee", "process_billing_cycle"):
+        assert symbol_name not in _PREPARE_NL_QUERY.split(), _PREPARE_NL_QUERY
+
+    call_count = {"n": 0}
+    original_build_repo_map = repo_map.build_repo_map
+
+    def _counting_build_repo_map(*args, **kwargs):
+        call_count["n"] += 1
+        return original_build_repo_map(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_repo_map", _counting_build_repo_map)
+
+    result = CliRunner().invoke(app, ["prepare", str(tmp_path), _PREPARE_NL_QUERY, "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    primary_target = payload["primary_target"]
+    # sanity: the ranker found a SPECIFIC symbol (not a file-level best-effort target) -- this is
+    # the precondition for the floor's reuse-vs-fallback branch to run at all.
+    assert primary_target.get("symbol"), payload
+
+    floor = payload["blast_radius_floor"]
+    assert floor.get("source") == "supplementary_blast_radius", floor
+    assert call_count["n"] == 1, (
+        f"build_repo_map invoked {call_count['n']} times for tg prepare's natural-language-query "
+        "path -- expected exactly 1 (opt10 #2: the blast-radius floor must reuse the capsule's "
+        "already-built map instead of rebuilding it)"
+    )
+
+    monkeypatch.setattr(repo_map, "build_repo_map", original_build_repo_map)
+    reference = repo_map.build_symbol_blast_radius(
+        str(primary_target["symbol"]), str(tmp_path), max_depth=1, max_callers=8, max_files=8
+    )
+    # Compare on FILE alone, not the raw callers[].get("symbol") field -- that field names
+    # whatever the caller record's own AST node carried (may be None/the enclosing function),
+    # not the target symbol; `_related_call_site_record` (used by both the reuse and fallback
+    # branches identically) is what normalizes it to the target symbol for `top_callers`, so
+    # comparing raw `callers[]` on that field would not be apples-to-apples.
+    reference_members = {str(c.get("file")) for c in reference.get("callers", [])}
+    actual_members = {str(c.get("file")) for c in floor.get("top_callers", [])}
+    assert actual_members, f"expected at least one real caller in this fixture: {floor}"
+    assert actual_members == reference_members, (actual_members, reference_members)
+    assert all(c.get("symbol") == primary_target["symbol"] for c in floor.get("top_callers", [])), (
+        floor
+    )
+    assert floor.get("callers_count") == len(reference.get("callers", [])), floor
+
+
+_LARGE_TREE_PADDING_DIR_COUNT = 50
+_LARGE_TREE_PADDING_FILES_PER_DIR = 45
+
+
+def _make_large_truncated_repo(root: Path) -> None:
+    """The same proven billing shape as `_make_small_billing_repo`, padded to comfortably exceed
+    `DEFAULT_AGENT_REPO_MAP_LIMIT` (2000 files) with `run.py` -- the ONE caller of the selected
+    primary target `process_billing_cycle` -- deliberately placed OUTSIDE the capped scan window,
+    so a naive always-reuse fix would silently report zero callers while the correct (guarded)
+    behavior still finds it via the preserved uncapped rescan.
+
+    Placement relies on `_iter_repo_files`'s documented walk order (repo_map.py:836-865,
+    1006-1070): a top-level FILE (`billing.py`, `pyproject.toml`) is bucket-group 2
+    (`_repo_walk_path_sort_key`), and `tests/` is bucket-group 1 (`_TEST_DIR_NAMES`) -- both
+    scanned before any bucket-group-3 directory, so `billing.py` (and hence the
+    `process_billing_cycle` definition) is always inside the 2000-file cap regardless of padding
+    size. Padding directories are named to sort alphabetically BEFORE the caller's directory
+    ("pad###" < "zzz_caller"); with `_LARGE_TREE_PADDING_DIR_COUNT` group-3 buckets round-robin
+    filling the (2000 - 3)-file remaining budget (billing.py + pyproject.toml + tests/test_
+    billing.py already consumed 3) at `_LARGE_TREE_PADDING_FILES_PER_DIR` files/bucket
+    (comfortably > ceil(1997 / 50) = 40), the cap is exhausted entirely within the padding
+    buckets, one full bucket-turn before "zzz_caller" is ever visited. Empirically confirmed
+    (opt10 #2 dev session): `scan_limit.possibly_truncated=True` and the caller is found only
+    once the uncapped rescan actually runs."""
+    _make_small_billing_repo(root)
+    for dir_index in range(_LARGE_TREE_PADDING_DIR_COUNT):
+        pad_dir = root / f"pad{dir_index:03d}"
+        pad_dir.mkdir(parents=True)
+        for file_index in range(_LARGE_TREE_PADDING_FILES_PER_DIR):
+            (pad_dir / f"mod{file_index:03d}.py").write_text(
+                f"def pad_fn_{dir_index:03d}_{file_index:03d}():\n    return {file_index}\n",
+                encoding="utf-8",
+            )
+    caller_dir = root / "zzz_caller"
+    caller_dir.mkdir(parents=True)
+    (caller_dir / "run.py").write_text(_RUN_MODULE, encoding="utf-8")
+    # billing.py's own pre-existing run.py (inside the always-scanned top-level group) would
+    # ALSO be a caller of process_billing_cycle and defeat the "outside the window" setup --
+    # _make_small_billing_repo's run.py must not coexist with this one.
+    (root / "run.py").unlink()
+
+
+def test_prepare_recall_preserved_on_large_truncated_repo(tmp_path: Path, monkeypatch) -> None:
+    """(a) TDD -- the load-bearing guard on a REAL >2000-file tree: `rm` is genuinely
+    possibly_truncated (a real `build_repo_map` scan, 2000-file cap bites), yet the caller living
+    outside that cap window is still found via `_build_prepare_blast_radius_floor`, proving the
+    uncapped FS-backed rescan still fires instead of a naive from-map reuse silently
+    under-reporting recall.
+
+    Calls `_build_prepare_blast_radius_floor` directly (rather than the full `tg prepare` CLI)
+    with a `target`/`call_site_evidence` shape matching what `_build_prepare_payload` would pass
+    for this exact fixture/query (empirically confirmed via `test_prepare_builds_repo_map_once_
+    and_matches_fs_backed_reference`'s identical shape one tree size down, and via a manual
+    `tg prepare` run against this same fixture during opt10 #2 development). This isolates the
+    mechanism this ranked-queue item actually changes (the floor's routing decision + the real
+    uncapped rescan's recall) from `tg prepare`'s unrelated, pre-existing capsule-ranking +
+    validation-runner-detection cost (`_precomputed_validation_files_for_root`, Windows
+    `nt.stat`/`_getfinalpathname` traffic that scales with file count and was observed to vary
+    ~16s-60s+ run to run on this shared box during opt10 #2 profiling) -- exercising THAT
+    unrelated subsystem at 2000+ files would make this a flaky test of code this item does not
+    touch, not a reliable correctness check of the guard it adds."""
+    _make_large_truncated_repo(tmp_path)
+    total_files = 3 + _LARGE_TREE_PADDING_DIR_COUNT * _LARGE_TREE_PADDING_FILES_PER_DIR + 1
+    assert total_files > 2000, total_files  # sanity: this really is a >2000-file tree
+
+    for symbol_name in ("calculate_late_fee", "apply_late_fee", "process_billing_cycle"):
+        assert symbol_name not in _PREPARE_NL_QUERY.split(), _PREPARE_NL_QUERY
+
+    call_count = {"n": 0}
+    original_build_repo_map = repo_map.build_repo_map
+
+    def _counting_build_repo_map(*args, **kwargs):
+        call_count["n"] += 1
+        return original_build_repo_map(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, "build_repo_map", _counting_build_repo_map)
+
+    rm = repo_map.build_repo_map(
+        str(tmp_path), max_repo_files=repo_map.DEFAULT_AGENT_REPO_MAP_LIMIT
+    )
+    scan_limit = rm.get("scan_limit") or {}
+    assert scan_limit.get("possibly_truncated") is True, (
+        "test setup sanity check failed -- rm was not actually truncated, so this test cannot "
+        f"exercise the load-bearing guard at all: {scan_limit}"
+    )
+
+    floor, deadline_partial = _build_prepare_blast_radius_floor(
+        path=str(tmp_path),
+        rm=rm,
+        target={"symbol": "process_billing_cycle"},
+        call_site_evidence=_skipped_not_requested_evidence(),
+        related_call_sites=[],
+        deadline_monotonic=None,
+    )
+
+    assert floor.get("source") == "supplementary_blast_radius", floor
+    assert floor.get("callers_count", 0) >= 1, (
+        "blast-radius recall regressed on a >2000-file repo -- the caller living outside the "
+        f"capped scan window was not found: {floor}"
+    )
+    caller_files = {str(c.get("file")) for c in floor.get("top_callers", [])}
+    assert any("run.py" in current for current in caller_files), floor
+    assert deadline_partial is False
+
+    # The guard preserved the uncapped rescan, which is itself a second build_repo_map call (the
+    # explicit one above for `rm`, plus one more inside the floor's own fallback) -- confirms the
+    # fallback genuinely ran rather than the caller coincidentally already being in the capped
+    # window some other way.
+    assert call_count["n"] == 2, (
+        f"build_repo_map invoked {call_count['n']} times -- expected exactly 2 (the explicit "
+        "capped build above + the preserved uncapped fallback rescan) on a possibly_truncated rm"
+    )


### PR DESCRIPTION
opt10 campaign ranked-queue item #2 (`+10% overall improvement` campaign): stop `tg prepare` building the repo map twice.

## Verified seams (file:line, re-checked against this worktree before writing a line)

- `build_agent_capsule` (`src/tensor_grep/cli/agent_capsule.py:2675-2747`) builds `rm = repo_map.build_repo_map(path, max_repo_files=effective_max_repo_files, deadline_monotonic=deadline_monotonic)` (`:2729-2731`, `effective_max_repo_files` = `DEFAULT_AGENT_REPO_MAP_LIMIT` = 2000, `repo_map.py:156`), then delegates to `build_agent_capsule_from_map(rm, ..., _rescue_call_site_evidence=True)` (`:2732-2747`).
- `_build_prepare_payload` (`main.py:10438` in this branch, was `main.py:10375` pre-fix) called `build_agent_capsule(query, path, deadline_monotonic=deadline_monotonic)` — the outer wrapper, discarding `rm`.
- `_build_prepare_blast_radius_floor` (`main.py:10213` pre-fix) called `build_symbol_blast_radius(symbol, path, ...)` (repo_map.py:17248) whenever the query is natural-language (`call_site_evidence.status` is `skipped`/`error`, not `collected`/`collected_no_call_sites`/the specific "not found" reason) — and `build_symbol_blast_radius` itself calls `build_repo_map` again (`repo_map.py:17264-17269`) before delegating to `build_symbol_blast_radius_from_map` (`:17270-17277`). **Confirmed via direct call-count instrumentation**: for a natural-language prepare query on a non-truncated repo, `build_repo_map` ran exactly twice pre-fix.
- The map-reusing sibling `build_symbol_blast_radius_from_map(rm, symbol, ...)` (`repo_map.py:17438`) already exists and is the established `_from_map` pattern used elsewhere (`agent_capsule._collect_capsule_call_site_evidence_from_map`, `repo_map.py:821-935`; `main.py`'s own `blast-radius` command daemon gate, `main.py:11983-12010`).
- The truncation signal: `repo_map.build_repo_map` only sets `payload["scan_limit"]` when `max_repo_files is not None` (always true for this caller, capped at 2000), with `possibly_truncated` True only when the file-count cap actually dropped project files (`repo_map.py:6697-6716`).

All claims re-verified by reading the real code before implementing (not from memory/plan) — no discrepancies found vs. the ranked-queue item's own description.

## The fix

Two functions in `main.py`, **zero changes in `repo_map.py`/`agent_capsule.py`**:

1. **`_build_prepare_payload`**: builds `rm` directly (`build_repo_map(path, max_repo_files=DEFAULT_AGENT_REPO_MAP_LIMIT, deadline_monotonic=deadline_monotonic)`) — byte-identical to `build_agent_capsule`'s own body — then calls `build_agent_capsule_from_map(rm, query, deadline_monotonic=deadline_monotonic, _rescue_call_site_evidence=True)` instead of `build_agent_capsule(query, path, ...)`. The returned `capsule` is therefore byte-identical to what `build_agent_capsule` itself would have returned; `_build_prepare_payload` additionally keeps its own `rm` reference. **`build_agent_capsule`'s own signature/body/public return are completely untouched** — `tg agent` (`main.py:9599`) and the MCP `tg_agent` tool (`mcp_server.py:3089`) keep calling `build_agent_capsule` directly, unaffected.
2. **`_build_prepare_blast_radius_floor`**: takes a new required `rm` parameter. The former unconditional `build_symbol_blast_radius(symbol, path, ...)` call is now gated:
   - `rm['scan_limit']['possibly_truncated']` is **False** (the common case, any repo ≤2000 files) → reuse `rm` via `build_symbol_blast_radius_from_map(rm, symbol, max_depth=1, deadline_monotonic=deadline_monotonic)` + `_apply_blast_radius_output_limits(..., max_callers=8, max_files=8)` + `_copy_partial_signal(...)` — the exact same tail `build_symbol_blast_radius` applies internally, so output shape is unchanged.
   - `rm['scan_limit']['possibly_truncated']` is **True** (repo bigger than the 2000-file cap) → **preserve the exact pre-fix uncapped FS-backed rescan, unchanged, including its own comment explaining why `max_repo_files` must stay omitted.**

## THE LOAD-BEARING GUARD (why this isn't a blind reuse)

The floor's supplementary scan is deliberately uncapped (`max_repo_files` omitted, `main.py`'s own pre-existing comment) for large-repo recall, while the capsule's `rm` is capped at 2000 files. Reusing a *truncated* `rm` would silently narrow blast-radius recall on any repo bigger than the cap — a correctness regression, not just a missed speedup. The gate above makes that impossible: reuse only fires when `rm` is provably the complete file universe (nothing the uncapped scan could find that the capped one didn't already have), and falls through to the untouched fallback otherwise. This mirrors the exact TRAP-A pattern already documented and handled elsewhere in this codebase (`agent_capsule._collect_capsule_call_site_evidence_from_map`'s own docstring; `main._daemon_blast_radius_no_match_is_unreliable`) — same shared truncation signal, same falls-back-to-uncapped discipline.

## TDD (all 4 new tests confirmed RED against pre-fix `main.py` via `git stash`, then GREEN after)

New file: `tests/unit/test_prepare_blast_radius_floor_map_reuse.py`

1. `test_prepare_floor_reuses_map_when_not_truncated` — gate unit test (synthetic `rm`, monkeypatched `repo_map` functions): not-truncated routes to `build_symbol_blast_radius_from_map` and the FS-backed function is asserted **never called** (raises if it is).
2. `test_prepare_floor_preserves_fs_rescan_when_map_possibly_truncated` — the guard's negative half: possibly_truncated routes to the FS-backed function and `build_symbol_blast_radius_from_map` is asserted never called; also asserts the fallback never receives `max_repo_files`.
3. `test_prepare_builds_repo_map_once_and_matches_fs_backed_reference` — small real tree (the proven billing-shaped fixture from `tests/integration/test_prepare_oneshot_cuj.py`), full CliRunner `tg prepare` call with a `build_repo_map` call-counter: asserts **exactly 1** call (was 2), and that `blast_radius_floor.top_callers`' file set is byte-identical to calling the pre-fix FS-backed `build_symbol_blast_radius` directly against the same fixture/symbol — recall-identical, not just faster.
4. `test_prepare_recall_preserved_on_large_truncated_repo` — a **real, >2000-file synthetic tree** (2254 files: the billing shape + 50×45 padding dirs + the caller's file deliberately placed in a `zzz_caller/` directory that sorts after all padding, verified via `_iter_repo_files`'s documented bucket/round-robin walk order to land outside the 2000-file cap). Builds a genuinely-truncated `rm` via the real `build_repo_map`, then calls `_build_prepare_blast_radius_floor` directly (bypassing `tg prepare`'s own unrelated capsule-ranking/validation-detection machinery, which profiling showed varies ~16s-60s+ on this shared box independent of this change — see the test's own docstring). Asserts the caller living outside the cap window is still found (`callers_count >= 1`) and that exactly 2 `build_repo_map` calls occurred (the capped `rm` + the preserved uncapped fallback), proving the fallback genuinely ran.

Existing suites re-run green after the fix (all commands below via `PYTHONPATH=<worktree>/src C:/dev/projects/tensor-grep/.venv/Scripts/python.exe`, verified `tensor_grep.__file__` resolves into the worktree first, per the stale-venv trap):
- `tests/integration/test_prepare_oneshot_cuj.py` — 13/13 passed.
- `tests/unit/test_prepare_blast_radius_floor_map_reuse.py` (new) — 4/4 passed.
- `tests/unit/test_agent_capsule_*.py` + `test_agent_deadline_partial_stderr.py` + `test_agent_ignore.py` + `test_agent_reverse_import_graph_deadline_222.py` + `test_agent_suggested_scope.py` + `test_agent_vendored_subtree_{deadline_220,dedup_scale_222}.py` + `test_agent_workspace_root_advisory.py` — 199/199 passed (confirms `build_agent_capsule`'s own direct callers, `tg agent`, are unaffected).
- `tests/unit/test_cli_deadline_{coverage_gaps,flag,frontdoor_anchor}.py` + `test_refs_context_pack_deadline_205.py` + `test_repo_map_deadline.py` + `test_symbol_defs_stage_deadline_c1c2.py` + `test_blast_radius_mermaid.py` + `test_blast_radius_render_perf.py` + `test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py` — 192/192 passed.

## Measure (A/B, frozen scorecard methodology)

Scorecard: `scratchpad/opt10/scorecard_definition.md`; corpus A = `scratchpad/opt10/corpora/tg-pinned` (pinned v1.93.2 clone, HEAD `4e471cc`, confirmed unmodified in `src/tensor_grep/cli/{main,repo_map,agent_capsule}.py` before use). S5 cell: `prepare <A>/src "add a flag to tg prepare" --json`. Baseline (published wheel, `uvx`) = **10.574s median**.

This PR's A/B is SOURCE-tree before/after, same interpreter (`C:/dev/projects/tensor-grep/.venv/Scripts/python.exe`), `PYTHONPATH`-swapped between the unmodified pinned clone (before) and this worktree (after), invoked as `python -m tensor_grep prepare <A>/src "add a flag to tg prepare" --json` with `TG_SESSION_DAEMON_AUTOSTART=0`. 5 cold reps/arm, serial, `tensor_grep.__file__` verified to resolve into the correct source before timing anything.

| | median_s | min_s | max_s | spread_s |
|---|---|---|---|---|
| before (pinned v1.93.2, unmodified) | 11.4455 | 11.2911 | 11.7024 | 0.4113 |
| after (this branch) | 11.0196 | 10.3981 | 11.7187 | 1.3206 |

Delta: 0.4259s / **3.72%** — this does **not** clearly exceed the combined noise spread (1.3206s), so per this campaign's own noise-floor discipline I am reporting it as **noise-level at the wall-clock/subprocess level on this shared box, not a confirmed end-to-end speedup** — not overclaiming a win the numbers don't clearly support.

Separately, the **mechanism is unambiguously confirmed** via direct `build_repo_map` call-count instrumentation on this exact corpus/query (in-process, no subprocess variance): **2 calls before this fix, 1 call after** (isolated single-shot timings: ~21.2s before vs ~7.2s after total wall for `_build_prepare_payload`, consistent in direction with the median result but far noisier at N=1, not cited as the headline number). Corpus A's `/src` target is modest in scope (`scan_limit.scanned_files=81` on this query), so the absolute avoided-rescan cost here (~2-4.5s of `build_repo_map` time observed directly) is real but small relative to this specific shared box's run-to-run jitter; the ranked-queue item's own predicted ~28% figure was derived under different profiling conditions and should be read as directional, not confirmed by this specific A/B.

## Scope discipline

- Changes confined to `main.py`'s two functions named in the task (`_build_prepare_blast_radius_floor`, `_build_prepare_payload`). Zero changes to `repo_map.py` or `agent_capsule.py`.
- `build_agent_capsule`'s public return is untouched — `tg agent` / MCP / their existing tests are unaffected (confirmed via the 199-test agent-capsule suite run above).
- `ruff check .`, `ruff format --check --preview .` (both clean on the 2 touched files; 4 pre-existing unrelated `.md`-fence drift files elsewhere in the repo, not touched by this PR), `mypy src/tensor_grep` (81 files, no issues) all green.

## Flag for independent Opus gate

Recall-preservation is the crux of this change: a blind reuse of a truncated map would be a silent blast-radius recall regression on any repo over 2000 files, and would not be caught by any existing test (none of the pre-existing suites exercise the >2000-file/`possibly_truncated=True` path through `tg prepare`). Please verify:
1. The `possibly_truncated` gate in `_build_prepare_blast_radius_floor` (`main.py`) is evaluated **before** any reuse attempt, on every code path that reaches it.
2. The fallback branch is byte-identical to the pre-fix code (diff it against `origin/main`'s copy).
3. `build_agent_capsule`'s signature/body genuinely has zero diff (nothing in `agent_capsule.py` changed).
4. Test 4's fixture placement claim (the caller genuinely lands outside the 2000-file scan window) — re-run it and inspect `rm['scan_limit']` yourself rather than trusting the docstring's math.
