### PR TITLE
perf(retrieval): max-combine fusion — accuracy ndcg@10 +62.6%

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
 
 # Rich's legacy Windows renderer can raise EINVAL when long help is piped through
@@ -4261,9 +4261,45 @@ def _find_dense_weight(query: str) -> float:
     # genuinely multi-word (space-separated) query is NL and gets the resolved `weight` above.
     # Whitespace, not `split_terms` morphemes -- see the module comment above `_FIND_DENSE_WEIGHT_ENV`
     # for the dogfood finding (#191) this fixes.
-    if len(query.split()) <= 1:
+    if _find_is_single_token_query(query):
         return _FIND_DENSE_WEIGHT_DEFAULT
     return weight
+
+
+def _find_is_single_token_query(query: str) -> bool:
+    """Shared literal/identifier-query predicate for `tg find`'s two query-adaptive knobs --
+    `_find_dense_weight`'s dense_weight (above) AND `_find_combine_mode`'s RRF combine mode
+    (below). A single whitespace-free token (or an empty/whitespace-only query, whose ``split()``
+    -> ``[]``) is a literal identifier lookup; anything with 2+ whitespace-separated words is NL.
+    Whitespace, not `split_terms` morphemes -- see the module comment above
+    `_FIND_DENSE_WEIGHT_ENV` for the #191 dogfood finding this rule fixes. Factored out to a single
+    canonical definition so the two knobs can never silently disagree on what counts as literal.
+    """
+    return len(query.split()) <= 1
+
+
+def _find_combine_mode(query: str) -> Literal["sum", "max"]:
+    """Query-adaptive RRF `combine` mode for `tg find`'s `rank_chunks` calls (accuracy-leg
+    max-fusion regression fix, Opus-gate finding on PR #717): `combine="max"` (`rank_chunks`'s own
+    default, see its docstring) lifts genuinely multi-word/NL queries (ndcg@10 +62.6% on the frozen
+    40-query golden set) but REGRESSES single-token literal/identifier lookups -- measured on
+    `benchmarks/datasets/literal_golden.jsonl` (10 queries, `dense_weight=1.0` as
+    `_find_dense_weight` already protects them at): sum scores a perfect 1.0 ndcg@10 (as it always
+    has); max drops to 0.9631, a real -0.0369 regression. Mechanism: a literal query's true answer
+    is frequently ranked #1 by BOTH the bm25 leg and the dense leg independently -- `"sum"`'s
+    per-leg-agreement bonus is exactly the confirming signal `"max"` discards, letting a
+    single-leg-only competitor tie the true answer's now-undiscounted best-single-term score.
+
+    Routes on the EXACT SAME whitespace predicate `_find_dense_weight` already uses
+    (`_find_is_single_token_query`) so the two adaptive knobs can never disagree on what counts as
+    literal: a single whitespace-free token -> `"sum"` (byte-identical to the pre-max-flip
+    behavior, recovering the regression); a genuinely multi-word query -> `"max"` (keeps the NL
+    win, including composed with the adaptive `dense_weight=5.0`, which reaches the dense-alone
+    ndcg@10 ceiling exactly). This is scoped to `tg find` only -- `rerank_hybrid` (the `tg search
+    --semantic` path) never passes `combine`, so it is unaffected and stays on the plain "max"
+    default.
+    """
+    return "sum" if _find_is_single_token_query(query) else "max"
 
 
 def _find_representative_line(chunk: "Chunk", query_terms: set[str]) -> tuple[int, str]:
@@ -4466,6 +4502,7 @@ def _execute_find(
             dense_index=dense_index,
             late_reranker=late_reranker,
             dense_weight=_find_dense_weight(query),
+            combine=_find_combine_mode(query),
         )
     except DenseUnavailableError as exc:
         # F1 (Opus-gate blocker; mirrors `_apply_semantic_rerank`'s own query-time catch,
