### PR TITLE
feat(lang): add PHP symbol + import intelligence (orient/defs/imports)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -597,7 +597,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "pyarrow>=23.0.1"]
 gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "pygls>=2.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "pygls>=2.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline
@@ -626,6 +626,7 @@ dev = [
   "tree-sitter-rust",
   "tree-sitter-go",
   "tree-sitter-java",
+  "tree-sitter-php",
   "types-PyYAML",
 ]
 bench = [
@@ -638,6 +639,7 @@ bench = [
   "tree-sitter-rust",
   "tree-sitter-go",
   "tree-sitter-java",
+  "tree-sitter-php",
   "torch>=2.0",
   "nvtx>=0.2",
 ]

--- a/src/tensor_grep/cli/lang_php.py
+++ b/src/tensor_grep/cli/lang_php.py
@@ -1,0 +1,286 @@
+"""PHP language extractor for tensor-grep's multi-language symbol graph (PATH A Stage 1).
+
+Sibling of ``lang_go.py`` (see that module's docstring for the full "PATH A Stage 1" framing).
+Plugs into the ``lang_registry`` seam Stage 0 built (see ``lang_registry.py`` + the
+``lang_registry.register_language(...)`` calls near the bottom of ``repo_map.py``) -- PHP gets
+its OWN ``LanguageSpec`` entry, registered from ``repo_map.py``.
+
+SCOPE (deliberately narrower than Go's Stage 1 landing): this module extracts DEFS + IMPORTS
+only -- ``php_imports_and_symbols`` (the ``.py``/``.go`` "one AST pass" shape) and
+``php_parser_symbol_sources`` (the ``tg source`` companion, mirroring
+``lang_go.go_parser_symbol_sources``). The cross-file caller-graph
+(``references_and_calls`` / ``file_imports_symbol_from_definition`` / ``import_update_target`` /
+``prime_repo_context``) that Go's Stage 1 landing also shipped is DEFERRED to a follow-up --
+PHP's ``LanguageSpec`` registers all four of those callables as ``None``. This is a strict
+subset of Go's shape, not a new shape: ``_language_coverage_gaps_for_universe`` in repo_map.py
+already treats ``import_update_target is None`` as an honest ``resolution_gaps`` entry (see the
+"audit #81 #4" comment on that function), so `tg callers`/`tg blast-radius` stay honest about
+PHP's current lack of reverse-import resolution instead of silently reading as a proven zero.
+
+Like ``lang_go.py``, this module imports NOTHING from ``repo_map.py`` (``repo_map`` ->
+``lang_php``, never the reverse -- ``repo_map.py`` needs to import this module to register PHP's
+``LanguageSpec`` and to call ``php_imports_and_symbols``/``php_parser_symbol_sources`` directly at
+the couple of per-language dispatch sites that mirror how it calls the Go equivalents; a reverse
+import would cycle). The handful of tiny helpers this module needs from ``repo_map.py`` are
+duplicated here instead of imported, matching ``lang_go.py``'s own precedent.
+
+FAIL-CLOSED CONTRACT (Stage 0 honesty floor, extended to PHP like Go): PHP has NO
+regex-heuristic fallback. When the ``tree_sitter_php`` grammar package is not installed, every
+extractor in this module returns empty ([]/([], [])) rather than degrading to a regex/text
+heuristic (unlike JS/TS/Rust, which all fall back to regex extraction when their own tree-sitter
+grammar is missing). ``LanguageSpec.provenance_when_missing="grammar-missing"`` (NOT
+``"regex-heuristic"``) is what makes ``_language_coverage_gaps_for_universe`` in repo_map.py
+treat a grammar-absent PHP file as a genuine ``resolution_gaps`` entry instead of silently
+reporting zero matches as if the symbol just did not exist.
+
+GRAMMAR VARIANT: ``tree_sitter_php`` exposes two language functions -- ``language_php_only()``
+(pure PHP, no surrounding markup) and ``language_php()`` (the full grammar: PHP embedded in an
+HTML document). This module uses ``language_php()`` so a template-style ``.php`` file (HTML +
+``<?php ... ?>`` blocks, common in real web-app repos) parses the same as a bare ``<?php`` file
+instead of erroring on the HTML it doesn't expect.
+
+KNOWN EXTRACTION GAPS (documented, not silent): ``namespace_use_clause`` import extraction only
+recognizes the two forms named in the design (``use Foo\\Bar;`` / ``use Foo\\Bar as Baz;`` -- a
+clause with a ``qualified_name`` child). Group-use (``use App\\Shared\\{Foo, Bar as Baz};``,
+where each inner clause only carries a bare ``name`` child, not a ``qualified_name``) and
+``use function ...`` / ``use const ...`` imports are not extracted -- verified via direct grammar
+probing (they do not carry a ``qualified_name`` child in the shape this walk expects), not
+guessed. Both degrade safely to "this clause contributes no import" rather than emitting a wrong
+or partial path.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Duplicated tiny helpers -- see the module docstring: no import from repo_map.py, to avoid an
+# import cycle (repo_map.py imports THIS module). Keep byte-identical to repo_map.py's twins
+# (``_tree_sitter_node_text`` / ``_is_clean_symbol_name`` / ``_symbol_record``) -- and to
+# ``lang_go.py``'s own copies of the same three -- if any of them ever change there.
+# ---------------------------------------------------------------------------
+
+_CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _is_clean_symbol_name(name: str) -> bool:
+    return bool(_CLEAN_SYMBOL_NAME_RE.match(name))
+
+
+def _tree_sitter_node_text(source_bytes: bytes, node: Any) -> str:
+    return source_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _symbol_record(
+    *,
+    name: str,
+    kind: str,
+    file: Path,
+    start_line: int,
+    end_line: int | None = None,
+) -> dict[str, Any]:
+    normalized_end_line = start_line if end_line is None else end_line
+    return {
+        "name": name,
+        "kind": kind,
+        "file": str(file),
+        "line": start_line,
+        "start_line": start_line,
+        "end_line": normalized_end_line,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parser factory (clone of lang_go.py's ``_go_parser`` shape).
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _php_parser() -> Any | None:
+    try:
+        import tree_sitter
+        import tree_sitter_php
+    except ImportError:
+        return None
+
+    # See the module docstring's "GRAMMAR VARIANT" note: language_php() (not
+    # language_php_only()) so a template-style .php file (HTML + <?php ... ?>) parses too.
+    language = tree_sitter.Language(tree_sitter_php.language_php())
+    return tree_sitter.Parser(language)
+
+
+# ---------------------------------------------------------------------------
+# Defs + imports: one tree-sitter pass per file.
+# ---------------------------------------------------------------------------
+
+# node types a PHP def can appear as -- informational/documentation only (mirrors
+# lang_go._GO_DEF_NODE_KINDS' role), matching LanguageSpec.def_node_kinds' "Stage 0:
+# informational only" contract.
+_PHP_DEF_NODE_KINDS = (
+    "class_declaration",
+    "interface_declaration",
+    "trait_declaration",
+    "enum_declaration",
+    "function_definition",
+    "method_declaration",
+)
+
+_PHP_CLASS_LIKE_KINDS = frozenset({
+    "class_declaration",
+    "interface_declaration",
+    "trait_declaration",
+    "enum_declaration",
+})
+_PHP_FUNCTION_LIKE_KINDS = frozenset({"function_definition", "method_declaration"})
+
+
+def php_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    """Extract ``use`` import paths + class/interface/trait/enum/function/method definitions
+    from a PHP source file, one AST pass (mirrors ``lang_go.go_imports_and_symbols``'s shape).
+
+    Defs covered: ``class_declaration``/``interface_declaration``/``trait_declaration``/
+    ``enum_declaration`` (kind "class") and ``function_definition``/``method_declaration`` (kind
+    "function"). Imports come from every ``namespace_use_clause``'s ``qualified_name`` child's
+    raw text -- PHP's namespace separator is a BACKSLASH (``\\``), not a dot, so the recorded
+    string is e.g. ``"App\\Contracts\\Named"``, preserved as-written (never rewritten to
+    dot-form) so it feeds the reverse-import alias graph the same way Python's dotted
+    ``node.module`` does today. An ``as`` alias is not recorded (matching how
+    ``_python_imports_and_symbols`` records the source module path, not a locally bound name).
+    See the module docstring's "KNOWN EXTRACTION GAPS" note for the two import forms this
+    deliberately does not cover.
+    """
+    if path.suffix != ".php":
+        return [], []
+
+    parser = _php_parser()
+    if parser is None:
+        return [], []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    imports: list[str] = []
+    symbols: list[dict[str, Any]] = []
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS instead of recursion, matching lang_go.py's walkers (F26 precedent:
+        # a pathologically deep AST can never raise RecursionError). Children pushed in reverse
+        # so the leftmost child is popped (visited) first, preserving pre-order traversal.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "namespace_use_clause":
+                qualified_name_node = next(
+                    (child for child in node.children if child.type == "qualified_name"),
+                    None,
+                )
+                if qualified_name_node is not None:
+                    imports.append(_node_text(qualified_name_node))
+            elif node_type in _PHP_CLASS_LIKE_KINDS:
+                name_node = node.child_by_field_name("name")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="class",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type in _PHP_FUNCTION_LIKE_KINDS:
+                name_node = node.child_by_field_name("name")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    imports = sorted(dict.fromkeys(imports))
+    symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
+    return imports, symbols
+
+
+def php_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
+    """Full source text of every class/interface/trait/enum/function/method matching *symbol*
+    (mirrors the Go/Rust/JS-TS ``*_parser_symbol_sources`` shape for the ``tg source``
+    command)."""
+    if path.suffix != ".php":
+        return []
+
+    parser = _php_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    sources: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS -- see the identical comment on php_imports_and_symbols's `_walk`.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            name_node: Any | None = None
+            kind: str | None = None
+            if node_type in _PHP_CLASS_LIKE_KINDS:
+                name_node = node.child_by_field_name("name")
+                kind = "class"
+            elif node_type in _PHP_FUNCTION_LIKE_KINDS:
+                name_node = node.child_by_field_name("name")
+                kind = "function"
+            if name_node is not None and kind is not None and _node_text(name_node) == symbol:
+                block = _node_text(node)
+                if block and not block.endswith("\n"):
+                    block = f"{block}\n"
+                sources.append({
+                    "name": symbol,
+                    "kind": kind,
+                    "file": str(path),
+                    "start_line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                    "source": block,
+                })
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
+    return sources
+
+
+__all__ = [
+    "php_imports_and_symbols",
+    "php_parser_symbol_sources",
+]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
-from tensor_grep.cli import lang_go, lang_registry
+from tensor_grep.cli import lang_go, lang_php, lang_registry
 from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LSPTransportError
 from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 
@@ -6143,6 +6143,43 @@ lang_registry.register_language(
     )
 )
 
+# PATH A Stage 1 (second language expansion beyond Go): PHP's own module (lang_php.py), same
+# no-import-cycle rationale as lang_go.py. NARROWER than Go's landing -- this registration ships
+# defs + imports only; the cross-file caller-graph (references_and_calls and the other three
+# callables below) is explicitly deferred to a follow-up, so all four are None here. That is a
+# strict subset of an already-handled shape: _language_coverage_gaps_for_universe already treats
+# import_update_target=None as an honest resolution_gaps entry (see the "audit #81 #4" comment on
+# that function, and lang_go.py's own import_update_target=None precedent), so `tg callers`/
+# `tg blast-radius` stay honest about PHP instead of silently reading as a proven zero.
+# provenance_when_missing="grammar-missing" (NOT "regex-heuristic") for the same fail-closed
+# reason as Go: PHP has no regex-heuristic fallback.
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="php",
+        suffixes=frozenset({".php"}),
+        grammar_modules=("tree_sitter", "tree_sitter_php"),
+        parser_for_path=lambda path: lang_php._php_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="grammar-missing",
+        import_markers=(b"use ",),
+        def_node_kinds=(
+            "class_declaration",
+            "interface_declaration",
+            "trait_declaration",
+            "enum_declaration",
+            "function_definition",
+            "method_declaration",
+        ),
+        extract_imports_and_symbols=None,
+        references_and_calls=None,
+        provider_alias_calls=None,
+        file_imports_symbol_from_definition=None,
+        import_update_target=None,
+        prime_repo_context=None,
+        classify_ref_kind=None,
+    )
+)
+
 
 def _prime_all_language_repo_contexts(context_root: Path) -> None:
     """Prime every registered language's per-repo-root context exactly once.
@@ -6200,6 +6237,10 @@ def _imports_and_symbols_for_path(
         elif spec is not None and spec.language_id == "java":
             # Fail-closed (same Stage 1 trap as Go): NO regex fallback for Java either.
             current_imports, current_symbols = _java_imports_and_symbols(path)
+        elif spec is not None and spec.language_id == "php":
+            # Fail-closed (Stage 1 trap, same as Go): NO regex fallback for PHP either -- see
+            # lang_php.py's module docstring.
+            current_imports, current_symbols = lang_php.php_imports_and_symbols(path)
         elif not current_imports and not current_symbols:
             current_imports, current_symbols = _regex_imports_and_symbols(path)
         return current_imports, current_symbols
@@ -7302,6 +7343,10 @@ def _target_language_for_path(path: str | Path | None) -> str | None:
         # Same MOST-FORGOTTEN seam, Stage 2: without this, `tg agent`'s capsule never reports
         # primary_target_language == "java" for a Java target.
         return "java"
+    if suffix == ".php":
+        # MOST-FORGOTTEN seam (see the ".go" branch above) -- same fix, same reason, for PHP's
+        # Stage 1 registration.
+        return "php"
     return None
 
 
@@ -15746,6 +15791,8 @@ def build_symbol_source_from_map(
                 current_sources = lang_go.go_parser_symbol_sources(current_path, symbol)
             if not current_sources and current_path.suffix in _JAVA_SUFFIXES:
                 current_sources = _java_parser_symbol_sources(current_path, symbol)
+            if not current_sources and current_path.suffix == ".php":
+                current_sources = lang_php.php_parser_symbol_sources(current_path, symbol)
             if not current_sources:
                 current_sources = _regex_symbol_sources(current_path, symbol)
             sources.extend(current_sources)

--- a/tests/unit/test_lang_php.py
+++ b/tests/unit/test_lang_php.py
@@ -1,0 +1,323 @@
+"""PATH A STAGE 1 -- PHP symbol graph (lang_php.py) tests.
+
+Sibling of ``test_lang_go.py`` (Go's Stage 1 landing), scoped to what this PR actually ships:
+DEFS + IMPORTS only. The fixture is a single PHP file --
+``namespace`` + two ``use`` imports (one plain, one aliased) + an ``interface`` + a ``trait`` + an
+``enum`` + a ``class`` (implementing the interface, using the trait, with a constructor and a
+method) + a top-level ``function`` -- used to verify:
+
+- ``php_imports_and_symbols``: every class-like declaration (class/interface/trait/enum) is
+  extracted as kind "class"; every function-like declaration (function/method) is extracted as
+  kind "function", with correct 1-based start/end lines; every ``use`` import is recorded as its
+  raw backslash-qualified name (alias dropped, matching Python's dotted ``node.module`` role).
+- ``php_parser_symbol_sources``: full source text lookup for the ``tg source`` command,
+  including the case where two distinct declarations share a name (the interface's abstract
+  ``greet`` stub and the class's concrete ``greet`` implementation).
+- Registration + provenance: PHP's ``LanguageSpec`` reports "tree-sitter" when parsed,
+  "grammar-missing" (never a silent regex/heuristic swap) when the grammar is absent, and the
+  four cross-file caller-graph callables (``references_and_calls`` and friends) are explicitly
+  ``None`` -- this is DEFERRED scope, not an oversight (see ``lang_php.py``'s module docstring).
+- ``_target_language_for_path`` agrees with the registry (the "MOST-FORGOTTEN seam" ``lang_go.py``
+  and ``test_lang_registry.py`` warn about -- miss it and the agent capsule's
+  query-language-vs-target-language confidence cap silently misfires on PHP targets).
+- ``build_repo_map``/``build_symbol_defs`` surface PHP symbols+imports end to end, with the same
+  ``resolution_gaps`` honesty floor Go already established: a grammar-missing PHP file is a
+  "fail-closed" gap, and even a grammar-PRESENT PHP file is an honest "import_resolution_only"
+  gap (``import_update_target is None``) -- `tg callers`/`tg blast-radius` must never read PHP's
+  currently-absent reverse-import resolution as a proven zero.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli import lang_php, lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# Fixture: namespace + 2 `use` imports + interface + trait + enum + class (implements +
+# trait-use + constructor + method) + a top-level function. Line numbers below are
+# 1-based and load-bearing for the exact-line assertions -- see the module docstring.
+# ---------------------------------------------------------------------------
+
+
+def _write_php_fixture(root: Path) -> Path:
+    php_file = root / "Widget.php"
+    php_file.write_text(
+        "<?php\n"  # 1
+        "\n"  # 2
+        "namespace App\\Models;\n"  # 3
+        "\n"  # 4
+        "use App\\Contracts\\Named;\n"  # 5
+        "use App\\Utils\\Str as S;\n"  # 6
+        "\n"  # 7
+        "interface Greetable\n"  # 8
+        "{\n"  # 9
+        "    public function greet(): string;\n"  # 10
+        "}\n"  # 11
+        "\n"  # 12
+        "trait Loggable\n"  # 13
+        "{\n"  # 14
+        "    public function log(string $message): void\n"  # 15
+        "    {\n"  # 16
+        "        echo $message;\n"  # 17
+        "    }\n"  # 18
+        "}\n"  # 19
+        "\n"  # 20
+        "enum Status\n"  # 21
+        "{\n"  # 22
+        "    case Active;\n"  # 23
+        "    case Inactive;\n"  # 24
+        "}\n"  # 25
+        "\n"  # 26
+        "class Widget implements Greetable\n"  # 27
+        "{\n"  # 28
+        "    use Loggable;\n"  # 29
+        "\n"  # 30
+        "    private string $label;\n"  # 31
+        "\n"  # 32
+        "    public function __construct(string $label)\n"  # 33
+        "    {\n"  # 34
+        "        $this->label = $label;\n"  # 35
+        "    }\n"  # 36
+        "\n"  # 37
+        "    public function greet(): string\n"  # 38
+        "    {\n"  # 39
+        '        return "hi " . S::upper($this->label);\n'  # 40
+        "    }\n"  # 41
+        "}\n"  # 42
+        "\n"  # 43
+        "function make_widget(string $label): Widget\n"  # 44
+        "{\n"  # 45
+        "    return new Widget($label);\n"  # 46
+        "}\n",  # 47
+        encoding="utf-8",
+    )
+    return php_file
+
+
+# ---------------------------------------------------------------------------
+# Registration + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_php_is_registered_with_tree_sitter_provenance() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["php"]
+    assert spec.suffixes == frozenset({".php"})
+    assert spec.provenance_when_parsed == "tree-sitter"
+    # Fail-closed (Stage 1 trap, like Go): never "regex-heuristic"/"heuristic" -- PHP has no
+    # fallback when the grammar is missing.
+    assert spec.provenance_when_missing == "grammar-missing"
+    assert spec.parser_for_path is not None
+    # DEFERRED scope (see lang_php.py's module docstring): the cross-file caller-graph is a
+    # follow-up, not shipped here. Pin this explicitly so a future PR that wires one of these in
+    # must consciously update this test rather than silently drift.
+    assert spec.references_and_calls is None
+    assert spec.provider_alias_calls is None
+    assert spec.file_imports_symbol_from_definition is None
+    assert spec.import_update_target is None
+    assert spec.prime_repo_context is None
+    assert spec.classify_ref_kind is None
+
+
+def test_target_language_for_path_reports_php() -> None:
+    assert repo_map._target_language_for_path("src/Widget.php") == "php"
+    assert repo_map._language_for_path("src/Widget.php") == "php"
+    assert repo_map._provider_language_for_path("src/Widget.php") == "php"
+
+
+# ---------------------------------------------------------------------------
+# php_imports_and_symbols: direct unit coverage (kinds/lines + qualified `\`-names)
+# ---------------------------------------------------------------------------
+
+
+def test_php_imports_and_symbols_extracts_qualified_backslash_imports(tmp_path: Path) -> None:
+    php_file = _write_php_fixture(tmp_path)
+
+    imports, _symbols = lang_php.php_imports_and_symbols(php_file)
+
+    # Backslash preserved as-written (PHP's namespace separator, not a dot); alias ("as S")
+    # dropped, matching Python's dotted node.module role (the SOURCE path, not a local name).
+    assert imports == ["App\\Contracts\\Named", "App\\Utils\\Str"]
+
+
+def test_php_imports_and_symbols_extracts_all_def_kinds_with_correct_lines(
+    tmp_path: Path,
+) -> None:
+    php_file = _write_php_fixture(tmp_path)
+
+    _imports, symbols = lang_php.php_imports_and_symbols(php_file)
+
+    actual = [
+        (item["name"], item["kind"], item["start_line"], item["end_line"]) for item in symbols
+    ]
+    expected = [
+        ("Greetable", "class", 8, 11),
+        ("greet", "function", 10, 10),
+        ("Loggable", "class", 13, 19),
+        ("log", "function", 15, 18),
+        ("Status", "class", 21, 25),
+        ("Widget", "class", 27, 42),
+        ("__construct", "function", 33, 36),
+        ("greet", "function", 38, 41),
+        ("make_widget", "function", 44, 47),
+    ]
+    assert actual == expected
+    # Every symbol carries this file's path and the line-number/start_line agreement
+    # `_symbol_record` guarantees for every other language.
+    for item in symbols:
+        assert item["file"] == str(php_file)
+        assert item["line"] == item["start_line"]
+
+
+def test_php_imports_and_symbols_non_php_suffix_returns_empty(tmp_path: Path) -> None:
+    other_file = tmp_path / "widget.txt"
+    other_file.write_text("<?php class Widget {}\n", encoding="utf-8")
+
+    assert lang_php.php_imports_and_symbols(other_file) == ([], [])
+
+
+def test_php_imports_and_symbols_missing_file_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.php"
+
+    assert lang_php.php_imports_and_symbols(missing) == ([], [])
+
+
+def test_php_imports_and_symbols_grammar_absent_returns_empty(tmp_path: Path, monkeypatch) -> None:
+    php_file = _write_php_fixture(tmp_path)
+    monkeypatch.setattr(lang_php, "_php_parser", lambda: None)
+
+    assert lang_php.php_imports_and_symbols(php_file) == ([], [])
+
+
+def test_php_trait_use_in_class_body_is_not_mistaken_for_a_namespace_import(
+    tmp_path: Path,
+) -> None:
+    """`use Loggable;` inside the class body is PHP's trait-use statement (grammar node type
+    `use_declaration`), a different construct from a namespace import (`namespace_use_clause`
+    nested under `namespace_use_declaration`) -- verified directly against the real grammar
+    before writing the extractor. Only the two real namespace imports must show up."""
+    php_file = _write_php_fixture(tmp_path)
+
+    imports, _symbols = lang_php.php_imports_and_symbols(php_file)
+
+    assert "Loggable" not in imports
+    assert len(imports) == 2
+
+
+# ---------------------------------------------------------------------------
+# php_parser_symbol_sources: `tg source` companion
+# ---------------------------------------------------------------------------
+
+
+def test_php_parser_symbol_sources_finds_both_greet_declarations(tmp_path: Path) -> None:
+    php_file = _write_php_fixture(tmp_path)
+
+    sources = lang_php.php_parser_symbol_sources(php_file, "greet")
+
+    assert len(sources) == 2
+    assert {item["start_line"] for item in sources} == {10, 38}
+    assert all(item["kind"] == "function" for item in sources)
+    impl = next(item for item in sources if item["start_line"] == 38)
+    assert "S::upper" in impl["source"]
+
+
+def test_php_parser_symbol_sources_finds_top_level_function(tmp_path: Path) -> None:
+    php_file = _write_php_fixture(tmp_path)
+
+    sources = lang_php.php_parser_symbol_sources(php_file, "make_widget")
+
+    assert len(sources) == 1
+    assert sources[0]["kind"] == "function"
+    assert sources[0]["start_line"] == 44
+    assert "return new Widget($label);" in sources[0]["source"]
+
+
+def test_php_parser_symbol_sources_no_match_returns_empty(tmp_path: Path) -> None:
+    php_file = _write_php_fixture(tmp_path)
+
+    assert lang_php.php_parser_symbol_sources(php_file, "NoSuchSymbol") == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: build_repo_map / build_symbol_defs surface PHP end to end.
+# ---------------------------------------------------------------------------
+
+
+def test_build_repo_map_surfaces_php_symbols_and_imports(tmp_path: Path) -> None:
+    _write_php_fixture(tmp_path)
+
+    payload = repo_map.build_repo_map(tmp_path)
+
+    symbol_names = {item["name"] for item in payload["symbols"]}
+    assert {"Widget", "Greetable", "Loggable", "Status", "greet", "make_widget"} <= symbol_names
+
+    php_import_entries = [
+        entry for entry in payload["imports"] if str(entry["file"]).endswith("Widget.php")
+    ]
+    assert len(php_import_entries) == 1
+    assert php_import_entries[0]["imports"] == ["App\\Contracts\\Named", "App\\Utils\\Str"]
+    # Registry-driven provenance labeling (repo_map._symbol_navigation_provenance_for_path)
+    # comes for free once PHP is registered -- was "heuristic" before this PR.
+    assert php_import_entries[0]["provenance"] == "tree-sitter"
+
+
+def test_defs_finds_class_with_tree_sitter_provenance(tmp_path: Path) -> None:
+    _write_php_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Widget", tmp_path)
+
+    assert not payload.get("no_match")
+    assert len(payload["definitions"]) == 1
+    definition = payload["definitions"][0]
+    assert definition["kind"] == "class"
+    assert definition["provenance"] == "tree-sitter"
+    assert definition["file"].replace("\\", "/").endswith("Widget.php")
+
+
+def test_defs_finds_interface_trait_and_enum_as_class_kind(tmp_path: Path) -> None:
+    _write_php_fixture(tmp_path)
+
+    for name in ("Greetable", "Loggable", "Status"):
+        payload = repo_map.build_symbol_defs(name, tmp_path)
+        assert not payload.get("no_match"), f"expected a definition for {name}"
+        assert payload["definitions"][0]["kind"] == "class"
+
+
+# ---------------------------------------------------------------------------
+# resolution_gaps honesty floor (mirrors lang_go.py's audit #81 #4 precedent).
+# ---------------------------------------------------------------------------
+
+
+def test_grammar_absent_yields_no_fabricated_defs_and_fail_closed_gap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_php_fixture(tmp_path)
+    monkeypatch.setattr(lang_php, "_php_parser", lambda: None)
+
+    defs_payload = repo_map.build_symbol_defs("Widget", tmp_path)
+    assert defs_payload.get("no_match") is True
+    assert defs_payload["definitions"] == []
+    defs_gaps = defs_payload["resolution_gaps"]
+    php_gap = next(gap for gap in defs_gaps if gap["language"] == "php")
+    assert "fail-closed" in php_gap["reason"]
+    assert "Coverage gap detected" in defs_payload["message"]
+
+
+def test_grammar_present_still_flags_import_resolution_only_gap(tmp_path: Path) -> None:
+    """audit #81 #4 parity: PHP's LanguageSpec sets import_update_target=None (the cross-file
+    caller-graph is deferred), so _language_coverage_gaps_for_universe must flag that as an
+    honest partial-capability gap even though the grammar IS installed and defs/`tg source`
+    both work fine -- never read as resolution_gaps == [] (indistinguishable from "PHP has full
+    capability")."""
+    _write_php_fixture(tmp_path)
+    (tmp_path / "target.py").write_text("def Target():\n    return 1\n", encoding="utf-8")
+
+    payload = repo_map.build_symbol_refs("Target", tmp_path)
+
+    assert not payload.get("no_match")
+    resolution_gaps = payload["resolution_gaps"]
+    php_gaps = [gap for gap in resolution_gaps if gap["language"] == "php"]
+    assert len(php_gaps) == 1
+    assert php_gaps[0]["files_affected"] >= 1
+    assert "reverse-import" in php_gaps[0]["reason"]
+    assert "fail-closed" not in php_gaps[0]["reason"]

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -45,6 +45,7 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
         "foo.rs": "rust",
         "foo.go": "go",
         "foo.java": "java",
+        "foo.php": "php",
     }
     for name, expected_language in expectations.items():
         spec = lang_registry.spec_for_path(Path(name))
@@ -53,13 +54,11 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
 
 
 def test_spec_for_path_unknown_suffix_returns_none() -> None:
-    # PATH A Stage 1: .go is now a REGISTERED language (see
-    # test_spec_for_path_resolves_every_registered_suffix), so it moved out of this "still
-    # unsupported" list -- .rb stands in as the still-unsupported example for the resolution_gaps
-    # tests below instead.
-    # PATH A Stage 2: .java is now a REGISTERED language too (foundational tier: symbols +
-    # imports, see tests/unit/test_lang_java.py) -- .kt stands in as a second still-unsupported
-    # example, same substitution Stage 1 made for .go.
+    # PATH A Stage 1/2: .go, .java, and .php are now all REGISTERED languages (see
+    # test_spec_for_path_resolves_every_registered_suffix), so they moved out of this "still
+    # unsupported" list -- .kt/.rb stand in as still-unsupported examples for the
+    # resolution_gaps tests below instead (same substitution each stage made for its own
+    # newly-registered suffix).
     for name in ("foo.kt", "foo.rb", "foo.txt", "foo", "foo.md"):
         assert lang_registry.spec_for_path(Path(name)) is None
 
@@ -76,6 +75,7 @@ def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
         ".rs",
         ".go",
         ".java",
+        ".php",
     })
 
 
