### PR TITLE
feat(lang): add C symbol + import intelligence (foundational tier, #include honest-unresolved)

### DIFF
--- a/.claude/skills/tensor-grep-add-language/SKILL.md
+++ b/.claude/skills/tensor-grep-add-language/SKILL.md
@@ -106,10 +106,25 @@ version (`main.py`/`repo_map.py` churn every release):
 | 2 | `_imports_and_symbols_for_path` | `repo_map.py:6244` | symbol/def extraction dispatch | new language absent from defs/symbols |
 | 3 | `_imports_with_lines_for_path` | `repo_map.py:6440` | `tg imports` (line-numbered import entries) | `tg imports` silently empty even though defs exist |
 | 4 | `build_symbol_source_from_map` | `repo_map.py:15815` | `tg source` | `tg source` returns nothing for a real symbol |
-| 5 | **`_target_language_for_path` — MOST-FORGOTTEN** | `repo_map.py:7383` | `tg agent` capsule's `primary_target_language` / confidence gate | a target file in the new language does not filter a mismatched-language validation suggestion |
+| 5a | **`_target_language_for_path` — MOST-FORGOTTEN** | `repo_map.py:7383` | `tg agent` capsule's `primary_target_language` / confidence gate | a target file in the new language does not filter a mismatched-language validation suggestion |
+| 5b | **`_provider_language_for_path` — a SIBLING seam, easy to miss because 5a's own comments never mention it** | `repo_map.py:14711` | the LSP-provider language dispatch (sits just above `_path_from_lsp_file_uri`/`_lsp_symbol_kind_name` — a DIFFERENT purpose than 5a's symbol-graph capsule gate, but it must resolve the SAME `language_id` for any suffix a `LanguageSpec` registers) | `test_target_and_provider_language_agree_with_registry` (below) fails loudly for the new suffix; less obviously, an LSP-provider code path silently disagrees with the symbol graph about what language a file is |
 | 6 | `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` | `repo_map.py:16633` | gates whether `tg imports`/`tg importers` even attempts dependency resolution | file-dependency graph silently (but honestly, see B3) excludes the language |
 
-Seam 5 is not a hypothesis — the live code says so in its own comments. Reading
+**Seam 5b is easy to miss precisely because seam 5a's own code comments never mention it** —
+unlike every other seam in this table, nothing in `_target_language_for_path` points you at
+`_provider_language_for_path`. The two functions serve different callers (5a feeds the agent
+capsule's confidence gate; 5b feeds the LSP-provider dispatch, e.g. clangd-via-LSP for a
+language whose symbol-graph tier is only foundational or absent) but **both must return the
+SAME `language_id` for every suffix a `LanguageSpec` registers**, or the dynamic parity test
+below fails. `_provider_language_for_path` sometimes ALREADY recognizes a suffix before its
+`LanguageSpec` is registered (a latent pre-wiring, not a bug) — e.g. it independently maps
+`.c`/`.cc`/`.cpp`/`.cxx`/`.h`/`.hh`/`.hpp`/`.hxx` to `"c"`/`"cpp"` for the LSP provider even
+before a C or C++ `LanguageSpec` exists — which means the CHOICE of `language_id` for a new
+language is not always free: check `_provider_language_for_path` for an existing mapping
+BEFORE naming your new `LanguageSpec.language_id`, or the two functions will disagree the
+moment you register it.
+
+Seam 5a is not a hypothesis — the live code says so in its own comments. Reading
 `_target_language_for_path` on `main` today:
 
 ```text
@@ -127,6 +142,11 @@ if suffix == ".php":
     # MOST-FORGOTTEN seam (see the ".go" branch above) -- same fix, same reason...
     return "php"
 ```
+
+Seam 5b has NO equivalent per-branch comment on `main` today — it is a plain suffix
+dispatch (`repo_map.py:14711-14739`) with no "MOST-FORGOTTEN"-style warning attached to any
+of its branches, which is exactly why it is the one this skill itself omitted until this
+pass: nothing in the code nudges you toward it the way seam 5a's comments do.
 
 **Worked example, UPDATED after PR #728 — seam 6 was closed for go/php/csharp, but only at
 the FOUNDATIONAL tier, not full resolution; re-read this before assuming "in the frozenset"
