### PR TITLE
ci(test-rust-core): retry the pinned-toolchain fetch to fix the macos network flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,17 @@ jobs:
             rustup toolchain install ${{ matrix.rust_channel }} --profile minimal --no-self-update
           fi
           rustup default ${{ matrix.rust_channel }}
+          # CI-harden: pre-fetch the rust_core/rust-toolchain.toml PIN (1.96.0) here, inside a
+          # retry loop, so the later `cargo test` (working-directory rust_core) does NOT trigger
+          # an un-retried on-demand toolchain download. A transient macos-runner network timeout
+          # on that pinned-manifest fetch red-failed CI on 2 consecutive PRs (#720, #721). The
+          # rustup-init curl above is already --retry 10; rustup's own toolchain fetch was not.
+          ( cd rust_core
+            for attempt in 1 2 3; do
+              cargo --version && break
+              [ "$attempt" = 3 ] && { echo "pinned-toolchain fetch failed after 3 attempts"; exit 1; }
+              echo "pinned-toolchain fetch attempt $attempt failed; retrying in 15s..."; sleep 15
+            done )
           rustc --version
           cargo --version
           


### PR DESCRIPTION
**Problem:** `test-rust-core` flaked on the macOS runner on **2 consecutive PRs** (#720, #721), each needing a manual rerun. Root cause: `rust_core/rust-toolchain.toml` pins **1.96.0**, so `cargo test` (working-directory `rust_core`) triggers an *on-demand* rustup download of the pinned toolchain manifest — and that fetch has **no retry** (the rustup-init `curl` in Setup Rust is `--retry 10`, but rustup's own toolchain fetch is not). A transient network timeout on `channel-rust-1.96.0.toml.sha256` red-failed the job.

**Fix (11 lines, scoped to test-rust-core):** pre-fetch the pin in `Setup Rust` inside a 3× retry loop (a cheap `cargo --version` in `rust_core` makes rustup install the toml pin), so `cargo test` finds it cached and never does the un-retried on-demand download. Behavior-preserving (same toolchains installed); fails the step only if the fetch genuinely fails 3×.

**Validation:** the PR's own matrix CI (ubuntu/windows/macos × stable/nightly) runs the exact modified setup — a green `test-rust-core (macos-latest, stable)` is the empirical proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)