@@ -87,6 +87,7 @@ def test_language_registry_has_exactly_the_stage2_languages() -> None:
         "rust",
         "go",
         "java",
+        "php",
     }
 
 

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -51,6 +51,16 @@ def test_ast_dev_bench_extras_include_tree_sitter_java_for_path_a_stage2() -> No
         )
 
 
+def test_ast_dev_bench_extras_include_tree_sitter_php_for_path_a_stage1() -> None:
+    # PATH A Stage 1 (PHP symbol graph, second language expansion beyond Go -- symbols +
+    # imports): same rule as tree-sitter-go/tree-sitter-java above -- tree-sitter-php must ship
+    # in every extra that already carries the other tree-sitter grammar packages, or an
+    # --all-extras --locked export silently drops PHP support.
+    deps = _optional_dependencies()
+    for extra_name in ("ast", "dev", "bench"):
+        assert "tree-sitter-php" in deps[extra_name], f"tree-sitter-php missing from [{extra_name}]"
+
+
 def test_ast_extra_pins_pygls_floor_matching_lsp_server_import() -> None:
     # cli/lsp_server.py imports `from pygls.lsp.server import LanguageServer`, a module path
     # that exists only in pygls 2.x (pygls 1.x has no `pygls.lsp.server` module at all -- its

