### PR TITLE
fix(lang-cpp): exclude function-pointer variables (were mis-kinded "function")

### DIFF
--- a/src/tensor_grep/cli/lang_cpp.py
+++ b/src/tensor_grep/cli/lang_cpp.py
@@ -384,20 +384,39 @@ def _cpp_parenthesized_declarator_wraps_bare_name(node: Any) -> bool:
     REDUNDANT around a real name (``int (foo)(void);``) -- as opposed to wrapping a
     ``pointer_declarator``/``array_declarator``/``qualified_identifier``/anything else (the tell
     for a function-pointer or pointer-to-member-function VARIABLE, e.g. ``void (*handler)(int);``
-    or ``void (C::*mp)(int);``, where the same parenthesized shape instead wraps a
-    ``pointer_declarator`` or a ``qualified_identifier`` -- live-verified against a real
-    tree_sitter_cpp 0.23.4 parse: ``void (C::*mp)(int);``'s ``parenthesized_declarator``'s single
-    named child is a ``qualified_identifier`` node (fields "scope"=``C``, "name"=a
-    ``pointer_type_declarator`` wrapping ``mp``), a node TYPE this function does not special-case
-    -- it does not need to, since a ``qualified_identifier`` is not in the bare-name set either
-    way, so the pointer-to-member-function variable is excluded by the exact same "wraps
-    something other than a bare name" rule as a plain function-pointer variable, with no extra
-    branch required). Ported byte-for-byte from ``lang_c.py``'s
-    ``_c_parenthesized_declarator_wraps_bare_name`` (same tell, same live-verified reasoning) --
-    duplicated rather than imported per this module's no-cross-import convention (see the
-    top-of-file comment). Only a single hop's own wrapped shape is inspected here; a nested
-    ``parenthesized_declarator`` falls through to False like any other non-bare-name wrap, same
-    residual edge case C's own copy documents."""
+    or a FILE/NAMESPACE-scope ``void (C::*mp)(int);``).
+
+    The pointer-to-member-function shape is DEPENDENT ON SCOPE -- live-verified against a real
+    tree_sitter_cpp 0.23.4 parse of BOTH forms, not assumed identical:
+
+    - At FILE or NAMESPACE scope (``void (C::*mp)(int);``, a plain ``declaration``), the
+      ``parenthesized_declarator``'s single named child IS a ``qualified_identifier`` node
+      (fields "scope"=``C`` a ``namespace_identifier``, "name"=a ``pointer_type_declarator``
+      wrapping ``mp``) -- exactly ONE named child, so this function's own ``len(named_children)
+      == 1`` check runs, and ``qualified_identifier`` is correctly rejected (it is not in the
+      bare-name set), so ``False`` is returned via the TYPE check on line below -- this is the
+      code path that actually excludes this shape from being (mis)treated as a real function.
+    - IN-CLASS (``class C { public: void (C::*mp)(int); };``, a ``field_declaration``),
+      tree-sitter-cpp's parser CANNOT resolve ``C::`` inside a class body the same way (there is
+      no enclosing scope for it to bind against in this local parse) and instead emits an
+      ``ERROR`` node for the ``C::`` portion, sibling to a plain ``pointer_declarator`` for
+      ``*mp`` -- so the ``parenthesized_declarator`` here has **TWO** named children
+      (``['ERROR', 'pointer_declarator']``), not one. This shape is excluded by the ``len(
+      named_children) != 1`` EARLY RETURN below -- a DIFFERENT code path than the file-scope
+      case, never reaching the bare-name TYPE check at all. (This in-class shape was already
+      excluded on the pre-fix ``main`` too, for an unrelated reason: the malformed 2-named-child
+      ``parenthesized_declarator`` also breaks ``_cpp_declarator_name_node``'s own single-
+      named-child fallback when it later tries to descend to a NAME, so ``name_node`` resolves
+      to ``None`` regardless of this function's verdict -- callers already discard a ``None``
+      name_node. Only the FILE-scope shape was the actual pre-fix bug, emitting ``mp`` as kind
+      "function".)
+
+    Ported (with the above scope-dependent nuance ADDED, not blindly copied) from ``lang_c.py``'s
+    ``_c_parenthesized_declarator_wraps_bare_name`` (C has no member-pointer syntax at all, so
+    this nuance is C++-only) -- duplicated rather than imported per this module's no-cross-import
+    convention (see the top-of-file comment). Only a single hop's own wrapped shape is inspected
+    here; a nested ``parenthesized_declarator`` falls through to False like any other
+    non-bare-name wrap, same residual edge case C's own copy documents."""
     named_children = [child for child in node.children if child.is_named]
     if len(named_children) != 1:
         return False

