### PR TITLE
feat(lang): add C++ symbol + import intelligence (foundational tier, #include honest-unresolved)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,9 +427,11 @@ the mandatory adversarial Opus gate, not by tests or CI.
 
 ## Adding a Language (symbol-graph tier)
 
-tg's deep symbol-graph tier covers 8 of the top-10 languages (Python, JS, TS, Java,
-C#, Go, Rust, PHP; C/C++ deferred — priority per TIOBE Jul-2026 + Stack Overflow 2025
-+ GitHub Octoverse 2025 consensus). Adding one is a **registration-completeness**
+tg's deep symbol-graph tier covers all 10 of the top-10 languages (Python, JS, TS,
+Java, C#, Go, Rust, PHP, C, C++ — priority per TIOBE Jul-2026 + Stack Overflow 2025
++ GitHub Octoverse 2025 consensus; C and C++ both landed foundational-tier only —
+defs/source/imports/agent, caller-graph deferred, see `lang_c.py`/`lang_cpp.py`).
+Adding one is a **registration-completeness**
 problem (see the universal bug class above): the CURRENT pattern is
 `lang_registry.register_language(LanguageSpec(...))` plus a self-contained
 `src/tensor_grep/cli/lang_<x>.py` module mirroring `lang_go.py` — NOT the inline
@@ -466,7 +468,7 @@ CURRENT code, not a mental model.
 
 **Positioning (the tiered model):** text search = ANY language (rg passthrough);
 structural scan/rewrite = 26 langs (`tg ast-info`, via ast-grep which tg WRAPS); deep
