### PR TITLE
perf(edit-plan): textual pre-check before per-candidate validation-test AST parse (byte-identical)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -10286,14 +10286,40 @@ def _framework_test_pattern_bonus(
     *,
     raw_query: str | None = None,
 ) -> int:
-    candidates = _framework_test_function_candidates(test_path)
-    if not candidates:
-        return 0
     expanded_terms: list[str] = list(terms)
     for candidate_term in _candidate_terms(raw_query):
         if candidate_term not in expanded_terms:
             expanded_terms.append(candidate_term)
     if not expanded_terms:
+        return 0
+    # perf(edit-plan): textual pre-check -- `_framework_test_function_candidates` triggers an
+    # expensive per-file AST parse for every `.py` candidate (`_python_parametrized_test_function_
+    # candidates` -> `_cached_ast_parse`), profiled at 46% of `tg context-render`'s wall / 23.9% of
+    # `tg prepare`'s, even though most candidates contribute a 0 bonus. Read the file's raw text
+    # ONCE and skip straight to the identical `return 0` outcome the expensive parse would have
+    # produced when nothing in `expanded_terms` could possibly score.
+    #
+    # BYTE-IDENTICAL: every string `_score_text_terms` is ever asked to score against is a literal
+    # substring of the raw file text -- EXCEPT the JS/TS `describe`+`test` name synthesized in
+    # `_javascript_test_function_candidates` (``f"{suite_name} {target_name}"``), which joins two
+    # literal-but-non-adjacent quoted-string substrings with an artificial single space. A term can
+    # only score against that synthesized string by being a literal substring of `suite_name` or of
+    # `target_name` alone (both real file substrings), OR by straddling exactly that one synthetic
+    # join space -- and in the straddle case each half is still individually a literal file
+    # substring. Checking each whitespace-split WORD of a term (not just the term as one contiguous
+    # run) against the raw file text closes that seam: it is a strictly safer over-approximation (a
+    # substring of a term that would have scored is still checked), so this short-circuit never
+    # produces a different answer than the un-short-circuited computation below.
+    try:
+        file_text = _read_source_text_cached(test_path).lower()
+    except (OSError, UnicodeDecodeError):
+        file_text = None  # can't prove absence -- fall through and let the real path handle it
+    if file_text is not None:
+        atoms = {word for term in expanded_terms for word in term.lower().split()}
+        if not any(atom in file_text for atom in atoms):
+            return 0
+    candidates = _framework_test_function_candidates(test_path)
+    if not candidates:
         return 0
     return (
         max((_score_text_terms(candidate, expanded_terms) for candidate in candidates), default=0)

--- a/tests/unit/test_validation_commands.py
+++ b/tests/unit/test_validation_commands.py
@@ -1622,3 +1622,193 @@ def test_build_agent_capsule_tie_confidence_and_ask_unchanged_by_edit_plan_parit
             "context consistency requires confirmation",
         ],
     }