--- a/src/tensor_grep/cli/lang_cpp.py
+++ b/src/tensor_grep/cli/lang_cpp.py
@@ -378,9 +378,45 @@ _CPP_DEF_NODE_KINDS = (
 _MAX_DECLARATOR_HOPS = 64
 
 
+def _cpp_parenthesized_declarator_wraps_bare_name(node: Any) -> bool:
+    """Return True when a ``parenthesized_declarator`` node's single named child is a bare
+    ``identifier``/``type_identifier``/``field_identifier`` -- i.e. the parens are purely
+    REDUNDANT around a real name (``int (foo)(void);``) -- as opposed to wrapping a
+    ``pointer_declarator``/``array_declarator``/``qualified_identifier``/anything else (the tell
+    for a function-pointer or pointer-to-member-function VARIABLE, e.g. ``void (*handler)(int);``
+    or ``void (C::*mp)(int);``, where the same parenthesized shape instead wraps a
+    ``pointer_declarator`` or a ``qualified_identifier`` -- live-verified against a real
+    tree_sitter_cpp 0.23.4 parse: ``void (C::*mp)(int);``'s ``parenthesized_declarator``'s single
+    named child is a ``qualified_identifier`` node (fields "scope"=``C``, "name"=a
+    ``pointer_type_declarator`` wrapping ``mp``), a node TYPE this function does not special-case
+    -- it does not need to, since a ``qualified_identifier`` is not in the bare-name set either
+    way, so the pointer-to-member-function variable is excluded by the exact same "wraps
+    something other than a bare name" rule as a plain function-pointer variable, with no extra
+    branch required). Ported byte-for-byte from ``lang_c.py``'s
+    ``_c_parenthesized_declarator_wraps_bare_name`` (same tell, same live-verified reasoning) --
+    duplicated rather than imported per this module's no-cross-import convention (see the
+    top-of-file comment). Only a single hop's own wrapped shape is inspected here; a nested
+    ``parenthesized_declarator`` falls through to False like any other non-bare-name wrap, same
+    residual edge case C's own copy documents."""
+    named_children = [child for child in node.children if child.is_named]
+    if len(named_children) != 1:
+        return False
+    return named_children[0].type in {"identifier", "type_identifier", "field_identifier"}
+
+
 def _cpp_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
     """Descend a declarator chain to its innermost identifier/type_identifier/field_identifier
-    NAME node, tracking whether the chain passed through a ``function_declarator`` along the way.
+    NAME node, tracking whether the chain passed through a ``function_declarator`` that names a
+    REAL function -- as opposed to a file-scope (or pointer-to-member) function-pointer
+    VARIABLE's declarator, which is also ``function_declarator``-shaped but must NOT set this
+    signal (see ``lang_c.py``'s ``_c_declarator_name_node`` docstring for the full explanation of
+    the underlying tell, unchanged here: a real function's ``function_declarator`` has its own
+    "declarator" field as a bare name -- directly, nested under a return-type
+    ``pointer_declarator``, or wrapped in REDUNDANT parens around a bare name -- while a
+    function-pointer/pointer-to-member-function VARIABLE's ``function_declarator`` instead has
+    its own "declarator" field as a ``parenthesized_declarator`` wrapping something OTHER than a
+    bare name. The boolean is never force-reset True->False, so a function that itself RETURNS a
+    function pointer still resolves True via its own INNER ``function_declarator`` hop).
 
     Extends ``lang_c.py``'s ``_c_declarator_name_node`` with ONE new branch (``qualified_
     identifier`` -> follow "name", never "scope") -- see the module docstring's "DECLARATOR NAME
@@ -399,20 +435,33 @@ def _cpp_declarator_name_node(declarator: Any) -> tuple[Any | None, bool]:
         hops += 1
         if current.type in {"identifier", "type_identifier", "field_identifier"}:
             return current, seen_function
+        next_node = current.child_by_field_name("declarator")
         if current.type == "function_declarator":
-            seen_function = True
+            # A `parenthesized_declarator` hop is not by itself the function-pointer-variable
+            # tell -- a redundant-paren prototype (`int (foo)(void);`) has one too, wrapping a
+            # bare identifier. Only a paren wrap around something ELSE (`pointer_declarator`,
+            # `qualified_identifier` for a pointer-to-member, ...) is the real tell (see the
+            # docstring). Not force-resetting `seen_function` to False here is deliberate: it lets
+            # a function that returns a function pointer still resolve True via its own (inner)
+            # function_declarator hop.
+            is_variable_shaped_parens = (
+                next_node is not None
+                and next_node.type == "parenthesized_declarator"
+                and not _cpp_parenthesized_declarator_wraps_bare_name(next_node)
+            )
+            if not is_variable_shaped_parens:
+                seen_function = True
         if current.type == "qualified_identifier":
             # Foo::bar / app::Thing::compute / Box<T>::get -- take the RHS "name" field (which
             # may itself be another qualified_identifier for a nested namespace::class chain, or
             # a destructor_name/operator_name leaf); NEVER the "scope" field (which may be a
             # template_type for a templated out-of-class method -- its <T> arguments must never
             # leak into the extracted name).
-            next_node = current.child_by_field_name("name")
-            if next_node is not None:
-                current = next_node
+            name_node = current.child_by_field_name("name")
+            if name_node is not None:
+                current = name_node
                 continue
             return None, seen_function
-        next_node = current.child_by_field_name("declarator")
         if next_node is not None:
             current = next_node
             continue

--- a/tests/unit/test_lang_cpp.py
+++ b/tests/unit/test_lang_cpp.py
@@ -238,6 +238,19 @@ def test_defs_excludes_plain_field_and_variable_declarations(tmp_path: Path) -> 
 # exclusion rule ("wraps something other than a bare name") already covers it with no new branch)
 # and shape 12 (qualified out-of-class method definitions must not regress: still kind "function",
 # still bare-name "getValue", covered by the existing tests just below this matrix).
+#
+# Shape 9 (pointer-to-MEMBER-function VARIABLE, `void (C::*mp)(int);`) is SCOPE-DEPENDENT --
+# live-verified against real tree_sitter_cpp 0.23.4 parses of BOTH forms (see
+# `_cpp_parenthesized_declarator_wraps_bare_name`'s docstring for the full node dump):
+# - FILE/NAMESPACE scope: `parenthesized_declarator`'s single named child IS a
+#   `qualified_identifier` -- excluded by the bare-name TYPE check. THIS is the shape the fix
+#   actually repairs: on pre-fix `main` it resolved and was emitted as kind "function" (`mp`).
+# - IN-CLASS (`class C { public: void (C::*mp)(int); }; `): tree-sitter-cpp cannot resolve `C::`
+#   inside a class body and emits an `ERROR` node alongside a `pointer_declarator`, giving the
+#   `parenthesized_declarator` TWO named children -- excluded by the `len(named_children) != 1`
+#   EARLY RETURN, a completely different code path. This shape was ALREADY excluded on pre-fix
+#   `main` (name resolution fails regardless of the fix), so it is a no-regression PIN, not a
+#   guard for the bug. Both are exercised below, separately labeled.
 # ---------------------------------------------------------------------------
 
 _DECLARATOR_SHAPES_CPP_SOURCE = (
@@ -259,10 +272,12 @@ _DECLARATOR_SHAPES_CPP_SOURCE = (
     "\n"
     "int (shape7_redundant_paren_prototype)(void);\n"
     "\n"
-    "class Shape9Class {\n"
+    "class Shape9bClass {\n"
     "public:\n"
-    "    void (Shape9Class::*shape9_member_fn_ptr_variable)(int);\n"
+    "    void (Shape9bClass::*shape9b_inclass_member_fn_ptr_variable)(int);\n"
     "};\n"
+    "\n"
+    "void (Shape9aFileScope::*shape9a_filescope_member_fn_ptr_variable)(int);\n"
 )
 
 
@@ -380,27 +395,53 @@ def test_declarator_function_returning_function_pointer_is_kind_function(tmp_pat
     assert payload["definitions"][0]["kind"] == "function"
 
 
-def test_declarator_shape_9_pointer_to_member_function_variable_is_excluded(
+def test_declarator_shape_9a_filescope_member_function_pointer_variable_is_excluded(
     tmp_path: Path,
 ) -> None:
-    """C++-ONLY wrinkle (not in C's matrix at all): `void (C::*mp)(int);` is a
-    POINTER-TO-MEMBER-FUNCTION variable. Live-verified real AST shape: the outer
-    `function_declarator`'s own "declarator" field is a `parenthesized_declarator` whose single
-    named child is a `qualified_identifier` ("scope"=`C`, "name"=a `pointer_type_declarator`
-    wrapping `mp`) -- a DIFFERENT node type than shape 4's plain `pointer_declarator` wrap, but
-    `_cpp_parenthesized_declarator_wraps_bare_name` excludes it via the exact same "not a bare
-    identifier/type_identifier/field_identifier" rule, with no dedicated branch needed. Must be
-    excluded from the symbol table, same as shape 4."""
+    """THE ACTUAL BUG THIS FIX REPAIRS (C++-only, not in C's matrix at all): a FILE-scope
+    pointer-to-MEMBER-function variable, `void (C::*mp)(int);`. On PRE-FIX `main` this resolved
+    all the way to a name and was mis-emitted as kind "function" (`mp`) -- verified by hand before
+    writing this fix (see the module docstring's dumped AST). Live-verified real AST shape: the
+    outer `function_declarator`'s own "declarator" field is a `parenthesized_declarator` whose
+    SINGLE named child is a `qualified_identifier` ("scope"=a `namespace_identifier`, "name"=a
+    `pointer_type_declarator` wrapping the member name) -- a DIFFERENT node type than shape 4's
+    plain `pointer_declarator` wrap, but `_cpp_parenthesized_declarator_wraps_bare_name` excludes
+    it via the exact same "not a bare identifier/type_identifier/field_identifier" TYPE check, no
+    dedicated branch needed. Guarded SEPARATELY from the in-class shape below (9b) -- that one is
+    excluded via a completely different code path (a length check, not the type check) and was
+    never actually broken."""
     shapes_cpp = _write_declarator_shapes_fixture(tmp_path)
 
     _imports, symbols = lang_cpp.cpp_imports_and_symbols(shapes_cpp)
     names = {s["name"] for s in symbols}
-    assert "shape9_member_fn_ptr_variable" not in names
+    assert "shape9a_filescope_member_fn_ptr_variable" not in names
+
+    payload = repo_map.build_symbol_defs("shape9a_filescope_member_fn_ptr_variable", tmp_path)
+    assert payload.get("no_match") is True
+
+
+def test_declarator_shape_9b_inclass_member_function_pointer_variable_is_excluded(
+    tmp_path: Path,
+) -> None:
+    """NO-REGRESSION PIN, not a guard for this fix (coverage-gap correction): an IN-CLASS
+    pointer-to-member-function variable, `void (C::*mp)(int);` written inside a class body. This
+    shape was ALREADY excluded on pre-fix `main` for an unrelated reason -- live-verified,
+    tree-sitter-cpp cannot resolve `C::` inside a class body and instead emits an `ERROR` node
+    sibling to a `pointer_declarator`, giving the `parenthesized_declarator` TWO named children
+    (`['ERROR', 'pointer_declarator']`). `_cpp_parenthesized_declarator_wraps_bare_name`'s own
+    `len(named_children) != 1` EARLY RETURN excludes it before the bare-name TYPE check even
+    runs -- a different code path than shape 9a above, exercised here so both parses stay
+    covered."""
+    shapes_cpp = _write_declarator_shapes_fixture(tmp_path)
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(shapes_cpp)
+    names = {s["name"] for s in symbols}
+    assert "shape9b_inclass_member_fn_ptr_variable" not in names
     # The enclosing class itself must still resolve normally -- the exclusion is scoped to the
     # member declaration, not the whole class body.
-    assert "Shape9Class" in names
+    assert "Shape9bClass" in names
 
-    payload = repo_map.build_symbol_defs("shape9_member_fn_ptr_variable", tmp_path)
+    payload = repo_map.build_symbol_defs("shape9b_inclass_member_fn_ptr_variable", tmp_path)
     assert payload.get("no_match") is True
 
 

--- a/tests/unit/test_lang_cpp.py
+++ b/tests/unit/test_lang_cpp.py
@@ -225,6 +225,229 @@ def test_defs_excludes_plain_field_and_variable_declarations(tmp_path: Path) -> 
 
 
 # ---------------------------------------------------------------------------
+# Declarator-shape matrix: the C sibling bug (#736/v1.98.2) -- a file-scope function-pointer
+# VARIABLE (`void (*handler)(int);`) was mis-kinded "function" because `_cpp_declarator_name_node`
+# unconditionally set `seen_function = True` for ANY `function_declarator` hop, but a
+# function-pointer variable's declarator chain is ALSO `function_declarator`-outermost. Ported
+# from `lang_c.py`'s own declarator-shape matrix (see `test_lang_c.py`'s identical section for the
+# full C-side narrative) -- live-verified against a REAL tree_sitter_cpp 0.23.4 parse (not ported
+# blind from C's shape, see `_cpp_parenthesized_declarator_wraps_bare_name`'s docstring) across
+# every shape below, PLUS two C++-only additions this matrix carries that C's never needed:
+# shape 9 (pointer-to-MEMBER-function variable, `void (C::*mp)(int);` -- its
+# `parenthesized_declarator` wraps a `qualified_identifier`, not a `pointer_declarator`, but the
+# exclusion rule ("wraps something other than a bare name") already covers it with no new branch)
+# and shape 12 (qualified out-of-class method definitions must not regress: still kind "function",
+# still bare-name "getValue", covered by the existing tests just below this matrix).
+# ---------------------------------------------------------------------------
+
+_DECLARATOR_SHAPES_CPP_SOURCE = (
+    "void shape1_prototype(int x);\n"
+    "\n"
+    "int shape2_definition(void) {\n"
+    "    return 0;\n"
+    "}\n"
+    "\n"
+    "int *shape3_returns_pointer(void);\n"
+    "\n"
+    "void (*shape4_fn_ptr_variable)(int);\n"
+    "\n"
+    "typedef void (*Shape5FnPtrTypedef)(int);\n"
+    "\n"
+    "struct Shape6Struct {\n"
+    "    int x;\n"
+    "};\n"
+    "\n"
+    "int (shape7_redundant_paren_prototype)(void);\n"
+    "\n"
+    "class Shape9Class {\n"
+    "public:\n"
+    "    void (Shape9Class::*shape9_member_fn_ptr_variable)(int);\n"
+    "};\n"
+)
+
+
+def _write_declarator_shapes_fixture(root: Path) -> Path:
+    shapes_cpp = root / "declarator_shapes.cpp"
+    shapes_cpp.write_text(_DECLARATOR_SHAPES_CPP_SOURCE, encoding="utf-8")
+    return shapes_cpp
+
+
+def test_declarator_shape_1_prototype_is_kind_function(tmp_path: Path) -> None:
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape1_prototype", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_2_definition_is_kind_function(tmp_path: Path) -> None:
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape2_definition", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_3_function_returning_pointer_is_kind_function(tmp_path: Path) -> None:
+    """The trap: `int *make_ptr(void);` -- the return-type `pointer_declarator` is outermost,
+    wrapping `function_declarator` whose own `declarator` field is a bare identifier. A real
+    function; must NOT be excluded by the shape-4 fix below."""
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape3_returns_pointer", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_4_function_pointer_variable_is_excluded(tmp_path: Path) -> None:
+    """THE BUG (C sibling of #736): `void (*handler)(int);` is a file-scope function-pointer
+    VARIABLE, not a function -- `function_declarator` is outermost, but ITS OWN `declarator`
+    field is a `parenthesized_declarator` (wrapping `pointer_declarator` -> the name), not a bare
+    identifier. Must be excluded from the symbol table entirely (this module does not track
+    top-level variables), same as a plain `int counter;`."""
+    shapes_cpp = _write_declarator_shapes_fixture(tmp_path)
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(shapes_cpp)
+    names = {s["name"] for s in symbols}
+    assert "shape4_fn_ptr_variable" not in names
+
+    payload = repo_map.build_symbol_defs("shape4_fn_ptr_variable", tmp_path)
+    assert payload.get("no_match") is True
+
+
+def test_declarator_shape_5_function_pointer_typedef_is_kind_type(tmp_path: Path) -> None:
+    """Unchanged by the shape-4 fix: a function-pointer TYPEDEF goes through the separate
+    `type_definition` branch, which always emits kind "type" regardless of
+    `_cpp_declarator_name_node`'s boolean return (the branch discards it)."""
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Shape5FnPtrTypedef", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "type"
+
+
+def test_declarator_shape_6_struct_is_kind_class(tmp_path: Path) -> None:
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("Shape6Struct", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "class"
+
+
+def test_declarator_shape_7_redundant_paren_prototype_is_kind_function(tmp_path: Path) -> None:
+    """Same Opus-gate-caught regression trap C's own fix disclosed: `int (foo)(void);` is a REAL
+    function prototype with meaningless redundant parens around the name -- its
+    `function_declarator` has its own `declarator` field as a `parenthesized_declarator`, the
+    exact same NODE TYPE as shape 4's function-pointer variable. The two are distinguished by
+    WHAT the parens wrap: shape 7 wraps a bare `identifier` directly (still a real function);
+    shape 4 wraps a `pointer_declarator` (a variable). A fix that treats "hop is
+    `parenthesized_declarator`" alone as the exclusion signal (rather than checking what it
+    wraps) wrongly excludes this real function too."""
+    _write_declarator_shapes_fixture(tmp_path)
+
+    payload = repo_map.build_symbol_defs("shape7_redundant_paren_prototype", tmp_path)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_function_returning_function_pointer_is_kind_function(tmp_path: Path) -> None:
+    """THE TRAP (shape 8 in the task matrix): a function that RETURNS a function pointer --
+    `void (*get_handler(int x))(int);`, the same shape as the standard library's `signal()`
+    prototype -- nests a SECOND `function_declarator` (the function's own parameter list) inside
+    the outer one's `parenthesized_declarator` wrap. The outer `function_declarator` hop is
+    skipped (its own declarator field is a `parenthesized_declarator` wrapping a
+    `pointer_declarator`, the same tell as shape 4 -- NOT a bare name, so shape 7's
+    redundant-parens carve-out does not apply here), but the INNER `function_declarator`'s own
+    declarator field is a bare identifier, so `seen_function` still ends up True. Guards against
+    an overly-broad fix that force-resets the signal to False the moment a
+    `parenthesized_declarator` appears anywhere in the chain, which would wrongly exclude this
+    real function too."""
+    root = tmp_path
+    (root / "returns_fn_ptr.cpp").write_text(
+        "void (*get_handler(int x))(int);\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("get_handler", root)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "function"
+
+
+def test_declarator_shape_9_pointer_to_member_function_variable_is_excluded(
+    tmp_path: Path,
+) -> None:
+    """C++-ONLY wrinkle (not in C's matrix at all): `void (C::*mp)(int);` is a
+    POINTER-TO-MEMBER-FUNCTION variable. Live-verified real AST shape: the outer
+    `function_declarator`'s own "declarator" field is a `parenthesized_declarator` whose single
+    named child is a `qualified_identifier` ("scope"=`C`, "name"=a `pointer_type_declarator`
+    wrapping `mp`) -- a DIFFERENT node type than shape 4's plain `pointer_declarator` wrap, but
+    `_cpp_parenthesized_declarator_wraps_bare_name` excludes it via the exact same "not a bare
+    identifier/type_identifier/field_identifier" rule, with no dedicated branch needed. Must be
+    excluded from the symbol table, same as shape 4."""
+    shapes_cpp = _write_declarator_shapes_fixture(tmp_path)
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(shapes_cpp)
+    names = {s["name"] for s in symbols}
+    assert "shape9_member_fn_ptr_variable" not in names
+    # The enclosing class itself must still resolve normally -- the exclusion is scoped to the
+    # member declaration, not the whole class body.
+    assert "Shape9Class" in names
+
+    payload = repo_map.build_symbol_defs("shape9_member_fn_ptr_variable", tmp_path)
+    assert payload.get("no_match") is True
+
+
+def test_declarator_shape_11_namespace_scoped_fnptr_variable_and_prototype(
+    tmp_path: Path,
+) -> None:
+    """Shapes 4 and 1, replayed inside a `namespace app { ... }` block -- same verdicts as at
+    file scope: the function-pointer variable is excluded, the prototype is kind "function", and
+    the namespace itself still resolves as kind "namespace"."""
+    root = tmp_path
+    (root / "ns_shapes.cpp").write_text(
+        "namespace app {\n"
+        "void (*ns_handler)(int);\n"
+        "\n"
+        "void ns_prototype(int x);\n"
+        "}  // namespace app\n",
+        encoding="utf-8",
+    )
+
+    _imports, symbols = lang_cpp.cpp_imports_and_symbols(root / "ns_shapes.cpp")
+    names = {s["name"]: s["kind"] for s in symbols}
+
+    assert "ns_handler" not in names
+    assert names.get("ns_prototype") == "function"
+    assert names.get("app") == "namespace"
+
+
+def test_using_alias_declaration_of_function_pointer_is_still_kind_type(tmp_path: Path) -> None:
+    """C++-ONLY requirement matrix item 10: `using FP2 = void (*)(int);` -- CURRENT behavior on
+    origin/main (unaffected by this fix): resolves via the `alias_declaration` branch, which reads
+    the alias's OWN "name" field (`FP2`) directly and always emits kind "type" -- it never touches
+    `_cpp_declarator_name_node`/the `function_declarator` walk at all (the aliased
+    `type_descriptor` -> `abstract_function_declarator` shape on the RHS is never traversed by the
+    declarator walker), so this fix cannot regress it. Documented here as a no-regression pin."""
+    root = tmp_path
+    (root / "alias_fnptr.cpp").write_text(
+        "using FP2 = void (*)(int);\n",
+        encoding="utf-8",
+    )
+
+    payload = repo_map.build_symbol_defs("FP2", root)
+
+    assert not payload.get("no_match")
+    assert payload["definitions"][0]["kind"] == "type"
+
+
+# ---------------------------------------------------------------------------
 # defs: functions, incl. qualified out-of-class methods (the central C++ wrinkle)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

C++ sibling of #736/v1.98.2's C fix. `src/tensor_grep/cli/lang_cpp.py`'s own declarator walker
(`_cpp_declarator_name_node`) carried the same latent bug: it set `seen_function = True` for ANY
`function_declarator` hop, so a file-scope (or member) function-pointer **VARIABLE** (e.g.
`void (*handler)(int);`) was mis-emitted as a symbol of kind `"function"`. These modules
deliberately do not track top-level/member variables — the fix excludes it, matching C's
foundational scope.

## Real AST verification (tree_sitter_cpp 0.23.4, live-dumped, not ported blind from C)

Per `AGENTS.md`'s campaign discipline and the task instructions, I dumped the actual
`tree_sitter_cpp` parse for every shape in the matrix before writing anything (the C fix's own
history — an Opus gate catching a wrong first-cut — proves blind porting is unsafe). Key findings:

- **`preproc_include`, `declaration`/`function_declarator`, `parenthesized_declarator` shapes are
  IDENTICAL to tree-sitter-c** for the base 8 shapes (prototype/definition/pointer-return/fn-ptr
  var/typedef/struct/redundant-paren/returns-fn-ptr) — C's fix (the
  `_c_parenthesized_declarator_wraps_bare_name` tell) ports over exactly unchanged for those.
- **C++-only wrinkle (shape 9, `void (C::*mp)(int);`, pointer-to-MEMBER-function variable) is
  SCOPE-DEPENDENT — corrected after an independent Opus gate caught the first cut only documenting
  one of the two parses:**
  - **FILE/NAMESPACE scope** (`void (C::*mp)(int);` as a plain top-level `declaration`): the
    `function_declarator`'s "declarator" field is a `parenthesized_declarator` whose **single**
    named child is a `qualified_identifier` (fields `"scope"`=a `namespace_identifier` (`C`),
    `"name"`=a `pointer_type_declarator` wrapping the member name) — a **different node type**
    than plain C's `pointer_declarator` wrap, but still excluded by
    `_cpp_parenthesized_declarator_wraps_bare_name`'s existing "is the single named child a bare
    `identifier`/`type_identifier`/`field_identifier`?" TYPE check (a `qualified_identifier` is
    none of those three) — zero extra code needed. **This is the shape the fix actually repairs**:
    on pre-fix `main` it resolved all the way to a name and was mis-emitted as kind "function".
  - **IN-CLASS** (`class C { public: void (C::*mp)(int); }; `): tree-sitter-cpp **cannot resolve
    `C::` inside a class body** the same way and instead emits an `ERROR` node for the `C::`
    portion, sibling to a plain `pointer_declarator` for the member name — so the
    `parenthesized_declarator` here has **TWO** named children (`['ERROR', 'pointer_declarator']`),
    not one. This is excluded by `_cpp_parenthesized_declarator_wraps_bare_name`'s
    `len(named_children) != 1` **early return** — a different code path that never reaches the
    type check at all. This shape was **already excluded on pre-fix `main`** too, for an unrelated
    reason (the malformed 2-named-child `parenthesized_declarator` also breaks
    `_cpp_declarator_name_node`'s single-named-child fallback when it tries to descend further, so
    `name_node` resolves to `None` regardless of the fix) — a no-regression pin, not a bug guard.
  Both fixture shapes are now dumped, documented in
  `_cpp_parenthesized_declarator_wraps_bare_name`'s docstring, and covered by separate tests (see
  Tests section below).
- **`using FP2 = void (*)(int);` (shape 10, alias-declaration)**: verified this is a **completely
  separate code path** — `alias_declaration` reads its own `"name"` field (`FP2`) directly and
  always emits kind `"type"`. It never calls `_cpp_declarator_name_node`/the `function_declarator`
  walk at all (the RHS `type_descriptor` → `abstract_function_declarator` shape is never
  traversed). **Unchanged by this fix**, pinned as a no-regression test.
- **Qualified out-of-class methods (shape 12, `app::Widget::getValue`)**: traced through
  `_cpp_declarator_name_node` by hand — the outer `function_declarator`'s "declarator" field is a
  bare `qualified_identifier` (not paren-wrapped), so `is_variable_shaped_parens` is False and
  `seen_function` still resolves True; the `qualified_identifier` branch (unchanged) still
  descends to the bare `"getValue"` leaf. Verified via a real extractor run (before AND after the
  fix) that `getValue` still resolves as 2 records (in-class prototype + out-of-class qualified
  definition), matching existing `test_defs_finds_inclass_prototype_and_outofclass_qualified_definition`.

## The fix

`src/tensor_grep/cli/lang_cpp.py`:
1. Added `_cpp_parenthesized_declarator_wraps_bare_name` (ported byte-for-byte from
   `lang_c.py`'s twin — same tell, same reasoning, duplicated per this module's no-cross-import
   convention).
2. `_cpp_declarator_name_node`'s `function_declarator` branch now only sets `seen_function = True`
   when the hop is NOT a `parenthesized_declarator`-wrapping-something-other-than-a-bare-name
   (i.e. withholds it exactly for the fn-ptr-variable / member-fn-ptr-variable shapes). The
   boolean is never force-reset True→False, so a function that itself *returns* a function
   pointer (`void (*get_handler(int))(int);`) still resolves True via its own inner
   `function_declarator` hop.

## 12-shape verification matrix (all live-run against the real extractor, before/after)

| # | Shape | Expected | Result |
|---|---|---|---|
| 1 | `void f(int);` prototype | function PRESENT | ✅ |
| 2 | `int fdef(void) { return 0; }` definition | function PRESENT | ✅ |
| 3 | `int *make_ptr();` (returns pointer) | function PRESENT | ✅ |
| 4 | `void (*handler)(int);` (fn-ptr VARIABLE) | **EXCLUDED** | ✅ (was wrongly "function" before fix) |
| 5 | `typedef void (*FP)(int);` | type PRESENT | ✅ (unaffected — separate branch) |
| 6 | `struct S {...};` / `class C { void m(); };` | class PRESENT | ✅ |
| 7 | `int (foo)(void);` (redundant-paren prototype) | function PRESENT | ✅ |
| 8 | `void (*get_handler(int))(int);` (returns fn-ptr, the trap) | function PRESENT | ✅ |
| 9a | `void (C::*mp)(int);` at FILE scope (pointer-to-MEMBER-fn VARIABLE, C++-only) | **EXCLUDED** | ✅ (was wrongly "function" before fix — THE actual repaired shape) |
| 9b | `void (C::*mp)(int);` IN-CLASS (pointer-to-MEMBER-fn VARIABLE, C++-only) | **EXCLUDED** | ✅ (already excluded pre-fix too — no-regression pin, different code path: `ERROR`-node 2-named-children early return, not the type check) |
| 10 | `using FP2 = void (*)(int);` (alias-declaration) | type PRESENT, **unchanged** | ✅ (never touches the fixed code path) |
| 11 | Namespace-scoped shapes 4 + 1 | same verdicts inside `namespace app {...}` | ✅ |
| 12 | Qualified method `app::Widget::getValue` | function PRESENT, bare-name pairing preserved | ✅ (no regression — dogfood-verified at v1.98.0) |

## Tests

Added to `tests/unit/test_lang_cpp.py` (mirrors `test_lang_c.py`'s own declarator-shape-matrix
section): shapes 1/2/3/4/5/6/7/8 (ported), shape 9a (new, C++-only FILE-scope member-fn-ptr-
variable exclusion — the actual bug guard), shape 9b (new, IN-CLASS member-fn-ptr-variable
exclusion — a no-regression pin, since this shape was already excluded pre-fix via a different
code path), shape 10 (new, `using` alias no-regression pin), shape 11 (new, namespace-scoped
replay of shapes 4+1). Shape 12's coverage already existed
(`test_defs_finds_inclass_prototype_and_outofclass_qualified_definition`) and was re-verified, not
duplicated.

**Gate follow-up (this revision):** an independent Opus review of the first cut found the shape-9
test guarded only the IN-CLASS fixture (already excluded pre-fix — a no-regression pin, not a
guard for the fix) and the docstring's AST claim was true for file-scope only, not in-class. Both
shapes were re-dumped from a real `tree_sitter_cpp` parse (see the corrected section above),
`_cpp_parenthesized_declarator_wraps_bare_name`'s docstring now documents both explicitly, and
shape 9 was split into 9a (file-scope, the real guard, new fixture entry
`shape9a_filescope_member_fn_ptr_variable`) + 9b (in-class, the pin, renamed fixture entries
`Shape9bClass`/`shape9b_inclass_member_fn_ptr_variable`).

## Verification run

Run WITHOUT a `PYTHONPATH` override — relying solely on `tests/conftest.py:10`'s
`sys.path.insert(0, SRC_DIR)`, which outranks `PYTHONPATH` and is the only trustworthy red/green
baseline (a `PYTHONPATH`-only baseline can give a false red-green, per the gate's own finding).

```
tests/unit/test_lang_cpp.py
  → 50 passed (was 49; +1 for the new shape-9a guard)

tests/unit/test_lang_cpp.py tests/unit/test_lang_c.py tests/unit/test_lang_go.py \
  tests/unit/test_lang_csharp.py tests/unit/test_lang_php.py tests/unit/test_lang_registry.py
  → 175 passed

tests/unit/test_medlow2_repo_map.py tests/unit/test_repo_map_binary_detection.py \
  tests/unit/test_repo_map_cache.py tests/unit/test_repo_map_deadline.py \
  tests/unit/test_repo_map_graph.py tests/unit/test_repo_map_lexical_ranking.py \
  tests/unit/test_repo_map_partial_propagation.py tests/unit/test_repo_map_spans.py \
  tests/unit/test_repo_map_targets.py
  → 169 passed

ruff check: All checks passed!
ruff format --check --preview: 2 files already formatted
```

CPU-SAFE: Python-only change, no cargo/rustc, e2e suite not run (it self-compiles Rust).

## Gating

v1.98.2 (the C fix, #736) has MERGED and released on `main`. This PR is **draft-only** pending an
**independent Opus review** per the repo's change-control discipline (a build agent's own self-gate
is a conflict of interest) — the first review round already ran and returned FIX (the two
non-behavioral findings addressed in this revision); awaiting re-review before un-drafting.
