### PR TITLE
fix(file-deps): restore importers-far-smaller-than-map invariant after #733 envelope growth

### DIFF
--- a/tests/unit/test_file_deps.py
+++ b/tests/unit/test_file_deps.py
@@ -833,11 +833,30 @@ def test_importers_payload_is_far_smaller_than_map(tmp_path: Path) -> None:
     importers_payload = repo_map.build_file_importers(target, project)
     map_payload = repo_map.build_repo_map(project)
 
-    importers_size = len(json.dumps(importers_payload))
-    map_size = len(json.dumps(map_payload))
+    # Both payloads carry the SAME shared `_envelope()` self-description block verbatim
+    # (version/schema_version/routing_backend/routing_reason/sidecar_used/coverage/path) --
+    # fixed metadata about tg's own capabilities, not DATA about this particular query. Its size
+    # legitimately grows over time (#733 made `coverage.language_scope`/`symbol_navigation`
+    # honest and derived live from the language registry, ~4x longer than the stale 4-language
+    # literal they replaced) with zero change to either payload's actual data volume. Comparing
+    # raw total serialized bytes conflates that identical-in-both-payloads fixed cost with real
+    # data; since the importers payload is intentionally tiny (one reverse edge), the fixed cost
+    # is a much larger FRACTION of its total than of the far-bigger map payload -- enough for an
+    # honest envelope-field growth to tip a total-bytes ratio over threshold with no data-volume
+    # regression at all (exactly what #733 did). Strip the shared envelope from BOTH payloads
+    # before comparing so the assertion proves what it actually claims -- the reverse EDGE DATA is
+    # far smaller than the whole-repo inventory DATA -- and stays robust to future envelope growth
+    # (any field, not just today's `coverage`) instead of re-breaking on the next honesty fix.
+    envelope_keys = set(repo_map._envelope(project))
+    importers_data = {k: v for k, v in importers_payload.items() if k not in envelope_keys}
+    map_data = {k: v for k, v in map_payload.items() if k not in envelope_keys}
+
+    importers_size = len(json.dumps(importers_data))
+    map_size = len(json.dumps(map_data))
 
     assert importers_size < 0.1 * map_size, (
-        f"importers payload ({importers_size}B) is not <0.1x the map payload ({map_size}B)"
+        f"importers payload data ({importers_size}B) is not <0.1x the map payload data "
+        f"({map_size}B), excluding the shared envelope keys {sorted(envelope_keys)}"
     )
 
 


### PR DESCRIPTION
## Root cause

`tests/unit/test_file_deps.py::test_importers_payload_is_far_smaller_than_map` broke CI (ubuntu py3.11+py3.12) after #733 (`e3c04be`, just merged onto `main`) made `coverage.language_scope` / `coverage.symbol_navigation` dynamic and registry-derived:

```
parser-backed-refs-callers:go-javascript-python-rust-typescript+foundational-defs-imports-only:c-cpp-csharp-java-php
```

(~116 chars vs. the old ~28-char hardcoded literal).

That descriptor lives in the shared `_envelope()` helper (`repo_map.py:603-616`), which **both** `build_repo_map` (`tg map`) and `build_file_importers_from_map` (`tg importers`) stamp onto their payload **verbatim, byte-identical in both**. The failing test compared raw total serialized bytes as a proxy for "importers carries far less data than a whole-repo map" — that proxy breaks down once the shared, non-data envelope grows: the fixed envelope cost is a small fraction of the large `map` payload but a large fraction of the intentionally-tiny `importers` payload (~1 reverse edge), so an *honest* envelope-field growth — with **zero** change to either payload's actual data volume — was enough to tip the total-bytes ratio over the 10% threshold:

```
AssertionError: importers payload (1076B) is not <0.1x the map payload (9745B)
assert 1076 < (0.1 * 9745)   # 1076 < 974.5 → False
```