+
+
+# --- perf(edit-plan): textual pre-check before per-candidate validation-test AST parse ---------
+#
+# `_framework_test_pattern_bonus` unconditionally called `_framework_test_function_candidates`
+# (an expensive AST parse for every `.py` candidate, via `_python_parametrized_test_function_
+# candidates` -> `_cached_ast_parse`) for EVERY test-file candidate `_discover_validation_tests_
+# for_primary_file` scores, even though most candidates contribute a 0 bonus. The fix reads the
+# candidate file's raw text ONCE up front and short-circuits to `return 0` when nothing in
+# `expanded_terms` could possibly score, before triggering that parse.
+#
+# Byte-identity argument: every string `_score_text_terms` is ever asked to score against is a
+# literal substring of the candidate file's raw text -- EXCEPT the JS/TS `describe`+`test` name
+# synthesized in `_javascript_test_function_candidates` (`f"{suite_name} {target_name}"`), which
+# joins two literal-but-non-adjacent quoted-string substrings with an artificial single space. A
+# term can only score against that synthesized string by being a literal substring of
+# `suite_name` or of `target_name` alone (both real file substrings), OR by straddling exactly
+# that one synthetic join space -- and in the straddle case each half is still individually a
+# literal file substring. Checking each whitespace-split WORD of a term (not just the term as one
+# contiguous run) against the raw file text closes that seam: it is a strictly safer
+# over-approximation (a substring of a term that would have scored is still checked), so the
+# short-circuit never produces a different answer than the un-short-circuited computation.
+#
+# `_bonus_without_textual_precheck` below reimplements the PRE-FIX function body directly from its
+# unchanged building blocks (`_framework_test_function_candidates` / `_candidate_terms` /
+# `_score_text_terms`), so every identity assertion compares the optimized function's real output
+# against what the un-short-circuited computation actually produces -- not a hard-coded number.
+
+
+def _bonus_without_textual_precheck(
+    test_path: str, terms: list[str], *, raw_query: str | None
+) -> int:
+    candidates = repo_map._framework_test_function_candidates(test_path)
+    if not candidates:
+        return 0
+    expanded_terms: list[str] = list(terms)
+    for candidate_term in repo_map._candidate_terms(raw_query):
+        if candidate_term not in expanded_terms:
+            expanded_terms.append(candidate_term)
+    if not expanded_terms:
+        return 0
+    return (
+        max(
+            (repo_map._score_text_terms(candidate, expanded_terms) for candidate in candidates),
+            default=0,
+        )
+        * 3
+    )
+
+
+def _counting_wrapper(
+    monkeypatch: pytest.MonkeyPatch, name: str
+) -> list[tuple[tuple[object, ...], dict[str, object]]]:
+    """Wrap ``repo_map.<name>`` to record every call while still delegating to the real
+    implementation, so callers get both an accurate call count AND a real return value."""
+    original = getattr(repo_map, name)
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def _wrapped(*args: object, **kwargs: object) -> object:
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(repo_map, name, _wrapped)
+    return calls
+
+
+def test_framework_test_pattern_bonus_matches_via_substring_term(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A long (>3 char) query term appearing as a plain substring of a Rust test function name
+    scores via `_score_text_terms`'s substring branch; the pre-check must let it through
+    unchanged."""
+    test_path = tmp_path / "widget_tests.rs"
+    test_path.write_text(
+        "#[test]\nfn test_widget_creation() {\n    assert!(true);\n}\n",
+        encoding="utf-8",
+    )
+    calls = _counting_wrapper(monkeypatch, "_framework_test_function_candidates")
+
+    bonus = repo_map._framework_test_pattern_bonus(str(test_path), ["widget"], raw_query="widget")
+
+    assert bonus > 0
+    assert len(calls) == 1  # candidate extraction DID run -- a real match must not be skipped
+    assert bonus == _bonus_without_textual_precheck(str(test_path), ["widget"], raw_query="widget")
+
+
+def test_framework_test_pattern_bonus_matches_via_short_token_term(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A <=3 char query term matches via `_score_text_terms`'s token-only branch (short terms
+    never match as a raw substring fragment -- they must be their own underscore-delimited
+    token); the pre-check must let it through unchanged."""
+    test_path = tmp_path / "io_tests.rs"
+    test_path.write_text(
+        "#[test]\nfn test_io_stream() {\n    assert!(true);\n}\n",
+        encoding="utf-8",
+    )
+    calls = _counting_wrapper(monkeypatch, "_framework_test_function_candidates")
+
+    bonus = repo_map._framework_test_pattern_bonus(str(test_path), ["io"], raw_query="io")
+
+    assert bonus > 0
+    assert len(calls) == 1
+    assert bonus == _bonus_without_textual_precheck(str(test_path), ["io"], raw_query="io")
+
+
+def test_framework_test_pattern_bonus_no_match_returns_zero_and_skips_extraction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Headline regression guard: when NONE of the query terms appear anywhere in the candidate
+    file's raw text, the textual pre-check must return 0 WITHOUT ever calling
+    `_framework_test_function_candidates` -- proving the expensive per-candidate AST parse
+    (`_python_parametrized_test_function_candidates` -> `_cached_ast_parse`) is actually skipped,
+    not just coincidentally equal to 0."""
+    test_path = tmp_path / "test_zeta.py"
+    test_path.write_text(
+        "import pytest\n\n\n@pytest.mark.parametrize('value', [1, 2, 3])\n"
+        "def test_zeta_response(value):\n    assert value\n",
+        encoding="utf-8",
+    )
+    calls = _counting_wrapper(monkeypatch, "_framework_test_function_candidates")
+
+    bonus = repo_map._framework_test_pattern_bonus(
+        str(test_path), ["widget", "gadget"], raw_query="widget gadget"
+    )
+
+    assert bonus == 0
+    assert calls == []  # the short-circuit fired -- candidate extraction (AST parse) never ran
+    assert bonus == _bonus_without_textual_precheck(
+        str(test_path), ["widget", "gadget"], raw_query="widget gadget"
+    )
+
+
+def test_framework_test_pattern_bonus_matches_parametrized_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Python candidates come ONLY from `_python_parametrized_test_function_candidates`, which
+    yields ONLY `@pytest.mark.parametrize`-decorated functions -- exercise that gate directly and
+    confirm the pre-check still lets a real Python match through."""
+    test_path = tmp_path / "test_discounts.py"
+    test_path.write_text(
+        "import pytest\n\n\n@pytest.mark.parametrize('value', [1, 2, 3])\n"
+        "def test_discount_applied(value):\n    assert value\n",
+        encoding="utf-8",
+    )
+    calls = _counting_wrapper(monkeypatch, "_framework_test_function_candidates")
+
+    bonus = repo_map._framework_test_pattern_bonus(
+        str(test_path), ["discount"], raw_query="discount"
+    )
+
+    assert bonus > 0
+    assert len(calls) == 1
+    assert bonus == _bonus_without_textual_precheck(
+        str(test_path), ["discount"], raw_query="discount"
+    )
+
+
+def test_framework_test_pattern_bonus_identity_holds_across_js_synthesized_suite_join(
+    tmp_path: Path,
+) -> None:
+    """Adversarial identity case found during plan verification (not in the original ask, added
+    for rigor): `_javascript_test_function_candidates` synthesizes a
+    ``f"{suite_name} {target_name}"`` candidate joining two literal-but-non-adjacent quoted
+    strings with an artificial single space. A multi-word TERM can straddle exactly that
+    synthetic join and score via `_score_text_terms`'s substring check even though the joined
+    phrase never appears literally in the file -- e.g. term "my component" against
+    ``describe("widgets and my")`` + ``it("component renders correctly")``. A NAIVE textual
+    pre-check (checking each whole term as one contiguous run against the raw file text) would
+    wrongly short-circuit to 0 here, since "my component" (with its internal space) is not a
+    literal file substring -- a byte-identity violation. The shipped fix splits each term on
+    whitespace before the membership check, which finds "my" and "component" independently (both
+    ARE literal file substrings) and correctly lets this candidate through to the real scoring
+    pass."""
+    test_path = tmp_path / "widget.test.js"
+    test_path.write_text(
+        "describe('widgets and my', () => {\n"
+        "  it('component renders correctly', () => {\n"
+        "    expect(true).toBe(true);\n"
+        "  });\n"
+        "});\n",
+        encoding="utf-8",
+    )
+
+    bonus = repo_map._framework_test_pattern_bonus(str(test_path), ["my component"], raw_query=None)
+
+    assert bonus > 0
+    assert bonus == _bonus_without_textual_precheck(
+        str(test_path), ["my component"], raw_query=None
+    )


### PR DESCRIPTION
## Measured headroom

`_framework_test_pattern_bonus` (`src/tensor_grep/cli/repo_map.py`) is called per-candidate from
`_discover_validation_tests_for_primary_file` for every test-file candidate, and unconditionally ran
`_framework_test_function_candidates(test_path)` — an expensive AST parse for every `.py` candidate
(`_python_parametrized_test_function_candidates` -> `_cached_ast_parse`). A profiling probe measured
this at **46% of `tg context-render`'s wall / 23.9% of `tg prepare`'s** — it parses hundreds of files
(254 parses vs 82 corpus files) just to score test candidates, most of which contribute a 0 bonus.

**The fix:** read the candidate file's raw text once up front and short-circuit to `return 0` when
nothing in `expanded_terms` could possibly score, before calling
`_framework_test_function_candidates(test_path)`.

## Byte-identity — verified, with one refinement over the original ask

Every string `_score_text_terms` (repo_map.py:7104) is ever asked to score against is a literal
substring of the candidate file's raw text — **except one seam**: `_javascript_test_function_candidates`
synthesizes a `f"{suite_name} {target_name}"` candidate joining two literal-but-non-adjacent quoted
string substrings with an artificial single space. During plan verification I constructed a concrete
counter-example: term `"my component"` against a file with `describe('widgets and my')` +
`it('component renders correctly')` — the synthesized candidate is `"widgets and my component renders
correctly"`, which the *unmodified* function scores > 0 against (the term straddles exactly the
synthetic join space), even though `"my component"` never appears literally in the file. A **naive**
pre-check (checking each whole term as one contiguous run against the raw file text) would wrongly
short-circuit that case to 0 — a real byte-identity violation. I verified this empirically before
shipping:

```
naive (whole-term) pre-check result: 0
shipped (word-split) pre-check result: 3
naive matches shipped: False
```

**The shipped fix splits each term on whitespace** before the membership check instead of checking
the term as one contiguous run. This is a strictly *safer* over-approximation — any substring of a
term that would have scored is still checked — and it closes the gap: in the straddle case, each half
of the straddle (`"my"`, `"component"`) is still individually a literal file substring, so the
word-split check correctly proceeds to the real scoring pass. For the overwhelming common case
(space-free terms — everything produced by `_query_terms`/`_candidate_terms`/most of
`_source_tokens`), this is byte-identical to checking the whole term, so there is no behavior change
for realistic terms; it only changes behavior for the one adversarial case that would otherwise have
been wrong.

`_read_source_text_cached` (the existing mtime+size-keyed shared read cache, repo_map.py:1282) is
reused for the pre-check's read rather than a fresh `Path.read_text()` — consistent with this file's
"PERF increment 1" precedent of routing reads through the shared cache — so a cache hit (e.g. the same
test file already read during repo-map symbol extraction) makes the pre-check itself close to free. A
read failure (`OSError`/`UnicodeDecodeError`) falls through to the original code path rather than
returning 0, so an unreadable file behaves exactly as before (handled/refused by the real read inside
`_framework_test_function_candidates`), never short-circuited on missing evidence.

## Lever 2 — verified already shipped, not bundled

Lever 2 asked me to verify whether `_build_edit_plan_seed` computes `validation_root`'s file list once
and threads it as `precomputed_file_paths` into both `_discover_validation_tests_for_primary_file` and
`_detect_validation_runners_from_root` (via `_validation_plan_and_alignment_for_tests`). I traced the
full second call chain end-to-end:

- `_build_edit_plan_seed` computes `validation_file_paths = _repo_map_validation_file_paths(repo_map,
  validation_root=validation_root)` once (repo_map.py:12486-12489) and passes it as
  `precomputed_file_paths` into `_discover_validation_tests_for_primary_file` (repo_map.py:12497) —
  this is the first chain the original probe traced.
- The **same** `validation_file_paths` value is *also* passed as `precomputed_file_paths` into
  `_validation_plan_and_alignment_for_tests` at repo_map.py:12586-12596 (and again at the
  `include_edit_plan_seed=False` lightweight-seed sibling, repo_map.py:12928-12951), which threads it
  through `_raw_validation_plan_for_tests` into every `_detect_validation_runners_from_root` call site
  (repo_map.py:10736, 10765, 10772) — the second chain.

This was already shipped in PR #645 (`78a6a37`, "fix(context): return-time deadline backstop + bound
the 2nd validation-plan chain for tg context-render/edit-plan/context (dogfood-#1 residual-of-residual,
#642 gate nit-1)"). The docstrings on `_detect_validation_runners_from_root` and
`_validation_plan_and_alignment_for_tests` explicitly name this as "the SECOND validation-plan chain"
and document that it mirrors the first chain's `precomputed_file_paths` contract. There is nothing left
to build — **Lever 2 is skipped, not bundled**, because the plumbing already exists on `main` (verified
against `origin/main` @ 714fbc8 / v1.93.9, the exact commit this worktree branched from).

## Tests

Added to `tests/unit/test_validation_commands.py` (existing file already covering
`_framework_test_function_candidates` / `_discover_validation_tests_for_primary_file`):

- `test_framework_test_pattern_bonus_matches_via_substring_term` — long (>3 char) term, Rust
  candidate, substring branch of `_score_text_terms`.
- `test_framework_test_pattern_bonus_matches_via_short_token_term` — <=3 char term, Rust candidate,
  token-only branch.
- `test_framework_test_pattern_bonus_no_match_returns_zero_and_skips_extraction` — headline guard:
  asserts `bonus == 0` **and** that `_framework_test_function_candidates` is never called (via a
  call-counting monkeypatch wrapper), proving the AST parse is actually skipped, not coincidentally
  equal.
- `test_framework_test_pattern_bonus_matches_parametrized_test` — `@pytest.mark.parametrize`-decorated
  Python function (the only shape `_python_parametrized_test_function_candidates` yields).
- `test_framework_test_pattern_bonus_identity_holds_across_js_synthesized_suite_join` — the adversarial
  straddle case above; pins the word-split refinement.

Every identity assertion compares the optimized function's real return value against
`_bonus_without_textual_precheck`, a same-file helper that reimplements the pre-fix body directly from
its unchanged building blocks (`_framework_test_function_candidates` / `_candidate_terms` /
`_score_text_terms`) — so the check is a genuine before/after comparison, not a hard-coded number.

**TDD sequence (real runs, this worktree, `origin/main` @ 714fbc8):**
1. RED: all 5 new tests against unmodified code — 4 passed (baseline characterization of unchanged
   scoring), 1 failed (`no_match_returns_zero_and_skips_extraction`, since the pre-fix code
   unconditionally calls `_framework_test_function_candidates`) — confirming the test suite actually
   exercises new behavior.
2. GREEN: same 5 tests after the fix — **5/5 passed**.
3. Regression sweep — **all green, zero failures**:
   - `tests/unit/test_validation_commands.py` — 69/69 passed (full file: my 5 new + 64 existing).
   - `tests/unit/test_framework_test_patterns.py`, `test_edit_plan_seed.py`,
     `test_edit_plan_max_files_bounds_suggested_edits.py`,
     `test_context_render_and_blast_radius_max_files_bounds_suggested_edits.py` — 65/65 passed
     (includes the existing JS `describe`/`it` framework-pattern test and the parametrize-association
     test).
   - Broader sweep — repo_map/agent_capsule/cli-deadline/session/profiling suites — see PR comment for
     the full file list and tally.
4. `ruff format --check --preview` — clean. `ruff check` — all checks passed. `mypy
   src/tensor_grep/cli/repo_map.py` — no issues found.

All runs used `PYTHONPATH=<worktree>/src` against the shared repo venv, verified to resolve
`tensor_grep.__file__` into this worktree (not the stale non-editable install) before trusting any
result.

## Scope

Change is confined to `_framework_test_pattern_bonus`'s short-circuit, per the caution that this is a
regression-sensitive seam (comments cite #639/#222/#642). `_score_text_terms` and the scoring math are
untouched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
