### PR TITLE
perf(imports): stdlib resolver fast-path

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import sys
 import tempfile
 import threading
 import time
@@ -1759,28 +1760,43 @@ def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
     """
     entries: list[dict[str, Any]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _is_python_dynamic_import_call(node):
-            continue
-        literal_module: str | None = None
-        if (
-            node.args
-            and isinstance(node.args[0], ast.Constant)
-            and isinstance(node.args[0].value, str)
-        ):
-            literal_module = node.args[0].value
-        dynamic_unresolved = literal_module is None
-        if literal_module is not None and (
-            literal_module.startswith(".") or _python_dynamic_import_call_is_relative(node)
-        ):
-            dynamic_unresolved = True
-        entries.append({
-            "module": literal_module or "",
-            "line": int(node.lineno),
-            "level": 0,
-            "dynamic": True,
-            "dynamic_unresolved": dynamic_unresolved,
-        })
+        entry = _python_dynamic_import_entry_for_call(node)
+        if entry is not None:
+            entries.append(entry)
     return entries
+
+
+def _python_dynamic_import_entry_for_call(node: ast.AST) -> dict[str, Any] | None:
+    """Per-node half of `_python_dynamic_import_entries` above: given a single AST node, return
+    its dynamic-import entry dict if `node` is one of the 3 dynamic-import call shapes (see
+    `_is_python_dynamic_import_call`), else `None`. Pulled out of that function's loop body
+    unchanged (same literal-extraction, same relative-literal fail-closed check, same entry
+    shape) so a caller that ALREADY walks `tree` for another purpose can fold this per-node check
+    into its own walk instead of paying for a second whole-tree `ast.walk` -- see
+    `_python_imports_with_lines` (opt10 F4.2), which merges its static-import walk with this one.
+
+    `_python_dynamic_import_entries` itself keeps doing its own `ast.walk` and calling this once
+    per node exactly as its inlined loop body used to -- this extraction changes nothing about
+    its behavior, signature, or the entries it returns for its existing caller
+    (`_python_imports_and_symbols`'s reverse-import alias-graph prefilter).
+    """
+    if not isinstance(node, ast.Call) or not _is_python_dynamic_import_call(node):
+        return None
+    literal_module: str | None = None
+    if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+        literal_module = node.args[0].value
+    dynamic_unresolved = literal_module is None
+    if literal_module is not None and (
+        literal_module.startswith(".") or _python_dynamic_import_call_is_relative(node)
+    ):
+        dynamic_unresolved = True
+    return {
+        "module": literal_module or "",
+        "line": int(node.lineno),
+        "level": 0,
+        "dynamic": True,
+        "dynamic_unresolved": dynamic_unresolved,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -5983,14 +5999,28 @@ def _python_imports_with_lines(path: Path) -> list[dict[str, Any]]:
         return []
 
     entries: list[dict[str, Any]] = []
+    dynamic_entries: list[dict[str, Any]] = []
     # Nested-scope recall fix: `ast.walk` (not `tree.body`) so a plain `import`/`from ... import`
     # STATEMENT nested inside a function body, an `if`/`try` block, or an `if TYPE_CHECKING:`
     # guard is collected too -- `tree.body` only ever visited module-top-level statements,
     # silently missing anything scope-nested (a `tg imports`/`tg importers` recall gap;
-    # `result_incomplete` stayed False, so the omission was invisible). This mirrors
-    # `_python_dynamic_import_entries` below, which already whole-tree-walks for dynamic
-    # `__import__`/`import_module(...)` CALLS; this closes the same gap for static import
-    # statements, the shape `tg imports`/`tg importers` mostly see.
+    # `result_incomplete` stayed False, so the omission was invisible).
+    #
+    # opt10 F4.2 speed fix: this single walk ALSO picks up `__import__`/`import_module`/
+    # `importlib.import_module` CALLS -- the #93 SUB-1 dynamic-import shape -- via
+    # `_python_dynamic_import_entry_for_call` (the extracted per-node half of
+    # `_python_dynamic_import_entries`), instead of a SEPARATE second `ast.walk(tree)` over the
+    # same tree the way this used to call that function wholesale. `ast.Import`/`ast.ImportFrom`
+    # and `ast.Call` are disjoint node types, so folding both checks into one walk and
+    # accumulating into two separate lists (`entries` for static, `dynamic_entries` for dynamic)
+    # produces the IDENTICAL two per-kind orderings `ast.walk` would produce run separately --
+    # `ast.walk` is a deterministic traversal of a fixed tree, so filtering it once for two
+    # disjoint predicates and concatenating the two result lists (`entries + dynamic_entries`,
+    # same order as the old `entries.extend(_python_dynamic_import_entries(tree))`) is exactly
+    # equivalent to filtering it twice. See
+    # test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass (walk-count +
+    # order-identity proof) and `_python_dynamic_import_entries`, which is UNCHANGED and still
+    # walks `tree` on its own for its other caller (`_python_imports_and_symbols`).
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -6012,11 +6042,11 @@ def _python_imports_with_lines(path: Path) -> list[dict[str, Any]]:
                         "line": int(node.lineno),
                         "level": int(node.level),
                     })
-    # #93 SUB-1: `ast.walk` (not `tree.body`) picks up `__import__`/`import_module`/
-    # `importlib.import_module` calls anywhere -- inside a function, a conditional, a
-    # try/except -- that the static scan above (now itself an `ast.walk`, see above) never
-    # visits, since these are `ast.Call` expressions, a different node type entirely.
-    entries.extend(_python_dynamic_import_entries(tree))
+        elif isinstance(node, ast.Call):
+            dynamic_entry = _python_dynamic_import_entry_for_call(node)
+            if dynamic_entry is not None:
+                dynamic_entries.append(dynamic_entry)
+    entries.extend(dynamic_entries)
     return entries
 
 
@@ -6461,6 +6491,61 @@ def _python_module_candidates(
     parts = _python_module_parts(module_name)
     if not parts:
         return {"paths": [], "provenance": [], "confidence": 0.0, "path_provenance": {}}
+
+    # opt10 F4.3 speed fast-path: skip the multi-root candidate-path construction below (2
+    # `Path` builds per root, each pushed through the `_resolved_path_str` resolve-and-dedupe
+    # machinery -- ~10-12 `Path.resolve()` calls for a typical root count, PLUS the caller's own
+    # `.is_file()` probe of every returned candidate) for a bare top-level stdlib import
+    # (`import os` / `import sys` / `import json`) -- the dominant import shape, 59-100% of
+    # imports in sampled real files per the opt10 speed campaign.
+    #
+    # SHADOW-SAFETY (the whole correctness risk of this fast-path): `parts[0] in
+    # sys.stdlib_module_names` alone is NOT sufficient -- a repo can ship a same-named top-level
+    # module (e.g. a local `json.py` at its root) that MUST still resolve to that local file, the
+    # same way it would via the general path below (see
+    # test_build_file_imports_stdlib_shadowed_by_local_module_resolves_to_local_file). So this
+    # only returns the fast-path shape after confirming NEITHER shape the general path's
+    # level==0 branch would also probe (`<root>/<name>.py`, `<root>/<name>/__init__.py`) exists
+    # as a real file at ANY of `_python_candidate_roots`' roots -- the exact same roots (repo
+    # root, src/ layout, sys-path-hacked dirs, importer's own dir and ancestors, package-top)
+    # the general path already computes, just probed with a cheap `.is_file()`/`.is_dir()` stat
+    # instead of building+resolving+deduping the full candidate list. Any doubt (an `OSError`
+    # probing a candidate, or `parts[0]` existing locally at all) falls CLOSED to the unchanged
+    # general path below, never guesses.
+    #
+    # Narrowed to `len(parts) == 1` (a bare `import json`, not a dotted `import os.path`):
+    # a dotted stdlib access still needs `root/parts[0]` to be an existing local DIRECTORY for
+    # any local shadow to be possible at all, so the `is_dir()` probe below already catches that
+    # case too and correctly falls through -- but the deeper submodule candidates the general
+    # path would build (`root/parts[0]/parts[1]/...`) are not worth fast-pathing separately here,
+    # so leave every dotted access on the general path unconditionally.
+    #
+    # Returns EXACTLY the shape the general (non-relative) branch below always sets for
+    # `provenance`/`confidence` -- unconditionally, before any candidate is even probed for
+    # existence -- so `_resolve_raw_import_entry` / `_python_module_match_details` read the
+    # identical values off this dict as they would off the general path's result for a module
+    # that genuinely has zero real candidates (see the opt10 PR body's captured baseline: an
+    # empty `paths: []` here is observationally identical to the general path's non-empty-but-
+    # entirely-nonexistent candidate list -- both make `resolved`/`matched` come out the same on
+    # the calling side, since neither contains a real file).
+    if level == 0 and len(parts) == 1 and parts[0] in sys.stdlib_module_names:
+        name = parts[0]
+        shadowed = False
+        for root in _python_candidate_roots(importer_path, repo_root):
+            try:
+                if (root / f"{name}.py").is_file() or (root / name).is_dir():
+                    shadowed = True
+                    break
+            except OSError:
+                shadowed = True  # can't prove no local shadow -- fail closed to the slow path
+                break
+        if not shadowed:
+            return {
+                "paths": [],
+                "provenance": ["python-path-heuristic"],
+                "confidence": 0.7,
+                "path_provenance": {},
+            }
 
     candidates: list[Path] = []
     # #152 fix: per-candidate provenance override, keyed by the candidate's OWN resolved path

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -2448,3 +2448,346 @@ def test_build_file_importers_unbounded_result_set_unaffected_by_tiering(tmp_pat
     importer_files = set(payload["importer_files"])
     expected = fixture["same_repo_importers"] | {fixture["distant_importer"]}
     assert importer_files == expected
+
+
+# ---------------------------------------------------------------------------------------------
+# opt10 campaign #4: `tg imports` speed bundle.
+#
+# F4.3: `_python_module_candidates` (the Python absolute-import resolver, shared by the forward
+# `tg imports` primitive and the reverse `tg importers` confirm step) fast-paths a bare
+# top-level stdlib import (`import os` / `import sys` / `import json` -- 59-100% of imports in
+# sampled real files) past its ~10-12-candidate filesystem probe, returning the SAME
+# provenance/confidence shape the general path always sets for a level==0 absolute import,
+# unconditionally, before any candidate is even constructed. THE CORRECTNESS RISK: a repo that
+# SHADOWS a stdlib name with a same-named local top-level module/package must still resolve to
+# THAT local file -- never silently swallowed by the fast path. The fast path is therefore gated
+# behind a cheap `.is_file()`/`.is_dir()` shadow probe over the exact same roots
+# `_python_candidate_roots` already computes for the general path, and narrowed to
+# `len(parts) == 1` (a dotted `import os.path` always takes the general path).
+#
+# F4.2: `_python_imports_with_lines` used to do TWO full-tree `ast.walk()` passes over the same
+# parsed AST -- its own static-import scan, plus a second whole-tree walk buried inside
+# `_python_dynamic_import_entries` (called for the dynamic-import shape). The per-node dynamic-
+# import-detection logic was extracted into `_python_dynamic_import_entry_for_call` (a pure,
+# stateless per-node check) so `_python_imports_with_lines` can fold it into its EXISTING walk
+# instead of triggering a second one -- while `_python_dynamic_import_entries` itself is
+# UNCHANGED (same signature, same behavior, still does its own single walk) for its OTHER
+# caller, `_python_imports_and_symbols` (the reverse-import alias-graph prefilter).
+# ---------------------------------------------------------------------------------------------
+
+
+def test_python_module_candidates_stdlib_fastpath_returns_general_path_shape(
+    tmp_path: Path,
+) -> None:
+    """F4.3 direct unit test: a bare top-level stdlib import with no local shadow must get an
+    empty `paths` list plus EXACTLY the `provenance`/`confidence`/`path_provenance` values the
+    general (non-relative) branch below always sets for ANY level==0 absolute import -- so
+    `_resolve_raw_import_entry`/`_python_module_match_details` read the identical values off
+    this dict as they would off the general path's result for the same genuinely-external
+    module (captured from the pre-change baseline; see the PR body)."""
+    project = tmp_path / "project"
+    project.mkdir()
+    importer = project / "app.py"
+    importer.write_text("import os\n", encoding="utf-8")
+
+    for module_name in ("os", "sys", "json"):
+        info = repo_map._python_module_candidates(importer, module_name, project)
+        assert info == {
+            "paths": [],
+            "provenance": ["python-path-heuristic"],
+            "confidence": 0.7,
+            "path_provenance": {},
+        }, module_name
+
+
+def test_python_module_candidates_dotted_stdlib_access_does_not_take_fastpath(
+    tmp_path: Path,
+) -> None:
+    """The fast path is narrowed to `len(parts) == 1` -- a dotted stdlib access like
+    `collections.abc` must still go through the general multi-root candidate search, proven here
+    by a non-empty `paths` list (only the general path ever populates candidates)."""
+    project = tmp_path / "project"
+    project.mkdir()
+    importer = project / "app.py"
+    importer.write_text("import collections.abc\n", encoding="utf-8")
+
+    info = repo_map._python_module_candidates(importer, "collections.abc", project)
+
+    assert info["paths"] != []
+    assert info["provenance"] == ["python-path-heuristic"]
+    assert info["confidence"] == 0.7
+
+
+def test_build_file_imports_stdlib_shadowed_by_local_module_resolves_to_local_file(
+    tmp_path: Path,
+) -> None:
+    """THE load-bearing F4.3 correctness test. A repo that ships a same-named top-level module
+    shadowing a stdlib name (here: a local `json.py` at the repo root) must still resolve
+    `import json` to THAT LOCAL FILE, never to the stdlib fast-path's external/unresolved shape.
+
+    Proven to actually exercise the shadow gate (not just pass vacuously): temporarily
+    stripping the shadow-probe loop out of `_python_module_candidates` down to an unconditional
+    `if level == 0 and len(parts) == 1 and parts[0] in sys.stdlib_module_names: return
+    {"paths": [], ...}` makes this test FAIL with `external=True, resolved=None` instead of
+    resolving to the local file -- the probe loop over `_python_candidate_roots` is what makes
+    it pass."""
+    project = tmp_path / "project"
+    project.mkdir()
+    local_json = project / "json.py"
+    local_json.write_text("def local_marker():\n    return 'LOCAL'\n", encoding="utf-8")
+    consumer = project / "app.py"
+    consumer.write_text("import json\n", encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "json")
+    assert entry["external"] is False
+    assert entry["resolved"] == str(local_json.resolve())
+    assert entry["resolution_confidence"] == 0.7
+
+
+def test_build_file_imports_stdlib_shadowed_by_local_package_resolves_to_local_file(
+    tmp_path: Path,
+) -> None:
+    """Sibling shadow shape: a local PACKAGE (a directory with `__init__.py`) rather than a bare
+    module file, shadowing a stdlib name -- `_python_module_candidates`'s general path resolves
+    a bare `import queue` to either `<root>/queue.py` OR `<root>/queue/__init__.py`, so the
+    shadow probe must catch both shapes, not just the module-file one."""
+    project = tmp_path / "project"
+    pkg_dir = project / "queue"
+    pkg_dir.mkdir(parents=True)
+    local_init = pkg_dir / "__init__.py"
+    local_init.write_text("def local_marker():\n    return 'LOCAL_PKG'\n", encoding="utf-8")
+    consumer = project / "app.py"
+    consumer.write_text("import queue\n", encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = next(current for current in payload["imports"] if current["module"] == "queue")
+    assert entry["external"] is False
+    assert entry["resolved"] == str(local_init.resolve())
+
+
+def test_build_file_imports_relative_import_of_stdlib_named_sibling_still_resolves(
+    tmp_path: Path,
+) -> None:
+    """The stdlib fast-path only applies when `level == 0` (absolute import) -- a RELATIVE
+    import of a stdlib-named sibling module (`from . import json`, `level=1`) must resolve to
+    the local sibling file exactly as before, never mistaken for the stdlib fast-path shape."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    sibling = pkg / "json.py"
+    sibling.write_text("def x():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "main.py"
+    consumer.write_text("from . import json\n", encoding="utf-8")
+
+    payload = repo_map.build_file_imports(consumer)
+
+    entry = payload["imports"][0]
+    assert entry["module"] == "json"
+    assert entry["resolved"] == str(sibling.resolve())
+    assert entry["external"] is False
+    assert entry["provenance"] == ["relative"]
+
+
+def test_build_file_imports_mixed_imports_results_identical_to_pre_fastpath_baseline(
+    tmp_path: Path,
+) -> None:
+    """Results-identical golden test for opt10 #4 (F4.3 + F4.2): a file with a realistic mix of
+    bare stdlib imports (single-part, the fast-path's target shape), a multi-part stdlib access,
+    a non-stdlib external, a real local dotted import, and a relative import. Expected values
+    were captured by running `build_file_imports` against the UNMODIFIED pre-change code on this
+    exact fixture (see the PR body for the captured receipts) -- every field
+    (module/line/resolved/external/provenance/resolution_confidence) must stay byte-identical
+    after the change; only the WORK done to get there should shrink."""
+    project = tmp_path / "project"
+    pkg = project / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    helpers_path = pkg / "helpers.py"
+    helpers_path.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    consumer = pkg / "main.py"
+    consumer.write_text(
+        "import os\n"
+        "import sys\n"
+        "import json\n"
+        "import collections.abc\n"
+        "import numpy\n"
+        "import pkg.helpers\n"
+        "from . import helpers\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_file_imports(consumer)
+
+    resolved_helpers = str(helpers_path.resolve())
+    expected = [
+        {
+            "module": "os",
+            "line": 1,
+            "resolved": None,
+            "provenance": ["python-path-heuristic"],
+            "resolution_confidence": 0.0,
+            "external": True,
+        },
+        {
+            "module": "sys",
+            "line": 2,
+            "resolved": None,
+            "provenance": ["python-path-heuristic"],
+            "resolution_confidence": 0.0,
+            "external": True,
+        },
+        {
+            "module": "json",
+            "line": 3,
+            "resolved": None,
+            "provenance": ["python-path-heuristic"],
+            "resolution_confidence": 0.0,
+            "external": True,
+        },
+        {
+            "module": "collections.abc",
+            "line": 4,
+            "resolved": None,
+            "provenance": ["python-path-heuristic"],
+            "resolution_confidence": 0.0,
+            "external": True,
+        },
+        {
+            "module": "numpy",
+            "line": 5,
+            "resolved": None,
+            "provenance": ["python-path-heuristic"],
+            "resolution_confidence": 0.0,
+            "external": True,
+        },
+        {
+            "module": "pkg.helpers",
+            "line": 6,
+            "resolved": resolved_helpers,
+            "provenance": ["python-path-heuristic"],
+            "resolution_confidence": 0.7,
+            "external": False,
+        },
+        {
+            "module": "helpers",
+            "line": 7,
+            "resolved": resolved_helpers,
+            "provenance": ["relative"],
+            "resolution_confidence": 1.0,
+            "external": False,
+        },
+    ]
+
+    actual = [
+        {
+            "module": entry["module"],
+            "line": entry["line"],
+            "resolved": entry["resolved"],
+            "provenance": entry["provenance"],
+            "resolution_confidence": entry["resolution_confidence"],
+            "external": entry["external"],
+        }
+        for entry in payload["imports"]
+    ]
+    assert actual == expected
+
+
+def test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """F4.2 walk-count assertion: a file mixing STATIC imports (module top-level and nested
+    inside an `if TYPE_CHECKING:` block) with DYNAMIC import calls (a non-literal
+    `importlib.import_module(name)` and a literal `__import__('re')`) must produce the exact
+    same entries, in the exact same order (all static entries first in AST-discovery order, then
+    all dynamic entries in AST-discovery order -- matching the pre-merge
+    `entries.extend(_python_dynamic_import_entries(tree))` shape), while calling `ast.walk`
+    exactly ONCE per file (was two: the static loop's own walk, plus a second whole-tree walk
+    buried inside `_python_dynamic_import_entries`)."""
+    import ast as ast_module
+
+    project = tmp_path / "project"
+    project.mkdir()
+    source_file = project / "mixed.py"
+    source_file.write_text(
+        "import os\n"
+        "from typing import TYPE_CHECKING\n"
+        "import importlib\n"
+        "\n"
+        "def load(name):\n"
+        "    return importlib.import_module(name)\n"
+        "\n"
+        "def load_builtin():\n"
+        "    return __import__('re')\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    import collections.abc\n",
+        encoding="utf-8",
+    )
+
+    walk_calls = 0
+    real_walk = ast_module.walk
+
+    def counting_walk(tree):
+        nonlocal walk_calls
+        walk_calls += 1
+        return real_walk(tree)
+
+    # `repo_map` did `import ast` at module scope, so `repo_map.ast is ast_module` -- patching
+    # the shared stdlib module object's `walk` attribute affects the call
+    # `_python_imports_with_lines` makes internally too.
+    monkeypatch.setattr(ast_module, "walk", counting_walk)
+
+    entries = repo_map._python_imports_with_lines(source_file)
+
+    assert walk_calls == 1, f"expected exactly 1 ast.walk call, got {walk_calls}"
+    assert entries == [
+        {"module": "os", "line": 1, "level": 0},
+        {"module": "typing", "line": 2, "level": 0},
+        {"module": "importlib", "line": 3, "level": 0},
+        {"module": "collections.abc", "line": 12, "level": 0},
+        {
+            "module": "",
+            "line": 6,
+            "level": 0,
+            "dynamic": True,
+            "dynamic_unresolved": True,
+        },
+        {
+            "module": "re",
+            "line": 9,
+            "level": 0,
+            "dynamic": True,
+            "dynamic_unresolved": False,
+        },
+    ]
+
+
+def test_python_dynamic_import_entries_unchanged_after_extraction(tmp_path: Path) -> None:
+    """Regression guard for the F4.2 refactor: `_python_dynamic_import_entries` itself (the
+    OTHER caller of `_python_dynamic_import_entry_for_call`, used by
+    `_python_imports_and_symbols`'s reverse-import alias-graph prefilter at a SEPARATE call
+    site) must still walk `tree` on its own and return the identical entries it always did --
+    the extraction must not have changed its standalone behavior."""
+    project = tmp_path / "project"
+    project.mkdir()
+    source_file = project / "dyn.py"
+    source_file.write_text(
+        "import importlib\n"
+        "def load(name):\n"
+        "    return importlib.import_module(name)\n"
+        "def load_builtin():\n"
+        "    return __import__('re')\n",
+        encoding="utf-8",
+    )
+    tree = repo_map._cached_ast_parse(source_file.read_text(encoding="utf-8"))
+
+    entries = repo_map._python_dynamic_import_entries(tree)
+
+    assert entries == [
+        {"module": "", "line": 3, "level": 0, "dynamic": True, "dynamic_unresolved": True},
+        {"module": "re", "line": 5, "level": 0, "dynamic": True, "dynamic_unresolved": False},
+    ]


### PR DESCRIPTION
## opt10 campaign #4: `tg imports` speed bundle

CPU-safe, results-identical performance change to the Python import resolver shared by
`tg imports` / `tg importers` / `tg agent` / `tg blast-radius` / `tg callers`. **Draft — an
independent Opus gate must run before merge (see "Load-bearing surface" below); do not un-draft.**

### Verify-plan-against-code (done before writing any code)

Re-verified every citation from the deep-dive against the real code on this worktree
(`origin/main` @ `b7d4725`, v1.93.3 + #712) before touching anything:

| Claim | Verified against real code |
|---|---|
| `_python_module_candidates` at repo_map.py:6454 | **Confirmed** (pre-edit). Signature: `(importer_path: Path, module_name: str, repo_root: Path \| str \| None = None, *, level: int = 0) -> dict[str, Any]`. |
| Static-import walk at repo_map.py:~5994 | **Confirmed** — `_python_imports_with_lines` (repo_map.py:5971, pre-edit), `for node in ast.walk(tree):` at line 5994. |
| `_python_dynamic_import_entries` at repo_map.py:1726, own walk at :1761 | **Confirmed exactly** — `for node in ast.walk(tree):` at line 1762 (pre-edit). |
| Callers of `_python_dynamic_import_entries` | **Enumerated, exactly 2**, both inside `repo_map.py`: `_python_imports_and_symbols` (repo_map.py:1911, call at line 2010 — the reverse-import alias-graph prefilter feeding `tg importers`/`tg blast-radius`/`tg callers`) and `_python_imports_with_lines` (repo_map.py:5971, call at line 6039 — the `tg imports` line-precise primitive, F4.2's target). No callers outside `repo_map.py` (grepped the whole repo; only `tests/unit/test_file_deps.py` and `CHANGELOG.md` reference the name). |
| Return shape for an external/unresolved module | **Read, not assumed.** `_python_module_candidates`'s `paths` list is populated with normalized-but-NOT-existence-checked candidate `Path`s (via `_resolved_path_str` = `Path.resolve()`, no `.exists()`/`.is_file()` call inside this function at all) — existence is checked by the CALLERS: `_resolve_raw_import_entry` (repo_map.py:16197-16212, pre-edit) does `Path(current).is_file()` per candidate to set `resolved`/`external`; `_python_module_match_details` (repo_map.py:6516-6550) does an `any(str(candidate) == resolved_definition ...)` membership check. For `level == 0`, `provenance`/`confidence` are set **unconditionally** to `["python-path-heuristic"]` / `0.7` before any candidate is even probed (pre-edit lines 6495-6496) — i.e. those two fields are IDENTICAL whether 0 or 12 candidates get constructed. This is the exact shape the fast-path must reproduce. |
| Local-module-shadow detection mechanism | **Read.** There is no separate "is this local" branch — the general path just builds `root.joinpath(*parts).with_suffix(".py")` / `root.joinpath(*parts, "__init__.py")` for every root in `_python_candidate_roots` and lets the caller's `.is_file()` decide. So the fast-path's shadow gate must independently probe the SAME two candidate shapes over the SAME roots before skipping construction — see "Shadow-safety proof" below. |

The deep-dive's mechanism matched the real code closely; the one adjustment made was **scoping
the fast-path to `len(parts) == 1`** (a bare `import json`, not a dotted `import os.path`) —
the deep-dive's sketch didn't specify this, and a dotted access needs a different shadow-probe
shape (`root/parts[0]` as a directory, not `root/parts[0].py`) that isn't worth the extra
complexity given single-segment imports are already the dominant shape.

### What shipped

**F4.3 (primary) — shipped.** `_python_module_candidates` (repo_map.py) fast-paths
`level == 0, len(parts) == 1, parts[0] in sys.stdlib_module_names` past the general multi-root
candidate construction (which does ~2 `Path` builds x ~5-6 roots, each pushed through
`_resolved_path_str`'s resolve-and-dedupe), returning `{"paths": [], "provenance":
["python-path-heuristic"], "confidence": 0.7, "path_provenance": {}}` — the exact shape the
general path produces for ANY level==0 import when nothing resolves.

**F4.2 (bonus) — shipped, provably clean.** Rather than touch `_python_dynamic_import_entries`
externally (its OTHER caller, `_python_imports_and_symbols`, must see zero behavior change), its
loop body was extracted unchanged into a new pure per-node helper,
`_python_dynamic_import_entry_for_call(node) -> dict | None`. `_python_dynamic_import_entries`
now just does `for node in ast.walk(tree): entry = _python_dynamic_import_entry_for_call(node)`
— same walk, same call-once-per-node, same output, zero behavior change for its existing caller.
`_python_imports_with_lines` then folds a call to that SAME helper into its own existing
`ast.walk(tree)` loop (an `elif isinstance(node, ast.Call):` branch alongside the existing
`Import`/`ImportFrom` branches), accumulating into a separate `dynamic_entries` list and
concatenating `entries + dynamic_entries` at the end — instead of calling
`_python_dynamic_import_entries(tree)` wholesale (a second full-tree walk).

### Shadow-safety proof (F4.3's load-bearing correctness risk)

**Order-preservation is provable, not incidental:** `ast.walk` is a deterministic BFS (a
`collections.deque`, pop-left / extend-with-children — no randomization) over a fixed tree, so
filtering it ONCE for two disjoint node-type predicates (`Import`/`ImportFrom` vs `Call`) and
concatenating the two per-predicate result lists produces the IDENTICAL two orderings that
filtering it TWICE (the old shape) would produce. `ast.Import`/`ast.ImportFrom` and `ast.Call`
are disjoint node types, so no entry can be double-counted or reordered relative to its own
kind.

**TDD proof it's load-bearing, not decorative:** per the task instructions, I temporarily
stripped the shadow-probe loop down to an unconditional
`if level == 0 and len(parts) == 1 and parts[0] in sys.stdlib_module_names: return {"paths": [],
...}` (no gate) and re-ran the two shadow tests:

```
tests/unit/test_file_deps.py::test_build_file_imports_stdlib_shadowed_by_local_module_resolves_to_local_file
  FAILED - assert entry["external"] is False  ->  AssertionError: assert True is False
tests/unit/test_file_deps.py::test_build_file_imports_stdlib_shadowed_by_local_package_resolves_to_local_file
  FAILED - assert entry["external"] is False  ->  AssertionError: assert True is False
```

Then restored the shadow-gated version — both pass again (see test list below). The gate
(`_python_candidate_roots` + a cheap `.is_file()`/`.is_dir()` probe per root, falling CLOSED to
the general path on any doubt, including `OSError`) is what makes them pass.

### Results-identical golden method

Captured `build_file_imports` output for a mixed fixture (`import os`, `import sys`, `import
json`, `import collections.abc`, `import numpy`, `import pkg.helpers`, `from . import helpers`)
against the **unmodified pre-change code**, then re-ran the identical fixture after the change —
every field (`module`/`line`/`resolved`/`external`/`provenance`/`resolution_confidence`) came
back byte-identical:

```
BEFORE (unmodified):
{"external": true,  "line": 1, "module": "os",              "provenance": ["python-path-heuristic"], "resolution_confidence": 0.0, "resolved": null}
{"external": true,  "line": 2, "module": "sys",             "provenance": ["python-path-heuristic"], "resolution_confidence": 0.0, "resolved": null}
{"external": true,  "line": 3, "module": "json",            "provenance": ["python-path-heuristic"], "resolution_confidence": 0.0, "resolved": null}
{"external": true,  "line": 4, "module": "collections.abc", "provenance": ["python-path-heuristic"], "resolution_confidence": 0.0, "resolved": null}
{"external": true,  "line": 5, "module": "numpy",           "provenance": ["python-path-heuristic"], "resolution_confidence": 0.0, "resolved": null}
{"external": false, "line": 6, "module": "pkg.helpers",     "provenance": ["python-path-heuristic"], "resolution_confidence": 0.7, "resolved": ".../project/pkg/helpers.py"}
{"external": false, "line": 7, "module": "helpers",         "provenance": ["relative"],              "resolution_confidence": 1.0, "resolved": ".../project/pkg/helpers.py"}

AFTER (this PR): identical, field-for-field.
```

The raw `_python_module_candidates()` dict DOES differ internally for the 3 bare-stdlib entries
(`paths: []` now vs. a populated-but-entirely-nonexistent 6-candidate list before) — this is
INTENTIONAL and provably inert: neither real consumer (`_resolve_raw_import_entry`'s
`.is_file()` filter, `_python_module_match_details`'s membership check) can distinguish "empty
list" from "list of only-nonexistent paths", since neither contains a real file. The shadow case
(`import json` with a local `json.py`) is the one case where this WOULD matter, and it's proven
identical above (`test_build_file_imports_stdlib_shadowed_by_local_module_resolves_to_local_file`).

This test is now baked into the suite as
`test_build_file_imports_mixed_imports_results_identical_to_pre_fastpath_baseline`.

### Informal timing sanity-check (NOT a certified benchmark-harness run)

Small, bounded, in-process microbenchmarks — evidence the two fast-paths do something
measurable, not a claim run through the project's official benchmark harness:

- **F4.3**: `_python_module_candidates("os", ...)` over 1200 distinct importer paths (fresh
  `_resolved_path_str` cache per path, fast/slow interleaved per-path to cancel ordering bias):
  **~2.7x faster** (1494 us/call fast-path-on vs 4095 us/call forced-off).
- **F4.2**: isolated walk-only comparison on a pre-parsed in-memory AST (excludes file I/O and
  AST-parse-cache noise; 5 alternating repetitions x 20000 calls to cancel warmup bias): merged
  single-walk **~1.75x faster** than the reconstructed old two-walk shape (0.62s median vs
  1.09s median per rep).
- A naive first attempt at this timing (same-triple repeated calls, sequential non-alternating
  loops) produced misleading numbers in BOTH directions — once from `_resolved_path_str`'s LRU
  cache trivializing repeat "slow path" calls, once from an OS file-content-cache ordering bias
  between two sequential loops reading the same 1500 files. Both are noted here as "profile the
  actual thing, not a benchmark artifact" receipts, not hidden.

### Test list (targeted pytest, PYTHONPATH into this worktree's src/)

`C:/dev/projects/tensor-grep/.venv/Scripts/python.exe -m pytest tests/unit/test_file_deps.py -p no:cacheprovider -q`
— **95 passed** (87 pre-existing + 8 new):

- `test_python_module_candidates_stdlib_fastpath_returns_general_path_shape` (new) — direct
  dict-shape contract for `os`/`sys`/`json`.
- `test_python_module_candidates_dotted_stdlib_access_does_not_take_fastpath` (new) — proves the
  `len(parts) == 1` gate via `collections.abc` still populating candidates.
- `test_build_file_imports_stdlib_shadowed_by_local_module_resolves_to_local_file` (new) — **the
  load-bearing shadow test** (a local `json.py` at repo root).
- `test_build_file_imports_stdlib_shadowed_by_local_package_resolves_to_local_file` (new) — the
  package-shadow sibling (a local `queue/__init__.py`).
- `test_build_file_imports_relative_import_of_stdlib_named_sibling_still_resolves` (new) —
  proves `level > 0` never takes the fast path.
- `test_build_file_imports_mixed_imports_results_identical_to_pre_fastpath_baseline` (new) — the
  golden byte-identical test.
- `test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass` (new) — F4.2
  walk-count (`monkeypatch`'d `ast.walk` counter, asserts exactly 1 call) + order-identity proof.
- `test_python_dynamic_import_entries_unchanged_after_extraction` (new) — regression guard for
  `_python_dynamic_import_entries`'s OTHER caller (`_python_imports_and_symbols`).

Also re-ran for collateral-impact coverage on functions that consume `_python_module_candidates`
/ `_python_imports_with_lines` transitively (`build_repo_map`, `build_agent_capsule`,
caller/blast-radius scans): `test_repo_map_targets.py`, `test_repo_map_spans.py`,
`test_repo_map_deadline.py`, `test_ast_parse_cache.py`, `test_medlow2_repo_map.py`,
`test_codemap.py`, `test_agent_capsule_outbound_deps.py`,
`test_agent_reverse_import_graph_deadline_222.py`, `test_impact_callers_shared_map.py`,
`test_graph_completeness_oracle.py` — **225 passed**. Plus the `agent_capsule_*` /
`agent_vendored_subtree_*` / `agent_suggested_scope` / `agent_ignore` group — **103 passed**.
**423 tests total, 0 failures.**

Gates: `ruff check` and `ruff format --check --preview` both clean on the 2 changed files
(`src/tensor_grep/cli/repo_map.py`, `tests/unit/test_file_deps.py`).

Verified `python -c "import tensor_grep; print(tensor_grep.__file__)"` resolves into this
worktree's `src/` before trusting any RED/GREEN (stale-venv trap).

### CPU-SAFE compliance

No `cargo`/`rustc`/`maturin` run. No `tests/e2e/test_routing_parity.py` run (verified the Rust
front-door is untouched by READING only — this change is 100% Python, `repo_map.py` +
`test_file_deps.py`). All test/format/lint runs were targeted, bounded, pre-built-venv Python.

### Disjoint from PR #713

Confirmed `_truncate_source_text_to_budget` (PR #713's territory) lives at repo_map.py:8923-9062
(pre-edit) — this PR's edits are at lines ~1726-1800 and ~5991-6055 and ~6454-6549 (pre-edit
numbering), nowhere near #713's range.

### Load-bearing surface: flag for independent review

**F4.3's shadow gate** (`_python_module_candidates`'s `if level == 0 and len(parts) == 1 and
parts[0] in sys.stdlib_module_names:` block) is the one piece of this PR with real correctness
risk — a wrong shadow probe silently mis-resolves any repo that happens to ship a top-level
module/package named the same as a stdlib module (`json.py`, `queue.py`, `types.py`, `token.py`,
`copy.py`, `string.py`, `pdb.py`, etc. are all plausible real filenames). Please independently
re-derive: (a) that `_python_candidate_roots` is genuinely the same root set the general path
uses (not a subset), and (b) that `(root / f"{name}.py").is_file() or (root / name).is_dir()`
can never be `False` while a real candidate the general path WOULD have matched exists at that
root. This PR is left in draft for that gate — do not merge without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
