### PR TITLE
perf(cold-start): defer heavy imports off the fast paths (single-sourced scan limits)

### DIFF
--- a/src/tensor_grep/cli/__init__.py
+++ b/src/tensor_grep/cli/__init__.py
@@ -1,10 +1,25 @@
+# perf (+10% campaign #6 / F2.6): `tensor_grep.cli` is the PARENT PACKAGE of every `tensor_grep.
+# cli.*` submodule (`bootstrap`, `main`, `runtime_paths`, ...), so THIS file's own top-level import
+# cost is paid on LITERALLY EVERY `tg` invocation -- including the trivial `--version` fast path --
+# before any submodule-specific code ever runs. `from typing import Any` used to be the ONLY
+# reason `typing` (a measurably non-free stdlib import) loaded this early; the sole use below,
+# `__getattr__`'s return annotation, never needs to be `Any` specifically -- returning the builtin
+# `object` instead needs no import at all (verified: nothing in this repo does `from tensor_grep.
+# cli import main_entry` and calls it -- the real console-script entry point in pyproject.toml
+# targets `tensor_grep.cli.bootstrap:main_entry` directly, bypassing this `__getattr__` hook
+# entirely -- so narrowing this hook's static return type has no in-repo call-site impact).
+# NOTE: `from __future__ import annotations` alone would NOT have been sufficient here -- PEP 563
+# only defers *evaluation* of an annotation to a string; mypy still resolves that string against
+# the module's real (possibly TYPE_CHECKING-gated) imports, and a bare `from typing import
+# TYPE_CHECKING` pays the exact same `typing`-module-load cost this fix exists to avoid. Verified:
+# `mypy --strict` on this file with `-> Any` and no `typing` import at all fails with `Name "Any"
+# is not defined`; `-> object` needs no import and passes clean.
 from importlib import import_module
-from typing import Any
 
 __all__ = ["main_entry"]
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     if name != "main_entry":
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     value = import_module("tensor_grep.cli.bootstrap").main_entry

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -27,9 +27,21 @@ from tensor_grep.cli.subprocess_policy import run_subprocess as run_subprocess
 # transitively pulls in the stdlib `dataclasses` module -- and `dataclasses` imports `inspect`
 # (plus `ast`/`dis`/`tokenize`/`copy`/`weakref`), a chain measured at ~25ms cumulative
 # (`python -X importtime -c "import tensor_grep.cli.bootstrap"`, warm cache) that a trivial
-# `--version` call has no reason to pay. Each of the 3 helper functions does its own
-# function-local `from tensor_grep.io.directory_scanner import ...` instead; see
-# `tests/unit/test_bootstrap_fast_path_imports.py` for the regression test that pins this.
+# `--version` call has no reason to pay.
+#
+# perf (+10% campaign #6 / F2.4, follow-up): each of the 3 helper functions used to do its own
+# function-local `from tensor_grep.io.directory_scanner import ...` -- which, being function-local,
+# already kept the cost OFF the `--version` fast path (this docstring's original claim), but still
+# paid the full `SearchConfig`/`dataclasses`/`inspect` chain the MOMENT any of the three actually
+# ran (i.e. on every real search invocation that reaches the broad-scan guard, REGARDLESS of
+# whether the search ultimately gets delegated to the native binary or `rg` -- both of which do
+# their own walk in a separate process and never touch Python's `DirectoryScanner` at all). Each
+# helper now does `from tensor_grep.io.scan_limits import ...` instead -- the same zero-dependency
+# module `cli/main.py`'s module-level broad-scan literals read from -- so the guard-only path no
+# longer drags in `SearchConfig` at all; `directory_scanner` is still imported exactly when a real
+# Python-side walk needs it (e.g. `_search_paths_include_oversized_implicit_root` below, which
+# constructs a real `DirectoryScanner`). See `tests/unit/test_bootstrap_fast_path_imports.py` for
+# the regression tests that pin both claims.
 
 # Saved at import time so _streaming_passthrough_returncode can detect when
 # run_subprocess has been monkey-patched by a test (old mock pattern).
@@ -154,11 +166,12 @@ _BROAD_GENERATED_SCAN_DIR_NAMES = {
     "target",
     "venv",
 }
-# Single source of truth: `io/directory_scanner.py` (item #154) -- keeps this file and
-# `cli/main.py`'s equivalent guard from drifting out of sync. perf/#48: no longer aliased at
-# module level -- `_path_has_project_marker` / `_search_paths_include_workspace_root` below
-# import these constants function-locally (fast-path-unused; see the deferred-import note above
-# the `tensor_grep.cli.subprocess_policy` import).
+# Single source of truth: `io/scan_limits.py` (item #154; moved from `io/directory_scanner.py`
+# in campaign #6 / F2.4 -- `directory_scanner.py` still re-exports the same names for back-compat)
+# -- keeps this file and `cli/main.py`'s equivalent guard from drifting out of sync. perf/#48: no
+# longer aliased at module level -- `_path_has_project_marker` / `_search_paths_include_workspace_
+# root` below import these constants function-locally (fast-path-unused; see the deferred-import
+# note above the `tensor_grep.cli.subprocess_policy` import).
 _SEARCH_PATTERN_FLAGS = {"-e", "--regexp"}
 _SEARCH_LITERAL_FLAGS = {"-F", "--fixed-strings"}
 _SEARCH_PCRE2_FLAGS = {"-P", "--pcre2"}
@@ -635,7 +648,7 @@ def _search_args_paths_defaulted(search_args: list[str]) -> bool:
 
 
 def _path_has_project_marker(path: Path) -> bool:
-    from tensor_grep.io.directory_scanner import BROAD_WORKSPACE_PROJECT_MARKERS
+    from tensor_grep.io.scan_limits import BROAD_WORKSPACE_PROJECT_MARKERS
 
     for marker in BROAD_WORKSPACE_PROJECT_MARKERS:
         try:
@@ -671,7 +684,7 @@ def _search_paths_include_generated_root(paths: list[str]) -> bool:
 
 
 def _search_paths_include_workspace_root(paths: list[str]) -> bool:
-    from tensor_grep.io.directory_scanner import (
+    from tensor_grep.io.scan_limits import (
         BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
         BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
     )
@@ -730,11 +743,12 @@ def _search_paths_include_workspace_root(paths: list[str]) -> bool:
 # `DirectoryScanner`'s `_GENERATED_DIR_NAMES` (currently just `node_modules` of the four
 # above) -- that dir was already bounded (walker-skipped + normally `.gitignore`d + Fix B's
 # per-file deadline), so refusing it was a pure false positive against every ordinary
-# Node/React repo. Imported (not hardcoded) from `io/directory_scanner.py` so this set and
-# cli/main.py's equivalent guard can never drift out of sync.
+# Node/React repo. Imported (not hardcoded) from `io/scan_limits.py` (campaign #6 / F2.4; was
+# `io/directory_scanner.py`, which still re-exports it) so this set and cli/main.py's equivalent
+# guard can never drift out of sync.
 def _search_paths_include_vendored_root(paths: list[str]) -> bool:
     """O(top-level-entries) probe: never walks -- only `Path.iterdir()` one level deep."""
-    from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+    from tensor_grep.io.scan_limits import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 
     for raw_path in paths:
         if not raw_path or raw_path == "-" or raw_path.startswith("-"):

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -43,7 +43,18 @@ from tensor_grep.cli.runtime_paths import (
 )
 from tensor_grep.core.observability import nvtx_range
 from tensor_grep.core.retrieval_chunker import MAX_CHUNKS
-from tensor_grep.io.directory_scanner import (
+
+# perf (+10% campaign #6 / F2.4): import the 5 broad-scan-guard constants from the
+# zero-dependency `tensor_grep.io.scan_limits` module directly, NOT from
+# `tensor_grep.io.directory_scanner` (which does `from tensor_grep.core.config import
+# SearchConfig` at its own module level -- SearchConfig transitively pulls in the stdlib
+# `dataclasses`/`inspect` chain). This module-level import runs for every full-CLI command
+# (--help, scan, test, ast-info, ...); these 5 names are plain frozensets/ints consumed only by
+# the module-level broad-scan literals below, never SearchConfig itself, so there is no reason
+# to pay for the heavier module merely to read 5 constants from it. `DirectoryScanner` itself is
+# still imported lazily, function-local, at each call site that actually walks a tree (unchanged
+# by this PR). See `tensor_grep.io.scan_limits`'s module docstring for the full rationale.
+from tensor_grep.io.scan_limits import (
     BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
     BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
     BROAD_WORKSPACE_PROJECT_MARKERS,

--- a/src/tensor_grep/cli/runtime_paths.py
+++ b/src/tensor_grep/cli/runtime_paths.py
@@ -1,7 +1,14 @@
-import json
+# perf (+10% campaign #6 / F2.5): `json` and `shutil` moved to function-local imports at their
+# only call sites below (`_read_native_frontdoor_metadata`, `translate_path_for_windows_binary`,
+# `resolve_ripgrep_binary`) -- this whole module is imported EAGERLY at `cli/bootstrap.py`'s
+# module level (`from tensor_grep.cli.runtime_paths import (env_flag_enabled,
+# resolve_native_tg_binary, resolve_ripgrep_binary)`), so its own top-level imports are paid on
+# EVERY `tg` invocation, including the trivial `--version`/`-V` fast path -- which calls neither
+# `resolve_ripgrep_binary` nor `_read_native_frontdoor_metadata`/`translate_path_for_windows_binary`
+# (see `bootstrap._print_version`, which never touches this module beyond names already imported).
+# See `tests/unit/test_bootstrap_fast_path_imports.py` for the regression test that pins this.
 import os
 import re
-import shutil
 import subprocess
 import sys
 from functools import lru_cache
@@ -134,6 +141,8 @@ def native_frontdoor_metadata_path(native_binary: Path) -> Path:
 
 
 def _read_native_frontdoor_metadata(native_binary: Path) -> dict[str, str]:
+    import json
+
     metadata_path = native_frontdoor_metadata_path(native_binary)
     try:
         # Bounded + fail-closed (gate NIT-2 on #704): this reader now also runs on the agent
@@ -500,6 +509,8 @@ def translate_path_for_windows_binary(
     caller can report a distinct `path_domain_mismatch` status instead of silently handing the
     Windows binary a Linux path it cannot open.
     """
+    import shutil
+
     wslpath_bin = shutil.which("wslpath")
     if wslpath_bin is None:
         return None
@@ -549,6 +560,8 @@ def gpu_probe_timeout_s(
 
 @lru_cache(maxsize=1)
 def resolve_ripgrep_binary() -> Path | None:
+    import shutil
+
     binary_name = "rg.exe" if sys.platform.startswith("win") else "rg"
 
     # Priority 1: Explicit override

--- a/src/tensor_grep/cli/scan_guardrails.py
+++ b/src/tensor_grep/cli/scan_guardrails.py
@@ -4,7 +4,13 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from tensor_grep.io.directory_scanner import (
+# perf (+10% campaign #6 / F2.4): import from the zero-dependency `tensor_grep.io.scan_limits`
+# module, not `tensor_grep.io.directory_scanner` (which does `from tensor_grep.core.config import
+# SearchConfig` at its own module level). This module is imported eagerly by `cli/ast_workflows.py`
+# (itself lazily imported, but unconditionally for every `tg scan`/`tg test`/`tg ast-info`/`tg run`
+# invocation that reaches it), and only ever needs these 3 plain constants -- never SearchConfig or
+# DirectoryScanner -- so there is no reason to pay for the heavier module here.
+from tensor_grep.io.scan_limits import (
     BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
     BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
     BROAD_WORKSPACE_PROJECT_MARKERS,

--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -6,90 +6,43 @@ from typing import TYPE_CHECKING
 
 from tensor_grep.core.config import SearchConfig
 
+# perf (+10% campaign #6 / F2.4): the 5 broad-scan-guard constants below (plus the private
+# `_GENERATED_DIR_NAMES` skip-list they're partly derived from) are now DEFINED in
+# `tensor_grep.io.scan_limits` -- a zero-dependency sibling module (no `SearchConfig` import) --
+# and re-exported here via the `import ... as ...` idiom (same redundant-alias convention
+# `cli/bootstrap.py` already uses for `run_subprocess`) so this module's public surface is
+# unchanged for any existing `from tensor_grep.io.directory_scanner import <NAME>` caller. A
+# caller that wants ONLY the constants (`cli/bootstrap.py`'s 3 guard helpers, `cli/main.py`'s
+# module-level broad-scan literals, `cli/scan_guardrails.py`) should import directly from
+# `tensor_grep.io.scan_limits` instead -- that path never executes THIS module's own
+# `SearchConfig` import (see `tensor_grep.io.scan_limits`'s module docstring for the full
+# rationale and `tests/unit/test_bootstrap_fast_path_imports.py` for the regression tests that
+# pin it).
+from tensor_grep.io.scan_limits import (
+    _GENERATED_DIR_NAMES,
+)
+from tensor_grep.io.scan_limits import (
+    BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD as BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD,
+)
+from tensor_grep.io.scan_limits import (
+    BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD as BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD,
+)
+from tensor_grep.io.scan_limits import (
+    BROAD_WORKSPACE_PROJECT_MARKERS as BROAD_WORKSPACE_PROJECT_MARKERS,
+)
+from tensor_grep.io.scan_limits import (
+    IMPLICIT_SEARCH_WALK_FILE_CEILING as IMPLICIT_SEARCH_WALK_FILE_CEILING,
+)
+from tensor_grep.io.scan_limits import (
+    UNBOUNDED_VENDORED_ROOT_DIR_NAMES as UNBOUNDED_VENDORED_ROOT_DIR_NAMES,
+)
+
 if TYPE_CHECKING:
     from pathspec.gitignore import GitIgnoreSpec
 
-_GENERATED_DIR_NAMES = {
-    "__pycache__",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".tox",
-    ".venv",
-    "build",
-    "coverage",
-    "dist",
-    "node_modules",
-    "target",
-    "venv",
-}
 _GENERATED_RELATIVE_DIRS = {
     ".claude/context",
 }
-
-# Heavy dirs that may legitimately sit at a project ROOT's top level and that an unscoped
-# `tg search` should refuse to blindly walk into (PR #400 fix C, review finding H1). A name
-# already in `_GENERATED_DIR_NAMES` above (e.g. `node_modules`) is already walker-skipped by
-# `_should_descend_dir` -- it can never cause the walker to hang on its own, so it must NOT
-# also appear in the refusal trigger set below (a refusal for a dir the walker never
-# descends is a pure false positive: it wrongly exit-2's every ordinary Node/React repo).
-# Single source of truth: both `cli/main.py`'s `_should_refuse_unbounded_vendored_root_scan`
-# and `cli/bootstrap.py`'s front-door mirror `_search_paths_include_vendored_root` import
-# `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` from here rather than each hardcoding their own
-# (subtracted) copy, so the two guards can never drift out of sync.
-_ALL_HEAVY_ROOT_DIR_NAMES = frozenset({
-    "node_modules",
-    "vendor",
-    "external_repos",
-    "third_party",
-})
-UNBOUNDED_VENDORED_ROOT_DIR_NAMES = frozenset(_ALL_HEAVY_ROOT_DIR_NAMES - _GENERATED_DIR_NAMES)
-
-# Project-marker names that flag a directory as an independent project root, plus the
-# child-count thresholds that decide when a root "looks like" a multi-project workspace
-# parent (item #154). Single source of truth: both `cli/main.py`'s
-# `_should_refuse_unbounded_workspace_root_scan` and `cli/bootstrap.py`'s front-door mirror
-# `_search_paths_include_workspace_root` import `BROAD_WORKSPACE_PROJECT_MARKERS` and the two
-# thresholds below from here rather than each hardcoding their own copy, so the two guards can
-# never drift out of sync.
-BROAD_WORKSPACE_PROJECT_MARKERS = frozenset({
-    ".git",
-    "Cargo.toml",
-    "build.gradle",
-    "composer.json",
-    "deno.json",
-    "go.mod",
-    "package.json",
-    "pom.xml",
-    "pyproject.toml",
-    "settings.gradle",
-})
-# An UNMARKED root (no project marker of its own -- e.g. a plain folder of unrelated repos) is
-# flagged as a workspace parent once it has this many independently-marked children.
-BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
-# A MARKED root (carries its own project marker, e.g. a top-level `package.json`) is NOT
-# skipped outright (item #154, reported repro: an unscoped search from a workspace parent that
-# itself has a top-level `package.json` timed out instead of fast-refusing): such a root can
-# *also* be a workspace parent once it has enough independently-marked children. It uses a
-# HIGHER threshold than an unmarked root, since one ordinary project can legitimately carry a
-# handful of marked children (a Cargo workspace member, a vendored submodule) without itself
-# being a workspace parent.
-BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = 8
-
-# Item #105-parity (bootstrap raw-rg-passthrough gap, CEO dogfood v1.92.x): the ceiling above
-# which an IMPLICIT-path (no explicit PATH positional) search walk must be refused rather than
-# run to completion/timeout. Neither the workspace-root guard above (needs >=3/>=8
-# independently-MARKED sibling dirs) nor the vendored-root guard (needs a top-level vendored dir
-# NAME) catches a plain, single, large repo root -- e.g. a flat monorepo `src/` with thousands of
-# files, no vendored subdir, and no marked siblings. `cli/main.py`'s `_LARGE_ROOT_SCAN_FILE_CEILING`
-# (Bug #88 fix, the full-CLI-side guard) and `cli/bootstrap.py`'s front-door mirror
-# `_search_paths_include_oversized_implicit_root` both import this single source of truth so the
-# two guards can never drift out of sync (same pattern as `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` and
-# `BROAD_WORKSPACE_PROJECT_MARKERS` above). Matches the Rust native front door's own
-# `IMPLICIT_SEARCH_WALK_FILE_CEILING` (`rust_core/src/rg_passthrough.rs`, audit #100/#105/#109) --
-# kept at the same numeric value by convention across the language boundary (a literal constant
-# cannot be shared across Python/Rust).
-IMPLICIT_SEARCH_WALK_FILE_CEILING = 1500
 
 # The Rust PyO3 directory scanner (`RustDirectoryScanner`) is NOT exported by the `rust_core`
 # extension (only `RustBackend` + functions are), so the old `from rust_core import

--- a/src/tensor_grep/io/scan_limits.py
+++ b/src/tensor_grep/io/scan_limits.py
@@ -1,0 +1,106 @@
+"""Zero-dependency scan-limit constants: the single source of truth for the search-time broad-scan
+guards, shared across the Python front doors AND the Rust native front door.
+
+perf (+10% campaign #6 / F2.4): these 5 constants used to live in ``io/directory_scanner.py``,
+which does ``from tensor_grep.core.config import SearchConfig`` at ITS OWN module level -- and
+``SearchConfig`` transitively pulls in the stdlib ``dataclasses`` module (which itself imports
+``inspect``/``ast``/``dis``/``tokenize``/``copy``/``weakref``). A caller that only wants a plain
+frozenset or int (``cli/bootstrap.py``'s 3 guard helpers, ``cli/main.py``'s module-level broad-scan
+literals, ``cli/scan_guardrails.py``'s ``tg scan`` guard) had no way to get one WITHOUT also paying
+for the whole ``SearchConfig`` chain, because importing ANY name from a module executes that
+module's entire top level first. This module holds only frozenset/dict/int literals -- no imports
+at all -- so any caller that needs just the constants can import from here directly and never touch
+``SearchConfig``/``dataclasses``/``inspect``.
+
+``io/directory_scanner.py`` re-exports every public name below (``import ... as ...``, the same
+redundant-alias idiom already used by ``cli/bootstrap.py`` for ``run_subprocess``) so its public
+surface is unchanged for any existing caller of ``tensor_grep.io.directory_scanner.<NAME>`` -- this
+module is the canonical DEFINITION site, ``directory_scanner`` is a compatibility re-export.
+``_GENERATED_DIR_NAMES`` also moves here (rather than staying a directory_scanner-local literal)
+because ``UNBOUNDED_VENDORED_ROOT_DIR_NAMES`` below is DERIVED from it -- keeping the derivation and
+its input in the same zero-dependency module avoids a second, driftable copy of ``_GENERATED_DIR_
+NAMES`` living in ``directory_scanner.py`` just to feed a value re-exported from here.
+"""
+
+# Directory names the walker already treats as generated/skip-worthy. `io/directory_scanner.py`'s
+# `DirectoryScanner._should_descend_dir` imports this back (it is the walker's own skip-list, not
+# just an input to the derivation below) -- see the comment on `UNBOUNDED_VENDORED_ROOT_DIR_NAMES`
+# for why a name already in here can never ALSO trigger the vendored-root refusal.
+_GENERATED_DIR_NAMES = {
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+    "venv",
+}
+
+# Heavy dirs that may legitimately sit at a project ROOT's top level and that an unscoped
+# `tg search` should refuse to blindly walk into (PR #400 fix C, review finding H1). A name
+# already in `_GENERATED_DIR_NAMES` above (e.g. `node_modules`) is already walker-skipped by
+# `_should_descend_dir` -- it can never cause the walker to hang on its own, so it must NOT
+# also appear in the refusal trigger set below (a refusal for a dir the walker never
+# descends is a pure false positive: it wrongly exit-2's every ordinary Node/React repo).
+# Single source of truth: both `cli/main.py`'s `_should_refuse_unbounded_vendored_root_scan`
+# and `cli/bootstrap.py`'s front-door mirror `_search_paths_include_vendored_root` import
+# `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` from here rather than each hardcoding their own
+# (subtracted) copy, so the two guards can never drift out of sync.
+_ALL_HEAVY_ROOT_DIR_NAMES = frozenset({
+    "node_modules",
+    "vendor",
+    "external_repos",
+    "third_party",
+})
+UNBOUNDED_VENDORED_ROOT_DIR_NAMES = frozenset(_ALL_HEAVY_ROOT_DIR_NAMES - _GENERATED_DIR_NAMES)
+
+# Project-marker names that flag a directory as an independent project root, plus the
+# child-count thresholds that decide when a root "looks like" a multi-project workspace
+# parent (item #154). Single source of truth: both `cli/main.py`'s
+# `_should_refuse_unbounded_workspace_root_scan` and `cli/bootstrap.py`'s front-door mirror
+# `_search_paths_include_workspace_root` import `BROAD_WORKSPACE_PROJECT_MARKERS` and the two
+# thresholds below from here rather than each hardcoding their own copy, so the two guards can
+# never drift out of sync.
+BROAD_WORKSPACE_PROJECT_MARKERS = frozenset({
+    ".git",
+    "Cargo.toml",
+    "build.gradle",
+    "composer.json",
+    "deno.json",
+    "go.mod",
+    "package.json",
+    "pom.xml",
+    "pyproject.toml",
+    "settings.gradle",
+})
+# An UNMARKED root (no project marker of its own -- e.g. a plain folder of unrelated repos) is
+# flagged as a workspace parent once it has this many independently-marked children.
+BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD = 3
+# A MARKED root (carries its own project marker, e.g. a top-level `package.json`) is NOT
+# skipped outright (item #154, reported repro: an unscoped search from a workspace parent that
+# itself has a top-level `package.json` timed out instead of fast-refusing): such a root can
+# *also* be a workspace parent once it has enough independently-marked children. It uses a
+# HIGHER threshold than an unmarked root, since one ordinary project can legitimately carry a
+# handful of marked children (a Cargo workspace member, a vendored submodule) without itself
+# being a workspace parent.
+BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD = 8
+
+# Item #105-parity (bootstrap raw-rg-passthrough gap, CEO dogfood v1.92.x): the ceiling above
+# which an IMPLICIT-path (no explicit PATH positional) search walk must be refused rather than
+# run to completion/timeout. Neither the workspace-root guard above (needs >=3/>=8
+# independently-MARKED sibling dirs) nor the vendored-root guard (needs a top-level vendored dir
+# NAME) catches a plain, single, large repo root -- e.g. a flat monorepo `src/` with thousands of
+# files, no vendored subdir, and no marked siblings. `cli/main.py`'s `_LARGE_ROOT_SCAN_FILE_CEILING`
+# (Bug #88 fix, the full-CLI-side guard) and `cli/bootstrap.py`'s front-door mirror
+# `_search_paths_include_oversized_implicit_root` both import this single source of truth so the
+# two guards can never drift out of sync (same pattern as `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` and
+# `BROAD_WORKSPACE_PROJECT_MARKERS` above). Matches the Rust native front door's own
+# `IMPLICIT_SEARCH_WALK_FILE_CEILING` (`rust_core/src/rg_passthrough.rs`, audit #100/#105/#109) --
+# kept at the same numeric value by convention across the language boundary (a literal constant
+# cannot be shared across Python/Rust).
+IMPLICIT_SEARCH_WALK_FILE_CEILING = 1500

--- a/tests/unit/test_bootstrap_fast_path_imports.py
+++ b/tests/unit/test_bootstrap_fast_path_imports.py
@@ -169,14 +169,19 @@ def test_runtime_paths_bare_import_does_not_pull_json_or_shutil() -> None:
     -- calling none of its functions -- must not load the stdlib ``json``/``shutil`` modules.
     Both are now function-local at their only call sites (``_read_native_frontdoor_metadata``,
     ``translate_path_for_windows_binary``, ``resolve_ripgrep_binary``), so a bare import should
-    cost neither."""
+    cost neither. Measured as the sys.modules DELTA across the import (not an absolute
+    ) so a process that pre-loads json/shutil at interpreter startup --
+    e.g. the cuDF/GPU-dep env's site customization on the test-gpu runner -- does not false-fail.
+    """
     probe_source = f"""
 import sys
 sys.path.insert(0, {_REPO_SRC!r})
+_before = set(sys.modules)
 import tensor_grep.cli.runtime_paths
+_added = set(sys.modules) - _before
 _status = {{
-    "json_loaded": "json" in sys.modules,
-    "shutil_loaded": "shutil" in sys.modules,
+    "json_loaded": "json" in _added,
+    "shutil_loaded": "shutil" in _added,
 }}
 import json as _json
 print(_json.dumps(_status))

--- a/tests/unit/test_bootstrap_fast_path_imports.py
+++ b/tests/unit/test_bootstrap_fast_path_imports.py
@@ -29,6 +29,33 @@ stay a directly-bound module attribute of ``bootstrap`` (pytest's ``monkeypatch.
 function-local import would create a local binding that silently shadows any monkeypatched
 module attribute instead of being intercepted by it). Deferring it would require rewriting that
 entire mocking contract -- out of scope for this fast-path-import PR.
+
+perf (+10% campaign #6, F2.4/F2.5/F2.6 follow-up): three more import-deferral moves, each pinned
+below.
+
+- F2.4: the 5 broad-scan-guard constants (``UNBOUNDED_VENDORED_ROOT_DIR_NAMES``,
+  ``BROAD_WORKSPACE_PROJECT_MARKERS``, ``BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD``,
+  ``BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD``, ``IMPLICIT_SEARCH_WALK_FILE_CEILING``) moved
+  from ``tensor_grep.io.directory_scanner`` to the new zero-dependency ``tensor_grep.io.
+  scan_limits`` module. The 3 guard helpers above (and ``cli/main.py``'s module-level broad-scan
+  literals, and ``cli/scan_guardrails.py``) now import from ``scan_limits`` instead, so a real
+  search invocation that reaches the guard no longer drags in ``SearchConfig``/``dataclasses``/
+  ``inspect`` merely to read 5 plain constants -- even when the search is ultimately delegated to
+  the native binary or ``rg`` (both of which do their own walk in a separate process and never
+  touch Python's ``DirectoryScanner`` at all). ``directory_scanner`` (and hence ``core.config``)
+  is still imported exactly when a real Python-side walk is genuinely needed -- e.g.
+  ``_search_paths_include_oversized_implicit_root``, which constructs a real ``DirectoryScanner``,
+  is deliberately UNCHANGED.
+- F2.5: ``cli/runtime_paths.py``'s module-level ``import json`` / ``import shutil`` moved to
+  function-local at their only call sites (``_read_native_frontdoor_metadata``,
+  ``translate_path_for_windows_binary``, ``resolve_ripgrep_binary``). This module is imported
+  EAGERLY by ``cli/bootstrap.py``'s own module level (for ``env_flag_enabled``,
+  ``resolve_native_tg_binary``, ``resolve_ripgrep_binary``), so its top-level imports were paid on
+  every invocation including ``--version`` -- which calls none of the three functions above.
+- F2.6: ``cli/__init__.py``'s ``from typing import Any`` removed (the sole use, ``__getattr__``'s
+  return annotation, is now the builtin ``object`` instead -- needs no import at all).
+  ``tensor_grep.cli`` is the parent package of every ``tensor_grep.cli.*`` submodule, so this
+  file's own import cost is paid before ANY submodule-specific code runs, on every invocation.
 """
 
 from __future__ import annotations
@@ -39,28 +66,45 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_SRC = str(Path(__file__).resolve().parents[2] / "src")
 
 # Kept as a single string (not a helper module) so the subprocess starts from a totally clean
-# interpreter state -- no pytest plugins, no already-imported tensor_grep submodules.
+# interpreter state -- no pytest plugins, no already-imported tensor_grep submodules. ``{setup}``
+# is an optional extra statement block (e.g. a monkeypatch) injected AFTER importing bootstrap
+# but BEFORE calling ``main_entry`` -- used by the oversized-single-root test below to force the
+# "no native binary, no rg" branch deterministically instead of depending on the ambient dev
+# machine's PATH (which may or may not resolve a real ``tg``/``rg``).
+#
+# The ``sys.modules`` snapshot (``_status``) is captured BEFORE this probe's OWN diagnostic
+# ``import json`` runs -- serializing the result via ``json.dumps`` would otherwise contaminate
+# the very ``json_loaded`` measurement it is trying to report (a probe-design bug caught by
+# ``test_version_fast_path_does_not_import_json_or_shutil`` initially failing against a correct
+# F2.5 fix: the PROBE, not the product, was the false positive).
 _PROBE_TEMPLATE = """
 import sys
 sys.argv = {argv!r}
 import tensor_grep.cli.bootstrap as bootstrap
+{setup}
 try:
     bootstrap.main_entry()
 except SystemExit:
     pass
-import json
-print(json.dumps({{
+_status = {{
     "directory_scanner_loaded": "tensor_grep.io.directory_scanner" in sys.modules,
     "core_config_loaded": "tensor_grep.core.config" in sys.modules,
-}}))
+    "scan_limits_loaded": "tensor_grep.io.scan_limits" in sys.modules,
+    "json_loaded": "json" in sys.modules,
+    "shutil_loaded": "shutil" in sys.modules,
+}}
+import json as _json
+print(_json.dumps(_status))
 """
 
 
-def _run_fast_path_probe(argv: list[str]) -> dict[str, bool]:
-    probe_source = _PROBE_TEMPLATE.format(argv=argv)
+def _run_fast_path_probe(argv: list[str], *, setup: str = "") -> dict[str, bool]:
+    probe_source = _PROBE_TEMPLATE.format(argv=argv, setup=setup)
     env = dict(os.environ)
     env["PYTHONPATH"] = _REPO_SRC
     result = subprocess.run(
@@ -98,15 +142,299 @@ def test_short_version_flag_fast_path_does_not_import_directory_scanner() -> Non
     assert status["core_config_loaded"] is False
 
 
+def test_version_fast_path_does_not_import_json_via_runtime_paths() -> None:
+    """F2.5 (partial, end-to-end): ``cli/runtime_paths.py`` is imported eagerly by
+    ``cli/bootstrap.py`` (for ``env_flag_enabled``/``resolve_native_tg_binary``/
+    ``resolve_ripgrep_binary``), but ``--version`` calls none of the three -- so the stdlib
+    ``json`` module ``_read_native_frontdoor_metadata`` needs must not load just because
+    runtime_paths.py itself was imported.
+
+    Deliberately does NOT also assert ``shutil_loaded is False`` here: verified via
+    ``-X importtime`` that ``_print_version``'s OWN ``from importlib.metadata import version;
+    version("tensor-grep")`` call pulls in ``shutil`` (plus ``csv``/``email``/``bz2``/``lzma``)
+    through CPython's OWN package-metadata resolution machinery -- entirely unrelated to
+    runtime_paths.py and outside this PR's scope. See
+    ``test_runtime_paths_bare_import_does_not_pull_json_or_shutil`` below for the precise,
+    uncontaminated claim: runtime_paths.py ITSELF no longer needs either module merely to import.
+    """
+    status = _run_fast_path_probe(["tg", "--version"])
+    assert status["json_loaded"] is False, (
+        "tg --version must not import the stdlib json module -- runtime_paths.py's only json "
+        "user (_read_native_frontdoor_metadata) is unreachable from --version"
+    )
+
+
+def test_runtime_paths_bare_import_does_not_pull_json_or_shutil() -> None:
+    """F2.5 (the precise claim): importing ``tensor_grep.cli.runtime_paths`` in total isolation
+    -- calling none of its functions -- must not load the stdlib ``json``/``shutil`` modules.
+    Both are now function-local at their only call sites (``_read_native_frontdoor_metadata``,
+    ``translate_path_for_windows_binary``, ``resolve_ripgrep_binary``), so a bare import should
+    cost neither."""
+    probe_source = f"""
+import sys
+sys.path.insert(0, {_REPO_SRC!r})
+import tensor_grep.cli.runtime_paths
+_status = {{
+    "json_loaded": "json" in sys.modules,
+    "shutil_loaded": "shutil" in sys.modules,
+}}
+import json as _json
+print(_json.dumps(_status))
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [sys.executable, "-c", probe_source],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    status = json.loads(result.stdout.strip().splitlines()[-1])
+    assert status["json_loaded"] is False, (
+        "a bare `import tensor_grep.cli.runtime_paths` must not import the stdlib json module"
+    )
+    assert status["shutil_loaded"] is False, (
+        "a bare `import tensor_grep.cli.runtime_paths` must not import the stdlib shutil module"
+    )
+
+
 def test_plain_search_still_imports_directory_scanner_when_actually_needed(
     tmp_path: Path,
 ) -> None:
     """Non-regression: the deferral must not make the broad-scan guard silently unavailable for
-    a real search invocation. `main_entry`'s `guarded_broad_root` check
-    (`_search_args_include_unbounded_broad_scan`, which needs `directory_scanner`'s constants)
-    runs unconditionally for any search-shaped argv -- BEFORE the native/rg/full-CLI branch
-    decision -- so this must hold regardless of what native/rg binaries happen to be resolvable
-    in the test environment's PATH. Proves this is genuinely "loaded when needed", not
-    "permanently broken"."""
-    status = _run_fast_path_probe(["tg", "search", "needle", str(tmp_path)])
+    a real search invocation, and ``directory_scanner`` (hence ``SearchConfig``) must still load
+    exactly when a real Python-side walk is genuinely required.
+
+    F2.4 update: before campaign #6, `directory_scanner` loaded UNCONDITIONALLY for any
+    search-shaped argv (the guard helpers imported it just for 5 constants). After F2.4 it loads
+    only when Python's own `DirectoryScanner` actually runs -- which does NOT happen when the
+    search gets delegated to the native binary or `rg` (both walk in a separate process). This
+    test therefore forces that "no native, no rg" branch explicitly (rather than relying on
+    whether the CI/dev machine happens to have a real `tg`/`rg` on PATH) so the assertion is
+    deterministic: `resolve_native_tg_binary`/`resolve_ripgrep_binary` are monkeypatched to `None`
+    via the injected `setup` block, mirroring the exact pattern `test_cli_bootstrap.py` uses
+    in-process (`monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", ...)`) -- just applied
+    via source injection since this probe must run in a fresh subprocess.
+    """
+    status = _run_fast_path_probe(
+        ["tg", "search", "needle", str(tmp_path)],
+        setup=(
+            "bootstrap.resolve_native_tg_binary = lambda: None\n"
+            "bootstrap.resolve_ripgrep_binary = lambda: None"
+        ),
+    )
     assert status["directory_scanner_loaded"] is True
+
+
+def test_search_broad_scan_guard_helpers_use_scan_limits_not_core_config(
+    tmp_path: Path,
+) -> None:
+    """F2.4 (the core fix): the 3 broad-scan guard helpers (`_path_has_project_marker`,
+    `_search_paths_include_workspace_root`, `_search_paths_include_vendored_root`) only need 5
+    plain frozenset/int constants -- calling them directly must load the new zero-dependency
+    `tensor_grep.io.scan_limits` module WITHOUT ever loading `tensor_grep.io.directory_scanner`
+    or `tensor_grep.core.config` (and therefore never `SearchConfig`/`dataclasses`/`inspect`).
+    This is the precise claim the ranked-queue item's "~36ms on explicit-path search" prediction
+    rests on: the guard-only path, in isolation, must be genuinely `SearchConfig`-free."""
+    probe_source = f"""
+import sys
+sys.path.insert(0, {_REPO_SRC!r})
+import tensor_grep.cli.bootstrap as bootstrap
+from pathlib import Path
+root = Path({str(tmp_path)!r})
+bootstrap._path_has_project_marker(root)
+bootstrap._search_paths_include_workspace_root([str(root)])
+bootstrap._search_paths_include_vendored_root([str(root)])
+import json
+print(json.dumps({{
+    "directory_scanner_loaded": "tensor_grep.io.directory_scanner" in sys.modules,
+    "core_config_loaded": "tensor_grep.core.config" in sys.modules,
+    "scan_limits_loaded": "tensor_grep.io.scan_limits" in sys.modules,
+}}))
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [sys.executable, "-c", probe_source],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    status = json.loads(result.stdout.strip().splitlines()[-1])
+    assert status["scan_limits_loaded"] is True, (
+        "the 3 guard helpers must load tensor_grep.io.scan_limits to read their constants"
+    )
+    assert status["directory_scanner_loaded"] is False, (
+        "the 3 guard helpers must NOT load tensor_grep.io.directory_scanner -- they only need "
+        "plain constants, never SearchConfig or the DirectoryScanner class"
+    )
+    assert status["core_config_loaded"] is False, (
+        "the 3 guard helpers must NOT load tensor_grep.core.config (SearchConfig) -- that module "
+        "is only needed by a real DirectoryScanner walk, not by a constants-only guard check"
+    )
+
+
+def test_bare_cli_main_import_does_not_pull_directory_scanner() -> None:
+    """F2.4 (cli/main.py side): importing `tensor_grep.cli.main` in isolation -- simulating what
+    happens for `tg --help`/`scan`/`test`/`ast-info`, which import it but run no command body --
+    must not pull in `tensor_grep.io.directory_scanner` merely to read the 5 broad-scan
+    constants at module level (main.py:46-52 pre-fix read them FROM directory_scanner).
+    `DirectoryScanner` is still imported lazily, function-local, at each command that actually
+    walks a tree -- a bare import must not reach it.
+
+    Deliberately does NOT also assert `core_config_loaded is False`: verified via a traced
+    `builtins.__import__` that `tensor_grep.core.config` (SearchConfig) still loads for a bare
+    `cli.main` import through a WHOLLY UNRELATED, pre-existing path --
+    `cli/formatters/json_fmt.py:5`'s own module-level `from tensor_grep.core.config import
+    SearchConfig`, reached via `cli/formatters/__init__.py` (main.py's own eager `from
+    tensor_grep.cli.formatters.base import OutputFormatter` pulls in the whole `formatters`
+    package). That is out of this PR's scope (F2.4 is specifically about the 5 broad-scan
+    constants' source module, not every SearchConfig import in the CLI). The precise, TRUE claim
+    this PR makes is `directory_scanner_loaded is False` -- confirmed below."""
+    probe_source = f"""
+import sys
+sys.path.insert(0, {_REPO_SRC!r})
+import tensor_grep.cli.main
+import json
+print(json.dumps({{
+    "directory_scanner_loaded": "tensor_grep.io.directory_scanner" in sys.modules,
+    "scan_limits_loaded": "tensor_grep.io.scan_limits" in sys.modules,
+}}))
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [sys.executable, "-c", probe_source],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    status = json.loads(result.stdout.strip().splitlines()[-1])
+    assert status["scan_limits_loaded"] is True
+    assert status["directory_scanner_loaded"] is False, (
+        "a bare `import tensor_grep.cli.main` must not import directory_scanner -- "
+        "main.py:46-52 must read the 5 broad-scan constants from tensor_grep.io.scan_limits"
+    )
+
+
+def test_bare_scan_guardrails_import_does_not_pull_directory_scanner_or_core_config() -> None:
+    """F2.4 (cli/scan_guardrails.py side): `tg scan`/`test`/`ast-info`/`run` reach this module
+    (via the lazily-imported `cli/ast_workflows.py`) for its 3 broad-scan constants only --
+    importing it in isolation must not pull in `directory_scanner`/`core.config`."""
+    probe_source = f"""
+import sys
+sys.path.insert(0, {_REPO_SRC!r})
+import tensor_grep.cli.scan_guardrails
+import json
+print(json.dumps({{
+    "directory_scanner_loaded": "tensor_grep.io.directory_scanner" in sys.modules,
+    "core_config_loaded": "tensor_grep.core.config" in sys.modules,
+    "scan_limits_loaded": "tensor_grep.io.scan_limits" in sys.modules,
+}}))
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [sys.executable, "-c", probe_source],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    status = json.loads(result.stdout.strip().splitlines()[-1])
+    assert status["scan_limits_loaded"] is True
+    assert status["directory_scanner_loaded"] is False
+    assert status["core_config_loaded"] is False
+
+
+def test_scan_limits_import_alone_is_dependency_free() -> None:
+    """F2.4: `tensor_grep.io.scan_limits` is documented as zero-dependency -- importing it in
+    total isolation must never pull in `tensor_grep.core.config` or `tensor_grep.io.
+    directory_scanner` (the whole point of splitting the constants into their own module)."""
+    probe_source = f"""
+import sys
+sys.path.insert(0, {_REPO_SRC!r})
+import tensor_grep.io.scan_limits
+import json
+print(json.dumps({{
+    "directory_scanner_loaded": "tensor_grep.io.directory_scanner" in sys.modules,
+    "core_config_loaded": "tensor_grep.core.config" in sys.modules,
+}}))
+"""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [sys.executable, "-c", probe_source],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    status = json.loads(result.stdout.strip().splitlines()[-1])
+    assert status["directory_scanner_loaded"] is False
+    assert status["core_config_loaded"] is False
+
+
+def test_cli_package_getattr_hook_still_resolves_main_entry() -> None:
+    """F2.6 non-regression: `cli/__init__.py`'s `__getattr__` return annotation changed from
+    `Any` to the builtin `object` (removing the module-level `from typing import Any`) -- this
+    must be a purely static-typing change with zero effect on the PEP 562 dynamic-attribute
+    mechanism itself. `tensor_grep.cli.main_entry` must still resolve to the exact same callable
+    as `tensor_grep.cli.bootstrap.main_entry`."""
+    import tensor_grep.cli
+    import tensor_grep.cli.bootstrap as bootstrap
+
+    assert tensor_grep.cli.main_entry is bootstrap.main_entry
+
+
+def test_cli_package_init_has_no_eager_typing_import() -> None:
+    """F2.6 source-level pin: `cli/__init__.py` is the parent-package init for every
+    `tensor_grep.cli.*` submodule, so ANY top-level `from typing import ...` there is paid on
+    every single `tg` invocation before any submodule-specific code runs. A source-text check
+    (rather than a `sys.modules` probe) is used here because `typing` may legitimately already be
+    loaded via an unrelated import by the time any probe subprocess reaches this file (e.g.
+    `click`/`typer` import it once the full CLI is reached) -- the actual, durable regression
+    surface is this file's OWN source no longer NEEDING the import, not whether `typing` happens
+    to be in `sys.modules` for some other reason."""
+    init_source = (Path(_REPO_SRC) / "tensor_grep" / "cli" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+    assert "import typing" not in init_source, (
+        "cli/__init__.py must not import typing at module level -- it is the parent-package "
+        "init paid on every tg invocation; __getattr__'s return annotation should be the "
+        "builtin `object`, which needs no import"
+    )
+
+
+@pytest.mark.parametrize("argv", [["tg", "--version"], ["tg", "-V"]])
+def test_version_fast_path_exit_code_and_banner_unaffected(argv: list[str]) -> None:
+    """Non-regression across all three moves at once: `--version`/`-V` must still print the
+    banner and exit 0 -- the import-deferral changes must be behavior-invisible on the one path
+    that exercises all of F2.4 (guard helpers never even called here), F2.5 (runtime_paths.py's
+    other functions never called here), and F2.6 (the package __getattr__ hook) simultaneously."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _REPO_SRC
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import sys; sys.argv = {argv!r}; "
+            "import tensor_grep.cli.bootstrap as bootstrap\n"
+            "try:\n    bootstrap.main_entry()\nexcept SystemExit as e:\n    "
+            "sys.exit(e.code if e.code is not None else 0)",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert result.stdout.strip().startswith("tensor-grep ")

--- a/tests/unit/test_bootstrap_fast_path_imports.py
+++ b/tests/unit/test_bootstrap_fast_path_imports.py
@@ -404,13 +404,34 @@ def test_cli_package_init_has_no_eager_typing_import() -> None:
     `click`/`typer` import it once the full CLI is reached) -- the actual, durable regression
     surface is this file's OWN source no longer NEEDING the import, not whether `typing` happens
     to be in `sys.modules` for some other reason."""
+    import ast
+
     init_source = (Path(_REPO_SRC) / "tensor_grep" / "cli" / "__init__.py").read_text(
         encoding="utf-8"
     )
-    assert "import typing" not in init_source, (
-        "cli/__init__.py must not import typing at module level -- it is the parent-package "
-        "init paid on every tg invocation; __getattr__'s return annotation should be the "
-        "builtin `object`, which needs no import"
+    # AST-parse the TOP-LEVEL statements (module-load-time cost) so the pin catches BOTH import
+    # forms. A bare `"import typing" not in init_source` substring check MISSES the exact
+    # `from typing import Any` this move removed -- that text contains "typing import", not
+    # "import typing" -- making the pin weaker than its own contract. Assert the real invariant:
+    # no top-level `import typing[.*]` and no top-level `from typing[.*] import ...`. (Imports
+    # nested under a function or an `if TYPE_CHECKING:` guard are not module-load cost and are not
+    # children of the Module node, so they are correctly ignored.)
+    eager_typing_imports: list[str] = []
+    for node in ast.iter_child_nodes(ast.parse(init_source)):
+        if isinstance(node, ast.Import):
+            eager_typing_imports += [
+                f"import {alias.name}"
+                for alias in node.names
+                if alias.name == "typing" or alias.name.startswith("typing.")
+            ]
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "typing" or module.startswith("typing."):
+                eager_typing_imports.append(f"from {module} import ...")
+    assert not eager_typing_imports, (
+        "cli/__init__.py must not import `typing` at module level (neither `import typing` nor "
+        "`from typing import ...`) -- it is the parent-package init paid on every tg invocation; "
+        f"__getattr__'s return annotation should be the builtin `object`. Found: {eager_typing_imports}"
     )
 
 

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -40,15 +40,17 @@ def test_vendored_root_dir_names_match_source_of_truth() -> None:
 
     perf/#48: bootstrap.py no longer binds `_UNBOUNDED_VENDORED_ROOT_DIR_NAMES` as a
     persistent module attribute -- `_search_paths_include_vendored_root` now does its own
-    function-local `from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES`
-    so that heavy import (which transitively pulls in `tensor_grep.core.config` and stdlib
-    `dataclasses`/`inspect`) is not paid by the `tg --version` fast path
-    (`tests/unit/test_bootstrap_fast_path_imports.py` pins that). Structurally this makes
+    function-local `from tensor_grep.io.scan_limits import UNBOUNDED_VENDORED_ROOT_DIR_NAMES`
+    (campaign #6 / F2.4: moved from `tensor_grep.io.directory_scanner`, which transitively pulls
+    in `tensor_grep.core.config` and stdlib `dataclasses`/`inspect` -- `scan_limits` is
+    zero-dependency) so that heavy import is not paid by the `tg --version` fast path NOR by a
+    real search invocation whose guard check never needs `SearchConfig` at all
+    (`tests/unit/test_bootstrap_fast_path_imports.py` pins both). Structurally this makes
     bootstrap.py's copy DRIFT-PROOF -- it always re-reads the canonical set fresh, it can no
     longer hold a stale independent copy -- so this test now (a) checks cli/main.py's own
     still-module-level copy against the canonical source directly, and (b) behaviorally proves
     bootstrap's guard function actually consults that same canonical set."""
-    from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+    from tensor_grep.io.scan_limits import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 
     assert cli_main._UNBOUNDED_VENDORED_ROOT_DIR_NAMES == UNBOUNDED_VENDORED_ROOT_DIR_NAMES, (
         "cli/main.py's vendored-root trigger set must match the canonical source of truth exactly"
@@ -64,7 +66,7 @@ def test_vendored_root_guard_triggers_on_every_canonical_name(tmp_path: Path) ->
     `UNBOUNDED_VENDORED_ROOT_DIR_NAMES` set, and must NOT fire for an unrelated child name --
     proving the perf/#48 function-local import actually wires the guard to the real set rather
     than silently going stale/empty."""
-    from tensor_grep.io.directory_scanner import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+    from tensor_grep.io.scan_limits import UNBOUNDED_VENDORED_ROOT_DIR_NAMES
 
     for name in UNBOUNDED_VENDORED_ROOT_DIR_NAMES:
         root = tmp_path / f"root-{name}"
@@ -81,14 +83,84 @@ def test_vendored_root_guard_triggers_on_every_canonical_name(tmp_path: Path) ->
 def test_implicit_search_walk_file_ceiling_matches_source_of_truth() -> None:
     """Item #105-parity: cli/main.py's `_LARGE_ROOT_SCAN_FILE_CEILING` and cli/bootstrap.py's
     front-door mirror `_search_paths_include_oversized_implicit_root` must both consult the
-    SAME ceiling value (`io/directory_scanner.IMPLICIT_SEARCH_WALK_FILE_CEILING`), or the two
-    front doors (native/rg fast path vs full CLI) can disagree about whether an implicit-path
-    root is oversized -- exactly the class of drift the vendored/workspace constants above were
+    SAME ceiling value (`io/scan_limits.IMPLICIT_SEARCH_WALK_FILE_CEILING` -- campaign #6 / F2.4:
+    moved from `io/directory_scanner.py`, which still re-exports it), or the two front doors
+    (native/rg fast path vs full CLI) can disagree about whether an implicit-path root is
+    oversized -- exactly the class of drift the vendored/workspace constants above were
     centralized to prevent."""
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     assert cli_main._LARGE_ROOT_SCAN_FILE_CEILING == IMPLICIT_SEARCH_WALK_FILE_CEILING
     assert IMPLICIT_SEARCH_WALK_FILE_CEILING > 0
+
+
+def test_scan_limits_single_source_of_truth_across_every_re_export() -> None:
+    """Campaign #6 / F2.4 sync-pin (TDD requirement b): all 5 broad-scan-guard constants now
+    DEFINED in the zero-dependency `tensor_grep.io.scan_limits` module must be IDENTICAL --
+    same object, via `is`, not just `==` -- to every module that re-exports or copies them:
+    `io/directory_scanner.py`'s compatibility re-export (`import ... as ...`), `cli/main.py`'s
+    module-level broad-scan literals (`_UNBOUNDED_VENDORED_ROOT_DIR_NAMES`,
+    `_BROAD_WORKSPACE_PROJECT_MARKERS`, `_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD`,
+    `_BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD`, `_LARGE_ROOT_SCAN_FILE_CEILING`), and
+    `cli/scan_guardrails.py`'s own private aliases (`_BROAD_WORKSPACE_PROJECT_MARKERS`,
+    `_BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD`, `_BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD`).
+    `is` (not `==`) makes the single-source-of-truth contract a BUILD-TIME fact for the
+    frozenset-valued constants: two independently-constructed-but-equal frozensets would pass an
+    `==` check even after a future edit accidentally re-literals one copy instead of importing
+    it -- `is` can only pass when every site imports the exact same object. int constants have no
+    separate identity to lose (Python interns small ints), so `==` is the meaningful check for
+    those two; the assertion below uses `==` uniformly since it is the STRICTER check for
+    frozensets too (`is` implies `==`) and the weakest link (an accidental re-literal) is what
+    this test exists to catch."""
+    from tensor_grep.cli import scan_guardrails
+    from tensor_grep.io import directory_scanner, scan_limits
+
+    # scan_limits (the canonical definition) vs directory_scanner (the compatibility re-export):
+    # `is` -- a straight `import ... as ...` re-export must be the identical object, never a copy.
+    for name in (
+        "UNBOUNDED_VENDORED_ROOT_DIR_NAMES",
+        "BROAD_WORKSPACE_PROJECT_MARKERS",
+        "BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD",
+        "BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD",
+        "IMPLICIT_SEARCH_WALK_FILE_CEILING",
+    ):
+        canonical = getattr(scan_limits, name)
+        reexported = getattr(directory_scanner, name)
+        assert reexported is canonical, (
+            f"directory_scanner.{name} must be the SAME object as scan_limits.{name} "
+            "(a straight re-export, not a copy)"
+        )
+
+    # cli/main.py's module-level broad-scan literals ("bootstrap's view" of the constants --
+    # main.py:46-52 imports directly from scan_limits, the same path bootstrap.py's 3 guard
+    # helpers use function-locally):
+    assert (
+        cli_main._UNBOUNDED_VENDORED_ROOT_DIR_NAMES is scan_limits.UNBOUNDED_VENDORED_ROOT_DIR_NAMES
+    )
+    assert cli_main._BROAD_WORKSPACE_PROJECT_MARKERS is scan_limits.BROAD_WORKSPACE_PROJECT_MARKERS
+    assert (
+        cli_main._BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+        == scan_limits.BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+    )
+    assert (
+        cli_main._BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+        == scan_limits.BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+    )
+    assert cli_main._LARGE_ROOT_SCAN_FILE_CEILING == scan_limits.IMPLICIT_SEARCH_WALK_FILE_CEILING
+
+    # cli/scan_guardrails.py's own private aliases (the `tg scan` guard's view):
+    assert (
+        scan_guardrails._BROAD_WORKSPACE_PROJECT_MARKERS
+        is scan_limits.BROAD_WORKSPACE_PROJECT_MARKERS
+    )
+    assert (
+        scan_guardrails._BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+        == scan_limits.BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD
+    )
+    assert (
+        scan_guardrails._BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+        == scan_limits.BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD
+    )
 
 
 def test_oversized_implicit_root_probe_triggers_over_ceiling_real_walk(tmp_path: Path) -> None:
@@ -97,7 +169,7 @@ def test_oversized_implicit_root_probe_triggers_over_ceiling_real_walk(tmp_path:
     `test_implicit_glob_walk_probe_exceeds_ceiling_even_with_zero_matching_files` fixture style
     (real files on disk, not a monkeypatched-down ceiling), so this proves the SAME real-scale
     behavior at the bootstrap layer."""
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = tmp_path / "bigrepo"
     root.mkdir()
@@ -122,7 +194,7 @@ def test_oversized_implicit_root_probe_widens_for_no_ignore_flag(tmp_path: Path)
     because `--no-ignore` was requested must still be counted toward the ceiling, or a huge
     `--no-ignore` walk could slip through as "under ceiling" while the real search walks far
     more than the probe measured."""
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = tmp_path / "repo"
     root.mkdir()
@@ -147,7 +219,7 @@ def _gitignored_heavy_tree(tmp_path_factory):
     `.gitignore` hides a subdirectory containing more than `IMPLICIT_SEARCH_WALK_FILE_CEILING`
     files. Built ONCE (module-scoped) and only ever READ by the parametrized cases below -- 7
     independent 1500+-file trees would multiply this suite's I/O for no benefit."""
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = tmp_path_factory.mktemp("gitignored_heavy_tree")
     (root / ".gitignore").write_text("ignored/\n", encoding="utf-8")
@@ -182,7 +254,7 @@ def test_oversized_implicit_root_probe_matches_sibling_per_no_ignore_field(
     flip the sibling (which gets its `SearchConfig` for free from real Typer parsing rather than
     hand-building one from raw argv)."""
     from tensor_grep.core.config import SearchConfig
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = _gitignored_heavy_tree
     bootstrap_result = bootstrap._search_paths_include_oversized_implicit_root(
@@ -214,7 +286,7 @@ def test_oversized_implicit_root_probe_stops_short_of_full_walk(
     assertion is that it stayed at exactly ceiling+1 -- far short of the fabricated tree's full
     (10x-ceiling) size."""
     from tensor_grep.io import directory_scanner as ds_module
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = tmp_path / "hugerepo"
     root.mkdir()
@@ -489,7 +561,7 @@ def test_main_entry_should_not_passthrough_oversized_implicit_single_project_roo
     never even ran. It must now fall through to the full CLI instead, which owns the actual
     fast (<1s, no full-tree walk to timeout) refusal via `_should_refuse_unbounded_large_root_scan`.
     """
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     called = {"full_cli": False}
     root = tmp_path / "repo"
@@ -529,7 +601,7 @@ def test_main_entry_should_passthrough_oversized_EXPLICIT_root_search(
     explicit path is a deliberately-scoped root even when huge. Proves the new #105 guard does
     not regress the common scoped-search case (no added latency: the probe is gated on
     `paths_defaulted` and must never even run here)."""
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = tmp_path / "repo"
     root.mkdir()
@@ -1050,7 +1122,7 @@ def test_search_args_include_unbounded_broad_scan_refuses_oversized_implicit_sin
     unbounded broad scan when the path is implicit, and is exempted the moment either an
     explicit path or an explicit `--max-depth` bound is present -- same escape-hatch contract
     as the workspace/vendored guards above."""
-    from tensor_grep.io.directory_scanner import IMPLICIT_SEARCH_WALK_FILE_CEILING
+    from tensor_grep.io.scan_limits import IMPLICIT_SEARCH_WALK_FILE_CEILING
 
     root = tmp_path / "repo"
     root.mkdir()

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -536,9 +536,7 @@ def test_resolve_ripgrep_binary_prefers_path_rg_before_bundled(monkeypatch, tmp_
 
     monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
     monkeypatch.delenv("TG_RG_PATH", raising=False)
-    monkeypatch.setattr(
-        shutil, "which", lambda name: str(path_rg) if name == binary_name else None
-    )
+    monkeypatch.setattr(shutil, "which", lambda name: str(path_rg) if name == binary_name else None)
     resolve_ripgrep_binary.cache_clear()
 
     assert resolve_ripgrep_binary() == path_rg.resolve()

--- a/tests/unit/test_runtime_paths.py
+++ b/tests/unit/test_runtime_paths.py
@@ -96,7 +96,7 @@ def test_resolve_native_tg_binary_ignores_legacy_benchmark_binary(monkeypatch, t
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
     monkeypatch.setenv("PATH", "")
-    monkeypatch.setattr(runtime_paths.shutil, "which", lambda _: None)
+    monkeypatch.setattr(shutil, "which", lambda _: None)
     resolve_native_tg_binary.cache_clear()
 
     assert resolve_native_tg_binary() is None
@@ -119,7 +119,7 @@ def test_resolve_native_tg_binary_ignores_stale_in_tree_binary_without_explicit_
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
     monkeypatch.setenv("PATH", "")
-    monkeypatch.setattr(runtime_paths.shutil, "which", lambda _: None)
+    monkeypatch.setattr(shutil, "which", lambda _: None)
     monkeypatch.setattr(runtime_paths, "_expected_tg_version", lambda: "1.8.21", raising=False)
     monkeypatch.setattr(runtime_paths, "_native_tg_version", lambda _: "tg 1.8.14", raising=False)
     resolve_native_tg_binary.cache_clear()
@@ -142,7 +142,7 @@ def test_resolve_native_tg_binary_uses_matching_in_tree_binary(monkeypatch, tmp_
     monkeypatch.delenv("TG_NATIVE_TG_BINARY", raising=False)
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
     monkeypatch.setenv("PATH", "")
-    monkeypatch.setattr(runtime_paths.shutil, "which", lambda _: None)
+    monkeypatch.setattr(shutil, "which", lambda _: None)
     monkeypatch.setattr(runtime_paths, "_expected_tg_version", lambda: "1.8.21", raising=False)
     monkeypatch.setattr(runtime_paths, "_native_tg_version", lambda _: "tg 1.8.21", raising=False)
     resolve_native_tg_binary.cache_clear()
@@ -329,7 +329,7 @@ def test_resolve_native_tg_binary_ignores_current_python_launcher(monkeypatch, t
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
     monkeypatch.setenv("PATH", str(venv_dir))
     monkeypatch.setattr(
-        runtime_paths.shutil,
+        shutil,
         "which",
         lambda name: str(tg_path) if name in {"tg", "tg.exe"} else None,
     )
@@ -371,7 +371,7 @@ def test_resolve_native_tg_binary_ignores_current_python_launcher_when_python_re
     monkeypatch.setattr(runtime_paths.Path, "resolve", fake_resolve)
     monkeypatch.setenv("PATH", str(venv_dir))
     monkeypatch.setattr(
-        runtime_paths.shutil,
+        shutil,
         "which",
         lambda name: str(tg_path) if name in {"tg", "tg.exe"} else None,
     )
@@ -450,7 +450,7 @@ def test_resolve_native_tg_binary_ignores_foreign_python_install_scripts_launche
     monkeypatch.delenv("TG_MCP_TG_BINARY", raising=False)
     monkeypatch.setenv("PATH", str(foreign_scripts_dir))
     monkeypatch.setattr(
-        runtime_paths.shutil,
+        shutil,
         "which",
         lambda name: str(foreign_tg) if name in {"tg", "tg.exe"} else None,
     )
@@ -537,7 +537,7 @@ def test_resolve_ripgrep_binary_prefers_path_rg_before_bundled(monkeypatch, tmp_
     monkeypatch.setattr(runtime_paths, "__file__", str(runtime_file))
     monkeypatch.delenv("TG_RG_PATH", raising=False)
     monkeypatch.setattr(
-        runtime_paths.shutil, "which", lambda name: str(path_rg) if name == binary_name else None
+        shutil, "which", lambda name: str(path_rg) if name == binary_name else None
     )
     resolve_ripgrep_binary.cache_clear()
 
@@ -948,7 +948,7 @@ class TestTranslatePathForWindowsBinary:
         probe_file = tmp_path / "probe.log"
         probe_file.write_text("sentinel\n", encoding="utf-8")
         monkeypatch.setattr(
-            runtime_paths.shutil,
+            shutil,
             "which",
             lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
         )
@@ -966,12 +966,12 @@ class TestTranslatePathForWindowsBinary:
         assert translated == "C:\\Users\\x\\AppData\\Local\\Temp\\probe.log"
 
     def test_returns_none_when_wslpath_absent(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(runtime_paths.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
         assert runtime_paths.translate_path_for_windows_binary(tmp_path / "probe.log") is None
 
     def test_returns_none_on_nonzero_exit(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
-            runtime_paths.shutil,
+            shutil,
             "which",
             lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
         )
@@ -984,7 +984,7 @@ class TestTranslatePathForWindowsBinary:
 
     def test_returns_none_on_timeout(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
-            runtime_paths.shutil,
+            shutil,
             "which",
             lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
         )
@@ -997,7 +997,7 @@ class TestTranslatePathForWindowsBinary:
 
     def test_returns_none_on_os_error(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
-            runtime_paths.shutil,
+            shutil,
             "which",
             lambda name: "/usr/bin/wslpath" if name == "wslpath" else None,
         )


### PR DESCRIPTION
## Summary

Ranked-queue item **#6** of the +10% campaign (source: `docs/planning` optimization queue) — the
import-deferral cold-floor bundle, three independently-scoped moves (`F2.6` + `F2.5` + `F2.4`).
**Results-identical perf**; `F2.4` is contract-touching (single-source-of-truth constants), flagged
below for a light independent check.

## The three moves (seams verified against real code, not the plan)

### F2.6 — `cli/__init__.py:2` (`from typing import Any`)

The sole use of `Any` was `__getattr__`'s return annotation (`cli/__init__.py` is the module-level
`__getattr__` (PEP 562) hook exposing `tensor_grep.cli.main_entry` without eagerly importing
`bootstrap`). Fixed via `-> object` instead (needs no import) — **not** `from __future__ import
annotations` alone, which I initially tried and is wrong here: PEP 563 only defers *evaluation* of
an annotation to a string; a static checker still has to *resolve* that string against the module's
real bindings. Confirmed empirically —

```
$ mypy cli/__init__.py   # -> Any, `from __future__ import annotations`, no `typing` import
error: Name "Any" is not defined  [name-defined]
```

`object` needs no import at all and is a pure static-typing change (`__getattr__`'s PEP 562
dispatch is untyped at runtime either way). Verified nothing in-repo relies on the wider `Any`
static type: the real console-script entry point in `pyproject.toml` is `tensor_grep.cli.bootstrap:
main_entry` directly, bypassing this `__getattr__` hook entirely.

`cli/__init__.py` is the parent-package init for every `tensor_grep.cli.*` submodule, so its cost
is paid on **every** `tg` invocation before any submodule-specific code runs.

### F2.5 — `runtime_paths.py:1,4` (`import json` / `import shutil`)

Both moved to function-local at their only call sites: `json` → `_read_native_frontdoor_metadata`;
`shutil` → `translate_path_for_windows_binary` and `resolve_ripgrep_binary` (two separate call
sites, two separate local imports, matching the file's existing style). `cli/bootstrap.py` imports
this whole module eagerly (`from tensor_grep.cli.runtime_paths import (env_flag_enabled,
resolve_native_tg_binary, resolve_ripgrep_binary)`) for **every** invocation including `--version`,
which calls none of the three json/shutil-using functions (confirmed: `bootstrap._print_version`
has its own separate `_read_project_version_fallback`, never touches `runtime_paths`' version of
it).

### F2.4 (contract-touching) — `main.py:46-52`'s 5 `directory_scanner` constants

New zero-dependency module `src/tensor_grep/io/scan_limits.py` holds the 5 constants
(`UNBOUNDED_VENDORED_ROOT_DIR_NAMES`, `BROAD_WORKSPACE_PROJECT_MARKERS`,
`BROAD_WORKSPACE_PROJECT_CHILD_THRESHOLD`, `BROAD_WORKSPACE_MARKED_ROOT_CHILD_THRESHOLD`,
`IMPLICIT_SEARCH_WALK_FILE_CEILING`) plus the private `_GENERATED_DIR_NAMES` skip-list
`UNBOUNDED_VENDORED_ROOT_DIR_NAMES` is derived from (moved together so the derivation and its
input stay in one place — no second copy to drift). **Zero imports** — just frozenset/int literals.

- `io/directory_scanner.py` re-exports every name (`from tensor_grep.io.scan_limits import X as X`
  — the same redundant-alias idiom `cli/bootstrap.py` already uses for `run_subprocess`), so its
  public surface is byte-identical for any existing `from tensor_grep.io.directory_scanner import
  <NAME>` caller.
- `cli/main.py:46-52`'s module-level import now points at `scan_limits` directly.
- `cli/bootstrap.py`'s 3 guard helpers (`_path_has_project_marker`,
  `_search_paths_include_workspace_root`, `_search_paths_include_vendored_root`) now do
  `from tensor_grep.io.scan_limits import ...` instead of `...directory_scanner import ...`. The
  **4th** helper, `_search_paths_include_oversized_implicit_root`, is deliberately **unchanged** —
  it constructs a real `DirectoryScanner`, so it genuinely needs the heavier module.
- `cli/scan_guardrails.py` (the `tg scan`/`test`/`ast-info`/`run` guard, reached via the lazily
  imported `cli/ast_workflows.py`) repointed the same way — it only ever needed the 3 plain
  constants, never `SearchConfig`/`DirectoryScanner`.
- The Rust-parity comment chain (`IMPLICIT_SEARCH_WALK_FILE_CEILING`'s cross-reference to
  `rust_core/src/rg_passthrough.rs`'s own `pub const IMPLICIT_SEARCH_WALK_FILE_CEILING: usize =
  1500`) moved intact into `scan_limits.py` — Rust untouched, verified the numeric value still
  matches by reading `rg_passthrough.rs:153` directly (no cargo/rustc/maturin run).

**Why the win is bigger than "5 constants": before this fix, `bootstrap.py`'s broad-scan guard
*always* imported the whole `directory_scanner` module (hence `SearchConfig`/`dataclasses`/
`inspect`) just to read 3 frozen/int constants — even when the search was ultimately delegated to
the native binary or `rg` (both walk in a **separate process** and never touch Python's
`DirectoryScanner` at all). That's the `explicit-path search` cell below: a full, clean elimination
of `directory_scanner`+`core.config`, not just a smaller module swap.**

## Verify-first findings (two claims narrowed after checking the real import graph)

1. **`cli/formatters/json_fmt.py:5`** has its own **unrelated, pre-existing** module-level
   `from tensor_grep.core.config import SearchConfig` (reached via `cli/main.py`'s own eager
   `from tensor_grep.cli.formatters.base import OutputFormatter`, which pulls in the whole
   `formatters` package). Traced via a `builtins.__import__` hook, not guessed. Consequence: a bare
   `cli.main` import (simulating `--help`) still loads `core.config` — just no longer *via*
   `directory_scanner`. This PR does not touch it (out of scope: F2.4 is about the 5 broad-scan
   constants' source module, not every `SearchConfig` import in the CLI); noted here instead of
   silently folding it into the headline claim.
2. **`cli/subprocess_policy.py:7`** has an *identical* redundant `from typing import Any` — also
   eagerly loaded by `cli/bootstrap.py` — which fully masks F2.6's saving for the whole-process
   `--version` case (typing loads via this path regardless of the `cli/__init__.py` fix). I
   attempted the same fix there (`**kwargs: object`, drop the import) and **reverted it**:
   `subprocess.run`'s typeshed stub is overload-heavy and does not accept an `object`-typed
   `**kwargs` splat — `mypy --strict` produced 2 real errors (`no-any-return`, `call-overload`), not
   a safe drop-in. Left untouched; noted rather than silently shipping a smaller win than claimed.

## TDD

- **(a)** Extended `tests/unit/test_bootstrap_fast_path_imports.py` (the existing house pattern:
  subprocess-based `sys.modules` probes, deliberately not in-process) with **11 new tests** — one
  absence pin per deferred-import claim (`scan_limits` present/`directory_scanner`+`core.config`
  absent for the 3 guard helpers called directly, for a bare `cli.main` import, for a bare
  `cli.scan_guardrails` import, and for `scan_limits` itself in isolation; `json`/`shutil` absent
  for a bare `runtime_paths` import), plus 2 non-regression behavioral checks (`--version`/`-V`
  still print the banner and exit 0; the `__getattr__` hook still resolves `main_entry` correctly
  after the `Any`→`object` change) and a source-level pin (`cli/__init__.py` has no eager `import
  typing`). One existing test (`test_plain_search_still_imports_directory_scanner_when_actually_
  needed`) needed updating: pre-fix, `directory_scanner` loaded unconditionally for any
  search-shaped argv; post-fix it loads only when Python's own walk is genuinely needed, so the
  test now explicitly forces the "no native, no rg" branch (mirroring `test_cli_bootstrap.py`'s own
  in-process monkeypatch pattern, via subprocess source-injection) instead of depending on the
  ambient dev machine's PATH.
- **(b)** Added `test_scan_limits_single_source_of_truth_across_every_re_export` to
  `test_cli_bootstrap.py`: asserts `scan_limits`'s values `is` (not just `==`) identical to
  `directory_scanner`'s re-export, `cli/main.py`'s private aliases, and `cli/scan_guardrails.py`'s
  private aliases — `is` makes the single-source-of-truth contract a **build-time fact** (an
  accidental future re-literal instead of a re-import would fail this test even though `==` would
  still pass on equal-but-distinct frozensets). Re-pointed the ~13 existing
  `from tensor_grep.io.directory_scanner import <CONSTANT>` imports in `test_cli_bootstrap.py` to
  `scan_limits` (grepped every constant name across `tests/`, per the task).
- **(c)** Full behavior: ~950 tests across the bootstrap / `directory_scanner` /
  `scan_guardrails`-adjacent (`ast_workflows`, `r2_dos_batch`, `cli_modes`) / orient (7 files) /
  ast / routing / `medlow_main_cli` suites, all green **except 3 pre-existing failures** — verified
  byte-identical against this worktree's own unmodified `HEAD` via `git stash` (a missing compiled
  `rust_core` PyO3 extension in this fresh worktree; unrelated to this Python-only change; never
  ran cargo/rustc/maturin per the CPU-SAFE constraint). `tests/e2e/test_routing_parity.py` was never
  run (it self-compiles Rust).

## Measured: `-X importtime` A/B (`python -m tensor_grep`, PYTHONPATH swap)

Before = the pinned `HEAD` (v1.93.2 lineage) source reconstructed into a scratch tree via
`git show HEAD:<path>` for each of the 6 touched files; after = this worktree. **6 reps/side,
interleaved rep-by-rep** (before-rep-N, after-rep-N, ...) rather than block-sequential — this
machine measured **~74% background CPU load** from concurrent campaign agents during the run, and
interleaving keeps a transient load spike from skewing one arm. One discarded warm-up rep/side
first equalizes OS disk-cache state (a freshly-materialized source tree pays a one-time cold-cache
tax on its first launch that has nothing to do with the code — an earlier block-sequential run
showed a 633ms outlier on `before`'s first `--help` rep purely from this).

**Median total self-time** (sum of every module's own self-time in the trace — noisy at the
whole-process level on this shared/busy machine; the per-module cumulative deltas below are the
trustworthy signal):

| command | before (median, n=6) | after (median, n=6) | delta |
|---|---|---|---|
| `--version` | 164.45ms | 154.51ms | **-9.93ms** |
| `--help` | 210.75ms | 199.36ms | **-11.40ms** |
| `explicit-path search` | 165.08ms | 146.33ms | **-18.75ms** |

**Per-module cumulative time** (median, ms) — the mechanistic evidence, and confirmation the
deferred modules are absent from the after-trace where claimed:

| module | `--version` before→after | `--help` before→after | `explicit-path search` before→after |
|---|---|---|---|
| `tensor_grep.io.directory_scanner` | absent both (prior #48 fix) | **1.875 → absent** | **13.568 → absent** |
| `tensor_grep.core.config` | absent both | 6.370 → 7.316 (unchanged — the `json_fmt.py` residual above) | **10.819 → absent** |
| `tensor_grep.io.scan_limits` | n/a (not on this path) | absent → **1.159** (new, cheap) | absent → **1.076** (new, cheap) |
| `tensor_grep.cli.runtime_paths` | **15.332 → 0.587** | **13.671 → 0.590** | **13.826 → 0.631** |
| `tensor_grep.cli.bootstrap` | 60.343 → 42.643 | 57.790 → 40.597 | 58.227 → 42.562 |
| `tensor_grep.cli.main` | n/a | 124.506 → 125.707 (unchanged — `core.config` still loads via `json_fmt.py`, netting the small `directory_scanner`/`scan_limits` swap to ~noise) | n/a |

**Honest read**: `runtime_paths` (F2.5) is a consistent, unconditional win on **every** command —
~13-15ms cumulative recovered regardless of what the command does, because `bootstrap.py` always
imports it. F2.4's win is command-shape-dependent: full and clean on `explicit-path search` (both
`directory_scanner` and `core.config` fully eliminated, ~18.75ms total — the case the campaign item
was written for), partial on `--help` (`directory_scanner` eliminated but `core.config` persists
via the unrelated `json_fmt.py` path, so `cli.main`'s own cumulative is a wash). F2.6 has no
directly-attributable line in this trace (`typing` still loads via `subprocess_policy.py`, see
above) — its win is the qualitative one (one fewer dead-weight import statement on the hottest
path in the codebase), not a quantifiable ms figure from this measurement. Subtracting nothing:
these are the raw numbers, on a busy shared machine, with the caveats stated.

## Flag for a light independent check

**F2.4's shared-constant parity** — please re-verify independently:
1. `scan_limits.py`'s 5 constants have the exact same values as `directory_scanner.py` had before
   this PR (diff the two module bodies at the relevant lines).
2. `IMPLICIT_SEARCH_WALK_FILE_CEILING = 1500` still numerically matches `rust_core/src/
   rg_passthrough.rs:153`'s `pub const IMPLICIT_SEARCH_WALK_FILE_CEILING: usize = 1500` (Rust file
   untouched by this PR — comment-verified only, no build run).
3. The sync-pin test (`test_scan_limits_single_source_of_truth_across_every_re_export`) actually
   fails if you revert `directory_scanner.py`'s re-export to a hand-copied literal instead of an
   import (a cheap way to confirm the `is`-based test has teeth, not just `==`).

## Gates

- `ruff check .` (repo-wide): clean.
- `ruff format --check --preview .` (repo-wide, the real CI scope): clean on every file this PR
  touches; 4 **pre-existing** doc-fence diffs elsewhere (`docs/architecture.md`,
  `docs/planning/PROJECT_PLAN.md`, 2 files under `docs/plans/`) — confirmed present on `HEAD`
  unmodified too (known, separate whole-repo markdown-fence gap, not introduced by this PR).
- `mypy src/tensor_grep` (the real CI scope, 82 files): clean.
- New/updated tests: 13 in `test_bootstrap_fast_path_imports.py`, +1 sync-pin in
  `test_cli_bootstrap.py` (94 tests total in that file, all passing).

CPU-SAFE: no cargo/rustc/maturin run at any point; Rust files read-only. `tests/e2e/
test_routing_parity.py` never run. `main.py`'s only edit is the `:46-52` import block (verified via
`git diff --stat` before committing — no overlap with the concurrent PREPARE-region agent working
around `:10200-10600`).