-symbol-graph = the tree-sitter grammars (the 8 above). tg = rg (text) + ast-grep
+symbol-graph = the tree-sitter grammars (the 10 above). tg = rg (text) + ast-grep
 (structural) + a symbol/retrieval/capsule LAYER on top. NOT "faster grep."
 
 **Parallel-drain hygiene:** a new grammar touches `test_lang_registry`, the pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -597,7 +597,7 @@ dependencies = [
 gpu = ["cudf-cu12", "kvikio-cu12", "torch>=2.0", "pyarrow>=23.0.1"]
 gpu-win = ["torch>=2.0"]
 nlp = ["transformers>=5.3.0", "tritonclient[http]"]
-ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "tree-sitter-c-sharp", "tree-sitter-c", "pygls>=2.0"]
+ast = ["tree-sitter>=0.22", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-rust", "tree-sitter-go", "tree-sitter-java", "tree-sitter-php", "tree-sitter-c-sharp", "tree-sitter-c", "tree-sitter-cpp", "pygls>=2.0"]
 # Local hybrid semantic search dense leg (`tg search --semantic`, roadmap #27, Path B Stage 1):
 # model2vec is a pure-numpy static-embedding runtime -- NO torch/GPU dependency, sub-ms CPU query
 # encode. Paired with the MIT-licensed minishlab/potion-code-16M model (fetched once, offline
@@ -629,6 +629,7 @@ dev = [
   "tree-sitter-php",
   "tree-sitter-c-sharp",
   "tree-sitter-c",
+  "tree-sitter-cpp",
   "types-PyYAML",
 ]
 bench = [
@@ -644,6 +645,7 @@ bench = [
   "tree-sitter-php",
   "tree-sitter-c-sharp",
   "tree-sitter-c",
+  "tree-sitter-cpp",
   "torch>=2.0",
   "nvtx>=0.2",
 ]

--- a/src/tensor_grep/cli/lang_cpp.py
+++ b/src/tensor_grep/cli/lang_cpp.py
@@ -1,0 +1,756 @@
+"""C++ language extractor for tensor-grep's multi-language symbol graph (PATH A Stage 3).
+
+Tenth language expansion (top-10 language-support campaign, Phase 2 of C/C++ -- closes the
+top-10 symbol-graph tier to 10/10; C shipped first as Phase 1, #731/v1.97.0). Sibling of
+``lang_c.py``/``lang_go.py``/``lang_csharp.py``/``lang_php.py`` (see those modules' docstrings
+for the full "PATH A Stage 1" framing). Plugs into the ``lang_registry`` seam Stage 0 built (see
+``lang_registry.py`` + the ``lang_registry.register_language(...)`` calls near the bottom of
+``repo_map.py``) -- C++ gets its OWN ``LanguageSpec`` entry, registered from ``repo_map.py``,
+separate from C's (two grammar packages, ``tree-sitter-c`` vs ``tree-sitter-cpp``, mirroring the
+shipped JS/TS "two specs, not one mode flag" precedent -- ``_SPEC_BY_SUFFIX`` is a flat
+suffix->ONE-spec dict, and ``.h`` must resolve to exactly one language, see below).
+
+FOUNDATIONAL SCOPE (same tier Java/PHP/C#/Go/C landed at): this module lights up
+``defs``/``source``/``imports``/``agent`` for C++ files -- function definitions AND prototypes
+(kind "function", including qualified out-of-class method definitions like ``Foo::bar()`` and
+in-class method prototypes), class/struct/union/enum definitions (kind "class", the same
+fail-closed struct/union/enum -> "class" mapping C/C#/Java already use), namespace definitions
+(kind "namespace", matching the label ``_lsp_symbol_kind_name`` already uses for LSP symbol kind
+3 -- not a novel vocabulary item), and type aliases -- both ``typedef`` (kind "type", mirroring
+C's own ``type_definition`` handling) and C++11 ``using X = ...`` alias declarations (kind
+"type", same bucket). Template-wrapped declarations (``template_declaration``) are NOT
+specially matched in the walker -- the explicit-stack DFS naturally descends into whatever a
+template wraps (a class/function/qualified method definition), so no separate branch is needed;
+the emitted kind is the WRAPPED construct's own kind, not a distinct "template" kind. C++20
+``concept_definition`` is DELIBERATELY NOT extracted (parses cleanly, but is low-value for a
+foundational landing -- deferred, matching the design plan's own "optional, can defer" call).
+The cross-file caller-graph (``references_and_calls``/``file_imports_symbol_from_definition``/
+``import_update_target``/``prime_repo_context``) is DEFERRED to a follow-up -- this module
+registers all four of those ``LanguageSpec`` fields as ``None``, exactly like every other
+foundational-tier language's own precedent. ``tg refs``/``tg callers``/``tg blast-radius`` on a
+C++ symbol fall through to the generic ``_regex_references_and_calls`` text-heuristic path
+(never a crash, never a fabricated AST-verified match) -- unaffected by this module.
+
+``.h`` IS claimed by this module (unlike ``lang_c.py``, which deliberately excludes it).
+``_provider_language_for_path`` (the LSP provider dispatch, repo_map.py) ALREADY assigns every
+C/C++ header suffix (``.h``, ``.hh``, ``.hpp``, ``.hxx``) plus ``.cc``/``.cpp``/``.cxx`` to
+``"cpp"`` -- a latent pre-wiring that PREDATES this module and effectively forces the choice:
+``language_id="cpp"`` and this exact 7-suffix set, or ``test_target_and_provider_language_agree_
+with_registry`` fails. tree-sitter-cpp is a strict grammar superset of tree-sitter-c, so a
+pure-C header parses fine under this module's grammar too (the header-ambiguity tradeoff
+``lang_c.py``'s own docstring already documents and defers to this module).
+
+FAIL-CLOSED CONTRACT (Stage 0 honesty floor, extended here exactly as it was for Go/PHP/C#/C):
+C++ has NO regex-heuristic fallback. When the ``tree_sitter_cpp`` grammar package is not
+installed, every extractor in this module returns empty ([]/([], [])) rather than degrading to a
+regex/text heuristic (unlike JS/TS/Rust, which all fall back to regex extraction when their own
+tree-sitter grammar is missing). ``LanguageSpec.provenance_when_missing="grammar-missing"`` (NOT
+``"regex-heuristic"``) is what makes ``_language_coverage_gaps_for_universe`` in repo_map.py
+treat a grammar-absent C++ file as a genuine ``resolution_gaps`` entry instead of silently
+reporting zero matches as if the symbol just did not exist.
+
+``#include`` IS a parse-tree node (tree-sitter-cpp does not run a preprocessor, so it never
+strips or expands a ``#include`` directive) -- ``preproc_include`` with a ``path`` field whose
+node SHAPE matches tree-sitter-c's exactly (live-verified against a real tree_sitter_cpp 0.23.4
+parse, not guessed from the grammar README or assumed identical to C without checking):
+  ``#include <stdio.h>``     -> path field type ``system_lib_string``, text ``"<stdio.h>"``
+  ``#include "local.h"``     -> path field type ``string_literal``, nested ``string_content``
+  ``#include MACRO_HEADER``  -> path field type ``identifier`` (macro-expanded form)
+  ``#include COMBINE(a,b)``  -> path field type ``call_expression`` (macro-combined form)
+``_cpp_include_target_text`` strips the ``<...>``/``"..."`` delimiters where present, matching
+every other language's extractor here. Resolution stays HONEST-UNRESOLVED: repo_map.py's
+``_resolve_raw_import_entry`` reports every row ``resolved=None, external=False`` (never a
+fabricated path, never a fabricated ``external=True``) -- true ``#include`` -> file resolution
+has no standardized C++ manifest to resolve against (no ``go.mod``/``composer.json``/``.csproj``
+equivalent) and stays deferred to BACKLOG, same as the go/php/csharp/c resolvers.
+
+DECLARATOR NAME RESOLUTION (extends C's ``_c_declarator_name_node`` with THREE live-verified
+C++-only wrinkles, none guessable from a grammar README):
+
+1. QUALIFIED OUT-OF-CLASS NAMES (``Foo::bar``): a ``qualified_identifier`` node has NO
+   "declarator" field of its own (its fields are "scope" and "name") and has TWO named children
+   (scope + name), so C's generic "single named child" fallback does not apply here -- an
+   explicit branch is required. ``_cpp_declarator_name_node`` follows the "name" field (never
+   "scope") to continue the descent. This also transparently handles NESTED qualification
+   (``app::Thing::compute`` -- the outer qualified_identifier's own "name" field is itself
+   ANOTHER qualified_identifier, ``Thing::compute``, requiring the loop to recurse through it) and
+   TEMPLATED scopes (``Box<T>::get`` -- the "scope" field is a ``template_type`` wrapping
+   ``Box``+``<T>``, but the loop never descends into "scope" at all, so the template arguments
+   never interfere with reaching "get"). The emitted symbol name is the BARE method name
+   (``getValue``, never ``Widget::getValue``) -- this is a deliberate design choice, not an
+   oversight: it is what makes the declaration/definition dedup in ``§1.4`` of the design plan
+   work at all (an in-class prototype's bare name and an out-of-class qualified definition's
+   resolved bare name must match for ``tg defs getValue`` to find BOTH records from either file).
+2. DESTRUCTORS (``~Widget``): a ``destructor_name`` node's own text includes the leading ``~``,
+   but it has exactly ONE named child (a plain ``identifier`` holding just ``Widget``, no tilde)
+   -- C's EXISTING generic "single named child" fallback already resolves through it correctly
+   with NO new branch needed (verified: this is not a coincidence to rely on blindly, it was
+   confirmed against a real parse before this module trusted it). The extracted name is the bare
+   class name (``Widget``), shared with the constructor's own name -- ``tg defs Widget`` then
+   surfaces the class, its constructor(s), AND its destructor together, which reads as useful
+   grouping rather than a collision (an explicit, disclosed design choice, not an accident).
+3. OPERATOR OVERLOADS (``operator+=``): an ``operator_name`` node has ZERO named children (its
+   ``operator`` keyword and the operator token itself are both anonymous) -- C's generic
+   fallback returns ``None`` here (0 != 1 named children), so operator overloads are HONESTLY
+   EXCLUDED from extraction, not crashed on and not mis-named. Even if a name node were somehow
+   produced, ``_is_clean_symbol_name``'s shared ``^[A-Za-z_$][A-Za-z0-9_$]*$`` regex (kept
+   byte-identical to every sibling module's own copy, per that regex's own cross-module contract)
+   would reject ``"operator+="`` anyway (it is not an identifier shape) -- this exclusion is
+   doubly honest, not a special-cased gap.
+
+A ``declaration`` node is ambiguous by TYPE ALONE, exactly as in C (a function PROTOTYPE vs a
+plain variable declaration, gated by whether the declarator chain passes through a
+``function_declarator``) -- see ``lang_c.py``'s own docstring for the full explanation, unchanged
+here. C++ ADDS a second, sibling ambiguity: inside a class/struct/union body, ``field_declaration``
+plays the SAME role ``declaration`` plays at file/namespace scope (a typed method prototype like
+``int getValue() const;`` vs a plain data member like ``int value_;``, live-verified to
+consistently carry the field name in a "declarator" field either way) -- a CONSTRUCTOR prototype
+(``Widget(int value);``, no return type) is the one in-class exception that parses as a plain
+``declaration`` node instead of ``field_declaration``, gated identically. Both node types are
+walked with the SAME ``function_declarator``-presence gate C already established; a plain field
+member is silently excluded from the symbol table, matching this module's and C's shared
+foundational scope (no top-level/member variable tracking here).
+
+A ``class_specifier``/``struct_specifier``/``union_specifier``/``enum_specifier`` is similarly
+ambiguous by type alone (a forward declaration / usage-as-type vs a real definition,
+indistinguishable except by a ``body`` field's presence) -- unchanged from C's own explanation;
+only a body-bearing specifier is emitted. A ``namespace_definition`` with NO "name" field
+(an anonymous ``namespace { ... }`` block, live-verified to omit the field entirely rather than
+supply an empty string) is likewise excluded from the symbol table -- its CONTENTS are still
+reached and extracted normally via the ordinary stack walk, only the anonymous wrapper itself is
+not emitted as a named symbol.
+
+KNOWN, DISCLOSED PREPROCESSOR-RECALL CEILING (live-verified, not merely theorized -- see the
+design plan's own risk #1 and this module's originating PR body for the concrete dogfood finding):
+tree-sitter-cpp does not expand macros. A plain visibility-macro-prefixed FREE FUNCTION
+(``API_EXPORT void f();``) still resolves correctly here (the macro token gets mis-attributed to
+the "type" field and an ``ERROR`` node appears as a sibling, but the "declarator" field --
+``function_declarator`` -- is UNAFFECTED, so the function name is still recovered). A
+macro-prefixed CLASS (``class MYLIB_PUBLIC Name { ... };``) does NOT recover: tree-sitter
+misparses the whole construct as a ``function_definition`` (the macro token becomes a fake
+"return type" via a body-less ``class_specifier``, and ``Name`` becomes the function's own
+declarator), so the class is extracted as kind "function" under its real name instead of kind
+"class" -- a genuinely WRONG (not merely missing) kind label. No guard was added to special-case
+this: the exact AST shape produced by the misparse (``function_definition`` whose "type" field is
+a body-less class/struct/union/enum specifier) is INDISTINGUISHABLE from the shape produced by a
+perfectly legitimate, common, non-macro construct -- a function that returns a struct/class BY
+VALUE (``struct Point make_point() { ... }`` parses identically). Suppressing the misparse case
+would also suppress the legitimate case, which is strictly more common in real code; the honest
+choice is to trust the parser's own (occasionally macro-confused) shape rather than add a
+heuristic that trades one wrong answer for a different, more frequent one. This is the disclosed,
+inherent ceiling of a preprocessor-unaware tool, not a bug to chase.
+
+CONFIRMED ON REAL, LIVE CODE (not just a synthetic fixture -- this module's originating PR
+dogfooded two real public headers, CPython's ``Include/object.h`` and LLVM's
+``llvm/ADT/StringRef.h``, both fetched fresh, neither vendored into this repo): LLVM's own
+``class LLVM_GSL_POINTER StringRef { ... }`` hits the exact misparse above -- the ~830-line
+`StringRef` class extracts as kind "function" (7 records, one per overloaded constructor) rather
+than one kind "class" record, while its sibling `StringLiteral : public StringRef` (no
+macro-prefix) extracts correctly as kind "class". The nuance worth disclosing: MEMBER recall
+mostly SURVIVES the container-level misparse -- of `StringRef`'s ~85 distinct public methods,
+essentially all of them (``begin``, ``find``, ``substr``, ``split``, ``getAsInteger``, etc.) still
+resolve as individual kind "function" symbols, because tree-sitter's error recovery is local to
+the misparsed node, not global -- only the ENCLOSING class's own kind label is wrong, not its
+members' discoverability. CPython's ``object.h`` (macro-guarded ``#ifdef``/``#else`` struct
+bodies, function-pointer typedef style) surfaced a SEPARATE real finding: an anonymous union
+prefixed with a visibility macro (``_Py_ANONYMOUS union { ... };``, no tag name) misparses such
+that the bare KEYWORD ``union`` itself becomes the extracted declarator text. Unlike the
+class/struct-vs-return-type ambiguity above, this ONE ceiling instance IS safely fixable: no valid
+C++ program can ever declare a symbol literally named a reserved keyword (``union``, ``class``,
+``struct``, ...), so rejecting the C++ keyword set as symbol names (``_is_clean_cpp_symbol_name``,
+layered on top of the shared ``_is_clean_symbol_name`` shape check) has ZERO legitimate-code
+false-negative cost -- this module does apply that guard, unlike the class-macro-misparse, which
+it deliberately does NOT special-case (the false-negative cost there is real and worse than the
+false-positive it would fix). See the module's originating PR body for the full dogfood
+methodology and quantified numbers.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Duplicated tiny helpers -- see the module docstring: no import from repo_map.py, to avoid an
+# import cycle (repo_map.py imports THIS module). Keep byte-identical to repo_map.py's twins
+# (``_tree_sitter_node_text`` / ``_is_clean_symbol_name`` / ``_symbol_record``) -- and to
+# ``lang_c.py``/``lang_go.py``/``lang_csharp.py``/``lang_php.py``'s own copies of the same three --
+# if any of them ever change there.
+# ---------------------------------------------------------------------------
+
+_CLEAN_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_$][A-Za-z0-9_$]*$")
+
+
+def _is_clean_symbol_name(name: str) -> bool:
+    return bool(_CLEAN_SYMBOL_NAME_RE.match(name))
+
+
+# Live-verified dogfood finding (see the module docstring's macro-recall-ceiling section): a
+# macro-prefixed ANONYMOUS union/struct/class (e.g. CPython's own
+# ``_Py_ANONYMOUS union { ... };``) can misparse such that the bare KEYWORD itself (``union``)
+# becomes the extracted "declarator" text -- `_is_clean_symbol_name`'s shape-only regex accepts
+# it (it IS identifier-shaped), but no valid C++ program can ever declare a symbol literally
+# named `union`/`class`/`struct`/etc. (reserved words can never be identifiers), so this is
+# unconditionally a misparse artifact, never a legitimate symbol -- unlike the "class MACRO Name"
+# -> function misparse (see the docstring), rejecting a reserved keyword has NO legitimate-code
+# false-negative cost, so it is a safe, zero-downside precision fix (found via the real-header
+# dogfood this module's originating PR required, not a hypothetical).
+_CPP_RESERVED_KEYWORDS = frozenset({
+    "alignas",
+    "alignof",
+    "and",
+    "and_eq",
+    "asm",
+    "auto",
+    "bitand",
+    "bitor",
+    "bool",
+    "break",
+    "case",
+    "catch",
+    "char",
+    "char8_t",
+    "char16_t",
+    "char32_t",
+    "class",
+    "compl",
+    "concept",
+    "const",
+    "consteval",
+    "constexpr",
+    "constinit",
+    "const_cast",
+    "continue",
+    "co_await",
+    "co_return",
+    "co_yield",
+    "decltype",
+    "default",
+    "delete",
+    "do",
+    "double",
+    "dynamic_cast",
+    "else",
+    "enum",
+    "explicit",
+    "export",
+    "extern",
+    "false",
+    "float",
+    "for",
+    "friend",
+    "goto",
+    "if",
+    "inline",
+    "int",
+    "long",
+    "mutable",
+    "namespace",
+    "new",
+    "noexcept",
+    "not",
+    "not_eq",
+    "nullptr",
+    "operator",
+    "or",
+    "or_eq",
+    "private",
+    "protected",
+    "public",
+    "register",
+    "reinterpret_cast",
+    "requires",
+    "return",
+    "short",
+    "signed",
+    "sizeof",
+    "static",
+    "static_assert",
+    "static_cast",
+    "struct",
+    "switch",
+    "template",
+    "this",
+    "thread_local",
+    "throw",
+    "true",
+    "try",
+    "typedef",
+    "typeid",
+    "typename",
+    "union",
+    "unsigned",
+    "using",
+    "virtual",
+    "void",
+    "volatile",
+    "wchar_t",
+    "while",
+    "xor",
+    "xor_eq",
+})
+
+
+def _is_clean_cpp_symbol_name(name: str) -> bool:
+    return _is_clean_symbol_name(name) and name not in _CPP_RESERVED_KEYWORDS
+
+
+def _tree_sitter_node_text(source_bytes: bytes, node: Any) -> str:
+    return source_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _symbol_record(
+    *,
+    name: str,
+    kind: str,
+    file: Path,
+    start_line: int,
+    end_line: int | None = None,
+) -> dict[str, Any]:
+    normalized_end_line = start_line if end_line is None else end_line
+    return {
+        "name": name,
+        "kind": kind,
+        "file": str(file),
+        "line": start_line,
+        "start_line": start_line,
+        "end_line": normalized_end_line,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parser factory (clone of lang_c.py's ``_c_parser`` shape).
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _cpp_parser() -> Any | None:
+    try:
+        import tree_sitter
+        import tree_sitter_cpp
+    except ImportError:
+        return None
+
+    language = tree_sitter.Language(tree_sitter_cpp.language())
+    return tree_sitter.Parser(language)
+
+
+# ---------------------------------------------------------------------------
+# Defs + imports: one tree-sitter pass per file.
+# ---------------------------------------------------------------------------
+
+# `.h` is claimed by C++ (not C) -- see the module docstring's header-ambiguity note.
+_CPP_SUFFIXES = frozenset({".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"})
+
+# class/struct/union/enum specifiers collapse to kind "class" -- the fail-closed cross-language
+# mapping this campaign's other struct-bearing languages already use (C's own struct/union/enum
+# and C#'s struct/interface/enum/record precedents).
+_CPP_CLASS_LIKE_KINDS = frozenset({
+    "class_specifier",
+    "struct_specifier",
+    "union_specifier",
+    "enum_specifier",
+})
+# Node types a C++ def can appear as -- informational/documentation only (mirrors
+# lang_c._C_DEF_NODE_KINDS' role), matching LanguageSpec.def_node_kinds' "Stage 0:
+# informational only" contract. `template_declaration` is listed even though the walker never
+# matches it directly -- see the module docstring: it is a transparent wrapper the explicit-stack
+# DFS descends into for free.
+_CPP_DEF_NODE_KINDS = (
+    "function_definition",
+    "declaration",
+    "field_declaration",
+    "class_specifier",
+    "struct_specifier",
+    "union_specifier",
+    "enum_specifier",
+    "namespace_definition",
+    "template_declaration",
+    "type_definition",
+    "alias_declaration",
+)
+# _cpp_declarator_name_node's backstop hop limit -- mirrors lang_c.py's own
+# _MAX_DECLARATOR_HOPS choice (64) with headroom above any plausible real nesting, including the
+# extra qualified_identifier/destructor_name/reference_declarator hops C++ adds over C; this only
+# guards against an unforeseen future grammar cycle, never hit in practice.
+_MAX_DECLARATOR_HOPS = 64
+
+
+def _cpp_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
+    """Descend a declarator chain to its innermost identifier/type_identifier/field_identifier
+    NAME node, tracking whether the chain passed through a ``function_declarator`` along the way.
+
+    Extends ``lang_c.py``'s ``_c_declarator_name_node`` with ONE new branch (``qualified_
+    identifier`` -> follow "name", never "scope") -- see the module docstring's "DECLARATOR NAME
+    RESOLUTION" section for why that is the only new branch needed: destructors and reference-
+    wrapped operators already resolve (or honestly fail to resolve, for operators) through the
+    same generic "declarator field, else the single named child" fallback C already has.
+
+    Returns ``(None, seen_function)`` if no name-bearing leaf was found (e.g. an operator overload,
+    whose ``operator_name`` node has zero named children) -- callers must check for ``None``
+    before using the result.
+    """
+    seen_function = False
+    current = declarator
+    hops = 0
+    while current is not None and hops < _MAX_DECLARATOR_HOPS:
+        hops += 1
+        if current.type in {"identifier", "type_identifier", "field_identifier"}:
+            return current, seen_function
+        if current.type == "function_declarator":
+            seen_function = True
+        if current.type == "qualified_identifier":
+            # Foo::bar / app::Thing::compute / Box<T>::get -- take the RHS "name" field (which
+            # may itself be another qualified_identifier for a nested namespace::class chain, or
+            # a destructor_name/operator_name leaf); NEVER the "scope" field (which may be a
+            # template_type for a templated out-of-class method -- its <T> arguments must never
+            # leak into the extracted name).
+            next_node = current.child_by_field_name("name")
+            if next_node is not None:
+                current = next_node
+                continue
+            return None, seen_function
+        next_node = current.child_by_field_name("declarator")
+        if next_node is not None:
+            current = next_node
+            continue
+        named_children = [child for child in current.children if child.is_named]
+        if len(named_children) == 1:
+            current = named_children[0]
+            continue
+        return None, seen_function
+    return None, seen_function
+
+
+def _cpp_include_target_text(path_field: Any, source_bytes: bytes) -> str | None:
+    """Return a ``preproc_include`` node's target text, quote/bracket-stripped where the include
+    form carries delimiters. Byte-identical logic to ``lang_c.py``'s ``_c_include_target_text``
+    (live-verified: tree-sitter-cpp's ``preproc_include`` node shape matches tree-sitter-c's
+    exactly across all four include forms) -- duplicated rather than imported, matching every
+    other cross-cutting helper's precedent in this module (see the top-of-file comment)."""
+    if path_field is None:
+        return None
+    if path_field.type == "system_lib_string":
+        raw = _tree_sitter_node_text(source_bytes, path_field)
+        if len(raw) >= 2 and raw[0] == "<" and raw[-1] == ">":
+            return raw[1:-1]
+        return raw
+    if path_field.type == "string_literal":
+        content_node = next(
+            (child for child in path_field.children if child.type == "string_content"),
+            None,
+        )
+        if content_node is not None:
+            return _tree_sitter_node_text(source_bytes, content_node)
+        # Fallback (mirrors lang_c.py's own fallback): an empty ``#include ""`` or an unusual
+        # grammar build with no ``string_content`` child still yields a clean module string
+        # instead of silently dropping the row.
+        raw = _tree_sitter_node_text(source_bytes, path_field)
+        if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+            return raw[1:-1]
+        return raw
+    # identifier (macro name, e.g. MACRO_HEADER) / call_expression (macro-combined, e.g.
+    # COMBINE(a,b)) / anything else: no delimiters to strip -- the raw text IS the honest
+    # include target (this module never fabricates a resolved path for these either way; see
+    # repo_map.py's `_resolve_raw_import_entry` "cpp" branch).
+    return _tree_sitter_node_text(source_bytes, path_field)
+
+
+def cpp_imports_and_symbols(path: Path) -> tuple[list[str], list[dict[str, Any]]]:
+    """Extract ``#include`` targets + function/class/namespace/type-alias definitions from a
+    C++ source file, one AST pass (mirrors ``lang_c.c_imports_and_symbols``'s shape).
+
+    Defs covered: ``function_definition`` (kind "function" -- free functions, in-class inline
+    methods, and out-of-class qualified method/constructor/destructor definitions all share this
+    node type), a ``declaration``/``field_declaration`` whose declarator chain passes through a
+    ``function_declarator`` (a prototype, kind "function" -- a plain data member or variable
+    declaration is excluded, see the module docstring), ``class_specifier``/``struct_specifier``/
+    ``union_specifier``/``enum_specifier`` WITH a body (kind "class" -- a body-less forward
+    declaration/usage-as-type is excluded), ``namespace_definition`` WITH a name (kind
+    "namespace" -- an anonymous namespace's own wrapper is excluded, its contents are not),
+    ``type_definition`` (kind "type", one record per declarator so ``typedef int A, B;`` yields
+    both), and ``alias_declaration`` (kind "type" -- a C++11 ``using X = ...`` alias). A
+    ``template_declaration`` is never matched directly; the walker naturally descends into
+    whatever it wraps. Imports come from every ``preproc_include`` directive's target text (see
+    ``_cpp_include_target_text``).
+    """
+    if path.suffix not in _CPP_SUFFIXES:
+        return [], []
+
+    parser = _cpp_parser()
+    if parser is None:
+        return [], []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    imports: list[str] = []
+    symbols: list[dict[str, Any]] = []
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS instead of recursion, matching lang_c.py/lang_go.py's walkers (F26
+        # precedent: a pathologically deep AST can never raise RecursionError). Children pushed
+        # in reverse so the leftmost child is popped (visited) first, preserving pre-order
+        # traversal. A plain (non-recursive) stack walk also naturally reaches nodes nested
+        # inside `preproc_ifdef`/`preproc_if`/`preproc_elif` guards AND inside a
+        # `template_declaration` wrapper AND inside nested class/namespace bodies -- live-verified:
+        # both branches of an `#ifdef`/`#else` parse simultaneously as ordinary children, and a
+        # template-wrapped or nested construct is just another descendant -- no special-casing
+        # needed for any of the three.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "preproc_include":
+                path_field = node.child_by_field_name("path")
+                target = _cpp_include_target_text(path_field, source_bytes)
+                if target:
+                    imports.append(target)
+            elif node_type == "function_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _cpp_declarator_name_node(declarator)
+                    if name_node is None:
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_cpp_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type in ("declaration", "field_declaration"):
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, is_function = _cpp_declarator_name_node(declarator)
+                    if not is_function or name_node is None:
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_cpp_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="function",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type in _CPP_CLASS_LIKE_KINDS:
+                body_field = node.child_by_field_name("body")
+                name_field = node.child_by_field_name("name")
+                if body_field is not None and name_field is not None:
+                    name = _node_text(name_field)
+                    if _is_clean_cpp_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="class",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type == "namespace_definition":
+                name_field = node.child_by_field_name("name")
+                if name_field is not None:
+                    name = _node_text(name_field)
+                    if _is_clean_cpp_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="namespace",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type == "type_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _cpp_declarator_name_node(declarator)
+                    if name_node is None:
+                        continue
+                    name = _node_text(name_node)
+                    if _is_clean_cpp_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="type",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            elif node_type == "alias_declaration":
+                name_field = node.child_by_field_name("name")
+                if name_field is not None:
+                    name = _node_text(name_field)
+                    if _is_clean_cpp_symbol_name(name):
+                        symbols.append(
+                            _symbol_record(
+                                name=name,
+                                kind="type",
+                                file=path,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                            )
+                        )
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    imports = sorted(dict.fromkeys(imports))
+    symbols.sort(key=lambda item: (item["file"], item["line"], item["kind"], item["name"]))
+    return imports, symbols
+
+
+# #74-follow-up: `tg imports` foundational-tier extractor (mirrors lang_c.c_imports_with_lines'
+# shape/role exactly). One row per `preproc_include` STATEMENT with its 1-based line number --
+# same extraction source as `cpp_imports_and_symbols` above (every `preproc_include`'s target
+# text via `_cpp_include_target_text`), just line-tagged instead of deduped into a flat list.
+#
+# Deliberately NOT resolved to a target file: repo_map.py's `_resolve_raw_import_entry` "cpp"
+# branch keeps every row unresolved (resolved=None, external=False) -- true `#include` -> file
+# resolution has no standardized C++ manifest to resolve against (see the module docstring), so a
+# real path is not guessable without fabricating one.
+def cpp_imports_with_lines(path: Path) -> list[dict[str, Any]]:
+    if path.suffix not in _CPP_SUFFIXES:
+        return []
+
+    parser = _cpp_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+
+    entries: list[dict[str, Any]] = []
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS -- see the identical comment on cpp_imports_and_symbols's `_walk`.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == "preproc_include":
+                path_field = node.child_by_field_name("path")
+                target = _cpp_include_target_text(path_field, source_bytes)
+                if target:
+                    entries.append({
+                        "module": target,
+                        "line": node.start_point[0] + 1,
+                    })
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    return entries
+
+
+def cpp_parser_symbol_sources(path: Path, symbol: str) -> list[dict[str, Any]]:
+    """Full source text of every function/class/namespace/type-alias matching *symbol* (mirrors
+    ``lang_c.c_parser_symbol_sources``'s shape for the ``tg source`` command).
+
+    A function/typedef appearing both as a prototype/forward form and a full definition emits a
+    source block for EACH matching AST node (no dedup/preference between them) -- the same
+    "every real AST node is a legitimate hit" behavior C's own module already ships (a prototype
+    and its later definition sharing a name both resolve as separate ``tg source`` blocks)."""
+    if path.suffix not in _CPP_SUFFIXES:
+        return []
+
+    parser = _cpp_parser()
+    if parser is None:
+        return []
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_bytes = source.encode("utf-8")
+    tree = parser.parse(source_bytes)
+    sources: list[dict[str, Any]] = []
+
+    def _node_text(node: Any) -> str:
+        return _tree_sitter_node_text(source_bytes, node)
+
+    def _append(node: Any, kind: str) -> None:
+        block = _node_text(node)
+        if block and not block.endswith("\n"):
+            block = f"{block}\n"
+        sources.append({
+            "name": symbol,
+            "kind": kind,
+            "file": str(path),
+            "start_line": node.start_point[0] + 1,
+            "end_line": node.end_point[0] + 1,
+            "source": block,
+        })
+
+    def _walk(root: Any) -> None:
+        # Explicit-stack DFS -- see the identical comment on cpp_imports_and_symbols's `_walk`.
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == "function_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _cpp_declarator_name_node(declarator)
+                    if name_node is not None and _node_text(name_node) == symbol:
+                        _append(node, "function")
+                        break
+            elif node_type in ("declaration", "field_declaration"):
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, is_function = _cpp_declarator_name_node(declarator)
+                    if is_function and name_node is not None and _node_text(name_node) == symbol:
+                        _append(node, "function")
+                        break
+            elif node_type in _CPP_CLASS_LIKE_KINDS:
+                body_field = node.child_by_field_name("body")
+                name_field = node.child_by_field_name("name")
+                if (
+                    body_field is not None
+                    and name_field is not None
+                    and _node_text(name_field) == symbol
+                ):
+                    _append(node, "class")
+            elif node_type == "namespace_definition":
+                name_field = node.child_by_field_name("name")
+                if name_field is not None and _node_text(name_field) == symbol:
+                    _append(node, "namespace")
+            elif node_type == "type_definition":
+                for declarator in node.children_by_field_name("declarator"):
+                    name_node, _seen_function = _cpp_declarator_name_node(declarator)
+                    if name_node is not None and _node_text(name_node) == symbol:
+                        _append(node, "type")
+                        break
+            elif node_type == "alias_declaration":
+                name_field = node.child_by_field_name("name")
+                if name_field is not None and _node_text(name_field) == symbol:
+                    _append(node, "type")
+            stack.extend(reversed(node.children))
+
+    _walk(tree.root_node)
+    sources.sort(key=lambda item: (item["file"], item["start_line"], item["kind"], item["name"]))
+    return sources
+
+
+__all__ = [
+    "cpp_imports_and_symbols",
+    "cpp_imports_with_lines",
+    "cpp_parser_symbol_sources",
+]

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Literal, NamedTuple, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
-from tensor_grep.cli import lang_c, lang_csharp, lang_go, lang_php, lang_registry
+from tensor_grep.cli import lang_c, lang_cpp, lang_csharp, lang_go, lang_php, lang_registry
 from tensor_grep.cli.lsp_external_provider import ExternalLSPProviderManager, LSPTransportError
 from tensor_grep.core.retrieval_lexical import score_term_overlap, split_terms
 
@@ -266,6 +266,10 @@ _JS_TS_SUFFIXES = {".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
 _TS_SUFFIXES = {".ts", ".tsx"}
 _RUST_SUFFIXES = {".rs"}
 _JAVA_SUFFIXES = {".java"}
+# Top-10 language campaign (Phase 2, C++): matches lang_cpp.py's LanguageSpec.suffixes AND
+# _provider_language_for_path's pre-existing "cpp" assignment exactly -- ".h" is claimed by C++
+# (not C), see lang_cpp.py's module docstring for the header-ambiguity rationale.
+_CPP_SUFFIXES = {".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"}
 _SOURCE_FIRST_DIR_NAMES = {
     ".claude",
     "app",
@@ -288,9 +292,12 @@ _SOURCE_FIRST_SUFFIXES = {
     ".cpp",
     ".cs",
     ".css",
+    ".cxx",
     ".go",
     ".h",
+    ".hh",
     ".hpp",
+    ".hxx",
     ".java",
     ".js",
     ".jsx",
@@ -6266,6 +6273,60 @@ lang_registry.register_language(
     )
 )
 
+# PATH A Stage 3 (Phase 2 of C/C++): C++ joins the symbol graph as a FOUNDATIONAL-TIER language,
+# closing the top-10 language-support campaign to 10/10. Own module (lang_cpp.py) for the same
+# no-import-cycle reason as C/Go/PHP/C# -- a SEPARATE LanguageSpec + grammar package
+# (tree-sitter-cpp) from C's, mirroring the shipped JS/TS "two specs, not one mode flag"
+# precedent (``_SPEC_BY_SUFFIX`` is a flat suffix->ONE-spec dict, so ".h" cannot belong to both).
+# FOUNDATIONAL scope only -- defs/source/imports/agent via `extract_imports_and_symbols`-shaped
+# extraction, wired at the `_imports_and_symbols_for_path` / `build_symbol_source_from_map`
+# dispatch sites below. The cross-file caller-graph (references_and_calls /
+# file_imports_symbol_from_definition / import_update_target / repo-root context priming for a
+# future `#include`-path resolver) is DEFERRED to a follow-up -- all four stay None here, same
+# shape as C/Go/PHP/C#'s own `import_update_target=None` gap, so `tg refs`/`tg callers`/`tg
+# blast-radius` on a C++ symbol fall through to the generic `_regex_references_and_calls`
+# text-heuristic path instead of crashing or fabricating an AST-verified match.
+# provenance_when_missing="grammar-missing" (NOT "regex-heuristic") is what makes a
+# grammar-absent C++ file a genuine `resolution_gaps` entry instead of a silent empty result
+# (C++ has no regex fallback, unlike JS/TS/Rust).
+#
+# ".h" IS in suffixes here (unlike lang_c.py, which deliberately excludes it) --
+# `_provider_language_for_path` (below) ALREADY assigns every C/C++ header suffix to "cpp"
+# (tree-sitter-cpp is a strict grammar superset of C), so this module is the pre-existing,
+# forced owner of ".h"/".hh"/".hpp"/".hxx" as well as ".cc"/".cpp"/".cxx". See lang_cpp.py's
+# module docstring for the full header-ambiguity rationale.
+lang_registry.register_language(
+    lang_registry.LanguageSpec(
+        language_id="cpp",
+        suffixes=frozenset(_CPP_SUFFIXES),
+        grammar_modules=("tree_sitter", "tree_sitter_cpp"),
+        parser_for_path=lambda path: lang_cpp._cpp_parser(),
+        provenance_when_parsed="tree-sitter",
+        provenance_when_missing="grammar-missing",
+        import_markers=(b"#include",),
+        def_node_kinds=(
+            "function_definition",
+            "declaration",
+            "field_declaration",
+            "class_specifier",
+            "struct_specifier",
+            "union_specifier",
+            "enum_specifier",
+            "namespace_definition",
+            "template_declaration",
+            "type_definition",
+            "alias_declaration",
+        ),
+        extract_imports_and_symbols=None,
+        references_and_calls=None,
+        provider_alias_calls=None,
+        file_imports_symbol_from_definition=None,
+        import_update_target=None,
+        prime_repo_context=None,
+        classify_ref_kind=None,
+    )
+)
+
 
 def _prime_all_language_repo_contexts(context_root: Path) -> None:
     """Prime every registered language's per-repo-root context exactly once.
@@ -6335,6 +6396,11 @@ def _imports_and_symbols_for_path(
             # Fail-closed (Stage 1 trap, same as Go): NO regex fallback for C. A grammar-missing
             # .c file returns ([], []) here -- surfaced honestly via `resolution_gaps`.
             current_imports, current_symbols = lang_c.c_imports_and_symbols(path)
+        elif spec is not None and spec.language_id == "cpp":
+            # Fail-closed (Stage 1 trap, same as Go/C): NO regex fallback for C++ either. A
+            # grammar-missing C++ file returns ([], []) here -- surfaced honestly via
+            # `resolution_gaps`.
+            current_imports, current_symbols = lang_cpp.cpp_imports_and_symbols(path)
         elif not current_imports and not current_symbols:
             current_imports, current_symbols = _regex_imports_and_symbols(path)
         return current_imports, current_symbols
@@ -6488,7 +6554,7 @@ def _rust_imports_with_lines(path: Path) -> list[dict[str, Any]]:
 
 
 def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
-    """Raw per-statement imports with 1-based line numbers for the 9 supported languages.
+    """Raw per-statement imports with 1-based line numbers for the 10 supported languages.
 
     Returns ``[]`` for an unsupported language (e.g. Kotlin) or an over-cap file -- callers that
     need to distinguish "genuinely no imports" from "not scanned" must check those conditions
@@ -6505,11 +6571,11 @@ def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
         return _rust_imports_with_lines(path)
     if spec.language_id == "java":
         return _java_imports_with_lines(path)
-    if spec.language_id in ("go", "php", "csharp", "c"):
-        # go/php/csharp/c's own extractors (lang_go.py/lang_php.py/lang_csharp.py/lang_c.py)
-        # mirror their `_X_imports_and_symbols` siblings, which get this SAME cap check for free
-        # from THEIR caller (`_imports_and_symbols_for_path`, above) rather than self-guarding --
-        # applied here once, at this dispatcher, for the identical reason.
+    if spec.language_id in ("go", "php", "csharp", "c", "cpp"):
+        # go/php/csharp/c/cpp's own extractors (lang_go.py/lang_php.py/lang_csharp.py/lang_c.py/
+        # lang_cpp.py) mirror their `_X_imports_and_symbols` siblings, which get this SAME cap
+        # check for free from THEIR caller (`_imports_and_symbols_for_path`, above) rather than
+        # self-guarding -- applied here once, at this dispatcher, for the identical reason.
         try:
             file_size = path.stat().st_size
         except OSError:
@@ -6522,7 +6588,9 @@ def _imports_with_lines_for_path(path: Path) -> list[dict[str, Any]]:
             return lang_php.php_imports_with_lines(path)
         if spec.language_id == "csharp":
             return lang_csharp.csharp_imports_with_lines(path)
-        return lang_c.c_imports_with_lines(path)
+        if spec.language_id == "c":
+            return lang_c.c_imports_with_lines(path)
+        return lang_cpp.cpp_imports_with_lines(path)
     return []
 
 
@@ -7464,10 +7532,16 @@ def _target_language_for_path(path: str | Path | None) -> str | None:
         return "csharp"
     if suffix == ".c":
         # Same MOST-FORGOTTEN seam, now for C (PATH A Stage 3, top-10 language campaign). Note
-        # ".h" is deliberately absent here -- it stays unregistered until a future lang_cpp.py
-        # claims it (see lang_c.py's module docstring's header-ambiguity note); this branch must
-        # match ONLY the suffixes lang_c.py's LanguageSpec actually registers.
+        # ".h" is deliberately absent here -- lang_cpp.py (below) is the registered owner of
+        # every C/C++ header suffix (see lang_c.py's module docstring's header-ambiguity note);
+        # this branch must match ONLY the suffixes lang_c.py's LanguageSpec actually registers.
         return "c"
+    if suffix in _CPP_SUFFIXES:
+        # Same MOST-FORGOTTEN seam, now for C++ (PATH A Stage 3, Phase 2 -- closes the top-10
+        # language campaign to 10/10). Must match lang_cpp.py's LanguageSpec.suffixes AND
+        # _provider_language_for_path's pre-existing "cpp" assignment exactly, or
+        # test_target_and_provider_language_agree_with_registry fails.
+        return "cpp"
     return None
 
 
@@ -15918,6 +15992,8 @@ def build_symbol_source_from_map(
                 current_sources = lang_csharp.csharp_parser_symbol_sources(current_path, symbol)
             if not current_sources and current_path.suffix == ".c":
                 current_sources = lang_c.c_parser_symbol_sources(current_path, symbol)
+            if not current_sources and current_path.suffix in _CPP_SUFFIXES:
+                current_sources = lang_cpp.cpp_parser_symbol_sources(current_path, symbol)
             if not current_sources:
                 current_sources = _regex_symbol_sources(current_path, symbol)
             sources.extend(current_sources)
@@ -16708,12 +16784,14 @@ _SUPPORTED_FILE_DEPENDENCY_LANGUAGES = frozenset({
     "go",
     "php",
     "csharp",
-    # Top-10 language campaign (Phase 1, C only -- C++ is a separate follow-up): raw `#include`
-    # directives + line numbers via lang_c.c_imports_with_lines, `_resolve_raw_import_entry`
-    # reporting them honestly unresolved. TRUE `#include` -> file resolution is deferred and
-    # harder than go/php/csharp's own deferred resolvers -- C has no standardized manifest
-    # (no go.mod/composer.json/.csproj equivalent) to resolve against; see docs/BACKLOG.md.
+    # Top-10 language campaign (Phase 1, C; Phase 2, C++ -- closes the campaign to 10/10): raw
+    # `#include` directives + line numbers via lang_c.c_imports_with_lines /
+    # lang_cpp.cpp_imports_with_lines, `_resolve_raw_import_entry` reporting them honestly
+    # unresolved. TRUE `#include` -> file resolution is deferred and harder than go/php/csharp's
+    # own deferred resolvers -- C/C++ have no standardized manifest (no
+    # go.mod/composer.json/.csproj equivalent) to resolve against; see docs/BACKLOG.md.
     "c",
+    "cpp",
 })
 
 
@@ -16786,23 +16864,23 @@ def _resolve_raw_import_entry(
         # dynamic_unresolved branch above uses -- rather than guessing (never fabricate
         # resolution precision this extractor doesn't actually have).
         resolved, external, provenance, confidence = None, False, [], 0.0
-    elif language_id in ("go", "php", "csharp", "c"):
+    elif language_id in ("go", "php", "csharp", "c", "cpp"):
         # Foundational tier (mirrors the "java" branch above): raw import statements are
         # extracted with their line numbers (see lang_go.go_imports_with_lines /
         # lang_php.php_imports_with_lines / lang_csharp.csharp_imports_with_lines /
-        # lang_c.c_imports_with_lines), but resolving WHICH file/module an import points to is
-        # deferred -- each of these four needs DIFFERENT missing machinery: go's existing
-        # `_go_import_path_to_dir` resolves to a PACKAGE DIRECTORY, not a file (no 1:1
-        # import-to-file mapping to wire); php has no PSR-4/composer.json autoload-map reader;
-        # csharp has no `.csproj`/namespace-to-file map; c has no standardized manifest at all
-        # (no go.mod/composer.json/.csproj equivalent) -- a bare `#include "foo.h"` needs the
-        # including file's own directory plus the compiler's `-iquote`/`-I` search order, and a
-        # bare `#include <foo.h>` is ENTIRELY build-system/toolchain defined, not in the source
-        # at all (see lang_c.py's module docstring). None of that resolver machinery exists yet
-        # for any of the four. Report as unresolved-but-not-presumed-external -- the same
-        # conservative tuple every other "resolution not yet built" branch in this function uses
-        # -- rather than guessing (never fabricate resolution precision these extractors don't
-        # actually have).
+        # lang_c.c_imports_with_lines / lang_cpp.cpp_imports_with_lines), but resolving WHICH
+        # file/module an import points to is deferred -- each of these five needs DIFFERENT
+        # missing machinery: go's existing `_go_import_path_to_dir` resolves to a PACKAGE
+        # DIRECTORY, not a file (no 1:1 import-to-file mapping to wire); php has no
+        # PSR-4/composer.json autoload-map reader; csharp has no `.csproj`/namespace-to-file map;
+        # c/cpp have no standardized manifest at all (no go.mod/composer.json/.csproj
+        # equivalent) -- a bare `#include "foo.h"` needs the including file's own directory plus
+        # the compiler's `-iquote`/`-I` search order, and a bare `#include <foo.h>` is ENTIRELY
+        # build-system/toolchain defined, not in the source at all (see lang_c.py's and
+        # lang_cpp.py's module docstrings). None of that resolver machinery exists yet for any of
+        # the five. Report as unresolved-but-not-presumed-external -- the same conservative tuple
+        # every other "resolution not yet built" branch in this function uses -- rather than
+        # guessing (never fabricate resolution precision these extractors don't actually have).
         resolved, external, provenance, confidence = None, False, [], 0.0
     else:
         resolved, external, provenance, confidence = None, True, [], 0.0

--- a/tests/unit/test_lang_c.py
+++ b/tests/unit/test_lang_c.py
@@ -104,12 +104,17 @@ def test_target_language_for_path_reports_c() -> None:
     assert repo_map._provider_language_for_path("widget.c") == "c"
 
 
-def test_header_suffix_is_deliberately_unregistered() -> None:
-    """`.h` is reserved for a future lang_cpp.py (tree-sitter-cpp is a strict grammar superset of
-    C) -- this module must NOT claim it, or `_target_language_for_path` would disagree with
-    `_provider_language_for_path`'s pre-existing "cpp" assignment for header suffixes."""
-    assert lang_registry.spec_for_path("widget.h") is None
+def test_header_suffix_is_claimed_by_cpp_not_c() -> None:
+    """`.h` is claimed by lang_cpp.py (tree-sitter-cpp is a strict grammar superset of C), NOT by
+    this module -- this module must NOT claim it, or `_target_language_for_path` would disagree
+    with `_provider_language_for_path`'s pre-existing "cpp" assignment for header suffixes. Was
+    "deliberately unregistered" before lang_cpp.py existed (Phase 1 of the top-10 language
+    campaign, #731); now registered under "cpp" (Phase 2, this module's own sibling)."""
+    spec = lang_registry.spec_for_path("widget.h")
+    assert spec is not None
+    assert spec.language_id == "cpp"
     assert repo_map._provider_language_for_path("widget.h") == "cpp"
+    assert repo_map._target_language_for_path("widget.h") == "cpp"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lang_cpp.py
+++ b/tests/unit/test_lang_cpp.py
@@ -1,0 +1,714 @@
+"""C++ symbol graph (lang_cpp.py) tests -- foundational-tier expansion, top-10 language campaign
+(Phase 2 of C/C++; closes the top-10 symbol-graph tier to 10/10; C shipped first as Phase 1,
+#731/v1.97.0).
+
+Foundational scope (mirrors PATH A Stage 1's lang_go.py / lang_php.py / lang_csharp.py / lang_c.py
+precedent): C++ gets its own ``LanguageSpec`` entry + dedicated module providing
+``defs``/``source``/``imports``/``agent`` support (function definitions/prototypes including
+qualified out-of-class methods, class/struct/union/enum definitions, namespaces, typedefs/using-
+aliases, templates, plus ``#include`` directive extraction). The cross-file caller-graph
+(``references_and_calls``/``file_imports_symbol_from_definition``/``import_update_target``) is
+explicitly DEFERRED to a follow-up, exactly like Go/PHP/C#/C's own ``import_update_target=None``
+gap -- `tg refs`/`tg callers`/`tg blast-radius` on a C++ symbol fall through to the generic
+``_regex_references_and_calls`` text-heuristic path (never a crash, never a fabricated AST-
+verified match).
+
+Covered here:
+- ``defs``: function definitions/prototypes resolve with kind "function" (free functions,
+  in-class inline methods, in-class prototypes, and out-of-class QUALIFIED method/constructor
+  definitions -- ``Foo::bar()`` -- all resolve under the BARE name, so an in-class prototype and
+  its out-of-class qualified definition are separate records under the SAME name, mirroring C's
+  own prototype+definition dual-recording pattern); class/struct/union/enum(-class) definitions
+  resolve with kind "class"; namespaces resolve with kind "namespace"; typedefs AND ``using``
+  alias declarations resolve with kind "type"; templates are transparently unwrapped (the kind is
+  the wrapped construct's own kind, no separate "template" kind); a body-less forward declaration
+  is NOT emitted; a plain variable/field declaration is NOT emitted; a destructor resolves under
+  its class's bare name (the tilde is stripped); an operator overload is honestly EXCLUDED (no
+  clean identifier to emit).
+- ``source``: full source text for a function definition and other extracted kinds.
+- ``imports``: ``#include`` directive targets (angle/quoted/macro forms), extracted by
+  ``cpp_imports_and_symbols`` and surfaced through ``build_repo_map``.
+- Grammar-absent (monkeypatched ``lang_cpp._cpp_parser`` -> ``None``): fail-closed, zero
+  fabricated rows, an honest ``resolution_gaps`` entry, an honest non-zero/non-crash CLI exit code
+  -- mirrors Go/PHP/C#/C's Stage 1 fail-closed contract exactly (``provenance_when_missing ==
+  "grammar-missing"``, never "regex-heuristic").
+- The agent capsule reports ``primary_target_language == "cpp"``.
+- All 7 registered suffixes (``.cc``/``.cpp``/``.cxx``/``.h``/``.hh``/``.hpp``/``.hxx``) resolve
+  to "cpp", including ``.h`` (claimed by C++, NOT by C -- the header-ambiguity resolution).
+- A pathologically deep AST does not raise ``RecursionError`` (F26-class regression guard,
+  applied preemptively since ``lang_go.py``/``lang_c.py`` already paid for this lesson once).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from tensor_grep.cli import agent_capsule, lang_cpp, lang_registry, repo_map
+
+# ---------------------------------------------------------------------------
+# Fixture: includes (angle + quoted) + a namespace wrapping a typedef/using-alias pair, a plain
+# enum + a scoped `enum class`, a union, a class with an in-class constructor + typed method
+# PROTOTYPE, matching out-of-class QUALIFIED definitions for both, and a template function.
+# ---------------------------------------------------------------------------
+
+_WIDGET_CPP_SOURCE = (
+    "#include <cstdio>\n"
+    "#include <vector>\n"
+    '#include "widget_types.h"\n'
+    "\n"
+    "namespace app {\n"
+    "\n"
+    "typedef struct Point {\n"
+    "    int x;\n"
+    "    int y;\n"
+    "} PointAlias;\n"
+    "\n"
+    "using ValueAlias = int;\n"
+    "\n"
+    "enum WidgetKind {\n"
+    "    SMALL,\n"
+    "    LARGE,\n"
+    "};\n"
+    "\n"
+    "enum class ScopedKind {\n"
+    "    A,\n"
+    "    B,\n"
+    "};\n"
+    "\n"
+    "union WidgetValue {\n"
+    "    int i;\n"
+    "    float f;\n"
+    "};\n"
+    "\n"
+    "class Widget {\n"
+    "public:\n"
+    "    Widget(int value);\n"
+    "    int getValue() const;\n"
+    "private:\n"
+    "    int value_;\n"
+    "};\n"
+    "\n"
+    "Widget::Widget(int value) : value_(value) {\n"
+    "}\n"
+    "\n"
+    "int Widget::getValue() const {\n"
+    "    return value_;\n"
+    "}\n"
+    "\n"
+    "template <typename T>\n"
+    "T identity(T value) {\n"
+    "    return value;\n"
+    "}\n"
+    "\n"
+    "}  // namespace app\n"
+)
+
+
+def _write_cpp_fixture(root: Path) -> Path:
+    widget_cpp = root / "widget.cpp"
+    widget_cpp.write_text(_WIDGET_CPP_SOURCE, encoding="utf-8")
+    return widget_cpp
+
+
+# ---------------------------------------------------------------------------
+# Registration + provenance + suffix ownership
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_is_registered_with_tree_sitter_provenance() -> None:
+    spec = lang_registry.LANGUAGE_REGISTRY["cpp"]
+    assert spec.suffixes == frozenset({".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"})
+    assert spec.provenance_when_parsed == "tree-sitter"
+    # Fail-closed (Stage 1 trap, mirrors Go/PHP/C#/C): never "regex-heuristic" -- C++ has no
+    # fallback.
+    assert spec.provenance_when_missing == "grammar-missing"
+    assert spec.parser_for_path is not None
+
+
+def test_target_language_for_path_reports_cpp_for_every_registered_suffix() -> None:
+    for suffix in (".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"):
+        name = f"widget{suffix}"
+        assert repo_map._target_language_for_path(name) == "cpp", suffix
+        assert repo_map._language_for_path(name) == "cpp", suffix
+        assert repo_map._provider_language_for_path(name) == "cpp", suffix
+
+
+def test_header_suffix_is_claimed_by_cpp_not_c() -> None:
+    """`.h` (and every other C/C++ header suffix) is registered under C++, NOT C -- tree-sitter-
+    cpp is a strict grammar superset of C, and `_provider_language_for_path` already assigned
+    every header suffix to "cpp" before this module existed (a latent pre-wiring lang_c.py's own
+    docstring defers to this module)."""
+    spec = lang_registry.spec_for_path("widget.h")
+    assert spec is not None
+    assert spec.language_id == "cpp"
+    assert lang_registry.spec_for_path("widget.c") is not None
+    assert lang_registry.spec_for_path("widget.c").language_id == "c"
+
+
+def test_c_suffix_is_not_claimed_by_cpp() -> None:
+    """`.c` stays owned by lang_c.py -- the two specs must never overlap."""
+    assert ".c" not in lang_registry.LANGUAGE_REGISTRY["cpp"].suffixes
+
+
+# ---------------------------------------------------------------------------
+# defs: class/struct/union/enum(-class)/namespace
+# ---------------------------------------------------------------------------
+
+
+def test_defs_finds_enum_scoped_enum_and_union_as_class_kind(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    for name in ("WidgetKind", "ScopedKind", "WidgetValue"):
+        payload = repo_map.build_symbol_defs(name, tmp_path)
+        assert not payload.get("no_match"), f"expected a definition for {name}"
+        assert payload["definitions"][0]["kind"] == "class", f"{name} should be kind=class"
+        assert payload["definitions"][0]["provenance"] == "tree-sitter"
+
+
+def test_defs_finds_struct_tag_and_typedef_alias_sharing_different_names(tmp_path: Path) -> None:
+    """`typedef struct Point {...} PointAlias;` -- the struct TAG (Point) and the typedef ALIAS
+    (PointAlias) are two separate, legitimately different-named defs."""
+    _write_cpp_fixture(tmp_path)
+
+    point_payload = repo_map.build_symbol_defs("Point", tmp_path)
+    alias_payload = repo_map.build_symbol_defs("PointAlias", tmp_path)
+
+    assert not point_payload.get("no_match")
+    assert point_payload["definitions"][0]["kind"] == "class"
+    assert not alias_payload.get("no_match")
+    assert alias_payload["definitions"][0]["kind"] == "type"
+
+
+def test_defs_finds_using_alias_as_type_kind(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("ValueAlias", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "type"
+
+
+def test_defs_finds_namespace_as_namespace_kind(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("app", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "namespace"
+
+
+def test_defs_excludes_body_less_forward_declaration(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "fwd.cpp").write_text(
+        "class ForwardOnly;\n\nvoid use_it(ForwardOnly *p) {\n}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("ForwardOnly", root)
+
+    assert payload.get("no_match") is True
+
+
+def test_defs_excludes_plain_field_and_variable_declarations(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "globals.cpp").write_text(
+        "int global_counter = 0;\nclass Holder {\npublic:\n    int held_value;\n};\n",
+        encoding="utf-8",
+    )
+
+    counter_payload = repo_map.build_symbol_defs("global_counter", root)
+    field_payload = repo_map.build_symbol_defs("held_value", root)
+
+    assert counter_payload.get("no_match") is True
+    assert field_payload.get("no_match") is True
+
+
+# ---------------------------------------------------------------------------
+# defs: functions, incl. qualified out-of-class methods (the central C++ wrinkle)
+# ---------------------------------------------------------------------------
+
+
+def test_defs_finds_inclass_prototype_and_outofclass_qualified_definition(
+    tmp_path: Path,
+) -> None:
+    """`int getValue() const;` (in-class prototype) and `int Widget::getValue() const {...}`
+    (out-of-class QUALIFIED definition) both resolve under the BARE name "getValue" -- this is
+    the central design decision documented in the module docstring: the qualified_identifier
+    descent must land on the bare name, not "Widget::getValue", or this pairing would break."""
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("getValue", tmp_path)
+
+    assert not payload.get("no_match")
+    assert len(payload["definitions"]) == 2
+    assert all(d["kind"] == "function" for d in payload["definitions"])
+    lines = sorted(d["start_line"] for d in payload["definitions"])
+    assert lines[0] != lines[1]
+
+
+def test_defs_finds_constructor_prototype_and_qualified_definition_plus_class(
+    tmp_path: Path,
+) -> None:
+    """The constructor is a THIRD "Widget" record alongside the class itself -- an in-class
+    constructor prototype (`Widget(int value);`, a plain `declaration` with no return type) and
+    its out-of-class qualified definition (`Widget::Widget(int value) : ... {}`) both resolve to
+    the bare name "Widget", same as the class. All three kinds (class + 2x function) are
+    legitimate, separate defs sharing one name -- an explicit, disclosed design choice."""
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Widget", tmp_path)
+
+    assert not payload.get("no_match")
+    kinds = sorted(d["kind"] for d in payload["definitions"])
+    assert kinds == ["class", "function", "function"]
+
+
+def test_defs_finds_template_function(tmp_path: Path) -> None:
+    """`template <typename T> T identity(T value) {...}` -- the walker transparently descends
+    into the `template_declaration` wrapper; the emitted kind is "function" (the wrapped
+    construct's own kind), not a distinct "template" kind."""
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("identity", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_defs_finds_template_class_and_templated_qualified_method(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "box.cpp").write_text(
+        "template <typename T>\n"
+        "class Box {\n"
+        "public:\n"
+        "    T get() const;\n"
+        "};\n"
+        "\n"
+        "template <typename T>\n"
+        "T Box<T>::get() const {\n"
+        "    return value_;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    box_payload = repo_map.build_symbol_defs("Box", root)
+    get_payload = repo_map.build_symbol_defs("get", root)
+
+    assert not box_payload.get("no_match")
+    assert box_payload["definitions"][0]["kind"] == "class"
+    assert not get_payload.get("no_match")
+    # In-class prototype + the templated out-of-class qualified definition (`Box<T>::get`) --
+    # the template arguments in the "scope" field must never leak into the extracted name.
+    assert len(get_payload["definitions"]) == 2
+    assert all(d["kind"] == "function" for d in get_payload["definitions"])
+
+
+def test_macro_prefixed_anonymous_union_does_not_emit_reserved_keyword_as_a_name(
+    tmp_path: Path,
+) -> None:
+    """Real-header dogfood finding (CPython's Include/object.h): a visibility-macro-prefixed
+    ANONYMOUS union (`_Py_ANONYMOUS union { ... };`, no tag name) misparses such that the bare
+    keyword `union` itself becomes the extracted declarator text. No valid C++ program can ever
+    declare a symbol literally named a reserved keyword, so this must be rejected -- a
+    zero-legitimate-cost precision fix, unlike the class-macro-misparse (which is NOT
+    special-cased, see the module docstring)."""
+    root = tmp_path
+    (root / "anon_union.cpp").write_text(
+        "struct Holder {\n"
+        "    _Py_ANONYMOUS union {\n"
+        "        int64_t full;\n"
+        "        uint32_t half;\n"
+        "    };\n"
+        "};\n",
+        encoding="utf-8",
+    )
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(root / "anon_union.cpp")
+
+    names = {s["name"] for s in symbols}
+    assert "union" not in names
+    assert "Holder" in names
+
+
+def test_reserved_keyword_helper_rejects_every_cpp_keyword() -> None:
+    for keyword in lang_cpp._CPP_RESERVED_KEYWORDS:
+        assert not lang_cpp._is_clean_cpp_symbol_name(keyword), keyword
+    assert lang_cpp._is_clean_cpp_symbol_name("Widget")
+    assert lang_cpp._is_clean_cpp_symbol_name("getValue")
+
+
+def test_defs_finds_destructor_under_bare_class_name(tmp_path: Path) -> None:
+    """A destructor's `destructor_name` node's single named child is the bare identifier (no
+    tilde) -- C's existing generic declarator-descent fallback resolves it for free."""
+    root = tmp_path
+    (root / "resource.cpp").write_text(
+        "class Resource {\npublic:\n    ~Resource();\n};\n\nResource::~Resource() {\n}\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("Resource", root)
+
+    assert not payload.get("no_match")
+    kinds = sorted(d["kind"] for d in payload["definitions"])
+    # class + in-class destructor prototype + out-of-class destructor definition.
+    assert kinds == ["class", "function", "function"]
+
+
+def test_operator_overload_is_honestly_excluded(tmp_path: Path) -> None:
+    """`operator_name` has zero named children (no clean identifier to descend to) -- an
+    operator overload is honestly excluded, not crashed on and not mis-named."""
+    root = tmp_path
+    (root / "ops.cpp").write_text(
+        "class Widget {\n"
+        "public:\n"
+        "    Widget& operator+=(int delta);\n"
+        "};\n"
+        "\n"
+        "Widget& Widget::operator+=(int delta) {\n"
+        "    return *this;\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(root / "ops.cpp")
+
+    names = {s["name"] for s in symbols}
+    assert "Widget" in names  # the class itself
+    assert not any("operator" in name for name in names)
+
+
+def test_anonymous_namespace_is_not_emitted_but_contents_are_reached(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "anon.cpp").write_text(
+        "namespace {\n    int hidden_helper() { return 1; }\n}\n",
+        encoding="utf-8",
+    )
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(root / "anon.cpp")
+
+    kinds_by_name = {s["name"]: s["kind"] for s in symbols}
+    assert kinds_by_name.get("hidden_helper") == "function"
+    assert not any(s["kind"] == "namespace" for s in symbols)
+
+
+# ---------------------------------------------------------------------------
+# source
+# ---------------------------------------------------------------------------
+
+
+def test_source_returns_full_function_body(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_source("getValue", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["sources"], "expected at least one source block for getValue"
+    combined = "\n".join(s["source"] for s in payload["sources"])
+    assert "Widget::getValue() const" in combined
+    assert "return value_;" in combined
+
+
+def test_source_for_inclass_prototype_plus_outofclass_definition_returns_both_blocks(
+    tmp_path: Path,
+) -> None:
+    cpp_file = _write_cpp_fixture(tmp_path)
+
+    sources = lang_cpp.cpp_parser_symbol_sources(cpp_file, "getValue")
+
+    assert len(sources) == 2
+    assert any(s["source"].strip() == "int getValue() const;" for s in sources)
+    assert any("return value_;" in s["source"] for s in sources)
+
+
+def test_source_returns_class_and_namespace_blocks(tmp_path: Path) -> None:
+    cpp_file = _write_cpp_fixture(tmp_path)
+
+    class_sources = lang_cpp.cpp_parser_symbol_sources(cpp_file, "Widget")
+    namespace_sources = lang_cpp.cpp_parser_symbol_sources(cpp_file, "app")
+
+    assert any(s["kind"] == "class" for s in class_sources)
+    assert any(s["kind"] == "namespace" for s in namespace_sources)
+
+
+# ---------------------------------------------------------------------------
+# imports: angle / quoted / macro #include forms
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_imports_and_symbols_extracts_include_targets(tmp_path: Path) -> None:
+    source = '#include <cstdio>\n#include "local.h"\n\nint main() {\n    return 0;\n}\n'
+    cpp_file = tmp_path / "main.cpp"
+    cpp_file.write_text(source, encoding="utf-8")
+
+    imports, symbols = lang_cpp.cpp_imports_and_symbols(cpp_file)
+
+    # Quote/bracket delimiters are stripped -- the recorded module string is the bare target.
+    assert imports == sorted({"cstdio", "local.h"})
+    assert any(s["name"] == "main" and s["kind"] == "function" for s in symbols)
+
+
+def test_build_repo_map_surfaces_cpp_imports_and_symbols(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    repo_map_payload = repo_map.build_repo_map(tmp_path)
+
+    file_imports = [
+        entry for entry in repo_map_payload["imports"] if entry["file"].endswith("widget.cpp")
+    ]
+    assert file_imports, "expected an imports entry for widget.cpp"
+    assert "cstdio" in file_imports[0]["imports"]
+    assert "vector" in file_imports[0]["imports"]
+    assert "widget_types.h" in file_imports[0]["imports"]
+
+    symbol_names = {
+        s["name"] for s in repo_map_payload["symbols"] if s["file"].endswith("widget.cpp")
+    }
+    assert {
+        "app",
+        "Point",
+        "PointAlias",
+        "ValueAlias",
+        "WidgetKind",
+        "ScopedKind",
+        "WidgetValue",
+        "Widget",
+        "getValue",
+        "identity",
+    }.issubset(symbol_names)
+
+
+# ---------------------------------------------------------------------------
+# #74-follow-up: tg imports (cpp_imports_with_lines / build_file_imports) -- foundational tier,
+# mirrors test_lang_c.py's own test_c_imports_with_lines_extracts_includes_with_lines.
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_imports_with_lines_extracts_includes_with_lines(tmp_path: Path) -> None:
+    cpp_file = _write_cpp_fixture(tmp_path)
+
+    entries = lang_cpp.cpp_imports_with_lines(cpp_file)
+
+    modules = {entry["module"]: entry["line"] for entry in entries}
+    assert modules == {
+        "cstdio": 1,
+        "vector": 2,
+        "widget_types.h": 3,
+    }
+
+
+def test_cpp_imports_with_lines_non_cpp_suffix_returns_empty(tmp_path: Path) -> None:
+    not_cpp = tmp_path / "widget.txt"
+    not_cpp.write_text("#include <cstdio>\n", encoding="utf-8")
+
+    assert lang_cpp.cpp_imports_with_lines(not_cpp) == []
+
+
+def test_cpp_imports_with_lines_grammar_absent_returns_empty(tmp_path: Path, monkeypatch) -> None:
+    cpp_file = _write_cpp_fixture(tmp_path)
+    monkeypatch.setattr(lang_cpp, "_cpp_parser", lambda: None)
+
+    assert lang_cpp.cpp_imports_with_lines(cpp_file) == []
+
+
+def test_file_imports_returns_cpp_include_directives_with_lines(tmp_path: Path) -> None:
+    cpp_file = _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_file_imports(cpp_file)
+
+    assert payload["result_incomplete"] is False
+    modules = {entry["module"]: entry["line"] for entry in payload["imports"]}
+    assert modules == {
+        "cstdio": 1,
+        "vector": 2,
+        "widget_types.h": 3,
+    }
+    # Foundational tier: raw #include directives are real, but resolving them to a specific file
+    # is deferred (C++ has no standardized manifest to resolve against) -- every row must be
+    # unresolved and never presumed external, matching the fail-closed contract.
+    assert all(entry["resolved"] is None for entry in payload["imports"])
+    assert all(entry["external"] is False for entry in payload["imports"])
+
+
+def test_file_imports_works_for_header_suffix(tmp_path: Path) -> None:
+    """`.h` files go through the SAME extractor as `.cpp` files (both are "cpp" per the registry) --
+    a header-only fixture must resolve its own #include directives too."""
+    header = tmp_path / "widget.h"
+    header.write_text('#include <vector>\n#include "helper.h"\n', encoding="utf-8")
+
+    payload = repo_map.build_file_imports(header)
+
+    assert payload["result_incomplete"] is False
+    modules = {entry["module"] for entry in payload["imports"]}
+    assert modules == {"vector", "helper.h"}
+
+
+def test_cpp_include_target_text_handles_macro_and_call_forms(tmp_path: Path) -> None:
+    """`#include MACRO_HEADER` (macro-expanded) and `#include COMBINE(a, b)` (macro-combined)
+    both parse as real preproc_include nodes (tree-sitter-cpp never runs a preprocessor) -- the
+    extractor records the raw macro/call text honestly rather than dropping the row."""
+    source = "#include MACRO_HEADER\n#include COMBINE(a, b)\n\nvoid noop() {\n}\n"
+    cpp_file = tmp_path / "macro_includes.cpp"
+    cpp_file.write_text(source, encoding="utf-8")
+
+    entries = lang_cpp.cpp_imports_with_lines(cpp_file)
+
+    modules = {entry["module"] for entry in entries}
+    assert "MACRO_HEADER" in modules
+    assert any("COMBINE" in module for module in modules)
+
+
+# ---------------------------------------------------------------------------
+# Deferred caller-graph, grammar PRESENT: honest resolution_gaps, not a silent proven-zero.
+# ---------------------------------------------------------------------------
+
+
+def test_refs_grammar_present_still_reports_import_resolution_gap(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_refs("getValue", tmp_path)
+
+    assert not payload.get("no_match")
+    gaps = payload["resolution_gaps"]
+    cpp_gaps = [gap for gap in gaps if gap["language"] == "cpp"]
+    assert len(cpp_gaps) == 1
+    # NOT "fail-closed" (that's the grammar-ABSENT case, covered separately below) -- this is
+    # the narrower "grammar works fine, but no reverse-import resolver exists yet" gap.
+    assert "fail-closed" not in cpp_gaps[0]["reason"]
+    assert "reverse-import" in cpp_gaps[0]["reason"]
+    assert cpp_gaps[0]["files_affected"] >= 1
+    # Honesty floor: the remediation must tell an agent to treat a zero count as UNKNOWN, not
+    # proven-zero -- the exact failure mode this test guards against.
+    assert (
+        "not proven-zero" in cpp_gaps[0]["remediation"] or "UNKNOWN" in (cpp_gaps[0]["remediation"])
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grammar-absent: fail-closed, resolution_gaps, honest exit code.
+# ---------------------------------------------------------------------------
+
+
+def test_grammar_absent_yields_no_fabricated_defs_and_resolution_gap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write_cpp_fixture(tmp_path)
+    # A python symbol elsewhere in the same repo so refs has something REAL to find -- the
+    # resolution_gaps floor is about a C++ file being an honestly-labeled BYSTANDER in the scan
+    # universe, not about the query's own target living in the grammar-missing language.
+    (tmp_path / "target.py").write_text("def Target():\n    return 1\n", encoding="utf-8")
+    monkeypatch.setattr(lang_cpp, "_cpp_parser", lambda: None)
+
+    defs_payload = repo_map.build_symbol_defs("getValue", tmp_path)
+    assert defs_payload.get("no_match") is True
+    assert defs_payload["definitions"] == []
+    defs_gaps = defs_payload["resolution_gaps"]
+    assert any(gap["language"] == "cpp" for gap in defs_gaps)
+    cpp_gap = next(gap for gap in defs_gaps if gap["language"] == "cpp")
+    assert "fail-closed" in cpp_gap["reason"]
+
+    refs_payload = repo_map.build_symbol_refs("Target", tmp_path)
+    assert not refs_payload.get("no_match")
+    gaps = refs_payload["resolution_gaps"]
+    assert any(gap["language"] == "cpp" for gap in gaps)
+    cpp_refs_gap = next(gap for gap in gaps if gap["language"] == "cpp")
+    assert "fail-closed" in cpp_refs_gap["reason"]
+    assert cpp_refs_gap["files_affected"] >= 1
+    assert "fall back to plain literal-text/regex matching" not in cpp_refs_gap["remediation"]
+
+
+def test_grammar_absent_cli_exit_code_is_honest_not_found(tmp_path: Path, monkeypatch) -> None:
+    """A C++-only target with the grammar missing must exit 1 (honest not-found) -- never a
+    silent 0 and never a crash."""
+    from typer.testing import CliRunner
+
+    from tensor_grep.cli.main import app
+
+    _write_cpp_fixture(tmp_path)
+    monkeypatch.setattr(lang_cpp, "_cpp_parser", lambda: None)
+
+    result = CliRunner().invoke(app, ["defs", str(tmp_path), "getValue"])
+
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Agent capsule
+# ---------------------------------------------------------------------------
+
+
+def test_agent_capsule_reports_cpp_target_language(tmp_path: Path) -> None:
+    _write_cpp_fixture(tmp_path)
+
+    payload = agent_capsule.build_agent_capsule("getValue", tmp_path)
+
+    assert payload["context_consistency"]["primary_target_language"] == "cpp"
+
+
+# ---------------------------------------------------------------------------
+# Deep-AST guard: explicit-stack DFS must not raise RecursionError (lang_go.py/lang_c.py F26
+# precedent).
+# ---------------------------------------------------------------------------
+
+
+def _deep_nested_cpp_source(depth: int) -> str:
+    return "int target()\n{\n    return " + ("(" * depth) + "1" + (")" * depth) + ";\n}\n"
+
+
+def test_cpp_walkers_survive_pathologically_deep_ast_without_recursion_error(
+    tmp_path: Path,
+) -> None:
+    depth = sys.getrecursionlimit() + 500
+    deep_cpp = tmp_path / "deep.cpp"
+    deep_cpp.write_text(_deep_nested_cpp_source(depth), encoding="utf-8")
+
+    imports, symbols = lang_cpp.cpp_imports_and_symbols(deep_cpp)
+    assert imports == []
+    assert any(s["name"] == "target" and s["kind"] == "function" for s in symbols)
+
+    sources = lang_cpp.cpp_parser_symbol_sources(deep_cpp, "target")
+    assert len(sources) == 1
+    assert sources[0]["kind"] == "function"
+
+
+# ---------------------------------------------------------------------------
+# Grammar-missing import failure (package not installed) -- distinct from monkeypatched None.
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_parser_returns_none_when_grammar_module_missing(monkeypatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "tree_sitter_cpp":
+            raise ImportError("simulated missing grammar")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    lang_cpp._cpp_parser.cache_clear()
+    try:
+        assert lang_cpp._cpp_parser() is None
+    finally:
+        lang_cpp._cpp_parser.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Read/parse-error guards return ([], []) rather than raising.
+# ---------------------------------------------------------------------------
+
+
+def test_cpp_imports_and_symbols_missing_file_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "DoesNotExist.cpp"
+    imports, symbols = lang_cpp.cpp_imports_and_symbols(missing)
+    assert imports == []
+    assert symbols == []
+
+
+def test_cpp_imports_and_symbols_non_cpp_suffix_returns_empty(tmp_path: Path) -> None:
+    other = tmp_path / "widget.txt"
+    other.write_text("not cpp", encoding="utf-8")
+    imports, symbols = lang_cpp.cpp_imports_and_symbols(other)
+    assert imports == []
+    assert symbols == []

--- a/tests/unit/test_lang_registry.py
+++ b/tests/unit/test_lang_registry.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tensor_grep.cli import lang_c, lang_csharp, lang_go, lang_registry, repo_map
+from tensor_grep.cli import lang_c, lang_cpp, lang_csharp, lang_go, lang_registry, repo_map
 
 # ---------------------------------------------------------------------------
 # spec_for_path / graph_suffixes
@@ -48,6 +48,15 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
         "foo.php": "php",
         "foo.cs": "csharp",
         "foo.c": "c",
+        # Top-10 language campaign, Phase 2: C++ -- ".h" (and every other C/C++ header suffix)
+        # resolves to "cpp", NOT "c" (see lang_cpp.py's module docstring's header-ambiguity note).
+        "foo.cc": "cpp",
+        "foo.cpp": "cpp",
+        "foo.cxx": "cpp",
+        "foo.h": "cpp",
+        "foo.hh": "cpp",
+        "foo.hpp": "cpp",
+        "foo.hxx": "cpp",
     }
     for name, expected_language in expectations.items():
         spec = lang_registry.spec_for_path(Path(name))
@@ -56,11 +65,11 @@ def test_spec_for_path_resolves_every_registered_suffix() -> None:
 
 
 def test_spec_for_path_unknown_suffix_returns_none() -> None:
-    # PATH A Stage 1/2: .go, .java, and .php are now all REGISTERED languages (see
-    # test_spec_for_path_resolves_every_registered_suffix), so they moved out of this "still
-    # unsupported" list -- .kt/.rb stand in as still-unsupported examples for the
-    # resolution_gaps tests below instead (same substitution each stage made for its own
-    # newly-registered suffix).
+    # PATH A Stage 1/2/3: .go, .java, .php, .c, and .cpp (+ every C/C++ header suffix) are now
+    # all REGISTERED languages (see test_spec_for_path_resolves_every_registered_suffix), so
+    # they moved out of this "still unsupported" list -- .kt/.rb stand in as still-unsupported
+    # examples for the resolution_gaps tests below instead (same substitution each stage made
+    # for its own newly-registered suffix).
     for name in ("foo.kt", "foo.rb", "foo.txt", "foo", "foo.md"):
         assert lang_registry.spec_for_path(Path(name)) is None
 
@@ -80,6 +89,13 @@ def test_graph_suffixes_matches_the_historical_hardcoded_union() -> None:
         ".php",
         ".cs",
         ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
     })
 
 
@@ -94,6 +110,7 @@ def test_language_registry_has_exactly_the_stage2_languages() -> None:
         "php",
         "csharp",
         "c",
+        "cpp",
     }
 
 
@@ -162,6 +179,11 @@ def test_c_provenance_is_tree_sitter_when_grammar_present() -> None:
     assert repo_map._symbol_navigation_provenance_for_path("foo.c") == "tree-sitter"
 
 
+def test_cpp_provenance_is_tree_sitter_when_grammar_present() -> None:
+    assert repo_map._symbol_navigation_provenance_for_path("foo.cpp") == "tree-sitter"
+    assert repo_map._symbol_navigation_provenance_for_path("foo.h") == "tree-sitter"
+
+
 def test_grammar_absent_monkeypatch_js_ts_provenance_flips_to_regex_heuristic(monkeypatch) -> None:
     """Simulate tree-sitter-javascript/typescript being uninstalled (ImportError inside the
     parser factory returns None, per repo_map._javascript_parser/_typescript_parser). The
@@ -216,6 +238,18 @@ def test_grammar_absent_monkeypatch_c_provenance_flips_to_grammar_missing(monkey
     monkeypatch.setattr(lang_c, "_c_parser", lambda: None)
 
     provenance = repo_map._symbol_navigation_provenance_for_path("foo.c")
+
+    assert provenance == "grammar-missing"
+    assert provenance != ""
+
+
+def test_grammar_absent_monkeypatch_cpp_provenance_flips_to_grammar_missing(monkeypatch) -> None:
+    """C++ has NO regex fallback (Stage 1 fail-closed trap, same as Go/PHP/C#/C): a
+    grammar-absent .cpp/.h file's provenance label must flip to "grammar-missing" (not
+    "regex-heuristic")."""
+    monkeypatch.setattr(lang_cpp, "_cpp_parser", lambda: None)
+
+    provenance = repo_map._symbol_navigation_provenance_for_path("foo.cpp")
 
     assert provenance == "grammar-missing"
     assert provenance != ""

--- a/uv.lock
+++ b/uv.lock
@@ -4129,6 +4129,7 @@ ast = [
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-cpp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -4145,6 +4146,7 @@ bench = [
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-cpp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -4169,6 +4171,7 @@ dev = [
     { name = "tree-sitter" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-cpp" },
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
@@ -4250,6 +4253,9 @@ requires-dist = [
     { name = "tree-sitter-c-sharp", marker = "extra == 'ast'" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'bench'" },
     { name = "tree-sitter-c-sharp", marker = "extra == 'dev'" },
+    { name = "tree-sitter-cpp", marker = "extra == 'ast'" },
+    { name = "tree-sitter-cpp", marker = "extra == 'bench'" },
+    { name = "tree-sitter-cpp", marker = "extra == 'dev'" },
     { name = "tree-sitter-go", marker = "extra == 'ast'" },
     { name = "tree-sitter-go", marker = "extra == 'bench'" },
     { name = "tree-sitter-go", marker = "extra == 'dev'" },
@@ -4538,6 +4544,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/2a/6c3e12ef0cf09138717fcc02e1de8b76a3928d1bed65c7e3c2bd3172bcef/tree_sitter_c_sharp-0.23.5-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8636dc70b5a373c35c1036ed5de98e801f2e4d105ae41e2e20b6804c36e3bf33", size = 357525, upload-time = "2026-04-14T16:11:18.214Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/bd287b092d611df95a9149117fd27b5947ce75527113d6898a4b4e2c8858/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_amd64.whl", hash = "sha256:41a28cfa3d9ea50f5629e44550a03188c8fbd5079803dfc03554b6fd594b33fa", size = 338756, upload-time = "2026-04-14T16:11:19.661Z" },
     { url = "https://files.pythonhosted.org/packages/7f/fb/114ff43fdd256d0befed32f77c1dadee9517867181c70794571f718ed05c/tree_sitter_c_sharp-0.23.5-cp310-abi3-win_arm64.whl", hash = "sha256:2de4ebf95ddc2e92cd3105c8a8e0e7ec646bc82f52bfaf2f3acec0fa2401ec09", size = 337260, upload-time = "2026-04-14T16:11:20.849Z" },
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/2c/4dd63d705a8933543cad9b92ff31be849b164fec91a6eb63475ebc9ce668/tree_sitter_cpp-0.23.4.tar.gz", hash = "sha256:6a59c4cebb1ad1dc2e8d586cf8a72b39d21b8108b7b139d089719e81a339e41d", size = 940358, upload-time = "2024-11-11T06:59:24.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/ac/11d56670f7b048362db872ca866fd00ba2002a322ab179f047b7c0fb2910/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aacb1759f0efd9dbc25bd8ee88184a340483018869f75412d9c3bc32c039a520", size = 287861, upload-time = "2024-11-11T06:59:15.005Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/0337c016bdc00a77a3326d12f10ee836401dd28f27db6fd5b7734bfb21ed/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc3c404d9f0cbd87951213a85440afbf4c31e718f8d907fa9ee12bea4b8d276f", size = 315513, upload-time = "2024-11-11T06:59:16.679Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4d/23e390234d2acd351f5563b1079c515d7c1fe13ddb7392cee543be74dda3/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:773d2cafc08bbc0f998687fa33f42f378c1a371cdb582870c4d13abb06092706", size = 316110, upload-time = "2024-11-11T06:59:19.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7b/dd38c049b10ed7fda118b903a1d28a8b55a36b98c30606ef90e8f374c6de/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc43ddf1279d5d5a4ef190373f4cb16522801bec4492bcd4754edf2aeba2b7b", size = 334813, upload-time = "2024-11-11T06:59:18.253Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c7/b94a7e0e803af9d3bd4608fb4f0cfb2e9e233abaf0a38c928bfb0b1a025d/tree_sitter_cpp-0.23.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:247d127f0eb6574b0f6b30c0151e0bd0774e2e7acf9c558bdf9fbb8adc2e80c0", size = 308242, upload-time = "2024-11-11T06:59:21.466Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7e/909e52b3dec09c475140b0e175511e275d0d00ba2dbd7c68102d377ae0f6/tree_sitter_cpp-0.23.4-cp39-abi3-win_amd64.whl", hash = "sha256:68606a45bea92669d155399e1239f771a7767d8683cd8f8e30e7d813107030ca", size = 290997, upload-time = "2024-11-11T06:59:22.432Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6a/65435d4d1f4c735be7ffe52d7c2e7b8a7f7c2790343a2719c60c548611c8/tree_sitter_cpp-0.23.4-cp39-abi3-win_arm64.whl", hash = "sha256:712f84f18be94cbe2a148fa4fdf40fcf4a8c25a8f7670efb9f8a47ddec2fc281", size = 288203, upload-time = "2024-11-11T06:59:23.404Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the top-10 language-support campaign to **10/10** (Python, JS, TS, Java, C#, Go, Rust,
PHP, C, C++). C shipped first as Phase 1 (#731, v1.97.0); this is Phase 2.

Adds `src/tensor_grep/cli/lang_cpp.py`, a new foundational-tier extractor mirroring
`lang_c.py`'s shape, live-verified against a real `tree_sitter_cpp` 0.23.4 parse (not guessed
from the grammar README — every node shape below was dumped from actual parse trees before any
extraction logic was written).

## What's extracted

- **Functions** (kind `"function"`): free functions, in-class inline methods, in-class
  prototypes, and — the central C++ wrinkle — out-of-class **qualified** method/constructor/
  destructor definitions (`Foo::bar()`, `Widget::Widget(...)`, `Widget::~Widget()`, nested
  `app::Thing::compute()`, templated `Box<T>::get()`). All resolve to the **bare** name, not the
  qualified form — a deliberate choice: it's what makes an in-class prototype and its
  out-of-class definition pair up as two records under the same name for `tg defs`, mirroring
  C's own prototype+definition dedup pattern.
- **Classes** (kind `"class"`): `class`/`struct`/`union`/`enum`/`enum class`, all collapsed to
  the same cross-language `"class"` bucket C#/Java/C already use. Only body-bearing specifiers
  are emitted (a forward declaration is excluded).
- **Namespaces** (kind `"namespace"`) — matches the label `_lsp_symbol_kind_name` already uses
  for LSP symbol kind 3, not a novel vocabulary item. An anonymous `namespace { ... }` is not
  itself emitted (no name to report), but its contents are still reached and extracted normally.
- **Type aliases** (kind `"type"`): both `typedef` and C++11 `using X = ...`.
- **Templates**: `template_declaration` is never matched directly — the explicit-stack DFS walk
  naturally descends into whatever it wraps (class/function/qualified method), so the emitted
  kind is the wrapped construct's own kind, never a separate `"template"` kind.
- **`#include`** (angle/quoted/macro-expanded/macro-combined forms — all four are real
  `preproc_include` nodes, tree-sitter-cpp never runs a preprocessor).
- Deliberately **not** extracted: C++20 `concept` (parses cleanly, low value for a foundational
  landing, matches the design plan's own "optional, can defer" call) and operator overloads (an
  `operator_name` node has zero named children — no clean identifier to descend to, so these are
  honestly excluded, never crashed on or mis-named).

## Seams wired (all 8)

1. `lang_registry.register_language(LanguageSpec(language_id="cpp", ...))`.
2. `_imports_and_symbols_for_path` — dispatches to `lang_cpp.cpp_imports_and_symbols`.
3. `_imports_with_lines_for_path` — dispatches to `lang_cpp.cpp_imports_with_lines` (`tg imports`).
4. `build_symbol_source_from_map` — dispatches to `lang_cpp.cpp_parser_symbol_sources` (`tg source`).
5. `_target_language_for_path` — returns `"cpp"` for all 7 registered suffixes (the
   "most-forgotten" seam that feeds the `tg agent` capsule's confidence gate).
6. `_provider_language_for_path` — **verified already correct, no change needed**: this LSP-provider
   dispatch function already returned `"cpp"` for every C/C++ header suffix before this module
   existed (a latent pre-wiring). This module's suffix set was chosen to match it exactly.
7. `_SUPPORTED_FILE_DEPENDENCY_LANGUAGES` — `"cpp"` added.
8. `_resolve_raw_import_entry` — extended the honest-unresolved tuple to include `"cpp"`
   (`resolved=None, external=False` — **never** the `external=True` else-branch; matches the
   go/php/csharp/c precedent from #728).

`.h` (and `.hh`/`.hpp`/`.hxx`/`.cc`/`.cpp`/`.cxx`) is claimed by **this** module, not `lang_c.py` —
tree-sitter-cpp is a strict superset grammar, and `_provider_language_for_path` already assigned
every header suffix to `"cpp"` before this PR, effectively forcing the choice. `lang_c.py`'s one
now-stale test (`test_header_suffix_is_deliberately_unregistered`) is updated to
`test_header_suffix_is_claimed_by_cpp_not_c` to match the new reality.

The caller-graph (`references_and_calls` / `file_imports_symbol_from_definition` /
`import_update_target` / `prime_repo_context`) is **deferred**, exactly like every other
foundational-tier language — all four stay `None`. `tg refs`/`tg callers`/`tg blast-radius` on a
C++ symbol fall through to the generic `_regex_references_and_calls` text-heuristic path (never a
crash, never a fabricated AST-verified match), and show up as an honest `resolution_gaps` entry
(`"reverse-import resolver"` gap, not `"fail-closed"` — the grammar works fine, the resolver just
doesn't exist yet).

## Honest-unresolved `#include` (the fail-closed contract)

`#include` directives are real, line-numbered import rows (`tg imports` works), but **true**
`#include → file` resolution is deferred to BACKLOG — it's genuinely harder than the already-
deferred go/php/csharp resolvers, since C/C++ has no standardized manifest (no
`go.mod`/`composer.json`/`.csproj` equivalent) to resolve against. Every row reports
`resolved=None, external=False`, never a fabricated path or a fabricated `external=True`.

## Macro-recall dogfood (the honest disclosure)

Per the design plan's risk #1, I dogfooded two **real, unmodified, fetched-fresh** public headers
(neither vendored into this repo) rather than relying on synthetic fixtures alone:

- **CPython's `Include/object.h`** (804 lines, macro-guarded `#ifdef`/`#else` struct bodies,
  heavy function-pointer typedef style): 49 symbols extracted cleanly (3 classes — including
  `_object` appearing twice, once per `#ifdef`/`#else` arm, exactly as the design plan predicted
  — 10 functions, 36 typedefs).
- **LLVM's `llvm/ADT/StringRef.h`** (967 lines, `LLVM_ABI`/`[[nodiscard]]`/`LLVM_GSL_POINTER`
  attribute macros throughout): confirms the disclosed ceiling on **live** code, not just a
  synthetic example — `class LLVM_GSL_POINTER StringRef { ... }` misparses to a
  `function_definition` (the macro token becomes a fake "return type", `StringRef` becomes the
  function's own declarator), so the ~830-line class extracts as kind `"function"` (7 records,
  one per overloaded constructor) instead of one kind `"class"` record. The nuanced finding worth
  disclosing: **member recall mostly survives** the container-level misparse — of `StringRef`'s
  ~85 distinct public methods, essentially all of them (`begin`, `find`, `substr`, `split`,
  `getAsInteger`, ...) still resolve as individual `"function"` symbols, because tree-sitter's
  error recovery is local to the misparsed node, not global. Only the *enclosing class's own kind
  label* is wrong — its members stay individually discoverable. `StringLiteral : public
  StringRef` (no macro prefix) extracts correctly as kind `"class"`.

No guard was added for the class-misparse: the AST shape it produces (`function_definition` whose
"type" field is a body-less class/struct/union/enum specifier) is **indistinguishable** from a
perfectly legitimate, more-common construct — a function returning a struct/class by value
(`struct Point make_point() { ... }` parses identically). Suppressing the misparse would also
suppress the legitimate case. This is the disclosed, inherent ceiling of a preprocessor-unaware
tool, not a bug to chase.

**One related bug the dogfood did catch and fix**: CPython's `object.h` also has an anonymous,
macro-prefixed union (`_Py_ANONYMOUS union { ... };`) that misparses such that the bare **keyword**
`union` itself becomes the extracted declarator text. Unlike the class case, this one is safely
fixable with zero legitimate-code cost — no valid C++ program can ever declare a symbol literally
named a reserved keyword — so `lang_cpp.py` layers a `_CPP_RESERVED_KEYWORDS` reject-list on top
of the shared `_is_clean_symbol_name` shape check. Regression-tested
(`test_macro_prefixed_anonymous_union_does_not_emit_reserved_keyword_as_a_name`).

## Packaging

- `tree-sitter-cpp` added to the `ast`/`dev`/`bench` extras in `pyproject.toml`.
- `uv.lock` **hand-spliced** (not a full `uv lock` regeneration, which churns ~280 unrelated
  lines): fetched real `tree-sitter-cpp` 0.23.4 metadata directly from the PyPI JSON API (real
  hashes/sizes/URLs, not fabricated), spliced in alphabetical order via a binary-mode,
  CRLF-preserving edit (verified 0 bare LFs introduced — the CRLF-flip trap this repo's docs warn
  about). The project's own self-referencing `[[package]] name = "tensor-grep"` entry also needed
  `tree-sitter-cpp` added in its `optional-dependencies` (x3 extras) and `requires-dist` (x3
  markers) blocks — a second splice site the design plan didn't call out explicitly.
- `tree-sitter` core stays pinned at **0.25.2** (unchanged) — verified the installed
  `tree-sitter-cpp` 0.23.4 grammar loads and parses fine against it (a real runtime smoke test,
  not just a version-string check).
- `uv export --format requirements.txt --all-extras --no-emit-project --locked` exits **0**.

## Testing

- `tests/unit/test_lang_cpp.py` — 38 new tests (registration/provenance, suffix ownership
  including the `.h`->cpp header-ambiguity resolution, defs for every construct including the
  qualified-method/destructor/template cases, source, imports with lines, fail-closed grammar-
  absent behavior, agent-capsule target-language reporting, the reserved-keyword regression test,
  a pathologically-deep-AST recursion guard).
- `tests/unit/test_lang_registry.py` — unioned `"cpp"` into all set-pin tests (the parallel-drain
  landmine this repo's skills warn about) + added the provenance test pair.
- `tests/unit/test_lang_c.py` — updated the one test whose premise (`.h` unregistered) this PR
  makes stale.
- `AGENTS.md` — the "Adding a Language" section's "8 of the top-10... C/C++ deferred" claim was
  already stale (C shipped in #731 without updating it); corrected to "all 10 of the top-10" here.

**Ran locally** (shared repo venv interpreter, `tree-sitter-cpp` installed `--no-deps` — prebuilt
wheel, no compile — `PYTHONPATH` pinned to this worktree's `src`, verified `tensor_grep.__file__`
resolves into the worktree, not the stale venv copy): all of the above, plus the full sibling
regression suite (`test_lang_c.py`, `test_lang_go.py`, `test_lang_csharp.py`, `test_lang_php.py`,
`test_lang_java.py`, `test_skill_index_sync.py`) — **all green**. Also ran a broad
`tests/unit/` sweep (~1500 tests, excluding slow/gpu/integration/acceptance/performance/eval
markers): found 3 failures, **each independently confirmed pre-existing** on a clean
`git stash`-baselined `origin/main` checkout (identical failure, identical pass-count, with and
without this PR's changes) — two CLI help-text content-pinning tests that only fail in full-
suite-process runs (pass in isolation) and one GPU-hardware-detection test that fails
identically in isolation on both branches. Not a regression from this PR; not fixed here (out of
scope). **Rust build was never touched or invoked** (CPU-safe: no local cargo/rustc).

**Not run locally, rely on CI**: the native Rust e2e routing-parity suite (would self-compile
Rust) and any GPU/CUDA-marked tests.

## Deferred (BACKLOG, not this PR)

True `#include -> file` resolution (a same-repo basename/relative-path heuristic, or full
`compile_commands.json` build-system integration) and the `tg importers` reverse-confirm step's
own separate allow-list (`_confirm_import_edges`, unchanged — still `("javascript",
"typescript", "rust", "python")` only). Both stay deferred exactly as they are for go/php/csharp,
and are genuinely harder here (no standardized C/C++ manifest at all).

## Plan drift from the design doc

The design plan predicted "7 code seams + 3 packaging/test seams" (the skill's 8-seam framing,
minus one drift correction of its own); this PR confirms that count holds, plus one seam the
plan didn't explicitly call out: the project's own self-referencing `uv.lock` package entry
needed the same `tree-sitter-cpp` addition in a second location (`optional-dependencies` +
`requires-dist`), not just the new `[[package]]` block.

---

Generated with [Claude Code](https://claude.com/claude-code)
