### PR TITLE
perf(repo-map): merge 3 redundant ast.walk passes in _python_imports_and_symbols into one

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1682,8 +1682,9 @@ def _is_python_dynamic_import_call(node: ast.Call) -> bool:
     ``import_module(...)`` (from ``from importlib import import_module``), or
     ``importlib.import_module(...)``.  These are ``ast.Call`` EXPRESSIONS that can appear
     anywhere -- inside a function body, a conditional, a try/except -- which is exactly why they
-    need a whole-tree ``ast.walk`` (see ``_python_dynamic_import_entries``) instead of the
-    ``tree.body``-only scan below (#93 SUB-1 audit finding).
+    need a whole-tree ``ast.walk`` (see ``_python_dynamic_import_entry_for_call``, the per-node
+    detector built on top of this predicate) instead of the ``tree.body``-only scan below
+    (#93 SUB-1 audit finding).
     """
     func = node.func
     if isinstance(func, ast.Name):
@@ -1724,61 +1725,51 @@ def _python_dynamic_import_call_is_relative(node: ast.Call) -> bool:
     return True  # non-literal level -- can't prove it's 0, fail closed (treat as relative)
 
 
-def _python_dynamic_import_entries(tree: ast.AST) -> list[dict[str, Any]]:
-    """Raw per-call dynamic-import entries: one dict per ``__import__``/``import_module``/
-    ``importlib.import_module`` call anywhere in ``tree``, shaped like the static entries
-    ``_python_imports_with_lines`` emits (``module``, ``line``, ``level``) plus the two #93 SUB-1
-    markers -- ``dynamic`` (always ``True`` here) and ``dynamic_unresolved`` (``True`` when there
-    is no static-string-literal target to resolve at all -- the first argument isn't a literal,
-    e.g. a variable or an f-string -- OR when the literal names a RELATIVE import this slice
-    deliberately does not attempt to resolve, see below).
-
-    Fails CLOSED on the non-literal-argument case: ``module`` is ``""`` rather than a guessed
-    name -- asserting a fabricated edge for an import whose target we can't actually read would
-    be a precision regression in a moat feature (see ``_resolve_raw_import_entry`` /
-    ``_confirm_import_edges``, which both skip resolution entirely when ``dynamic_unresolved``
-    is set).
-
-    Also fails CLOSED on a RELATIVE literal -- a leading-dot ``import_module(".sibling",
-    package=...)`` module string, or an ``__import__(name, ..., level=N)`` call with a nonzero
-    (or non-literal, unprovable) ``level`` (``_python_dynamic_import_call_is_relative`` above --
-    scope slice #6, the tractable dynamic-import LITERAL slice). Both forms carry a real literal
-    name, kept here (unlike the non-literal case, ``module`` is NOT blanked to ``""`` -- nothing
-    is fabricated, the literal text is exactly what the source says), but the downstream absolute
-    resolver (``_python_module_candidates``) must never see it: its ``_python_module_parts``
-    splitter drops a leading empty component from ``".sibling".split(".")``, so an unguarded
-    relative literal would silently be searched for as if it were the ABSOLUTE module "sibling" --
-    a PROVEN false-edge risk (a same-named-but-unrelated top-level file can exist anywhere in the
-    search roots) not merely a theoretical one. Resolving the relative form correctly needs a
-    second, chained lookup (resolve the ``package``/enclosing-package argument to a directory
-    FIRST, only then walk it by the relative level) that this slice does not build -- out of scope
-    per the "no false edges, missing is fine" contract; a future slice can add it. ``package``
-    itself is never read here (a non-literal ``package`` -- the overwhelmingly common real-world
-    shape, ``package=__name__``/``package=__package__`` -- couldn't be resolved statically anyway,
-    and even a literal ``package`` string is left for that future slice), so this is a pure
-    detect-and-refuse guard on the ``module``/``level`` shape alone.
-    """
-    entries: list[dict[str, Any]] = []
-    for node in ast.walk(tree):
-        entry = _python_dynamic_import_entry_for_call(node)
-        if entry is not None:
-            entries.append(entry)
-    return entries
-
-
 def _python_dynamic_import_entry_for_call(node: ast.AST) -> dict[str, Any] | None:
-    """Per-node half of `_python_dynamic_import_entries` above: given a single AST node, return
-    its dynamic-import entry dict if `node` is one of the 3 dynamic-import call shapes (see
-    `_is_python_dynamic_import_call`), else `None`. Pulled out of that function's loop body
-    unchanged (same literal-extraction, same relative-literal fail-closed check, same entry
-    shape) so a caller that ALREADY walks `tree` for another purpose can fold this per-node check
-    into its own walk instead of paying for a second whole-tree `ast.walk` -- see
-    `_python_imports_with_lines` (opt10 F4.2), which merges its static-import walk with this one.
+    """Given a single AST node, return its dynamic-import entry dict if `node` is one of the 3
+    dynamic-import call shapes -- ``__import__(...)``, bare ``import_module(...)``, or
+    ``importlib.import_module(...)`` (see `_is_python_dynamic_import_call`) -- else `None`. The
+    returned dict is shaped like the static entries `_python_imports_with_lines` emits (`module`,
+    `line`, `level`) plus two #93 SUB-1 markers: `dynamic` (always `True` here) and
+    `dynamic_unresolved` (`True` when there is no static-string-literal target to resolve at all
+    -- the first argument isn't a literal, e.g. a variable or an f-string -- OR when the literal
+    names a RELATIVE import this slice deliberately does not attempt to resolve, see below).
 
-    `_python_dynamic_import_entries` itself keeps doing its own `ast.walk` and calling this once
-    per node exactly as its inlined loop body used to -- this extraction changes nothing about
-    its behavior, signature, or the entries it returns for its existing caller
-    (`_python_imports_and_symbols`'s reverse-import alias-graph prefilter).
+    Both `_python_imports_with_lines` (opt10 F4.2) and `_python_imports_and_symbols` (opt10
+    lever-1) fold this per-node check into their own single `ast.walk(tree)` pass instead of
+    paying for a second whole-tree walk. This used to be the loop body of a separate whole-tree
+    helper, `_python_dynamic_import_entries` -- pulled out unchanged (same literal-extraction,
+    same relative-literal fail-closed check, same entry shape) so `_python_imports_with_lines`
+    could fold it into its existing walk (opt10 F4.2) while `_python_imports_and_symbols` kept
+    calling `_python_dynamic_import_entries` wholesale for its own separate walk. Once opt10
+    lever-1 migrated that last remaining caller to call this per-node function directly too,
+    `_python_dynamic_import_entries` had zero callers left and was removed as dead code -- there
+    is no longer a standalone whole-tree dynamic-import walk anywhere in this module.
+
+    Fails CLOSED on the non-literal-argument case: `module` is `""` rather than a guessed name --
+    asserting a fabricated edge for an import whose target we can't actually read would be a
+    precision regression in a moat feature (see `_resolve_raw_import_entry` /
+    `_confirm_import_edges`, which both skip resolution entirely when `dynamic_unresolved` is
+    set).
+
+    Also fails CLOSED on a RELATIVE literal -- a leading-dot `import_module(".sibling",
+    package=...)` module string, or an `__import__(name, ..., level=N)` call with a nonzero (or
+    non-literal, unprovable) `level` (`_python_dynamic_import_call_is_relative` above -- scope
+    slice #6, the tractable dynamic-import LITERAL slice). Both forms carry a real literal name,
+    kept here (unlike the non-literal case, `module` is NOT blanked to `""` -- nothing is
+    fabricated, the literal text is exactly what the source says), but the downstream absolute
+    resolver (`_python_module_candidates`) must never see it: its `_python_module_parts` splitter
+    drops a leading empty component from `".sibling".split(".")`, so an unguarded relative
+    literal would silently be searched for as if it were the ABSOLUTE module "sibling" -- a
+    PROVEN false-edge risk (a same-named-but-unrelated top-level file can exist anywhere in the
+    search roots) not merely a theoretical one. Resolving the relative form correctly needs a
+    second, chained lookup (resolve the `package`/enclosing-package argument to a directory
+    FIRST, only then walk it by the relative level) that this slice does not build -- out of
+    scope per the "no false edges, missing is fine" contract; a future slice can add it.
+    `package` itself is never read here (a non-literal `package` -- the overwhelmingly common
+    real-world shape, `package=__name__`/`package=__package__` -- couldn't be resolved statically
+    anyway, and even a literal `package` string is left for that future slice), so this is a pure
+    detect-and-refuse guard on the `module`/`level` shape alone.
     """
     if not isinstance(node, ast.Call) or not _is_python_dynamic_import_call(node):
         return None
@@ -1936,6 +1927,21 @@ def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, A
     imports: list[str] = []
     symbols: list[dict[str, Any]] = []
 
+    # opt10/lever-1 speed fix: merge the imports / symbols / dynamic-import scans into a SINGLE
+    # `ast.walk(tree)` pass instead of three separate whole-tree walks (one for imports, one for
+    # symbols, and a third buried inside `_python_dynamic_import_entries`) -- the same
+    # single-walk-plus-helper-reuse pattern #716 already shipped for the sibling
+    # `_python_imports_with_lines` (see that function's own comment, and its F4.2 test, in
+    # tests/unit/test_file_deps.py). `ast.Import`, `ast.ImportFrom`, `ast.ClassDef`,
+    # `ast.FunctionDef`/`ast.AsyncFunctionDef`, and `ast.Call` are mutually-exclusive node
+    # subclasses, so each node dispatches to at most one branch below -- identical in effect to
+    # filtering three separate walks for three disjoint predicates and concatenating the
+    # results. The trailing `sorted(dict.fromkeys(imports))` + `symbols.sort(...)` below make
+    # append ORDER irrelevant, so interleaving all three kinds of appends into one walk is
+    # byte-identical to the old three-walk output. See
+    # test_python_imports_and_symbols_merges_all_three_walks_into_one (walk-count + output-
+    # identity proof).
+    #
     # Nested-scope recall fix (companion to the same change in `_python_imports_with_lines`):
     # `ast.walk` (not `tree.body`) so a plain `import`/`from ... import` STATEMENT nested inside a
     # function body, an `if`/`try` block, or an `if TYPE_CHECKING:` guard feeds this alias-graph
@@ -1973,59 +1979,67 @@ def _python_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, A
                 # actually resolves to -- this only widens the prefilter's candidate set.
                 for alias in node.names:
                     imports.append(alias.name)
-
-    for symbol_node in ast.walk(tree):
-        if isinstance(symbol_node, ast.ClassDef):
+        elif isinstance(node, ast.ClassDef):
             symbols.append(
                 _symbol_record(
-                    name=symbol_node.name,
+                    name=node.name,
                     kind="class",
                     file=path,
-                    start_line=symbol_node.lineno,
-                    end_line=getattr(symbol_node, "end_lineno", symbol_node.lineno),
+                    start_line=node.lineno,
+                    end_line=getattr(node, "end_lineno", node.lineno),
                 )
             )
-        elif isinstance(symbol_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             symbols.append(
                 _symbol_record(
-                    name=symbol_node.name,
+                    name=node.name,
                     kind="function",
                     file=path,
-                    start_line=symbol_node.lineno,
-                    end_line=getattr(symbol_node, "end_lineno", symbol_node.lineno),
+                    start_line=node.lineno,
+                    end_line=getattr(node, "end_lineno", node.lineno),
                 )
             )
-
-    # #93 SUB-1: fold in dynamic-import call targets (only the STATICALLY resolvable ones -- an
-    # unresolved dynamic import has no literal name to add to this alias-graph prefilter list;
-    # see `_python_dynamic_import_entries`) so a file that ONLY reaches a target dynamically is
-    # still discoverable as a candidate by the reverse `tg importers` prefilter
-    # (`_reverse_importers`), not just by the forward `tg imports` primitive.
-    #
-    # #703 gate NIT-1 fix: a plain `dynamic_entry["module"]` truthiness check was NOT actually
-    # equivalent to "statically resolvable" once #703 taught `_python_dynamic_import_entries` to
-    # also mark a RELATIVE literal (leading-dot `import_module(".sibling", package=...)`) or an
-    # explicit-nonzero-`level` `__import__(...)` as `dynamic_unresolved` -- unlike the original
-    # non-literal-argument case, those keep their real literal text in `module` (nothing is
-    # fabricated/blanked, see that function's docstring) rather than blanking it to `""`. So an
-    # unresolved-but-non-blank literal like `".sibling"` used to slip past this `if` into
-    # `imports`, which becomes `repo_map["imports"]` -- the alias graph `tg blast-radius`'s
-    # reverse SCORING prefilter (`_reverse_import_distances`/`_reverse_importers`) reads. A
-    # same-named-but-unrelated top-level file (`_import_alias_candidates` + the substring test in
-    # `_import_graph_bonus`) could then fuzzy-match that unresolved literal and be pulled into
-    # `affected_files`/`dependent_files` -- even though the precise `tg importers` edge
-    # (`_resolve_raw_import_entry` / `_confirm_import_edges`) already excluded it correctly, since
-    # THAT path has always skipped resolution whenever `dynamic_unresolved` is set. Requiring
-    # `not dynamic_entry["dynamic_unresolved"]` here makes this prefilter honor the exact same
-    # "no false edges, missing is fine" contract the precise resolvers already enforce -- an
-    # unresolved dynamic import (relative-literal or non-literal-argument alike) now contributes
-    # nothing to the alias graph, closing the fuzzy-match gap. Pinned by
-    # test_blast_radius_excludes_unresolved_dynamic_literal_fuzzy_match (regression-lock) and
-    # test_blast_radius_legitimate_dependent_ranking_pin (proves the legitimate reverse-scoring
-    # ranking is unaffected) in tests/unit/test_file_deps.py.
-    for dynamic_entry in _python_dynamic_import_entries(tree):
-        if dynamic_entry["module"] and not dynamic_entry["dynamic_unresolved"]:
-            imports.append(str(dynamic_entry["module"]))
+        elif isinstance(node, ast.Call):
+            # #93 SUB-1: fold in dynamic-import call targets (only the STATICALLY resolvable
+            # ones -- an unresolved dynamic import has no literal name to add to this
+            # alias-graph prefilter list; see `_python_dynamic_import_entry_for_call`) so a file
+            # that ONLY reaches a target dynamically is still discoverable as a candidate by the
+            # reverse `tg importers` prefilter (`_reverse_importers`), not just by the forward
+            # `tg imports` primitive. Reuses `_python_dynamic_import_entry_for_call` -- the
+            # ALREADY-TESTED per-node helper `_python_imports_with_lines` folds into its own
+            # single walk too (see that function) -- instead of calling the whole-tree
+            # `_python_dynamic_import_entries(tree)` this call site used to call, so the
+            # dynamic-import check rides the SAME walk as the import/symbol checks above instead
+            # of paying for a separate (third) whole-tree `ast.walk`. This was
+            # `_python_dynamic_import_entries`'s last remaining caller -- with it migrated to the
+            # per-node helper too, that whole-tree function had zero callers left and was removed
+            # as dead code (opt10 lever-1).
+            #
+            # #703 gate NIT-1 fix: a plain `entry["module"]` truthiness check is NOT actually
+            # equivalent to "statically resolvable" -- `_python_dynamic_import_entry_for_call`
+            # marks a RELATIVE literal (leading-dot `import_module(".sibling", package=...)`) or
+            # an explicit-nonzero-`level` `__import__(...)` as `dynamic_unresolved` too, and
+            # unlike the non-literal-argument case, those keep their real literal text in
+            # `module` (nothing is fabricated/blanked, see that helper's docstring) rather than
+            # blanking it to `""`. So an unresolved-but-non-blank literal like `".sibling"` must
+            # not slip into `imports`, which becomes `repo_map["imports"]` -- the alias graph
+            # `tg blast-radius`'s reverse SCORING prefilter
+            # (`_reverse_import_distances`/`_reverse_importers`) reads. A
+            # same-named-but-unrelated top-level file (`_import_alias_candidates` + the
+            # substring test in `_import_graph_bonus`) could then fuzzy-match that unresolved
+            # literal and be pulled into `affected_files`/`dependent_files` -- even though the
+            # precise `tg importers` edge (`_resolve_raw_import_entry` / `_confirm_import_edges`)
+            # already excludes it correctly, since THAT path has always skipped resolution
+            # whenever `dynamic_unresolved` is set. Requiring `not entry["dynamic_unresolved"]`
+            # here makes this prefilter honor the exact same "no false edges, missing is fine"
+            # contract the precise resolvers already enforce. Pinned by
+            # test_blast_radius_excludes_unresolved_dynamic_literal_fuzzy_match
+            # (regression-lock) and test_blast_radius_legitimate_dependent_ranking_pin (proves
+            # the legitimate reverse-scoring ranking is unaffected) in
+            # tests/unit/test_file_deps.py.
+            entry = _python_dynamic_import_entry_for_call(node)
+            if entry is not None and entry["module"] and not entry["dynamic_unresolved"]:
+                imports.append(str(entry["module"]))
 
     imports = sorted(dict.fromkeys(imports))
     symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
@@ -6008,19 +6022,23 @@ def _python_imports_with_lines(path: Path) -> list[dict[str, Any]]:
     #
     # opt10 F4.2 speed fix: this single walk ALSO picks up `__import__`/`import_module`/
     # `importlib.import_module` CALLS -- the #93 SUB-1 dynamic-import shape -- via
-    # `_python_dynamic_import_entry_for_call` (the extracted per-node half of
-    # `_python_dynamic_import_entries`), instead of a SEPARATE second `ast.walk(tree)` over the
-    # same tree the way this used to call that function wholesale. `ast.Import`/`ast.ImportFrom`
-    # and `ast.Call` are disjoint node types, so folding both checks into one walk and
-    # accumulating into two separate lists (`entries` for static, `dynamic_entries` for dynamic)
-    # produces the IDENTICAL two per-kind orderings `ast.walk` would produce run separately --
-    # `ast.walk` is a deterministic traversal of a fixed tree, so filtering it once for two
-    # disjoint predicates and concatenating the two result lists (`entries + dynamic_entries`,
-    # same order as the old `entries.extend(_python_dynamic_import_entries(tree))`) is exactly
-    # equivalent to filtering it twice. See
-    # test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass (walk-count +
-    # order-identity proof) and `_python_dynamic_import_entries`, which is UNCHANGED and still
-    # walks `tree` on its own for its other caller (`_python_imports_and_symbols`).
+    # `_python_dynamic_import_entry_for_call` (originally the extracted per-node half of a
+    # whole-tree helper, `_python_dynamic_import_entries`), instead of a SEPARATE second
+    # `ast.walk(tree)` over the same tree the way this used to call that function wholesale.
+    # `ast.Import`/`ast.ImportFrom` and `ast.Call` are disjoint node types, so folding both checks
+    # into one walk and accumulating into two separate lists (`entries` for static,
+    # `dynamic_entries` for dynamic) produces the IDENTICAL two per-kind orderings `ast.walk`
+    # would produce run separately -- `ast.walk` is a deterministic traversal of a fixed tree, so
+    # filtering it once for two disjoint predicates and concatenating the two result lists
+    # (`entries + dynamic_entries`, same order as the old
+    # `entries.extend(_python_dynamic_import_entries(tree))`) is exactly equivalent to filtering
+    # it twice. See test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass
+    # (walk-count + order-identity proof). `_python_dynamic_import_entries` itself -- the
+    # whole-tree helper this per-node check was extracted from -- kept its own separate `ast.walk`
+    # alive at the time (opt10 F4.2) purely for its OTHER remaining caller,
+    # `_python_imports_and_symbols`; opt10 lever-1 later migrated that caller to this same
+    # per-node helper too, leaving `_python_dynamic_import_entries` with zero callers, so it was
+    # removed as dead code.
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:

--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -2470,9 +2470,16 @@ def test_build_file_importers_unbounded_result_set_unaffected_by_tiering(tmp_pat
 # `_python_dynamic_import_entries` (called for the dynamic-import shape). The per-node dynamic-
 # import-detection logic was extracted into `_python_dynamic_import_entry_for_call` (a pure,
 # stateless per-node check) so `_python_imports_with_lines` can fold it into its EXISTING walk
-# instead of triggering a second one -- while `_python_dynamic_import_entries` itself is
-# UNCHANGED (same signature, same behavior, still does its own single walk) for its OTHER
-# caller, `_python_imports_and_symbols` (the reverse-import alias-graph prefilter).
+# instead of triggering a second one -- while `_python_dynamic_import_entries` itself, at the
+# time, stayed UNCHANGED (same signature, same behavior, still doing its own single walk) for
+# its OTHER caller, `_python_imports_and_symbols` (the reverse-import alias-graph prefilter).
+#
+# opt10 lever-1 (see tests further below): that OTHER caller was later migrated to call
+# `_python_dynamic_import_entry_for_call` directly too, folding its own dynamic-import check into
+# ITS single merged walk -- leaving `_python_dynamic_import_entries` with zero callers, so it was
+# removed as dead code. `test_python_dynamic_import_entries_unchanged_after_extraction` (the
+# regression guard for this function's post-extraction standalone behavior) was removed alongside
+# it for the same reason: there is no longer any caller whose behavior it could regress.
 # ---------------------------------------------------------------------------------------------
 
 
@@ -2765,29 +2772,111 @@ def test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass
         },
     ]
 
+    # NOTE: `test_python_dynamic_import_entries_unchanged_after_extraction` used to live here --
+    # a regression guard pinning `_python_dynamic_import_entries`'s standalone behavior for its
+    # then-last caller, `_python_imports_and_symbols`. opt10 lever-1 (below) migrated that caller
+    # to call `_python_dynamic_import_entry_for_call` directly instead, leaving
+    # `_python_dynamic_import_entries` with zero callers; it was removed as dead code, and this
+    # test was removed with it since there is no longer any caller whose behavior it could pin.
 
-def test_python_dynamic_import_entries_unchanged_after_extraction(tmp_path: Path) -> None:
-    """Regression guard for the F4.2 refactor: `_python_dynamic_import_entries` itself (the
-    OTHER caller of `_python_dynamic_import_entry_for_call`, used by
-    `_python_imports_and_symbols`'s reverse-import alias-graph prefilter at a SEPARATE call
-    site) must still walk `tree` on its own and return the identical entries it always did --
-    the extraction must not have changed its standalone behavior."""
+
+def test_python_imports_and_symbols_merges_all_three_walks_into_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lever-1 walk-count assertion (mirrors
+    test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass above):
+    `_python_imports_and_symbols` used to call `ast.walk(tree)` THREE separate times -- once for
+    the imports scan (module-level function body, ~1953), once for the symbols scan (~1977), and
+    once more buried inside `_python_dynamic_import_entries` (called from a third loop, ~2026) --
+    all three walking the identical tree. This was `_python_dynamic_import_entries`'s last
+    remaining caller; once migrated to call the per-node `_python_dynamic_import_entry_for_call`
+    helper directly (like the merged walk below does), that whole-tree function had zero callers
+    left and was removed as dead code. A file mixing a module-top-level import, a
+    TYPE_CHECKING-nested import, a relative `from . import x`, a class, a sync function, an
+    async function, a RESOLVABLE dynamic `importlib.import_module("os.path")` call, and an
+    UNRESOLVABLE dynamic `import_module(name)` call (non-literal argument) must produce the exact
+    same `(imports, symbols)` tuple as before the merge (values captured from the pre-merge
+    implementation), while calling `ast.walk` exactly ONCE."""
+    import ast as ast_module
+
     project = tmp_path / "project"
     project.mkdir()
-    source_file = project / "dyn.py"
+    source_file = project / "mixed.py"
     source_file.write_text(
-        "import importlib\n"
-        "def load(name):\n"
-        "    return importlib.import_module(name)\n"
-        "def load_builtin():\n"
-        "    return __import__('re')\n",
+        "import os\n"
+        "from typing import TYPE_CHECKING\n"
+        "from importlib import import_module\n"
+        "\n"
+        "if TYPE_CHECKING:\n"
+        "    import collections.abc\n"
+        "\n"
+        "from . import sibling\n"
+        "\n"
+        "\n"
+        "class Widget:\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "def build(name):\n"
+        "    return import_module('os.path')\n"
+        "\n"
+        "\n"
+        "async def build_async(name):\n"
+        "    return import_module(name)\n",
         encoding="utf-8",
     )
-    tree = repo_map._cached_ast_parse(source_file.read_text(encoding="utf-8"))
 
-    entries = repo_map._python_dynamic_import_entries(tree)
+    walk_calls = 0
+    real_walk = ast_module.walk
 
-    assert entries == [
-        {"module": "", "line": 3, "level": 0, "dynamic": True, "dynamic_unresolved": True},
-        {"module": "re", "line": 5, "level": 0, "dynamic": True, "dynamic_unresolved": False},
+    def counting_walk(tree):
+        nonlocal walk_calls
+        walk_calls += 1
+        return real_walk(tree)
+
+    # `repo_map` did `import ast` at module scope, so `repo_map.ast is ast_module` -- patching
+    # the shared stdlib module object's `walk` attribute affects the call
+    # `_python_imports_and_symbols` makes internally too (its only `ast.walk` call now that the
+    # merge folds the dynamic-import check into the same walk via the per-node
+    # `_python_dynamic_import_entry_for_call` helper instead of a separate whole-tree call).
+    monkeypatch.setattr(ast_module, "walk", counting_walk)
+
+    imports, symbols = repo_map._python_imports_and_symbols(source_file)
+
+    assert walk_calls == 1, f"expected exactly 1 ast.walk call, got {walk_calls}"
+    assert imports == [
+        "collections.abc",
+        "importlib",
+        "importlib.import_module",
+        "os",
+        "os.path",
+        "sibling",
+        "typing",
+        "typing.TYPE_CHECKING",
+    ]
+    assert symbols == [
+        {
+            "name": "Widget",
+            "kind": "class",
+            "file": str(source_file),
+            "line": 11,
+            "start_line": 11,
+            "end_line": 12,
+        },
+        {
+            "name": "build",
+            "kind": "function",
+            "file": str(source_file),
+            "line": 15,
+            "start_line": 15,
+            "end_line": 16,
+        },
+        {
+            "name": "build_async",
+            "kind": "function",
+            "file": str(source_file),
+            "line": 19,
+            "start_line": 19,
+            "end_line": 20,
+        },
     ]


### PR DESCRIPTION
## Summary

`_python_imports_and_symbols` (`src/tensor_grep/cli/repo_map.py`) walked the parsed AST **three
separate times** per file:

1. Imports walk (`ast.Import`/`ast.ImportFrom`).
2. Symbols walk (`ast.ClassDef`/`ast.FunctionDef`/`ast.AsyncFunctionDef` via `_symbol_record`).
3. Dynamic-imports walk — `for dynamic_entry in _python_dynamic_import_entries(tree):`, which
   itself does its own internal `ast.walk(tree)` over `ast.Call` nodes.

Profiling showed this function at **82% of `tg orient`'s cold wall** (also 66.9% callers, 53%
agent, 27.3% prepare) — the dominant cold-start cost in the repo-map build.

This PR merges the three walks into **one** `ast.walk(tree)` pass that dispatches each node by
type, reusing the already-tested per-node helper `_python_dynamic_import_entry_for_call` instead
of re-walking the tree a third time inside `_python_dynamic_import_entries`.

## Why it's byte-identical

`ast.Import`, `ast.ImportFrom`, `ast.ClassDef`, `ast.FunctionDef`/`ast.AsyncFunctionDef`, and
`ast.Call` are mutually-exclusive node subclasses, so every node dispatches to exactly one branch
— identical in effect to filtering three separate walks for three disjoint predicates and
concatenating the results. The trailing `imports = sorted(dict.fromkeys(imports))` and
`symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))` are
left **unchanged** — they normalize final order, which is exactly why interleaving the appends
from all three checks into one walk produces byte-identical output to the old three-walk version.

## Dead-code removal (`_python_dynamic_import_entries`) — a direct consequence of the merge

`_python_dynamic_import_entries` (the whole-tree helper the dynamic-imports walk used to call)
had exactly **one** live caller left on `origin/main`: the `:2026` call site inside
`_python_imports_and_symbols` that this PR's merge replaces. #716 had already migrated its other
caller, `_python_imports_with_lines`, to call the per-node helper
`_python_dynamic_import_entry_for_call` directly instead (its own comment block said so:
"`_python_dynamic_import_entries`, which is UNCHANGED and still walks `tree` on its own for its
**other** caller (`_python_imports_and_symbols`)").

Once this PR's merge migrates that last caller to the same per-node helper,
`_python_dynamic_import_entries` has **zero** callers left, so it is removed as dead code in this
same PR:

- Removed `_python_dynamic_import_entries` (`repo_map.py`).
- Kept `_python_dynamic_import_entry_for_call` — the still-live per-node helper both
  `_python_imports_with_lines` (#716) and `_python_imports_and_symbols` (this PR) fold into their
  own single walk.
- Updated its docstring (previously written as "the per-node half of
  `_python_dynamic_import_entries` above") to describe it standalone, and to record the removal
  history.
- Updated 2 other stale comment blocks in `repo_map.py` (near `_is_python_dynamic_import_call`
  and inside `_python_imports_with_lines`) that referenced `_python_dynamic_import_entries` as
  still-live.
- Removed its dedicated regression test, `test_python_dynamic_import_entries_unchanged_after_extraction`
  (`tests/unit/test_file_deps.py`) — verified it had no other purpose: it existed solely to pin
  `_python_dynamic_import_entries`'s standalone behavior "for its other caller
  (`_python_imports_and_symbols`)" per its own docstring, a caller this PR removes. Verified via
  `grep -rn "_python_dynamic_import_entries\b" src/ tests/` that no other test or `src/` call site
  references it (only historical prose comments remain, describing why/when it was removed).

## Precedent

This is the same single-walk-plus-helper-reuse pattern #716
(`2e8f379` — `perf(imports): stdlib resolver fast-path + single-walk dynamic-import merge`)
already shipped for the sibling function `_python_imports_with_lines`, which merged its static-
import walk with the dynamic-import-call walk into one pass via the same
`_python_dynamic_import_entry_for_call` per-node helper. This PR applies the identical technique
to `_python_imports_and_symbols`, which #716 explicitly left as future work (that function has a
third walk — the symbols scan — that #716 didn't touch), and finishes the cleanup #716 set up by
retiring the now-fully-superseded whole-tree helper.

## TDD

New test `test_python_imports_and_symbols_merges_all_three_walks_into_one` in
`tests/unit/test_file_deps.py`, mirroring the #716 sibling test
`test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass`:

- Monkeypatches `ast.walk` to count invocations.
- Exercises a fixture file with a module-top-level import, a `TYPE_CHECKING`-nested import, a
  relative `from . import x`, a class, a sync function, an async function, a **resolvable**
  dynamic `importlib.import_module("os.path")` call, and an **unresolvable** dynamic
  `import_module(name)` call (non-literal argument).
- Asserts `ast.walk` is called **exactly once**, and asserts the returned `(imports, symbols)`
  tuple is byte-identical to the pre-merge output (values captured by running the unmodified
  function against the same fixture before making the change).

Confirmed RED on the pre-merge code (`walk_calls == 3`, assertion fails as expected) and GREEN
after the merge (`walk_calls == 1`, full output match).

## Tests run

All targeted Python unit tests (no Rust build, no e2e — CPU-safe per house rules), from the
worktree, via the main repo's venv Python with `PYTHONPATH` pointed at the worktree `src/`
(stale-venv trap avoidance): `tests/unit/test_file_deps.py` (includes the new walk-count/output-
identity test) plus 56 further files that reference `_python_imports_and_symbols` /
`build_repo_map` / `build_file_importers_from_map` / `build_symbol_callers_from_map` /
`build_symbol_blast_radius_from_map` / `build_context_render` (the direct + downstream consumers
of this function's output: `tg imports`/`importers`/`agent`/`blast-radius`/`callers`/`orient`/
`prepare`/`context` and the MCP server).

**Result: 2462 passed, 1 skipped, 5 failed** (338.88s; ruff format and ruff check --fix both clean
on the two changed files). All 5 failures are **pre-existing and unrelated** to this change —
each independently verified via `git stash` in this same worktree to fail identically against
unmodified `origin/main`:

- 4 in `tests/unit/test_mcp_server.py`, all in the embedded-rewrite/native-binary-missing
  fallback cluster (`test_tg_rewrite_plan_uses_embedded_fallback_without_native_binary`,
  `test_execute_rewrite_apply_json_should_use_embedded_rust_when_native_binary_missing`,
  `test_execute_rewrite_apply_json_embedded_checkpoint_when_native_binary_missing`,
  `test_execute_rewrite_plan_json_should_restore_windows_variadic_metavar_escaping`) — nothing to
  do with Python import/symbol extraction.
- 1 in `tests/unit/test_cli_modes.py`
  (`test_cli_search_warns_when_gpu_device_id_out_of_local_inventory`) — a GPU device-inventory
  warning test, nothing to do with this change either.

All 105 tests in `tests/unit/test_file_deps.py` (the file this PR's new test lives in) pass, and
the sibling #716 tests (`test_python_imports_with_lines_merges_dynamic_walk_into_single_ast_walk_pass`
and friends) are unaffected.

## Scope

- `src/tensor_grep/cli/repo_map.py` — the walk merge + the dead-code removal it causes.
- `tests/unit/test_file_deps.py` — the new TDD test, the removed obsolete test, and 2 stale
  comment-block updates.

No other files touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
