### PR TITLE
fix(agent): coverage.language_scope under-reported actual language coverage (dogfood-found; now reflects 10 symbol-graph languages)

### DIFF
--- a/docs/examples/blast_radius.json
+++ b/docs/examples/blast_radius.json
@@ -138,8 +138,8 @@
     "C:\\dev\\projects\\tensor-grep\\bench_data\\harness_api_doc_inputs\\rewrite\\test_rewrite_api.py"
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/blast_radius_plan.json
+++ b/docs/examples/blast_radius_plan.json
@@ -4,8 +4,8 @@
   "routing_reason": "symbol-blast-radius-plan",
   "sidecar_used": false,
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   },
   "path": "C:\\dev\\projects\\tensor-grep\\artifacts\\harness_api_doc_inputs_regen\\rewrite",
@@ -287,7 +287,7 @@
   ],
   "ranking_quality": "moderate",
   "coverage_summary": {
-    "language_scope": "python-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
     "parser_backed_fields": [
       "defs",
       "source",
@@ -505,7 +505,7 @@
     ],
     "ranking_quality": "moderate",
     "coverage_summary": {
-      "language_scope": "python-js-ts-rust",
+      "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
       "parser_backed_fields": [
         "defs",
         "source",

--- a/docs/examples/blast_radius_render.json
+++ b/docs/examples/blast_radius_render.json
@@ -4,8 +4,8 @@
   "routing_reason": "symbol-blast-radius-render",
   "sidecar_used": false,
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   },
   "path": "C:\\dev\\projects\\tensor-grep\\artifacts\\harness_api_doc_inputs_regen\\rewrite",
@@ -267,7 +267,7 @@
   ],
   "ranking_quality": "moderate",
   "coverage_summary": {
-    "language_scope": "python-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
     "parser_backed_fields": [
       "defs",
       "source",
@@ -645,7 +645,7 @@
     ],
     "ranking_quality": "moderate",
     "coverage_summary": {
-      "language_scope": "python-js-ts-rust",
+      "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
       "parser_backed_fields": [
         "defs",
         "source",

--- a/docs/examples/callers.json
+++ b/docs/examples/callers.json
@@ -40,8 +40,8 @@
     "C:\\dev\\projects\\tensor-grep\\bench_data\\harness_api_doc_inputs\\rewrite\\rewrite_fixture.py"
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/context_pack.json
+++ b/docs/examples/context_pack.json
@@ -70,8 +70,8 @@
     "C:\\dev\\projects\\tensor-grep\\bench_data\\harness_api_doc_inputs_regen\\context_pack\\tests\\test_payments.py"
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/context_render.json
+++ b/docs/examples/context_render.json
@@ -5,8 +5,8 @@
   "sidecar_used": false,
   "semantic_provider": "native",
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   },
   "path": "C:\\dev\\projects\\tensor-grep\\artifacts\\harness_api_doc_inputs_regen\\context_pack",
@@ -146,7 +146,7 @@
   ],
   "ranking_quality": "strong",
   "coverage_summary": {
-    "language_scope": "python-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
     "parser_backed_fields": [
       "defs",
       "source",
@@ -402,7 +402,7 @@
     ],
     "ranking_quality": "strong",
     "coverage_summary": {
-      "language_scope": "python-js-ts-rust",
+      "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
       "parser_backed_fields": [
         "defs",
         "source",

--- a/docs/examples/defs.json
+++ b/docs/examples/defs.json
@@ -36,8 +36,8 @@
     }
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/defs_provider_disagreement.json
+++ b/docs/examples/defs_provider_disagreement.json
@@ -41,8 +41,8 @@
         }
     ],
     "coverage": {
-        "language_scope": "python-js-ts-rust",
-        "symbol_navigation": "python-ast+parser-js-ts-rust",
+        "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+        "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
         "test_matching": "filename+import+graph-heuristic"
     },
     "provider_agreement": {

--- a/docs/examples/edit_plan.json
+++ b/docs/examples/edit_plan.json
@@ -5,8 +5,8 @@
   "sidecar_used": false,
   "semantic_provider": "native",
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   },
   "path": "C:\\dev\\projects\\tensor-grep\\artifacts\\harness_api_doc_inputs_regen\\context_pack",
@@ -146,7 +146,7 @@
   ],
   "ranking_quality": "strong",
   "coverage_summary": {
-    "language_scope": "python-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
     "parser_backed_fields": [
       "defs",
       "source",
@@ -298,7 +298,7 @@
     ],
     "ranking_quality": "strong",
     "coverage_summary": {
-      "language_scope": "python-js-ts-rust",
+      "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
       "parser_backed_fields": [
         "defs",
         "source",

--- a/docs/examples/impact.json
+++ b/docs/examples/impact.json
@@ -55,8 +55,8 @@
     "C:\\dev\\projects\\tensor-grep\\bench_data\\harness_api_doc_inputs\\rewrite\\rewrite_fixture.py"
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/refs.json
+++ b/docs/examples/refs.json
@@ -45,8 +45,8 @@
     }
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/repo_map.json
+++ b/docs/examples/repo_map.json
@@ -37,8 +37,8 @@
     "C:\\dev\\projects\\tensor-grep\\bench_data\\harness_api_doc_inputs_regen\\repo_map\\tests\\test_sample.py"
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/session_context.json
+++ b/docs/examples/session_context.json
@@ -48,8 +48,8 @@
   ],
   "session_id": "session-20260320071200-rewrite",
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/examples/source.json
+++ b/docs/examples/source.json
@@ -46,8 +46,8 @@
     }
   ],
   "coverage": {
-    "language_scope": "python-js-ts-rust",
-    "symbol_navigation": "python-ast+parser-js-ts-rust",
+    "language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+    "symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
     "test_matching": "filename+import+graph-heuristic"
   }
 }