@@ -337,7 +357,11 @@ rule, not specific to language PRs.
   already carries the pattern a new language must fit: `test_spec_for_path_resolves_every_
   registered_suffix`, `test_language_registry_has_exactly_the_stage2_languages` (the
   union-pin set — add your `language_id` here), `test_target_and_provider_language_agree_
-  with_registry`, and the `test_*_provenance_is_tree_sitter_when_grammar_present` /
+  with_registry` (this ONE dynamic test pins BOTH seam 5a `_target_language_for_path` AND
+  seam 5b `_provider_language_for_path` at once — it iterates every registered `LanguageSpec`
+  and asserts both functions return that spec's own `language_id` for each of its suffixes,
+  so it fails loudly if you wire only one of the pair), and the
+  `test_*_provenance_is_tree_sitter_when_grammar_present` /
   `test_grammar_absent_monkeypatch_*_provenance_flips_to_grammar_missing` pair (17 tests
   total as of this writing — `grep -c "def test_" tests/unit/test_lang_registry.py`).
 - **Fixture/parity dogfood**: write a minimal real-world-shaped fixture file in the new
@@ -363,9 +387,10 @@ uv run python -c "from tensor_grep.cli import lang_registry, repo_map; print(sor
 # Does a suffix resolve, and what does provenance_when_missing say?
 uv run python -c "from tensor_grep.cli import lang_registry, repo_map; s = lang_registry.spec_for_path('x.go'); print(s.language_id, s.provenance_when_missing)"
 
-# Re-derive the current registered-language set + re-locate the 5 seams before citing a line number
+# Re-derive the current registered-language set + re-locate the 6 seams (5a+5b count as two)
+# before citing a line number
 grep -n "register_language(" src/tensor_grep/cli/repo_map.py
-grep -n "^def _imports_and_symbols_for_path\|^def _imports_with_lines_for_path\|^def build_symbol_source_from_map\|^def _target_language_for_path\|_SUPPORTED_FILE_DEPENDENCY_LANGUAGES" src/tensor_grep/cli/repo_map.py
+grep -n "^def _imports_and_symbols_for_path\|^def _imports_with_lines_for_path\|^def build_symbol_source_from_map\|^def _target_language_for_path\|^def _provider_language_for_path\|_SUPPORTED_FILE_DEPENDENCY_LANGUAGES" src/tensor_grep/cli/repo_map.py
 
 # Version identity
 tg --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -597,7 +597,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "pyarrow>=23.0.1"]
 gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "tree-sitter-c-sharp", "pygls>=2.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "tree-sitter-c-sharp", "tree-sitter-c", "pygls>=2.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline
@@ -628,6 +628,7 @@ dev = [
   "tree-sitter-java",
   "tree-sitter-php",
   "tree-sitter-c-sharp",
+  "tree-sitter-c",
   "types-PyYAML",
 ]
 bench = [
@@ -642,6 +643,7 @@ bench = [
   "tree-sitter-java",
   "tree-sitter-php",
   "tree-sitter-c-sharp",
+  "tree-sitter-c",
   "torch>=2.0",
   "nvtx>=0.2",
 ]

--- a/src/tensor_grep/cli/lang_c.py
+++ b/src/tensor_grep/cli/lang_c.py
@@ -1,0 +1,494 @@
+"""C language extractor for tensor-grep's multi-language symbol graph (PATH A Stage 3).
+
+Ninth language expansion (top-10 language-support campaign, Phase 1 of C/C++ -- C++ is a
+SEPARATE follow-up, out of scope here). Sibling of ``lang_go.py``/``lang_csharp.py``/
+``lang_php.py`` (see those modules' docstrings for the full "PATH A Stage 1" framing). Plugs
+into the ``lang_registry`` seam Stage 0 built (see ``lang_registry.py`` + the
+``lang_registry.register_language(...)`` calls near the bottom of ``repo_map.py``) -- C gets its
+OWN ``LanguageSpec`` entry, registered from ``repo_map.py``.
+
+FOUNDATIONAL SCOPE (same tier Java/PHP/C#/Go landed at): this module lights up
+``defs``/``source``/``imports``/``agent`` for ``.c`` files -- function definitions AND
+prototypes (kind "function"), struct/union/enum definitions (kind "class", per the fail-closed
+struct/union/enum -> "class" mapping this campaign's other languages already use), and typedefs
+(kind "type", mirroring Go's ``type_spec`` -> "type" kind). The cross-file caller-graph
+(``references_and_calls``/``file_imports_symbol_from_definition``/``import_update_target``/
+``prime_repo_context``) is DEFERRED to a follow-up -- this module registers all four of those
+``LanguageSpec`` fields as ``None``, exactly like PHP's own precedent. ``tg refs``/``tg
+callers``/``tg blast-radius`` on a C symbol fall through to the generic
+``_regex_references_and_calls`` text-heuristic path in repo_map.py (never a crash, never a
+fabricated AST-verified match) -- unaffected by this module.
+
+``.h`` is DELIBERATELY NOT claimed by this module. ``_provider_language_for_path`` (the LSP
+provider dispatch, repo_map.py) already assigns every C/C++ header suffix (``.h``, ``.hh``,
+``.hpp``, ``.hxx``) to ``"cpp"`` -- since tree-sitter-cpp is a strict grammar superset of C, a
+future ``lang_cpp.py`` (Phase 2, not built here) is the natural owner of ``.h`` so that pure-C
+headers still parse under the C++ grammar. Registering ``.h`` here too would make this module's
+``language_id="c"`` disagree with that pre-existing "cpp" assignment and fail
+``test_target_and_provider_language_agree_with_registry``.
+
+FAIL-CLOSED CONTRACT (Stage 0 honesty floor, extended here exactly as it was for Go/PHP/C#): C
+has NO regex-heuristic fallback. When the ``tree_sitter_c`` grammar package is not installed,
+every extractor in this module returns empty ([]/([], [])) rather than degrading to a regex/text
+heuristic (unlike JS/TS/Rust, which all fall back to regex extraction when their own tree-sitter
+grammar is missing). ``LanguageSpec.provenance_when_missing="grammar-missing"`` (NOT
+``"regex-heuristic"``) is what makes ``_language_coverage_gaps_for_universe`` in repo_map.py
+treat a grammar-absent C file as a genuine ``resolution_gaps`` entry instead of silently
+reporting zero matches as if the symbol just did not exist.
+
+``#include`` IS a parse-tree node (tree-sitter-c does not run a preprocessor, so it never strips
+or expands a ``#include`` directive) -- ``preproc_include`` with a ``path`` field whose node
+SHAPE varies by include form (live-verified against a real tree_sitter_c 0.24.2 parse, not
+guessed from the grammar README):
+  ``#include <stdio.h>``     -> path field type ``system_lib_string``, text ``"<stdio.h>"``
+  ``#include "local.h"``     -> path field type ``string_literal``, nested ``string_content``
+  ``#include MACRO_HEADER``  -> path field type ``identifier`` (macro-expanded form)
+  ``#include COMBINE(a,b)``  -> path field type ``call_expression`` (macro-combined form)
+``_c_include_target_text`` strips the ``<...>``/``"..."`` delimiters where present so the
+recorded ``module`` string is the bare target (``"stdio.h"``, not ``"<stdio.h>"``), matching how
+every other language's extractor here records a delimiter-free module string. Resolution stays
+HONEST-UNRESOLVED: repo_map.py's ``_resolve_raw_import_entry`` reports every row
+``resolved=None, external=False`` (never a fabricated path, never a fabricated ``external=True``)
+-- true ``#include`` -> file resolution has no standardized C manifest to resolve against (no
+``go.mod``/``composer.json``/``.csproj`` equivalent) and stays deferred to BACKLOG, same as the
+go/php/csharp resolvers.
+
+DECLARATOR NAME RESOLUTION (the one genuinely new wrinkle vs Go/PHP/C#): a C declarator can nest
+a name arbitrarily deep -- ``int *make_ptr(void)`` wraps ``function_declarator`` inside
+``pointer_declarator``; ``typedef void (*FuncPtr)(int);`` wraps a ``parenthesized_declarator``
+(exposing NO named "declarator" field of its own, unlike every other wrapper) around a
+``pointer_declarator`` around the ``type_identifier`` leaf. ``_c_declarator_name_node`` handles
+both: it follows the named "declarator" field where one exists, and falls back to the single
+NAMED child when a wrapper (like ``parenthesized_declarator``) exposes none. Live-verified against
+real parses of plain/pointer/array/function-pointer declarators (including the
+``typedef char *(*ComplexFuncPtr)(int, char);`` double-wrap case) before being written here --
+see the module's originating PR description for the exact fixtures probed.
+
+A ``declaration`` node is ambiguous by TYPE ALONE -- it is a function PROTOTYPE
+(``int add(int a, int b);``) or a plain variable declaration (``int counter = 0;``,
+``extern int flag;``) depending purely on whether its declarator chain passes through a
+``function_declarator``. ``_c_declarator_name_node`` also returns that boolean so the extractor
+can gate: only a ``declaration`` whose chain passed through ``function_declarator`` is emitted
+(as kind "function"); a plain variable declaration is silently excluded from the symbol table,
+matching this module's foundational scope (top-level variables are not a tracked symbol kind
+here, mirroring every other ``lang_*.py`` module -- none of them track module-level variables
+either, except Go's explicit ``const_spec``/``var_spec`` kinds, which this module does not add).
+A ``struct_specifier``/``union_specifier``/``enum_specifier`` is similarly ambiguous by type
+alone -- ``struct Foo;`` (forward declaration) and ``struct Foo *p`` (usage as a type) both parse
+as the SAME node type with no ``body`` field, indistinguishable from a real definition except by
+checking for a ``body`` field's presence -- only a body-bearing specifier is emitted.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Duplicated tiny helpers -- see the module docstring: no import from repo_map.py, to avoid an
+# import cycle (repo_map.py imports THIS module). Keep byte-identical to repo_map.py's twins
+# (``_tree_sitter_node_text`` / ``_is_clean_symbol_name`` / ``_symbol_record``) -- and to
+# ``lang_go.py``/``lang_csharp.py``/``lang_php.py``'s own copies of the same three -- if any of
+# them ever change there.
+# ---------------------------------------------------------------------------
+
+_CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _is_clean_symbol_name(name: str) -> bool:
+    return bool(_CLEAN_SYMBOL_NAME_RE.match(name))
+
+
+def _tree_sitter_node_text(source_bytes: bytes, node: Any) -> str:
+    return source_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _symbol_record(
+    *,
+    name: str,
+    kind: str,
+    file: Path,
+    start_line: int,
+    end_line: int | None = None,
+) -> dict[str, Any]:
+    normalized_end_line = start_line if end_line is None else end_line
+    return {
+        "name": name,
+        "kind": kind,
+        "file": str(file),
+        "line": start_line,
+        "start_line": start_line,
+        "end_line": normalized_end_line,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parser factory (clone of lang_go.py's ``_go_parser`` shape).
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _c_parser() -> Any | None:
+    try:
+        import tree_sitter
+        import tree_sitter_c
+    except ImportError:
+        return None
+
+    language = tree_sitter.Language(tree_sitter_c.language())
+    return tree_sitter.Parser(language)
+
+
+# ---------------------------------------------------------------------------
+# Defs + imports: one tree-sitter pass per file.
+# ---------------------------------------------------------------------------
+
+# struct/union/enum specifiers collapse to kind "class" -- the fail-closed cross-language mapping
+# this campaign's other struct-bearing languages already use (C#'s own struct/interface/enum ->
+# "class" precedent).
+_C_CLASS_LIKE_KINDS = frozenset({"struct_specifier", "union_specifier", "enum_specifier"})
+# Node types a C def can appear as -- informational/documentation only (mirrors
+# lang_go._GO_DEF_NODE_KINDS' role), matching LanguageSpec.def_node_kinds' "Stage 0:
+# informational only" contract.
+_C_DEF_NODE_KINDS = (
+    "function_definition",
+    "declaration",
+    "struct_specifier",
+    "union_specifier",
+    "enum_specifier",
+    "type_definition",
+)
+# _c_declarator_name_node's backstop hop limit: no real C declarator nests anywhere close to this
+# deep (the deepest live-verified fixture -- `typedef char *(*ComplexFuncPtr)(int, char);`, a
+# pointer-returning function-pointer typedef -- took 5 hops: pointer_declarator ->
+# function_declarator -> parenthesized_declarator -> pointer_declarator -> type_identifier); this
+# only guards against an unforeseen future grammar cycle, never hit in practice.
+_MAX_DECLARATOR_HOPS = 64
+
+
+def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
+    """Descend a declarator chain to its innermost identifier/type_identifier NAME node, tracking
+    whether the chain passed through a ``function_declarator`` along the way.
+
+    Live-verified against real tree_sitter_c 0.24.2 parses (see the module docstring's
+    "DECLARATOR NAME RESOLUTION" section) across every shape this module's callers hit:
+    plain (``identifier``/``type_identifier`` directly), pointer (``pointer_declarator``),
+    array (``array_declarator``), function (``function_declarator``, whose OWN "declarator"
+    field is the plain name), pointer-to-function (``pointer_declarator`` wrapping
+    ``function_declarator``), and the function-pointer typedef's ``parenthesized_declarator``
+    (which, uniquely among these, exposes NO named "declarator" field -- the loop falls back to
+    the wrapper's single NAMED child, which resolves through to the inner
+    ``pointer_declarator``/name).
+
+    Returns ``(None, seen_function)`` if no name-bearing leaf was found (e.g. an abstract
+    declarator with no name, such as a bare ``void`` parameter) -- callers must check for
+    ``None`` before using the result.
+    """
+    seen_function = False
+    current = declarator
+    hops = 0
+    while current is not None and hops < _MAX_DECLARATOR_HOPS:
+        hops += 1
+        if current.type in {"identifier", "type_identifier", "field_identifier"}:
+            return current, seen_function
+        if current.type == "function_declarator":
+            seen_function = True
+        next_node = current.child_by_field_name("declarator")
+        if next_node is not None:
+            current = next_node
+            continue
+        named_children = [child for child in current.children if child.is_named]
+        if len(named_children) == 1:
+            current = named_children[0]
+            continue
+        return None, seen_function
+    return None, seen_function
+
+
+def _c_include_target_text(path_field: Any, source_bytes: bytes) -> str | None:
+    """Return a ``preproc_include`` node's target text, quote/bracket-stripped where the include
+    form carries delimiters. See the module docstring's ``#include`` node-shape table for the
+    four forms this handles."""
+    if path_field is None:
+        return None
+    if path_field.type == "system_lib_string":
+        raw = _tree_sitter_node_text(source_bytes, path_field)
+        if len(raw) >= 2 and raw[0] == "<" and raw[-1] == ">":
+            return raw[1:-1]
+        return raw
+    if path_field.type == "string_literal":
+        content_node = next(
+            (child for child in path_field.children if child.type == "string_content"),
+            None,
+        )
+        if content_node is not None:
+            return _tree_sitter_node_text(source_bytes, content_node)
+        # Fallback (mirrors lang_go.py's F11 quote-stripping fallback): an empty ``#include ""``
+        # or an unusual grammar build with no ``string_content`` child still yields a clean
+        # module string instead of silently dropping the row.
+        raw = _tree_sitter_node_text(source_bytes, path_field)
+        if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+            return raw[1:-1]
+        return raw
+    # identifier (macro name, e.g. MACRO_HEADER) / call_expression (macro-combined, e.g.
+    # COMBINE(a,b)) / anything else: no delimiters to strip -- the raw text IS the honest
+    # include target (this module never fabricates a resolved path for these either way; see
+    # repo_map.py's `_resolve_raw_import_entry` "c" branch).
+    return _tree_sitter_node_text(source_bytes, path_field)
+
+
+def c_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    """Extract ``#include`` targets + function/struct/union/enum/typedef definitions from a C
+    source file, one AST pass (mirrors ``lang_go.go_imports_and_symbols``'s shape).
+
+    Defs covered: ``function_definition`` (kind "function"), a ``declaration`` whose declarator
+    chain passes through a ``function_declarator`` (a prototype, kind "function" -- a plain
+    variable declaration is excluded, see the module docstring), ``struct_specifier``/
+    ``union_specifier``/``enum_specifier`` WITH a body (kind "class" -- a body-less
+    forward-declaration/usage-as-type is excluded), and ``type_definition`` (kind "type", one
+    record per declarator so ``typedef int A, B;`` yields both). Imports come from every
+    ``preproc_include`` directive's target text (see ``_c_include_target_text``).
+    """
+    if path.suffix != ".c":
+        return [], []
+
+    parser = _c_parser()
+    if parser is None:
+        return [], []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    imports: list[str] = []
+    symbols: list[dict[str, Any]] = []
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS instead of recursion, matching lang_go.py's walkers (F26 precedent:
+        # a pathologically deep AST can never raise RecursionError). Children pushed in reverse
+        # so the leftmost child is popped (visited) first, preserving pre-order traversal. A
+        # plain (non-recursive) stack walk also naturally reaches nodes nested inside
+        # `preproc_ifdef`/`preproc_if`/`preproc_elif` guards (live-verified: both branches of an
+        # `#ifdef`/`#else` parse simultaneously as ordinary children) -- no special-casing needed.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "preproc_include":
+                path_field = node.child_by_field_name("path")
+                target = _c_include_target_text(path_field, source_bytes)
+                if target:
+                    imports.append(target)
+            elif node_type == "function_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _c_declarator_name_node(declarator)
+                    if name_node is None:
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type == "declaration":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, is_function = _c_declarator_name_node(declarator)
+                    if not is_function or name_node is None:
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type in _C_CLASS_LIKE_KINDS:
+                body_field = node.child_by_field_name("body")
+                name_field = node.child_by_field_name("name")
+                if body_field is not None and name_field is not None:
+                    name = _node_text(name_field)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="class",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type == "type_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _c_declarator_name_node(declarator)
+                    if name_node is None:
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="type",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    imports = sorted(dict.fromkeys(imports))
+    symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
+    return imports, symbols
+
+
+# #74-follow-up: `tg imports` foundational-tier extractor (mirrors repo_map.py's
+# `_java_imports_with_lines` shape/role exactly). One row per `preproc_include` STATEMENT with
+# its 1-based line number -- same extraction source as `c_imports_and_symbols` above (every
+# `preproc_include`'s target text via `_c_include_target_text`), just line-tagged instead of
+# deduped into a flat list.
+#
+# Deliberately NOT resolved to a target file: repo_map.py's `_resolve_raw_import_entry` "c"
+# branch keeps every row unresolved (resolved=None, external=False) -- true `#include` -> file
+# resolution has no standardized C manifest to resolve against (see the module docstring), so a
+# real path is not guessable without fabricating one.
+def c_imports_with_lines(path: Path) -> list[dict[str, Any]]:
+    if path.suffix != ".c":
+        return []
+
+    parser = _c_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    entries: list[dict[str, Any]] = []
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS -- see the identical comment on c_imports_and_symbols's `_walk`.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == "preproc_include":
+                path_field = node.child_by_field_name("path")
+                target = _c_include_target_text(path_field, source_bytes)
+                if target:
+                    entries.append({
+                        "module": target,
+                        "line": node.start_point[0] + 1,
+                    })
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    return entries
+
+
+def c_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
+    """Full source text of every function/struct/union/enum/typedef matching *symbol* (mirrors
+    the Go/C#/PHP ``*_parser_symbol_sources`` shape for the ``tg source`` command).
+
+    A function/typedef appearing both as a prototype/forward form and a full definition emits a
+    source block for EACH matching AST node (no dedup/preference between them) -- the same
+    "every real AST node is a legitimate hit" behavior C#'s own module already ships (an
+    interface method and its class implementation sharing a name both resolve as separate
+    ``tg source`` blocks)."""
+    if path.suffix != ".c":
+        return []
+
+    parser = _c_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    sources: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _append(node: Any, kind: str) -> None:
+        block = _node_text(node)
+        if block and not block.endswith("\n"):
+            block = f"{block}\n"
+        sources.append({
+            "name": symbol,
+            "kind": kind,
+            "file": str(path),
+            "start_line": node.start_point[0] + 1,
+            "end_line": node.end_point[0] + 1,
+            "source": block,
+        })
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS -- see the identical comment on c_imports_and_symbols's `_walk`.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "function_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _c_declarator_name_node(declarator)
+                    if name_node is not None and _node_text(name_node) == symbol:
+                        _append(node, "function")
+                        break
+            elif node_type == "declaration":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, is_function = _c_declarator_name_node(declarator)
+                    if is_function and name_node is not None and _node_text(name_node) == symbol:
+                        _append(node, "function")
+                        break
+            elif node_type in _C_CLASS_LIKE_KINDS:
+                body_field = node.child_by_field_name("body")
+                name_field = node.child_by_field_name("name")
+                if (
+                    body_field is not None
+                    and name_field is not None
+                    and _node_text(name_field) == symbol
+                ):
+                    _append(node, "class")
+            elif node_type == "type_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _c_declarator_name_node(declarator)
+                    if name_node is not None and _node_text(name_node) == symbol:
+                        _append(node, "type")
+                        break
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
+    return sources
+
+
+__all__ = [
+    "c_imports_and_symbols",
+    "c_imports_with_lines",
+    "c_parser_symbol_sources",
+]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
-from tensor_grep.cli import lang_csharp, lang_go, lang_php, lang_registry
+from tensor_grep.cli import lang_c, lang_csharp, lang_go, lang_php, lang_registry
 from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LSPTransportError
 from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 