--- a/uv.lock
+++ b/uv.lock
@@ -4130,6 +4130,7 @@ ast = [
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
@@ -4143,6 +4144,7 @@ bench = [
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
@@ -4164,6 +4166,7 @@ dev = [
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-php" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
@@ -4244,6 +4247,9 @@ requires-dist = [
     { name = "tree-sitter-javascript", marker = "extra == 'ast'" },
     { name = "tree-sitter-javascript", marker = "extra == 'bench'" },
     { name = "tree-sitter-javascript", marker = "extra == 'dev'" },
+    { name = "tree-sitter-php", marker = "extra == 'ast'" },
+    { name = "tree-sitter-php", marker = "extra == 'bench'" },
+    { name = "tree-sitter-php", marker = "extra == 'dev'" },
     { name = "tree-sitter-python", marker = "extra == 'ast'" },
     { name = "tree-sitter-python", marker = "extra == 'bench'" },
     { name = "tree-sitter-python", marker = "extra == 'dev'" },
@@ -4535,6 +4541,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
     { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
     { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/c8/1a499038cb4036bea1d560ffbc807a6fb940261aa22296bd49a62ed8bcba/tree_sitter_php-0.24.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d56e2dcf025450f84a2cdbf4b18a09e6cb88b92e9e6858e63de3d4133ab2e43e", size = 219550, upload-time = "2025-08-16T22:14:30.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/b52f2599acb29f6899470f7137d3d491c752b88df3950fb7408aea57ddca/tree_sitter_php-0.24.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:29759c67d4c27a68c227ed82c0b7e4699617b1bd23757d50c081f81a12b4f80d", size = 229632, upload-time = "2025-08-16T22:14:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/58/ca290da45380bd6ba7c6b0b98cc5fc30325c32c7f14f0c93196a451b19c4/tree_sitter_php-0.24.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b89832ac09f078eed2acd88598838bc51012224cbcebb916dbb6a37e74357e", size = 325351, upload-time = "2025-08-16T22:14:33Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c6/fd863a7a779d0ab67688939eba0e08bff7b1ffe731288d3d3610df21217b/tree_sitter_php-0.24.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a1404a30f2972498ace040b0029738b8dac45d0a12932ccb8b605eb94bafbe4", size = 313021, upload-time = "2025-08-16T22:14:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ed/aace12f30c4f5474a9ad0e9da85c060174e3764342c9860974bb0feb02fc/tree_sitter_php-0.24.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3e96f61462a960c78e5389c7ba6c16c25e66b465c763b8e63ad66423326c2fa7", size = 305905, upload-time = "2025-08-16T22:14:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c4/6c690c33b1ae9cae9505c0a2896f046fda174d72c46bdafce6aab3b2f2e7/tree_sitter_php-0.24.1-cp310-abi3-win_amd64.whl", hash = "sha256:1a1b65b72a8410d421f914ee13d38fd546a94d01cb834f69b27c78ba7589a5b5", size = 208014, upload-time = "2025-08-16T22:14:37.206Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/69/54c670d725c092b89e76ca6984582b6a768b128ac1859ed48141b124da1d/tree_sitter_php-0.24.1-cp310-abi3-win_arm64.whl", hash = "sha256:56a70c5ef1bddb15f220a479b2f2edf3042c764b6c443921fbd7ca9174d664e3", size = 206033, upload-time = "2025-08-16T22:14:38.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lights up `.php` files for `tg orient`/`defs`/`source`/`agent` by registering PHP as a Stage 1
language in the multi-language symbol graph (`lang_registry`), mirroring `lang_go.py`'s module
shape exactly (self-contained module, no import cycle with `repo_map.py`, `LanguageSpec`
registered from `repo_map.py`).

### Covered

- **Symbols** (`lang_php.php_imports_and_symbols`): `class_declaration` /
  `interface_declaration` / `trait_declaration` / `enum_declaration` -> kind `"class"`;
  `function_definition` / `method_declaration` -> kind `"function"`. Name from the node's `name`
  field; 1-based start/end lines from the declaration node's own span.
- **Imports**: every `namespace_use_clause`'s `qualified_name` child, recorded as written with
  the backslash preserved (e.g. `"App\Contracts\Named"`) -- PHP's namespace separator is `\`,
  not `.`; an `as` alias is not recorded (matches how Python's dotted `node.module` records the
  source path, not a local bound name).
- **`tg source`** (`lang_php.php_parser_symbol_sources`): full source-text lookup for a symbol
  name, mirroring `lang_go.go_parser_symbol_sources`'s shape, wired into
  `build_symbol_source_from_map`'s per-language fallback chain.
- **`_target_language_for_path`**: added the `.php` branch `lang_go.py`'s own comments flag as
  the "MOST-FORGOTTEN seam" -- without it, the agent capsule's query-language-vs-target-language
  confidence cap never sees `"php"` as a candidate. Verified live: `tg agent . Widget --json` now
  reports `context_consistency.primary_target_language == "php"` and correctly filters out a
  mismatched `uv run pytest -q` validation-command suggestion for the PHP target.

### Deferred (documented in `lang_php.py`'s module docstring, not silently dropped)

- **Cross-file caller-graph**: `references_and_calls` / `provider_alias_calls` /
  `file_imports_symbol_from_definition` / `import_update_target` / `prime_repo_context` /
  `classify_ref_kind` are all registered `None`. This is a strict subset of an already-handled
  shape, not a new one: `_language_coverage_gaps_for_universe` already treats
  `import_update_target is None` as an honest `resolution_gaps` entry (the "audit #81 #4" fix,
  already proven for Go). Verified end-to-end via a real `tg agent --json` dogfood -- see below.
- **`tg imports`/`tg importers`** (the line-level `_imports_with_lines_for_path` primitive) is
  not wired for PHP -- this matches Go's own documented limitation
  (`_imports_with_lines_for_path`'s docstring literally says "unsupported language (e.g. Go)"),
  so PHP is not being held to a lower bar than the actual current precedent.
- **Import extraction gaps** (verified directly against the grammar, not guessed): group-use
  (`use App\Shared\{Foo, Bar as Baz};`) and `use function ...` / `use const ...` imports are not
  extracted -- probed live and confirmed neither shape carries the `qualified_name` child this
  walk keys on, so they degrade safely to "no import recorded" rather than a wrong/partial path.

## Deviation from the original task brief (verify-plan-against-code)

The brief described mirroring the Rust extractor shape directly (`_RUST_SUFFIXES`,
`_rust_parser()`, a `_parser_for_source_suffix` branch, `_symbol_record`/`_tree_sitter_node_text`
imported from `repo_map.py`). Reading the real code first showed the repo has since grown a
`lang_registry` abstraction and already has a second, more recent Stage 1 precedent: Go
(`lang_go.py`), added as a self-contained module with its own `LanguageSpec`, explicitly *not*
wired into `_parser_for_source_suffix`/`_RUST_SUFFIXES` (that machinery backs the older shared
JS/TS/Rust parse-product cache; Go bypasses it, using its own local parser cache instead -- same
pattern PHP uses here). PHP mirrors Go, the fresher template, rather than reintroducing the
older Rust-only shape. `.php` was already in `_SOURCE_FIRST_SUFFIXES`/`_CODE_CONTEXT_SUFFIXES`
(and already had a `_provider_language_for_path` entry), so no suffix-set change was needed there
-- the actual gap was purely the AST extraction + the two registry/dispatch seams above.

## Grammar

`tree-sitter-php==0.24.1` (added to the `ast`/`dev`/`bench` extras in `pyproject.toml`, matching
`tree-sitter-go`'s 3 locations). It exposes two language functions; this uses the full grammar so
a template-style file (HTML + `<?php ... ?>`) parses like a bare `<?php` file instead of erroring:

```python
import tree_sitter, tree_sitter_php
language = tree_sitter.Language(tree_sitter_php.language_php())  # NOT language_php_only()
parser = tree_sitter.Parser(language)
```

Confirmed via direct import + parse in the shared venv (prebuilt wheel, no compilation -- CPU-safe,
no cargo/rustc/maturin touched).

## Tests

New `tests/unit/test_lang_php.py` (16 tests, mirroring `test_lang_go.py`'s structure): direct
`php_imports_and_symbols` coverage (exact kinds/lines for all 6 def node types + the 2 qualified
imports), `php_parser_symbol_sources` (including the two-declarations-share-a-name case:
interface stub + class impl of `greet`), grammar-absent fail-closed behavior, the trait-use-vs-
namespace-use disambiguation (`use Loggable;` inside a class body is a different grammar node,
verified not to leak into imports), and integration tests through the real `build_repo_map`/
`build_symbol_defs`/`build_symbol_refs` entry points (not just the extractor in isolation).

Updated `tests/unit/test_lang_registry.py`'s 3 exact-set assertions to include `"php"`/`".php"`
-- this file is a likely 3-way merge-conflict hotspot with the parallel Java/C# language PRs
(same shared sets); trivial to reconcile (each PR just adds its own entry).

```
tests/unit/test_lang_php.py tests/unit/test_lang_registry.py tests/unit/test_lang_go.py
tests/unit/test_file_deps.py tests/unit/test_cross_lang_resolution.py
  161 passed

tests/unit/ (60 files that import repo_map, full regression sweep across 3 batches)
  1615 passed, 0 failed
```

The pre-existing `test_target_and_provider_language_agree_with_registry` ratchet test in
`test_lang_registry.py` (dynamically parametrized over `LANGUAGE_REGISTRY`) automatically
validated the `_target_language_for_path` fix with zero additional code.

## Real dogfood (PYTHONPATH-overridden real `tg` binary, not CliRunner)

```
$ tg defs src/Widget.php Widget
Definitions for Widget in .../php_dogfood
definitions=1
.../src/Widget.php:27 class Widget

$ tg source . greet
Source for greet in .../php_dogfood
sources=2 files=1        # interface stub (L10) + class impl (L38-41)

$ tg orient .
central files (1):
  .../src/Widget.php  (in-degree=9.0)

$ tg agent . Widget --json
primary_target: {file: Widget.php, symbol: "Widget", kind: "class", line: 27,
                  confidence: 0.65, evidence: ["parser-backed", "heuristic"]}
context_consistency.primary_target_language: "php"
context_consistency.validation_alignment.status: "mismatch-filtered"   # correctly filtered
  a python "uv run pytest -q" suggestion because the target language is php, not python
call_site_evidence.resolution_gaps: [{
  "language": "php",
  "reason": "registered language extractor has no reverse-import resolver -- ...",
  "remediation": "tg has a 'php' extractor registered and its parser/grammar is installed,
    but no reverse-import resolver is wired for 'php' yet ... Treat a zero
    import-graph-consumer count for a php definition as UNKNOWN, not proven-zero ..."
}]
```

Rust extension untouched -- this PR is pure-Python (`repo_map.py` + new `lang_php.py`), so the
dogfood above uses the existing compiled `tensor_grep.rust_core` with `PYTHONPATH` pointed at
this worktree's `src`.

## Scope note

Java and C# are being added in parallel by other agents against the same dispatch/registry
sites -- a small merge conflict there is expected; sequencing is the coordinator's job.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