@@ -4491,6 +4528,7 @@ def _execute_find(
             dense_index=None,
             late_reranker=None,
             dense_weight=_find_dense_weight(query),
+            combine=_find_combine_mode(query),
         )
     if late_fallback_reason:
         result.rank_fallback_reason = (

--- a/src/tensor_grep/core/reranker.py
+++ b/src/tensor_grep/core/reranker.py
@@ -15,6 +15,7 @@ import os
 import sys
 import threading
 from collections import defaultdict
+from typing import Literal
 
 from tensor_grep.core.result import SearchResult
 from tensor_grep.core.retrieval_bm25 import Bm25Index
@@ -223,6 +224,7 @@ def rank_chunks(
     late_reranker: LateReranker | None,
     k: int = DEFAULT_K,
     dense_weight: float = 1.0,
+    combine: Literal["sum", "max"] = "max",
 ) -> tuple[list[int], str | None]:
     """Fuse BM25 [+ dense] [+ path] chunk rankings via RRF, then optionally MaxSim-rerank the head
     via ``late_reranker`` -- the pure, fail-closed rank core shared by :func:`rerank_hybrid` and
@@ -243,6 +245,20 @@ def rank_chunks(
     ``dense_index is None``: there is no dense leg to weight. Callers own picking a non-default
     value; `tg find` is the only current caller that ever does (``cli/main.py``'s
     ``_find_dense_weight``, itself gated behind ``TG_FIND_DENSE_WEIGHT`` and default-OFF).
+
+    ``combine`` (accuracy-leg campaign; passed straight through to
+    :func:`~tensor_grep.core.retrieval_fusion.reciprocal_rank_fusion`, see its own docstring for
+    the full derivation): ``"max"`` (this function's default, matching that function's own default
+    -- an omitted kwarg here is therefore byte-identical to one there) lifts NL/vocabulary-mismatched
+    queries (ndcg@10 +62.6% on the frozen 40-query golden set) but REGRESSES single-token
+    literal/identifier lookups (measured on ``benchmarks/datasets/literal_golden.jsonl``: sum=1.0
+    exact vs max=0.9631) -- a literal query's true answer is often independently ranked #1 by BOTH
+    legs, and ``"sum"``'s per-leg-agreement bonus is exactly the signal ``"max"`` discards. `tg
+    find` (``cli/main.py``'s ``_find_combine_mode``) is the one caller that ever passes a
+    non-default value, choosing per-query on the SAME whitespace predicate
+    ``_find_dense_weight`` already uses for its own knob, so the two adaptive decisions can never
+    disagree on what counts as literal. :func:`rerank_hybrid` (the ``tg search --semantic`` path)
+    never passes this kwarg, so it always gets the default ``"max"`` -- unaffected by this fix.
 
     Returns ``(fused_order, late_fallback_reason)``:
 
@@ -272,7 +288,7 @@ def rank_chunks(
             rankings.append(path_ranking)
             weights.append(PATH_CHANNEL_WEIGHT)
 
-    fused_order = reciprocal_rank_fusion(rankings, k=k, weights=weights)
+    fused_order = reciprocal_rank_fusion(rankings, k=k, weights=weights, combine=combine)
 
     # T5/T6: the late-interaction splice. Order-only over `fused_order`'s chunk indices -- same
     # matches, same membership, same JSON shape (design doc "The seam"). `late_reranker=None`

--- a/src/tensor_grep/core/retrieval_fusion.py
+++ b/src/tensor_grep/core/retrieval_fusion.py
@@ -3,14 +3,30 @@
 Pure, dependency-free fusion for combining the BM25 lexical leg and the dense embedding leg into
 one ranking without ever comparing their raw scores directly -- a BM25 score and a cosine
 similarity live on unrelated scales, so normalizing-and-adding them would be an apples-to-oranges
-hack that silently drifts as either scorer changes. RRF sidesteps this by fusing on RANK alone:
-``fused(c) = sum over legs of 1 / (k + rank_r(c))`` (1-based rank; a chunk absent from a leg
-contributes 0 for that leg). This is the standard formulation (Cormack, Clarke & Buettcher 2009).
+hack that silently drifts as either scorer changes. RRF sidesteps this by fusing on RANK alone,
+per-leg term ``1 / (k + rank_r(c))`` (1-based rank; a chunk absent from a leg contributes a 0.0
+floor for that leg -- every term is strictly positive, so 0.0 is always a correct lower bound).
+
+Two ways to COMBINE those per-leg terms into one fused score are supported (``combine``):
+
+- ``"max"`` (the DEFAULT, accuracy-leg campaign): ``fused(c) = max over legs of term_r(c)`` --
+  best-rank-wins. A chunk's fused score is the single strongest leg contribution it earns, never
+  the sum of every leg -- so a weak/near-floor leg (e.g. BM25 on a vocabulary-mismatched NL query)
+  can only ever HELP a chunk's rank (by ranking it even higher than the strong leg did) and can
+  never DRAG a strong leg's pick down merely by failing to rank it. Measured on the frozen
+  golden-set harness (``benchmarks/eval_late_rerank_quality.py``'s ``rrf`` arm): ndcg@10 lifts from
+  0.3047 (sum) to 0.4953 (max), +62.6%, uniformly across recall@10 (0.55->0.825) and mrr
+  (0.228->0.391) -- re-run ``uv run --no-sync python benchmarks/eval_late_rerank_quality.py`` to
+  reproduce.
+- ``"sum"`` (the ORIGINAL formulation, Cormack, Clarke & Buettcher 2009): ``fused(c) = sum over
+  legs of term_r(c)``. Byte-identical to this module's pre-max-flip behavior; kept for any call
+  site that must reproduce it exactly.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 DEFAULT_K: int = 60
 
@@ -20,21 +36,27 @@ def reciprocal_rank_fusion(
     *,
     k: int = DEFAULT_K,
     weights: Sequence[float] | None = None,
+    combine: Literal["sum", "max"] = "max",
 ) -> list[int]:
     """Fuse per-leg chunk-index rankings into one ranking via Reciprocal Rank Fusion.
 
     Each element of ``rankings`` is an ordered sequence of chunk indices for one retrieval leg
-    (best first). A chunk missing from a leg's ranking contributes 0 to that leg's term. Ties in
-    the fused score break by ascending chunk index (mirrors ``retrieval_bm25.py``'s tie-break),
-    so the result is fully deterministic.
+    (best first). A chunk missing from a leg's ranking contributes a 0.0 floor to that leg's term.
+    Ties in the fused score break by ascending chunk index (mirrors ``retrieval_bm25.py``'s
+    tie-break), so the result is fully deterministic.
 
     ``weights`` (optional) is a per-leg multiplier parallel to ``rankings`` -- leg ``i``'s
     contribution becomes ``weight[i] / (k + rank)`` instead of the plain ``1 / (k + rank)``, so a
     channel can be trusted more (>1.0) or less (<1.0) than the others without changing how it is
-    ranked internally. ``weights=None`` (the default) is a byte-identical no-op: every leg is
-    implicitly weighted 1.0, reproducing the un-weighted fusion exactly (multiplying by 1.0 is an
-    exact IEEE-754 operation). Raises :class:`ValueError` if ``weights`` is given and its length
-    does not match ``rankings``.
+    ranked internally. This multiplier is applied to a leg's term BEFORE ``combine`` folds the
+    legs together (i.e. before the sum, or before the max). ``weights=None`` (the default) is a
+    byte-identical no-op: every leg is implicitly weighted 1.0, reproducing the unweighted fusion
+    exactly (multiplying by 1.0 is an exact IEEE-754 operation). Raises :class:`ValueError` if
+    ``weights`` is given and its length does not match ``rankings``.
+
+    ``combine`` (``"sum"`` or ``"max"``, default ``"max"`` -- see the module docstring for the
+    full derivation and the golden-set evidence behind the default): how each chunk's per-leg
+    terms are folded into one fused score.
 
     Returns the fused chunk indices ordered best-first. Chunks that appear in NO leg are absent
     from the input entirely and therefore never appear in the output.
@@ -45,12 +67,18 @@ def reciprocal_rank_fusion(
         raise ValueError(
             f"weights length ({len(weights)}) must match rankings length ({len(rankings)})"
         )
+    if combine not in ("sum", "max"):
+        raise ValueError(f"combine must be 'sum' or 'max', got {combine!r}")
 
     scores: dict[int, float] = {}
     for leg_index, ranking in enumerate(rankings):
         weight = 1.0 if weights is None else weights[leg_index]
         for rank, chunk_index in enumerate(ranking, start=1):
-            scores[chunk_index] = scores.get(chunk_index, 0.0) + (1.0 / (k + rank)) * weight
+            term = (1.0 / (k + rank)) * weight
+            if combine == "max":
+                scores[chunk_index] = max(scores.get(chunk_index, 0.0), term)
+            else:
+                scores[chunk_index] = scores.get(chunk_index, 0.0) + term
 
     ordered = sorted(scores.items(), key=lambda item: (-item[1], item[0]))
     return [chunk_index for chunk_index, _ in ordered]

--- a/tests/unit/test_find_command.py
+++ b/tests/unit/test_find_command.py
@@ -655,3 +655,140 @@ def test_find_dense_weight_nonfinite_env_never_reaches_rank_chunks(
         f"expected dense_weight=5.0 (adaptive, treated like unset) for every call with a "
         f"non-finite env value, got {captured}"
     )
+
+
+# --- Accuracy-leg regression fix (Opus-gate finding, PR #717): query-adaptive `combine` routing --
+# max-combine REGRESSES single-token literal/identifier queries (benchmarks/datasets/
+# literal_golden.jsonl: sum=1.0 exact vs max=0.9631, -0.0369 ndcg@10) because a literal query's
+# true answer is often independently ranked #1 by BOTH bm25 and dense -- sum's per-leg-agreement
+# bonus is exactly the signal max discards. `tg find` now routes combine="sum" for a single
+# whitespace-free token (recovering the exact pre-max-flip behavior) and combine="max" for
+# genuinely multi-word NL (keeping the +62.6% win), on the SAME whitespace predicate
+# `_find_dense_weight` already uses for its own knob.
+
+
+def _spy_on_rank_chunks_combine(monkeypatch) -> list[str]:  # type: ignore[no-untyped-def]
+    """Sibling of `_spy_on_rank_chunks` above that records the `combine` kwarg instead of
+    `dense_weight` -- same monkeypatch target/rationale (`rank_chunks` is imported LOCALLY inside
+    `_execute_find`, so the module attribute on `tensor_grep.core.reranker` is what must be
+    patched). Kept as a SEPARATE spy rather than extending the existing one so every pre-existing
+    test asserting `captured[-1] == <float>` on the dense_weight spy is untouched."""
+    from tensor_grep.core import reranker as reranker_module
+
+    real_rank_chunks = reranker_module.rank_chunks
+    captured: list[str] = []
+
+    def _spy(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(kwargs.get("combine", "max"))
+        return real_rank_chunks(*args, **kwargs)
+
+    monkeypatch.setattr(reranker_module, "rank_chunks", _spy)
+    return captured
+
+
+def test_find_combine_mode_helper() -> None:
+    """Direct-call companion: pins `_find_combine_mode`'s routing decision across the SAME
+    identifier shapes `test_find_dense_weight_default_protects_literal_identifiers` already proves
+    stay at `dense_weight=1.0` -- the two query-adaptive knobs share one predicate
+    (`_find_is_single_token_query`) so they can never disagree on what counts as literal."""
+    from tensor_grep.cli.main import _find_combine_mode
+
+    protected_identifiers = [
+        "mint_access_token",
+        "getUserName",
+        "_confine_mcp_path",
+        "BackendExecutionError",
+        "reciprocal_rank_fusion",
+        "_iter_repo_files",
+        "rank_chunks",
+    ]
+    for identifier in protected_identifiers:
+        assert _find_combine_mode(identifier) == "sum", (
+            f"single-token identifier {identifier!r} must route to combine='sum', recovering "
+            "the literal_golden.jsonl regression"
+        )
+
+    for nl_query in (
+        "how does the retry backoff work",
+        "borrow a connection out of a shared pool",
+        "verify login credentials",
+        "shared pool",  # boundary: even a bare 2-word phrase is multi-word -> max
+    ):
+        assert _find_combine_mode(nl_query) == "max", (
+            f"multi-word query {nl_query!r} must keep combine='max' (the +62.6% ndcg@10 win)"
+        )
+
+
+def test_find_combine_mode_routes_single_token_to_sum_multiword_to_max_end_to_end(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    """End-to-end companion: proves the routing decision reaches the real `rank_chunks` call
+    inside the full `tg find` CLI invocation, not just the helper in isolation -- mirrors
+    `test_find_dense_weight_default_is_adaptive_end_to_end`'s shape exactly, for `combine` instead
+    of `dense_weight`. Was RED before this fix: `_execute_find` used to call `rank_chunks(...)`
+    with no `combine` kwarg at all (implicit default "max"), regardless of query shape."""
+    monkeypatch.delenv("TG_FIND_DENSE_WEIGHT", raising=False)
+    _stub_dense_clean(monkeypatch)
+    captured = _spy_on_rank_chunks_combine(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    literal_result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+    assert literal_result.exit_code == 0, literal_result.output
+    assert captured, "rank_chunks was never called"
+    assert captured[-1] == "sum", f"single-token query must route to combine='sum', got {captured}"
+
+    nl_result = CliRunner().invoke(
+        app, ["find", "invoice processing helper", str(tmp_path), "--json"]
+    )
+    assert nl_result.exit_code == 0, nl_result.output
+    assert captured[-1] == "max", f"multi-word NL query must keep combine='max', got {captured}"
+
+
+def test_find_combine_mode_dense_unavailable_retry_also_routes(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The F1 BM25-only retry path (a query-time DenseUnavailableError degrade, main.py's second
+    `rank_chunks` call site) must ALSO pass `combine=_find_combine_mode(query)`, not silently fall
+    back to the implicit "max" default -- mirrors the existing dense_weight retry coverage. Does
+    not assert an exact call count (CliRunner/Typer plumbing may invoke the command's underlying
+    callback more than the minimal primary+retry pair) -- the invariant that matters is that EVERY
+    call along the way, however many there are, routes this single-token query the same way."""
+    from tensor_grep.core.retrieval_dense import DenseUnavailableError
+
+    monkeypatch.delenv("TG_FIND_DENSE_WEIGHT", raising=False)
+    _stub_dense_clean(monkeypatch)
+    (tmp_path / "invoice.py").write_text(
+        "def make_invoice(invoice_id):\n    invoice = invoice_id\n    return invoice\n",
+        encoding="utf-8",
+    )
+
+    from tensor_grep.core import reranker as reranker_module
+
+    real_rank_chunks = reranker_module.rank_chunks
+    captured: list[str] = []
+    dense_leg_calls: list[bool] = []
+
+    def _raise_once_per_dense_leg_call(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(kwargs.get("combine", "max"))
+        # Raise only the FIRST time a real dense leg is attached (the primary call for THIS
+        # query) -- a retry call always passes dense_index=None, so it is never re-raised into an
+        # infinite loop regardless of how many times the surrounding CLI plumbing invokes this.
+        has_dense = kwargs.get("dense_index") is not None
+        dense_leg_calls.append(has_dense)
+        if has_dense and dense_leg_calls.count(True) == 1:
+            raise DenseUnavailableError("query-time dim mismatch")
+        return real_rank_chunks(*args, **kwargs)
+
+    monkeypatch.setattr(reranker_module, "rank_chunks", _raise_once_per_dense_leg_call)
+
+    result = CliRunner().invoke(app, ["find", "invoice", str(tmp_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) >= 2, (
+        f"expected at least a primary call + a BM25-only retry, got {captured}"
+    )
+    assert all(c == "sum" for c in captured), (
+        f"every rank_chunks call along the retry path must route this single-token query to "
+        f"combine='sum', got {captured}"
+    )

--- a/tests/unit/test_rank_chunks.py
+++ b/tests/unit/test_rank_chunks.py
@@ -223,9 +223,9 @@ def test_rank_chunks_dense_weight(monkeypatch) -> None:  # type: ignore[no-untyp
     real_fusion = reranker_module.reciprocal_rank_fusion
     captured_weights: list[list[float] | None] = []
 
-    def _spy_fusion(rankings, *, k=DEFAULT_K, weights=None):  # type: ignore[no-untyped-def]
+    def _spy_fusion(rankings, *, k=DEFAULT_K, weights=None, combine="max"):  # type: ignore[no-untyped-def]
         captured_weights.append(list(weights) if weights is not None else None)
-        return real_fusion(rankings, k=k, weights=weights)
+        return real_fusion(rankings, k=k, weights=weights, combine=combine)
 
     monkeypatch.setattr(reranker_module, "reciprocal_rank_fusion", _spy_fusion)
 
@@ -313,3 +313,104 @@ def test_rank_chunks_dense_weight_ignored_without_dense_index() -> None:
         dense_weight=5.0,
     )
     assert with_weight == baseline == [0]
+
+
+def test_rank_chunks_combine_parameter_threads_to_fusion(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """``combine`` (accuracy-leg max-fusion regression fix, PR #717): threads verbatim into
+    ``reciprocal_rank_fusion``, spied the same way ``test_rank_chunks_dense_weight`` proves
+    ``dense_weight``/``weights`` thread through -- an omitted kwarg (the implicit default here,
+    "max") must match ``reciprocal_rank_fusion``'s own default exactly, and an explicit "sum" must
+    be threaded through, not silently coerced back to "max"."""
+    from tensor_grep.core import reranker as reranker_module
+
+    real_fusion = reranker_module.reciprocal_rank_fusion
+    captured_combine: list[str] = []
+
+    def _spy_fusion(rankings, *, k=DEFAULT_K, weights=None, combine="max"):  # type: ignore[no-untyped-def]
+        captured_combine.append(combine)
+        return real_fusion(rankings, k=k, weights=weights, combine=combine)
+
+    monkeypatch.setattr(reranker_module, "reciprocal_rank_fusion", _spy_fusion)
+
+    chunks, bm25_index = _build_chunks()
+
+    rank_chunks("invoice", chunks, bm25_index=bm25_index, dense_index=None, late_reranker=None)
+    assert captured_combine[-1] == "max", "an omitted combine kwarg must default to 'max'"
+
+    rank_chunks(
+        "invoice",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=None,
+        late_reranker=None,
+        combine="sum",
+    )
+    assert captured_combine[-1] == "sum", "an explicit combine='sum' must thread through verbatim"
+
+
+def test_rank_chunks_combine_sum_recovers_literal_regression_scenario() -> None:
+    """A black-box (output-order) proof of WHY the routing fix matters, reproducing the exact
+    mechanism the Opus gate found on ``literal_golden.jsonl`` (query "bind_address", the set's own
+    first entry) with real ``Bm25Index``/``DenseIndex`` objects, not hand-rolled score dicts.
+
+    chunk 0 ("competitor.py") is absent from bm25 for this query but ranks BEST on the dense leg
+    (an unrelated file the embedding happens to favor). chunk 1 ("true_answer.py") is the ONLY bm25
+    match (its text contains the "bind"+"address" tokens) and ranks SECOND on dense -- the doc
+    BOTH legs partially agree on, which is exactly the "true answer" shape a literal lookup has.
+    (Chunk 1's text is deliberately NOT byte-identical to the query string itself -- a fake
+    dict-keyed encoder maps exact strings to vectors, so reusing the query string verbatim as a
+    chunk's text would make the query's own encode() call collide with that chunk's entry.)
+
+    Both chunks' BEST single-leg term is identically ``1/(k+1)`` (chunk 0's dense-rank-1 term;
+    chunk 1's bm25-rank-1 term) -- k is shared across every leg by ``reciprocal_rank_fusion``'s own
+    contract, so a rank-1 term is worth the same regardless of which leg produced it. Under
+    combine="max" this is a genuine bit-identical TIE, broken by ascending chunk index -- chunk 0
+    (the wrong doc, lower index) wins. Under combine="sum" chunk 1's second-leg (dense rank 2)
+    contribution breaks the tie correctly in its favor, exactly as it always did pre-max-flip.
+    """
+    chunks = [
+        Chunk(file_path="competitor.py", start_line=1, end_line=1, text="server_config"),
+        Chunk(
+            file_path="true_answer.py", start_line=1, end_line=1, text="target_bind_address_value"
+        ),
+    ]
+    bm25_index = Bm25Index(chunks)
+    # true_answer (1) is the ONLY bm25 match ("bind"+"address" tokens); competitor (0) shares none.
+    assert [i for i, _ in bm25_index.query("bind_address", top_k=2)] == [1]
+
+    dense_model = _FixedVectorModel({
+        "bind_address": [1.0, 0.0],  # the QUERY's own vector
+        "server_config": [1.0, 0.0],  # chunk 0 text: cosine 1.0 -> dense rank 1 (BEST dense match)
+        "target_bind_address_value": [1.0, 0.5],  # chunk 1 text: cosine ~0.894 -> dense rank 2
+    })
+    dense_index = DenseIndex(chunks, dense_model)
+    assert [i for i, _ in dense_index.query("bind_address", top_k=2)] == [0, 1], (
+        "sanity-check the scenario setup: chunk 0 must be the BEST dense match, chunk 1 second"
+    )
+
+    max_order, _ = rank_chunks(
+        "bind_address",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=dense_index,
+        late_reranker=None,
+        combine="max",
+    )
+    assert max_order[0] == 0, (
+        "max: chunk 0 (dense-only) and chunk 1 (bm25+dense) tie at the same best-single-leg term "
+        "1/(k+1) -- the ascending-index tie-break picks chunk 0, reproducing the literal-query "
+        "regression the Opus gate found"
+    )
+
+    sum_order, _ = rank_chunks(
+        "bind_address",
+        chunks,
+        bm25_index=bm25_index,
+        dense_index=dense_index,
+        late_reranker=None,
+        combine="sum",
+    )
+    assert sum_order[0] == 1, (
+        "sum: chunk 1's second-leg (dense rank 2) contribution correctly breaks the tie in its "
+        "favor -- the doc both legs partially agree on wins, recovering the regression"
+    )

--- a/tests/unit/test_retrieval_fusion.py
+++ b/tests/unit/test_retrieval_fusion.py
@@ -7,6 +7,14 @@ import pytest
 
 from tensor_grep.core.retrieval_fusion import DEFAULT_K, reciprocal_rank_fusion
 
+# --- Legacy SUM-combine regression pins ---------------------------------------------------------
+# Accuracy-leg campaign (max-fusion default flip, #711-class): `combine` defaults to "max" as of
+# this change, so every test below pins `combine="sum"` EXPLICITLY -- these tests exist to prove
+# the SUM path (the ORIGINAL, pre-flip behavior) stays byte-identical forever, for any future call
+# site that must keep it (see `retrieval_fusion.py`'s own docstring). Before this change none of
+# these calls passed `combine` at all (there was no such parameter); pinning it here is what makes
+# "byte-identical to today" a checked fact rather than a claim.
+
 
 def test_default_k_is_60() -> None:
     assert DEFAULT_K == 60
@@ -14,20 +22,20 @@ def test_default_k_is_60() -> None:
 
 def test_identity_single_leg_preserves_order() -> None:
     ranking = [3, 1, 2]
-    assert reciprocal_rank_fusion([ranking]) == ranking
+    assert reciprocal_rank_fusion([ranking], combine="sum") == ranking
 
 
 def test_empty_rankings_returns_empty() -> None:
-    assert reciprocal_rank_fusion([]) == []
-    assert reciprocal_rank_fusion([[]]) == []
+    assert reciprocal_rank_fusion([], combine="sum") == []
+    assert reciprocal_rank_fusion([[]], combine="sum") == []
 
 
 def test_chunk_absent_from_a_leg_contributes_zero() -> None:
     # chunk 2 is ranked last by leg_a but ALSO ranked (first) by leg_b -- it should out-rank
-    # chunks that only appear in leg_a, since RRF sums contributions across legs.
+    # chunks that only appear in leg_a, since RRF SUMS contributions across legs.
     leg_a = [0, 1, 2]
     leg_b = [2]
-    fused = reciprocal_rank_fusion([leg_a, leg_b], k=60)
+    fused = reciprocal_rank_fusion([leg_a, leg_b], k=60, combine="sum")
     assert fused[0] == 2
     assert set(fused) == {0, 1, 2}
 
@@ -37,13 +45,13 @@ def test_two_legs_combine_by_reciprocal_rank() -> None:
     leg_b = [1, 0, 2]
     # score(0) = 1/(1+1) + 1/(1+2) = 0.8333...; score(1) = 1/(1+2) + 1/(1+1) = 0.8333... (tie)
     # score(2) = 1/(1+3) + 1/(1+3) = 0.5 -- last regardless of the leg_a/leg_b tie-break above.
-    fused = reciprocal_rank_fusion([leg_a, leg_b], k=1)
+    fused = reciprocal_rank_fusion([leg_a, leg_b], k=1, combine="sum")
     assert fused == [0, 1, 2]  # tie between 0 and 1 broken by ascending chunk index
 
 
 def test_ties_break_by_ascending_chunk_index() -> None:
     # Each leg ranks a single, distinct chunk at position 1 -> identical fused score for both.
-    fused = reciprocal_rank_fusion([[5], [3]], k=60)
+    fused = reciprocal_rank_fusion([[5], [3]], k=60, combine="sum")
     assert fused == [3, 5]
 
 
@@ -52,7 +60,7 @@ def test_k_is_a_tunable_smoothing_parameter() -> None:
     # reorders a single ranking).
     ranking = [4, 2, 0, 1]
     for k in (1, 10, 60, 1000):
-        assert reciprocal_rank_fusion([ranking], k=k) == ranking
+        assert reciprocal_rank_fusion([ranking], k=k, combine="sum") == ranking
 
 
 def test_invalid_k_raises() -> None:
@@ -64,11 +72,13 @@ def test_invalid_k_raises() -> None:
 
 def test_deterministic_repeated_calls() -> None:
     rankings = [[2, 0, 1], [1, 2, 0]]
-    assert reciprocal_rank_fusion(rankings) == reciprocal_rank_fusion(rankings)
+    assert reciprocal_rank_fusion(rankings, combine="sum") == reciprocal_rank_fusion(
+        rankings, combine="sum"
+    )
 
 
 def test_chunks_absent_from_every_leg_never_appear() -> None:
-    fused = reciprocal_rank_fusion([[0, 1], [1, 0]])
+    fused = reciprocal_rank_fusion([[0, 1], [1, 0]], combine="sum")
     assert 2 not in fused
     assert set(fused) == {0, 1}
 
@@ -77,12 +87,13 @@ def test_chunks_absent_from_every_leg_never_appear() -> None:
 # ADDITIVE: `weights=None` (the default) must reproduce today's output bit-for-bit. Every test
 # above this marker calls `reciprocal_rank_fusion` without `weights` and continues to pass
 # UNMODIFIED after this change -- that is itself the strongest byte-identical no-op proof.
+# (All now pinned to combine="sum" too, per the note above.)
 
 
 def test_weights_omitted_and_weights_none_are_identical() -> None:
     rankings = [[2, 0, 1], [1, 2, 0], [0, 1, 2]]
-    assert reciprocal_rank_fusion(rankings, k=17) == reciprocal_rank_fusion(
-        rankings, k=17, weights=None
+    assert reciprocal_rank_fusion(rankings, k=17, combine="sum") == reciprocal_rank_fusion(
+        rankings, k=17, weights=None, combine="sum"
     )
 
 
@@ -90,9 +101,9 @@ def test_weights_all_ones_is_bit_identical_to_none() -> None:
     # Multiplying by 1.0 is an exact IEEE-754 no-op, so all-ones weights must reproduce the
     # unweighted fused order exactly -- not just an equivalent order, the SAME order.
     rankings = [[0, 1, 2], [2, 1, 0], [1, 0, 2]]
-    assert reciprocal_rank_fusion(rankings, k=10, weights=None) == reciprocal_rank_fusion(
-        rankings, k=10, weights=[1.0, 1.0, 1.0]
-    )
+    assert reciprocal_rank_fusion(
+        rankings, k=10, weights=None, combine="sum"
+    ) == reciprocal_rank_fusion(rankings, k=10, weights=[1.0, 1.0, 1.0], combine="sum")
 
 
 def test_weights_changes_fused_order_in_expected_direction() -> None:
@@ -101,10 +112,10 @@ def test_weights_changes_fused_order_in_expected_direction() -> None:
     # to chunk 1.
     leg_a = [0, 1]
     leg_b = [1, 0]
-    equal = reciprocal_rank_fusion([leg_a, leg_b], k=10)
+    equal = reciprocal_rank_fusion([leg_a, leg_b], k=10, combine="sum")
     assert equal[0] == 0
 
-    weighted = reciprocal_rank_fusion([leg_a, leg_b], k=10, weights=[1.0, 2.0])
+    weighted = reciprocal_rank_fusion([leg_a, leg_b], k=10, weights=[1.0, 2.0], combine="sum")
     assert weighted[0] == 1
 
 
@@ -118,6 +129,98 @@ def test_weights_length_mismatch_raises() -> None:
 def test_deterministic_repeated_calls_with_weights() -> None:
     rankings = [[2, 0, 1], [1, 2, 0]]
     weights = [1.5, 0.5]
-    assert reciprocal_rank_fusion(rankings, weights=weights) == reciprocal_rank_fusion(
-        rankings, weights=weights
+    assert reciprocal_rank_fusion(
+        rankings, weights=weights, combine="sum"
+    ) == reciprocal_rank_fusion(rankings, weights=weights, combine="sum")
+
+
+# --- Accuracy-leg campaign: max-combine (best-rank-wins), the NEW default ----------------------
+# `combine="max"` lifts the frozen golden-set `rrf` arm's ndcg@10 from 0.3047 to 0.4953 (+62.6%)
+# by construction: a chunk's fused score is the BEST single-leg contribution it earns, never the
+# sum of all legs -- so a weak/near-floor leg (bm25 on a vocabulary-mismatched NL query) can only
+# ever HELP a doc's rank (if it ranks the doc even higher than the strong leg did) and can never
+# DRAG a strong leg's pick down by simply failing to rank it. See docs/PAPER.md for the full
+# golden-set evidence; these tests pin the MECHANISM in isolation.
+
+
+def test_default_combine_is_max() -> None:
+    """DEFAULT = "max": omitting `combine` entirely must be byte-identical to passing
+    combine="max" explicitly -- this is what makes the default change actually move every
+    existing call site (reranker.py's `rank_chunks`, `tg find`, the eval harness's `rrf`/
+    `rrf_shipped` arms) with ZERO call-site edits. And it must NOT reproduce the old sum default
+    on a scenario where the two provably diverge (see test_chunk_absent_from_a_leg_contributes_zero
+    above, the sum-pinned twin of this exact scenario)."""
+    leg_a, leg_b = [0, 1, 2], [2]
+    assert reciprocal_rank_fusion([leg_a, leg_b], k=60) == reciprocal_rank_fusion(
+        [leg_a, leg_b], k=60, combine="max"
     )
+    assert reciprocal_rank_fusion([leg_a, leg_b], k=60) != reciprocal_rank_fusion(
+        [leg_a, leg_b], k=60, combine="sum"
+    )
+
+
+def test_max_combine_absent_leg_floors_at_zero_not_added() -> None:
+    """Mirrors test_chunk_absent_from_a_leg_contributes_zero's SUM scenario exactly, but pins the
+    MAX outcome: chunk 2 is worst-ranked (#3) in leg_a yet #1 in leg_b. Under sum this SUMS to the
+    top score (see the sum-pinned twin above); under max, chunk 2's score is just its BEST single
+    term (``max(1/(k+3), 1/(k+1)) == 1/(k+1)``) -- which exactly TIES chunk 0 (leg_a's own #1,
+    absent from leg_b, floored at +0.0 there: ``max(1/(k+1), 0.0) == 1/(k+1)``). The tie resolves
+    to ascending chunk index, so chunk 0 -- not chunk 2 -- now leads."""
+    leg_a = [0, 1, 2]
+    leg_b = [2]
+    fused = reciprocal_rank_fusion([leg_a, leg_b], k=60, combine="max")
+    assert fused[0] == 0, "chunk 0 and chunk 2 tie at 1/(k+1) under max; ascending index wins"
+    assert set(fused) == {0, 1, 2}
+
+
+def test_max_combine_uses_best_rank_not_sum() -> None:
+    """The hand-computed fixture: a doc ranked #1 by one leg and #50 by another must fuse to
+    EXACTLY that leg's #1 contribution under combine="max" (``1/(k+1)``) -- NOT the sum of both
+    contributions (``1/(k+1) + 1/(k+50)``). Proven black-box (no internal score access) via a
+    second doc that is ALSO rank #1, but in a THIRD leg `x` never appears in: under combine="max"
+    the two docs' scores are bit-identical (both exactly ``1/(k+1)``), so only the ascending-index
+    tie-break can order them; under combine="sum" `x`'s extra leg_b contribution makes it strictly
+    higher, so `x` wins outright regardless of index order. `y`'s index is deliberately LOWER than
+    `x`'s so the two combine modes visibly disagree on the winner."""
+    k = 60
+    x, y = 100, 0
+    leg_a = [x]  # x: rank 1
+    leg_b = [*range(1, 50), x]  # x: rank 50 (49 unrelated fillers ranked ahead of it)
+    leg_c = [y]  # y: rank 1, in a leg x never appears in
+
+    fused_sum = reciprocal_rank_fusion([leg_a, leg_b, leg_c], k=k, combine="sum")
+    assert fused_sum.index(x) < fused_sum.index(y), (
+        "sum: x's extra leg_b contribution must make it strictly outrank y"
+    )
+
+    fused_max = reciprocal_rank_fusion([leg_a, leg_b, leg_c], k=k, combine="max")
+    assert fused_max.index(y) < fused_max.index(x), (
+        "max: x's leg_b rank-50 contribution must be DISCARDED (leg_a's rank-1 term already "
+        "wins x's own max) -- x and y both score exactly 1/(k+1), so the ascending tie-break "
+        "(lower index y=0 first) decides, proving leg_b was never summed in"
+    )
+
+
+def test_max_combine_weights_apply_before_max() -> None:
+    """A per-leg weight multiplies that leg's OWN term BEFORE the max is taken across legs --
+    mirrors reranker.py's `dense_weight` composing with combine="max" (the production `tg find` /
+    `--semantic` path, and the `rrf_shipped` eval arm). leg_a ranks chunk 0 at #1 (weight 1.0 ->
+    term ``1/(k+1)``); leg_b ranks chunk 1 at #1 too but weighted 3x (term ``3/(k+1)``) -- under
+    max, chunk 1's weighted term dominates."""
+    leg_a = [0]
+    leg_b = [1]
+    k = 10
+    fused = reciprocal_rank_fusion([leg_a, leg_b], k=k, weights=[1.0, 3.0], combine="max")
+    assert fused[0] == 1, "leg_b's 3x-weighted rank-1 term must beat leg_a's unweighted rank-1 term"
+
+
+def test_max_combine_deterministic_repeated_calls() -> None:
+    rankings = [[2, 0, 1], [1, 2, 0]]
+    assert reciprocal_rank_fusion(rankings, combine="max") == reciprocal_rank_fusion(
+        rankings, combine="max"
+    )
+
+
+def test_invalid_combine_raises() -> None:
+    with pytest.raises(ValueError):
+        reciprocal_rank_fusion([[0, 1]], combine="average")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

`opt10` Phase-2 ACCURACY lever: switch retrieval fusion from sum-RRF to **max-combine** (best-rank-wins), default-flipped with zero call-site edits — **plus a query-adaptive routing fix (commit 2) that keeps single-token literal/identifier `tg find` queries on the sum path**, after an independent Opus gate falsified this PR's original "never worse than sum" claim on the committed `literal_golden.jsonl` slice.

**LOAD-BEARING shared-ranking default change — independent Opus gate ran once already (SHIP-WITH-NITS, folded below); re-verifying the fold before un-draft.**

## UPDATE (commit 2): the gate found a real regression, now fixed

The gate confirmed every correctness claim below (rrf arm +62.6% reproduced at both endpoints, capsule 16/16, the tie mechanism mutation-proven) **but correctly falsified** this PR's original "never worse than sum / 6/6" framing: on the committed `benchmarks/datasets/literal_golden.jsonl` slice (10 single-token literal/identifier queries, `dense_weight=1.0` as `_find_dense_weight` already protects them at), max-combine is a **real ndcg@10 regression vs sum: 0.9631 vs 1.0000 (−0.0369)**. `identifier3_golden.jsonl` (10 longer, 3+-morpheme identifiers) is a wash — 1.0000 both modes. The **6/6 dogfood queries and the 40-query golden set below are ALL natural-language** — they do not cover, and never claimed to cover, the literal/identifier query shape where this regression lives. That was this PR's honesty gap: the "never worse than sum" line implied a claim broader than what was actually tested.

**Root cause:** a literal query's true answer is frequently ranked #1 by BOTH the bm25 leg and the dense leg independently. Under `combine="max"`, that doc's fused score is just its best SINGLE-leg term (`1/(k+1)`) — identical to a false competitor that is rank-1 in only ONE leg. The two tie bit-for-bit, and the ascending-chunk-index tie-break can pick the wrong one. Under `combine="sum"`, the true answer's second-leg agreement adds a small but real bonus that correctly breaks the tie — the exact signal `max` discards.

**The fold (not just documented — fixed):** `rank_chunks` (`reranker.py:275`, now `:291` post-edit) gains `combine: Literal["sum", "max"] = "max"` (matching `reciprocal_rank_fusion`'s own default, so an omitted kwarg — `rerank_hybrid`'s `--semantic` path — is unaffected). `tg find`'s two `rank_chunks` call sites (`_execute_find`, `main.py`) now also pass `combine=_find_combine_mode(query)` — a new sibling of `_find_dense_weight` sharing the exact same whitespace predicate (`_find_is_single_token_query`, factored out of both so the two adaptive knobs can never disagree): a single whitespace-free token → `"sum"` (byte-identical to the pre-max-flip behavior, recovering the regression); genuinely multi-word NL → `"max"` (keeps the +62.6% win). `reciprocal_rank_fusion`'s own DEFAULT is **untouched** — the scorecard's `rrf` arm still scores exactly 0.4953.

### Verified after the fold

| check | result |
|---|---|
| eval `rrf` arm (default max, 40 NL, direct `reciprocal_rank_fusion` call — untouched by this fix) | **0.4953, unchanged** |
| `literal_golden.jsonl` via `rank_chunks(dense_weight=1.0, combine=...)` — the exact shipped `tg find` path for every one of its 10 real queries | `combine="max"`: **0.9631** (byte-matches the gate's finding exactly, incl. the single missing query `lit-02`/"remember") → `combine="sum"` (what `_find_combine_mode` now actually returns for all 10): **1.0000 — regression fully recovered** |
| `identifier3_golden.jsonl` | 1.0000 both modes — unaffected, as expected (a wash) |
| 40-query NL set via `rank_chunks(dense_weight=5.0, combine=...)` — the exact shipped `tg find` path for every one of its queries (`_find_combine_mode` confirmed to return `"max"` for all 40) | **0.6026 — the dense-alone ceiling, unchanged** |
| Capsule agent-accuracy gate (`tests/eval/test_agent_accuracy.py`) | **16/16, unchanged** |
| Routing confirmed directly: `_find_combine_mode(q)` for every real query in both golden slices | `"sum"` for all 10+10; `"max"` for all 40 NL queries |
| New tests | `test_rank_chunks_combine_parameter_threads_to_fusion` (wiring spy), `test_rank_chunks_combine_sum_recovers_literal_regression_scenario` (a hand-built, real-`Bm25Index`/`DenseIndex` reproduction of the exact tie mechanism — proves `max_order[0]==0` (wrong) vs `sum_order[0]==1` (correct) deterministically), `test_find_combine_mode_helper` (direct-call, mirrors the existing dense_weight identifier list), `test_find_combine_mode_routes_single_token_to_sum_multiword_to_max_end_to_end` (CLI-level), `test_find_combine_mode_dense_unavailable_retry_also_routes` (the F1 BM25-only retry path also routes correctly) |
| `ruff check` / `ruff format --check --preview` / `mypy` on all changed files | clean |
| Full downstream suite | **128/128** (`test_retrieval_fusion` 21, `test_rank_chunks` 9, `test_reranker` 18, `test_reranker_hybrid` 14, `test_eval_late_rerank_quality` 20, `test_find_command` 24, `test_search_semantic_rerank` 5, `test_semantic_search_flag` 18 incl. real dense model, `test_bm25_search_flag` 3 — some totals differ slightly from commit 1's report after the spy-signature fix below) |

One incidental fix needed to land this: a pre-existing test (`test_rank_chunks_dense_weight`) had a local spy with a hardcoded `reciprocal_rank_fusion(rankings, *, k, weights)` signature that didn't accept the new `combine` kwarg `rank_chunks` now always passes — updated its signature to accept and forward `combine`, no behavior change to what it asserts.

**Methodology note (transparency):** I initially tried to reproduce the `literal_golden.jsonl` regression by running the *full* `_execute_find` pipeline (its own independent repo walk + chunking) and got 1.0 for both `max` and `sum` — it did not reproduce the gate's number. Root cause: `_execute_find`'s own file-walk order assigns different chunk INDICES than the eval harness's `load_corpus_files`+`chunk_file` convention, and the tie-break is by ascending chunk index — a different index assignment can accidentally dodge the tie for this one query. I do not rely on that walk-order-dependent luck: the verification above uses `rank_chunks` directly over the harness's own chunk build (the same convention the frozen 40-query numbers already use), which is the apples-to-apples comparison and is what byte-matches the gate's cited 0.9631. The routing fix is unconditional on query SHAPE (whitespace), not on walk order, so it holds regardless of which convention chunks it.

---

## Commit 1 (original): the max-combine default change

## The change (file:line)

`src/tensor_grep/core/retrieval_fusion.py`, `reciprocal_rank_fusion` (`:18`-`:56` pre-change, core loop was `:53`). Added `combine: Literal["sum", "max"] = "max"`:

- `combine="max"` (**new default**): `scores[i] = max(scores.get(i, 0.0), (1.0/(k+rank))*weight)` — a chunk's fused score is the single best leg contribution it earns, never the sum of every leg.
- `combine="sum"`: byte-identical to the pre-change behavior, for any call site that must keep it.

Every existing call site (`reranker.py`'s `rank_chunks` — used by both `tg search --semantic` and `tg find` — and the eval harness's `rrf`/`rrf_shipped` arms) calls `reciprocal_rank_fusion(...)` **without** `combine`, so the default change moves all of them with zero call-site edits.

## Why (mechanism)

A weak/near-floor leg (BM25 on a vocabulary-mismatched NL query) can now only ever **help** a chunk's rank — by ranking it even higher than the strong (dense) leg did — and can never **drag** the strong leg's pick down merely by failing to rank it or ranking it worse. Under sum, a doc that the dense leg loves but BM25 never sees is diluted by every other doc's tiny same-two-leg sum; under max, that dilution disappears. **Caveat (see UPDATE above): this same discarding-of-agreement is exactly what regresses a literal query where BOTH legs independently agree — the routing fix scopes `max` to where it actually helps.**

## Eval re-run (frozen golden-set harness, live, not replayed)

`benchmarks/eval_late_rerank_quality.py`, 40 queries (100% NL — see the UPDATE's caveat), oracle-validated, 2/2 runs byte-identical:

| arm | ndcg@10 before | ndcg@10 after | recall@10 | mrr |
|---|---|---|---|---|
| `bm25` | 0.1093 | **0.1093 (unchanged)** | 0.25 | 0.068 |
| `dense` | 0.6026 | **0.6026 (unchanged)** | 0.90 | 0.507 |
| `rrf` (the scored arm) | 0.3047 | **0.4953 (+62.6%)** | 0.55 → 0.825 | 0.228 → 0.391 |
| `rrf_shipped` (dense_weight=5.0, the real `tg find` production weight for NL queries) | *(not measured pre-change; sum+weighted independently reproduced at 0.4466)* | **0.6026 — reaches the dense-alone ceiling exactly** | 0.90 | 0.507 |
| `rrf+maxsim` | 0.0679 | 0.0743 | 0.225 | 0.032 |

`rrf+maxsim` stays clearly below bm25/rrf both before and after — already a known-dead arm per the eval script's own docstring ("twice-confirmed dead at the current model tier"), unaffected in verdict.

I independently reproduced the pre-change baseline byte-for-byte (rrf 0.3047, dense 0.6026 — exact match to the frozen `baseline_results.json` from the opt10 campaign) before trusting the after-change numbers.

Determinism: `--runs 2` → 2/2 byte-identical. Oracle: `--validate-oracle` → PASSED (gold=1.0 exact, reversed/empty at-or-below ceiling).

## Capsule agent-accuracy gate (hard 16/16 floor)

`pytest tests/eval/test_agent_accuracy.py` (real `tg prepare` subprocess, 16 golden tasks): **16/16, unchanged** (re-confirmed again after commit 2). Confirmed `agent_capsule.py` has zero `reciprocal_rank_fusion` references (AST retrieval, not dense/RRF) — it was structurally unaffected, and the live re-run confirms it, including the task literally named `"fix a weighting bug in reciprocal_rank_fusion between BM25 and dense scores"` resolving correctly to `core/retrieval_fusion.py`.

## `search --rank` decision: no scoping needed — it structurally never touches this function

Traced both flags before assuming the mandate's framing was accurate:

- `tg search --rank`/`--bm25` (no `--semantic`) → `main.py:8029-8032` → `rerank_by_bm25` (`reranker.py:161`). This function builds a **plain BM25 index with no dense leg at all** and never calls `reciprocal_rank_fusion`. It is **structurally unaffected** by this change — confirmed by 3/3 green in `tests/integration/test_bm25_search_flag.py` and 18/18 in `tests/unit/test_reranker.py`.
- `tg search --semantic` (`main.py:8010-8023` → `_apply_semantic_rerank` → `rerank_hybrid` → `rank_chunks` → `reciprocal_rank_fusion`) and `tg find` (`main.py`, direct `rank_chunks` call) are the **actual** consumers of RRF fusion on the search side. `--semantic` never passes `combine` (stays on plain `max`, unaffected by commit 2's fix, and its own test suite is fully green — 14/14 `test_reranker_hybrid.py`, 5/5 `test_search_semantic_rerank.py`, 18/18 `test_semantic_search_flag.py` including the real dense model). `tg find` is the one surface that now routes per-query (commit 2).

One real regression caught and fixed WITHIN commit 1: `test_chunk_absent_from_a_leg_contributes_zero` (pre-existing, `test_retrieval_fusion.py`) asserted a SUM-specific tie outcome that flips under the new default — fixed by pinning `combine="sum"` explicitly (its intent was always to test the sum path). Every other pre-existing test in that file is now pinned to `combine="sum"` too, as an explicit byte-identical regression guard.

## Weighted-max interaction (dense_weight=5.0, `tg find`'s real NL production weight)

Not just "not harmful" — **optimal for NL**: `rrf_shipped`/the routed multi-word find path (max-combine + the shipped `dense_weight=5.0`) scores **exactly** the dense-alone ceiling (0.6026). Mechanism: `max(bm25_term, 5.0 * dense_term)` — a 5x-amplified dense term all but always wins the max unless BM25 ranks the doc at least 5x higher, so the fused order collapses toward (and here, onto) the dense ranking. Under the OLD sum+weighted behavior (independently reproduced: 0.4466), the weak BM25 leg's contribution was still being *added in*, diluting the fused result relative to dense alone.

## Real-corpus dogfood (tensor-grep's own `src/`, 6 real queries — **all NL/multi-word, see the UPDATE's caveat**, `tg find`'s real pipeline `_execute_find`)

MAX vs SUM top-5, forced via the same monkeypatch pattern `test_rank_chunks_dense_weight` already uses (`reranker_module.reciprocal_rank_fusion`), so this exercises the shipped code path end-to-end, not a toy reproduction:

| query | top-1 (both modes) | notes |
|---|---|---|
| "where is the broad scan guard enforced" | `cli/scan_guardrails.py` (identical) | positions 2-5 reshuffle among plausible files (`apply_policy.py` vs `mcp_server.py`) |
| "how does the daemon warm cache work" | `cli/session_daemon.py` x3 (identical) | MAX concentrates MORE of top-5 on the correct file (4/5 vs 3/5 under sum) |
| "fusion of bm25 and dense rankings" | `core/reranker.py` (identical, full top-5 identical) | correctly surfaces the real fusion-consumer file at rank 1 |
| "where is the symlink follow disclosure prevented" | `cli/evidence_signing.py` (identical) | neither mode surfaces `io/directory_scanner.py` (the ideal answer) in top-5 — a **pre-existing** gap shared by both modes equally, not a MAX regression |
| "how does the backend fail closed contract work" | `cli/mcp_server.py` (identical) | genuinely a wash: sum surfaces more `backends/*.py` files, max surfaces `core/pipeline.py` (also a legitimate fail-closed-contract file per `AGENTS.md`) |
| "where is the session daemon idle shutdown timeout configured" | `cli/session_daemon.py` x5 (identical, full top-5 identical) | matches the capsule gate's own golden answer for this exact task phrasing |

**Corrected verdict (was overclaimed as "never worse than sum / 6/6" — see UPDATE):** on these 6 **NL** queries, MAX matches or is comparably-plausible to SUM at rank 1 in every case. This says nothing about literal/identifier queries, where a real regression existed and is now fixed by the routing above — that is the honesty gap the gate correctly caught.

## TDD

- `tests/unit/test_retrieval_fusion.py`: every pre-existing test now pins `combine="sum"` explicitly (the byte-identical regression guard for the original formulation). Added 6 new tests for `combine="max"`: default-is-max, the exact hand-computed fixture from the campaign brief, the max-specific tie/floor behavior, weights-apply-before-max, determinism, and invalid-`combine` raises. 21/21 pass.
- `tests/unit/test_rank_chunks.py`: +2 tests (combine-threading wiring, the hand-built tie-mechanism regression proof); 1 pre-existing test's local spy signature updated to accept the new `combine` kwarg. 9/9 pass.
- `tests/unit/test_find_command.py`: +3 tests (`_find_combine_mode` direct-call, end-to-end CLI routing, the DenseUnavailableError retry path). 24/24 pass.
- Full downstream suite re-run green, **128/128**: `test_reranker` (18), `test_reranker_hybrid` (14), `test_eval_late_rerank_quality` (20), `test_search_semantic_rerank` (5), `test_semantic_search_flag` (18, incl. real dense model), `test_bm25_search_flag` (3), plus the three files above.
- `ruff check` / `ruff format --check --preview` / `mypy` on all changed files: clean.

## Scope note

Ran targeted Python tests only (CPU-safe, shared box) — no cargo/rustc/maturin, no e2e Rust-compiling suites. Full CI matrix will run on this PR.

Leaving this **DRAFT** — awaiting the coordinator's re-verification of the fold's numbers before un-draft.
