### PR TITLE
feat(lang): add C# symbol + import intelligence (orient/defs/imports)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -597,7 +597,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "pyarrow>=23.0.1"]
 gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "pygls>=2.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "tree-sitter-c-sharp", "pygls>=2.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline
@@ -627,6 +627,7 @@ dev = [
   "tree-sitter-go",
   "tree-sitter-java",
   "tree-sitter-php",
+  "tree-sitter-c-sharp",
   "types-PyYAML",
 ]
 bench = [
@@ -640,6 +641,7 @@ bench = [
   "tree-sitter-go",
   "tree-sitter-java",
   "tree-sitter-php",
+  "tree-sitter-c-sharp",
   "torch>=2.0",
   "nvtx>=0.2",
 ]

--- a/src/tensor_grep/cli/lang_csharp.py
+++ b/src/tensor_grep/cli/lang_csharp.py
@@ -1,0 +1,296 @@
+"""C# language extractor for tensor-grep's multi-language symbol graph (PATH A Stage 1).
+
+Second language expansion beyond the original four (python/javascript/typescript/rust), added
+alongside Go. Plugs into the ``lang_registry`` seam Stage 0 built (see ``lang_registry.py`` +
+the ``lang_registry.register_language(...)`` calls near the bottom of ``repo_map.py``) -- C# gets
+its OWN ``LanguageSpec`` entry, registered from ``repo_map.py``, with zero special-casing beyond
+the couple of dispatch sites documented in the module docstring there.
+
+Like ``lang_go.py``, this module imports NOTHING from ``repo_map.py`` (``repo_map`` -> this
+module, never the reverse -- ``repo_map.py`` needs to import this module to register C#'s
+``LanguageSpec`` and to call its ``csharp_parser_symbol_sources`` directly at the ``tg source``
+dispatch site; a reverse import would cycle). The handful of tiny helpers this module needs from
+``repo_map.py`` are duplicated here instead of imported, matching ``lang_go.py``'s own precedent.
+
+FOUNDATIONAL SCOPE: this module lights up ``defs``/``source``/``imports``/``agent`` for ``.cs``
+files (symbols: class/interface/struct/enum/record declarations as kind "class", method/
+constructor declarations as kind "function"; imports: dotted ``using``-directive namespace
+names). The cross-file caller-graph (``references_and_calls`` / ``file_imports_symbol_from_
+definition`` / ``import_update_target`` / per-repo-root context priming for a `.csproj`/
+namespace-to-file resolver) is DEFERRED to a follow-up -- this module registers those
+``LanguageSpec`` fields as ``None``, exactly like Go's own ``import_update_target=None`` gap.
+``tg refs``/``tg callers``/`tg blast-radius`` on a C# symbol fall through to the generic
+``_regex_references_and_calls`` text-heuristic path in repo_map.py (never a crash, never a
+fabricated AST-verified match) -- unaffected by this module.
+
+FAIL-CLOSED CONTRACT (Stage 0 honesty floor, extended here exactly as it was for Go): C# has NO
+regex-heuristic fallback. When the ``tree_sitter_c_sharp`` grammar package is not installed,
+every extractor in this module returns empty ([]/([], [])) rather than degrading to a regex/text
+heuristic (unlike JS/TS/Rust, which all fall back to regex extraction when their own tree-sitter
+grammar is missing). ``LanguageSpec.provenance_when_missing="grammar-missing"`` (NOT
+``"regex-heuristic"``) is what makes ``_language_coverage_gaps_for_universe`` in repo_map.py
+treat a grammar-absent C# file as a genuine ``resolution_gaps`` entry instead of silently
+reporting zero matches as if the symbol just did not exist.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Duplicated tiny helpers -- see the module docstring: no import from repo_map.py, to avoid an
+# import cycle (repo_map.py imports THIS module). Keep byte-identical to repo_map.py's twins
+# (``_tree_sitter_node_text`` / ``_is_clean_symbol_name`` / ``_symbol_record``) if any of them
+# ever change there.
+# ---------------------------------------------------------------------------
+
+_CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _is_clean_symbol_name(name: str) -> bool:
+    return bool(_CLEAN_SYMBOL_NAME_RE.match(name))
+
+
+def _tree_sitter_node_text(source_bytes: bytes, node: Any) -> str:
+    return source_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _symbol_record(
+    *,
+    name: str,
+    kind: str,
+    file: Path,
+    start_line: int,
+    end_line: int | None = None,
+) -> dict[str, Any]:
+    normalized_end_line = start_line if end_line is None else end_line
+    return {
+        "name": name,
+        "kind": kind,
+        "file": str(file),
+        "line": start_line,
+        "start_line": start_line,
+        "end_line": normalized_end_line,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parser factory (clone of repo_map.py's ``_rust_parser`` / lang_go.py's ``_go_parser`` shape).
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _csharp_parser() -> Any | None:
+    try:
+        import tree_sitter
+        import tree_sitter_c_sharp
+    except ImportError:
+        return None
+
+    language = tree_sitter.Language(tree_sitter_c_sharp.language())
+    return tree_sitter.Parser(language)
+
+
+# ---------------------------------------------------------------------------
+# Defs + imports: one tree-sitter pass per file.
+# ---------------------------------------------------------------------------
+
+# Type-declaration node kinds -> symbol kind "class" (matches how tensor-grep already collapses
+# TS interfaces/JS classes into a single "class" bucket for defs/orient rather than minting a
+# kind per C# declaration form).
+_CSHARP_CLASS_NODE_TYPES = frozenset({
+    "class_declaration",
+    "interface_declaration",
+    "struct_declaration",
+    "enum_declaration",
+    "record_declaration",
+})
+# Member-declaration node kinds -> symbol kind "function".
+_CSHARP_FUNCTION_NODE_TYPES = frozenset({"method_declaration", "constructor_declaration"})
+# ``using_directive``'s target-namespace child is always the RIGHTMOST ``identifier``/
+# ``qualified_name`` child regardless of modifier -- verified against the installed
+# tree_sitter_c_sharp 0.23.x grammar's node shapes for all four directive forms:
+#   using System;                              -> identifier
+#   using System.Collections.Generic;          -> qualified_name
+#   using MyAlias = System.Text.StringBuilder;  -> [identifier "MyAlias", qualified_name TARGET]
+#   using static System.Math;                   -> qualified_name (after the "static" token)
+#   global using System.Linq;                   -> qualified_name (after the "global"/"using" tokens)
+# In the aliased form the ALIAS name is emitted FIRST (leftmost), so taking the last matching
+# child is what discriminates "the namespace actually being imported" from "the local alias" --
+# never the reverse (an alias is never emitted after its target).
+_CSHARP_USING_TARGET_NODE_TYPES = frozenset({"identifier", "qualified_name"})
+# Informational/documentation only (Stage 0/1 convention) -- no dispatch seam reads this field
+# yet; see lang_registry.LanguageSpec.def_node_kinds docstring.
+_CSHARP_DEF_NODE_KINDS = (
+    "class_declaration",
+    "interface_declaration",
+    "struct_declaration",
+    "enum_declaration",
+    "record_declaration",
+    "method_declaration",
+    "constructor_declaration",
+)
+
+
+def _csharp_using_directive_target(node: Any, source_bytes: bytes) -> str | None:
+    """Return a ``using_directive`` node's target namespace text, or ``None``.
+
+    See ``_CSHARP_USING_TARGET_NODE_TYPES`` docstring comment above for why "last matching
+    child" is correct across all four directive forms (plain/dotted/aliased/static/global).
+    """
+    target: Any | None = None
+    for child in node.children:
+        if child.type in _CSHARP_USING_TARGET_NODE_TYPES:
+            target = child
+    if target is None:
+        return None
+    return _tree_sitter_node_text(source_bytes, target)
+
+
+def csharp_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    """Extract ``using``-directive namespace names + type/member declarations from a C# source
+    file, one AST pass.
+
+    Defs covered: ``class_declaration``/``interface_declaration``/``struct_declaration``/
+    ``enum_declaration``/``record_declaration`` (kind "class"), and ``method_declaration``/
+    ``constructor_declaration`` (kind "function", including an interface's body-less method
+    signature -- the C# grammar reuses ``method_declaration`` for both an abstract interface
+    member and a concrete class method, discriminated only by the presence of a ``body`` field,
+    which this extractor does not need to distinguish since both are legitimate definitions).
+    Imports come from every ``using_directive``'s target namespace (alias/static/global
+    qualifiers do not change what gets recorded -- see ``_csharp_using_directive_target``).
+    """
+    if path.suffix != ".cs":
+        return [], []
+
+    parser = _csharp_parser()
+    if parser is None:
+        return [], []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    imports: list[str] = []
+    symbols: list[dict[str, Any]] = []
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS (not recursion): a pathologically deep AST must never raise
+        # RecursionError -- mirrors lang_go.py's F26 fix (audit #63) precedent, applied here
+        # preemptively rather than retrofitted after an incident. Children are pushed in
+        # reverse so the leftmost child is popped (and thus visited) first, preserving the
+        # original pre-order traversal.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "using_directive":
+                target_text = _csharp_using_directive_target(node, source_bytes)
+                if target_text is not None:
+                    imports.append(target_text)
+            elif node_type in _CSHARP_CLASS_NODE_TYPES:
+                name_node = node.child_by_field_name("name")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="class",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type in _CSHARP_FUNCTION_NODE_TYPES:
+                name_node = node.child_by_field_name("name")
+                if name_node is not None:
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    imports = sorted(dict.fromkeys(imports))
+    symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
+    return imports, symbols
+
+
+def csharp_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
+    """Full source text of every declaration matching *symbol* (mirrors the Rust/JS-TS/Go
+    ``*_parser_symbol_sources`` shape for the ``tg source`` command)."""
+    if path.suffix != ".cs":
+        return []
+
+    parser = _csharp_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    sources: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS -- see the identical comment on csharp_imports_and_symbols's
+        # `_walk` above for the rationale/precedent.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            name_node: Any | None = None
+            kind: str | None = None
+            if node_type in _CSHARP_CLASS_NODE_TYPES:
+                name_node = node.child_by_field_name("name")
+                kind = "class"
+            elif node_type in _CSHARP_FUNCTION_NODE_TYPES:
+                name_node = node.child_by_field_name("name")
+                kind = "function"
+            if name_node is not None and kind is not None and _node_text(name_node) == symbol:
+                block = _node_text(node)
+                if block and not block.endswith("\n"):
+                    block = f"{block}\n"
+                sources.append({
+                    "name": symbol,
+                    "kind": kind,
+                    "file": str(path),
+                    "start_line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                    "source": block,
+                })
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
+    return sources
+
+
+__all__ = [
+    "csharp_imports_and_symbols",
+    "csharp_parser_symbol_sources",
+]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
-from tensor_grep.cli import lang_go, lang_php, lang_registry
+from tensor_grep.cli import lang_csharp, lang_go, lang_php, lang_registry
 from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LSPTransportError
 from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 
@@ -6180,6 +6180,46 @@ lang_registry.register_language(
     )
 )
 
+# PATH A Stage 1 (second expansion, alongside Go): C# gets its own module (lang_csharp.py) for
+# the same no-import-cycle reason as Go. FOUNDATIONAL scope only -- defs/source/imports/agent
+# via `extract_imports_and_symbols`-shaped extraction, wired at the `_imports_and_symbols_for_path`
+# / `build_symbol_source_from_map` dispatch sites below. The cross-file caller-graph
+# (references_and_calls / file_imports_symbol_from_definition / import_update_target / repo-root
+# context priming for a future .csproj/namespace resolver) is DEFERRED to a follow-up -- all four
+# stay None here, same shape as Go's own `import_update_target=None` gap, so `tg refs`/`tg
+# callers`/`tg blast-radius` on a C# symbol fall through to the generic
+# `_regex_references_and_calls` text-heuristic path instead of crashing or fabricating an
+# AST-verified match. provenance_when_missing="grammar-missing" (NOT "regex-heuristic") is what
+# makes a grammar-absent C# file a genuine `resolution_gaps` entry instead of a silent empty
+# result (C# has no regex fallback, unlike JS/TS/Rust).
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="csharp",
+        suffixes=frozenset({".cs"}),
+        grammar_modules=("tree_sitter", "tree_sitter_c_sharp"),
+        parser_for_path=lambda path: lang_csharp._csharp_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="grammar-missing",
+        import_markers=(b"using ",),
+        def_node_kinds=(
+            "class_declaration",
+            "interface_declaration",
+            "struct_declaration",
+            "enum_declaration",
+            "record_declaration",
+            "method_declaration",
+            "constructor_declaration",
+        ),
+        extract_imports_and_symbols=None,
+        references_and_calls=None,
+        provider_alias_calls=None,
+        file_imports_symbol_from_definition=None,
+        import_update_target=None,
+        prime_repo_context=None,
+        classify_ref_kind=None,
+    )
+)
+
 
 def _prime_all_language_repo_contexts(context_root: Path) -> None:
     """Prime every registered language's per-repo-root context exactly once.