--- a/docs/harness_api.md
+++ b/docs/harness_api.md
@@ -330,8 +330,8 @@ Current `coverage` values:
 
 | Field | Type | Notes |
 | --- | --- | --- |
-| `language_scope` | `string` | Currently `python-js-ts-rust`. |
-| `symbol_navigation` | `string` | Currently `python-ast+parser-js-ts-rust`. |
+| `language_scope` | `string` | Every language with a registered symbol-graph `LanguageSpec` (`lang_registry.LANGUAGE_REGISTRY`), sorted and hyphen-joined. Currently `c-cpp-csharp-go-java-javascript-php-python-rust-typescript` (10 languages). Derived live from the registry, not a hand-maintained literal, so onboarding a new language updates this automatically. |
+| `symbol_navigation` | `string` | Two tiers, derived live from the same registry. `parser-backed-refs-callers:<languages>` lists languages whose `tg refs`/`tg callers`/`tg blast-radius` are AST/tree-sitter-verified. `foundational-defs-imports-only:<languages>` lists languages with parser-backed defs/imports but where refs/callers fall back to a generic regex-heuristic text match (no AST verification) -- these languages' own registration comments in `repo_map.py` self-label "FOUNDATIONAL-TIER". Currently `parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php`. |
 | `test_matching` | `string` | Currently `filename+import+graph-heuristic`. |
 
 ## Context Pack JSON

--- a/docs/harness_cookbook.md
+++ b/docs/harness_cookbook.md
@@ -81,8 +81,8 @@ Recommended consumer behavior:
 
 Current coverage values describe the limits of this surface:
 
-- `"language_scope": "python-js-ts-rust"`
-- `"symbol_navigation": "python-ast+heuristic-js-ts-rust"`
+- `"language_scope": "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"` -- every language with a registered symbol-graph `LanguageSpec`, derived live from `lang_registry.LANGUAGE_REGISTRY` (10 languages as of this writing).
+- `"symbol_navigation": "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"` -- honest about tiers: `tg refs`/`tg callers`/`tg blast-radius` are AST/tree-sitter-verified only for the first group; the second group has parser-backed defs/imports but refs/callers fall back to a regex-heuristic text match.
 - `"test_matching": "filename+import+graph-heuristic"`
 
 ## Context Pack Flow

