### PR TITLE
docs(skills): fold session learnings into AGENTS.md/CLAUDE.md + register add-language & optimization skills

### DIFF
--- a/.claude/skill_rules.json
+++ b/.claude/skill_rules.json
@@ -58,6 +58,21 @@
             "priority": "medium",
             "minKeywordHits": 1,
             "keywords": ["review-bundle", "review bundle", "change review package", "audit-history"]
+        },
+        "tensor-grep-add-language": {
+            "priority": "medium",
+            "minKeywordHits": 1,
+            "keywords": ["add a language", "new grammar", "tree-sitter grammar", "lang_registry", "register_language", "symbol-graph language", "onboard a language"]
+        },
+        "profile-guided-byte-identical-optimization": {
+            "priority": "medium",
+            "minKeywordHits": 1,
+            "keywords": ["byte-identical", "cprofile", "profiling probe", "optimize hot path", "microbench", "warm dogfood", "cold path", "differential fuzz", "shipped wheel"]
+        },
+        "tensor-grep-large-repo-scale-campaign": {
+            "priority": "medium",
+            "minKeywordHits": 1,
+            "keywords": ["deadline", "hang", "large repo", "timeout", "scandir", "unscoped search", "workspace scale"]
         }
     }
 }

--- a/.claude/skill_rules.json
+++ b/.claude/skill_rules.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0",
-    "description": "Project-local skill triggers for tensor-grep (consumed by the global ~/.claude/hooks/skill_activation_gate.py engine; merged over global rules, invisible outside this project). Seeded 2026-07-17 from the project's local skill library -- see AGENTS.md's skill index for the current, authoritative skill count and set; expand from gate_fires.jsonl conversion data. This file is harness config for the activation hook, not a product contract, and is invisible to tests/unit/test_skill_index_sync.py.",
+    "description": "Project-local skill triggers for tensor-grep (consumed by the global ~/.claude/hooks/skill_activation_gate.py engine; merged over global rules, invisible outside this project). Seeded 2026-07-17 from the project's local skill library (12 initial entries; 15 as of 2026-07-23) -- see AGENTS.md's skill index for the current, authoritative skill count and set (this file's own entry count has no governance test, so treat it as a snapshot, not a promise); expand from gate_fires.jsonl conversion data. This file is harness config for the activation hook, not a product contract, and is invisible to tests/unit/test_skill_index_sync.py.",
     "skills": {
         "tensor-grep-debugging-playbook": {
             "priority": "high",

--- a/.claude/skills/tensor-grep-add-language/SKILL.md
+++ b/.claude/skills/tensor-grep-add-language/SKILL.md
@@ -8,10 +8,11 @@ description: Use when adding a new language to tensor-grep's tree-sitter symbol 
 The registration checklist for extending tensor-grep's tree-sitter symbol graph
 (`defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports`) to a new language.
 Ground-truthed directly against `src/tensor_grep/cli/lang_registry.py` (full file),
-`lang_go.py` and `lang_php.py` (the two shipped module-shaped languages), and
-`src/tensor_grep/cli/repo_map.py`'s real dispatch sites — not from memory or the
-session ledger alone. Sibling of `tensor-grep-architecture-contract`, scoped to one
-subsystem (the symbol-graph tier), not the front door / routing / backend contract.
+`lang_go.py`, `lang_php.py`, and `lang_csharp.py` (the three shipped module-shaped
+languages), and `src/tensor_grep/cli/repo_map.py`'s real dispatch sites — not from
+memory or the session ledger alone. Sibling of `tensor-grep-architecture-contract`,
+scoped to one subsystem (the symbol-graph tier), not the front door / routing /
+backend contract.
 
 ## When to use this skill vs. a sibling
 
@@ -26,17 +27,18 @@ subsystem (the symbol-graph tier), not the front door / routing / backend contra
 | Drain several language PRs that all touch `test_lang_registry.py` / `uv.lock` / the pyproject `ast` extra | `tensor-grep-change-control`'s Campaign Orchestration cross-ref (AGENTS.md A22) |
 | Use `tg` as a consumer (search/orient/callers flags) | `code-search-and-retrieval-reference` |
 
-## Current status (verified against v1.95.0, `origin/main`)
+## Current status (verified against v1.95.0 + #726, `origin/main`)
 
-`repo_map.py` currently carries **7** `lang_registry.register_language(...)` call sites
+`repo_map.py` currently carries **8** `lang_registry.register_language(...)` call sites
 (`grep -n "register_language(" src/tensor_grep/cli/repo_map.py`): `python`, `javascript`,
-`typescript`, `rust` (the original four, inline in `repo_map.py`), plus `go`, `java`, `php`
-— confirmed via `language_id=` greps and `tests/unit/test_lang_registry.py::
-test_language_registry_has_exactly_the_stage2_languages`'s literal set-pin. **C# (`csharp`)
-is NOT yet in this set** — PR #726 is still draining as of this writing; there is no
-`lang_csharp.py` on `main` and no `tree-sitter-csharp` in `pyproject.toml`'s `ast` extra
-yet. **Re-run the grep above before trusting any "N of top-10" count** — it is a snapshot,
-not a promise.
+`typescript`, `rust` (the original four, inline in `repo_map.py`), plus `go`, `java`,
+`php`, and `csharp` — confirmed via `language_id=` greps and
+`tests/unit/test_lang_registry.py::test_language_registry_has_exactly_the_stage2_languages`'s
+literal set-pin (which now includes `"csharp"`). C# landed via PR #726 as a
+module-shaped language (`lang_csharp.py`, mirrors `lang_go.py`, not Java's inline
+shape) — **all top-10 languages except C/C++ are now registered.** **Re-run the grep
+above before trusting any "N of top-10" count** — it is a snapshot, not a promise; this
+count changed twice in the span of authoring this skill.
 
 The tiered language model (unchanged shape, re-verify the coverage numbers):
 
@@ -44,7 +46,7 @@ The tiered language model (unchanged shape, re-verify the coverage numbers):
 |---|---|---|---|
 | Text search | any file | rg passthrough (bootstrap front door) | universal |
 | Structural scan/rewrite | many languages | ast-grep, which `tg` wraps (`tg ast-info`, `tg run`) | ~26 langs (ast-grep's own list) |
-| **Symbol graph (this skill)** | tree-sitter grammars in `lang_registry` | `defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports` | 7 live on `main` + C# draining (#726) = 8 of top-10; **C/C++ deferred** |
+| **Symbol graph (this skill)** | tree-sitter grammars in `lang_registry` | `defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports` | 8 of top-10 live on `main` (Python/JS/TS/Java/C#/Go/Rust/PHP); **C/C++ deferred** |
 
 Positioning: tg = rg (text) + ast-grep (structural) + this symbol/retrieval/capsule layer —
 "not faster grep" (mirrors `tensor-grep-architecture-contract`'s moat framing). Top-10
@@ -61,8 +63,8 @@ JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP.
 refactor wrapped it, it did not replace it). Java is the one exception that used
 inline-in-`repo_map.py` (`_java_imports_and_symbols` etc., `repo_map.py:4544`+) and still
 registers through `lang_registry` — both shapes are contract-consistent, but **the module
-shape is what Go and PHP (the two most recent additions) both converged on**, and is what
-`lang_go.py`'s own docstring recommends: it keeps `repo_map.py` from growing further.
+shape is what Go, PHP, and C# (the three most recent additions) all converged on**, and is
+what `lang_go.py`'s own docstring recommends: it keeps `repo_map.py` from growing further.
 
 One-directional import rule (stated in both `lang_registry.py:10-12` and `lang_go.py:9-15`):
 `repo_map.py` → `lang_<x>.py`, never the reverse. A helper the new module needs that
@@ -218,13 +220,17 @@ source covering every construct you plan to extract through the target `tree_sit
 package directly, and print `node.type`/`node.children` recursively, before writing
 extraction logic.
 
-**One example flagged as ledger-sourced, not independently re-verified this pass**: the
-session ledger records that C#'s `using Alias = Target;` parses with the alias identifier
-*before* the target, so a `_csharp_using_directive_target`-style extractor must record the
-target, not the alias — worth knowing as a preview of C#'s own node-shape surprise, but
-**PR #726 has not merged as of this writing**, so there is no `lang_csharp.py` on `main` to
-cite a line number against yet. Re-verify against the real file once #726 lands rather than
-trusting this secondhand.
+**A fourth, independently-verified example (PR #726 merged mid-authoring-pass — re-checked
+against the real file rather than left as a secondhand ledger note): C#'s aliased `using`
+directive.** `using MyAlias = System.Text.StringBuilder;` parses with the alias identifier
+emitted **first** (leftmost child) and the actual target namespace **last** (rightmost
+child) — the reverse of what you might guess. `_csharp_using_directive_target`
+(`lang_csharp.py:138-150`) handles all four `using` forms (plain, dotted, aliased,
+`static`/`global`-qualified) with one rule: take the **last** matching
+`identifier`/`qualified_name` child, never the first — verified against the installed
+`tree_sitter_c_sharp` 0.23.x grammar for all four forms (`lang_csharp.py:113-124`'s own
+comment table). Getting this backwards would record every aliased import as its local
+alias name instead of the namespace actually being imported.
 
 ## B6 — tiered model recap (see "Current status" above for the live table)
 
@@ -238,9 +244,9 @@ ast-grep supports it) structural scan/rewrite; it just has no `defs`/`refs`/`cal
 ## E1 — priority and what's next
 
 Top-10 by TIOBE Jul-2026 + Stack Overflow 2025 + GitHub Octoverse 2025 consensus: Python,
-JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP. 7 are registered on `main` today;
-C# is draining in PR #726. **C/C++ is the next concrete target after that lands**, and it is
-harder than any language shipped so far — scope before starting, not while coding:
+JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP. All 8 non-C/C++ entries are now
+registered on `main` (C# landed via PR #726). **C/C++ is the next concrete target**, and it
+is harder than any language shipped so far — scope before starting, not while coding:
 
 1. **No module system.** Go has `go.mod`/`go.work`; C/C++ has no compiler-enforced
    namespace-to-directory mapping. The honest floor for a first landing is per-file symbol
@@ -294,7 +300,7 @@ rule, not specific to language PRs.
   registered_suffix`, `test_language_registry_has_exactly_the_stage2_languages` (the
   union-pin set — add your `language_id` here), `test_target_and_provider_language_agree_
   with_registry`, and the `test_*_provenance_is_tree_sitter_when_grammar_present` /
-  `test_grammar_absent_monkeypatch_*_provenance_flips_to_grammar_missing` pair (15 tests
+  `test_grammar_absent_monkeypatch_*_provenance_flips_to_grammar_missing` pair (17 tests
   total as of this writing — `grep -c "def test_" tests/unit/test_lang_registry.py`).
 - **Fixture/parity dogfood**: write a minimal real-world-shaped fixture file in the new
   language exercising every construct you extract (functions, types/generics if the
@@ -329,22 +335,29 @@ tg --version
 
 ## Provenance and maintenance
 
-- **Verified against tg v1.95.0** (`main` HEAD at authoring time; PyPI publish completing).
-  Ground truth read directly for this skill: `src/tensor_grep/cli/lang_registry.py` (full
-  file), `src/tensor_grep/cli/lang_go.py` (docstring + parser/walk/seam functions),
-  `src/tensor_grep/cli/lang_php.py` (docstring + `__all__`), and the cited `repo_map.py`
-  seam locations, `pyproject.toml`'s `ast` extra, and `tests/unit/test_lang_registry.py` —
-  all read live from `origin/main` this pass, not carried over from a prior draft.
+- **Verified against tg v1.95.0 + PR #726** (`main` HEAD at authoring time; PR #726 merged
+  mid-authoring-pass and this skill was re-checked against it before finalizing, rather than
+  left stale). Ground truth read directly for this skill: `src/tensor_grep/cli/
+  lang_registry.py` (full file), `src/tensor_grep/cli/lang_go.py` (docstring +
+  parser/walk/seam functions), `src/tensor_grep/cli/lang_php.py` (docstring + `__all__`),
+  `src/tensor_grep/cli/lang_csharp.py` (the `using`-directive target-selection logic + its
+  own grammar-verification comment), the cited `repo_map.py` seam locations,
+  `pyproject.toml`'s `ast` extra, and `tests/unit/test_lang_registry.py` — all read live
+  from `origin/main` this pass, not carried over from a prior draft.
 - **Not independently verified this pass**: the exact `repo_map.py` line numbers for seam 7
   (per-language `references_and_calls`/`file_imports_symbol_from_definition` dispatch arms)
   and seam 8 (the daemon-refresh cache-clear sweep call site); the Java inline extractor's
-  own line-level shape beyond its function names; anything about C# beyond the ledger's
-  secondhand `using Alias` note (PR #726 not yet merged — no code to cite).
-  Re-verify all of these — and every line number above — before citing them in a later
-  session; `repo_map.py` moves fast (~100+ lines/release, per `tensor-grep-run-and-operate`).
+  own line-level shape beyond its function names; C#'s def/import extraction logic beyond
+  the `using`-directive target-selection function cited above (`csharp_imports_and_symbols`
+  and any caller-graph fields were not read line-by-line this pass — check whether C#
+  shipped the narrower PHP-style defs+imports-only slice or the fuller Go-style caller graph
+  before citing either). Re-verify all of these — and every line number above — before
+  citing them in a later session; `repo_map.py` moves fast (~100+ lines/release, per
+  `tensor-grep-run-and-operate`).
 - **Session ledger source**: `session_learnings_2026-07-24.md` (a scratch file, not a
-  permanent repo artifact) supplied the B1-B6/E1 framing and the C# node-shape lead; every
-  claim above was re-derived against the live repo rather than copied, and is cited to the
-  real file where it was possible to check.
+  permanent repo artifact) supplied the B1-B6/E1 framing and the original C# node-shape
+  lead (itself later independently confirmed against `lang_csharp.py` once #726 landed);
+  every claim above was re-derived against the live repo rather than copied, and is cited
+  to the real file where it was possible to check.
 - If a re-verify disagrees with this skill, fix the skill — a wrong runbook is worse than
   none — and route any actual code change through `tensor-grep-change-control`.

--- a/.claude/skills/tensor-grep-add-language/SKILL.md
+++ b/.claude/skills/tensor-grep-add-language/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: tensor-grep-add-language
+description: Use when adding a new language to tensor-grep's tree-sitter symbol graph (defs/refs/callers/blast-radius, `tg source`, `tg imports`) — registering a `LanguageSpec` in `lang_registry.py`, writing a new `src/tensor_grep/cli/lang_<x>.py` extractor module, or scoping the deferred C/C++ language-expansion follow-up. Triggers and keywords include add a language, add <language> to tensor-grep, new grammar, tree-sitter grammar, lang_registry, register_language, new lang_<x>.py module, symbol-graph language, onboard a language, "tg doesn't find symbols in <language>", `_target_language_for_path`, grammar-missing provenance, C/C++ symbol graph.
+---
+
+# tensor-grep: adding a language to the symbol graph
+
+The registration checklist for extending tensor-grep's tree-sitter symbol graph
+(`defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports`) to a new language.
+Ground-truthed directly against `src/tensor_grep/cli/lang_registry.py` (full file),
+`lang_go.py` and `lang_php.py` (the two shipped module-shaped languages), and
+`src/tensor_grep/cli/repo_map.py`'s real dispatch sites — not from memory or the
+session ledger alone. Sibling of `tensor-grep-architecture-contract`, scoped to one
+subsystem (the symbol-graph tier), not the front door / routing / backend contract.
+
+## When to use this skill vs. a sibling
+
+| You are about to… | Use |
+|---|---|
+| Add/extend the symbol graph for a language (this skill) | **you are here** |
+| Understand the front door, routing, or the Backend Fail-Closed Contract for search itself | `tensor-grep-architecture-contract` |
+| Land the change safely (registration gates, one-merge-per-tick, dogfood) | `tensor-grep-change-control` |
+| Adversarially check an AI-drafted add-language plan against real code before dispatch | `verify-plan-against-code` (global skill) |
+| Debug a live "no symbols found" / wrong-result report for an already-supported language | `tensor-grep-debugging-playbook` |
+| Find a hot-path lever and prove an optimization byte-identical (not language-specific) | `profile-guided-byte-identical-optimization` (global skill) |
+| Drain several language PRs that all touch `test_lang_registry.py` / `uv.lock` / the pyproject `ast` extra | `tensor-grep-change-control`'s Campaign Orchestration cross-ref (AGENTS.md A22) |
+| Use `tg` as a consumer (search/orient/callers flags) | `code-search-and-retrieval-reference` |
+
+## Current status (verified against v1.95.0, `origin/main`)
+
+`repo_map.py` currently carries **7** `lang_registry.register_language(...)` call sites
+(`grep -n "register_language(" src/tensor_grep/cli/repo_map.py`): `python`, `javascript`,
+`typescript`, `rust` (the original four, inline in `repo_map.py`), plus `go`, `java`, `php`
+— confirmed via `language_id=` greps and `tests/unit/test_lang_registry.py::
+test_language_registry_has_exactly_the_stage2_languages`'s literal set-pin. **C# (`csharp`)
+is NOT yet in this set** — PR #726 is still draining as of this writing; there is no
+`lang_csharp.py` on `main` and no `tree-sitter-csharp` in `pyproject.toml`'s `ast` extra
+yet. **Re-run the grep above before trusting any "N of top-10" count** — it is a snapshot,
+not a promise.
+
+The tiered language model (unchanged shape, re-verify the coverage numbers):
+
+| Tier | Scope | Mechanism | Coverage |
+|---|---|---|---|
+| Text search | any file | rg passthrough (bootstrap front door) | universal |
+| Structural scan/rewrite | many languages | ast-grep, which `tg` wraps (`tg ast-info`, `tg run`) | ~26 langs (ast-grep's own list) |
+| **Symbol graph (this skill)** | tree-sitter grammars in `lang_registry` | `defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports` | 7 live on `main` + C# draining (#726) = 8 of top-10; **C/C++ deferred** |
+
+Positioning: tg = rg (text) + ast-grep (structural) + this symbol/retrieval/capsule layer —
+"not faster grep" (mirrors `tensor-grep-architecture-contract`'s moat framing). Top-10
+ranking (TIOBE Jul-2026 + Stack Overflow 2025 + GitHub Octoverse 2025 consensus): Python,
+JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP.
+
+## B1 — the pattern: `register_language` + a `lang_<x>.py` module
+
+**The current, correct pattern for a NEW language is a self-contained
+`src/tensor_grep/cli/lang_<x>.py` module** (clone `lang_go.py`) that ends in a
+`lang_registry.register_language(LanguageSpec(...))` call from `repo_map.py`. This is
+**not** the inline `_rust_*` / `_parser_for_source_suffix` machinery still visible in
+`repo_map.py` for Rust and Python — that style predates the registry (Stage 0's pure-parity
+refactor wrapped it, it did not replace it). Java is the one exception that used
+inline-in-`repo_map.py` (`_java_imports_and_symbols` etc., `repo_map.py:4544`+) and still
+registers through `lang_registry` — both shapes are contract-consistent, but **the module
+shape is what Go and PHP (the two most recent additions) both converged on**, and is what
+`lang_go.py`'s own docstring recommends: it keeps `repo_map.py` from growing further.
+
+One-directional import rule (stated in both `lang_registry.py:10-12` and `lang_go.py:9-15`):
+`repo_map.py` → `lang_<x>.py`, never the reverse. A helper the new module needs that
+`repo_map.py` already has must be **duplicated locally** (see `lang_go.py:37-87`'s
+byte-identical-to-`repo_map.py` tiny helpers), not imported — importing back creates a
+cycle.
+
+`LanguageSpec` (`lang_registry.py:67-111`, frozen dataclass) is the single contract. Fields
+worth knowing before writing one:
+
+| Field | Status | Note |
+|---|---|---|
+| `language_id`, `suffixes` | wired, required | e.g. `"go"`, `frozenset({".go"})` |
+| `parser_for_path` | wired | returns the parser or `None` if the grammar package isn't installed — the fail-closed gate |
+| `provenance_when_missing` | wired, **default `"regex-heuristic"`** | a language with no regex fallback (every language after the original four) **must override this to `"grammar-missing"`** — see B3 |
+| `extract_imports_and_symbols`, `references_and_calls`, `provider_alias_calls`, `file_imports_symbol_from_definition`, `import_update_target` | wired | any of these left `None` = an honestly-deferred capability, not a bug — see PHP's precedent in B3 |
+| `prime_repo_context` | wired | `None` if the language has no per-repo workspace state to prime (tsconfig/`go.mod`-style) |
+| `def_node_kinds`, `classify_ref_kind` | **doc-only in Stage 0** | no dispatch seam reads these yet — populate for self-documentation, do not assume they are wired |
+
+`register_language()` is idempotent (`lang_registry.py:118-128`) — re-registering the same
+`language_id` replaces the entry and re-derives every suffix pointer, so a stale mapping
+never survives a reload. `LANGUAGE_REGISTRY` starts **empty** (`:114`) until whatever module
+calls `register_language(...)` is imported — a bare `import lang_registry` with no
+`import repo_map` gets an empty dict (see "Fast self-check" below).
+
+## B2 — the critical seams (miss one = a silent half-integration)
+
+Enumerate every seam `lang_go.py` touches and hit **all** of them. These are re-verified
+`repo_map.py` locations on v1.95.0 — re-grep the symbol before trusting the line number on a
+later version (`main.py`/`repo_map.py` churn every release):
+
+| # | Seam | Location | Feeds | Miss-it symptom |
+|---|---|---|---|---|
+| 1 | `lang_registry.register_language(LanguageSpec(...))` | `repo_map.py` (7 call sites, "near the bottom") | wiring the suffix at all | new suffix never resolves; silently excluded everywhere |
+| 2 | `_imports_and_symbols_for_path` | `repo_map.py:6204` | symbol/def extraction dispatch | new language absent from defs/symbols |
+| 3 | `_imports_with_lines_for_path` | `repo_map.py:6396` | `tg imports` (line-numbered import entries) | `tg imports` silently empty even though defs exist |
+| 4 | `build_symbol_source_from_map` | `repo_map.py:15752` | `tg source` | `tg source` returns nothing for a real symbol |
+| 5 | **`_target_language_for_path` — MOST-FORGOTTEN** | `repo_map.py:7323` | `tg agent` capsule's `primary_target_language` / confidence gate | a target file in the new language does not filter a mismatched-language validation suggestion |
+| 6 | `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` | `repo_map.py:16568` | gates whether `tg imports`/`tg importers` even attempts dependency resolution | file-dependency graph silently (but honestly, see B3) excludes the language |
+
+Seam 5 is not a hypothesis — the live code says so in its own comments. Reading
+`_target_language_for_path` on `main` today:
+
+```text
+if suffix == ".go":
+    # MOST-FORGOTTEN seam (PATH A Stage 1 design note): without this, the capsule's
+    # query-language-vs-target-language 0.55 confidence cap (agent_capsule.py) never even
+    # sees "go" as a candidate target language...
+    return "go"
+...
+if suffix in _JAVA_SUFFIXES:
+    # Same MOST-FORGOTTEN seam, Stage 2: without this, `tg agent`'s capsule never reports
+    # primary_target_language == "java" for a Java target.
+    return "java"
+if suffix == ".php":
+    # MOST-FORGOTTEN seam (see the ".go" branch above) -- same fix, same reason...
+    return "php"
+```
+
+**Worked example that seam 6 is not theoretical — it is currently, honestly open for two
+shipped languages.** `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` on `main` today is
+`frozenset({"python", "javascript", "typescript", "rust", "java"})` — **`go` and `php` are
+registered languages with working defs/source/`_target_language_for_path` entries, but are
+NOT in this set.** `build_file_imports` (`tg imports`) checks
+`language_id in _SUPPORTED_FILE_DEPENDENCY_LANGUAGES`; when it's absent it does **not**
+silently return an empty import list — it sets `result_incomplete=True` and
+`incomplete_reason="'go' has no import-resolution support in \`tg imports\` yet"`
+(`repo_map.py`, `build_file_imports`, ~line 16714). This is the fail-closed contract (B3)
+holding even where seam 6 was genuinely missed for Go/PHP — a live example of the
+difference between "forgot a seam" (bad, silent) and "forgot a seam but the honesty floor
+caught it" (recoverable, visible). Closing this for `go`/`php` is a good first PR for
+whoever reads this skill next; the fix is a one-line frozenset addition plus whatever real
+import-path resolution the language needs behind it.
+
+Two more seams exist beyond this table, found by reading `lang_go.py` itself rather than
+the ledger (not independently re-grepped against `repo_map.py`'s call sites this pass —
+verify before citing a line number): (7) the per-language dispatch arms that call
+`references_and_calls` / `file_imports_symbol_from_definition` directly, which feed
+`tg callers`/`tg blast-radius`; (8) `clear_<lang>_repo_context_cache` (`lang_go.py:398`)
+wired into the daemon-refresh sweep, so `tg session refresh` doesn't serve stale
+import-resolution context after a repo change.
+
+## B3 — fail-closed contract, extended per-language
+
+- **Override `provenance_when_missing`.** The registry default is `"regex-heuristic"`
+  (`lang_registry.py:89`) — true for the original JS/TS/Rust languages, which have a real
+  regex fallback. Every language shipped since (Go, PHP) has **no** regex fallback and
+  explicitly sets `provenance_when_missing="grammar-missing"` in its `LanguageSpec(...)`
+  call. Skipping this override makes a grammar-absent file for the new language read as
+  "zero symbols found" instead of a genuine `resolution_gaps` entry — a silent lie by
+  omission (`lang_go.py:17-24`).
+- **A `None` callable field is an honest deferral, not a bug — PHP is the shipped
+  precedent.** `lang_php.py`'s own docstring states its Stage 1 landing is "deliberately
+  narrower than Go's": it implements `extract_imports_and_symbols` +
+  `parser_symbol_sources` only, and registers `references_and_calls`,
+  `file_imports_symbol_from_definition`, `import_update_target`, and `prime_repo_context`
+  all as `None`. `repo_map.py`'s `_language_coverage_gaps_for_universe` already treats
+  `import_update_target is None` as a `resolution_gaps` entry — so `tg callers`/
+  `tg blast-radius` stay honest about PHP's current lack of reverse-import resolution
+  instead of reading as a proven zero. **You do not have to land every seam in one PR** —
+  land a real, honestly-labeled subset, exactly like PHP did.
+- Every extractor function returns the empty shape (`[]` / `([], [])`), **never raises**,
+  when the grammar is missing (every public function in `lang_go.py` starts with
+  `parser = _go_parser(); if parser is None: return <empty>`).
+- **Symbol-kind vocabulary — emit the language's own, do not pre-collapse.** Each module
+  emits its native kind strings (Go: `"function"`/`"method"`/`"struct"`/`"interface"`/
+  `"const"`/`"var"`/`"type"`, `lang_go.py:110-113`). A later normalization layer (not
+  independently re-verified this pass — presumably in `repo_map.py`) is what the ledger
+  records as the cross-language collapse: class/interface/struct/enum/record/trait →
+  `"class"`; method/constructor/function → `"function"`. Emit the real vocabulary in the new
+  module; re-verify where the collapse actually happens before assuming its exact shape.
+- **`resolution_confidence` banding is the same fail-closed principle per-match.**
+  `go_references_and_calls` (`lang_go.py:660`) bands 0.95 for a confirmed resolution
+  (`resolution_provenance=["go-import-resolution"]`) vs. 0.7
+  `"receiver-heuristic"` for a textually-plausible-but-statically-unconfirmed one
+  (`lang_go.py:769`) — an unconfirmed match is **demoted, never dropped**. This is the
+  per-match instance of the Backend Fail-Closed Contract: never fabricate certainty.
+
+## B4 — verify the plan against current code before dispatch
+
+A real onboarding brief this session said "mirror inline `_rust_*`" — **stale**, because the
+repo had already grown `lang_registry.py` and the module pattern since that mental model
+formed. All three build agents that received the brief independently caught it via the
+`verify-plan-against-code` discipline before writing code, and corrected to the module
+shape. **Rule: before dispatching an add-a-language plan — to a subagent, codex, cursor, or
+your own future self — re-read `lang_registry.py` plus the most recently added `lang_<x>.py`
+sibling fresh.** Do not trust a memory, an old skill snapshot (including this one — see the
+"Fast self-check" below), or a prior session's summary about which shape is current.
+
+## B5 — live-verify grammar node shapes before writing extraction logic
+
+**Do not guess a node shape from documentation, another language's grammar, or intuition —
+dump the real parse tree.** `lang_go.py` shipped with at least three node-shape surprises
+found exactly this way, each pinned by an inline `F<n> fix` comment — worked, re-verified
+proof this step cannot be skipped:
+
+- **Generic receiver type nesting** (`lang_go.py:126-159`, F8 fix): `func (r *MyType[T]) M()`
+  parses the receiver's type as a `generic_type` node whose raw text is `"MyType[T]"` — never
+  matching the plain `"MyType"` a `type_spec` declares, unless you descend into
+  `generic_type`'s own `type` field.
+- **Grammar-version-dependent content node** (`lang_go.py:162-189`, F11 fix): a recent
+  `tree_sitter_go` exposes `interpreted_string_literal_content` as a child of an import path;
+  an older/differently-built grammar can omit it — silently zeroing out every import in the
+  file with no error and no `resolution_gaps` entry (the parser loaded fine, so nothing marks
+  a gap). Fix: fall back to quote-stripping the raw node text.
+- **Row-counting divergence** (`lang_go.py:226-229`, F26 fix): tree-sitter's row index
+  advances only on `"\n"`; naive Python line-splitting also splits on other separators — one
+  stray separator shifts every later line lookup out of alignment with tree-sitter's own rows
+  unless you count rows the same way tree-sitter does.
+
+None of these were guessable from a grammar README. Parse real (or minimal handwritten)
+source covering every construct you plan to extract through the target `tree_sitter_<lang>`
+package directly, and print `node.type`/`node.children` recursively, before writing
+extraction logic.
+
+**One example flagged as ledger-sourced, not independently re-verified this pass**: the
+session ledger records that C#'s `using Alias = Target;` parses with the alias identifier
+*before* the target, so a `_csharp_using_directive_target`-style extractor must record the
+target, not the alias — worth knowing as a preview of C#'s own node-shape surprise, but
+**PR #726 has not merged as of this writing**, so there is no `lang_csharp.py` on `main` to
+cite a line number against yet. Re-verify against the real file once #726 lands rather than
+trusting this secondhand.
+
+## B6 — tiered model recap (see "Current status" above for the live table)
+
+text search (any language, rg passthrough) → structural scan/rewrite (~26 langs via the
+ast-grep wrapper `tg` wraps) → deep symbol graph (this skill's tier, the tree-sitter
+grammars in `lang_registry`). Adding a language to the symbol graph does not change the
+other two tiers — a language with no `LanguageSpec` still gets full-text search and (if
+ast-grep supports it) structural scan/rewrite; it just has no `defs`/`refs`/`callers`/
+`tg source` support until it clears this checklist.
+
+## E1 — priority and what's next
+
+Top-10 by TIOBE Jul-2026 + Stack Overflow 2025 + GitHub Octoverse 2025 consensus: Python,
+JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP. 7 are registered on `main` today;
+C# is draining in PR #726. **C/C++ is the next concrete target after that lands**, and it is
+harder than any language shipped so far — scope before starting, not while coding:
+
+1. **No module system.** Go has `go.mod`/`go.work`; C/C++ has no compiler-enforced
+   namespace-to-directory mapping. The honest floor for a first landing is per-file symbol
+   extraction (filename-as-scope), not a full `compile_commands.json`/CMake include-graph.
+2. **`#include` is textual, not semantic.** tree-sitter has no preprocessor; a
+   `#define`-wrapped declaration (export/visibility macros are common in real C/C++ headers)
+   can hide or reshape the node the extractor expects — B5's live-verify discipline is
+   mandatory here, not optional, on a much larger surface than Go's.
+3. **Declaration/definition split.** A C/C++ function typically appears twice (a header
+   prototype, a body-bearing definition) — which one is canonical for `tg source`/`tg defs`
+   is a design decision to make explicitly, not an assumption carried over from Go's
+   one-declaration model.
+4. **C and C++ are two separate grammar packages** (`tree-sitter-c` vs. `tree-sitter-cpp`) —
+   decide upfront whether they are one `LanguageSpec` or two (recommend two, mirroring how
+   JS/TS already get two specs rather than one with a mode flag).
+5. A first Stage 1 landing can reasonably scope to per-file extraction +
+   declaration/definition dedup by name, in the same 0.7 `"receiver-heuristic"`-equivalent
+   confidence band Go uses for anything short of confirmed resolution — a real,
+   honestly-labeled feature now, rather than blocking on `#include`-graph resolution.
+
+## Parallel-drain hygiene (cross-ref: AGENTS.md Campaign Orchestration A22)
+
+A new grammar touches three files that several in-flight language PRs are likely to touch
+at once: `tests/unit/test_lang_registry.py` (the `LANGUAGE_REGISTRY.keys()` set-pin test,
+`test_language_registry_has_exactly_the_stage2_languages`), the pyproject `ast` extra
+(`pyproject.toml:600`, plus the mirrored `dev`/`bench` extras), and `uv.lock` (a new
+`tree-sitter-<lang>` `[[package]]` block). When more than one language PR is in flight:
+
+- Drain ONE at a time and rebase each onto the prior, **UNIONing** the assertions — e.g. the
+  set-pin test must assert the full accumulated language set, never take-one-side.
+- A CLEAN rebase (no conflict marker) is **not** proof of correctness — a silent auto-merge
+  can drop a `lang_*` import. Always re-run `pytest tests/unit/test_lang_registry.py` after
+  every rebase, not just after the final one.
+- `uv lock` regenerated from scratch churns ~280 unrelated lines (local-vs-CI uv-version
+  marker-expr reformatting) — hand-splice only the new dependency's `[[package]]` block
+  (alphabetical) plus its `requires-dist`/optional-dependency refs, and verify with
+  `uv export --format requirements.txt --all-extras --no-emit-project --locked` (must exit
+  0 — the exact `audit.yml` "Dependency & License Audit" gate).
+- If you edit `uv.lock`/`ci.yml` (CRLF-committed files) with a Python text-mode write
+  (`open(path, newline="\n")`), it flips every line ending in the file, turning an 11-line
+  change into a 1000+ line diff. Read/write in binary mode (`rb`/`wb`) and byte-replace,
+  preserving `\r\n`.
+
+See `AGENTS.md`'s Campaign Orchestration Disciplines (A22) for the general form of this
+rule, not specific to language PRs.
+
+## Validation
+
+- **Extend `tests/unit/test_lang_registry.py`**, not just a new bespoke test file — it
+  already carries the pattern a new language must fit: `test_spec_for_path_resolves_every_
+  registered_suffix`, `test_language_registry_has_exactly_the_stage2_languages` (the
+  union-pin set — add your `language_id` here), `test_target_and_provider_language_agree_
+  with_registry`, and the `test_*_provenance_is_tree_sitter_when_grammar_present` /
+  `test_grammar_absent_monkeypatch_*_provenance_flips_to_grammar_missing` pair (15 tests
+  total as of this writing — `grep -c "def test_" tests/unit/test_lang_registry.py`).
+- **Fixture/parity dogfood**: write a minimal real-world-shaped fixture file in the new
+  language exercising every construct you extract (functions, types/generics if the
+  language has them, qualified access, imports) and run `tg defs`/`tg refs`/`tg callers`/
+  `tg source`/`tg imports` against it through the **real installed binary**, not `CliRunner`
+  (`AGENTS.md`'s "Dogfood the Real Binary, Not CliRunner").
+- **Confirm `_target_language_for_path` (seam 5) with a live `tg agent` capsule run** on a
+  fixture in the new language and check `primary_target_language` in the JSON — this is the
+  seam a unit test on `lang_registry` alone will not catch, because it lives in
+  `repo_map.py`, not the registry module.
+- Never trust a subagent's "I added the language and it works" as a self-report — confirm
+  against external state: the registry dict, a real symbol-command run, and (if
+  `_target_language_for_path` was touched) a capsule run.
+
+## Fast self-check before trusting a claim about this design
+
+```powershell
+# Import side effect: LANGUAGE_REGISTRY is empty until the registering module (repo_map) is imported
+uv run python -c "from tensor_grep.cli import lang_registry; print(sorted(lang_registry.LANGUAGE_REGISTRY.keys()))"
+uv run python -c "from tensor_grep.cli import lang_registry, repo_map; print(sorted(lang_registry.LANGUAGE_REGISTRY.keys()))"
+
+# Does a suffix resolve, and what does provenance_when_missing say?
+uv run python -c "from tensor_grep.cli import lang_registry, repo_map; s = lang_registry.spec_for_path('x.go'); print(s.language_id, s.provenance_when_missing)"
+
+# Re-derive the current registered-language set + re-locate the 5 seams before citing a line number
+grep -n "register_language(" src/tensor_grep/cli/repo_map.py
+grep -n "^def _imports_and_symbols_for_path\|^def _imports_with_lines_for_path\|^def build_symbol_source_from_map\|^def _target_language_for_path\|_SUPPORTED_FILE_DEPENDENCY_LANGUAGES" src/tensor_grep/cli/repo_map.py
+
+# Version identity
+tg --version
+```
+
+## Provenance and maintenance
+
+- **Verified against tg v1.95.0** (`main` HEAD at authoring time; PyPI publish completing).
+  Ground truth read directly for this skill: `src/tensor_grep/cli/lang_registry.py` (full
+  file), `src/tensor_grep/cli/lang_go.py` (docstring + parser/walk/seam functions),
+  `src/tensor_grep/cli/lang_php.py` (docstring + `__all__`), and the cited `repo_map.py`
+  seam locations, `pyproject.toml`'s `ast` extra, and `tests/unit/test_lang_registry.py` —
+  all read live from `origin/main` this pass, not carried over from a prior draft.
+- **Not independently verified this pass**: the exact `repo_map.py` line numbers for seam 7
+  (per-language `references_and_calls`/`file_imports_symbol_from_definition` dispatch arms)
+  and seam 8 (the daemon-refresh cache-clear sweep call site); the Java inline extractor's
+  own line-level shape beyond its function names; anything about C# beyond the ledger's
+  secondhand `using Alias` note (PR #726 not yet merged — no code to cite).
+  Re-verify all of these — and every line number above — before citing them in a later
+  session; `repo_map.py` moves fast (~100+ lines/release, per `tensor-grep-run-and-operate`).
+- **Session ledger source**: `session_learnings_2026-07-24.md` (a scratch file, not a
+  permanent repo artifact) supplied the B1-B6/E1 framing and the C# node-shape lead; every
+  claim above was re-derived against the live repo rather than copied, and is cited to the
+  real file where it was possible to check.
+- If a re-verify disagrees with this skill, fix the skill — a wrong runbook is worse than
+  none — and route any actual code change through `tensor-grep-change-control`.

--- a/.claude/skills/tensor-grep-add-language/SKILL.md
+++ b/.claude/skills/tensor-grep-add-language/SKILL.md
@@ -27,7 +27,7 @@ backend contract.
 | Drain several language PRs that all touch `test_lang_registry.py` / `uv.lock` / the pyproject `ast` extra | `tensor-grep-change-control`'s Campaign Orchestration cross-ref (AGENTS.md A22) |
 | Use `tg` as a consumer (search/orient/callers flags) | `code-search-and-retrieval-reference` |
 
-## Current status (verified against v1.95.0 + #726, `origin/main`)
+## Current status (verified against tg v1.96.0-pending, `origin/main` @ `6c09424`)
 
 `repo_map.py` currently carries **8** `lang_registry.register_language(...)` call sites
 (`grep -n "register_language(" src/tensor_grep/cli/repo_map.py`): `python`, `javascript`,
@@ -93,17 +93,18 @@ calls `register_language(...)` is imported — a bare `import lang_registry` wit
 ## B2 — the critical seams (miss one = a silent half-integration)
 
 Enumerate every seam `lang_go.py` touches and hit **all** of them. These are re-verified
-`repo_map.py` locations on v1.95.0 — re-grep the symbol before trusting the line number on a
-later version (`main.py`/`repo_map.py` churn every release):
+`repo_map.py` locations on v1.96.0-pending (re-grepped fresh after PR #726/C# shifted every
+line below its insertion point by roughly +40) — re-grep the symbol before trusting the line
+number on a later version (`main.py`/`repo_map.py` churn every release):
 
 | # | Seam | Location | Feeds | Miss-it symptom |
 |---|---|---|---|---|
-| 1 | `lang_registry.register_language(LanguageSpec(...))` | `repo_map.py` (7 call sites, "near the bottom") | wiring the suffix at all | new suffix never resolves; silently excluded everywhere |
-| 2 | `_imports_and_symbols_for_path` | `repo_map.py:6204` | symbol/def extraction dispatch | new language absent from defs/symbols |
-| 3 | `_imports_with_lines_for_path` | `repo_map.py:6396` | `tg imports` (line-numbered import entries) | `tg imports` silently empty even though defs exist |
-| 4 | `build_symbol_source_from_map` | `repo_map.py:15752` | `tg source` | `tg source` returns nothing for a real symbol |
-| 5 | **`_target_language_for_path` — MOST-FORGOTTEN** | `repo_map.py:7323` | `tg agent` capsule's `primary_target_language` / confidence gate | a target file in the new language does not filter a mismatched-language validation suggestion |
-| 6 | `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` | `repo_map.py:16568` | gates whether `tg imports`/`tg importers` even attempts dependency resolution | file-dependency graph silently (but honestly, see B3) excludes the language |
+| 1 | `lang_registry.register_language(LanguageSpec(...))` | `repo_map.py` (8 call sites, "near the bottom") | wiring the suffix at all | new suffix never resolves; silently excluded everywhere |
+| 2 | `_imports_and_symbols_for_path` | `repo_map.py:6244` | symbol/def extraction dispatch | new language absent from defs/symbols |
+| 3 | `_imports_with_lines_for_path` | `repo_map.py:6440` | `tg imports` (line-numbered import entries) | `tg imports` silently empty even though defs exist |
+| 4 | `build_symbol_source_from_map` | `repo_map.py:15799` | `tg source` | `tg source` returns nothing for a real symbol |
+| 5 | **`_target_language_for_path` — MOST-FORGOTTEN** | `repo_map.py:7367` | `tg agent` capsule's `primary_target_language` / confidence gate | a target file in the new language does not filter a mismatched-language validation suggestion |
+| 6 | `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` | `repo_map.py:16617` | gates whether `tg imports`/`tg importers` even attempts dependency resolution | file-dependency graph silently (but honestly, see B3) excludes the language |
 
 Seam 5 is not a hypothesis — the live code says so in its own comments. Reading
 `_target_language_for_path` on `main` today:
@@ -124,20 +125,24 @@ if suffix == ".php":
     return "php"
 ```
 
-**Worked example that seam 6 is not theoretical — it is currently, honestly open for two
-shipped languages.** `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` on `main` today is
-`frozenset({"python", "javascript", "typescript", "rust", "java"})` — **`go` and `php` are
-registered languages with working defs/source/`_target_language_for_path` entries, but are
-NOT in this set.** `build_file_imports` (`tg imports`) checks
+**Worked example that seam 6 is not theoretical — it is currently, honestly open for THREE
+shipped languages, not just two.** `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` on `main` today is
+still `frozenset({"python", "javascript", "typescript", "rust", "java"})` — **`go`, `php`,
+AND `csharp` are all registered languages with working defs/source/
+`_target_language_for_path` entries, but NONE of the three are in this set** (re-verified
+after #726 landed: C# did not add itself here either, same gap as Go/PHP). `build_file_imports`
+(`tg imports`, `repo_map.py:16719`) checks
 `language_id in _SUPPORTED_FILE_DEPENDENCY_LANGUAGES`; when it's absent it does **not**
 silently return an empty import list — it sets `result_incomplete=True` and
-`incomplete_reason="'go' has no import-resolution support in \`tg imports\` yet"`
-(`repo_map.py`, `build_file_imports`, ~line 16714). This is the fail-closed contract (B3)
-holding even where seam 6 was genuinely missed for Go/PHP — a live example of the
-difference between "forgot a seam" (bad, silent) and "forgot a seam but the honesty floor
-caught it" (recoverable, visible). Closing this for `go`/`php` is a good first PR for
-whoever reads this skill next; the fix is a one-line frozenset addition plus whatever real
-import-path resolution the language needs behind it.
+`incomplete_reason="'go' has no import-resolution support in \`tg imports\` yet"` (same
+f-string shape for `php`/`csharp`). This is the fail-closed contract (B3) holding even where
+seam 6 was genuinely missed for three languages in a row — a live example of the difference
+between "forgot a seam" (bad, silent) and "forgot a seam but the honesty floor caught it"
+(recoverable, visible), and a reminder that copying an existing module (C# copied Go's shape
+closely) does not automatically close a gap the template itself never closed. Closing this
+for `go`/`php`/`csharp` is a good first PR for whoever reads this skill next; the fix is a
+one-line frozenset addition plus whatever real import-path resolution each language needs
+behind it.
 
 Two more seams exist beyond this table, found by reading `lang_go.py` itself rather than
 the ledger (not independently re-grepped against `repo_map.py`'s call sites this pass —
@@ -335,15 +340,18 @@ tg --version
 
 ## Provenance and maintenance
 
-- **Verified against tg v1.95.0 + PR #726** (`main` HEAD at authoring time; PR #726 merged
-  mid-authoring-pass and this skill was re-checked against it before finalizing, rather than
-  left stale). Ground truth read directly for this skill: `src/tensor_grep/cli/
-  lang_registry.py` (full file), `src/tensor_grep/cli/lang_go.py` (docstring +
-  parser/walk/seam functions), `src/tensor_grep/cli/lang_php.py` (docstring + `__all__`),
-  `src/tensor_grep/cli/lang_csharp.py` (the `using`-directive target-selection logic + its
-  own grammar-verification comment), the cited `repo_map.py` seam locations,
-  `pyproject.toml`'s `ast` extra, and `tests/unit/test_lang_registry.py` — all read live
-  from `origin/main` this pass, not carried over from a prior draft.
+- **Verified against tg v1.96.0-pending** (`main` HEAD `6c09424`, `pyproject.toml` still
+  stamps `1.95.0` since semantic-release derives the version at publish time — #726 is a
+  `feat:` commit, so the next publish is v1.96.0). PR #726 (C#) merged mid-authoring-pass;
+  this skill was re-checked against the real post-merge code TWICE — once when #726 first
+  landed, and again after every `repo_map.py` line number below shifted by roughly +40 on a
+  rebase — rather than left stale either time. Ground truth read directly for this skill:
+  `src/tensor_grep/cli/lang_registry.py` (full file), `src/tensor_grep/cli/lang_go.py`
+  (docstring + parser/walk/seam functions), `src/tensor_grep/cli/lang_php.py` (docstring +
+  `__all__`), `src/tensor_grep/cli/lang_csharp.py` (the `using`-directive target-selection
+  logic + its own grammar-verification comment), every cited `repo_map.py` seam location
+  (re-grepped fresh post-#726, not carried over), `pyproject.toml`'s `ast` extra, and
+  `tests/unit/test_lang_registry.py` — all read live from `origin/main` this pass.
 - **Not independently verified this pass**: the exact `repo_map.py` line numbers for seam 7
   (per-language `references_and_calls`/`file_imports_symbol_from_definition` dispatch arms)
   and seam 8 (the daemon-refresh cache-clear sweep call site); the Java inline extractor's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,12 @@ concrete failure observed this session.
   CLI-dispatcher misroute), which was then fixed and locked as a new permanent pinned task. Every real
   misroute found in the wild becomes a new permanent pinned task; this is a capability-regression gate,
   distinct from a contract test.
+- **A22 — Sequential-drain-union-rebase for N PRs on a shared file.** When several parallel PRs each
+  edit the SAME file (e.g. `test_lang_registry`, the pyproject `ast` extra, `uv.lock`), drain ONE at a
+  time and rebase each onto the prior, UNIONing the assertions (assert the FULL set, never
+  take-one-side). A CLEAN rebase (no conflict marker) is NOT proof of correctness — a silent auto-merge
+  dropped a `lang_*` import, caught only by re-running pytest (`ImportError`). ALWAYS re-run the test
+  suite after every rebase.
 
 ## Current Handoff
 
@@ -419,6 +425,58 @@ envelope embeds `mcp_contract_version` from the single `_TG_MCP_SERVER_CONTRACT_
 sites" bug class: the `tg_find` MCP PR (#627) shipped with an un-bumped contract version, caught only by
 the mandatory adversarial Opus gate, not by tests or CI.
 
+## Adding a Language (symbol-graph tier)
+
+tg's deep symbol-graph tier covers 8 of the top-10 languages (Python, JS, TS, Java,
+C#, Go, Rust, PHP; C/C++ deferred — priority per TIOBE Jul-2026 + Stack Overflow 2025
++ GitHub Octoverse 2025 consensus). Adding one is a **registration-completeness**
+problem (see the universal bug class above): the CURRENT pattern is
+`lang_registry.register_language(LanguageSpec(...))` plus a self-contained
+`src/tensor_grep/cli/lang_<x>.py` module mirroring `lang_go.py` — NOT the inline
+`_rust_*` / `_parser_for_source_suffix` machinery (that is the STALE style; Rust and
+Python predate the registry). Java used inline+registry (mirrors Rust); C# and PHP
+used module+registry (mirrors Go). Both are contract-consistent.
+
+**Five critical seams — miss one = a silent half-integration.** Enumerate the seams
+`lang_go.py` touches and hit ALL:
+
+1. `_imports_and_symbols_for_path` — `tg imports`.
+2. `_imports_with_lines_for_path` — `tg imports` line spans.
+3. `build_symbol_source_from_map` — `tg source`.
+4. `_target_language_for_path` — **MOST-FORGOTTEN.** Feeds the `tg agent` capsule
+   confidence gate; without it a Java target won't filter a mismatched Python/pytest
+   validation suggestion.
+5. `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES`.
+
+**Fail closed (per the Backend Fail-Closed Contract).** Grammar-missing → labeled gap
+(`provenance_when_missing="grammar-missing"`, NO regex fallback). Deferred caller-graph
+fields → explicit `None` → an honest `resolution_gaps` entry (treat zero as UNKNOWN,
+never silent proven-zero). Symbol-kind mapping:
+class/interface/struct/enum/record/trait → "class"; method/constructor/function →
+"function".
+
+**Live-verify the grammar node shapes** — dump the real tree-sitter AST, do not guess.
+e.g. C# `using Alias = Target;` puts the alias identifier BEFORE the target, so
+`_csharp_using_directive_target` must record the TARGET, not the alias.
+
+**Verify the plan against the real code before dispatch** (see "Verify AI-Drafted Plans
+Against the Real Code" below): a brief that says "mirror inline `_rust_*`" is STALE —
+all three build agents caught it against the grown `lang_registry`. Verify against
+CURRENT code, not a mental model.
+
+**Positioning (the tiered model):** text search = ANY language (rg passthrough);
+structural scan/rewrite = 26 langs (`tg ast-info`, via ast-grep which tg WRAPS); deep
+symbol-graph = the tree-sitter grammars (the 8 above). tg = rg (text) + ast-grep
+(structural) + a symbol/retrieval/capsule LAYER on top. NOT "faster grep."
+
+**Parallel-drain hygiene:** a new grammar touches `test_lang_registry`, the pyproject
+`ast` extra, and `uv.lock` — apply the uv.lock hand-splice (Local Dev Gotchas) and the
+A22 sequential-drain-union-rebase discipline (Campaign Orchestration Disciplines).
+
+See `.claude/skills/tensor-grep-add-language/SKILL.md` for the full registration
+checklist (field-by-field `LanguageSpec` reference, live-verified `repo_map.py` seam
+locations, and the deferred C/C++ scoping notes) — this section is the gist, not the copy.
+
 ## Dogfood the Real Binary, Not CliRunner
 
 The `tg` entry point is `tensor_grep.cli.bootstrap:main_entry`. It intercepts plain text searches and forwards them to ripgrep **before** the Typer app sees the argv. `CliRunner` invokes the Typer app directly and bypasses this front door entirely — so bugs in the bootstrap routing layer are invisible to unit tests.
@@ -544,12 +602,15 @@ Three kinds of skills apply to this repo; load the relevant one before non-trivi
   - `anti-hang-test-protocol` — hang-class test hygiene: wrap every test run in a shell timeout, and write the fix BEFORE the red-phase adversarial test (a ReDoS/deadlock red-test executed against un-fixed code IS the hang it is testing).
   - `instrumented-build-gate` — measure real demand before building a speculative feature.
   - `agent-liveness-probe` — before killing, restarting, or `TaskStop`-ing a background subagent that looks stalled, probe liveness via `SendMessage` rather than trusting output-file mtime/size (see A9 above).
+  - `profile-guided-byte-identical-optimization` — find a lever on the shipped wheel + prove output
+    byte-identical; the warm/cold measurement trap (see "Optimization Discipline" above).
   (the global-skill half of this list is manually maintained — no CI gate — diff it by hand against `CLAUDE.md`'s copy.)
-- **Carrying the project forward -- the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **26 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent -- this exact bucket list is kept byte-identical with `CLAUDE.md`'s skill index; `tests/unit/test_skill_index_sync.py` fails if either doc drifts from the real `.claude/skills/` folder set:
+- **Carrying the project forward -- the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **27 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent -- this exact bucket list is kept byte-identical with `CLAUDE.md`'s skill index; `tests/unit/test_skill_index_sync.py` fails if either doc drifts from the real `.claude/skills/` folder set:
   - **Change safely:** `tensor-grep-change-control` (the gates), `tensor-grep-debugging-playbook`, `tensor-grep-failure-archaeology` (don't re-fight settled battles), `tensor-grep-validation-and-qa`.
   - **Understand:** `tensor-grep-architecture-contract`, `code-search-and-retrieval-reference` (domain theory), `tensor-grep-config-and-flags`.
   - **Operate:** `tensor-grep-build-and-env`, `tensor-grep-run-and-operate`, `tensor-grep-diagnostics-and-tooling`, `tensor-grep-docs-and-writing`, `tensor-grep-release-and-positioning`, `tensor-grep-workspace-dogfood` (multi-repo stress dogfood), `tensor-grep-enterprise-agent` (enterprise readiness gaps + agent hard-stops), `tensor-grep-prepare` (one-call edit readiness), `tensor-grep-ledger` (advisory multi-agent claim/finding-reuse), `tensor-grep-find-and-route` (whole-repo hybrid find + route-test), `tensor-grep-multi-project-search` (scoped cross-repo search), `tensor-grep-enterprise-review-bundle` (review-bundle create/verify), `tensor-grep-gpu` (experimental GPU probes).
   - **Advance (SOTA):** `tensor-grep-semantic-search-campaign`, `tensor-grep-benchmark-and-proof-toolkit`, `tensor-grep-research-frontier`, `tensor-grep-research-methodology`, `tensor-grep-large-repo-scale-campaign` (bounding scale/deadline on large repos).
+  - **Extend:** `tensor-grep-add-language` (the symbol-graph language-onboarding checklist).
   - **Orchestrate:** `tensor-grep-backlog-campaign` (the multi-PR drain+build campaign playbook).
 - When working ON tensor-grep, use `tg search`/`tg defs`/`tg callers` for code navigation rather than generic grep/find — this exercises the tool's own surfaces and catches routing regressions early (mind the scoped-path workaround above).
 - `.claude/skill_rules.json` is Claude-Code harness config for the global `skill_activation_gate.py` hook (trigger keywords that auto-suggest a skill) — it is **not a product contract** and is invisible to `test_skill_index_sync.py` (it has no `SKILL.md`); update its per-skill trigger entries when a skill is added/renamed, but do not treat its content as authoritative over a skill's own frontmatter `description`.
@@ -740,6 +801,39 @@ Use these rules consistently:
 4. Do not update docs or the paper with speed claims until the benchmark line is accepted.
 5. If a candidate is correct but slower, revert it and record the attempt.
 
+## Optimization Discipline (how to discover a lever and PROVE equivalence)
+
+"Benchmark Rules" says which script to run; "Performance Discipline" sets the
+acceptance bar. This is the third layer: how to FIND a lever and prove an
+output-preserving optimization is byte-identical. See the global skill
+`profile-guided-byte-identical-optimization`.
+
+1. **Measure-first — never project.** Do not declare a surface "optimized-out" by
+   reasoning; measure it. A validation-scan lever was deferred as "no clean path" (only
+   a recall-risky `score>0` gate had been considered); a fresh profiling probe found a
+   BYTE-IDENTICAL substring pre-check that had been missed → shipped ~68% faster.
+2. **Profiling-probe.** cProfile the hot commands on the PUBLISHED wheel
+   (`uvx --from tensor-grep==<ver>`), rank hot fns by cumtime%, EXCLUDE already-shipped
+   work, hunt redundant-work levers (a file parsed/walked >once; N full-tree passes
+   mergeable into 1; an index rebuilt per call). Output ranked levers with `file:line`
+   + measured %. An empty result is an honest null (valuable).
+3. **Byte-identical PROOF (load-bearing).** When merging/skipping work, prove output
+   byte-identical TWO ways: (a) ENUMERATE every producer/branch and argue exhaustiveness
+   (AST node types are mutually exclusive; a token is always a substring of its string;
+   candidate names ⊆ file text ⇒ no-term-in-text ⇒ bonus 0); (b) DIFFERENTIAL FUZZ —
+   run OLD-vs-NEW over N real files, assert 0 mismatches (386-file / 26-case receipts).
+   An INDEPENDENT Opus gate is the proof-of-record; a build agent's self-verify is a
+   hypothesis.
+4. **Warm dogfood HIDES a cold-path win.** A warm end-to-end run measures the CACHED
+   path where the optimized fn doesn't run → false read (`tg orient` warm dogfood read
+   −36% on a fn that is actually ~54% FASTER). To verify a cold-path optimization:
+   microbench the FUNCTION directly (isolate the change) OR clear the cache between
+   reps. NEVER a warm end-to-end run.
+5. **Microbench on the SHIPPED wheel.** Isolate the target fn on the published wheel,
+   single pass over DISTINCT inputs (fresh process = cold cache), old-vs-new + assert
+   OUTPUT-IDENTITY (`total == total` both sides = byte-identical AND faster). Receipts:
+   ast.walk-merge 961→446 ms (~54%); validation-scan 3657→1172 ms (~68%).
+
 ## CI / Release Rules
 
 CI is not just a test runner. It enforces:
@@ -764,6 +858,12 @@ below the patch on a future bare resolve. Regenerate the lockfile, then re-run t
 surface unmodified (`tests/unit/test_mcp_server.py`, `tests/unit/test_mcp_tg_find.py`,
 `tests/integration/test_mcp_stdio_protocol.py`, `tests/unit/test_harness_api_docs.py`) — a passing
 dependency bump with zero code changes is the expected GOOD outcome, not a reason to skip verification.
+
+(h) **Rustup's PINNED-toolchain fetch has NO retry (#720-#722).** `rust_core/rust-toolchain.toml`
+pins a version, so `cargo test` triggers an on-demand rustup toolchain fetch — and unlike
+Setup-Rust's `curl | sh` (`--retry 10`), rustup's own toolchain download is not retried, so a
+macOS runner network blip flakes the job (#720/#721). Pre-fetch the pinned toolchain in a 3×
+retry loop in the Setup Rust step (#722).
 
 Any Rust helper reachable only from a `#[cfg(feature = "cuda")]`-gated test must be re-gated
 `#[cfg(any(feature = "cuda", test))]` -- co-gating every helper it transitively calls -- instead of
@@ -905,6 +1005,19 @@ Small, non-obvious traps that have each cost a real cycle on this desktop. None 
 - **A stray `nul` file in the tree is a Windows `2>nul` redirect artifact.** Use `2>$null` (PowerShell) or `2>/dev/null` (bash); clean up with `rm -f ./nul`.
 - **CRLF makes a local bare `ruff format --check` false-alarm** over LF-committed blobs. Run `ruff format --preview <files>` (which normalizes) before commit — see "Required Local Validation" for why `--preview` is mandatory and must never be passed to `ruff check`.
 - **The full local gate is four steps, not two — and re-run them after your LAST edit.** `ruff check` + `pytest` passing is NOT green: the CI "Formatting & Linting" job also runs `ruff format --check --preview .` (a *formatter*, distinct from the `ruff check` *linter* — a post-edit line-wrap or over-long comment passes `ruff check` but fails `ruff format --check`) AND `mypy src/tensor_grep` (catches type errors nothing else flags, e.g. assigning to a `Final` attribute like click's `UsageError.message` — mutate it and mypy errors; raise a fresh `UsageError(...)` instead). Running only `ruff check` + `pytest` — or running the gate before an *intermediate* edit that a later edit then invalidates — cost two drain-blocking CI failures in a single session (a mypy `Final`-assign and a `ruff format` line-wrap). Run all four (`ruff check` · `ruff format --check --preview` · `mypy src/tensor_grep` · `pytest`) on the touched files AFTER the final edit.
+- **Editing a CRLF file in text mode flips every line ending.** Python
+  `open(path, newline="\n")` (or any text-mode write) on a CRLF-committed file
+  (`ci.yml`, `uv.lock` are CRLF) rewrites ALL line endings — an 11-line change becomes
+  a 1443-line diff. Fix: BINARY read (`rb`) + byte-replace preserving `\r\n` + binary
+  write (`wb`). Same failure one layer down from the `ruff format --check` CRLF
+  false-alarm above.
+- **`uv lock` churns ~280 unrelated lines; hand-splice a new dep instead.** A raw
+  `uv lock` reformats GPU/CUDA marker exprs (local-vs-CI uv-version mismatch). For a new
+  dependency, hand-splice ONLY its `[[package]]` block (alphabetical) plus its
+  requires-dist / optional-dependency refs. VERIFY with
+  `uv export --format requirements.txt --all-extras --no-emit-project --locked` (must
+  exit 0) — the exact `audit.yml` "Dependency & License Audit" gate that reddens every
+  new-dep PR.
 
 ## Documentation Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,23 +55,31 @@ Claude Code guidance for the **tensor-grep** repository.
   scheduler-independent concurrency tests, independent-gate-is-a-hypothesis, gate-nit folding,
   published-wheel closing dogfood, and the loop-4 accuracy gate (A13-A21) — are in `AGENTS.md`'s full
   list; this bullet is the gist, not the copy.
+- **Adding a Language** — the `lang_registry.register_language` + `lang_<x>.py` module
+  pattern (mirror `lang_go.py`, not inline `_rust_*`) and the 5 critical seams
+  (most-forgotten: `_target_language_for_path`, the capsule confidence gate).
+- **Optimization Discipline** — measure-first, cProfile the shipped wheel, byte-identical
+  PROOF (enumerate + differential-fuzz), and the warm-dogfood-hides-a-cold-path-win trap.
 - The ruff `--preview` (format only, not lint), line-ending, decode-the-structured-CI-failure-first,
   and release rules.
 
 ## Skills that apply here
 
 - **Using `tg`**: `.claude/skills/tensor-grep/SKILL.md` (+ `REFERENCE.md`).
-- **Carrying the project forward -- the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **26 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent -- this exact bucket list is kept byte-identical with `AGENTS.md`'s skill index; `tests/unit/test_skill_index_sync.py` fails if either doc drifts from the real `.claude/skills/` folder set:
+- **Carrying the project forward -- the in-repo skill library** (`.claude/skills/tensor-grep-*` + `code-search-and-retrieval-reference`, **27 skills**): the onboarding handbook so a new engineer or a Sonnet-class session can debug, extend, validate, and advance `tg` without the original authors. Each auto-loads by its `description`; load the one matching your task. Index by intent -- this exact bucket list is kept byte-identical with `AGENTS.md`'s skill index; `tests/unit/test_skill_index_sync.py` fails if either doc drifts from the real `.claude/skills/` folder set:
   - **Change safely:** `tensor-grep-change-control` (the gates), `tensor-grep-debugging-playbook`, `tensor-grep-failure-archaeology` (don't re-fight settled battles), `tensor-grep-validation-and-qa`.
   - **Understand:** `tensor-grep-architecture-contract`, `code-search-and-retrieval-reference` (domain theory), `tensor-grep-config-and-flags`.
   - **Operate:** `tensor-grep-build-and-env`, `tensor-grep-run-and-operate`, `tensor-grep-diagnostics-and-tooling`, `tensor-grep-docs-and-writing`, `tensor-grep-release-and-positioning`, `tensor-grep-workspace-dogfood` (multi-repo stress dogfood), `tensor-grep-enterprise-agent` (enterprise readiness gaps + agent hard-stops), `tensor-grep-prepare` (one-call edit readiness), `tensor-grep-ledger` (advisory multi-agent claim/finding-reuse), `tensor-grep-find-and-route` (whole-repo hybrid find + route-test), `tensor-grep-multi-project-search` (scoped cross-repo search), `tensor-grep-enterprise-review-bundle` (review-bundle create/verify), `tensor-grep-gpu` (experimental GPU probes).
   - **Advance (SOTA):** `tensor-grep-semantic-search-campaign`, `tensor-grep-benchmark-and-proof-toolkit`, `tensor-grep-research-frontier`, `tensor-grep-research-methodology`, `tensor-grep-large-repo-scale-campaign` (bounding scale/deadline on large repos).
+  - **Extend:** `tensor-grep-add-language` (the symbol-graph language-onboarding checklist).
   - **Orchestrate:** `tensor-grep-backlog-campaign` (the multi-PR drain+build campaign playbook).
 - **Build/release discipline** (global, `~/.claude/skills/`): `dogfood-the-shipped-artifact`,
   `verify-plan-against-code`, `supply-chain-hardening`, `worktree-fanout-verification-gate`,
   `anti-hang-test-protocol` (hang-class test hygiene: shell-timeout + fix-before-red-test),
   `instrumented-build-gate` (measure demand before building a speculative feature),
-  `agent-liveness-probe` (probe via `SendMessage` before killing/`TaskStop`-ing a stalled subagent).
+  `agent-liveness-probe` (probe via `SendMessage` before killing/`TaskStop`-ing a stalled subagent),
+  `profile-guided-byte-identical-optimization` (find a lever on the shipped wheel + prove
+  output byte-identical; the warm/cold measurement trap).
 - **Post-release dogfood harness**: `scripts/dogfood/`.
 - `.claude/skill_rules.json` is harness config for the skill-activation hook, not a product contract —
   it has no `SKILL.md` and is invisible to `test_skill_index_sync.py`.


### PR DESCRIPTION
## Summary

Docs-only PR. Folds this session's verified engineering learnings (`session_learnings_2026-07-24.md`) into `AGENTS.md` / `CLAUDE.md`, and registers a new in-repo skill. Implements **SECTION 1, SECTION 2, and SECTION 4b** of the capture plan (SECTION 3 and SECTION 4a — the per-skill staleness sweep and the global `profile-guided-byte-identical-optimization` skill body — are owned by sibling agents).

No `src/` changes. No Rust/cargo builds. No `~/.claude/skills` changes.

## Applied

**AGENTS.md**
- New `## Adding a Language (symbol-graph tier)` section — the `lang_registry.register_language` + `lang_<x>.py` module pattern, the 5 critical seams (most-forgotten: `_target_language_for_path`), the fail-closed contract, live-verify-grammar-node-shapes.
- New `## Optimization Discipline` section — measure-first, profiling-probe, byte-identical proof (enumerate + differential-fuzz), the warm-dogfood-hides-a-cold-path-win trap, shipped-wheel microbench.
- 2 new **Local Dev Gotchas** bullets — CRLF-binary-preserve edit; `uv.lock` hand-splice + `uv export --locked` verify.
- New **`(h)`** CI/Release Rules supply-chain bullet — rustup's pinned-toolchain fetch has no retry (#720-#722).
- New **`A22`** Campaign Orchestration bullet — sequential-drain-union-rebase for N PRs sharing a file (`test_lang_registry`, the pyproject `ast` extra, `uv.lock`); a clean rebase is not proof of correctness.
- Registered `tensor-grep-add-language` in the `## Skills` section (bumped **26 → 27 skills**) under a new **Extend:** bucket, and mirrored the new global `profile-guided-byte-identical-optimization` skill into AGENTS.md's own manually-synced global-skill list (its own text says to keep that in sync "by hand" with CLAUDE.md).

**CLAUDE.md**
- 2 new DRY-pointer bullets (Adding a Language; Optimization Discipline).
- In-repo skill-library bullet: **26 → 27 skills**, new **Extend:** bucket with `tensor-grep-add-language`.
- Global build/release skill list: added `profile-guided-byte-identical-optimization`.

**`.claude/skill_rules.json`**
- Added 3 trigger entries: `tensor-grep-add-language`, `profile-guided-byte-identical-optimization`, `tensor-grep-large-repo-scale-campaign` (the last had zero prior rule).

**New skill** — `.claude/skills/tensor-grep-add-language/SKILL.md` (363 lines, condensed from a 31KB draft)
- Every seam claim re-derived against the live repo this pass (`lang_registry.py` full file, `lang_go.py`, `lang_php.py`, `lang_csharp.py`, the cited `repo_map.py` seam locations, `pyproject.toml`'s `ast` extra, `tests/unit/test_lang_registry.py`), not copied from the draft or the ledger.
- Encodes B1 (registry + module pattern), B2 (the 5 seams), B3 (fail-closed contract), B4 (verify-plan-against-code), B5 (live-verify grammar node shapes — including a verified C# aliased-`using` example), B6 (tiered model), E1 (top-10 priority, C/C++ now the sole deferred item).
- `Verified against tg v1.95.0 + PR #726` provenance line + a validation section (extend `test_lang_registry.py`, fixture/parity dogfood, live capsule check for `_target_language_for_path`).
- A live, currently-true finding surfaced by reading the real code (not in the source ledger): `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` (`repo_map.py:16568`) does not yet include `go`/`php` despite both being registered languages — `tg imports` on those files honestly reports `result_incomplete` rather than a silent lie, and closing it is flagged as a good first follow-up PR.

## Deviations from the plan (verified against real code, not trusted blindly)

- **A9 → A22, `(g)` → `(h)`**: the plan's raw numbering had drifted — `AGENTS.md` already had `A1`-`A21` and CI/Release items `(a)`-`(g)` on `main`, so the new bullets use the next free label instead of colliding.
- **1f skipped**: the plan wanted to append a `release-tag-smoke` JOB-conclusion check to push-race step 7 — that check already exists verbatim as step 8 on `main`. No-op, not applied twice.
- **`release_docs_current_tag`**: already `v1.95.0` on `main` (the plan assumed a stale `v1.74.0`). No change needed.
- **Skill count**: `AGENTS.md`/`CLAUDE.md` already said "26 skills" (not the plan's assumed "16 skills") and the bucket list already enumerated all 27 real folders (26 bucketed + the standalone `tensor-grep` usage skill). Only the +1 bump for the new skill was needed.
- **PR #726 (C#) merged mid-flight**: while this PR was open, `#726` (C# symbol/import intelligence) landed on `main`. Rebased via a real merge commit (not a force-push) and re-verified the new skill's C# references against the actual `src/tensor_grep/cli/lang_csharp.py` rather than leaving them as a secondhand "PR not yet merged" caveat — see the second commit. Symbol-graph tier is now genuinely 8 of top-10 on `main`.

## Governance / validation

- `tests/unit/test_skill_index_sync.py` — the gate that fails if `AGENTS.md`/`CLAUDE.md`'s Skills sections drift from the real `.claude/skills/*/SKILL.md` folder set, or from each other. **4/4 passed** after these edits.
- `tests/unit/test_public_docs_governance.py` — the broader content-pinning suite over `AGENTS.md`/`SKILL.md`/etc. **All 47 tests (both files) passed.**
- `python -c "import json; json.load(open('.claude/skill_rules.json'))"` — **exits 0.**
- `grep -rn skill_rules tests/` and `.github/` — **zero matches.** `.claude/skill_rules.json` is not referenced by any test or workflow gate; it's harness-only config, exactly as `AGENTS.md`/`CLAUDE.md` already document. No governance gate needed reconciling beyond `test_skill_index_sync.py`.
- New skill's YAML frontmatter — verified with `yaml.safe_load` after fixing one bug: my first draft description had an unquoted `keywords:` colon inside a plain scalar, which is invalid YAML. Fixed by rephrasing (`Triggers and keywords include...`). Note for context: 3 *existing* sibling skills already carry this same latent issue (`tensor-grep-backlog-campaign`, `-release-and-positioning`, `-research-frontier`) — not caused by this PR, not fixed here (out of scope), but worth flagging since nothing currently enforces strict YAML on this repo's skill frontmatter.
- `ruff format --check --preview` on all 4 touched files — clean. `.claude/skills/` is excluded from ruff entirely via `pyproject.toml`'s `extend-exclude` (skill docs are prose). `.claude/skill_rules.json` is outside ruff's real file-discovery scope for the whole-repo `ruff format --check --preview .` gate (verified: the JSON file only "would reformat" when named explicitly on the command line, bypassing discovery — the actual CI-equivalent whole-repo run does not touch it). The whole-repo run does flag 4 **pre-existing, unrelated** `docs/*.md` files (not part of this diff) — FYI only, out of scope for a docs-only skills PR.

## Test plan

- [x] `python -m pytest tests/unit/test_skill_index_sync.py -v` — 4 passed
- [x] `python -m pytest tests/unit/test_public_docs_governance.py -q` — 47 passed
- [x] `python -c "import json; json.load(open('.claude/skill_rules.json'))"` — exits 0
- [x] `ruff format --check --preview AGENTS.md CLAUDE.md .claude/skill_rules.json .claude/skills/tensor-grep-add-language/SKILL.md` — clean
- [ ] Independent Opus review (per campaign discipline — mandatory before merge)
- [ ] Merge only after the current release pipe (v1.95.0 chore(release) + PyPI) has fully published, per the push-race rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
