### PR TITLE
feat(lang): add Java symbol + import intelligence (orient/defs/imports)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -597,7 +597,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "pyarrow>=23.0.1"]
 gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "pygls>=2.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "pygls>=2.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline
@@ -625,6 +625,7 @@ dev = [
   "tree-sitter-typescript",
   "tree-sitter-rust",
   "tree-sitter-go",
+  "tree-sitter-java",
   "types-PyYAML",
 ]
 bench = [
@@ -636,6 +637,7 @@ bench = [
   "tree-sitter-typescript",
   "tree-sitter-rust",
   "tree-sitter-go",
+  "tree-sitter-java",
   "torch>=2.0",
   "nvtx>=0.2",
 ]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -265,6 +265,7 @@ _VENDOR_CACHE_DIR_COMPONENTS: frozenset[str] = frozenset(
 _JS_TS_SUFFIXES = {".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
 _TS_SUFFIXES = {".ts", ".tsx"}
 _RUST_SUFFIXES = {".rs"}
+_JAVA_SUFFIXES = {".java"}
 _SOURCE_FIRST_DIR_NAMES = {
     ".claude",
     "app",
@@ -1321,6 +1322,8 @@ def _parser_for_source_suffix(suffix: str) -> Any | None:
         return _javascript_parser()
     if suffix in _RUST_SUFFIXES:
         return _rust_parser()
+    if suffix in _JAVA_SUFFIXES:
+        return _java_parser()
     return None
 
 
@@ -2084,6 +2087,18 @@ def _rust_parser() -> Any | None:
         return None
 
     language = tree_sitter.Language(tree_sitter_rust.language())
+    return tree_sitter.Parser(language)
+
+
+@lru_cache(maxsize=1)
+def _java_parser() -> Any | None:
+    try:
+        import tree_sitter
+        import tree_sitter_java
+    except ImportError:
+        return None
+
+    language = tree_sitter.Language(tree_sitter_java.language())
     return tree_sitter.Parser(language)
 
 
@@ -4497,6 +4512,166 @@ def _rust_parser_symbols(path: Path) -> list[dict[str, Any]]:
     return symbols
 
 
+# PATH A Stage 2: Java's kind map (shared between the symbol extractor below and
+# `_java_parser_symbol_sources`, mirroring the two Rust functions above that each inline their
+# own copy). classes/interfaces/enums/records -> "class"; methods/constructors -> "function",
+# matching the Python convention (`_python_imports_and_symbols` above: ClassDef -> "class",
+# every FunctionDef/AsyncFunctionDef -> "function") rather than Go's separate "method" kind.
+_JAVA_SYMBOL_KIND_MAP: dict[str, str] = {
+    "class_declaration": "class",
+    "interface_declaration": "class",
+    "enum_declaration": "class",
+    "record_declaration": "class",
+    "method_declaration": "function",
+    "constructor_declaration": "function",
+}
+
+# Verified against the real tree-sitter-java grammar (0.23.5): an `import_declaration` node has
+# NO `name` field (unlike class/method/etc.) -- its children are the `import` keyword, an
+# optional `static` keyword, a `scoped_identifier`/`identifier` (optionally followed by a
+# trailing `.` + `asterisk` for a wildcard import), and the closing `;`. Reconstructing the
+# dotted name via node-text + strip is therefore simpler and more robust than chasing child
+# field names, and naturally preserves a trailing `.*` for a wildcard import.
+_JAVA_IMPORT_STRIP_RE = re.compile(r"^import\s+(?:static\s+)?(.*?)\s*;?\s*$", re.DOTALL)
+
+
+def _java_import_declaration_text(node: Any, source_bytes: bytes) -> str:
+    text = _tree_sitter_node_text(source_bytes, node).strip()
+    match = _JAVA_IMPORT_STRIP_RE.match(text)
+    return match.group(1).strip() if match else text
+
+
+def _java_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    """Foundational-tier Java extractor: classes/interfaces/enums/records/methods/constructors
+    plus raw import declarations, in ONE tree walk (mirrors `_python_imports_and_symbols`'s
+    combined shape, since Java -- like Python -- has no separate regex-heuristic extractor to
+    split imports from symbols the way the JS/TS/Rust split does).
+
+    Fail-closed like Go (mirrors `_python_imports_and_symbols`'s guard): parser-None or a
+    read/parse error returns ``([], [])``, never a partial regex degrade -- Java has no regex
+    fallback (see the `.java` branch in `_imports_and_symbols_for_path` below).
+    """
+    if path.suffix not in _JAVA_SUFFIXES:
+        return [], []
+
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
+        return [], []
+    _source, source_bytes, tree = parsed
+
+    imports: list[str] = []
+    symbols: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _walk(node: Any) -> None:
+        if node.type == "import_declaration":
+            imports.append(_java_import_declaration_text(node, source_bytes))
+        elif node.type in _JAVA_SYMBOL_KIND_MAP:
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                for child in node.children:
+                    if child.type == "identifier":
+                        name_node = child
+                        break
+            if name_node is not None:
+                name = _node_text(name_node)
+                if _is_clean_symbol_name(name):
+                    symbols.append(
+                        _symbol_record(
+                            name=name,
+                            kind=_JAVA_SYMBOL_KIND_MAP[node.type],
+                            file=path,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                        )
+                    )
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    imports = sorted(dict.fromkeys(imports))
+    symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
+    return imports, symbols
+
+
+def _java_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
+    """`tg source` extractor for Java -- exact source block for a named class/interface/enum/
+    record/method/constructor. Mirrors `_rust_parser_symbol_sources` exactly, reusing the shared
+    cached parse product (`_parsed_source_and_tree`) instead of re-parsing directly."""
+    if path.suffix not in _JAVA_SUFFIXES:
+        return []
+
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
+        return []
+    _source, source_bytes, tree = parsed
+    sources: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _walk(node: Any) -> None:
+        if node.type in _JAVA_SYMBOL_KIND_MAP:
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                for child in node.children:
+                    if child.type == "identifier":
+                        name_node = child
+                        break
+            if name_node is not None and _node_text(name_node) == symbol:
+                block = _node_text(node)
+                if block and not block.endswith("\n"):
+                    block = f"{block}\n"
+                sources.append({
+                    "name": symbol,
+                    "kind": _JAVA_SYMBOL_KIND_MAP[node.type],
+                    "file": str(path),
+                    "start_line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                    "source": block,
+                })
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
+    return sources
+
+
+def _java_imports_with_lines(path: Path) -> list[dict[str, Any]]:
+    """`tg imports` extractor for Java -- one row per `import_declaration` STATEMENT with its
+    1-based line number (mirrors `_rust_imports_with_lines`'s shape/role exactly, but tree-sitter
+    -backed rather than regex-backed since Java has no regex fallback)."""
+    if path.suffix not in _JAVA_SUFFIXES:
+        return []
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        file_size = 0
+    if file_size > _max_parse_bytes():
+        return []
+    parsed = _parsed_source_and_tree(str(path))
+    if parsed is None:
+        return []
+    _source, source_bytes, tree = parsed
+
+    entries: list[dict[str, Any]] = []
+
+    def _walk(node: Any) -> None:
+        if node.type == "import_declaration":
+            entries.append({
+                "module": _java_import_declaration_text(node, source_bytes),
+                "line": node.start_point[0] + 1,
+            })
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    return entries
+
+
 def _python_classify_ref_kind(node: ast.AST, parent: ast.AST | None, *, in_annotation: bool) -> str:
     """Classify an already-matched Python Name/Attribute reference node (T1 additive).
 
@@ -5931,6 +6106,43 @@ lang_registry.register_language(
     )
 )
 
+# PATH A Stage 2: Java joins the symbol graph as a FOUNDATIONAL-TIER language -- symbols
+# (classes/interfaces/enums/records/methods/constructors) and raw import declarations flow into
+# build_repo_map / `tg defs` / `tg source` / `tg imports` / `tg agent` via
+# _java_imports_and_symbols / _java_parser_symbol_sources / _java_imports_with_lines. The deep
+# caller-graph tier (references_and_calls, provider_alias_calls,
+# file_imports_symbol_from_definition, import_update_target, prime_repo_context,
+# classify_ref_kind -- cross-file method-call resolution powering `tg callers`/
+# `tg blast-radius`) is intentionally left None here, deferred to a follow-up PR (see the
+# feat/java-symbol-intelligence PR body). provenance_when_missing="grammar-missing" (NOT
+# "regex-heuristic"): Java has no regex fallback, mirroring Go's fail-closed contract.
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="java",
+        suffixes=frozenset({".java"}),
+        grammar_modules=("tree_sitter", "tree_sitter_java"),
+        parser_for_path=lambda path: _java_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="grammar-missing",
+        import_markers=(b"import ",),
+        def_node_kinds=(
+            "class_declaration",
+            "interface_declaration",
+            "enum_declaration",
+            "record_declaration",
+            "method_declaration",
+            "constructor_declaration",
+        ),
+        extract_imports_and_symbols=_java_imports_and_symbols,
+        references_and_calls=None,
+        provider_alias_calls=None,
+        file_imports_symbol_from_definition=None,
+        import_update_target=None,
+        prime_repo_context=None,
+        classify_ref_kind=None,
+    )
+)
+
 
 def _prime_all_language_repo_contexts(context_root: Path) -> None:
     """Prime every registered language's per-repo-root context exactly once.
@@ -5985,6 +6197,9 @@ def _imports_and_symbols_for_path(
             # returns ([], []) here -- surfaced honestly via `resolution_gaps`, never silently
             # degraded to a text heuristic the way JS/TS/Rust are.
             current_imports, current_symbols = lang_go.go_imports_and_symbols(path)
+        elif spec is not None and spec.language_id == "java":
+            # Fail-closed (same Stage 1 trap as Go): NO regex fallback for Java either.
+            current_imports, current_symbols = _java_imports_and_symbols(path)
         elif not current_imports and not current_symbols:
             current_imports, current_symbols = _regex_imports_and_symbols(path)
         return current_imports, current_symbols
@@ -6138,7 +6353,7 @@ def _rust_imports_with_lines(path: Path) -> list[dict[str, Any]]:
 
 
 def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
-    """Raw per-statement imports with 1-based line numbers for the 4 supported languages.
+    """Raw per-statement imports with 1-based line numbers for the 5 supported languages.
 
     Returns ``[]`` for an unsupported language (e.g. Go) or an over-cap file -- callers that
     need to distinguish "genuinely no imports" from "not scanned" must check those conditions
@@ -6153,6 +6368,8 @@ def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
         return _js_ts_imports_with_lines(path)
     if spec.language_id == "rust":
         return _rust_imports_with_lines(path)
+    if spec.language_id == "java":
+        return _java_imports_with_lines(path)
     return []
 
 
@@ -7081,6 +7298,10 @@ def _target_language_for_path(path: str | Path | None) -> str | None:
         # e.g. treating a Go primary file as having "no target language" instead of correctly
         # reporting primary_target_language == "go".
         return "go"
+    if suffix in _JAVA_SUFFIXES:
+        # Same MOST-FORGOTTEN seam, Stage 2: without this, `tg agent`'s capsule never reports
+        # primary_target_language == "java" for a Java target.
+        return "java"
     return None
 
 
@@ -7656,13 +7877,17 @@ def _language_coverage_gaps_for_universe(bounded_files: list[Path]) -> list[dict
     fail-closed with no regex fallback, no usable parser) instead of silently degrading them.
     Zero behavior change for python/javascript/typescript/rust today -- every file with one of
     those suffixes always resolves a spec, so this only ever fires for a language tensor-grep's
-    symbol graph does not yet cover (e.g. .go, .java) that happens to sit in the scan universe.
+    symbol graph does not yet cover (e.g. .kt, .swift) that happens to sit in the scan universe.
 
     Also covers a NARROWER partial-capability gap (audit #81 #4): a language can be fully
     registered with a working parser (defs/refs/callers all resolve normally) yet still have
-    ``LanguageSpec.import_update_target is None`` -- Go today. Before this fix, that combination
-    fell through the two branches above straight to ``continue``, so a Go-only repo with the
-    grammar installed reported an EMPTY ``resolution_gaps`` even though
+    ``LanguageSpec.import_update_target is None`` -- Go today (PATH A Stage 2: Java hits this
+    same branch too, but for Java refs/callers are not just import-resolution-incomplete, they
+    are UNIMPLEMENTED entirely -- foundational tier only, see the Java LanguageSpec registration
+    above; `tg refs`/`tg callers` simply find nothing in a Java file rather than resolving
+    normally). Before this fix, that combination fell through the two branches above straight to
+    ``continue``, so a Go-only repo with the grammar installed reported an EMPTY
+    ``resolution_gaps`` even though
     ``_build_import_graph_consumers_from_map`` can never produce a single reverse-import edge for
     it -- indistinguishable from "genuinely has zero import-graph consumers". The third branch
     below flags that combination explicitly so `tg callers`/`tg blast-radius` stay honest about
@@ -15519,6 +15744,8 @@ def build_symbol_source_from_map(
                 current_sources = _rust_parser_symbol_sources(current_path, symbol)
             if not current_sources and current_path.suffix == ".go":
                 current_sources = lang_go.go_parser_symbol_sources(current_path, symbol)
+            if not current_sources and current_path.suffix in _JAVA_SUFFIXES:
+                current_sources = _java_parser_symbol_sources(current_path, symbol)
             if not current_sources:
                 current_sources = _regex_symbol_sources(current_path, symbol)
             sources.extend(current_sources)
@@ -16291,7 +16518,13 @@ def _infer_project_root(file_path: Path) -> Path:
     return current
 
 
-_SUPPORTED_FILE_DEPENDENCY_LANGUAGES = frozenset({"python", "javascript", "typescript", "rust"})
+_SUPPORTED_FILE_DEPENDENCY_LANGUAGES = frozenset({
+    "python",
+    "javascript",
+    "typescript",
+    "rust",
+    "java",
+})
 
 
 def _resolve_raw_import_entry(
@@ -16354,6 +16587,15 @@ def _resolve_raw_import_entry(
             if tagged_provenance is not None:
                 provenance = [tagged_provenance]
         confidence = float(candidate_info["confidence"]) if resolved is not None else 0.0
+    elif language_id == "java":
+        # Foundational tier (symbols+imports only): raw import statements are extracted and
+        # reported with their line numbers (see _java_imports_with_lines), but resolving WHICH
+        # file/module an import points to is cross-file resolution machinery (mirrors Rust/JS/
+        # Python's own `_*_module_candidates` helpers) deferred to a follow-up PR. Report as
+        # unresolved-but-not-presumed-external -- the same conservative tuple the
+        # dynamic_unresolved branch above uses -- rather than guessing (never fabricate
+        # resolution precision this extractor doesn't actually have).
+        resolved, external, provenance, confidence = None, False, [], 0.0
     else:
         resolved, external, provenance, confidence = None, True, [], 0.0
 

--- a/tests/unit/test_lang_go.py
+++ b/tests/unit/test_lang_go.py
@@ -346,7 +346,8 @@ def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
     assert go_gap["files_affected"] >= 1
     # F12: the remediation text must be HONEST for Go -- it has no regex fallback, so it must not
     # claim "falls back to plain literal-text/regex matching" (that claim is only true for a
-    # genuinely UNREGISTERED language, e.g. .java).
+    # genuinely UNREGISTERED language, e.g. .kt -- PATH A Stage 2 registered .java too, see
+    # tests/unit/test_lang_java.py, so it no longer illustrates "genuinely unregistered").
     assert "fall back to plain literal-text/regex matching" not in go_gap["remediation"]
     assert (
         "NO rows" in go_gap["remediation"]
@@ -356,7 +357,7 @@ def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
 
 def test_go_coverage_gap_remediation_is_honest_about_zero_rows() -> None:
     fail_closed_text = repo_map._language_coverage_gap_remediation("go", fail_closed=True)
-    fallback_text = repo_map._language_coverage_gap_remediation("java", fail_closed=False)
+    fallback_text = repo_map._language_coverage_gap_remediation("kotlin", fail_closed=False)
 
     assert "fall back to plain literal-text/regex matching" not in fail_closed_text
     assert "fall back to plain literal-text/regex matching" in fallback_text

--- a/tests/unit/test_lang_java.py
+++ b/tests/unit/test_lang_java.py
@@ -1,0 +1,397 @@
+"""PATH A STAGE 2 -- Java symbol graph (FOUNDATIONAL TIER) tests.
+
+Java joins the symbol graph the same way Go did (own ``LanguageSpec``, tree-sitter-backed,
+fail-closed with no regex fallback), but SCOPED to the foundational tier only: symbols
+(classes/interfaces/enums/records/methods/constructors) and raw import declarations flow into
+``build_repo_map`` / `tg defs` / `tg source` / `tg imports` / `tg agent`. The deep caller-graph
+(cross-file method-call resolution powering `tg callers` / `tg blast-radius`) is intentionally
+NOT implemented here -- ``LanguageSpec.references_and_calls`` /
+``file_imports_symbol_from_definition`` / ``import_update_target`` / ``prime_repo_context`` /
+``classify_ref_kind`` are all ``None``, deferred to a follow-up PR. See the last section below
+for the honesty-floor coverage of that deferral (never a crash, always a labeled
+``resolution_gaps`` entry).
+
+Covered here:
+- Registration + provenance (``tree-sitter`` when the grammar is installed, ``grammar-missing``
+  when it is not -- Java has no regex fallback, mirroring Go's fail-closed contract).
+- ``_target_language_for_path`` / ``_provider_language_for_path`` / ``_language_for_path`` all
+  agree Java resolves to ``"java"`` (the "MOST-FORGOTTEN seam" ``test_lang_registry.py`` already
+  guards dynamically for every registered language).
+- ``_java_imports_and_symbols``: classes/interfaces/enums/records -> kind "class"; methods/
+  constructors -> kind "function"; dotted import names (plain, multi-segment, ``static``, and
+  wildcard ``*`` imports) all extracted; sorted/deduped exactly like
+  ``_python_imports_and_symbols``.
+- ``build_repo_map`` surfaces those symbols/imports for a real ``.java`` file on disk (the
+  actual dispatch path `tg orient`/`tg agent` read).
+- `tg defs` (``build_symbol_defs``) and `tg source` (``build_symbol_source``) resolve a Java
+  symbol with ``provenance == "tree-sitter"`` and the exact source block.
+- `tg imports` (``build_file_imports``) returns real import rows (module + line) for a ``.java``
+  file instead of ``result_incomplete``.
+- `tg agent` (``agent_capsule.build_agent_capsule``) reports
+  ``primary_target_language == "java"``.
+- Grammar-absent: fail-closed, zero fabricated symbols, an honest ``resolution_gaps`` entry.
+- Deferred caller-graph: `tg refs`/`tg callers` on a Java-only target never crash and surface an
+  honest ``import_resolution_only`` resolution gap instead of silently reading as "confirmed
+  zero".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli import agent_capsule, lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# Fixture: a package-declared Java file with plain/multi-segment/static/wildcard imports, a
+# class (with a field, a constructor, and two methods, one annotated), and a separate interface
+# declaration in the same file.
+# ---------------------------------------------------------------------------
+
+
+def _write_java_fixture(root: Path) -> dict[str, Path]:
+    widget_java = root / "Widget.java"
+    widget_java.write_text(
+        "package com.example.widgets;\n"
+        "\n"
+        "import java.util.List;\n"
+        "import java.util.Map;\n"
+        "import static java.lang.Math.max;\n"
+        "import com.example.other.*;\n"
+        "\n"
+        "public class Widget implements Runnable {\n"
+        "    private int count;\n"
+        "\n"
+        "    public Widget(int count) {\n"
+        "        this.count = count;\n"
+        "    }\n"
+        "\n"
+        "    public int getCount() {\n"
+        "        return count;\n"
+        "    }\n"
+        "\n"
+        "    @Override\n"
+        "    public void run() {\n"
+        "        System.out.println(count);\n"
+        "    }\n"
+        "}\n"
+        "\n"
+        "interface Shape {\n"
+        "    double area();\n"
+        "}\n"
+        "\n"
+        "enum Color {\n"
+        "    RED, GREEN, BLUE\n"
+        "}\n"
+        "\n"
+        "record Point(int x, int y) {\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    return {"Widget.java": widget_java}
+
+
+# ---------------------------------------------------------------------------
+# Registration + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_java_is_registered_with_tree_sitter_provenance() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["java"]
+    assert spec.suffixes == frozenset({".java"})
+    assert spec.provenance_when_parsed == "tree-sitter"
+    # Fail-closed (mirrors Go's Stage 1 trap): never "regex-heuristic"/"heuristic" -- Java has
+    # no plain-text fallback when the grammar is missing.
+    assert spec.provenance_when_missing == "grammar-missing"
+    assert spec.parser_for_path is not None
+    # Foundational tier only: the caller-graph fields are explicitly deferred.
+    assert spec.references_and_calls is None
+    assert spec.provider_alias_calls is None
+    assert spec.file_imports_symbol_from_definition is None
+    assert spec.import_update_target is None
+    assert spec.prime_repo_context is None
+    assert spec.classify_ref_kind is None
+
+
+def test_target_and_provider_language_for_path_report_java() -> None:
+    assert repo_map._target_language_for_path("Widget.java") == "java"
+    assert repo_map._language_for_path("Widget.java") == "java"
+    assert repo_map._provider_language_for_path("Widget.java") == "java"
+
+
+def test_java_provenance_is_tree_sitter_when_grammar_present() -> None:
+    assert repo_map._symbol_navigation_provenance_for_path("Widget.java") == "tree-sitter"
+
+
+def test_grammar_absent_monkeypatch_java_provenance_flips_to_grammar_missing(monkeypatch) -> None:
+    monkeypatch.setattr(repo_map, "_java_parser", lambda: None)
+
+    provenance = repo_map._symbol_navigation_provenance_for_path("Widget.java")
+
+    assert provenance == "grammar-missing"
+    assert provenance != ""
+
+
+# ---------------------------------------------------------------------------
+# _java_imports_and_symbols: direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_java_imports_and_symbols_extracts_classes_interface_and_methods(tmp_path: Path) -> None:
+    fixture = _write_java_fixture(tmp_path)
+
+    imports, symbols = repo_map._java_imports_and_symbols(fixture["Widget.java"])
+
+    assert imports == [
+        "com.example.other.*",
+        "java.lang.Math.max",
+        "java.util.List",
+        "java.util.Map",
+    ]
+
+    # "Widget" is deliberately BOTH the class name and its constructor's name (Java convention),
+    # so a flat name -> symbol dict would collapse the two entries -- key on (name, kind) pairs
+    # instead to keep them distinct, exactly as _java_imports_and_symbols itself must.
+    by_name_kind = {(s["name"], s["kind"]): s for s in symbols}
+    assert set(by_name_kind) == {
+        ("Widget", "class"),
+        ("Widget", "function"),  # the constructor
+        ("Shape", "class"),
+        ("Color", "class"),
+        ("Point", "class"),
+        ("getCount", "function"),
+        ("run", "function"),
+        ("area", "function"),
+    }
+
+    widget_class = by_name_kind[("Widget", "class")]
+    assert widget_class["start_line"] == 8
+    assert widget_class["file"] == str(fixture["Widget.java"])
+
+    widget_constructor = by_name_kind[("Widget", "function")]
+    assert widget_constructor["start_line"] == 11
+
+    # Sort order pinned exactly like _python_imports_and_symbols: (file, line, kind, name).
+    ordering = [(s["file"], s["line"], s["kind"], s["name"]) for s in symbols]
+    assert ordering == sorted(ordering)
+
+
+def test_java_imports_and_symbols_returns_empty_for_non_java_suffix(tmp_path: Path) -> None:
+    not_java = tmp_path / "Widget.txt"
+    not_java.write_text("class Widget {}\n", encoding="utf-8")
+
+    imports, symbols = repo_map._java_imports_and_symbols(not_java)
+
+    assert imports == []
+    assert symbols == []
+
+
+def test_java_imports_and_symbols_fails_closed_when_grammar_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    fixture = _write_java_fixture(tmp_path)
+    monkeypatch.setattr(repo_map, "_java_parser", lambda: None)
+
+    imports, symbols = repo_map._java_imports_and_symbols(fixture["Widget.java"])
+
+    # Mirrors _python_imports_and_symbols's guard: parser-None -> ([], []), never a crash and
+    # never a silent partial-regex degrade (Java has no regex fallback).
+    assert imports == []
+    assert symbols == []
+
+
+def test_java_imports_and_symbols_handles_unreadable_file(tmp_path: Path) -> None:
+    missing = tmp_path / "DoesNotExist.java"
+
+    imports, symbols = repo_map._java_imports_and_symbols(missing)
+
+    assert imports == []
+    assert symbols == []
+
+
+# ---------------------------------------------------------------------------
+# build_repo_map integration
+# ---------------------------------------------------------------------------
+
+
+def test_build_repo_map_surfaces_java_symbols_and_imports(tmp_path: Path) -> None:
+    _write_java_fixture(tmp_path)
+
+    repo_map_payload = repo_map.build_repo_map(tmp_path)
+
+    symbol_names = {symbol["name"] for symbol in repo_map_payload["symbols"]}
+    assert {"Widget", "Shape", "Color", "Point", "getCount", "run", "area"} <= symbol_names
+
+    java_import_entries = [
+        entry for entry in repo_map_payload["imports"] if entry["file"].endswith("Widget.java")
+    ]
+    assert len(java_import_entries) == 1
+    assert set(java_import_entries[0]["imports"]) == {
+        "com.example.other.*",
+        "java.lang.Math.max",
+        "java.util.List",
+        "java.util.Map",
+    }
+    assert java_import_entries[0]["provenance"] == "tree-sitter"
+
+
+# ---------------------------------------------------------------------------
+# tg defs / tg source
+# ---------------------------------------------------------------------------
+
+
+def test_defs_finds_class_interface_and_method_with_tree_sitter_provenance(
+    tmp_path: Path,
+) -> None:
+    _write_java_fixture(tmp_path)
+
+    class_payload = repo_map.build_symbol_defs("Widget", tmp_path)
+    interface_payload = repo_map.build_symbol_defs("Shape", tmp_path)
+    method_payload = repo_map.build_symbol_defs("getCount", tmp_path)
+
+    assert not class_payload.get("no_match")
+    # "Widget" genuinely has TWO definitions in the fixture: the class_declaration itself and
+    # its same-named constructor_declaration -- both are real, correct hits, not a dedup bug.
+    class_kinds = {d["kind"] for d in class_payload["definitions"]}
+    assert class_kinds == {"class", "function"}
+    assert all(d["provenance"] == "tree-sitter" for d in class_payload["definitions"])
+
+    assert not interface_payload.get("no_match")
+    assert interface_payload["definitions"][0]["kind"] == "class"
+
+    assert not method_payload.get("no_match")
+    assert method_payload["definitions"][0]["kind"] == "function"
+    assert method_payload["definitions"][0]["file"].replace("\\", "/").endswith("Widget.java")
+
+
+def test_source_returns_exact_method_body_for_java_symbol(tmp_path: Path) -> None:
+    _write_java_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_source("getCount", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["sources"], "expected a source block for getCount"
+    source_block = payload["sources"][0]
+    assert source_block["kind"] == "function"
+    assert "return count;" in source_block["source"]
+    assert source_block["source"].strip().startswith("public int getCount()")
+
+
+# ---------------------------------------------------------------------------
+# tg imports (build_file_imports)
+# ---------------------------------------------------------------------------
+
+
+def test_file_imports_returns_java_import_statements_with_lines(tmp_path: Path) -> None:
+    fixture = _write_java_fixture(tmp_path)
+
+    payload = repo_map.build_file_imports(fixture["Widget.java"])
+
+    assert payload["result_incomplete"] is False
+    modules = {entry["module"]: entry["line"] for entry in payload["imports"]}
+    assert modules == {
+        "java.util.List": 3,
+        "java.util.Map": 4,
+        "java.lang.Math.max": 5,
+        "com.example.other.*": 6,
+    }
+    # Foundational tier: raw import statements are real, but resolving them to a specific file
+    # (cross-file resolution) is deferred -- every row must be unresolved, never fabricated.
+    assert all(entry["resolved"] is None for entry in payload["imports"])
+
+
+# ---------------------------------------------------------------------------
+# tg agent (agent_capsule)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_capsule_reports_java_target_language(tmp_path: Path) -> None:
+    _write_java_fixture(tmp_path)
+
+    payload = agent_capsule.build_agent_capsule("Widget", tmp_path)
+
+    assert payload["context_consistency"]["primary_target_language"] == "java"
+
+
+# ---------------------------------------------------------------------------
+# Grammar-absent: fail-closed, resolution_gaps, no fabricated defs.
+# ---------------------------------------------------------------------------
+
+
+def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_java_fixture(tmp_path)
+    # A python symbol elsewhere in the same repo so refs has something real to find -- the
+    # resolution_gaps floor is about the Java file being an honestly-labeled bystander in the
+    # scan universe, not about the query's own target living in the grammar-missing language.
+    (tmp_path / "target.py").write_text("def Target():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(repo_map, "_java_parser", lambda: None)
+
+    defs_payload = repo_map.build_symbol_defs("Widget", tmp_path)
+    assert defs_payload.get("no_match") is True
+    assert defs_payload["definitions"] == []
+    defs_gaps = defs_payload["resolution_gaps"]
+    java_gap = next(gap for gap in defs_gaps if gap["language"] == "java")
+    assert "fail-closed" in java_gap["reason"]
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    assert not refs_payload.get("no_match")
+    gaps = refs_payload["resolution_gaps"]
+    java_refs_gap = next(gap for gap in gaps if gap["language"] == "java")
+    assert "fail-closed" in java_refs_gap["reason"]
+    assert java_refs_gap["files_affected"] >= 1
+    assert "fall back to plain literal-text/regex matching" not in java_refs_gap["remediation"]
+
+
+# ---------------------------------------------------------------------------
+# Deferred caller-graph: never a crash, always an honest resolution gap.
+# ---------------------------------------------------------------------------
+
+
+def test_refs_and_callers_never_crash_and_flag_java_as_import_resolution_gap(
+    tmp_path: Path,
+) -> None:
+    _write_java_fixture(tmp_path)
+    (tmp_path / "target.py").write_text(
+        "def Target():\n    return 1\n\n\ndef caller():\n    return Target()\n",
+        encoding="utf-8",
+    )
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    callers_payload = repo_map.build_symbol_callers("Target", tmp_path)
+
+    assert not refs_payload.get("no_match")
+    assert not callers_payload.get("no_match")
+    for payload in (refs_payload, callers_payload):
+        gaps = payload["resolution_gaps"]
+        java_gap = next(gap for gap in gaps if gap["language"] == "java")
+        assert java_gap["files_affected"] >= 1
+        assert "reverse-import" in java_gap["reason"]
+        assert "fail-closed" not in java_gap["reason"]
+
+
+def test_java_only_target_symbol_has_no_cross_file_callers_yet(tmp_path: Path) -> None:
+    """Honesty check for the explicit deferral: a caller of a Java method living in a SEPARATE
+    Java file is not yet discoverable (no cross-file reference/call resolver wired for Java) --
+    this must degrade to an empty, non-crashing result, never a silent wrong answer."""
+    root = tmp_path
+    (root / "Widget.java").write_text(
+        "public class Widget {\n    public int getCount() {\n        return 1;\n    }\n}\n",
+        encoding="utf-8",
+    )
+    (root / "Main.java").write_text(
+        "public class Main {\n"
+        "    public static void main(String[] args) {\n"
+        "        Widget w = new Widget();\n"
+        "        System.out.println(w.getCount());\n"
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_callers("getCount", root)
+
+    assert not payload.get("no_match")
+    assert payload["callers"] == []
+    gaps = payload["resolution_gaps"]
+    assert any(gap["language"] == "java" for gap in gaps)

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -44,6 +44,7 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
         "foo.tsx": "typescript",
         "foo.rs": "rust",
         "foo.go": "go",
+        "foo.java": "java",
     }
     for name, expected_language in expectations.items():
         spec = lang_registry.spec_for_path(Path(name))
@@ -56,7 +57,10 @@ def test_spec_for_path_unknown_suffix_returns_none() -> None:
     # test_spec_for_path_resolves_every_registered_suffix), so it moved out of this "still
     # unsupported" list -- .rb stands in as the still-unsupported example for the resolution_gaps
     # tests below instead.
-    for name in ("foo.java", "foo.rb", "foo.txt", "foo", "foo.md"):
+    # PATH A Stage 2: .java is now a REGISTERED language too (foundational tier: symbols +
+    # imports, see tests/unit/test_lang_java.py) -- .kt stands in as a second still-unsupported
+    # example, same substitution Stage 1 made for .go.
+    for name in ("foo.kt", "foo.rb", "foo.txt", "foo", "foo.md"):
         assert lang_registry.spec_for_path(Path(name)) is None
 
 
@@ -71,16 +75,18 @@ def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
         ".tsx",
         ".rs",
         ".go",
+        ".java",
     })
 
 
-def test_language_registry_has_exactly_the_stage1_languages() -> None:
+def test_language_registry_has_exactly_the_stage2_languages() -> None:
     assert set(lang_registry.LANGUAGE_REGISTRY.keys()) == {
         "python",
         "javascript",
         "typescript",
         "rust",
         "go",
+        "java",
     }
 
 
@@ -185,22 +191,26 @@ def test_grammar_absent_monkeypatch_go_provenance_flips_to_grammar_missing(monke
 
 def _write_python_symbol_plus_unsupported_language_file(tmp_path: Path) -> tuple[Path, Path]:
     # PATH A Stage 1: .go moved from "unsupported" to "registered" (it has its own LanguageSpec
-    # now), so .java stands in here instead -- still genuinely unregistered, AND (like .go
-    # before it) already a member of _SOURCE_FIRST_SUFFIXES, so it actually enters the
-    # refs/callers scan universe (a suffix outside that set, e.g. .rb, would be invisible to
-    # the scan and never produce a gap at all). This fixture is about the resolution_gaps floor
-    # for a language tensor-grep does NOT yet cover.
+    # now), so .java stood in here instead. PATH A Stage 2: .java ALSO moved to "registered"
+    # (foundational tier: symbols + imports, see tests/unit/test_lang_java.py) -- .kt stands in
+    # now, still genuinely unregistered, AND (like .go and .java before it) already a member of
+    # _SOURCE_FIRST_SUFFIXES, so it actually enters the refs/callers scan universe (a suffix
+    # outside that set, e.g. .rb, would be invisible to the scan and never produce a gap at
+    # all). This fixture is about the resolution_gaps floor for a language tensor-grep does NOT
+    # yet cover at all (contrast with Java's own PARTIAL-capability gap, covered separately in
+    # test_lang_java.py's test_refs_and_callers_never_crash_and_flag_java_as_import_resolution_
+    # gap).
     py_path = tmp_path / "target.py"
     py_path.write_text(
         "def Target():\n    return 1\n\n\ndef caller():\n    return Target()\n",
         encoding="utf-8",
     )
-    java_path = tmp_path / "Helper.java"
-    java_path.write_text(
-        "class Helper {\n  void helper() { Target(); }\n}\n",
+    kt_path = tmp_path / "Helper.kt"
+    kt_path.write_text(
+        "class Helper {\n  fun helper() { Target() }\n}\n",
         encoding="utf-8",
     )
-    return py_path, java_path
+    return py_path, kt_path
 
 
 def test_refs_emits_resolution_gaps_for_unsupported_language_file(tmp_path: Path) -> None:
@@ -211,11 +221,11 @@ def test_refs_emits_resolution_gaps_for_unsupported_language_file(tmp_path: Path
     assert not payload.get("no_match")
     assert "resolution_gaps" in payload
     gaps = payload["resolution_gaps"]
-    assert any(gap["language"] == "java" for gap in gaps)
-    java_gap = next(gap for gap in gaps if gap["language"] == "java")
-    assert java_gap["files_affected"] >= 1
-    assert java_gap["reason"]
-    assert java_gap["remediation"]
+    assert any(gap["language"] == "kotlin" for gap in gaps)
+    kt_gap = next(gap for gap in gaps if gap["language"] == "kotlin")
+    assert kt_gap["files_affected"] >= 1
+    assert kt_gap["reason"]
+    assert kt_gap["remediation"]
     # Additive-only: existing fields must still be present and shaped as before.
     assert "coverage_summary" in payload
     assert "references" in payload
@@ -229,7 +239,7 @@ def test_callers_emits_resolution_gaps_for_unsupported_language_file(tmp_path: P
     assert not payload.get("no_match")
     assert "resolution_gaps" in payload
     gaps = payload["resolution_gaps"]
-    assert any(gap["language"] == "java" for gap in gaps)
+    assert any(gap["language"] == "kotlin" for gap in gaps)
     assert "coverage_summary" in payload
     assert "callers" in payload
 

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -41,6 +41,16 @@ def test_ast_dev_bench_extras_include_tree_sitter_go_for_path_a_stage1() -> None
         assert "tree-sitter-go" in deps[extra_name], f"tree-sitter-go missing from [{extra_name}]"
 
 
+def test_ast_dev_bench_extras_include_tree_sitter_java_for_path_a_stage2() -> None:
+    # PATH A Stage 2 (Java symbol graph, foundational tier -- symbols + imports): same rule as
+    # Stage 1's tree-sitter-go above, one extra later.
+    deps = _optional_dependencies()
+    for extra_name in ("ast", "dev", "bench"):
+        assert "tree-sitter-java" in deps[extra_name], (
+            f"tree-sitter-java missing from [{extra_name}]"
+        )
+
+
 def test_ast_extra_pins_pygls_floor_matching_lsp_server_import() -> None:
     # cli/lsp_server.py imports `from pygls.lsp.server import LanguageServer`, a module path
     # that exists only in pygls 2.x (pygls 1.x has no `pygls.lsp.server` module at all -- its

--- a/uv.lock
+++ b/uv.lock
@@ -4128,6 +4128,7 @@ ast = [
     { name = "pygls" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -4140,6 +4141,7 @@ bench = [
     { name = "torch" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -4160,6 +4162,7 @@ dev = [
     { name = "stringzilla" },
     { name = "tree-sitter" },
     { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
@@ -4235,6 +4238,9 @@ requires-dist = [
     { name = "tree-sitter-go", marker = "extra == 'ast'" },
     { name = "tree-sitter-go", marker = "extra == 'bench'" },
     { name = "tree-sitter-go", marker = "extra == 'dev'" },
+    { name = "tree-sitter-java", marker = "extra == 'ast'" },
+    { name = "tree-sitter-java", marker = "extra == 'bench'" },
+    { name = "tree-sitter-java", marker = "extra == 'dev'" },
     { name = "tree-sitter-javascript", marker = "extra == 'ast'" },
     { name = "tree-sitter-javascript", marker = "extra == 'bench'" },
     { name = "tree-sitter-javascript", marker = "extra == 'dev'" },
@@ -4498,6 +4504,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
     { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
     { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/dc/eb9c8f96304e5d8ae1663126d89967a622a80937ad2909903569ccb7ec8f/tree_sitter_java-0.23.5.tar.gz", hash = "sha256:f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38", size = 138121, upload-time = "2024-12-21T18:24:26.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df", size = 58926, upload-time = "2024-12-21T18:24:12.53Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69", size = 62288, upload-time = "2024-12-21T18:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7", size = 85533, upload-time = "2024-12-21T18:24:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1", size = 84033, upload-time = "2024-12-21T18:24:18.758Z" },
+    { url = "https://files.pythonhosted.org/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
+    { url = "https://files.pythonhosted.org/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **Java** to tensor-grep's deep symbol-intelligence tier (`repo_map.py`'s
bespoke tree-sitter symbol/import extractors, alongside Python/JS/TS/Rust/Go),
scoped to the **foundational tier**: symbols (classes/interfaces/enums/records/
methods/constructors) and import declarations now flow into `build_repo_map`,
lighting up `tg orient`, `tg defs`, `tg source`, `tg imports`, and `tg agent`
for `.java` files.

Java registers as its own `LanguageSpec` in `lang_registry.py`, tree-sitter
-backed, **fail-closed** with no regex fallback (`provenance_when_missing =
"grammar-missing"`) -- the same contract Go established (PATH A Stage 1); this
PR is PATH A Stage 2.

## What's covered (foundational tier)

- **Symbols**: `class_declaration` / `interface_declaration` / `enum_declaration`
  / `record_declaration` -> kind `"class"`; `method_declaration` /
  `constructor_declaration` -> kind `"function"` (matches the Python convention
  -- classes -> `"class"`, every callable -> `"function"` -- rather than Go's
  separate `"method"` kind, per the task spec).
- **Imports**: `import_declaration` nodes -> dotted names (plain, multi-segment,
  `static`, and wildcard `.*` imports all handled).
- Wired into every dispatch site a real `.java` file needs to reach, not
  just the `build_repo_map` symbols/imports list:
  - `_imports_and_symbols_for_path` (feeds `repo_map["symbols"]`/`["imports"]`
    -> `tg orient`/`tg defs`/`tg agent`).
  - `_java_parser_symbol_sources` -> `build_symbol_source_from_map` (`tg source`).
  - `_java_imports_with_lines` -> `_imports_with_lines_for_path` +
    `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` + `_resolve_raw_import_entry`
    (`tg imports`, the standalone `build_file_imports` primitive -- a separate
    dispatch layer from `build_repo_map` that also needed teaching).
  - `_target_language_for_path` (the "MOST-FORGOTTEN seam" per the Go
    precedent's own code comment -- without it, `tg agent`'s capsule never
    reports `primary_target_language == "java"`).
- `tree-sitter-java` added to the `ast`/`dev`/`bench` optional-dependency
  extras in `pyproject.toml` + `uv.lock` (see Dependency notes below).

## What's explicitly deferred (follow-up PR)

The deep **caller-graph** tier -- cross-file method-call resolution powering
`tg callers` / `tg blast-radius` -- is **not** implemented here.
`LanguageSpec.references_and_calls`, `provider_alias_calls`,
`file_imports_symbol_from_definition`, `import_update_target`,
`prime_repo_context`, and `classify_ref_kind` are all `None` for Java.

This degrades **honestly, never silently**: `tg callers`/`tg blast-radius` on
a Java target return an empty result (never a crash, never a fabricated hit)
plus a labeled `resolution_gaps` entry:

```json
{"language": "java", "reason": "registered language extractor has no reverse-import resolver -- import_graph_consumers can never be computed for this language", ...}
```

Similarly, `tg imports` reports each import statement's raw module text +
line number, but does not attempt to resolve which file/module it points
to (`resolved: null`, `external: false` -- never guessed/fabricated).
Cross-file import/reference resolution is the natural scope of the follow-up
PR, alongside `references_and_calls`.

## Tree-sitter grammar verification

Confirmed against a real parse-tree dump of `tree-sitter-java` 0.23.5 before
writing the extractor (not from memory): `import_declaration` has no
`name` field (its dotted name is reconstructed via node-text + strip, which
also naturally preserves a trailing `.*` for wildcard imports); `class` /
`interface` / `enum` / `record` / `method` / `constructor_declaration` all do
have a `name` field pointing to an `identifier`.

## Dependency notes

`tree-sitter-java` (0.23.5) imports cleanly via the exact pattern the other
languages use (`tree_sitter.Language(tree_sitter_java.language())`), verified
directly:

```
$ python -c "import tree_sitter, tree_sitter_java; tree_sitter.Language(tree_sitter_java.language())"
parser ok: <tree_sitter.Parser object at ...>
```

A raw `uv lock` run pulled in ~280 lines of unrelated marker-format churn
across many unrelated packages (cuda-bindings, cuda-pathfinder, etc.) from a
local uv-version mismatch against CI's pinned `astral-sh/setup-uv@v8.0.0`.
That was reverted; `uv.lock` was instead hand-spliced with only the new
`tree-sitter-java` package block + its 3 references in the `tensor-grep`
package's `ast`/`bench`/`dev` optional-dependency lists (21 insertions, 0
unrelated changes) -- verified to satisfy `uv export --locked` (the exact
check CI's `audit.yml` runs) with exit code 0 and zero re-resolve.

## Tests

New: `tests/unit/test_lang_java.py` (16 tests) -- registration/provenance,
`_java_imports_and_symbols` direct coverage (classes/interface/enum/record/
methods/constructor, dotted imports incl. static+wildcard, sort order,
non-.java guard, unreadable-file guard), `build_repo_map` integration,
`tg defs`/`tg source`/`tg imports`/`tg agent` end-to-end, grammar-absent
fail-closed, and the deferred-caller-graph honesty floor (never crashes,
always a labeled `resolution_gaps` entry).

Updated (both used `.java` as their "still unregistered language" example --
swapped to `.kt`, mirroring the exact substitution Stage 1 made when Go was
promoted out of that same role):
- `tests/unit/test_lang_registry.py` -- registry/suffix/gap tests now also
  assert Java resolves correctly; the "unsupported" gap fixture moved to `.kt`.
- `tests/unit/test_lang_go.py` -- one remediation-text test and one comment
  updated to use `.kt` instead of `.java` as the "genuinely unregistered"
  example.
- `tests/unit/test_pyproject_dependencies.py` -- added
  `test_ast_dev_bench_extras_include_tree_sitter_java_for_path_a_stage2`,
  mirroring the existing Go governance test.

**Pass tally**: 65/65 in the 4 directly-changed test files
(`test_lang_java.py` 16, `test_lang_registry.py` 15, `test_lang_go.py` 24,
`test_pyproject_dependencies.py` 10). Broader regression sweep: 287/287
(`test_repo_map_*`, `test_file_deps.py`, `test_parse_product_cache.py`,
etc.), 135/135 (`test_agent_capsule_*`, `test_orient_capsule.py`), and 89/89
more (`test_blast_radius_render_perf.py`, `test_impact_callers_shared_map.py`,
`test_incremental_refresh.py`, `test_profiling_harness.py`,
`test_result_incomplete_payload_layer.py`,
`test_session_daemon_default_deadline.py`,
`test_symbol_defs_stage_deadline_c1c2.py`) -- every test file that references
the dispatch functions this PR touches. **576/576 total, zero regressions.**
`ruff format --preview --check` and `ruff check` both clean.

## Real dogfood (the actual `tg` CLI, not `CliRunner`)

Against a real `Widget.java` (package decl, 4 imports incl. `static`/plain,
a class implementing an interface with a field/constructor/2 methods, plus a
separate `interface Shape`) on disk:

- **`tg orient <dir>`** -> finds the file as a central node (`in-degree=6.0`).
- **`tg defs <dir> Widget --json`** -> 2 definitions (the class + its
  same-named constructor), `provenance: "tree-sitter"` on both.
- **`tg source <dir> getCount`** -> `sources=1 files=1`, exact method body.
- **`tg imports <file> --json`** -> 3 real import rows with correct line
  numbers (3/4/5), `resolved: null`, `external: false`, `result_incomplete:
  false` (previously this returned `result_incomplete: true`).
- **`tg agent <dir> "getCount widget count accessor" --json`** ->
  `primary_target_language: "java"`, finds `getCount` (`evidence:
  ["parser-backed", "heuristic"]`), honestly downgrades confidence to 0.65
  with `ask_user_before_editing: true` (no Java validation-command inference
  yet -- correctly humble, not falsely confident).
- **`tg callers <dir> getCount --json`** (deferred surface) -> `callers: []`,
  a clear `resolution_gaps` entry, exit code 0 (no crash).

## Not merging

Draft PR per instructions -- leaving the worktree
(`.claude/worktrees/lang-java`) in place for gating.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