Reproduced locally by forcing pytest's `tmp_path` through a short `--basetemp` (mimicking Linux CI's shorter `/tmp/pytest-of-.../pytest-N/...` vs. Windows' longer `AppData\Local\Temp\pytest-of-...\...` paths) — this also explains why the test passed on local Windows dev runs pre-fix (the map payload has ~26x more file-path occurrences than importers, so on Windows the longer per-path byte cost dilutes the fixed-envelope fraction back under threshold; on Linux's shorter paths it doesn't).

## Fix chosen: (A) test robustness — not (B) descriptor scoping

Strip the shared `_envelope()` keys (`version`/`schema_version`/`routing_backend`/`routing_reason`/`sidecar_used`/`coverage`/`path`) from **both** payloads before comparing, so the assertion measures what it actually claims — reverse *edge data* vs. whole-repo inventory *data* — instead of total bytes including duplicated boilerplate. The excluded-key set is derived live from `repo_map._envelope(project)` itself (not a hand-copied literal), so the test stays robust to **any** future envelope growth, not just today's `coverage` string.

**Why not (B):** scoping the verbose `symbol_navigation`/`coverage` fields out of the `tg importers` envelope specifically was considered but rejected — no documented contract or pinned test ties `coverage.symbol_navigation` to the `tg importers` JSON shape (checked `docs/harness_api.md`'s per-command field tables, `test_harness_api_docs.py`'s doc-example loop — no `importers.json` fixture exists there — `test_mcp_server.py`, `test_session_cli.py`). `_envelope()` is deliberately **one** shared self-description builder used at ~9 call sites across `repo_map.py`; carving out an importers-only lightweight envelope would fragment that contract for a reason (an unrelated test's byte-ratio threshold) that has nothing to do with whether the field semantically belongs there. It would also be a real, unbudgeted behavior change to `tg importers`'/`tg_file_importers`' actual JSON output.

This is **not** a magic-number threshold loosening either — the underlying "importers is lightweight" invariant is verified to still hold with comfortable margin (~0.06–0.08 ratio, well under the existing 0.1 threshold) once the shared boilerplate is excluded, on both short and long tmp roots. Mathematically, subtracting an equal fixed cost from both the smaller and larger payload can only *decrease* the ratio (never increase it), so this fix is strictly more robust than the original metric, not a coincidental patch.

## #733 honesty descriptor: confirmed intact, unchanged

No production code (`repo_map.py`, `_envelope`, `_language_scope_descriptor`, `_symbol_navigation_descriptor`) was touched. This is a test-only diff. Every `coverage.symbol_navigation`/`language_scope` pinned assertion across `test_harness_api_docs.py`, `test_session_cli.py`, and `test_mcp_server.py` still asserts the full 10-language, two-tier descriptor from #733 and passed.

## Verification

- PYTHONPATH pinned to this worktree's `src`; `tensor_grep.__file__` confirmed resolving into the worktree, not the shared venv's stale install (no cargo/rustc build; CPU-safe).
- `tests/unit/test_file_deps.py`: **95/95 passed**, including the fixed test forced through a short `--basetemp` to reproduce CI's Linux path-length regime (the exact scenario that fails on `main`).
- `tests/unit/test_harness_api_docs.py`: **8/8 passed**.
- `tests/unit/test_session_cli.py`: **72/72 passed**.
- `tests/unit/test_mcp_server.py`: **481/485 passed** — the same 4 failures #733's own merge commit already reported (`rewrite_plan`/`execute_rewrite_apply` native-binary-fallback tests that need the compiled `rust_core` extension, unavailable under this worktree's no-cargo-build PYTHONPATH-override constraint; unrelated to file-deps/envelope). All `symbol_navigation`/`language_scope` pins in this file passed.
- `ruff check` + `ruff format --check --preview`: clean.
- LF line endings preserved (no CRLF introduced).

## Gating

Gated on an independent Opus review before merge. Unblocks `main` / the stalled `v1.98.2` release.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
