### PR TITLE
fix(lang-c): exclude file-scope function-pointer variables (were mis-kinded "function")

### DIFF
--- a/src/tensor_grep/cli/lang_c.py
+++ b/src/tensor_grep/cli/lang_c.py
@@ -172,6 +172,23 @@ _C_DEF_NODE_KINDS = (
 _MAX_DECLARATOR_HOPS = 64
 
 
+def _c_parenthesized_declarator_wraps_bare_name(node: Any) -> bool:
+    """Return True when a ``parenthesized_declarator`` node's single named child is a bare
+    ``identifier``/``type_identifier``/``field_identifier`` -- i.e. the parens are purely
+    REDUNDANT around a real name (``int (foo)(void);``, live-verified: ``function_declarator``'s
+    own "declarator" field is a ``parenthesized_declarator`` wrapping ``identifier`` "foo"
+    directly) -- as opposed to wrapping a ``pointer_declarator``/``array_declarator``/anything
+    else (the tell for a function-pointer or array variable, e.g. ``void (*handler)(int);``,
+    where the same parenthesized shape instead wraps a ``pointer_declarator``). Only a single
+    hop's own wrapped shape is inspected here; a nested ``parenthesized_declarator`` (doubly
+    redundant parens) falls through to False like any other non-bare-name wrap -- a residual,
+    exceedingly rare edge case, not one any live-verified fixture has hit."""
+    named_children = [child for child in node.children if child.is_named]
+    if len(named_children) != 1:
+        return False
+    return named_children[0].type in {"identifier", "type_identifier", "field_identifier"}
+
+
 def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
     """Descend a declarator chain to its innermost identifier/type_identifier NAME node, tracking
     whether the chain passed through a ``function_declarator`` that names a REAL function --
@@ -193,17 +210,27 @@ def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
     almost identically to a real function -- its outermost node is ALSO a
     ``function_declarator`` ("outermost-direct" does NOT distinguish the two; both are
     outermost-direct). The real, live-verified tell: a REAL function's ``function_declarator``
-    has its own "declarator" FIELD as a bare name -- directly (``void f(int);``), or nested one
-    hop under a return-type ``pointer_declarator`` (``int *make_ptr(void);``) -- while a
-    function-pointer VARIABLE's ``function_declarator`` instead has its own "declarator" field as
-    a ``parenthesized_declarator`` (the paren-grouped ``(*name)``, wrapping a
-    ``pointer_declarator`` down to the name). A hop through that parenthesized shape does not, by
-    itself, mark ``seen_function`` True -- but the boolean is never force-reset to False either,
-    so a function that itself RETURNS a function pointer (``void (*get_handler(int))(int);``,
-    the classic ``signal()`` prototype shape) still resolves correctly: its outer
-    ``function_declarator`` hop is skipped by this same tell, but the INNER
+    has its own "declarator" FIELD as a bare name -- directly (``void f(int);``), nested one hop
+    under a return-type ``pointer_declarator`` (``int *make_ptr(void);``), OR wrapped in
+    REDUNDANT parens (``int (foo)(void);`` -- ``function_declarator``'s own "declarator" field is
+    a ``parenthesized_declarator`` wrapping ``identifier`` "foo" directly, still a real function,
+    the parens are meaningless noise) -- while a function-pointer VARIABLE's
+    ``function_declarator`` instead has its own "declarator" field as a
+    ``parenthesized_declarator`` wrapping something OTHER than a bare name -- a
+    ``pointer_declarator`` down to the name (the paren-grouped ``(*name)``). So a
+    ``parenthesized_declarator`` hop is not by itself the tell (a redundant-paren prototype has
+    one too); ``_c_parenthesized_declarator_wraps_bare_name`` resolves the ambiguity by checking
+    what it wraps. A hop through the variable-shaped form does not, by itself, mark
+    ``seen_function`` True -- but the boolean is never force-reset to False either, so a function
+    that itself RETURNS a function pointer (``void (*get_handler(int))(int);``, the classic
+    ``signal()`` prototype shape) still resolves correctly: its outer ``function_declarator`` hop
+    is skipped (its parens wrap a ``pointer_declarator``, not a bare name), but the INNER
     ``function_declarator`` -- the function's own parameter list -- has a bare-identifier
-    declarator field, so ``seen_function`` still ends up True from that hop.
+    declarator field directly (no parens at all), so ``seen_function`` still ends up True from
+    that hop. Live-verified against real tree_sitter_c 0.24.2 parses of all of the above,
+    including the full ``void (*signal(int sig, void (*func)(int)))(int);`` shape (the
+    function-pointer PARAMETER inside is never visited -- only the top-level declarator chain
+    is walked).
 
     Returns ``(None, seen_function)`` if no name-bearing leaf was found (e.g. an abstract
     declarator with no name, such as a bare ``void`` parameter) -- callers must check for
@@ -218,12 +245,19 @@ def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
             return current, seen_function
         next_node = current.child_by_field_name("declarator")
         if current.type == "function_declarator":
-            # A function-pointer VARIABLE's own declarator field is a `parenthesized_declarator`
-            # (`(*name)`), never a bare name directly -- that is the tell that rules it out as a
-            # real function on THIS hop (see the docstring). Not force-resetting `seen_function`
-            # to False here is deliberate: it lets a function that returns a function pointer
-            # still resolve True via its own (inner) function_declarator hop.
-            if next_node is None or next_node.type != "parenthesized_declarator":
+            # A `parenthesized_declarator` hop is not by itself the function-pointer-variable
+            # tell -- a redundant-paren prototype (`int (foo)(void);`) has one too, wrapping a
+            # bare identifier. Only a paren wrap around something ELSE (`pointer_declarator`,
+            # `array_declarator`, ...) is the real tell (see the docstring). Not
+            # force-resetting `seen_function` to False here is deliberate: it lets a function
+            # that returns a function pointer still resolve True via its own (inner)
+            # function_declarator hop.
+            is_variable_shaped_parens = (
+                next_node is not None
+                and next_node.type == "parenthesized_declarator"
+                and not _c_parenthesized_declarator_wraps_bare_name(next_node)
+            )
+            if not is_variable_shaped_parens:
                 seen_function = True
         if next_node is not None:
             current = next_node

--- a/src/tensor_grep/cli/lang_c.py
+++ b/src/tensor_grep/cli/lang_c.py
@@ -65,14 +65,18 @@ real parses of plain/pointer/array/function-pointer declarators (including the
 see the module's originating PR description for the exact fixtures probed.
 
 A ``declaration`` node is ambiguous by TYPE ALONE -- it is a function PROTOTYPE
-(``int add(int a, int b);``) or a plain variable declaration (``int counter = 0;``,
-``extern int flag;``) depending purely on whether its declarator chain passes through a
-``function_declarator``. ``_c_declarator_name_node`` also returns that boolean so the extractor
-can gate: only a ``declaration`` whose chain passed through ``function_declarator`` is emitted
-(as kind "function"); a plain variable declaration is silently excluded from the symbol table,
-matching this module's foundational scope (top-level variables are not a tracked symbol kind
-here, mirroring every other ``lang_*.py`` module -- none of them track module-level variables
-either, except Go's explicit ``const_spec``/``var_spec`` kinds, which this module does not add).
+(``int add(int a, int b);``), a file-scope function-pointer VARIABLE (``void (*handler)(int);``),
+or a plain variable declaration (``int counter = 0;``, ``extern int flag;``) depending on its
+declarator shape. ``_c_declarator_name_node`` returns a ``seen_function`` boolean so the
+extractor can gate: only a ``declaration`` whose chain named a REAL function is emitted (as kind
+"function"); a plain variable declaration AND a function-pointer variable are both silently
+excluded from the symbol table, matching this module's foundational scope (top-level variables
+are not a tracked symbol kind here, mirroring every other ``lang_*.py`` module -- none of them
+track module-level variables either, except Go's explicit ``const_spec``/``var_spec`` kinds,
+which this module does not add). "Chain passes through ``function_declarator``" is NOT by itself
+the gate -- a function-pointer variable's chain also passes through one (it is
+``function_declarator``-outermost too); see ``_c_declarator_name_node``'s own docstring for the
+real, live-verified ``parenthesized_declarator`` tell that distinguishes the two.
 A ``struct_specifier``/``union_specifier``/``enum_specifier`` is similarly ambiguous by type
 alone -- ``struct Foo;`` (forward declaration) and ``struct Foo *p`` (usage as a type) both parse
 as the SAME node type with no ``body`` field, indistinguishable from a real definition except by
@@ -170,7 +174,10 @@ _MAX_DECLARATOR_HOPS = 64
 
 def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
     """Descend a declarator chain to its innermost identifier/type_identifier NAME node, tracking
-    whether the chain passed through a ``function_declarator`` along the way.
+    whether the chain passed through a ``function_declarator`` that names a REAL function --
+    a prototype/definition, or a function that returns a pointer or a function pointer -- as
+    opposed to a file-scope function-pointer VARIABLE's declarator, which is also
+    ``function_declarator``-shaped but must NOT set this signal (see below).
 
     Live-verified against real tree_sitter_c 0.24.2 parses (see the module docstring's
     "DECLARATOR NAME RESOLUTION" section) across every shape this module's callers hit:
@@ -181,6 +188,22 @@ def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
     (which, uniquely among these, exposes NO named "declarator" field -- the loop falls back to
     the wrapper's single NAMED child, which resolves through to the inner
     ``pointer_declarator``/name).
+
+    A file-scope function-pointer VARIABLE (``void (*handler)(int);``) is declarator-shaped
+    almost identically to a real function -- its outermost node is ALSO a
+    ``function_declarator`` ("outermost-direct" does NOT distinguish the two; both are
+    outermost-direct). The real, live-verified tell: a REAL function's ``function_declarator``
+    has its own "declarator" FIELD as a bare name -- directly (``void f(int);``), or nested one
+    hop under a return-type ``pointer_declarator`` (``int *make_ptr(void);``) -- while a
+    function-pointer VARIABLE's ``function_declarator`` instead has its own "declarator" field as
+    a ``parenthesized_declarator`` (the paren-grouped ``(*name)``, wrapping a
+    ``pointer_declarator`` down to the name). A hop through that parenthesized shape does not, by
+    itself, mark ``seen_function`` True -- but the boolean is never force-reset to False either,
+    so a function that itself RETURNS a function pointer (``void (*get_handler(int))(int);``,
+    the classic ``signal()`` prototype shape) still resolves correctly: its outer
+    ``function_declarator`` hop is skipped by this same tell, but the INNER
+    ``function_declarator`` -- the function's own parameter list -- has a bare-identifier
+    declarator field, so ``seen_function`` still ends up True from that hop.
 
     Returns ``(None, seen_function)`` if no name-bearing leaf was found (e.g. an abstract
     declarator with no name, such as a bare ``void`` parameter) -- callers must check for
@@ -193,9 +216,15 @@ def _c_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
         hops += 1
         if current.type in {"identifier", "type_identifier", "field_identifier"}:
             return current, seen_function
-        if current.type == "function_declarator":
-            seen_function = True
         next_node = current.child_by_field_name("declarator")
+        if current.type == "function_declarator":
+            # A function-pointer VARIABLE's own declarator field is a `parenthesized_declarator`
+            # (`(*name)`), never a bare name directly -- that is the tell that rules it out as a
+            # real function on THIS hop (see the docstring). Not force-resetting `seen_function`
+            # to False here is deliberate: it lets a function that returns a function pointer
+            # still resolve True via its own (inner) function_declarator hop.
+            if next_node is None or next_node.type != "parenthesized_declarator":
+                seen_function = True
         if next_node is not None:
             current = next_node
             continue

--- a/tests/unit/test_lang_c.py
+++ b/tests/unit/test_lang_c.py
@@ -194,6 +194,134 @@ def test_defs_excludes_plain_and_extern_variable_declarations(tmp_path: Path) ->
 
 
 # ---------------------------------------------------------------------------
+# Declarator-shape matrix: a file-scope function-pointer VARIABLE (e.g. `void (*handler)(int);`)
+# was mis-kinded "function" -- `_c_declarator_name_node`'s `seen_function` boolean went True for
+# ANY `function_declarator` anywhere in the chain, but a function-pointer variable's declarator
+# chain also passes through `function_declarator` (it is the OUTERMOST node). The distinguishing
+# tell (live-verified against a real tree-sitter-c 0.24.2 parse): a REAL function's
+# `function_declarator` has its own `declarator` FIELD as a bare identifier (directly or nested
+# under a return-type `pointer_declarator`); a function-pointer VARIABLE's `function_declarator`
+# has its own `declarator` field as a `parenthesized_declarator` (wrapping a `pointer_declarator`
+# -> the name) instead. Every shape below must resolve exactly as annotated -- this is the full
+# no-regression matrix, not just the bug being fixed.
+# ---------------------------------------------------------------------------
+
+_DECLARATOR_SHAPES_C_SOURCE = (
+    "void shape1_prototype(int x);\n"
+    "\n"
+    "int shape2_definition(void) {\n"
+    "    return 0;\n"
+    "}\n"
+    "\n"
+    "int *shape3_returns_pointer(void);\n"
+    "\n"
+    "void (*shape4_fn_ptr_variable)(int);\n"
+    "\n"
+    "typedef void (*Shape5FnPtrTypedef)(int);\n"
+    "\n"
+    "struct Shape6Struct {\n"
+    "    int x;\n"
+    "};\n"
+)
+
+
+def _write_declarator_shapes_fixture(root: Path) -> Path:
+    shapes_c = root / "declarator_shapes.c"
+    shapes_c.write_text(_DECLARATOR_SHAPES_C_SOURCE, encoding="utf-8")
+    return shapes_c
+
+
+def test_declarator_shape_1_prototype_is_kind_function(tmp_path: Path) -> None:
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape1_prototype", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_2_definition_is_kind_function(tmp_path: Path) -> None:
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape2_definition", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_3_function_returning_pointer_is_kind_function(tmp_path: Path) -> None:
+    """The trap: `int *make_ptr(void);` -- the return-type `pointer_declarator` is outermost,
+    wrapping `function_declarator` whose own `declarator` field is a bare identifier. A real
+    function; must NOT be excluded by the shape-4 fix below."""
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape3_returns_pointer", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_4_function_pointer_variable_is_excluded(tmp_path: Path) -> None:
+    """The bug: `void (*handler)(int);` is a file-scope function-pointer VARIABLE, not a
+    function -- `function_declarator` is outermost, but ITS OWN `declarator` field is a
+    `parenthesized_declarator` (wrapping `pointer_declarator` -> the name), not a bare
+    identifier. Must be excluded from the symbol table entirely (this module does not track
+    top-level variables), same as a plain `int counter;`."""
+    shapes_c = _write_declarator_shapes_fixture(tmp_path)
+
+    _imports, symbols = lang_c.c_imports_and_symbols(shapes_c)
+    names = {s["name"] for s in symbols}
+    assert "shape4_fn_ptr_variable" not in names
+
+    payload = repo_map.build_symbol_defs("shape4_fn_ptr_variable", tmp_path)
+    assert payload.get("no_match") is True
+
+
+def test_declarator_shape_5_function_pointer_typedef_is_kind_type(tmp_path: Path) -> None:
+    """Unchanged by the shape-4 fix: a function-pointer TYPEDEF goes through the separate
+    `type_definition` branch, which always emits kind "type" regardless of
+    `_c_declarator_name_node`'s boolean return (the branch discards it)."""
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Shape5FnPtrTypedef", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "type"
+
+
+def test_declarator_shape_6_struct_is_kind_class(tmp_path: Path) -> None:
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Shape6Struct", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "class"
+
+
+def test_declarator_function_returning_function_pointer_is_kind_function(tmp_path: Path) -> None:
+    """Bonus real-world guard (not in the required 6-shape matrix, but live-verified against a
+    real parse): a function that RETURNS a function pointer -- e.g.
+    `void (*get_handler(int x))(int);`, the same shape as the standard library's `signal()`
+    prototype -- nests a SECOND `function_declarator` (the function's own parameter list) inside
+    the outer one's `parenthesized_declarator` wrap. The outer `function_declarator` hop is
+    skipped (its own declarator field IS `parenthesized_declarator`, the same tell as shape 4),
+    but the INNER `function_declarator`'s own declarator field is a bare identifier, so
+    `seen_function` still ends up True. Guards against an overly-broad fix that force-resets the
+    signal to False the moment a `parenthesized_declarator` appears anywhere in the chain, which
+    would wrongly exclude this real function too."""
+    root = tmp_path
+    (root / "returns_fn_ptr.c").write_text(
+        "void (*get_handler(int x))(int);\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("get_handler", root)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+# ---------------------------------------------------------------------------
 # source
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_lang_c.py
+++ b/tests/unit/test_lang_c.py
@@ -199,11 +199,17 @@ def test_defs_excludes_plain_and_extern_variable_declarations(tmp_path: Path) ->
 # ANY `function_declarator` anywhere in the chain, but a function-pointer variable's declarator
 # chain also passes through `function_declarator` (it is the OUTERMOST node). The distinguishing
 # tell (live-verified against a real tree-sitter-c 0.24.2 parse): a REAL function's
-# `function_declarator` has its own `declarator` FIELD as a bare identifier (directly or nested
-# under a return-type `pointer_declarator`); a function-pointer VARIABLE's `function_declarator`
-# has its own `declarator` field as a `parenthesized_declarator` (wrapping a `pointer_declarator`
-# -> the name) instead. Every shape below must resolve exactly as annotated -- this is the full
-# no-regression matrix, not just the bug being fixed.
+# `function_declarator` has its own `declarator` FIELD as a bare identifier -- directly, nested
+# under a return-type `pointer_declarator`, OR wrapped in REDUNDANT parens (shape 7: a
+# `parenthesized_declarator` wrapping a bare identifier directly, still a real function); a
+# function-pointer VARIABLE's `function_declarator` has its own `declarator` field as a
+# `parenthesized_declarator` wrapping something OTHER than a bare name -- a `pointer_declarator`
+# -> the name -- instead. A `parenthesized_declarator` hop is therefore NOT by itself the tell
+# (an Opus-gate-caught regression on the first cut of this fix: shape 7 was wrongly excluded
+# before `_c_parenthesized_declarator_wraps_bare_name` was added to distinguish "redundant parens
+# around a bare name" from "parens around a pointer/array declarator"). Every shape below must
+# resolve exactly as annotated -- this is the full no-regression matrix, not just the bug being
+# fixed.
 # ---------------------------------------------------------------------------
 
 _DECLARATOR_SHAPES_C_SOURCE = (
@@ -222,6 +228,8 @@ _DECLARATOR_SHAPES_C_SOURCE = (
     "struct Shape6Struct {\n"
     "    int x;\n"
     "};\n"
+    "\n"
+    "int (shape7_redundant_paren_prototype)(void);\n"
 )
 
 
@@ -298,17 +306,36 @@ def test_declarator_shape_6_struct_is_kind_class(tmp_path: Path) -> None:
     assert payload["definitions"][0]["kind"] == "class"
 
 
+def test_declarator_shape_7_redundant_paren_prototype_is_kind_function(tmp_path: Path) -> None:
+    """Opus-gate-caught regression on the first cut of this fix: `int (foo)(void);` is a REAL
+    function prototype with meaningless redundant parens around the name -- its
+    `function_declarator` has its own `declarator` field as a `parenthesized_declarator`, the
+    exact same NODE TYPE as shape 4's function-pointer variable. The two are distinguished by
+    WHAT the parens wrap: shape 7 wraps a bare `identifier` directly (still a real function);
+    shape 4 wraps a `pointer_declarator` (a variable). A fix that treats "hop is
+    `parenthesized_declarator`" alone as the exclusion signal (rather than checking what it
+    wraps) wrongly excludes this real function too -- exactly what the gate caught."""
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape7_redundant_paren_prototype", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
 def test_declarator_function_returning_function_pointer_is_kind_function(tmp_path: Path) -> None:
     """Bonus real-world guard (not in the required 6-shape matrix, but live-verified against a
     real parse): a function that RETURNS a function pointer -- e.g.
     `void (*get_handler(int x))(int);`, the same shape as the standard library's `signal()`
     prototype -- nests a SECOND `function_declarator` (the function's own parameter list) inside
     the outer one's `parenthesized_declarator` wrap. The outer `function_declarator` hop is
-    skipped (its own declarator field IS `parenthesized_declarator`, the same tell as shape 4),
-    but the INNER `function_declarator`'s own declarator field is a bare identifier, so
-    `seen_function` still ends up True. Guards against an overly-broad fix that force-resets the
-    signal to False the moment a `parenthesized_declarator` appears anywhere in the chain, which
-    would wrongly exclude this real function too."""
+    skipped (its own declarator field is a `parenthesized_declarator` wrapping a
+    `pointer_declarator`, the same tell as shape 4 -- NOT a bare name, so shape 7's
+    redundant-parens carve-out does not apply here), but the INNER `function_declarator`'s own
+    declarator field is a bare identifier, so `seen_function` still ends up True. Guards against
+    an overly-broad fix that force-resets the signal to False the moment a
+    `parenthesized_declarator` appears anywhere in the chain, which would wrongly exclude this
+    real function too."""
     root = tmp_path
     (root / "returns_fn_ptr.c").write_text(
         "void (*get_handler(int x))(int);\n",
@@ -316,6 +343,30 @@ def test_declarator_function_returning_function_pointer_is_kind_function(tmp_pat
     )
 
     payload = repo_map.build_symbol_defs("get_handler", root)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_full_signal_prototype_with_function_pointer_parameter_is_kind_function(
+    tmp_path: Path,
+) -> None:
+    """The full classic `signal()` prototype shape, live-verified with tree-sitter-c's
+    `abstract_function_declarator`/`abstract_parenthesized_declarator`/`abstract_pointer_declarator`
+    node types for its unnamed function-pointer PARAMETER (`void (*)(int)`) -- those
+    "abstract_" node types are entirely distinct from the plain declarator types this module's
+    walker recognizes, and live only inside the PARAMETER list, never on the top-level declarator
+    chain `_c_declarator_name_node` walks for `signal` itself, so they cannot interfere. Same
+    outer-skip/inner-sets-True resolution as the `get_handler` guard above, just with a real
+    function-pointer-typed parameter present (the shape most likely to trip up a parameter-aware
+    regression)."""
+    root = tmp_path
+    (root / "signal_prototype.c").write_text(
+        "void (*signal(int sig, void (*func)(int)))(int);\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("signal", root)
 
     assert not payload.get("no_match")
     assert payload["definitions"][0]["kind"] == "function"


### PR DESCRIPTION
## Summary

Fixes a subtle correctness bug in `lang_c.py`'s C symbol extraction: a **file-scope
function-pointer VARIABLE** (`void (*handler)(int);`) was mis-kinded `"function"` in the symbol
table. This module deliberately does not track top-level variables (see the module docstring) —
a function pointer is a variable, so it must be excluded entirely, not re-kinded.

Name and location were already correct; only the kind/inclusion decision was wrong.

**Update:** the independent Opus gate on this PR caught a regression in the first cut (a
redundant-paren function prototype, `int (foo)(void);`, was wrongly excluded too) — see
"Gate-caught refinement" below. The fix now correctly distinguishes all known declarator shapes;
zero known-limitations remain for this bug class.

## Root cause (verified against a real, live-dumped AST — not assumed from the grammar docs)

`_c_declarator_name_node` (`lang_c.py`) walks a declarator chain and returns a `seen_function`
boolean: "did the chain pass through a `function_declarator`?" The bug: **"outermost-direct
`function_declarator`" does not distinguish a real function from a function-pointer variable —
both are outermost-direct.** I dumped the real `tree_sitter_c` 0.24.2 AST for every shape below
before writing any fix code (`node.walk()` field-name + type dump, not read from the grammar
README):

| Shape | Outer declarator | `function_declarator`'s own `declarator` field |
|---|---|---|
| `void f(int);` (prototype) | `function_declarator` | `identifier "f"` (bare name) |
| `int *make_ptr(void);` (returns pointer) | `pointer_declarator` -> `function_declarator` | `identifier "make_ptr"` (bare name) |
| `void (*handler)(int);` (fn-ptr **variable**, the bug) | `function_declarator` | `parenthesized_declarator` (wraps `pointer_declarator` -> `identifier`) |
| `typedef void (*FP)(int);` (fn-ptr **typedef**) | `function_declarator` | `parenthesized_declarator` (same shape as the variable case) |

The real, live-verified tell: a REAL function's `function_declarator` has its own `declarator`
FIELD as a bare name (directly, or one hop under a return-type `pointer_declarator`). A
function-pointer variable's `function_declarator` instead has its own `declarator` field as a
`parenthesized_declarator` (the paren-grouped `(*name)`).

**Bonus verification (not required by the original test matrix, sanity-checked to avoid a new
regression):** a function that itself *returns* a function pointer —
`void (*get_handler(int x))(int);`, the classic `signal()` prototype shape — nests a *second*
`function_declarator` (the function's own parameter list) inside the outer one's
`parenthesized_declarator` wrap:

```
function_declarator                              <- outer: own declarator = parenthesized_declarator (SKIP hop)
  declarator: parenthesized_declarator
    pointer_declarator
      declarator: function_declarator             <- inner: own declarator = identifier (SETS True)
        declarator: identifier "get_handler"
```

This is why the fix does not *force-reset* the boolean to `False` on a parenthesized hop — it
only *skips setting it `True`* on that hop. `seen_function` is "sticky": once any hop in the
chain has a bare-name `declarator` field, it stays `True` for the rest of the walk. That's what
keeps `get_handler` correctly classified as a real function while still excluding `handler`.

## Gate-caught refinement: redundant-paren prototypes

The first cut's rule — "a `function_declarator` hop whose own `declarator` field is a
`parenthesized_declarator` does not set `seen_function`" — is too coarse. C allows meaningless
redundant parens directly around a function name: `int (foo)(void);` declares a real function
`foo`, identical in every way to `int foo(void);`. Its AST (live-dumped, not assumed):

```
declaration
  declarator: function_declarator                 text='(foo)(void)'
    declarator: parenthesized_declarator           text='(foo)'
      identifier "foo"                             <-- wraps a BARE NAME directly
    parameters: parameter_list                     text='(void)'
```

This is the **exact same node shape** (`function_declarator` -> `parenthesized_declarator`) as
the function-pointer-variable bug (`void (*handler)(int);`, which wraps `pointer_declarator` ->
`identifier`, not a bare identifier directly). "Hop is `parenthesized_declarator`" alone cannot
distinguish them — **what the parens wrap** is the real signal.

Fix: a new `_c_parenthesized_declarator_wraps_bare_name` helper inspects the parenthesized
wrap's single named child. Bare `identifier`/`type_identifier`/`field_identifier` → redundant
parens around a real name → `seen_function` still gets set `True` at this hop.
`pointer_declarator`/`array_declarator`/anything else → the function-pointer/array-variable
tell → withhold `seen_function` at this hop (unchanged from the original fix).

Re-verified via a direct end-to-end script (not hand-traced) calling the real, patched
`_c_declarator_name_node` against real parsed ASTs for every shape, including the two the gate
named explicitly:

| Case | Source | Result |
|---|---|---|
| Redundant-paren prototype | `int (foo)(void);` | `name='foo', is_function=True` (fixed) |
| `get_handler` trap (must still work) | `void (*get_handler(int x))(int);` | `name='get_handler', is_function=True` |
| Full `signal()` prototype, named params | `void (*signal(int sig, void (*func)(int)))(int);` | `name='signal', is_function=True` |
| Full `signal()` prototype, abstract/unnamed params (exact gate wording) | `void (*signal(int, void (*)(int)))(int);` | `name='signal', is_function=True` |
| Function-pointer variable (still excluded) | `void (*handler)(int);` | `name='handler', is_function=False` |
| Plain prototype (sanity) | `void f(int);` | `name='f', is_function=True` |
| Returns-pointer (sanity) | `int *make_ptr(void);` | `name='make_ptr', is_function=True` |

All 7 match expectation. The abstract/unnamed-parameter form of `signal()` parses its
function-pointer parameter with entirely distinct `abstract_function_declarator`/
`abstract_parenthesized_declarator`/`abstract_pointer_declarator` node types, confirming those
never interfere — only the top-level declarator chain is walked, never into a parameter list.

## The fix

```python
def _c_parenthesized_declarator_wraps_bare_name(node: Any) -> bool:
    named_children = [child for child in node.children if child.is_named]
    if len(named_children) != 1:
        return False
    return named_children[0].type in {"identifier", "type_identifier", "field_identifier"}
```

```python
next_node = current.child_by_field_name("declarator")
if current.type == "function_declarator":
    is_variable_shaped_parens = (
        next_node is not None
        and next_node.type == "parenthesized_declarator"
        and not _c_parenthesized_declarator_wraps_bare_name(next_node)
    )
    if not is_variable_shaped_parens:
        seen_function = True
```

(first cut: `if next_node is None or next_node.type != "parenthesized_declarator": seen_function = True`
— treated every parenthesized hop as the variable tell, regardless of what it wrapped)

Both docstrings (module-level + the function's own) are updated to describe the real,
live-verified tell.

## Test matrix (TDD throughout: written first, confirmed RED, then GREEN)

All 7 shapes (6 originally required + redundant-paren shape 7 added by the gate-caught
refinement), plus 2 bonus real-world regression guards, in `tests/unit/test_lang_c.py`:

| # | Shape | Expected | Result |
|---|---|---|---|
| 1 | `void f(int);` (prototype) | kind `"function"` PRESENT | PASS |
| 2 | `int f(void) { return 0; }` (definition) | kind `"function"` PRESENT | PASS |
| 3 | `int *make_ptr(void);` (returns pointer — a trap) | kind `"function"` PRESENT | PASS |
| 4 | `void (*handler)(int);` (fn-ptr variable — the original bug) | EXCLUDED entirely | PASS |
| 5 | `typedef void (*FP)(int);` (fn-ptr typedef) | kind `"type"` PRESENT | PASS |
| 6 | struct | kind `"class"` unchanged | PASS |
| 7 | `int (foo)(void);` (redundant-paren prototype — gate-caught regression) | kind `"function"` PRESENT | PASS |
| bonus | `void (*get_handler(int x))(int);` (returns fn-ptr) | kind `"function"` PRESENT | PASS |
| bonus | `void (*signal(int sig, void (*func)(int)))(int);` (full signal() shape) | kind `"function"` PRESENT | PASS |

Original pre-fix run: exactly 1 of 7 failed (shape 4), confirming the fix was targeted. All 9
pass after the full (gate-refined) fix.

Full regression sweep (shared venv, `PYTHONPATH` verified to resolve `tensor_grep.__file__` into
this worktree, not the stale root venv install):
- `tests/unit/test_lang_c.py` — **35/35** (9 declarator-shape/regression tests + 26 pre-existing)
- `test_lang_c.py` + `test_lang_cpp.py` + `test_lang_go.py` + `test_lang_csharp.py` +
  `test_lang_php.py` + `test_lang_registry.py` — **163/163**
- repo_map suite (`test_medlow2_repo_map`, `test_repo_map_binary_detection`,
  `test_repo_map_cache`, `test_repo_map_deadline`, `test_repo_map_graph`,
  `test_repo_map_lexical_ranking`, `test_repo_map_partial_propagation`, `test_repo_map_spans`,
  `test_repo_map_targets`) + `test_skill_index_sync.py` — **173/173**
- `agent_capsule` suite (9 files) — **128/128**
- `ruff check` — clean
- `ruff format --check --preview` — clean
- LF-only line endings verified on both touched files

Zero regressions across every module reachable from the changed function.

## Scope notes (found during verification, deliberately NOT fixed here)

- `lang_cpp.py` has its **own independent** duplicate declarator-walker
  (`_cpp_declarator_name_node`) with the same latent bug shape (unconditional
  `seen_function = True` on any `function_declarator`) — and, by extension, would need the same
  redundant-paren refinement if fixed. It is a separate file with its own extra wrinkles
  (`qualified_identifier` etc.) and was not part of this task's scope — flagging as a natural
  follow-up, not fixing here to keep this PR minimal and reviewable.
- `docs/BACKLOG.md` has a "Known limitation" note (C symbol-graph entry) describing this exact
  bug, including a wrong root-cause hypothesis ("distinguishing an outermost-direct
  `function_declarator`" — which this PR's own AST dumps show does NOT distinguish real
  functions from function-pointer variables, since both are outermost-direct). Left untouched
  here since no test pins that text and this repo's convention is a separate
  `docs(backlog): reconcile` PR after fixes land.
- No further known-limitations remain for this specific bug class (file-scope function-pointer
  variable mis-kinding) after the gate-caught refinement — every declarator shape this PR's
  matrix + regression guards cover resolves correctly, including the previously-untested
  redundant-paren and full-`signal()`-with-function-pointer-parameter shapes.

## Release note

`fix:` prefix — this is a patch release. Gated on an independent Opus review before un-drafting,
per this repo's change-control discipline (a build agent's own gate is a conflict of interest on
load-bearing symbol-graph logic). The first independent Opus gate returned SHIP with the
redundant-paren regression noted above; that regression is now fixed and re-verified in this PR.