@@ -6241,6 +6281,10 @@ def _imports_and_symbols_for_path(
             # Fail-closed (Stage 1 trap, same as Go): NO regex fallback for PHP either -- see
             # lang_php.py's module docstring.
             current_imports, current_symbols = lang_php.php_imports_and_symbols(path)
+        elif spec is not None and spec.language_id == "csharp":
+            # Fail-closed (Stage 1 trap, same as Go): NO regex fallback for C#. A grammar-missing
+            # .cs file returns ([], []) here -- surfaced honestly via `resolution_gaps`.
+            current_imports, current_symbols = lang_csharp.csharp_imports_and_symbols(path)
         elif not current_imports and not current_symbols:
             current_imports, current_symbols = _regex_imports_and_symbols(path)
         return current_imports, current_symbols
@@ -7347,6 +7391,9 @@ def _target_language_for_path(path: str | Path | None) -> str | None:
         # MOST-FORGOTTEN seam (see the ".go" branch above) -- same fix, same reason, for PHP's
         # Stage 1 registration.
         return "php"
+    if suffix == ".cs":
+        # Same MOST-FORGOTTEN seam, now for C# (PATH A Stage 1, second expansion).
+        return "csharp"
     return None
 
 
@@ -15793,6 +15840,8 @@ def build_symbol_source_from_map(
                 current_sources = _java_parser_symbol_sources(current_path, symbol)
             if not current_sources and current_path.suffix == ".php":
                 current_sources = lang_php.php_parser_symbol_sources(current_path, symbol)
+            if not current_sources and current_path.suffix == ".cs":
+                current_sources = lang_csharp.csharp_parser_symbol_sources(current_path, symbol)
             if not current_sources:
                 current_sources = _regex_symbol_sources(current_path, symbol)
             sources.extend(current_sources)

--- a/tests/unit/test_lang_csharp.py
+++ b/tests/unit/test_lang_csharp.py
@@ -1,0 +1,380 @@
+"""C# symbol graph (lang_csharp.py) tests -- deep symbol-intelligence tier expansion.
+
+Foundational scope (mirrors PATH A Stage 1's lang_go.py precedent, not the pre-registry
+Rust/JS/TS inline pattern): C# gets its own ``LanguageSpec`` entry + dedicated module providing
+``defs``/``source``/``imports``/``agent`` support (classes/interfaces/structs/enums/records +
+methods/constructors, plus ``using`` directive extraction). The cross-file caller-graph
+(``references_and_calls``/``file_imports_symbol_from_definition``/``import_update_target``) is
+explicitly DEFERRED to a follow-up, exactly like Go's own ``import_update_target=None`` gap --
+`tg refs`/`tg callers`/`tg blast-radius` on a C# symbol fall through to the generic
+``_regex_references_and_calls`` text-heuristic path (never a crash, never a fabricated
+AST-verified match).
+
+Covered here:
+- ``defs``: class/interface/struct/enum/record declarations resolve with kind "class"; method/
+  constructor declarations resolve with kind "function"; both report provenance "tree-sitter".
+- ``source``: full source text for a method definition.
+- ``imports``: dotted namespace names from plain/multi-segment/aliased/``static``/``global``
+  ``using`` directives, extracted by ``csharp_imports_and_symbols`` and surfaced through
+  ``build_repo_map``.
+- Grammar-absent (monkeypatched ``lang_csharp._csharp_parser`` -> ``None``): fail-closed, zero
+  fabricated rows, an honest ``resolution_gaps`` entry, an honest non-zero/non-crash CLI exit
+  code -- mirrors Go's Stage 1 fail-closed contract exactly (``provenance_when_missing ==
+  "grammar-missing"``, never "regex-heuristic").
+- The agent capsule reports ``primary_target_language == "csharp"``.
+- A pathologically deep AST does not raise ``RecursionError`` (F26-class regression guard,
+  applied preemptively since ``lang_go.py`` already paid for this lesson once).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from tensor_grep.cli import agent_capsule, lang_csharp, lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# Fixture: namespace + using directives (plain/dotted/aliased) + interface + enum + record +
+# struct + a class implementing the interface, with a constructor and two methods (one of which
+# shares its name with the interface's abstract method -- both must resolve as separate defs).
+# ---------------------------------------------------------------------------
+
+_WIDGET_CS_SOURCE = (
+    "using System;\n"
+    "using System.Collections.Generic;\n"
+    "using MyAlias = System.Text.StringBuilder;\n"
+    "\n"
+    "namespace Widgets.Core\n"
+    "{\n"
+    "    public interface IWidget\n"
+    "    {\n"
+    "        int GetValue();\n"
+    "    }\n"
+    "\n"
+    "    public enum WidgetKind\n"
+    "    {\n"
+    "        Small,\n"
+    "        Large,\n"
+    "    }\n"
+    "\n"
+    "    public record WidgetRecord(string Name, int Value);\n"
+    "\n"
+    "    public struct WidgetStruct\n"
+    "    {\n"
+    "        public int X;\n"
+    "    }\n"
+    "\n"
+    "    public class Widget : IWidget\n"
+    "    {\n"
+    "        private readonly string _name;\n"
+    "\n"
+    "        public Widget(string name)\n"
+    "        {\n"
+    "            _name = name;\n"
+    "        }\n"
+    "\n"
+    "        public int GetValue()\n"
+    "        {\n"
+    "            return 42;\n"
+    "        }\n"
+    "\n"
+    "        public static Widget Create(string name)\n"
+    "        {\n"
+    "            return new Widget(name);\n"
+    "        }\n"
+    "    }\n"
+    "}\n"
+)
+
+
+def _write_csharp_fixture(root: Path) -> Path:
+    widget_cs = root / "Widget.cs"
+    widget_cs.write_text(_WIDGET_CS_SOURCE, encoding="utf-8")
+    return widget_cs
+
+
+# ---------------------------------------------------------------------------
+# Registration + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_is_registered_with_tree_sitter_provenance() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["csharp"]
+    assert spec.suffixes == frozenset({".cs"})
+    assert spec.provenance_when_parsed == "tree-sitter"
+    # Fail-closed (Stage 1 trap, mirrors Go): never "regex-heuristic" -- C# has no fallback.
+    assert spec.provenance_when_missing == "grammar-missing"
+    assert spec.parser_for_path is not None
+
+
+def test_target_language_for_path_reports_csharp() -> None:
+    assert repo_map._target_language_for_path("Widget.cs") == "csharp"
+    assert repo_map._language_for_path("Widget.cs") == "csharp"
+    assert repo_map._provider_language_for_path("Widget.cs") == "csharp"
+
+
+# ---------------------------------------------------------------------------
+# defs
+# ---------------------------------------------------------------------------
+
+
+def test_defs_finds_class_with_tree_sitter_provenance(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    # "IWidget" (unlike "Widget") has no same-named constructor, so this is the clean
+    # single-definition case; see test_defs_finds_constructor_and_method_as_function_kind below
+    # for the "Widget" class-plus-constructor-share-a-name case.
+    payload = repo_map.build_symbol_defs("IWidget", tmp_path)
+
+    assert not payload.get("no_match")
+    assert len(payload["definitions"]) == 1
+    definition = payload["definitions"][0]
+    assert definition["kind"] == "class"
+    assert definition["provenance"] == "tree-sitter"
+    assert definition["file"].replace("\\", "/").endswith("Widget.cs")
+
+
+def test_defs_finds_interface_struct_enum_record_as_class_kind(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    for name in ("IWidget", "WidgetStruct", "WidgetKind", "WidgetRecord"):
+        payload = repo_map.build_symbol_defs(name, tmp_path)
+        assert not payload.get("no_match"), f"expected a definition for {name}"
+        assert payload["definitions"][0]["kind"] == "class", f"{name} should be kind=class"
+
+
+def test_defs_finds_constructor_and_method_as_function_kind(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    ctor_payload = repo_map.build_symbol_defs("Widget", tmp_path)
+    create_payload = repo_map.build_symbol_defs("Create", tmp_path)
+
+    # "Widget" itself resolves to the class declaration (kind=class); the constructor sharing
+    # the same name is a distinct node also named "Widget" -- both are legitimate definitions.
+    kinds = {d["kind"] for d in ctor_payload["definitions"]}
+    assert "class" in kinds
+    assert "function" in kinds
+
+    assert not create_payload.get("no_match")
+    assert all(d["kind"] == "function" for d in create_payload["definitions"])
+
+
+def test_defs_finds_both_interface_and_impl_methods_sharing_a_name(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("GetValue", tmp_path)
+
+    assert not payload.get("no_match")
+    # One method_declaration in IWidget (no body), one in Widget (with body) -- both resolve.
+    assert len(payload["definitions"]) == 2
+    assert all(d["kind"] == "function" for d in payload["definitions"])
+    lines = sorted(d["start_line"] for d in payload["definitions"])
+    assert lines[0] != lines[1]
+
+
+# ---------------------------------------------------------------------------
+# source
+# ---------------------------------------------------------------------------
+
+
+def test_source_returns_full_method_body(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_source("Create", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["sources"], "expected at least one source block for Create"
+    source_text = payload["sources"][0]["source"]
+    assert "public static Widget Create(string name)" in source_text
+    assert "return new Widget(name);" in source_text
+
+
+# ---------------------------------------------------------------------------
+# imports: plain / dotted / aliased / static / global using directives
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_imports_and_symbols_extracts_using_directive_targets(tmp_path: Path) -> None:
+    source = (
+        "using System;\n"
+        "using System.Collections.Generic;\n"
+        "using MyAlias = System.Text.StringBuilder;\n"
+        "using static System.Math;\n"
+        "global using System.Linq;\n"
+        "\n"
+        "namespace App;\n"
+        "\n"
+        "public class Program\n"
+        "{\n"
+        "}\n"
+    )
+    cs_file = tmp_path / "Program.cs"
+    cs_file.write_text(source, encoding="utf-8")
+
+    imports, symbols = lang_csharp.csharp_imports_and_symbols(cs_file)
+
+    assert imports == sorted({
+        "System",
+        "System.Collections.Generic",
+        "System.Text.StringBuilder",  # the ALIASED target, never the alias "MyAlias" itself
+        "System.Math",
+        "System.Linq",
+    })
+    assert any(s["name"] == "Program" and s["kind"] == "class" for s in symbols)
+
+
+def test_build_repo_map_surfaces_csharp_imports_and_symbols(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    repo_map_payload = repo_map.build_repo_map(tmp_path)
+
+    file_imports = [
+        entry for entry in repo_map_payload["imports"] if entry["file"].endswith("Widget.cs")
+    ]
+    assert file_imports, "expected an imports entry for Widget.cs"
+    assert "System" in file_imports[0]["imports"]
+    assert "System.Collections.Generic" in file_imports[0]["imports"]
+    assert "System.Text.StringBuilder" in file_imports[0]["imports"]
+
+    symbol_names = {
+        s["name"] for s in repo_map_payload["symbols"] if s["file"].endswith("Widget.cs")
+    }
+    assert {"Widget", "IWidget", "WidgetKind", "WidgetRecord", "WidgetStruct", "Create"}.issubset(
+        symbol_names
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grammar-absent: fail-closed, resolution_gaps, honest exit code.
+# ---------------------------------------------------------------------------
+
+
+def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_csharp_fixture(tmp_path)
+    # A python symbol elsewhere in the same repo so refs has something REAL to find -- the
+    # resolution_gaps floor is about a C# file being an honestly-labeled BYSTANDER in the scan
+    # universe, not about the query's own target living in the grammar-missing language.
+    (tmp_path / "target.py").write_text("def Target():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(lang_csharp, "_csharp_parser", lambda: None)
+
+    defs_payload = repo_map.build_symbol_defs("Widget", tmp_path)
+    assert defs_payload.get("no_match") is True
+    assert defs_payload["definitions"] == []
+    defs_gaps = defs_payload["resolution_gaps"]
+    assert any(gap["language"] == "csharp" for gap in defs_gaps)
+    csharp_gap = next(gap for gap in defs_gaps if gap["language"] == "csharp")
+    assert "fail-closed" in csharp_gap["reason"]
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    assert not refs_payload.get("no_match")
+    gaps = refs_payload["resolution_gaps"]
+    assert any(gap["language"] == "csharp" for gap in gaps)
+    csharp_refs_gap = next(gap for gap in gaps if gap["language"] == "csharp")
+    assert "fail-closed" in csharp_refs_gap["reason"]
+    assert csharp_refs_gap["files_affected"] >= 1
+    assert "fall back to plain literal-text/regex matching" not in csharp_refs_gap["remediation"]
+
+
+def test_grammar_absent_cli_exit_code_is_honest_not_found(tmp_path: Path, monkeypatch) -> None:
+    """A C#-only target with the grammar missing must exit 1 (honest not-found) -- never a
+    silent 0 and never a crash."""
+    from typer.testing import CliRunner
+
+    from tensor_grep.cli.main import app
+
+    _write_csharp_fixture(tmp_path)
+    monkeypatch.setattr(lang_csharp, "_csharp_parser", lambda: None)
+
+    result = CliRunner().invoke(app, ["defs", str(tmp_path), "Widget"])
+
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Agent capsule
+# ---------------------------------------------------------------------------
+
+
+def test_agent_capsule_reports_csharp_target_language(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    payload = agent_capsule.build_agent_capsule("Widget", tmp_path)
+
+    assert payload["context_consistency"]["primary_target_language"] == "csharp"
+
+
+# ---------------------------------------------------------------------------
+# Deep-AST guard: explicit-stack DFS must not raise RecursionError (lang_go.py F26 precedent).
+# ---------------------------------------------------------------------------
+
+
+def _deep_nested_csharp_source(depth: int) -> str:
+    return (
+        "public class Deep\n{\n    public int Target()\n    {\n        return "
+        + ("(" * depth)
+        + "1"
+        + (")" * depth)
+        + ";\n    }\n}\n"
+    )
+
+
+def test_csharp_walkers_survive_pathologically_deep_ast_without_recursion_error(
+    tmp_path: Path,
+) -> None:
+    depth = sys.getrecursionlimit() + 500
+    deep_cs = tmp_path / "Deep.cs"
+    deep_cs.write_text(_deep_nested_csharp_source(depth), encoding="utf-8")
+
+    imports, symbols = lang_csharp.csharp_imports_and_symbols(deep_cs)
+    assert imports == []
+    assert any(s["name"] == "Target" and s["kind"] == "function" for s in symbols)
+    assert any(s["name"] == "Deep" and s["kind"] == "class" for s in symbols)
+
+    sources = lang_csharp.csharp_parser_symbol_sources(deep_cs, "Target")
+    assert len(sources) == 1
+    assert sources[0]["kind"] == "function"
+
+
+# ---------------------------------------------------------------------------
+# Grammar-missing import failure (package not installed) -- distinct from monkeypatched None.
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_parser_returns_none_when_grammar_module_missing(monkeypatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "tree_sitter_c_sharp":
+            raise ImportError("simulated missing grammar")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    lang_csharp._csharp_parser.cache_clear()
+    try:
+        assert lang_csharp._csharp_parser() is None
+    finally:
+        lang_csharp._csharp_parser.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Read/parse-error guards return ([], []) rather than raising.
+# ---------------------------------------------------------------------------
+
+
+def test_csharp_imports_and_symbols_missing_file_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "DoesNotExist.cs"
+    imports, symbols = lang_csharp.csharp_imports_and_symbols(missing)
+    assert imports == []
+    assert symbols == []
+
+
+def test_csharp_imports_and_symbols_non_cs_suffix_returns_empty(tmp_path: Path) -> None:
+    other = tmp_path / "Widget.txt"
+    other.write_text("not csharp", encoding="utf-8")
+    imports, symbols = lang_csharp.csharp_imports_and_symbols(other)
+    assert imports == []
+    assert symbols == []

--- a/tests/unit/test_lang_csharp.py
+++ b/tests/unit/test_lang_csharp.py
@@ -245,6 +245,42 @@ def test_build_repo_map_surfaces_csharp_imports_and_symbols(tmp_path: Path) -> N
 
 
 # ---------------------------------------------------------------------------
+# Deferred caller-graph, grammar PRESENT: honest resolution_gaps, not a silent proven-zero.
+#
+# Coordinator-flagged verification (parallel Go/PHP precedent): a language whose grammar IS
+# installed (defs/source/imports all work) but whose LanguageSpec.import_update_target is None
+# must still surface a resolution_gaps entry -- otherwise `tg refs`/`tg callers`/
+# `tg blast-radius` returning zero rows for a C# consumer is indistinguishable from "genuinely
+# zero", when it actually means "the reverse-import graph was never built for this language".
+# This is the SAME generic mechanism Go's own import_update_target=None gap exercises
+# (_language_coverage_gaps_for_universe, driven purely by `spec.import_update_target is None`) --
+# no C#-specific code required, but pinned here as an explicit regression guard.
+# ---------------------------------------------------------------------------
+
+
+def test_refs_grammar_present_still_reports_import_resolution_gap(tmp_path: Path) -> None:
+    _write_csharp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_refs("Widget", tmp_path)
+
+    assert not payload.get("no_match")
+    gaps = payload["resolution_gaps"]
+    csharp_gaps = [gap for gap in gaps if gap["language"] == "csharp"]
+    assert len(csharp_gaps) == 1
+    # NOT "fail-closed" (that's the grammar-ABSENT case, covered separately below) -- this is
+    # the narrower "grammar works fine, but no reverse-import resolver exists yet" gap.
+    assert "fail-closed" not in csharp_gaps[0]["reason"]
+    assert "reverse-import" in csharp_gaps[0]["reason"]
+    assert csharp_gaps[0]["files_affected"] >= 1
+    # Honesty floor: the remediation must tell an agent to treat a zero count as UNKNOWN, not
+    # proven-zero -- the exact failure mode this test guards against.
+    assert (
+        "not proven-zero" in csharp_gaps[0]["remediation"]
+        or "UNKNOWN" in (csharp_gaps[0]["remediation"])
+    )
+
+
+# ---------------------------------------------------------------------------
 # Grammar-absent: fail-closed, resolution_gaps, honest exit code.
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tensor_grep.cli import lang_go, lang_registry, repo_map
+from tensor_grep.cli import lang_csharp, lang_go, lang_registry, repo_map
 
 # ---------------------------------------------------------------------------
 # spec_for_path / graph_suffixes
@@ -46,6 +46,7 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
         "foo.go": "go",
         "foo.java": "java",
         "foo.php": "php",
+        "foo.cs": "csharp",
     }
     for name, expected_language in expectations.items():
         spec = lang_registry.spec_for_path(Path(name))
@@ -76,6 +77,7 @@ def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
         ".go",
         ".java",
         ".php",
+        ".cs",
     })
 
 
@@ -88,6 +90,7 @@ def test_language_registry_has_exactly_the_stage2_languages() -> None:
         "go",
         "java",
         "php",
+        "csharp",
     }
 
 
@@ -148,6 +151,10 @@ def test_go_provenance_is_tree_sitter_when_grammar_present() -> None:
     assert repo_map._symbol_navigation_provenance_for_path("foo.go") == "tree-sitter"
 
 
+def test_csharp_provenance_is_tree_sitter_when_grammar_present() -> None:
+    assert repo_map._symbol_navigation_provenance_for_path("foo.cs") == "tree-sitter"
+
+
 def test_grammar_absent_monkeypatch_js_ts_provenance_flips_to_regex_heuristic(monkeypatch) -> None:
     """Simulate tree-sitter-javascript/typescript being uninstalled (ImportError inside the
     parser factory returns None, per repo_map._javascript_parser/_typescript_parser). The
@@ -180,6 +187,17 @@ def test_grammar_absent_monkeypatch_go_provenance_flips_to_grammar_missing(monke
     monkeypatch.setattr(lang_go, "_go_parser", lambda: None)
 
     provenance = repo_map._symbol_navigation_provenance_for_path("foo.go")
+
+    assert provenance == "grammar-missing"
+    assert provenance != ""
+
+
+def test_grammar_absent_monkeypatch_csharp_provenance_flips_to_grammar_missing(monkeypatch) -> None:
+    """C# has NO regex fallback (Stage 1 fail-closed trap, same as Go): a grammar-absent .cs
+    file's provenance label must flip to "grammar-missing" (not "regex-heuristic")."""
+    monkeypatch.setattr(lang_csharp, "_csharp_parser", lambda: None)
+
+    provenance = repo_map._symbol_navigation_provenance_for_path("foo.cs")
 
     assert provenance == "grammar-missing"
     assert provenance != ""

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -61,6 +61,18 @@ def test_ast_dev_bench_extras_include_tree_sitter_php_for_path_a_stage1() -> Non
         assert "tree-sitter-php" in deps[extra_name], f"tree-sitter-php missing from [{extra_name}]"
 
 
+def test_ast_dev_bench_extras_include_tree_sitter_c_sharp_for_path_a_stage1() -> None:
+    # PATH A Stage 1 (C# symbol graph, second language expansion, alongside Go): the PyPI
+    # package is "tree-sitter-c-sharp" (matching the upstream tree-sitter/tree-sitter-c-sharp
+    # GitHub repo name), NOT "tree-sitter-csharp" -- the latter does not exist on PyPI. Its
+    # Python import name is the underscored `tree_sitter_c_sharp` (see lang_csharp.py).
+    deps = _optional_dependencies()
+    for extra_name in ("ast", "dev", "bench"):
+        assert "tree-sitter-c-sharp" in deps[extra_name], (
+            f"tree-sitter-c-sharp missing from [{extra_name}]"
+        )
+
+
 def test_ast_extra_pins_pygls_floor_matching_lsp_server_import() -> None:
     # cli/lsp_server.py imports `from pygls.lsp.server import LanguageServer`, a module path
     # that exists only in pygls 2.x (pygls 1.x has no `pygls.lsp.server` module at all -- its

--- a/uv.lock
+++ b/uv.lock
@@ -550,8 +550,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pywin32", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/75/0814c3ca505d5fb1986e381b4967cc1d0d62c6d5f52d271546f51cd4991c/cuda_bindings-12.9.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b65cbe73aa657daf8cc0137da2223e1858e4057056aad727aae5f839f35a724c", size = 12515235, upload-time = "2025-08-18T15:47:27.748Z" },
@@ -576,8 +576,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "cuda-pathfinder", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -605,7 +605,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/a5/e9d37c10f6c27c9c65d53c6cd6d9763e1df99c004780585fc2ad9041fbe3/cuda_bindings-12.9.6-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2662f59db67d9aeaf8959c593c91f600792c2970cf02cae2814387fc687b115a", size = 7090971, upload-time = "2026-03-11T14:47:29.526Z" },
@@ -624,7 +624,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/62/ed3039d866879872099fc855f8ad8b5e2ae9010b5e30d702fde3d66f23df/cuda_core-0.6.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07df8dd46494bd53943759232051facd4372104f2997732e0d39c5bc12a616d5", size = 21790662, upload-time = "2026-02-23T18:59:27.064Z" },
@@ -653,8 +653,8 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/83/03139c7d9c0425ec4824d6269cfd9e1ac8ae1cc88f12540578a405113083/cuda_core-0.7.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69946d1d5e2d96fc65b7bb36164d26c328cca75d9482b74ee7d61b2c1e1d33a7", size = 30374690, upload-time = "2026-04-08T17:03:08.962Z" },
@@ -717,7 +717,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/3c/4475aebeaab9651f2e61000fbe76f91a476d371dbfbf0a1cf46e689af253/cuda_python-12.9.0-py3-none-any.whl", hash = "sha256:926acba49b2c0a0374c61b7c98f337c085199cf51cdfe4d6423c4129c20547a7", size = 7532, upload-time = "2025-05-06T19:14:07.771Z" },
@@ -734,7 +734,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
@@ -751,7 +751,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/69/4a79126959ad6f1653504122ee1eb22d089dd6272d3fa37694dcdeb78ba5/cuda_python-12.9.6-py3-none-any.whl", hash = "sha256:ed5cf30e1129729eecf4605dff6e8bce84f2d30c17b17c7e5ac4b76448de35d2", size = 7596, upload-time = "2026-03-11T15:35:17.282Z" },
@@ -773,19 +773,19 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.8.90", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.8.93", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -804,16 +804,16 @@ wheels = [
 
 [package.optional-dependencies]
 cccl = [
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvcc = [
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -827,24 +827,24 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"] },
-    { name = "numpy" },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pynvjitlink-cu12" },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cachetools", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numba-cuda", version = "0.14.1", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pandas", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "pynvjitlink-cu12", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rich", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/d3/1686e1a2d6187bf8cc248b7d0a8efbea6eb20784a707176dfdd881529149/cudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:888641383ee908b820a7acafec028e8bd9851b8884009c61281d19b312c15ca9", size = 2630152, upload-time = "2025-08-07T12:23:36.002Z" },
@@ -870,25 +870,25 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cachetools" },
+    { name = "cachetools", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
     { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "cupy-cuda12x" },
-    { name = "fsspec" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "fsspec", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numba", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "numba-cuda", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
-    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "python_full_version < '3.14' or platform_machine != 'x86_64'" },
-    { name = "numpy" },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numba-cuda", version = "0.28.2", source = { registry = "https://pypi.org/simple" }, extra = ["cu12"], marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pandas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pyarrow", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "pylibcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rich", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/36/5caed16456ce318abb32ce66717231d5ce7b9713047ac4ae315d3f9b179e/cudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:43cbc0175e5016fa94ae96de83355c578dc149b644961301b47c6e28d5f61f49", size = 2715406, upload-time = "2026-04-09T09:42:26.382Z" },
@@ -920,7 +920,7 @@ name = "donfig"
 version = "0.8.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
 wheels = [
@@ -1412,7 +1412,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/bd/fa8ce65b0a7d4b6d143ec23b0f5fd3f7ab80121078c465bc02baeaab22dc/importlib_metadata-8.4.0.tar.gz", hash = "sha256:9a547d3bc3608b025f93d403fdd1aae741c24fbb8314df4b155675742ce303c5", size = 54320, upload-time = "2024-08-20T17:11:42.348Z" }
 wheels = [
@@ -1435,7 +1435,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1510,12 +1510,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "zarr" },
+    { name = "cupy-cuda12x", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "zarr", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/b7/fbc1968592c92396efd3dc68f330d0e3da98a1150bfae414029bea9f9fe1/kvikio_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51094df8e0793485ae5021174b65bcd2bc584853cd832c142e6b463380bf4109", size = 672337, upload-time = "2025-08-07T13:50:13.422Z" },
@@ -1541,10 +1541,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cupy-cuda12x" },
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "cupy-cuda12x", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/24/95abc4335e8db5b8e140dbe7bdaa9bd7c8620cc087b33ccf748f474c43b0/kvikio_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72cf92d7786b9cb34c60d616a25ef1c802ee465ebc20dd4b5ca2a365b409be16", size = 587150, upload-time = "2026-04-09T11:38:07.743Z" },
@@ -1622,9 +1622,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/69/529bd3a5b6d8edac3e530a0b71c3a8f620a544248c9e22d509852be269a7/libcudf_cu12-25.8.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2ae790b881a67511b414451821ec894f014e4c49d3c62e8f230c45b56cfce0cb", size = 521220643, upload-time = "2025-08-07T11:49:07.039Z" },
@@ -1646,10 +1646,10 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-libnvcomp-cu12" },
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "libkvikio-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-libnvcomp-cu12", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/26/f0ae0915b0efac09de00229a205912e25691163e3a6cb51d5327b75d2119/libcudf_cu12-26.4.0-py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2448f34ec63ef9bca6ec47b2089fb331826a834e5e256ae9e0f21a5a7e56df", size = 674674052, upload-time = "2026-04-20T17:52:44.693Z" },
@@ -1701,7 +1701,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.1.19", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fe/35789d6aed0df9336ca07fcb57e756f0f91df4136c5c3087ffa97f912f4e/librmm_cu12-25.8.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18381166e7d855d1ee9ab4684d2ab8af67a115e2015753f1ce91b8ef1ad06013", size = 3539813, upload-time = "2025-08-07T11:22:46.099Z" },
@@ -1723,7 +1723,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "rapids-logger", version = "0.2.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/dc/04009da12d0ebccee9c7319929194839d1b3c0f306877c32e85ae1778fb3/librmm_cu12-26.4.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7fa86af3cf2fdd956c5906f8bd9c2a139ddcbb1a5e4c9c4aa33f391623be6c3", size = 3969220, upload-time = "2026-04-09T12:45:21.77Z" },
@@ -2243,7 +2243,7 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "numba" },
+    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/94/63e54c690f093869c5ed3e811ff440554e87085e4301ba9fe37953a6dd80/numba_cuda-0.14.1.tar.gz", hash = "sha256:2e23bc9f5946e850f21f42cb2dcd24a2cb8ea84b60ad020b6e3b357830a9a697", size = 491974, upload-time = "2025-08-22T16:40:43.58Z" }
 wheels = [
@@ -2252,11 +2252,11 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-cccl-cu12", version = "12.9.27", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvcc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc-cu12", version = "12.9.86", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvidia-cuda-runtime-cu12", version = "12.9.79", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 
 [[package]]
@@ -2267,10 +2267,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "numba", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "packaging", marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/51/8935ff9ae5150e1ffed945bf1b95002a6a5e1f9256aeb1143e1c159b68c5/numba_cuda-0.24.0.tar.gz", hash = "sha256:f15a11a8d224e160e9cb2345049c5fa0bbd49eb255b2e8f661086746a7feb378", size = 1347749, upload-time = "2026-01-12T22:38:08.289Z" }
 wheels = [
@@ -2284,9 +2284,9 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"] },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-core", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvjitlink", "nvrtc"], marker = "python_full_version >= '3.14' and platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2303,11 +2303,11 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numba" },
-    { name = "packaging" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-core", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "numba", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/aa/78ba931a3ddce12d0948302ae46b6fd7a5fe9009cf0e0add84d8f7ad9197/numba_cuda-0.28.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:733ca2823c208baab10d5d67107c267c248bca11ad94eee14c5a90cb57041b33", size = 1838625, upload-time = "2026-03-03T18:17:37.461Z" },
@@ -2326,12 +2326,12 @@ wheels = [
 
 [package.optional-dependencies]
 cu12 = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine != 'x86_64'" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "cuda-pathfinder", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
+    { name = "cuda-toolkit", version = "12.8.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "python_full_version < '3.14' and platform_machine == 'x86_64'" },
+    { name = "cuda-toolkit", version = "12.9.2.0", source = { registry = "https://pypi.org/simple" }, extra = ["cccl", "cudart", "nvcc", "nvrtc"], marker = "platform_machine == 'aarch64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.14' and platform_machine == 'x86_64') or platform_machine == 'aarch64'" },
 ]
 
 [[package]]
@@ -2339,8 +2339,8 @@ name = "numcodecs"
 version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "typing-extensions" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
 wheels = [
@@ -2571,7 +2571,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2582,7 +2582,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2609,9 +2609,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2622,7 +2622,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -3221,12 +3221,12 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "packaging" },
-    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "libcudf-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "rmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/12/023332074131122d839be397fe78195eb51eae131a82004438933e9ffbbc/pylibcudf_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18d7032242d2b8a136f226b7ae4fd8e631e526cbc886186cb7571eb1c25fbcef", size = 28162734, upload-time = "2025-08-07T11:45:56.918Z" },
@@ -3253,10 +3253,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvtx" },
-    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "libcudf-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "rmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ad/d2a1961ae8b194ce33a9d8269dd046629fb556147aca74223cabc632a07b/pylibcudf_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d0b191096b574cff4d709bb0880d2f0a346120493090cc8103098de9abead71", size = 8009026, upload-time = "2026-04-09T13:28:51.019Z" },
@@ -3714,9 +3714,9 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64'",
 ]
 dependencies = [
-    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "librmm-cu12", version = "25.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/2c/3363bbf6f5ee3699e28f5a3c525a165bedfa496b5a2a426777648a0297d6/rmm_cu12-25.8.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:856c38c22e8e1ea8a7216ff9c55d902a9a59b0a18a7affd426338743781f6725", size = 1139163, upload-time = "2025-08-07T11:18:37.215Z" },
@@ -3743,9 +3743,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-python", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64'" },
-    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
-    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
+    { name = "cuda-python", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64'" },
+    { name = "librmm-cu12", version = "26.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c1/6c3a3c0e14ccd1f92e43dd90d1137bd3d0592794c02e871bbcc6cdbf2888/rmm_cu12-26.4.0-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be5e54e32bfac027803a658e1ee41d0c0c4fd89849a77c5ed148c3edcdc0269d", size = 1197307, upload-time = "2026-04-09T14:23:55.527Z" },
@@ -4127,6 +4127,7 @@ dependencies = [
 ast = [
     { name = "pygls" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -4141,6 +4142,7 @@ bench = [
     { name = "stringzilla" },
     { name = "torch" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -4163,6 +4165,7 @@ dev = [
     { name = "ruff" },
     { name = "stringzilla" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -4238,6 +4241,9 @@ requires-dist = [
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'bench'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'dev'", specifier = ">=0.22" },
+    { name = "tree-sitter-c-sharp", marker = "extra == 'ast'" },
+    { name = "tree-sitter-c-sharp", marker = "extra == 'bench'" },
+    { name = "tree-sitter-c-sharp", marker = "extra == 'dev'" },
     { name = "tree-sitter-go", marker = "extra == 'ast'" },
     { name = "tree-sitter-go", marker = "extra == 'bench'" },
     { name = "tree-sitter-go", marker = "extra == 'dev'" },
@@ -4494,6 +4500,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/fb/7e2962bc1901daf264e7ce263b168e0139304a5f8f66c9b2baf20e550f87/tree_sitter_c_sharp-0.23.5.tar.gz", hash = "sha256:2635c7d5ec93e59f2e831b571bed99c4cc68a5d183a0994020aa769e1b990a71", size = 1147914, upload-time = "2026-04-14T16:11:22.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/c4/86d8d469400a856757a464a6ac01af97d8cdacbb595e62bdb98bf1e9db90/tree_sitter_c_sharp-0.23.5-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:61e1981cf21b09ee547b9c4c68e64fb4394325f8fc8d5f6d50d41471eba923ea", size = 333658, upload-time = "2026-04-14T16:11:11.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/13/593c8603f834eaf15082b81e079289fc9f062b4c0ab5b9489134084eec06/tree_sitter_c_sharp-0.23.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a75994a11f6fed3f5b8c36ad6a00e5dc43205bd912c43af3a2a54fdf649664eb", size = 376296, upload-time = "2026-04-14T16:11:12.972Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5a/a8855cbb5bbab28adb29c2c7f0e7be5a9f1d21450c13b3c3e613190d9b8c/tree_sitter_c_sharp-0.23.5-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:aa88a780204cd153c4c1ae2d59c654cee1402212fa0d069823d6d34301587438", size = 358333, upload-time = "2026-04-14T16:11:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c8/e0f391e343f5424d0627e3b6886c77baeb1249a3f10986be00b0b64ecdab/tree_sitter_c_sharp-0.23.5-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ea38fb095d85d360dc5a0bec2fa605e496228876f798c9e089d5f0e72bcef46", size = 359448, upload-time = "2026-04-14T16:11:15.419Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fc/10f807ac79f928241c5e0d827fdaf91e97dfba662fc7e07d7bd664140ec1/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:05a9256415e7f24d4f133133794a9c224c60d19f677a04e2f6a94c25090b6d65", size = 358144, upload-time = "2026-04-14T16:11:17.087Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2a/6c3e12ef0cf09138717fcc02e1de8b76a3928d1bed65c7e3c2bd3172bcef/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8636dc70b5a373c35c1036ed5de98e801f2e4d105ae41e2e20b6804c36e3bf33", size = 357525, upload-time = "2026-04-14T16:11:18.214Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/bd287b092d611df95a9149117fd27b5947ce75527113d6898a4b4e2c8858/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_amd64.whl", hash = "sha256:41a28cfa3d9ea50f5629e44550a03188c8fbd5079803dfc03554b6fd594b33fa", size = 338756, upload-time = "2026-04-14T16:11:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fb/114ff43fdd256d0befed32f77c1dadee9517867181c70794571f718ed05c/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_arm64.whl", hash = "sha256:2de4ebf95ddc2e92cd3105c8a8e0e7ec646bc82f52bfaf2f3acec0fa2401ec09", size = 337260, upload-time = "2026-04-14T16:11:20.849Z" },
 ]
 
 [[package]]
@@ -4840,12 +4862,12 @@ name = "zarr"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "donfig" },
-    { name = "google-crc32c" },
-    { name = "numcodecs" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "donfig", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "google-crc32c", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numcodecs", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "packaging", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
+    { name = "typing-extensions", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/76/7fa87f57c112c7b9c82f0a730f8b6f333e792574812872e2cd45ab604199/zarr-3.1.5.tar.gz", hash = "sha256:fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b", size = 366825, upload-time = "2025-11-21T14:06:01.492Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Lights up `.cs` files for `tg orient`/`defs`/`source`/`imports`/`agent` by registering a **"csharp"** `LanguageSpec` in tensor-grep's multi-language symbol graph (`lang_registry`, PATH A Stage 1) — mirroring the **Go precedent** (`lang_go.py`) rather than the older pre-registry Rust/JS/TS inline pattern.

- **New module** `src/tensor_grep/cli/lang_csharp.py`:
  - `_csharp_parser()` — tree-sitter grammar factory.
  - `csharp_imports_and_symbols(path)` — one AST pass: `class_declaration`/`interface_declaration`/`struct_declaration`/`enum_declaration`/`record_declaration` → kind `"class"`; `method_declaration`/`constructor_declaration` → kind `"function"` (including an interface's body-less method signature — the grammar reuses `method_declaration` for both). `using`-directive target namespaces, correctly handling plain (`using System;`), dotted (`using System.Collections.Generic;`), **aliased** (`using X = Y;` → records `Y`, never the alias `X`), `using static`, and `global using` forms.
  - `csharp_parser_symbol_sources(path, symbol)` — full source text for `tg source`.
- **Wired at exactly the dispatch sites Go touches** in `repo_map.py`: `lang_registry.register_language(...)`, `_imports_and_symbols_for_path`, `_target_language_for_path`, `build_symbol_source_from_map`. (`_provider_language_for_path`/`_language_for_path` already covered `.cs` generically/pre-existing.)

## Plan deviation (verify-plan-against-code)

The original task plan described mirroring the **old pre-registry Rust pattern** (`_RUST_SUFFIXES`, editing `_parser_for_source_suffix`, scattering suffix checks across ~15 legacy sites). Since that plan was drafted, `main` grew a `lang_registry`/`LanguageSpec` abstraction (PATH A Stage 0), and **Go was added as the first language under that new model** (PATH A Stage 1) via its own dedicated module — deliberately *not* touching `_parser_for_source_suffix` or the legacy scattered suffix sets, which only matter for the (out-of-scope) caller-graph / validation-runner / query-hint machinery.

I verified this against the real code (traced every `.language_id ==` branch and every scattered `_RUST_SUFFIXES`/`_JS_TS_SUFFIXES` site in `repo_map.py`) and followed the newer Go precedent instead — DRYer, smaller merge-conflict surface with the parallel Java PR, identical customer-visible outcome. `_parser_for_source_suffix` and the legacy suffix sets are **untouched**.

## Deferred (per task SCOPE)

- **Cross-file caller-graph**: `references_and_calls`/`provider_alias_calls`/`file_imports_symbol_from_definition`/`import_update_target`/`prime_repo_context` are all registered `None` — exactly matching Go's own `import_update_target=None` gap. `tg refs`/`tg callers`/`tg blast-radius` on a C# symbol fall through to the existing generic `_regex_references_and_calls` text-heuristic path (never a crash, never a fabricated AST match). Needs a `.csproj`/namespace-to-file resolution model in a follow-up — materially bigger than Go's package==directory model, since C# namespaces don't map 1:1 to file paths.
- **`tg imports FILE`'s line-numbered resolved-edge view** (`_imports_with_lines_for_path` / `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES`) — C# is not in that set, matching Go's *existing* gap exactly (Go isn't either). `tg imports <file.cs>` returns an honest `result_incomplete: true` / `"'csharp' has no import-resolution support in \`tg imports\` yet"`. The **coarse** imports list that feeds `orient`/`agent`/`build_repo_map` (the task's actual "imports (using directives)" ask) **is** fully populated.

## Grammar package

PyPI: **`tree-sitter-c-sharp`** (NOT `tree-sitter-csharp` — does not exist). Import name: `tree_sitter_c_sharp` (underscored). Verified: `tree_sitter.Language(tree_sitter_c_sharp.language())` succeeds (grammar v15, `name="c_sharp"`). Added to the `ast`/`dev`/`bench` extras in `pyproject.toml` + `uv.lock`, pinned by a new `test_ast_dev_bench_extras_include_tree_sitter_c_sharp_for_path_a_stage1` test.

## Tests (TDD: RED confirmed before GREEN)

- New `tests/unit/test_lang_csharp.py` — **16 tests**: registration/provenance, target/provider-language agreement, defs for class/interface/struct/enum/record + constructor-vs-class disambiguation + interface-vs-impl same-name-method disambiguation, `tg source` full-body retrieval, `using`-directive extraction (incl. alias/static/global), `build_repo_map` integration, grammar-absent fail-closed + `resolution_gaps` + honest CLI exit code, agent-capsule `primary_target_language`, deep-AST RecursionError guard (F26-class, applied preemptively), missing-file/wrong-suffix guards.
- `tests/unit/test_lang_registry.py` — extended registry-shape assertions to include `csharp`/`.cs`, + 2 new provenance tests mirroring Go's pair.
- `tests/unit/test_pyproject_dependencies.py` — 1 new pin test.
- **43/43 passed** (targeted). **154/154 passed** (adjacent regression: `test_lang_go.py`, `test_file_deps.py`, `test_repo_map_spans.py`, `test_ast_parse_cache.py`). Full `tests/unit/` suite run in progress at PR-open time; will report the final tally.
- `ruff check .` clean; `ruff format --check --preview .` clean on every file this PR touches; `mypy src/tensor_grep/cli/lang_csharp.py src/tensor_grep/cli/repo_map.py` clean.

## Dogfood (real `tg` CLI entry point, not CliRunner)

2-file sample (`Widget.cs`: namespace + 3 usings incl. one aliased + interface + enum + record + struct + class implementing the interface with a constructor and 2 methods; `Program.cs`: a `Main` consuming it):

```
$ tg orient <dir>
central files (2):
  Widget.cs   (in-degree=9.0)
  Program.cs  (in-degree=2.0)

$ tg defs <dir> Widget
definitions=2
  Widget.cs:25 class Widget
  Widget.cs:29 function Widget      # constructor, correctly disambiguated from the class

$ tg defs <dir> GetValue
definitions=2
  Widget.cs:9  function GetValue    # interface signature (no body)
  Widget.cs:34 function GetValue    # class implementation

$ tg source <dir> Create --json
"source": "public static Widget Create(string name)\n{\n    return new Widget(name);\n}\n"

$ tg agent <dir> Widget --json
"primary_target_language": "csharp"

$ tg imports Widget.cs --json
"result_incomplete": true, "incomplete_reason": "'csharp' has no import-resolution support in `tg imports` yet"
```

## Follow-ups (not this PR)

- Cross-file caller-graph for C# (needs a `.csproj`/namespace resolver).
- `tg imports FILE`'s line-numbered resolved-edge view for C#.

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