@@ -6220,6 +6220,52 @@ lang_registry.register_language(
     )
 )
 
+# PATH A Stage 3: C joins the symbol graph as a FOUNDATIONAL-TIER language (top-10 language
+# campaign, Phase 1 of C/C++ -- C++ is a SEPARATE follow-up, not built here). Own module
+# (lang_c.py) for the same no-import-cycle reason as Go/PHP/C#. FOUNDATIONAL scope only --
+# defs/source/imports/agent via `extract_imports_and_symbols`-shaped extraction, wired at the
+# `_imports_and_symbols_for_path` / `build_symbol_source_from_map` dispatch sites below. The
+# cross-file caller-graph (references_and_calls / file_imports_symbol_from_definition /
+# import_update_target / repo-root context priming for a future `#include`-path resolver) is
+# DEFERRED to a follow-up -- all four stay None here, same shape as Go/PHP/C#'s own
+# `import_update_target=None` gap, so `tg refs`/`tg callers`/`tg blast-radius` on a C symbol fall
+# through to the generic `_regex_references_and_calls` text-heuristic path instead of crashing or
+# fabricating an AST-verified match. provenance_when_missing="grammar-missing" (NOT
+# "regex-heuristic") is what makes a grammar-absent C file a genuine `resolution_gaps` entry
+# instead of a silent empty result (C has no regex fallback, unlike JS/TS/Rust).
+#
+# ".h" is deliberately NOT in suffixes -- `_provider_language_for_path` (below) already assigns
+# every C/C++ header suffix to "cpp" (tree-sitter-cpp is a strict grammar superset of C), so a
+# future lang_cpp.py is the natural owner of ".h"; claiming it here would disagree with that
+# pre-existing assignment and fail test_target_and_provider_language_agree_with_registry. See
+# lang_c.py's module docstring for the full header-ambiguity rationale.
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="c",
+        suffixes=frozenset({".c"}),
+        grammar_modules=("tree_sitter", "tree_sitter_c"),
+        parser_for_path=lambda path: lang_c._c_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="grammar-missing",
+        import_markers=(b"#include",),
+        def_node_kinds=(
+            "function_definition",
+            "declaration",
+            "struct_specifier",
+            "union_specifier",
+            "enum_specifier",
+            "type_definition",
+        ),
+        extract_imports_and_symbols=None,
+        references_and_calls=None,
+        provider_alias_calls=None,
+        file_imports_symbol_from_definition=None,
+        import_update_target=None,
+        prime_repo_context=None,
+        classify_ref_kind=None,
+    )
+)
+
 
 def _prime_all_language_repo_contexts(context_root: Path) -> None:
     """Prime every registered language's per-repo-root context exactly once.
@@ -6285,6 +6331,10 @@ def _imports_and_symbols_for_path(
             # Fail-closed (Stage 1 trap, same as Go): NO regex fallback for C#. A grammar-missing
             # .cs file returns ([], []) here -- surfaced honestly via `resolution_gaps`.
             current_imports, current_symbols = lang_csharp.csharp_imports_and_symbols(path)
+        elif spec is not None and spec.language_id == "c":
+            # Fail-closed (Stage 1 trap, same as Go): NO regex fallback for C. A grammar-missing
+            # .c file returns ([], []) here -- surfaced honestly via `resolution_gaps`.
+            current_imports, current_symbols = lang_c.c_imports_and_symbols(path)
         elif not current_imports and not current_symbols:
             current_imports, current_symbols = _regex_imports_and_symbols(path)
         return current_imports, current_symbols
@@ -6438,7 +6488,7 @@ def _rust_imports_with_lines(path: Path) -> list[dict[str, Any]]:
 
 
 def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
-    """Raw per-statement imports with 1-based line numbers for the 8 supported languages.
+    """Raw per-statement imports with 1-based line numbers for the 9 supported languages.
 
     Returns ``[]`` for an unsupported language (e.g. Kotlin) or an over-cap file -- callers that
     need to distinguish "genuinely no imports" from "not scanned" must check those conditions
@@ -6455,11 +6505,11 @@ def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
         return _rust_imports_with_lines(path)
     if spec.language_id == "java":
         return _java_imports_with_lines(path)
-    if spec.language_id in ("go", "php", "csharp"):
-        # go/php/csharp's own extractors (lang_go.py/lang_php.py/lang_csharp.py) mirror their
-        # `_X_imports_and_symbols` siblings, which get this SAME cap check for free from THEIR
-        # caller (`_imports_and_symbols_for_path`, above) rather than self-guarding -- applied
-        # here once, at this dispatcher, for the identical reason.
+    if spec.language_id in ("go", "php", "csharp", "c"):
+        # go/php/csharp/c's own extractors (lang_go.py/lang_php.py/lang_csharp.py/lang_c.py)
+        # mirror their `_X_imports_and_symbols` siblings, which get this SAME cap check for free
+        # from THEIR caller (`_imports_and_symbols_for_path`, above) rather than self-guarding --
+        # applied here once, at this dispatcher, for the identical reason.
         try:
             file_size = path.stat().st_size
         except OSError:
@@ -6470,7 +6520,9 @@ def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
             return lang_go.go_imports_with_lines(path)
         if spec.language_id == "php":
             return lang_php.php_imports_with_lines(path)
-        return lang_csharp.csharp_imports_with_lines(path)
+        if spec.language_id == "csharp":
+            return lang_csharp.csharp_imports_with_lines(path)
+        return lang_c.c_imports_with_lines(path)
     return []
 
 
@@ -7410,6 +7462,12 @@ def _target_language_for_path(path: str | Path | None) -> str | None:
     if suffix == ".cs":
         # Same MOST-FORGOTTEN seam, now for C# (PATH A Stage 1, second expansion).
         return "csharp"
+    if suffix == ".c":
+        # Same MOST-FORGOTTEN seam, now for C (PATH A Stage 3, top-10 language campaign). Note
+        # ".h" is deliberately absent here -- it stays unregistered until a future lang_cpp.py
+        # claims it (see lang_c.py's module docstring's header-ambiguity note); this branch must
+        # match ONLY the suffixes lang_c.py's LanguageSpec actually registers.
+        return "c"
     return None
 
 
@@ -15858,6 +15916,8 @@ def build_symbol_source_from_map(
                 current_sources = lang_php.php_parser_symbol_sources(current_path, symbol)
             if not current_sources and current_path.suffix == ".cs":
                 current_sources = lang_csharp.csharp_parser_symbol_sources(current_path, symbol)
+            if not current_sources and current_path.suffix == ".c":
+                current_sources = lang_c.c_parser_symbol_sources(current_path, symbol)
             if not current_sources:
                 current_sources = _regex_symbol_sources(current_path, symbol)
             sources.extend(current_sources)
@@ -16648,6 +16708,12 @@ _SUPPORTED_FILE_DEPENDENCY_LANGUAGES = frozenset({
     "go",
     "php",
     "csharp",
+    # Top-10 language campaign (Phase 1, C only -- C++ is a separate follow-up): raw `#include`
+    # directives + line numbers via lang_c.c_imports_with_lines, `_resolve_raw_import_entry`
+    # reporting them honestly unresolved. TRUE `#include` -> file resolution is deferred and
+    # harder than go/php/csharp's own deferred resolvers -- C has no standardized manifest
+    # (no go.mod/composer.json/.csproj equivalent) to resolve against; see docs/BACKLOG.md.
+    "c",
 })
 
 
@@ -16720,18 +16786,23 @@ def _resolve_raw_import_entry(
         # dynamic_unresolved branch above uses -- rather than guessing (never fabricate
         # resolution precision this extractor doesn't actually have).
         resolved, external, provenance, confidence = None, False, [], 0.0
-    elif language_id in ("go", "php", "csharp"):
+    elif language_id in ("go", "php", "csharp", "c"):
         # Foundational tier (mirrors the "java" branch above): raw import statements are
         # extracted with their line numbers (see lang_go.go_imports_with_lines /
-        # lang_php.php_imports_with_lines / lang_csharp.csharp_imports_with_lines), but
-        # resolving WHICH file/module an import points to is deferred -- go/php/csharp each need
-        # DIFFERENT missing machinery: go's existing `_go_import_path_to_dir` resolves to a
-        # PACKAGE DIRECTORY, not a file (no 1:1 import-to-file mapping to wire); php has no PSR-4/
-        # composer.json autoload-map reader; csharp has no `.csproj`/namespace-to-file map. None
-        # of that resolver machinery exists yet for any of the three. Report as
-        # unresolved-but-not-presumed-external -- the same conservative tuple every other
-        # "resolution not yet built" branch in this function uses -- rather than guessing (never
-        # fabricate resolution precision these extractors don't actually have).
+        # lang_php.php_imports_with_lines / lang_csharp.csharp_imports_with_lines /
+        # lang_c.c_imports_with_lines), but resolving WHICH file/module an import points to is
+        # deferred -- each of these four needs DIFFERENT missing machinery: go's existing
+        # `_go_import_path_to_dir` resolves to a PACKAGE DIRECTORY, not a file (no 1:1
+        # import-to-file mapping to wire); php has no PSR-4/composer.json autoload-map reader;
+        # csharp has no `.csproj`/namespace-to-file map; c has no standardized manifest at all
+        # (no go.mod/composer.json/.csproj equivalent) -- a bare `#include "foo.h"` needs the
+        # including file's own directory plus the compiler's `-iquote`/`-I` search order, and a
+        # bare `#include <foo.h>` is ENTIRELY build-system/toolchain defined, not in the source
+        # at all (see lang_c.py's module docstring). None of that resolver machinery exists yet
+        # for any of the four. Report as unresolved-but-not-presumed-external -- the same
+        # conservative tuple every other "resolution not yet built" branch in this function uses
+        # -- rather than guessing (never fabricate resolution precision these extractors don't
+        # actually have).
         resolved, external, provenance, confidence = None, False, [], 0.0
     else:
         resolved, external, provenance, confidence = None, True, [], 0.0

--- a/tests/unit/test_lang_c.py
+++ b/tests/unit/test_lang_c.py
@@ -1,0 +1,478 @@
+"""C symbol graph (lang_c.py) tests -- foundational-tier expansion, top-10 language campaign
+(Phase 1 of C/C++; C++ is a separate follow-up, not covered here).
+
+Foundational scope (mirrors PATH A Stage 1's lang_go.py / lang_php.py / lang_csharp.py
+precedent): C gets its own ``LanguageSpec`` entry + dedicated module providing
+``defs``/``source``/``imports``/``agent`` support (function definitions/prototypes,
+struct/union/enum definitions, typedefs, plus ``#include`` directive extraction). The
+cross-file caller-graph (``references_and_calls``/``file_imports_symbol_from_definition``/
+``import_update_target``) is explicitly DEFERRED to a follow-up, exactly like Go/PHP/C#'s own
+``import_update_target=None`` gap -- `tg refs`/`tg callers`/`tg blast-radius` on a C symbol fall
+through to the generic ``_regex_references_and_calls`` text-heuristic path (never a crash, never
+a fabricated AST-verified match).
+
+Covered here:
+- ``defs``: function definitions/prototypes resolve with kind "function" (both a prototype and
+  its later definition resolve as SEPARATE records, no dedup -- mirrors C#'s own
+  interface-method/impl-method shared-name precedent); struct/union/enum definitions resolve
+  with kind "class"; typedefs resolve with kind "type"; a body-less forward declaration
+  (``struct Foo;``) is NOT emitted; a plain/extern variable declaration is NOT emitted.
+- ``source``: full source text for a function definition.
+- ``imports``: ``#include`` directive targets (angle/quoted forms), extracted by
+  ``c_imports_and_symbols`` and surfaced through ``build_repo_map``.
+- Grammar-absent (monkeypatched ``lang_c._c_parser`` -> ``None``): fail-closed, zero fabricated
+  rows, an honest ``resolution_gaps`` entry, an honest non-zero/non-crash CLI exit code --
+  mirrors Go/PHP/C#'s Stage 1 fail-closed contract exactly (``provenance_when_missing ==
+  "grammar-missing"``, never "regex-heuristic").
+- The agent capsule reports ``primary_target_language == "c"``.
+- A pathologically deep AST does not raise ``RecursionError`` (F26-class regression guard,
+  applied preemptively since ``lang_go.py`` already paid for this lesson once).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from tensor_grep.cli import agent_capsule, lang_c, lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# Fixture: includes (angle + quoted) + a struct/typedef sharing one name (dual-namespace case)
+# + a standalone enum/union/struct + a function with BOTH a prototype and a definition (sharing
+# a name) + a definition-only function.
+# ---------------------------------------------------------------------------
+
+_WIDGET_C_SOURCE = (
+    "#include <stdio.h>\n"
+    "#include <stdlib.h>\n"
+    '#include "widget_types.h"\n'
+    "\n"
+    "typedef struct Point {\n"
+    "    int x;\n"
+    "    int y;\n"
+    "} Point;\n"
+    "\n"
+    "enum WidgetKind {\n"
+    "    SMALL,\n"
+    "    LARGE,\n"
+    "};\n"
+    "\n"
+    "union WidgetValue {\n"
+    "    int i;\n"
+    "    float f;\n"
+    "};\n"
+    "\n"
+    "struct WidgetStruct {\n"
+    "    int x;\n"
+    "};\n"
+    "\n"
+    "int widget_create(int value);\n"
+    "\n"
+    "int widget_create(int value) {\n"
+    "    return value;\n"
+    "}\n"
+    "\n"
+    "static int widget_get_value(int value) {\n"
+    "    return value * 2;\n"
+    "}\n"
+)
+
+
+def _write_c_fixture(root: Path) -> Path:
+    widget_c = root / "widget.c"
+    widget_c.write_text(_WIDGET_C_SOURCE, encoding="utf-8")
+    return widget_c
+
+
+# ---------------------------------------------------------------------------
+# Registration + provenance
+# ---------------------------------------------------------------------------
+
+
+def test_c_is_registered_with_tree_sitter_provenance() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["c"]
+    assert spec.suffixes == frozenset({".c"})
+    assert spec.provenance_when_parsed == "tree-sitter"
+    # Fail-closed (Stage 1 trap, mirrors Go/PHP/C#): never "regex-heuristic" -- C has no fallback.
+    assert spec.provenance_when_missing == "grammar-missing"
+    assert spec.parser_for_path is not None
+
+
+def test_target_language_for_path_reports_c() -> None:
+    assert repo_map._target_language_for_path("widget.c") == "c"
+    assert repo_map._language_for_path("widget.c") == "c"
+    assert repo_map._provider_language_for_path("widget.c") == "c"
+
+
+def test_header_suffix_is_deliberately_unregistered() -> None:
+    """`.h` is reserved for a future lang_cpp.py (tree-sitter-cpp is a strict grammar superset of
+    C) -- this module must NOT claim it, or `_target_language_for_path` would disagree with
+    `_provider_language_for_path`'s pre-existing "cpp" assignment for header suffixes."""
+    assert lang_registry.spec_for_path("widget.h") is None
+    assert repo_map._provider_language_for_path("widget.h") == "cpp"
+
+
+# ---------------------------------------------------------------------------
+# defs
+# ---------------------------------------------------------------------------
+
+
+def test_defs_finds_enum_union_struct_as_class_kind(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    for name in ("WidgetKind", "WidgetValue", "WidgetStruct"):
+        payload = repo_map.build_symbol_defs(name, tmp_path)
+        assert not payload.get("no_match"), f"expected a definition for {name}"
+        assert payload["definitions"][0]["kind"] == "class", f"{name} should be kind=class"
+        assert payload["definitions"][0]["provenance"] == "tree-sitter"
+
+
+def test_defs_finds_struct_tag_and_typedef_alias_sharing_a_name(tmp_path: Path) -> None:
+    """`typedef struct Point {...} Point;` -- the struct TAG and the typedef ALIAS occupy
+    different C namespaces even though they share text; both are legitimate, separate defs."""
+    _write_c_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Point", tmp_path)
+
+    assert not payload.get("no_match")
+    kinds = {d["kind"] for d in payload["definitions"]}
+    assert "class" in kinds
+    assert "type" in kinds
+
+
+def test_defs_finds_prototype_and_definition_as_two_function_records(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("widget_create", tmp_path)
+
+    assert not payload.get("no_match")
+    assert len(payload["definitions"]) == 2
+    assert all(d["kind"] == "function" for d in payload["definitions"])
+    lines = sorted(d["start_line"] for d in payload["definitions"])
+    assert lines[0] != lines[1]
+
+
+def test_defs_finds_definition_only_function(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("widget_get_value", tmp_path)
+
+    assert not payload.get("no_match")
+    assert len(payload["definitions"]) == 1
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_defs_excludes_body_less_forward_declaration(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "fwd.c").write_text(
+        "struct ForwardOnly;\n\nvoid use_it(struct ForwardOnly *p) {\n}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("ForwardOnly", root)
+
+    assert payload.get("no_match") is True
+
+
+def test_defs_excludes_plain_and_extern_variable_declarations(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "globals.c").write_text(
+        "int global_counter = 0;\nextern int shared_flag;\n\nvoid touch(void) {\n}\n",
+        encoding="utf-8",
+    )
+
+    counter_payload = repo_map.build_symbol_defs("global_counter", root)
+    flag_payload = repo_map.build_symbol_defs("shared_flag", root)
+
+    assert counter_payload.get("no_match") is True
+    assert flag_payload.get("no_match") is True
+
+
+# ---------------------------------------------------------------------------
+# source
+# ---------------------------------------------------------------------------
+
+
+def test_source_returns_full_function_body(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_source("widget_get_value", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["sources"], "expected at least one source block for widget_get_value"
+    source_text = payload["sources"][0]["source"]
+    assert "static int widget_get_value(int value)" in source_text
+    assert "return value * 2;" in source_text
+
+
+def test_source_for_prototype_plus_definition_returns_both_blocks(tmp_path: Path) -> None:
+    c_file = _write_c_fixture(tmp_path)
+
+    sources = lang_c.c_parser_symbol_sources(c_file, "widget_create")
+
+    assert len(sources) == 2
+    assert any(s["source"].strip() == "int widget_create(int value);" for s in sources)
+    assert any("return value;" in s["source"] for s in sources)
+
+
+# ---------------------------------------------------------------------------
+# imports: angle / quoted #include forms
+# ---------------------------------------------------------------------------
+
+
+def test_c_imports_and_symbols_extracts_include_targets(tmp_path: Path) -> None:
+    source = '#include <stdio.h>\n#include "local.h"\n\nint main(void) {\n    return 0;\n}\n'
+    c_file = tmp_path / "main.c"
+    c_file.write_text(source, encoding="utf-8")
+
+    imports, symbols = lang_c.c_imports_and_symbols(c_file)
+
+    # Quote/bracket delimiters are stripped -- the recorded module string is the bare target.
+    assert imports == sorted({"stdio.h", "local.h"})
+    assert any(s["name"] == "main" and s["kind"] == "function" for s in symbols)
+
+
+def test_build_repo_map_surfaces_c_imports_and_symbols(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    repo_map_payload = repo_map.build_repo_map(tmp_path)
+
+    file_imports = [
+        entry for entry in repo_map_payload["imports"] if entry["file"].endswith("widget.c")
+    ]
+    assert file_imports, "expected an imports entry for widget.c"
+    assert "stdio.h" in file_imports[0]["imports"]
+    assert "stdlib.h" in file_imports[0]["imports"]
+    assert "widget_types.h" in file_imports[0]["imports"]
+
+    symbol_names = {
+        s["name"] for s in repo_map_payload["symbols"] if s["file"].endswith("widget.c")
+    }
+    assert {
+        "Point",
+        "WidgetKind",
+        "WidgetValue",
+        "WidgetStruct",
+        "widget_create",
+        "widget_get_value",
+    }.issubset(symbol_names)
+
+
+# ---------------------------------------------------------------------------
+# #74-follow-up: tg imports (c_imports_with_lines / build_file_imports) -- foundational tier,
+# mirrors test_lang_csharp.py's test_file_imports_returns_csharp_using_directives_with_lines.
+# ---------------------------------------------------------------------------
+
+
+def test_c_imports_with_lines_extracts_includes_with_lines(tmp_path: Path) -> None:
+    c_file = _write_c_fixture(tmp_path)
+
+    entries = lang_c.c_imports_with_lines(c_file)
+
+    modules = {entry["module"]: entry["line"] for entry in entries}
+    assert modules == {
+        "stdio.h": 1,
+        "stdlib.h": 2,
+        "widget_types.h": 3,
+    }
+
+
+def test_c_imports_with_lines_non_c_suffix_returns_empty(tmp_path: Path) -> None:
+    not_c = tmp_path / "widget.txt"
+    not_c.write_text("#include <stdio.h>\n", encoding="utf-8")
+
+    assert lang_c.c_imports_with_lines(not_c) == []
+
+
+def test_c_imports_with_lines_grammar_absent_returns_empty(tmp_path: Path, monkeypatch) -> None:
+    c_file = _write_c_fixture(tmp_path)
+    monkeypatch.setattr(lang_c, "_c_parser", lambda: None)
+
+    assert lang_c.c_imports_with_lines(c_file) == []
+
+
+def test_file_imports_returns_c_include_directives_with_lines(tmp_path: Path) -> None:
+    c_file = _write_c_fixture(tmp_path)
+
+    payload = repo_map.build_file_imports(c_file)
+
+    assert payload["result_incomplete"] is False
+    modules = {entry["module"]: entry["line"] for entry in payload["imports"]}
+    assert modules == {
+        "stdio.h": 1,
+        "stdlib.h": 2,
+        "widget_types.h": 3,
+    }
+    # Foundational tier: raw #include directives are real, but resolving them to a specific file
+    # is deferred (C has no standardized manifest to resolve against) -- every row must be
+    # unresolved and never presumed external, matching the fail-closed contract.
+    assert all(entry["resolved"] is None for entry in payload["imports"])
+    assert all(entry["external"] is False for entry in payload["imports"])
+
+
+def test_c_include_target_text_handles_macro_and_call_forms(tmp_path: Path) -> None:
+    """`#include MACRO_HEADER` (macro-expanded) and `#include COMBINE(a, b)` (macro-combined)
+    both parse as real preproc_include nodes (tree-sitter-c never runs a preprocessor) -- the
+    extractor records the raw macro/call text honestly rather than dropping the row."""
+    source = "#include MACRO_HEADER\n#include COMBINE(a, b)\n\nvoid noop(void) {\n}\n"
+    c_file = tmp_path / "macro_includes.c"
+    c_file.write_text(source, encoding="utf-8")
+
+    entries = lang_c.c_imports_with_lines(c_file)
+
+    modules = {entry["module"] for entry in entries}
+    assert "MACRO_HEADER" in modules
+    assert any("COMBINE" in module for module in modules)
+
+
+# ---------------------------------------------------------------------------
+# Deferred caller-graph, grammar PRESENT: honest resolution_gaps, not a silent proven-zero.
+# ---------------------------------------------------------------------------
+
+
+def test_refs_grammar_present_still_reports_import_resolution_gap(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_refs("widget_create", tmp_path)
+
+    assert not payload.get("no_match")
+    gaps = payload["resolution_gaps"]
+    c_gaps = [gap for gap in gaps if gap["language"] == "c"]
+    assert len(c_gaps) == 1
+    # NOT "fail-closed" (that's the grammar-ABSENT case, covered separately below) -- this is
+    # the narrower "grammar works fine, but no reverse-import resolver exists yet" gap.
+    assert "fail-closed" not in c_gaps[0]["reason"]
+    assert "reverse-import" in c_gaps[0]["reason"]
+    assert c_gaps[0]["files_affected"] >= 1
+    # Honesty floor: the remediation must tell an agent to treat a zero count as UNKNOWN, not
+    # proven-zero -- the exact failure mode this test guards against.
+    assert "not proven-zero" in c_gaps[0]["remediation"] or "UNKNOWN" in (c_gaps[0]["remediation"])
+
+
+# ---------------------------------------------------------------------------
+# Grammar-absent: fail-closed, resolution_gaps, honest exit code.
+# ---------------------------------------------------------------------------
+
+
+def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_c_fixture(tmp_path)
+    # A python symbol elsewhere in the same repo so refs has something REAL to find -- the
+    # resolution_gaps floor is about a C file being an honestly-labeled BYSTANDER in the scan
+    # universe, not about the query's own target living in the grammar-missing language.
+    (tmp_path / "target.py").write_text("def Target():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(lang_c, "_c_parser", lambda: None)
+
+    defs_payload = repo_map.build_symbol_defs("widget_create", tmp_path)
+    assert defs_payload.get("no_match") is True
+    assert defs_payload["definitions"] == []
+    defs_gaps = defs_payload["resolution_gaps"]
+    assert any(gap["language"] == "c" for gap in defs_gaps)
+    c_gap = next(gap for gap in defs_gaps if gap["language"] == "c")
+    assert "fail-closed" in c_gap["reason"]
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    assert not refs_payload.get("no_match")
+    gaps = refs_payload["resolution_gaps"]
+    assert any(gap["language"] == "c" for gap in gaps)
+    c_refs_gap = next(gap for gap in gaps if gap["language"] == "c")
+    assert "fail-closed" in c_refs_gap["reason"]
+    assert c_refs_gap["files_affected"] >= 1
+    assert "fall back to plain literal-text/regex matching" not in c_refs_gap["remediation"]
+
+
+def test_grammar_absent_cli_exit_code_is_honest_not_found(tmp_path: Path, monkeypatch) -> None:
+    """A C-only target with the grammar missing must exit 1 (honest not-found) -- never a
+    silent 0 and never a crash."""
+    from typer.testing import CliRunner
+
+    from tensor_grep.cli.main import app
+
+    _write_c_fixture(tmp_path)
+    monkeypatch.setattr(lang_c, "_c_parser", lambda: None)
+
+    result = CliRunner().invoke(app, ["defs", str(tmp_path), "widget_create"])
+
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Agent capsule
+# ---------------------------------------------------------------------------
+
+
+def test_agent_capsule_reports_c_target_language(tmp_path: Path) -> None:
+    _write_c_fixture(tmp_path)
+
+    payload = agent_capsule.build_agent_capsule("widget_create", tmp_path)
+
+    assert payload["context_consistency"]["primary_target_language"] == "c"
+
+
+# ---------------------------------------------------------------------------
+# Deep-AST guard: explicit-stack DFS must not raise RecursionError (lang_go.py F26 precedent).
+# ---------------------------------------------------------------------------
+
+
+def _deep_nested_c_source(depth: int) -> str:
+    return "int target(void)\n{\n    return " + ("(" * depth) + "1" + (")" * depth) + ";\n}\n"
+
+
+def test_c_walkers_survive_pathologically_deep_ast_without_recursion_error(
+    tmp_path: Path,
+) -> None:
+    depth = sys.getrecursionlimit() + 500
+    deep_c = tmp_path / "deep.c"
+    deep_c.write_text(_deep_nested_c_source(depth), encoding="utf-8")
+
+    imports, symbols = lang_c.c_imports_and_symbols(deep_c)
+    assert imports == []
+    assert any(s["name"] == "target" and s["kind"] == "function" for s in symbols)
+
+    sources = lang_c.c_parser_symbol_sources(deep_c, "target")
+    assert len(sources) == 1
+    assert sources[0]["kind"] == "function"
+
+
+# ---------------------------------------------------------------------------
+# Grammar-missing import failure (package not installed) -- distinct from monkeypatched None.
+# ---------------------------------------------------------------------------
+
+
+def test_c_parser_returns_none_when_grammar_module_missing(monkeypatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "tree_sitter_c":
+            raise ImportError("simulated missing grammar")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    lang_c._c_parser.cache_clear()
+    try:
+        assert lang_c._c_parser() is None
+    finally:
+        lang_c._c_parser.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Read/parse-error guards return ([], []) rather than raising.
+# ---------------------------------------------------------------------------
+
+
+def test_c_imports_and_symbols_missing_file_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "DoesNotExist.c"
+    imports, symbols = lang_c.c_imports_and_symbols(missing)
+    assert imports == []
+    assert symbols == []
+
+
+def test_c_imports_and_symbols_non_c_suffix_returns_empty(tmp_path: Path) -> None:
+    other = tmp_path / "widget.txt"
+    other.write_text("not c", encoding="utf-8")
+    imports, symbols = lang_c.c_imports_and_symbols(other)
+    assert imports == []
+    assert symbols == []

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tensor_grep.cli import lang_csharp, lang_go, lang_registry, repo_map
+from tensor_grep.cli import lang_c, lang_csharp, lang_go, lang_registry, repo_map
 
 # ---------------------------------------------------------------------------
 # spec_for_path / graph_suffixes
@@ -47,6 +47,7 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
         "foo.java": "java",
         "foo.php": "php",
         "foo.cs": "csharp",
+        "foo.c": "c",
     }
     for name, expected_language in expectations.items():
         spec = lang_registry.spec_for_path(Path(name))
@@ -78,6 +79,7 @@ def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
         ".java",
         ".php",
         ".cs",
+        ".c",
     })
 
 
@@ -91,6 +93,7 @@ def test_language_registry_has_exactly_the_stage2_languages() -> None:
         "java",
         "php",
         "csharp",
+        "c",
     }
 
 
@@ -155,6 +158,10 @@ def test_csharp_provenance_is_tree_sitter_when_grammar_present() -> None:
     assert repo_map._symbol_navigation_provenance_for_path("foo.cs") == "tree-sitter"
 
 
+def test_c_provenance_is_tree_sitter_when_grammar_present() -> None:
+    assert repo_map._symbol_navigation_provenance_for_path("foo.c") == "tree-sitter"
+
+
 def test_grammar_absent_monkeypatch_js_ts_provenance_flips_to_regex_heuristic(monkeypatch) -> None:
     """Simulate tree-sitter-javascript/typescript being uninstalled (ImportError inside the
     parser factory returns None, per repo_map._javascript_parser/_typescript_parser). The
@@ -198,6 +205,17 @@ def test_grammar_absent_monkeypatch_csharp_provenance_flips_to_grammar_missing(m
     monkeypatch.setattr(lang_csharp, "_csharp_parser", lambda: None)
 
     provenance = repo_map._symbol_navigation_provenance_for_path("foo.cs")
+
+    assert provenance == "grammar-missing"
+    assert provenance != ""
+
+
+def test_grammar_absent_monkeypatch_c_provenance_flips_to_grammar_missing(monkeypatch) -> None:
+    """C has NO regex fallback (Stage 1 fail-closed trap, same as Go/PHP/C#): a grammar-absent
+    .c file's provenance label must flip to "grammar-missing" (not "regex-heuristic")."""
+    monkeypatch.setattr(lang_c, "_c_parser", lambda: None)
+
+    provenance = repo_map._symbol_navigation_provenance_for_path("foo.c")
 
     assert provenance == "grammar-missing"
     assert provenance != ""

--- a/tests/unit/test_pyproject_dependencies.py
+++ b/tests/unit/test_pyproject_dependencies.py
@@ -73,6 +73,18 @@ def test_ast_dev_bench_extras_include_tree_sitter_c_sharp_for_path_a_stage1() ->
         )
 
 
+def test_ast_dev_bench_extras_include_tree_sitter_c_for_path_a_stage3() -> None:
+    # PATH A Stage 3 (C symbol graph, top-10 language campaign, Phase 1 of C/C++ -- C++ is a
+    # separate follow-up): same rule as tree-sitter-go/java/php/c-sharp above -- tree-sitter-c
+    # must ship in every extra that already carries the other tree-sitter grammar packages, or
+    # an --all-extras --locked export silently drops C support. Bare package name (no `[core]`
+    # extra) so it does not pull in its own `tree-sitter~=0.24` constraint, which would conflict
+    # with this repo's pinned `tree-sitter>=0.22` (currently locked to 0.25.2) -- see uv.lock.
+    deps = _optional_dependencies()
+    for extra_name in ("ast", "dev", "bench"):
+        assert "tree-sitter-c" in deps[extra_name], f"tree-sitter-c missing from [{extra_name}]"
+
+
 def test_ast_extra_pins_pygls_floor_matching_lsp_server_import() -> None:
     # cli/lsp_server.py imports `from pygls.lsp.server import LanguageServer`, a module path
     # that exists only in pygls 2.x (pygls 1.x has no `pygls.lsp.server` module at all -- its

--- a/uv.lock
+++ b/uv.lock
@@ -4127,6 +4127,7 @@ dependencies = [
 ast = [
     { name = "pygls" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
@@ -4142,6 +4143,7 @@ bench = [
     { name = "stringzilla" },
     { name = "torch" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
@@ -4165,6 +4167,7 @@ dev = [
     { name = "ruff" },
     { name = "stringzilla" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
@@ -4241,8 +4244,11 @@ requires-dist = [
     { name = "tree-sitter", marker = "extra == 'ast'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'bench'", specifier = ">=0.22" },
     { name = "tree-sitter", marker = "extra == 'dev'", specifier = ">=0.22" },
+    { name = "tree-sitter-c", marker = "extra == 'ast'" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'ast'" },
+    { name = "tree-sitter-c", marker = "extra == 'bench'" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'bench'" },
+    { name = "tree-sitter-c", marker = "extra == 'dev'" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'dev'" },
     { name = "tree-sitter-go", marker = "extra == 'ast'" },
     { name = "tree-sitter-go", marker = "extra == 'bench'" },
@@ -4500,6 +4506,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/c9/3834f3d9278251aea7312274971bc4c45b17aec2490fd4b884d93bd7019a/tree_sitter_c-0.24.2.tar.gz", hash = "sha256:1628584df0299b5a340aa63f8e67b6c97c91517f52fa7e7a4c557e40adb330a9", size = 228397, upload-time = "2026-04-22T08:06:14.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/c1/26ed17730ec2c17bedc1b673349e5e0a466c578e3eb0327c3b73cf52bf97/tree_sitter_c-0.24.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4d4579a8b54f0a442f903d88d3304cab77cd5c2031d4015baa4f2f8e15d6dcb7", size = 81016, upload-time = "2026-04-22T08:06:07.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1c/1140db75e7e375cda3c68792a33826c4fd40b5b98c3259d93c75f6c8368f/tree_sitter_c-0.24.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:97bc80a224d48215d4e6e6376bf30d114f4c317b8145ff1b02afe785d4ba7bdd", size = 86213, upload-time = "2026-04-22T08:06:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8c/0dfb88d726f8821d1c4c36042f092be974a800afd734307a595b8604190c/tree_sitter_c-0.24.2-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5041ef67eb68ce6bc8bb0b1f8ef3a5585ce523dae0c7eec109ab0627dd75aede", size = 94264, upload-time = "2026-04-22T08:06:08.918Z" },
+    { url = "https://files.pythonhosted.org/packages/87/78/47dc570e7aee6b0a1ecc2520b30639cc2b06003154c9ab0672d86bf720d5/tree_sitter_c-0.24.2-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c098bedcd5ac86ff93fa734d51d1dd86aed40fd5ed7d634c7af11380a0469969", size = 94560, upload-time = "2026-04-22T08:06:09.852Z" },
+    { url = "https://files.pythonhosted.org/packages/29/37/75d59d3f74f4cfc00f04472917e933d8a9c9fdc6eff980ef9552e010e6aa/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82842c5a5f2acd93f4de10038c33ac179c8979defc39376f990348d6289e933b", size = 94023, upload-time = "2026-04-22T08:06:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/64/57/8fc655d5a446a70a637e92b98bd2fdaab88bf5bb5b36076ac4add544808d/tree_sitter_c-0.24.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e2b42e8e22202c251f8629306f9321233542e07a6e01611b5fe83489272143eb", size = 94160, upload-time = "2026-04-22T08:06:11.497Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f7/72a1d6b42dd31fd37e03ff67e7dc5ee572301499e6b216002b8dd42a1714/tree_sitter_c-0.24.2-cp310-abi3-win_amd64.whl", hash = "sha256:abb549225091f7b25df2dd3a0143ece6e208f7055d8bcb4700b41ee79b9ef1e1", size = 84669, upload-time = "2026-04-22T08:06:12.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9d/7475d9ae8ef679aa36c7dfe6c903ab78e573651c68b6ef9862d6a3f994db/tree_sitter_c-0.24.2-cp310-abi3-win_arm64.whl", hash = "sha256:4a2f4371cd816cc3153458f69062135ebb2ea5f275ddd90494e5c823d778204a", size = 82956, upload-time = "2026-04-22T08:06:13.364Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lights up `.c` files for `tg orient`/`defs`/`source`/`imports`/`agent` by registering a **`"c"`** `LanguageSpec` in tensor-grep's multi-language symbol graph (`lang_registry`, PATH A Stage 3) — **Phase 1 of the top-10 language campaign's last gap (C/C++). C++ is a separate follow-up and is explicitly NOT built here.** Mirrors the `lang_go.py`/`lang_php.py`/`lang_csharp.py` module pattern, built from the CEO-approved design plan (`cpp_language_support_plan.md`, verified against `origin/main` @ `03dd0c0` / v1.96.1).

- **New module** `src/tensor_grep/cli/lang_c.py`:
  - `_c_parser()` — tree-sitter grammar factory (`tree_sitter_c`).
  - `c_imports_and_symbols(path)` — one AST pass: `function_definition` → kind `"function"`; a `declaration` whose declarator chain passes through a `function_declarator` (a **prototype**) → kind `"function"` (a plain variable declaration, e.g. `int counter = 0;`/`extern int flag;`, is excluded); `struct_specifier`/`union_specifier`/`enum_specifier` **with a body** → kind `"class"` (a body-less forward declaration/type-usage is excluded); `type_definition` → kind `"type"` (one record per declarator, so `typedef int A, B;` yields both). `#include` directives → one row per directive, quote/bracket-stripped (`<stdio.h>` → `"stdio.h"`).
  - `c_parser_symbol_sources(path, symbol)` — full source text for `tg source`; a prototype+definition pair both resolve (no dedup — same "every real AST node is a legit hit" behavior C#'s own module already ships for shared-name interface/impl methods).
  - `c_imports_with_lines(path)` — line-numbered `#include` rows for `tg imports`.
- **Wired at all 8 code seams** (re-verified against `origin/main` before editing, per `file:line`): `lang_registry.register_language(...)`, `_imports_and_symbols_for_path`, `_imports_with_lines_for_path`, `build_symbol_source_from_map`, `_target_language_for_path`, `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES`, `_resolve_raw_import_entry`'s honest-unresolved branch, and the module import line. `_provider_language_for_path` was **already** returning `"c"` for `.c` (a latent pre-wiring the design plan's verification pass found) — confirmed, no change needed there.
- **`.h` is deliberately NOT claimed.** `_provider_language_for_path` already assigns every C/C++ header suffix (`.h`/`.hh`/`.hpp`/`.hxx`) to `"cpp"` (tree-sitter-cpp is a strict grammar superset of C) — a future `lang_cpp.py` is the natural owner. Claiming `.h` here would disagree with that pre-existing assignment and fail `test_target_and_provider_language_agree_with_registry`. Pinned by a dedicated test (`test_header_suffix_is_deliberately_unregistered`).

## The `#include` honest-unresolved contract

`#include` **is a real parse-tree node** — `preproc_include` with a `path` field — because tree-sitter-c does not run a preprocessor. Live-verified node shapes (real parse, not README-guessed):

```
#include <stdio.h>     -> path field type system_lib_string, text "<stdio.h>"
#include "local.h"     -> path field type string_literal, nested string_content child
#include MACRO_HEADER  -> path field type identifier (macro-expanded form)
#include COMBINE(a,b)  -> path field type call_expression (macro-combined form)
```

All four forms extract real, line-numbered rows. **Resolution stays honest-unresolved**: `_resolve_raw_import_entry`'s new `"c"` branch (joining the existing `("go", "php", "csharp")` tuple) always returns `resolved=None, external=False` — never a fabricated path, never a fabricated `external=True`. This mirrors the exact fail-closed contract go/php/csharp shipped in #728, extended to C, which needs the same kind of missing machinery those three do **plus more**: C has *no* standardized manifest at all (no `go.mod`/`composer.json`/`.csproj` equivalent) — a bare `#include "foo.h"` needs the including file's own directory plus the compiler's `-iquote`/`-I` search order, and a bare `#include <foo.h>` is entirely build-system/toolchain defined, not in the source at all. True resolution stays deferred to `docs/BACKLOG.md`, harder than the three already-deferred resolvers.

## Declarator name resolution (the one real wrinkle vs Go/PHP/C#)

A C declarator can nest a name arbitrarily deep, and — unlike anything Go/PHP/C# hit — one wrapper shape exposes **no named `"declarator"` field at all**. Live-verified against real `tree_sitter_c` 0.24.2 parses before writing any extraction logic (not guessed from the grammar README or the design plan's own "TBD" note on this exact case):

- `int *make_ptr(void)` → `pointer_declarator` wraps `function_declarator` (named field chain, as expected).
- `typedef void (*FuncPtr)(int);` → `type_definition`'s declarator is `function_declarator` directly, whose own `.declarator` field is a `parenthesized_declarator` (`(*FuncPtr)`) — and **that node exposes no named `"declarator"` field of its own**. `_c_declarator_name_node` falls back to the wrapper's single **named** child (tree-sitter's own named/anonymous distinction, not a punctuation blocklist) when no field match exists, which resolves through to the inner `pointer_declarator` → `type_identifier "FuncPtr"`.
- Verified end-to-end (not just reasoned about) against `typedef char *(*ComplexFuncPtr)(int, char);` (a pointer-returning function-pointer typedef, 5 hops) and a multi-declarator `typedef int A, B;` / `int add(int a), sub(int a);` (both correctly yield 2 separate records via `children_by_field_name("declarator")`, not just the first).
- The same function also returns whether the chain passed through a `function_declarator`, which is how a `declaration` node — ambiguous by type alone (`struct Foo *make_foo(void);` is a prototype; `struct Foo local;` is a plain variable declaration, same node type) — gets correctly classified.

## Packaging

- `tree-sitter-c` (PyPI, v0.24.2, MIT) added to the `ast`/`dev`/`bench` extras in `pyproject.toml` (bare, no `[core]` extra — avoids its `tree-sitter~=0.24` constraint conflicting with this repo's pinned `tree-sitter>=0.22`, currently locked to 0.25.2).
- **Hand-spliced** into `uv.lock` (not a raw `uv lock` re-resolve, which would churn ~280 unrelated lines) — a scripted, byte-precise CRLF-preserving splice (verified `uv.lock` stayed 100% CRLF before and after: same CRLF count delta as lines added, zero stray LF). The new `[[package]]` block's URLs/hashes/sizes/timestamps were pulled programmatically from PyPI's real JSON API (never hand-typed), including the millisecond-truncation transformation `uv` itself applies to upload timestamps (cross-checked against an existing entry's real vs. stored timestamp to confirm truncate-not-round).
- **`uv export --format requirements.txt --all-extras --no-emit-project --locked` exits 0** (the `audit.yml` gate) — confirmed `tree-sitter-c==0.24.2` resolves alongside the existing 8 grammars. **`uv lock --check` also exits 0** (independent second confirmation the lockfile is fully consistent with `pyproject.toml`, no drift).
- Grammar core (`tree-sitter` 0.25.2) is untouched.

## Skill fix (as directed)

`.claude/skills/tensor-grep-add-language/SKILL.md` had a documented gap: its seam table listed only `_target_language_for_path` (seam 5, "MOST-FORGOTTEN") and never mentioned `_provider_language_for_path` — even though `test_target_and_provider_language_agree_with_registry` dynamically pins **both** functions for every registered language. Fixed: renamed to seam 5a/5b, added an explanation of why 5b is easy to miss (5a's own code comments never point at it), the "check `_provider_language_for_path` for a pre-existing suffix mapping before naming a new `language_id`" lesson this PR itself hit, and an explicit note in the Validation section that the one dynamic test pins both. Scoped strictly to this gap, per the task's ask — not a full re-verification pass of the rest of the skill (that's the established pattern: dedicated docs-only refresh PRs land *after* a language PR merges, e.g. #729/#730 after #728).

## Deferred (this LanguageSpec, all `None` — matches PHP/Go/C#'s own precedent)

`references_and_calls`, `provider_alias_calls`, `file_imports_symbol_from_definition`, `import_update_target`, `prime_repo_context`. `tg refs`/`tg callers`/`tg blast-radius` on a C symbol fall through to the generic `_regex_references_and_calls` text-heuristic path (never a crash, never a fabricated AST-verified match) — and still surface an honest `resolution_gaps` entry (`_language_coverage_gaps_for_universe` already treats `import_update_target is None` generically), pinned by `test_refs_grammar_present_still_reports_import_resolution_gap`.

**The preprocessor-recall ceiling is real and disclosed, not hidden**: tree-sitter never expands macros, so a visibility/export-macro-wrapped declaration (`API_EXPORT void f();`) or an X-macro-generated declaration can hide or reshape the node this extractor expects. This is a correctness ceiling inherent to the tree-sitter-without-preprocessor approach (documented in the design plan and this module's docstring), not a bug — the honest floor is "no toolchain needed," not "clangd parity" (a separate, much larger LSP program `_provider_language_for_path` already has a seam for).

## Tests

- **New `tests/unit/test_lang_c.py` — 26 tests**, mirroring `test_lang_csharp.py`'s shape: registration/provenance, target/provider-language agreement, `.h`-is-unregistered guard, defs for enum/union/struct (kind `"class"`) + the struct-tag/typedef-alias dual-namespace case (`typedef struct Point {...} Point;` → both `"class"` and `"type"`) + prototype-and-definition (2 records) + definition-only + body-less-forward-decl exclusion + plain/extern-variable exclusion, `tg source` full-body + prototype-and-definition-both-blocks, `#include` extraction (angle/quoted/macro/call forms), `build_repo_map` integration, `tg imports` line-numbered rows + `resolved=None`/`external=False`, grammar-present-but-no-resolver `resolution_gaps`, grammar-absent fail-closed + honest CLI exit code, agent-capsule `primary_target_language == "c"`, deep-AST `RecursionError` guard, grammar-module-missing simulation, missing-file/wrong-suffix guards.
- `tests/unit/test_lang_registry.py` — extended registry-shape assertions (suffix resolution, `graph_suffixes()` union, the `LANGUAGE_REGISTRY` set-pin) to include `"c"`/`.c`, plus the provenance test pair mirroring C#'s.
- `tests/unit/test_pyproject_dependencies.py` — 1 new pin test (`tree-sitter-c` present in `ast`/`dev`/`bench`).
- **Locally verified with the REAL grammar** (not just the fail-closed/grammar-absent branches): installed `tree-sitter-c==0.24.2` (`--no-deps`, prebuilt wheel, no compile — the shared repo `.venv` already carried the go/java/php/csharp grammars from a prior sync, so this makes C consistent with its siblings). Ran via the shared repo venv interpreter with `PYTHONPATH` pinned to this worktree's `src/`, `tensor_grep.__file__` confirmed to resolve into the worktree (not the venv's stale non-editable v1.76.11 install) before trusting any result.
- **Results**: `test_lang_c.py` 26/26 passed. `test_lang_registry.py` 19/19 passed. `test_pyproject_dependencies.py` 13/13 passed. All 6 `test_lang_*.py` files together (go/php/java/csharp/registry/c): 130/130 passed, no cross-language regression. `test_skill_index_sync.py` + `test_public_docs_governance.py`: 47/47 passed. All `test_repo_map_*.py`: 151/151 passed. Capsule + import-graph suites (13 files): 172/172 passed. `ruff check` and `ruff format --check --preview` clean on every file this PR touches.
- **Full `tests/unit/` suite** (5695 tests, this repo's default `-x` fail-fast addopt): reached **1051/5695 (1050 passed, 4 skipped)** before stopping on `test_cli_bootstrap.py::test_root_help_should_surface_current_agent_gpu_launcher_and_validation_contracts`. **Verified this is a PRE-EXISTING, unrelated flake, not a regression from this PR**: (1) the assertion checks a 100%-static CLI help-text string (`cli/main.py:187`) this PR never touches; (2) it passes in isolation on this branch (both alone and as the whole `test_cli_bootstrap.py` file); (3) **reproduced identically on a clean `origin/main` checkout with zero of this PR's changes applied — same exact tally, `1 failed, 1050 passed, 4 skipped`, same test, same position in the run**.
- **Also ran the full suite with `-x` disabled** (`-o addopts=...` override, no early stop) to check for any *other* unrelated failures. Machine note: this dev box is running heavy concurrent load from other sessions (multiple long-lived `python` processes observed via `Get-Process`), which made the un-bounded 5695-test run itself slow/CPU-starved — it progressed to ~31% (~1770 tests) with the same `test_cli_bootstrap.py` flake recurring plus a second distinct failure signature, `test_cli_modes.py::test_cli_search_warns_when_gpu_device_id_out_of_local_inventory` (a GPU-device-inventory assertion). **Independently confirmed pre-existing** the same way: reproduces alone (`pytest tests/unit/test_cli_modes.py` in isolation: 526/527 pass, same 1 failure) and **reproduces identically on a clean `origin/main` checkout** (same assertion, same exit code). Both confirmed-pre-existing failure classes are CLI-output/hardware-inventory assertions with zero surface overlap with this PR's language/symbol-graph/import code — `test_cross_lang_resolution.py` (the one file name that could plausibly interact with a new registered language) passes 11/11 clean. No failure in the portion of the no-`-x` run I was able to observe touched anything this PR changed.

## Dogfood

Full end-to-end module verification against real fixtures (every construct: 3 `#include` forms, struct/union/enum both tagged and standalone, plain/array/function-pointer/pointer-returning-function-pointer typedefs, prototype+definition pairs, plain/extern variable exclusion, forward-declaration exclusion, `#ifdef`/`#else`-nested functions reachable, fail-closed grammar-absent, missing-file, deep-AST) run directly against the shipped module functions — all assertions passed. **CLI-binary-level dogfood** (`tg defs`/`tg source`/`tg imports`/`tg agent` through the compiled Rust `tg` binary, not `CliRunner`) needs a native rebuild, which is out of scope under this session's CPU-SAFE constraint (no local cargo/rustc builds on the shared box) — deferred to CI (`ci.yml`'s `test-python` matrix + the release build), consistent with how this campaign's prior C#/Java/PHP PRs also relied on CI for the compiled-binary check when a build wasn't available locally.

## Plan drift vs the design plan

- The plan's `_resolve_raw_import_entry` draft (§1.5) wasn't fully prescriptive about exact wording; I extended the existing `("go", "php", "csharp")` branch to `("go", "php", "csharp", "c")` (DRY, one shared honest-unresolved branch) rather than a standalone `"c"`-only `elif`, since C's outcome (`resolved=None, external=False`) is identical in shape to the other three, just for a different underlying reason (documented in the branch's comment).
- The plan's §1.4 "dedup by `(name, kind)` within a file" recommendation for prototype+definition pairs was **not implemented** — I emit every real AST node untouched (no dedup), matching the actual shipped C# precedent (`test_defs_finds_both_interface_and_impl_methods_sharing_a_name` expects 2 records for a shared-name interface/impl pair, not a deduped 1), which is simpler and has no independent precedent for the dedup mechanism anywhere else in the codebase. Noted as a deliberate simplification, not an oversight.
- Everything else (seam locations, the `_provider_language_for_path` latent pre-wiring, the `.h` header-ambiguity call, the `preproc_include` node shapes, the "8 code + 3 packaging/test seams" count) verified true against the real code exactly as the plan described.

## Gating

Per the task brief: this PR is gated on an **independent Opus review** and a **CEO go/no-go on the C/C++ direction** before merge — not a self-certified "ready to merge." Draft, not ready for auto-merge.

---

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