--- a/rust_core/tests/test_schema_compat.rs
+++ b/rust_core/tests/test_schema_compat.rs
@@ -4322,16 +4322,21 @@ fn assert_common_envelope(path: &Path, version: u32, routing_backend: &str, rout
 }
 
 fn assert_repo_map_coverage(path: &Path, coverage: &CoverageExample) {
+    // Honesty-bug fix (dogfood-found): language_scope/symbol_navigation are now derived live
+    // from lang_registry.LANGUAGE_REGISTRY (see repo_map.py's _language_scope_descriptor /
+    // _symbol_navigation_descriptor) instead of a hand-maintained 4-language literal, so these
+    // pinned values track the full 10-language symbol-graph registry (python, javascript,
+    // typescript, rust, go, java, php, csharp, c, cpp) instead of under-reporting it.
     assert_eq!(
         coverage.language_scope,
-        "python-js-ts-rust",
-        "{} coverage.language_scope must stay python-js-ts-rust",
+        "c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
+        "{} coverage.language_scope must stay c-cpp-csharp-go-java-javascript-php-python-rust-typescript",
         path.display()
     );
     assert_eq!(
         coverage.symbol_navigation,
-        "python-ast+parser-js-ts-rust",
-        "{} coverage.symbol_navigation must stay python-ast+parser-js-ts-rust",
+        "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
+        "{} coverage.symbol_navigation must stay parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php",
         path.display()
     );
     assert_eq!(

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -540,6 +540,66 @@ def _attach_profiling(
     return payload
 
 
+def _language_scope_descriptor() -> str:
+    """Dynamically derive the honest ``coverage.language_scope`` value from
+    ``lang_registry.LANGUAGE_REGISTRY`` -- the single source of truth for which languages have
+    a registered symbol-graph ``LanguageSpec`` (see lang_registry.py's module docstring) --
+    instead of a hand-maintained literal.
+
+    Dogfood-found honesty bug fix: this used to be the hardcoded 4-language literal
+    ``"python-js-ts-rust"``, which silently under-reported coverage to agent/MCP consumers
+    once go/java/php/csharp/c/cpp were onboarded (the language-support campaign registered 6
+    more languages in ``lang_registry`` without anyone updating this string -- a classic
+    N-site-registration miss, since nothing wired the envelope to the registry). Deriving it
+    live means the NEXT language onboarded (see AGENTS.md's "Adding a Language" section) can
+    never cause the same drift: as soon as its ``LanguageSpec`` is registered, it appears here
+    automatically. Sorted for a deterministic value independent of registration order.
+    """
+    return "-".join(sorted(lang_registry.LANGUAGE_REGISTRY))
+
+
+def _symbol_navigation_descriptor() -> str:
+    """Dynamically derive the honest ``coverage.symbol_navigation`` value, split into the two
+    real navigation tiers instead of one flat language list (same honesty-bug fix as
+    ``_language_scope_descriptor`` above -- see that function's docstring for the incident).
+
+    - ``parser-backed-refs-callers``: languages whose ``LanguageSpec.references_and_calls`` is
+      wired up get AST/tree-sitter-VERIFIED ``tg refs``/``tg callers``/``tg blast-radius``
+      (see the explicit per-``language_id`` dispatch branches in
+      ``build_symbol_refs_from_map`` / ``build_symbol_callers_from_map``, e.g. around the
+      ``current_spec.language_id == "go"`` branch). Verified live: this tier currently also
+      includes go, which several PR-comment summaries lump in with the "foundational-only"
+      languages below -- that undercounts it. Go's own dedicated
+      ``lang_go.go_references_and_calls`` is a full tree-sitter extractor (package-alias
+      resolution, node-type-based ref_kind), not a regex fallback, so it belongs here.
+    - ``foundational-defs-imports-only``: languages with ``references_and_calls is None``
+      still get parser-backed defs/imports (see ``_imports_and_symbols_for_path``'s
+      fail-closed per-language branches -- NO regex fallback, an unparseable file becomes an
+      honest ``resolution_gaps`` entry), but ``tg refs``/``tg callers``/``tg blast-radius``
+      fall through to the generic ``_regex_references_and_calls`` text heuristic instead of an
+      AST-verified match -- these languages' own registration comments in this module
+      self-label "FOUNDATIONAL-TIER" for exactly this reason.
+
+    Both groups are derived live from ``LANGUAGE_REGISTRY`` and sorted, so a newly onboarded
+    language lands in the correct bucket automatically the moment its ``LanguageSpec`` is
+    registered, without a repeat of the drift ``_language_scope_descriptor`` fixes.
+    """
+    parser_backed = sorted(
+        language_id
+        for language_id, spec in lang_registry.LANGUAGE_REGISTRY.items()
+        if spec.references_and_calls is not None
+    )
+    foundational = sorted(
+        language_id
+        for language_id, spec in lang_registry.LANGUAGE_REGISTRY.items()
+        if spec.references_and_calls is None
+    )
+    parts = [f"parser-backed-refs-callers:{'-'.join(parser_backed)}"]
+    if foundational:
+        parts.append(f"foundational-defs-imports-only:{'-'.join(foundational)}")
+    return "+".join(parts)
+
+
 def _envelope(path: Path) -> dict[str, Any]:
     return {
         "version": JSON_OUTPUT_VERSION,
@@ -548,8 +608,8 @@ def _envelope(path: Path) -> dict[str, Any]:
         "routing_reason": ROUTING_REASON,
         "sidecar_used": False,
         "coverage": {
-            "language_scope": "python-js-ts-rust",
-            "symbol_navigation": "python-ast+parser-js-ts-rust",
+            "language_scope": _language_scope_descriptor(),
+            "symbol_navigation": _symbol_navigation_descriptor(),
             "test_matching": "filename+import+graph-heuristic",
         },
         "path": str(path),

--- a/tests/unit/test_harness_api_docs.py
+++ b/tests/unit/test_harness_api_docs.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from tensor_grep.cli import repo_map
+
 DOC_PATH = Path("docs/harness_api.md")
 EXAMPLES_DIR = Path("docs/examples")
 EXPECTED_EXAMPLES = {
@@ -125,8 +127,11 @@ def test_harness_api_doc_covers_all_required_json_shapes() -> None:
     assert "routing_reason" in doc
     assert "version" in doc
     assert "coverage" in doc
-    assert "python-js-ts-rust" in doc
-    assert "python-ast+parser-js-ts-rust" in doc
+    assert "c-cpp-csharp-go-java-javascript-php-python-rust-typescript" in doc
+    assert (
+        "parser-backed-refs-callers:go-javascript-python-rust-typescript"
+        "+foundational-defs-imports-only:c-cpp-csharp-java-php" in doc
+    )
     assert "filename+import+graph-heuristic" in doc
     assert "tg_repo_map" in doc
     assert "tg_context_pack" in doc
@@ -363,8 +368,17 @@ def test_harness_api_examples_exist_and_have_unified_envelope() -> None:
                 "blast_radius_render.json",
                 "session_context.json",
             }:
-                assert payload["coverage"]["language_scope"] == "python-js-ts-rust"
-                assert payload["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+                # Invariant, not a re-rottable hardcoded literal (honesty-bug fix): assert
+                # against the SAME live lang_registry-derived value _envelope() computes, so a
+                # future language onboarded without regenerating these doc-example fixtures
+                # fails this test loudly instead of the fixtures silently drifting stale again.
+                assert (
+                    payload["coverage"]["language_scope"] == repo_map._language_scope_descriptor()
+                )
+                assert (
+                    payload["coverage"]["symbol_navigation"]
+                    == repo_map._symbol_navigation_descriptor()
+                )
                 assert payload["coverage"]["test_matching"] == "filename+import+graph-heuristic"
             if file_name == "rulesets.json":
                 assert isinstance(payload["rulesets"], list)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -4601,8 +4601,14 @@ def test_tg_session_mcp_tools_wrap_session_store(tmp_path, monkeypatch):
     context = json.loads(mcp_server.tg_session_context(session_id, "add", str(project)))
     assert context["session_id"] == session_id
     assert context["routing_reason"] == "session-context"
-    assert context["coverage"]["language_scope"] == "python-js-ts-rust"
-    assert context["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        context["coverage"]["language_scope"]
+        == "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"
+    )
+    assert (
+        context["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert context["coverage"]["test_matching"] == "filename+import+graph-heuristic"
     assert context["files"] == [str((src_dir / "sample.py").resolve())]
 
@@ -5226,7 +5232,10 @@ def test_tg_repo_map_returns_json_inventory(tmp_path, monkeypatch):
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "repo-map"
     assert payload["sidecar_used"] is False
-    assert payload["coverage"]["language_scope"] == "python-js-ts-rust"
+    assert (
+        payload["coverage"]["language_scope"]
+        == "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"
+    )
     assert payload["path"] == str(project.resolve())
     assert payload["scan_limit"]["max_repo_files"] == mcp_server._DEFAULT_MCP_REPO_SCAN_LIMIT
     assert payload["scan_limit"]["possibly_truncated"] is False
@@ -5312,7 +5321,10 @@ def test_tg_repo_map_includes_typescript_and_rust_inventory(tmp_path, monkeypatc
 
     payload = json.loads(mcp_server.tg_repo_map(str(project)))
 
-    assert payload["coverage"]["language_scope"] == "python-js-ts-rust"
+    assert (
+        payload["coverage"]["language_scope"]
+        == "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"
+    )
     assert any(
         symbol["name"] == "PaymentService"
         and symbol["kind"] == "class"
@@ -5552,7 +5564,10 @@ def test_tg_context_pack_returns_ranked_inventory(tmp_path, monkeypatch):
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "context-pack"
     assert payload["sidecar_used"] is False
-    assert payload["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        payload["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert payload["query"] == "invoice payment"
     assert payload["path"] == str(project.resolve())
     assert payload["files"][0] == str(module_path.resolve())
@@ -6190,7 +6205,10 @@ def test_tg_symbol_defs_returns_exact_definition_matches(tmp_path, monkeypatch):
 
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "symbol-defs"
-    assert payload["coverage"]["language_scope"] == "python-js-ts-rust"
+    assert (
+        payload["coverage"]["language_scope"]
+        == "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"
+    )
     assert payload["symbol"] == "create_invoice"
     assert len(payload["definitions"]) == 1
     assert payload["definitions"][0]["file"] == str(module_path.resolve())
@@ -6220,7 +6238,10 @@ def test_tg_symbol_defs_can_find_rust_and_typescript_symbols(tmp_path, monkeypat
     ts_payload = json.loads(mcp_server.tg_symbol_defs("createInvoice", str(project)))
     rust_payload = json.loads(mcp_server.tg_symbol_defs("issue_invoice", str(project)))
 
-    assert ts_payload["coverage"]["language_scope"] == "python-js-ts-rust"
+    assert (
+        ts_payload["coverage"]["language_scope"]
+        == "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"
+    )
     assert ts_payload["definitions"][0]["file"] == str(ts_path.resolve())
     assert ts_payload["definitions"][0]["kind"] == "function"
     assert rust_payload["definitions"][0]["file"] == str(rust_path.resolve())
@@ -6313,7 +6334,10 @@ def test_tg_symbol_impact_returns_related_files_and_tests(tmp_path, monkeypatch)
 
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "symbol-impact"
-    assert payload["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        payload["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert payload["symbol"] == "create_invoice"
     assert payload["files"][0] == str(module_path.resolve())
     assert str(other_path.resolve()) in payload["files"]
@@ -6513,7 +6537,10 @@ def test_tg_symbol_refs_returns_python_reference_sites(tmp_path, monkeypatch):
 
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "symbol-refs"
-    assert payload["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        payload["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert payload["graph_completeness"] == "moderate"
     assert any(ref["provenance"] == "python-ast" for ref in payload["references"])
     assert any(ref["file"] == str(other_path.resolve()) for ref in payload["references"])
@@ -6553,7 +6580,10 @@ def test_tg_symbol_refs_and_callers_include_typescript_and_rust_heuristics(tmp_p
     rust_refs = json.loads(mcp_server.tg_symbol_refs("issue_invoice", str(project)))
     rust_callers = json.loads(mcp_server.tg_symbol_callers("issue_invoice", str(project)))
 
-    assert ts_refs["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        ts_refs["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert any(ref["file"] == str(ts_path.resolve()) for ref in ts_refs["references"])
     assert any(
         ref["provenance"] in {"tree-sitter", "regex-heuristic"} for ref in ts_refs["references"]
@@ -6598,7 +6628,10 @@ def test_tg_symbol_callers_returns_python_call_sites(tmp_path, monkeypatch):
 
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "symbol-callers"
-    assert payload["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        payload["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert payload["coverage"]["test_matching"] == "filename+import+graph-heuristic"
     assert any(caller["file"] == str(other_path.resolve()) for caller in payload["callers"])
     assert payload["tests"][0] == str(test_path.resolve())
@@ -6684,7 +6717,10 @@ def test_tg_symbol_blast_radius_returns_transitive_call_tree(tmp_path, monkeypat
 
     assert payload["routing_backend"] == "RepoMap"
     assert payload["routing_reason"] == "symbol-blast-radius"
-    assert payload["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        payload["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert payload["symbol"] == "create_invoice"
     assert payload["max_depth"] == 2
     assert payload["definitions"][0]["file"] == str(module_path.resolve())

--- a/tests/unit/test_session_cli.py
+++ b/tests/unit/test_session_cli.py
@@ -49,8 +49,14 @@ def test_session_open_show_and_context_reuse_repo_map(tmp_path: Path) -> None:
     assert context["schema_version"] == context["version"]
     assert context["session_id"] == session_id
     assert context["routing_reason"] == "session-context"
-    assert context["coverage"]["language_scope"] == "python-js-ts-rust"
-    assert context["coverage"]["symbol_navigation"] == "python-ast+parser-js-ts-rust"
+    assert (
+        context["coverage"]["language_scope"]
+        == "c-cpp-csharp-go-java-javascript-php-python-rust-typescript"
+    )
+    assert (
+        context["coverage"]["symbol_navigation"]
+        == "parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php"
+    )
     assert context["coverage"]["test_matching"] == "filename+import+graph-heuristic"
     assert context["files"][0] == str(module_path.resolve())
     assert context["tests"][0] == str(test_path.resolve())


### PR DESCRIPTION
## The honesty bug

`repo_map.py`'s coverage envelope (consumed by `tg map`/`tg agent`/`tg context`/`tg session`/every MCP tool that returns a `RepoMap`-derived payload) hardcoded:

```python
"language_scope": "python-js-ts-rust",
"symbol_navigation": "python-ast+parser-js-ts-rust",
```

This was accurate when written, but `lang_registry.LANGUAGE_REGISTRY` now has **10** registered symbol-graph languages (python, javascript, typescript, rust, go, java, php, csharp, c, cpp) after the language-support campaign (#725/#726/#724/#731/#732). Nothing wired the envelope string to the registry, so 6 languages silently vanished from what agent/MCP consumers are told `tg` covers — even though `tg defs`/`tg imports`/`tg agent` genuinely work on all 10. A classic N-site-registration miss: each language's `LanguageSpec` got registered, but the one human-readable "what do we cover" string never got updated.

## The fix

Derived both fields **live** from `lang_registry.LANGUAGE_REGISTRY` instead of a hand-maintained literal (`_language_scope_descriptor` / `_symbol_navigation_descriptor`, added just above `_envelope()` in `repo_map.py`), so the *next* onboarded language can never cause the same drift — the moment its `LanguageSpec` is registered, it appears here automatically.

**`language_scope`** — sorted, hyphen-joined list of every registered `language_id` (10 today):
```
c-cpp-csharp-go-java-javascript-php-python-rust-typescript
```

**`symbol_navigation`** — honest about *tiers* instead of one flat list, using `LanguageSpec.references_and_calls is not None` as the objective, registry-derived criterion:
```
parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php
```

I verified the tier split against the real dispatch code (`build_symbol_refs_from_map`/`build_symbol_callers_from_map`'s per-`language_id` branches around `repo_map.py:16494-16580`), not just registration comments — and found the task brief's assumed 2-tier split (go lumped in with the 5 "foundational" languages) **undercounts go**: its own `lang_go.go_references_and_calls` is a full tree-sitter extractor (package-alias resolution, node-type-based `ref_kind`), dispatched through the *same* `if/elif` chain as python/js/ts/rust, not the generic `_regex_references_and_calls` fallback that java/php/csharp/c/cpp fall through to. So go correctly lands in the `parser-backed-refs-callers` tier alongside python/js/ts/rust, and only java/php/csharp/c/cpp — which self-label "FOUNDATIONAL-TIER" in their own registration comments and have every advanced `LanguageSpec` callable set to `None` — land in `foundational-defs-imports-only`.

## Atomically updated pins (contract-change discipline)

- `tests/unit/test_harness_api_docs.py` — the doc-substring pins now assert against the **live** `repo_map._language_scope_descriptor()`/`_symbol_navigation_descriptor()` invariant instead of a new hardcoded string, so this specific test can never re-rot again.
- `tests/unit/test_mcp_server.py` (12 sites) and `tests/unit/test_session_cli.py` (2 sites) — scattered spot-check snapshot assertions across many independent MCP-tool tests; updated to the new pinned value (consistent with how they were already written).
- `docs/harness_api.md`, `docs/harness_cookbook.md` — also fixed a pre-existing `"heuristic"` vs `"parser"` wording drift between the cookbook's `symbol_navigation` example and the harness-api doc/JSON examples.
- `docs/examples/*.json` (14 fixture files) — including the nested `coverage_summary.language_scope` copies inside `blast_radius_plan.json`/`blast_radius_render.json`/`context_render.json`/`edit_plan.json` that a first pass missed (caught by re-grepping after the first edit and a `json.loads()` validity sweep over all 36 example files).
- `rust_core/tests/test_schema_compat.rs` — literal string pins updated to match. **Not locally compiled or run** per this worktree's CPU-safe no-cargo/rustc-build constraint; relies on CI's Rust matrix to verify.

Deliberately **not** touched: `src/tensor_grep/cli/inventory.py`'s own `coverage.language_scope = "extension-heuristic"` (a different field on a different command, `tg inventory`, describing *how* language is detected rather than *which* languages are covered) and `CHANGELOG.md` (historical, semantic-release-owned).

## Verification

- PYTHONPATH pinned to this worktree's `src`; confirmed `tensor_grep.__file__`/`repo_map.__file__` resolve into the worktree, not the shared venv's stale install (stale-venv trap avoided).
- `ruff check` + `ruff format --check --preview` clean on all touched Python files.
- `tests/unit/test_harness_api_docs.py`: 8/8 passed.
- `tests/unit/test_session_cli.py`: 72/72 passed.
- `tests/unit/test_mcp_server.py`: 481/485 passed. The 4 failures (`test_tg_rewrite_plan_uses_embedded_fallback_without_native_binary` and 3 siblings, all in the "embedded native rewrite fallback" cluster) are a **pre-existing environment limitation unrelated to this diff** — confirmed by direct reproduction outside pytest: they require importing the compiled `tensor_grep.rust_core` extension, which is unavailable when testing via `PYTHONPATH` override with no local `cargo`/`maturin` build (the CPU-safe constraint for this worktree). All 12 assertions this PR touches in that file were explicitly re-run by name and pass.
- Broader regression sweep on the shared `lang_registry` read path: `test_typed_ref_kinds.py`/`test_trust_planning.py`/`test_trust_navigation.py`/`test_lang_registry.py` (53/53) and all 7 `test_lang_*.py` files (170/170).
- All 36 `docs/examples/*.json` fixtures re-validated as parseable JSON after editing.
- `git diff --check`: no whitespace/CRLF issues; confirmed 0 CRLF bytes introduced across touched files.

This is gated on an **independent Opus review** before merge (build-agent self-gating is a conflict of interest per this repo's change-control discipline).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>