### PR TITLE
docs(agents): capture 9 session lessons (governance-test fragility, detached-HEAD push, banked-hypothesis, restart backstops)

### DIFF
--- a/.claude/skills/tensor-grep-add-language/SKILL.md
+++ b/.claude/skills/tensor-grep-add-language/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tensor-grep-add-language
-description: Use when adding a new language to tensor-grep's tree-sitter symbol graph (defs/refs/callers/blast-radius, `tg source`, `tg imports`) — registering a `LanguageSpec` in `lang_registry.py`, writing a new `src/tensor_grep/cli/lang_<x>.py` extractor module, or scoping the deferred C/C++ language-expansion follow-up. Triggers and keywords include add a language, add <language> to tensor-grep, new grammar, tree-sitter grammar, lang_registry, register_language, new lang_<x>.py module, symbol-graph language, onboard a language, "tg doesn't find symbols in <language>", `_target_language_for_path`, grammar-missing provenance, C/C++ symbol graph.
+description: Use when adding a new language to tensor-grep's tree-sitter symbol graph (defs/refs/callers/blast-radius, `tg source`, `tg imports`) — registering a `LanguageSpec` in `lang_registry.py`, writing a new `src/tensor_grep/cli/lang_<x>.py` extractor module, debugging a C/C++ declarator-walker mis-kind, or verifying a banked "the fix is obviously X" hypothesis against a live parse tree before writing declarator-shape logic. Triggers and keywords include add a language, add <language> to tensor-grep, new grammar, tree-sitter grammar, lang_registry, register_language, new lang_<x>.py module, symbol-graph language, onboard a language, "tg doesn't find symbols in <language>", `_target_language_for_path`, grammar-missing provenance, C/C++ symbol graph, function-pointer variable mis-kinded as function, declarator shape.
 ---
 
 # tensor-grep: adding a language to the symbol graph
@@ -27,18 +27,22 @@ backend contract.
 | Drain several language PRs that all touch `test_lang_registry.py` / `uv.lock` / the pyproject `ast` extra | `tensor-grep-change-control`'s Campaign Orchestration cross-ref (AGENTS.md A22) |
 | Use `tg` as a consumer (search/orient/callers flags) | `code-search-and-retrieval-reference` |
 
-## Current status (verified against tg v1.96.1-pending, `origin/main` @ `29cf59f`)
+## Current status (verified against tg v1.98.2, `origin/main` @ `ba63aa0`)
 
-`repo_map.py` currently carries **8** `lang_registry.register_language(...)` call sites
+`repo_map.py` currently carries **10** `lang_registry.register_language(...)` call sites
 (`grep -n "register_language(" src/tensor_grep/cli/repo_map.py`): `python`, `javascript`,
 `typescript`, `rust` (the original four, inline in `repo_map.py`), plus `go`, `java`,
-`php`, and `csharp` — confirmed via `language_id=` greps and
+`php`, `csharp`, `c`, and `cpp` — confirmed via `language_id=` greps and
 `tests/unit/test_lang_registry.py::test_language_registry_has_exactly_the_stage2_languages`'s
-literal set-pin (which now includes `"csharp"`). C# landed via PR #726 as a
-module-shaped language (`lang_csharp.py`, mirrors `lang_go.py`, not Java's inline
-shape) — **all top-10 languages except C/C++ are now registered.** **Re-run the grep
-above before trusting any "N of top-10" count** — it is a snapshot, not a promise; this
-count changed twice in the span of authoring this skill.
+literal set-pin (which now includes `"c"` and `"cpp"`). **All top-10 languages are now
+registered — the "C/C++ deferred" framing below this line in earlier passes of this skill is
+STALE; C landed via PR #731 (v1.97.0) and C++ via PR #732 (v1.98.0), each a self-contained
+module (`lang_c.py`/`lang_cpp.py`, mirroring `lang_go.py`'s shape), both at the same
+foundational tier as Java/PHP/C# (defs/imports only, no `references_and_calls`).** A
+follow-up C fix (#736, v1.98.2) corrected a file-scope function-pointer-variable mis-kind —
+see B5's declarator-shape addendum below before writing similar C/C++ declarator-walking
+logic. **Re-run the grep above before trusting any "N of top-10" count** — it is a snapshot,
+not a promise; this count has changed on every pass of this skill so far.
 
 The tiered language model (unchanged shape, re-verify the coverage numbers):
 
@@ -46,7 +50,7 @@ The tiered language model (unchanged shape, re-verify the coverage numbers):
 |---|---|---|---|
 | Text search | any file | rg passthrough (bootstrap front door) | universal |
 | Structural scan/rewrite | many languages | ast-grep, which `tg` wraps (`tg ast-info`, `tg run`) | ~26 langs (ast-grep's own list) |
-| **Symbol graph (this skill)** | tree-sitter grammars in `lang_registry` | `defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports` | 8 of top-10 live on `main` (Python/JS/TS/Java/C#/Go/Rust/PHP); **C/C++ deferred** |
+| **Symbol graph (this skill)** | tree-sitter grammars in `lang_registry` | `defs`/`refs`/`callers`/`blast-radius`/`tg source`/`tg imports` | **10 of 10 top-10 languages live on `main`** (Python/JS/TS/Java/C#/C++/C/Go/Rust/PHP) |
 
 Positioning: tg = rg (text) + ast-grep (structural) + this symbol/retrieval/capsule layer —
 "not faster grep" (mirrors `tensor-grep-architecture-contract`'s moat framing). Top-10
@@ -290,6 +294,36 @@ child) — the reverse of what you might guess. `_csharp_using_directive_target`
 comment table). Getting this backwards would record every aliased import as its local
 alias name instead of the namespace actually being imported.
 
+**A fifth example, and the most important one for C-family declarator walkers (PR #736, v1.98.2):
+a "seems obviously right" tell was FALSIFIED by the live AST, not confirmed by it.** `lang_c.py`'s
+`_c_declarator_name_node` walks a declarator chain to decide `seen_function: bool` — "did the chain
+pass through a `function_declarator`?" A banked note from an earlier session proposed the fix as
+"require `function_declarator` to be OUTERMOST" to exclude a file-scope function-pointer VARIABLE
+(`void (*handler)(int);`, which this module deliberately must NOT report as a function). Dumping the
+real `tree_sitter_c` 0.24.2 AST before writing any code showed that hypothesis was simply wrong: a
+function-pointer variable's declarator chain ALSO has `function_declarator` outermost — identical in
+that one respect to a real prototype `void f(int);`. "Outermost" is not the discriminator at all. The
+real tell lives one level deeper, in what that `function_declarator` node's OWN `declarator` field
+WRAPS:
+
+| Shape | `function_declarator`'s own `declarator` field |
+|---|---|
+| `void f(int);` (real prototype) | bare `identifier` |
+| `int *make_ptr(void);` (returns pointer) | bare `identifier`, one hop under a `pointer_declarator` |
+| `void (*handler)(int);` (fn-ptr VARIABLE — exclude) | `parenthesized_declarator` wrapping a `pointer_declarator` |
+| `int (foo)(void);` (redundant-paren real prototype — keep, gate-caught refinement) | `parenthesized_declarator` wrapping a bare `identifier` directly |
+
+A `parenthesized_declarator` hop alone is not the signal — a real function can be wrapped in
+meaningless redundant parens too (row 4); what matters is whether the parens wrap a bare name (real
+function) or a pointer declarator (variable). `lang_cpp.py` has its OWN, independently-written
+declarator walker (`_cpp_declarator_name_node`) with the same latent bug shape — do not assume fixing
+one fixes the other; C++ also has a member-function-pointer wrinkle (`void (C::*mp)(int);`, which
+wraps a `qualified_identifier` instead of a `pointer_declarator`) that C alone does not have. **Rule
+for this skill's audience specifically:** a banked "the fix is obviously X" note — even one written in
+a prior session about this exact bug class — is a hypothesis about a declarator SHAPE, and declarator
+shapes are exactly the thing B5 already tells you not to guess. Dump the real parse tree for every
+shape you plan to include/exclude before trusting a one-line fix description, including your own.
+
 ## B6 — tiered model recap (see "Current status" above for the live table)
 
 text search (any language, rg passthrough) → structural scan/rewrite (~26 langs via the
@@ -302,28 +336,49 @@ ast-grep supports it) structural scan/rewrite; it just has no `defs`/`refs`/`cal
 ## E1 — priority and what's next
 
 Top-10 by TIOBE Jul-2026 + Stack Overflow 2025 + GitHub Octoverse 2025 consensus: Python,
-JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP. All 8 non-C/C++ entries are now
-registered on `main` (C# landed via PR #726). **C/C++ is the next concrete target**, and it
-is harder than any language shipped so far — scope before starting, not while coding:
+JavaScript, TypeScript, Java, C#, C++, C, Go, Rust, PHP. **All 10 are now registered on
+`main`** — C landed via PR #731 (v1.97.0), C++ via PR #732 (v1.98.0), both scoped exactly per
+items 1-5 below (a Stage-1, per-file, foundational-tier landing, not the full
+`#include`-graph resolution items 1-2 warn against blocking on). The five scoping notes
+below are kept as a worked EXAMPLE of "scope before starting, not while coding" for the
+next language beyond the top-10, not as an open task:
 
 1. **No module system.** Go has `go.mod`/`go.work`; C/C++ has no compiler-enforced
    namespace-to-directory mapping. The honest floor for a first landing is per-file symbol
    extraction (filename-as-scope), not a full `compile_commands.json`/CMake include-graph.
+   **Confirmed as shipped:** `#include` resolution stays deferred/BACKLOG for both C and
+   C++ (an honest `resolution_gaps` entry, never a fabricated resolved path) — a true
+   `#include`-graph resolver is a separate, much larger scope (clangd-grade), tracked but
+   not started.
 2. **`#include` is textual, not semantic.** tree-sitter has no preprocessor; a
    `#define`-wrapped declaration (export/visibility macros are common in real C/C++ headers)
    can hide or reshape the node the extractor expects — B5's live-verify discipline is
-   mandatory here, not optional, on a much larger surface than Go's.
+   mandatory here, not optional, on a much larger surface than Go's. **Confirmed as shipped:**
+   `class MACRO Name` (a macro-decorated class declaration) misparses on the installed C++
+   grammar — an INHERENT tree-sitter ceiling, not a bug in this codebase's extractor, and
+   disclosed as accepted in PR #732.
 3. **Declaration/definition split.** A C/C++ function typically appears twice (a header
    prototype, a body-bearing definition) — which one is canonical for `tg source`/`tg defs`
    is a design decision to make explicitly, not an assumption carried over from Go's
    one-declaration model.
 4. **C and C++ are two separate grammar packages** (`tree-sitter-c` vs. `tree-sitter-cpp`) —
    decide upfront whether they are one `LanguageSpec` or two (recommend two, mirroring how
-   JS/TS already get two specs rather than one with a mode flag).
+   JS/TS already get two specs rather than one with a mode flag). **Confirmed as shipped:**
+   they landed as two separate modules (`lang_c.py`/`lang_cpp.py`), each its own
+   `LanguageSpec`, exactly as recommended here.
 5. A first Stage 1 landing can reasonably scope to per-file extraction +
    declaration/definition dedup by name, in the same 0.7 `"receiver-heuristic"`-equivalent
    confidence band Go uses for anything short of confirmed resolution — a real,
    honestly-labeled feature now, rather than blocking on `#include`-graph resolution.
+
+**Known post-ship correction (PR #736, v1.98.2 — see B5's declarator-shape addendum above for
+the full worked example):** C's file-scope function-pointer VARIABLE
+(`void (*handler)(int);`) was initially mis-kinded `"function"` — fixed by distinguishing
+what a `function_declarator`'s own `declarator` field wraps, not whether it's outermost. A
+sibling fix for `lang_cpp.py`'s independently-written declarator walker (same bug shape, plus
+a C++-only member-function-pointer wrinkle) is tracked as a follow-up, not yet landed as of
+this pass — re-verify with `git log --oneline -- src/tensor_grep/cli/lang_cpp.py` before
+assuming it's done.
 
 ## Parallel-drain hygiene (cross-ref: AGENTS.md Campaign Orchestration A22)
 
@@ -398,6 +453,21 @@ tg --version
 
 ## Provenance and maintenance
 
+- **Third re-verify pass, 2026-07-24, against tg v1.98.2** (`main` HEAD `ba63aa0`). Corrected the
+  "Current status" section and E1 from stale "C/C++ deferred, C# is next" framing (accurate as of
+  the prior pass, staled by C landing in PR #731/v1.97.0 and C++ in PR #732/v1.98.0 — both merged
+  after the prior pass) to the current true state: all 10 top-10 languages are registered
+  (`grep -c "register_language(" src/tensor_grep/cli/repo_map.py` -> 10;
+  `test_language_registry_has_exactly_the_stage2_languages` now pins `c`/`cpp` alongside the prior
+  8). Added the B5 declarator-shape addendum documenting PR #736 (v1.98.2) — a banked "the fix is
+  obviously X" hypothesis for a C symbol-graph mis-kind that a live AST dump FALSIFIED before any
+  fix code was written; this is the single most directly relevant fact this skill carries for the
+  next C/C++-family declarator-walker change, since `lang_cpp.py`'s own independently-written
+  walker has the same latent bug shape and is not yet fixed (`lang_cpp.py`'s own log has no commit
+  past #732 as of this pass — re-verify with `git log --oneline -- src/tensor_grep/cli/lang_cpp.py`
+  before assuming a fix has landed). Ground truth this pass: `git log --oneline` for `lang_c.py`/
+  `lang_cpp.py`, PR #731/#732/#736's real commit messages and diffs, and
+  `tests/unit/test_lang_registry.py`'s current set-pin.
 - **Verified against tg v1.96.1-pending** (`main` HEAD `29cf59f`, `pyproject.toml` still
   stamps `1.96.0` since semantic-release derives the version at publish time — #728 is a
   `fix:` commit, so the next publish is v1.96.1). This is the skill's **second** re-verify

--- a/.claude/skills/tensor-grep-backlog-campaign/SKILL.md
+++ b/.claude/skills/tensor-grep-backlog-campaign/SKILL.md
@@ -149,6 +149,12 @@ from #20 as of the 2026-07-22 session-capture — 6 new registrations, #20-25 ab
 schedule every session, so any recorded id goes stale immediately. Do NOT trust a previously-recorded id
 (this file, MEMORY.md, a handoff note). Verify the live cron via `CronList` at session start; re-arm if
 absent. (Verified 2026-07-16: three different sources cited three different ids/schedules — all stale.)
+Re-confirmed **2026-07-24**: a session-scoped cron also dies SILENTLY on a mid-session CLI restart or a
+PC reboot, not only at session boundary — the same steward was lost twice in one session this way, once
+to each. There is no error or notification when it dies; the only way to know is to check. After ANY
+restart or crash — not only at the start of a fresh session — re-verify with `CronList` and re-arm if
+absent, and keep the durable state (queue, in-flight PRs, "resume here") in the task store + `MEMORY.md`,
+which survive a restart even when the cron itself does not (AGENTS.md A25).
 
 ---
 
@@ -172,6 +178,10 @@ absent. (Verified 2026-07-16: three different sources cited three different ids/
 **Resume-from-transcript, not re-dispatch (broadened 2026-07-08 — ANY transient failure, not just session-limit kills).** A background subagent (Fable or otherwise) that dies mid-task — a session-limit kill (`had-no-active-task`) **or** a transient `"Agent terminated early due to an API error: 500"` — is resumed via `SendMessage` to its agent ID, not re-dispatched fresh: the transcript carries the partial work forward. Message it plainly: *"you hit a transient error, your work is intact, continue + <the finish criteria>."* Receipt: happened 3x in one session (2 builds + 1 security-gate agent hit a transient API 500) and all 3 recovered cleanly with zero lost work. Re-dispatching fresh instead of resuming loses everything the agent had already done.
 
 **Don't kill a build on staleness (2026-07-08 receipt).** A complex build (a routing redesign, heavy test-rewiring) can legitimately run 10–15+ minutes between visible output flushes. A "stale, no output for N minutes → kill it" heuristic **destroys a working agent** — this exact heuristic killed an in-progress build TWICE on this session before the kill-notes proved it had been actively rewiring tests the whole time, not hung. Trust the harness's own completion notification; only intervene on a **genuine** hang, and diagnose from the kill-note's last line (or `anti-hang-test-protocol`'s exit-124/137 signal), never from an elapsed-time guess alone.
+
+**A "stopped" agent may have already committed — check the worktree before re-dispatching (2026-07-24 receipt).** A build agent's process exited after committing but before emitting its own completion summary; the notification read as "no completion record found," which looks like the work is lost. It was not: `git -C <worktree> status`/`log` showed a clean tree with the real commits present and correct. Re-dispatching fresh on a "stopped" notification without checking the worktree first risks duplicating (or conflicting with) work that already landed — run `git -C <worktree> status` and `git -C <worktree> log --oneline -5` BEFORE deciding the work needs to be redone. Full incident: AGENTS.md Campaign Orchestration A23.
+
+**A worktree agent can commit on a detached HEAD — verify `HEAD` matches the branch ref before pushing/opening a PR (2026-07-24 receipt).** `git push origin <branchname>` can push a stale branch REF (still at `main`'s tip) while the agent's real commit sits at the worktree's detached `HEAD`, unreachable from that ref — GitHub then rejects the PR with "No commits between main and `<branch>`," which reads like the work vanished a second, distinct way. Compare `git rev-parse HEAD` against `git rev-parse <branchname>`; if they differ, push the SHA explicitly (`git push origin <sha>:refs/heads/<branchname>`) before opening the PR. See `tensor-grep-debugging-playbook` §16 for the full triage row and AGENTS.md's A24.
 
 **External CLIs:**
 - **codex** — **MANDATORY** adversarial gate on every **money / auth / security / migration** diff before merge (separate quota; catches agent over-claims). **Fallback** for general peer review when Agent subagents are throttled. When `codex`'s WSL path is unreliable, an **Opus** Agent subagent is the reliable substitute for the mandatory gate (Hard Rule 11) — never skip the gate outright.

--- a/.claude/skills/tensor-grep-change-control/SKILL.md
+++ b/.claude/skills/tensor-grep-change-control/SKILL.md
@@ -261,6 +261,23 @@ Before implementing any AI/subagent-drafted plan, **cite `file:line` for every f
 
 **Post-merge gotcha:** apply follow-up fixes **by SYMBOL, not line number** — a squash-merge shifts every line below the change, so "fix `main.py:8468`" is stale the moment anything above it lands. Re-anchor on the function/const name via `tg defs` or grep (`AGENTS.md:902`).
 
+**A banked hypothesis is not exempt from this gate, even your own (#736, 2026-07-24).** A one-line
+memory note claiming a C symbol-graph mis-kind was fixable by "requiring `function_declarator`
+outermost" was FALSIFIED by re-deriving it against a live-dumped AST before any fix code was written —
+a function-pointer variable's declarator chain also has `function_declarator` outermost, so that tell
+cannot distinguish it from a real function. The real tell lived one level deeper (what the node's own
+`declarator` field wraps). Treat a carried-forward "we already know the fix" note the same as a fresh
+AI-drafted plan: cite `file:line` against the CURRENT code before dispatching it, not just against your
+memory of a prior session. See `tensor-grep-failure-archaeology` and `tensor-grep-add-language` for the
+full worked example (the declarator-shape table).
+
+**A gate's disclosed edge case is still-open work, not a new backlog item, while the PR is draft (same
+#736).** An independent Opus gate returned `SHIP` on that fix but disclosed the first cut now dropped a
+narrower case (redundant-paren real-function prototypes, `int (foo)(void);`) it hadn't dropped before.
+Because the PR was still draft, the refinement landed in the SAME PR before un-drafting — zero new
+known-limitations shipped. Read a `SHIP`-with-disclosed-edge verdict as "fix this before un-drafting,"
+not "ship now, file it for later" — the marginal cost of fixing it in-PR is near zero.
+
 ---
 
 ## Part 7 — Push discipline & the push-race (one-merge-per-tick)

--- a/.claude/skills/tensor-grep-debugging-playbook/SKILL.md
+++ b/.claude/skills/tensor-grep-debugging-playbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tensor-grep-debugging-playbook
-description: Use when a tensor-grep (tg) run fails, hangs, returns wrong/empty/silently-degraded results, a CI check goes red, or a release doesn't publish. Symptom-to-triage table, each row giving a discriminating experiment and a fix pointer, for CI red, release not published (push-race), search hangs/slow, silent-empty result (fail-closed contract), argv/flag injection, mock-green-but-real-dead FFI, dependency-cap silent downgrade, ranking flip, a `CliRunner`/`capfd` test that goes green-on-PR-red-on-main after a delegation/routing change, and a latency fix/regression report that needs profiling-at-scale instead of a code-reading guess. Load BEFORE theorizing from a traceback or re-running a failing gate blind.
+description: Use when a tensor-grep (tg) run fails, hangs, returns wrong/empty/silently-degraded results, a CI check goes red, a release doesn't publish, or a worktree agent's PR reports "No commits between main and <branch>" after a reported commit. Symptom-to-triage table, each row giving a discriminating experiment and a fix pointer, for CI red, release not published (push-race), search hangs/slow, silent-empty result (fail-closed contract), argv/flag injection, mock-green-but-real-dead FFI, dependency-cap silent downgrade, ranking flip, a `CliRunner`/`capfd` test that goes green-on-PR-red-on-main after a delegation/routing change, a latency fix/regression report that needs profiling-at-scale instead of a code-reading guess, and a detached-HEAD worktree push that pushes a stale branch ref instead of the real commit. Load BEFORE theorizing from a traceback or re-running a failing gate blind.
 ---
 
 # tensor-grep Debugging Playbook
@@ -73,6 +73,7 @@ If your symptom isn't in the table below, it's probably not covered here — che
 | A shell one-liner that pipes `tg`/a probe script into `tail`/`grep`/`python -c ...` reports success (`exit 0`) even though the FIRST command in the pipe actually failed | Pipe exit-code masking: a shell pipeline's exit code is the LAST command's, not the first's | Re-run the first command alone and check its own `$?`/`$LASTEXITCODE`; or use `${PIPESTATUS[0]}` (bash) / split into two statements | [S13](#13-pipe-exit-code-masking) |
 | An automated dogfood/verdict script says PASS or FAIL, but the underlying behavior looks wrong when you inspect it directly | The scoring logic misread the JSON shape (a renamed field, a nested-vs-top-level key) — a shape misread can silently read as either a clean pass or a clean fail | Read the RAW `--json` output at least once by eye before trusting the automated verdict for a new/changed probe | [S14](#14-raw-json-before-scoring) |
 | A macOS-only CI job with a `Setup Rust` step (e.g. `test-rust-core`) fails with a network/timeout error during Rust toolchain setup — not a compile error, not something your diff touched | `rust_core/rust-toolchain.toml` pins an exact Rust version; the first `cargo` invocation with `rust_core/` as its working directory triggers an on-demand rustup fetch for that pin, and unlike the `rustup-init` bootstrap curl (`--retry 10`), rustup's own pinned-toolchain download had no retry | `gh run view <run-id> --log-failed` on the `Setup Rust` step specifically — a transient network/timeout message on the pinned-toolchain fetch, not a `rustc`/`cargo` compile error | [S15](#15-macos-rustup-pinned-toolchain-fetch-timeout-network-flake-already-mitigated) |
+| `gh pr create` (or the GitHub UI) rejects a branch push with **"No commits between main and `<branch>`"** even though a worktree agent reported it committed real work | The agent committed on a DETACHED `HEAD` (not the named branch), then `git push origin <branchname>` pushed the branch REF — still sitting at `main`'s tip — instead of the commit; the work is not lost, just not reachable from the ref that was pushed | `git -C <worktree> rev-parse HEAD` vs `git -C <worktree> rev-parse <branchname>` — if they differ, the commit is real but the branch ref never moved | [S16](#16-no-commits-between-main-and-branch-detached-head-push) |
 
 ---
 
@@ -695,6 +696,44 @@ same pre-fetch-with-retry pattern rather than re-diagnosing it as a new class of
 
 ---
 
+## 16. "No commits between main and `<branch>`" (detached-HEAD push)
+
+**Symptom:** a worktree agent reports it committed real work, but opening a PR (or `gh pr create`)
+fails with GitHub's "No commits between main and `<branch>`," or the diff shows nothing changed. This
+reads exactly like the work vanished.
+
+**Root cause:** the agent's commit landed on a **detached `HEAD`** inside its worktree, not on the
+named branch it was supposed to be working on (common after certain worktree-setup or checkout
+sequences). `git push origin <branchname>` then pushes the BRANCH REF — which never moved off `main`'s
+tip, because the commit isn't reachable from it — instead of the commit itself. The commit is real and
+sitting at the worktree's `HEAD`; it is simply not on the ref that got pushed.
+
+**Discriminating experiment:**
+
+```bash
+git -C <worktree> rev-parse HEAD          # the real commit, if one exists
+git -C <worktree> rev-parse <branchname>  # what actually got pushed
+git -C <worktree> log --oneline -3        # confirm the commit's content/message
+```
+
+If `HEAD` and `<branchname>` resolve to different SHAs, the work is intact — do not re-dispatch the
+agent to redo it.
+
+**Fix:** push the SHA explicitly instead of trusting the branch name:
+
+```bash
+git -C <worktree> push origin <sha>:refs/heads/<branchname>
+```
+
+Then open the PR against `<branchname>` as usual — it will now show the real diff.
+
+**Rule:** before opening a PR from a worktree agent's branch, compare `git rev-parse HEAD` against
+`git rev-parse <branch>` rather than assuming a plain `git push origin <branch>` moved the ref you
+expect. See `tensor-grep-backlog-campaign`'s harvest pattern for the broader worktree-to-PR sequence,
+and AGENTS.md's Campaign Orchestration Disciplines (A24) for the incident this section is drawn from.
+
+---
+
 ## Provenance and maintenance
 
 Facts here were originally verified **2026-07-02, tensor-grep v1.17.25** for §1–§8, and
@@ -713,7 +752,9 @@ added the §3 `tg inventory --deadline` pathological-workspace-union-tree scandi
 low-priority, not a regression — `repo_map.py:987`/`:1009`), added §10 Incident 3 (a warm
 `tg orient` dogfood run hid PR #719's real ~54% win, plus the microbench-on-the-shipped-wheel
 discipline that catches it), and added §15 (macOS rustup pinned-toolchain fetch timeout, already
-mitigated by #722). Re-verify anything below before trusting it on a later version — this table
+mitigated by #722); **2026-07-24 against v1.98.2** added §16 ("No commits between main and
+`<branch>`" — a detached-HEAD worktree push, cross-referenced to AGENTS.md's Campaign Orchestration
+A24). Re-verify anything below before trusting it on a later version — this table
 drifts whenever the cited line numbers, defaults, or contracts change.
 
 Re-verification commands:

--- a/.claude/skills/tensor-grep-failure-archaeology/SKILL.md
+++ b/.claude/skills/tensor-grep-failure-archaeology/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tensor-grep-failure-archaeology
-description: Use when about to "fix" or "optimize" something in tensor-grep that feels novel — before proposing PyO3/FFI for directory walking, re-enabling free-threading, adding a --json self-test, tightening a dependency upper-cap, blaming an IDF/ranking flip, trusting a green mock/FFI test, diagnosing a release that "didn't publish", chasing a reported latency "regression" without profiling at scale, shipping a doc-drift/precision heuristic off green fixtures alone, adding a "differs-from-default" native-delegation gate, reading a `capfd`-based CliRunner test result, micro-optimizing a hot loop without checking who actually consumes the value, re-proposing cAST structural chunking as the default, re-proposing dense int8/binary/PCA embedding compression, proposing a warm-session/daemon search-index shortcut, proposing GPU-for-search or re-litigating the PFAC-vs-brute-force kernel claim, hitting the many-pattern Aho-Corasick dedup bug, trusting an unverified "cheap win" from a paper/research steal-list, cloning a "mirror language X" onboarding brief without checking which module is the CURRENT template, or trusting a conflict-free git rebase across several PRs that touch the same shared registration file as proof nothing was silently dropped. A chronicle of settled battles (symptom -> root cause -> evidence -> status) so no one re-fights them. Load it to check "has this already been tried and lost?" before spending effort. For a live NEW failure use tensor-grep-debugging-playbook; for the process gates to re-attempt one use tensor-grep-change-control.
+description: Use when about to "fix" or "optimize" something in tensor-grep that feels novel — before proposing PyO3/FFI for directory walking, re-enabling free-threading, adding a --json self-test, tightening a dependency upper-cap, blaming an IDF/ranking flip, trusting a green mock/FFI test, diagnosing a release that "didn't publish", chasing a reported latency "regression" without profiling at scale, shipping a doc-drift/precision heuristic off green fixtures alone, adding a "differs-from-default" native-delegation gate, reading a `capfd`-based CliRunner test result, micro-optimizing a hot loop without checking who actually consumes the value, re-proposing cAST structural chunking as the default, re-proposing dense int8/binary/PCA embedding compression, proposing a warm-session/daemon search-index shortcut, proposing GPU-for-search or re-litigating the PFAC-vs-brute-force kernel claim, hitting the many-pattern Aho-Corasick dedup bug, trusting an unverified "cheap win" from a paper/research steal-list, cloning a "mirror language X" onboarding brief without checking which module is the CURRENT template, trusting a conflict-free git rebase across several PRs that touch the same shared registration file as proof nothing was silently dropped, or trusting a BANKED fix hypothesis (a memory note from a prior session) without re-deriving it against the real AST/code. A chronicle of settled battles (symptom -> root cause -> evidence -> status) so no one re-fights them. Load it to check "has this already been tried and lost?" before spending effort. For a live NEW failure use tensor-grep-debugging-playbook; for the process gates to re-attempt one use tensor-grep-change-control.
 ---
 
 # Tensor-Grep Failure Archaeology
@@ -18,8 +18,10 @@ GPU-for-search, the many-pattern dedup bug, and the "5/5 mirage" meta-lesson), a
 **2026-07-24 at v1.96.0** adding Battles 23-24 (the language-expansion campaign's stale onboarding-brief
 catch and its sequential multi-PR shared-file union-rebase discipline), a warm-hides-cold addendum to
 Battle 12, and re-pointing Battle 16's evidence at its post-squash commit hashes (`501dc26`/`6d79945`)
-plus fixing a stale `AGENTS.md` section-letter reference. Re-verify anything load-bearing with the
-commands in **Provenance and maintenance** before you act on it.
+plus fixing a stale `AGENTS.md` section-letter reference, and a seventh, same-day pass **2026-07-24 at
+v1.98.2** adding Battle 25 (the banked C function-pointer fix hypothesis, falsified before any code was
+written). Re-verify anything load-bearing with the commands in **Provenance and maintenance** before
+you act on it.
 
 ## When to use this skill
 
@@ -474,6 +476,22 @@ semantic completeness; re-run the affected tests after every rebase, before merg
 "gate on verified state, not on the absence of a visible problem" discipline Battle 14 requires for
 a release watcher.
 
+## Battle 25 -- a banked "fix hypothesis" for the C function-pointer mis-kind was WRONG; the real tell was one level deeper (2026-07-24, #736)
+
+| Field | Detail |
+|---|---|
+| **Symptom** | A file-scope C function-pointer VARIABLE (`void (*handler)(int);`) was mis-kinded `"function"` in the symbol table. A one-line note carried forward from an earlier session proposed the fix: "require `function_declarator` outermost" to distinguish a real function from a function-pointer variable. |
+| **Root cause** | The banked hypothesis was FALSIFIED before any fix code was written, by `verify-plan-against-code` against a live-dumped `tree_sitter_c` 0.24.2 AST: a function-pointer variable's declarator chain ALSO has `function_declarator` outermost — identical in that respect to a real function prototype. "Outermost-direct `function_declarator`" cannot distinguish the two cases; it was never a valid discriminator, and the note that banked it as one had not been checked against a real parse tree. The actual tell lives one level deeper: what that `function_declarator` node's OWN `declarator` field WRAPS — a `parenthesized_declarator` wrapping a `pointer_declarator` (`(*handler)`) means a variable (exclude); wrapping a bare `identifier` directly means a real, redundantly-parenthesized function name (`int (foo)(void);`, keep). |
+| **Evidence** | PR #736 (`226d887`, merged into v1.98.2). Its own description states the root cause was "verified against a real, live-dumped AST — not assumed from the grammar docs" and that the banked "outermost-direct" framing "does NOT distinguish real functions from function-pointer variables, since both are outermost-direct." An independent Opus gate then caught a SECOND-order miss in the first cut (see the "Gate-caught refinement" note in the PR body) — the coarse rule also wrongly excluded a redundant-paren real prototype, fixed in the same still-draft PR before merge. |
+| **Status** | **SETTLED.** |
+
+**Rule:** A banked "we already know the fix" note is a HYPOTHESIS, not a fact, even when it's your own
+prior session's conclusion carried forward in memory — re-derive it against the real AST/code (dump the
+actual parse tree, don't reason from the grammar's shape in the abstract) before dispatching it as a
+plan. This is Cross-cutting lesson 9 (verify a steal/brief against the LIVE code) applied to a
+carried-forward memory note instead of an external paper or a same-session orchestration brief — same
+failure shape as Battle 23, a third venue.
+
 ---
 
 ## Cross-cutting lessons (the meta-patterns behind the battles)
@@ -593,6 +611,10 @@ grep -n "MOST-FORGOTTEN" src/tensor_grep/cli/repo_map.py
 # Battle 24 (sequential multi-PR shared-file union-rebase discipline)
 grep -n "\"java\"\|\"php\"\|\"csharp\"" tests/unit/test_lang_registry.py
 grep -n "tree-sitter-java\|tree-sitter-php\|tree-sitter-c-sharp" pyproject.toml
+
+# Battle 25 (banked C function-pointer fix hypothesis, falsified before code was written)
+git show 226d887 --stat
+grep -n "_c_parenthesized_declarator_wraps_bare_name\|def _c_declarator_name_node" src/tensor_grep/cli/lang_c.py
 ```
 
 If any command's output no longer matches the entry (e.g. the typer cap moved, a guard file was

--- a/.claude/skills/tensor-grep-validation-and-qa/SKILL.md
+++ b/.claude/skills/tensor-grep-validation-and-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tensor-grep-validation-and-qa
-description: Use when deciding what counts as proof that a tensor-grep (tg) change works — before trusting a subagent's "tests pass", writing a new test, claiming a routing/docs/release fix is done, shipping a doc-drift/ranking/classification heuristic off green fixture tests, or running the pre-push gate. Covers TDD-first discipline, the CliRunner-vs-real-binary trap, the fixture-green-vs-real-corpus-dogfood trap for precision/heuristic features, the `capfd`-vs-`result.stdout` capture-surface trap on routing/delegation changes (needs `tests/integration/` run with the native `tg` binary rebuilt, not just `tests/unit/`), the certified/golden inventory (routing parity, docs governance, release-asset validation), agent-readiness/`tg dogfood`, benchmark-gated speed claims, acceptance thresholds, and which suite/marker/fixture to use for a new test, plus the `--preview` / `--no-sync` / `-x` gotchas.
+description: Use when deciding what counts as proof that a tensor-grep (tg) change works — before trusting a subagent's "tests pass", writing a new test, claiming a routing/docs/release fix is done, shipping a doc-drift/ranking/classification heuristic off green fixture tests, proving a red-green baseline on a reverted/pre-fix commit, reviewing a payload-byte/ratio governance test, or running the pre-push gate. Covers TDD-first discipline, the CliRunner-vs-real-binary trap, the fixture-green-vs-real-corpus-dogfood trap for precision/heuristic features, the `capfd`-vs-`result.stdout` capture-surface trap on routing/delegation changes (needs `tests/integration/` run with the native `tg` binary rebuilt, not just `tests/unit/`), the `tests/conftest.py` `sys.path.insert`-outranks-`PYTHONPATH` trap that can falsify a red-green baseline even with `tensor_grep.__file__` verified, a shared-envelope field growth breaking a payload-ratio governance test plus its tmp-path-length platform sensitivity, the self-gate-suite-subset-is-not-full-CI-matrix trap, the certified/golden inventory (routing parity, docs governance, release-asset validation), agent-readiness/`tg dogfood`, benchmark-gated speed claims, acceptance thresholds, and which suite/marker/fixture to use for a new test, plus the `--preview` / `--no-sync` / `-x` gotchas.
 ---
 
 # tensor-grep validation and QA
@@ -161,6 +161,24 @@ Ranked by how hard each is to fake, cheapest-to-check first:
    the affected test suite after every rebase in a multi-branch drain, not only when a conflict marker
    forced a manual look; a dropped import surfaces as an `ImportError` the rebase itself will never
    flag.
+
+   **Amendment (2026-07-24) -- PYTHONPATH alone does not prove a RED-GREEN baseline; it only proves
+   which tree a normal run imported.** The standing stale-venv fix above ("pin PYTHONPATH to the
+   worktree src, verify `tensor_grep.__file__` resolves into the worktree") is necessary but NOT
+   sufficient the moment the goal shifts from "run tests against the right tree" to "prove this test
+   genuinely fails on a BASELINE commit" (pre-fix origin/main, a tag, a reverted file) -- the two are
+   different claims and need different verification. `tests/conftest.py:10` runs
+   `sys.path.insert(0, str(SRC_DIR))`, where SRC_DIR is derived from `conftest.py`'s own `__file__`
+   location, and `sys.path.insert(0, ...)` takes precedence over whatever PYTHONPATH points at. An
+   independent gate that reverted one source file to its pre-fix state and re-ran with PYTHONPATH
+   pointed at that reverted tree got a FALSE "passed on main" result, because the worktree's OWN
+   `conftest.py` silently re-pointed imports back at the worktree's unmodified src regardless of
+   PYTHONPATH -- and checking `tensor_grep.__file__` did not catch it either, since it correctly
+   reported the worktree's file, which was exactly the wrong tree for a baseline check. Fix: to prove
+   a test fails on a baseline commit, use a FULLY ISOLATED TREE COPY with the target file reverted
+   INSIDE that copy -- never a PYTHONPATH swap layered on top of the current working tree's own
+   `conftest.py`. This matters most for exactly the readers of this skill's Part 1 -- an independent
+   gate proving a fix's red-phase test is real, not a build agent's self-report of it.
 10. **A security-touching change is not "done" on green tests alone — it needs a mandatory adversarial
     review before merge.** Any PR touching `apply_policy`, `mcp_server`, `cpu_backend`/native-argv
     construction, `index_lock`, auth, money, a migration, or **native asset / installer / doctor-probe
@@ -231,6 +249,37 @@ Ranked by how hard each is to fake, cheapest-to-check first:
     aggregate "looks fine" claim would have hidden. Cross-reference, don't duplicate: the pipe-exit-mask
     and raw-JSON-first traps also live in `tensor-grep-debugging-playbook` (§13/§14) as debugging
     fix-pointers; this item is the QA-tier methodology framing of the same two traps.
+16. **A payload-byte-RATIO governance test is fragile to two things a code-review pass rarely
+    checks: a SHARED envelope field growing, and tmp-path LENGTH across platforms (#733/#734,
+    2026-07-24).** `test_importers_payload_is_far_smaller_than_map` (`tests/unit/test_file_deps.py`)
+    compares total serialized bytes of `tg importers` (deliberately tiny) against `tg map`
+    (deliberately large) as a proxy for "importers carries far less data." That proxy breaks the
+    moment a field in the SHARED `_envelope()` helper (`repo_map.py`, stamped byte-identically onto
+    both payloads) grows: an honest field-honesty fix in #733 made `coverage.language_scope`/
+    `symbol_navigation` dynamic (~28 -> ~116 chars) — a small fraction of the large `map` payload
+    but a large fraction of the tiny `importers` one, tripping the `< 0.1 * map` threshold with
+    **zero** change to either payload's actual data volume. Separately, the SAME test PASSED on
+    Windows and FAILED on Linux CI: Windows' longer `AppData\Local\Temp` paths inflate both
+    payloads and dilute the fixed-envelope fraction back under threshold; Linux's short `/tmp`
+    paths do not, so a Windows-local green run does not prove a Linux-CI green run. **Fix (#734):**
+    strip the shared `_envelope()` keys SYMMETRICALLY from both payloads before comparing bytes,
+    deriving the excluded-key set LIVE (`set(repo_map._envelope(project))`) rather than a
+    hand-copied literal — this makes the assertion robust to any future envelope growth instead of
+    re-breaking on the next honesty fix. Before adding or reviewing any payload-byte or
+    payload-ratio assertion: (a) check whether either side's payload includes a shared, non-data
+    envelope/header the assertion doesn't intend to measure, and (b) reproduce with a SHORT
+    `pytest --basetemp` locally before trusting a Windows-local pass as proof of a Linux-CI pass.
+17. **A self-gate's declared test SUBSET is not the full CI matrix — state what ran, not just that
+    "tests passed" (#733/#734, 2026-07-24).** The build agent's own pre-merge gate on #733 ran a
+    real, substantial suite (`test_harness_api_docs.py`, `test_session_cli.py`,
+    `test_mcp_server.py`, the full `lang_registry`/`test_lang_*.py` sweep) but never named
+    `tests/unit/test_file_deps.py` — the exact file whose invariant #733 broke, deterministically,
+    on every platform. This is an instance of Part 1 point 9 ("never trust a self-report") applied
+    to test **scope**, not just test **result**: a subagent that reports "N tests passed" without
+    naming which suites it ran and which it did NOT is not proof of a clean merge, even when every
+    number it reports is true. When reviewing or writing a self-gate report, require an explicit
+    ran/skipped suite list, and treat the CI run itself — not the self-gate's own suite selection —
+    as the actual merge arbiter.
 
 ---
 
@@ -601,6 +650,15 @@ was never observed to fail cannot be trusted to catch a regression.
       never wall-clock thread overlap (Part 1 point 14, C-concurrency).
 - [ ] A campaign/release drain closed → every fixed item verified against the **published wheel**, one
       PASS/FAIL row + raw JSON each, not one aggregate claim (Part 1 point 15, C-wheel).
+- [ ] If it grows a field inside a SHARED envelope/header (`_envelope()` or similar): every test that
+      compares two payloads' byte SIZE was audited, and any byte-ratio assertion was reproduced with a
+      short `pytest --basetemp` (not just a Windows-local run) before trusting it (Part 1 point 16).
+- [ ] A self-gate/subagent report names the SUITES it ran and the suites it skipped, not just a pass
+      count — the CI run, not the self-gate's suite selection, is the merge arbiter (Part 1 point 17).
+- [ ] A claimed red-green baseline (proving a test fails on a pre-fix/reverted commit) used a fully
+      isolated tree copy, not a `PYTHONPATH` swap — `tests/conftest.py`'s `sys.path.insert` outranks
+      `PYTHONPATH` and can silently re-point imports at the current worktree regardless (Part 1 point 9
+      amendment).
 
 ---
 
@@ -620,7 +678,11 @@ the new `test_retrieval_quality_regression.py` and the registered `eval` pytest 
 cold-path dogfood caveat to Part 1 point 3 and the byte-identical-optimization-proof technique plus the
 clean-rebase corollary to Part 1 point 9, added the `uv.lock` hand-splice gotcha to Part 2, and added
 the new-language/grammar test shape to Part 6 (tracking the Java/C#/PHP symbol-graph expansion,
-#724/#725/#726). Re-verify before relying on them:
+#724/#725/#726). A same-day second pass **2026-07-24, release `v1.98.2`** added Part 1 points 16-17
+(the shared-envelope payload-ratio governance-test trap plus its tmp-path-length platform sensitivity,
+and the self-gate-suite-subset-is-not-full-CI-matrix trap, both from #733/#734) and the PYTHONPATH/
+`conftest.py` red-green-baseline amendment to Part 1 point 9 (an independent gate's false "passed on
+main" result, caught the same day). Re-verify before relying on them:
 
 | Claim | Re-verify command |
 |---|---|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,30 @@ concrete failure observed this session.
   take-one-side). A CLEAN rebase (no conflict marker) is NOT proof of correctness — a silent auto-merge
   dropped a `lang_*` import, caught only by re-running pytest (`ImportError`). ALWAYS re-run the test
   suite after every rebase.
+- **A23 — A "stopped" agent notification may mean the work already landed, not that it was lost
+  (2026-07-24).** A build agent's process exited after committing but before emitting its own
+  completion summary; the orchestrator's notification said no completion record was found — which
+  reads like the work vanished. It had not: `git -C <worktree> status`/`log` showed a clean tree with
+  both commits present and correct. **Rule:** on any "stopped"/"no completion record" notification,
+  inspect the worktree's `git status`/`git log` BEFORE re-dispatching fresh work — re-dispatching would
+  have duplicated (or conflicted with) work that was already done.
+- **A24 — A worktree agent can commit on a DETACHED HEAD; push the SHA, not the branch name
+  (2026-07-24).** `git push origin <branchname>` pushed the branch ref (still sitting at `main`'s tip,
+  since the agent's commit landed on a detached `HEAD` rather than that branch) instead of the new
+  commit — GitHub then rejected the PR with "No commits between main and `<branch>`," which reads like
+  the work vanished a second, distinct way from A23. It had not: the commit was sitting at the
+  worktree's `HEAD`, just not reachable from the branch ref being pushed. **Rule:** before pushing,
+  compare `git rev-parse HEAD` against `git rev-parse <branch>` — if they differ, push the SHA
+  explicitly (`git push origin <sha>:refs/heads/<name>`), then open the PR against that branch. See
+  `tensor-grep-debugging-playbook` for the symptom-table row.
+- **A25 — Session-scoped crons/monitors die silently on a CLI restart or reboot; always re-verify,
+  never re-dispatch on an assumption (2026-07-24).** This is the same lesson as A15 (session-only
+  crons die on crash/reboot) reconfirmed a session later — a steward cron was lost TWICE in one
+  session, once to a CLI restart and once to a PC reboot, and both times the backstop vanished with no
+  error, not a visible failure. **Rule:** after any restart or crash, re-create the recurring backstop
+  and CONFIRM it with `CronList` rather than assuming a previously-recorded id/schedule is still armed;
+  keep the durable state (queue, in-flight PRs, "resume here") in the task store + `MEMORY.md`, which
+  survive a restart even when the cron itself does not.
 
 ## Current Handoff
 
@@ -493,7 +517,26 @@ This matters because AI-generated plans have a consistent failure mode: they ide
 
 Re-run any validation a subagent claims to have passed — subagents can assert success without executing. For PRs that ship generated or detached code (install scripts, Windows self-upgrade helpers), adversarial-review by EXECUTING the code, not only reading it: `compile()` + `exec()` the generated string and assert the behavior (e.g. that the checksum gate fires BEFORE `os.replace`, and that the fail-closed branch is reachable). Test behavior, not substrings.
 
+**A banked "fix hypothesis" is a guess, not a plan (task #736, 2026-07-24).** A one-line note carried
+forward in memory claimed the C function-pointer-variable mis-kind was fixable by "requiring
+`function_declarator` outermost." `verify-plan-against-code` FALSIFIED it before a line of fix code
+was written: a function-pointer *variable*'s declarator chain also has `function_declarator`
+outermost — same as a real function prototype — so that tell cannot distinguish them. The real tell
+was one level deeper: what that node's OWN `declarator` field wraps (`parenthesized_declarator`
+wrapping a `pointer_declarator` -> variable, exclude; wrapping a bare `identifier` -> a
+redundant-paren real function `int (foo)(void);`, keep). Re-derive a banked hypothesis — including
+your own prior session's note — against the real AST/code before dispatching it as a plan; a
+carried-forward guess is not exempt from the same verification a fresh AI-drafted plan gets.
+
 After building, run a mandatory post-build ADVERSARIAL AUDIT — a distinct named stage from the pre-build planning council. This audit caught a HIGH CUDA-fork hazard that 203 passing tests missed. A finding or claim with no `file:line` citation is DISCARDED. Re-audit → fix-wave → re-audit until ZERO must-fix findings remain; that zero-finding state is the convergence gate before promoting a build to a draft PR.
+
+**A gate's disclosed edge case is in-scope while the PR is still draft, not a new backlog item (same
+task #736).** An independent Opus gate returned SHIP on the C function-pointer fix but disclosed that
+the first cut now dropped a rarer case (redundant-paren prototypes, `int (foo)(void);`) it hadn't
+before — trading one cosmetic bug for a narrower one. Because the PR was still draft, the refinement
+landed in the SAME PR before un-drafting, shipping with zero new known-limitations. Treat a
+SHIP-with-disclosed-edge verdict as work still owed on the open PR, not a "ship now, file a follow-up"
+signal — the cost of fixing it right there is near zero; the cost of a new tracked gap is real.
 
 ## Backend Fail-Closed Contract
 
@@ -667,6 +710,23 @@ uv run pytest -q
 CI runs `ruff format --check --preview .`. Running only `uv run ruff check .` is not enough to prove formatter parity, and running `ruff format` WITHOUT `--preview` actively REVERTS preview-style formatting on disk — a "clean" bare `ruff format` will undo CI-mandated style and red the next `ruff format --check --preview` run even when local lint passes. Always pass `--preview` to `ruff format` locally; never pass it to `ruff check`. The trailing `.` (whole repo) is load-bearing too: under `--preview`, ruff formats Python code fences INSIDE Markdown, so a scoped run (`ruff format --check --preview src/tensor_grep tests`) passes locally yet MISSES an unformatted `docs/**/*.md` snippet — which reds CI's release-gating `static-analysis` job and blocked v1.67.0. Always run the whole-repo `.` form; never a `src`/`tests` subset.
 
 `uv run pytest -q` can take substantially longer than 70-90 seconds on this Windows machine when the full JS/TS and e2e surface is hot; use a timeout of at least 120 seconds for narrow suites and a much larger timeout for the full suite when running it through automation.
+
+**`tests/conftest.py`'s `sys.path.insert` OUTRANKS `PYTHONPATH` — a `PYTHONPATH`-only baseline swap
+gives a FALSE red-green (2026-07-24).** The standing stale-venv discipline ("pin `PYTHONPATH` to the
+worktree `src`, verify `tensor_grep.__file__` resolves into the worktree") proves WHICH TREE you
+imported for a normal test run, but it is NOT sufficient to prove a test genuinely fails on a baseline
+commit. `tests/conftest.py:10` does `sys.path.insert(0, str(SRC_DIR))`, where `SRC_DIR` is derived from
+`conftest.py`'s own `__file__` location — this takes precedence over `PYTHONPATH` on `sys.path`. A gate
+that tried to prove a fix's regression test genuinely fails on `origin/main` (by reverting one source
+file to its pre-fix state and re-running with `PYTHONPATH` pointed at that reverted tree) got a FALSE
+"passed on main," because the *worktree's* `conftest.py` silently re-pointed imports back at the
+worktree's own `src`, not the reverted one, regardless of `PYTHONPATH`. Verifying
+`tensor_grep.__file__` does not catch this either — it correctly reports the worktree's file, which is
+exactly the wrong answer for a baseline check. **Rule:** to prove a test fails on a baseline commit
+(pre-fix `origin/main`, a specific tag, a reverted file), use a FULLY ISOLATED TREE COPY with the file
+reverted INSIDE that copy — never a `PYTHONPATH` swap layered on top of the working tree's own
+`conftest.py`. This applies doubly to an independent gate proving a fix's red-phase test is real, since
+gates are the primary consumers of a red-green baseline.
 
 For focused changes, run the relevant narrow suite first, then the full suite if the change is intended to land:
 
@@ -879,6 +939,32 @@ enabled (unchanged production behavior) OR whenever `cfg(test)` is set, so the t
 and is not itself dead code, while staying absent from the default non-test release build. Precedent:
 `GpuRouteFailureKind` / `sanitize_cuda_detail` / `classify_gpu_route_failure` in `rust_core/src/main.rs`
 (gate-nit #172 NIT-4 / MF-1, shipped in `#597` / v1.75.4).
+
+(i) **A dynamic value that grows a SHARED envelope can break a payload-RATIO governance test on the
+SMALL side (#733/#734).** PR #733 made `coverage.language_scope`/`symbol_navigation` dynamic and
+registry-derived (~28 -> ~116 chars). `_envelope()` in `repo_map.py` stamps that field byte-identically
+onto BOTH `tg map` (a large payload) and `tg importers` (a deliberately tiny one), so the same fixed
+growth was ~5% of the large payload but ~37% of the small one — tripping
+`test_importers_payload_is_far_smaller_than_map`'s `< 0.1 * map` invariant and reddening `main`. Fix
+(#734): strip the shared `_envelope()` keys SYMMETRICALLY from both payloads before comparing, deriving
+the excluded key set LIVE (`set(repo_map._envelope(project))`), never a hand-copied literal, so the
+test stays robust to any FUTURE envelope growth instead of re-breaking on the next honesty fix. Rule:
+when a shared self-description helper grows a field, audit every test that compares two payloads'
+byte sizes, not just the payload the new field conceptually belongs to.
+
+**Same incident, a second trap: PATH LENGTH shifts payload-byte governance tests across platforms.**
+The test above PASSED on Windows and FAILED on Linux CI for the SAME code — Windows' longer
+`AppData\Local\Temp` tmp paths inflate both payloads and dilute the fixed-envelope fraction back under
+the 10% threshold; Linux's shorter `/tmp` paths do not. Rule: reproduce a byte-size/ratio assertion
+that uses pytest's `tmp_path` with a short `--basetemp` before trusting a local green — a Windows-local
+pass does not prove the same assertion holds on Linux CI.
+
+**A self-gate's test SUBSET is not the full CI matrix.** The build agent's own pre-merge gate on #733
+ran a real but partial suite that omitted `tests/unit/test_file_deps.py` — the exact file containing
+the test #734 later had to fix — so a fully deterministic failure reached `main` anyway. Rule: when
+reporting what a self-gate verified, state explicitly which suites ran and which were skipped; treat
+the CI run itself, not a self-gate's suite selection, as the merge arbiter (this repo's "never trust a
+self-report" rule applied to test SCOPE, not just test RESULT).
 
 Do not casually edit:
 


### PR DESCRIPTION
## Summary

Captures 9 hard-won engineering lessons from the 2026-07-24 session (v1.97.0 C, v1.98.0 C++,
v1.98.1, v1.98.2) into AGENTS.md and the in-repo skill library. Docs/markdown only, no code
changes.

## Lesson -> destination table

| Lesson | AGENTS.md | Skill(s) |
|---|---|---|
| L1 — banked "fix hypothesis" is a guess, not a plan (C function-pointer mis-kind, #736) | "Verify AI-Drafted Plans Against the Real Code Before Building" | `tensor-grep-change-control` Part 6; `tensor-grep-failure-archaeology` (new Battle 25); `tensor-grep-add-language` (B5 declarator-shape addendum) |
| L2 — a dynamic value growing a SHARED envelope can break a payload-RATIO governance test on the small side (#733/#734) | CI/Release Rules item (i) | `tensor-grep-validation-and-qa` Part 1 point 16 |
| L3 — tmp-path LENGTH shifts payload-byte governance tests across platforms | CI/Release Rules item (i) | `tensor-grep-validation-and-qa` Part 1 point 16 |
| L4 — a self-gate's test SUBSET is not the full CI matrix | CI/Release Rules item (i) | `tensor-grep-validation-and-qa` Part 1 point 17 + checklist |
| L5 — a "stopped" agent may have already committed; check the worktree before re-dispatching | Campaign Orchestration A23 | `tensor-grep-backlog-campaign` |
| L6 — a worktree agent can commit on a detached HEAD; push the SHA, not the branch name | Campaign Orchestration A24 | `tensor-grep-backlog-campaign`; `tensor-grep-debugging-playbook` (new §16 + triage-table row) |
| L7 — session-scoped crons/monitors die silently on a CLI restart or reboot | Campaign Orchestration A25 | `tensor-grep-backlog-campaign` (Steward cron section) |
| L8 — a gate's disclosed edge is in-scope while the PR is still draft, not a new backlog item (same #736) | "Verify AI-Drafted Plans Against the Real Code Before Building" | `tensor-grep-change-control` Part 6 |
| L9 — `tests/conftest.py`'s `sys.path.insert` outranks `PYTHONPATH`, so a PYTHONPATH-only baseline swap gives a false red-green even with `tensor_grep.__file__` verified (flagged mid-task by an independent gate) | "Required Local Validation" | `tensor-grep-validation-and-qa` Part 1 point 9 amendment + checklist |

`tensor-grep-add-language` also got a scope correction while I was in there for L1: its "Current
status" and E1 sections still said "C/C++ deferred, C# is next," stale since PR #731 (C, v1.97.0)
and PR #732 (C++, v1.98.0) both merged after the prior pass — corrected to the real current state
(all 10 top-10 languages registered) and noted `lang_cpp.py`'s own declarator walker (same latent
bug shape as the C fix) is not yet patched (PR #737 is still open/draft).

No new skill directory was created (folded into existing skills per the brief), so CLAUDE.md's
skill bucket list needed no change and stays byte-identical with AGENTS.md's.

## Test plan

- [x] `tests/unit/test_skill_index_sync.py` — 4/4 passed
- [x] `tests/unit/test_harness_api_docs.py` + `test_public_docs_governance.py` +
      `test_enterprise_docs_governance.py` — 66/66 passed
- [x] `tests/unit/test_file_deps.py` (the #733/#734 file this PR discusses) — 95/95 passed
- [x] `tests/unit/test_stamp_release_assets.py` — 7/7 passed
- [x] All runs used `PYTHONPATH` pinned to this worktree's `src` against the shared repo `.venv`,
      with `tensor_grep.__file__` confirmed resolving into the worktree (stale-venv trap avoided)
- [x] `ruff format --check --preview` on the 7 touched files specifically — clean. The whole-repo
      `ruff format --check --preview .` run has 4 pre-existing failures
      (`docs/architecture.md`, `docs/planning/PROJECT_PLAN.md`, two `docs/plans/*.md` files) —
      confirmed untouched by this PR (`git status --short` on those paths is empty) and present on
      `origin/main` before this branch, so not introduced or fixed here.
- [x] `git diff --check` clean; LF endings preserved (git diff shows additive-only hunks, no
      whole-file line-ending flips, on all 7 touched files)

## Notes / things I could not independently verify

- L5/L6/L7 are agent-orchestration/git-mechanics events from this session's live operation (a
  stopped-agent notification, a detached-HEAD push, a lost steward cron) rather than facts with a
  durable code/PR artifact to cite — I wrote them per the task brief's description without adding
  invented specifics (no fabricated PR numbers/SHAs), since there is no repo history to verify
  them against.
- L9 was supplied mid-task by the coordinator (discovered by an independent gate this same hour);
  I verified the cited line (`tests/conftest.py:10`, `sys.path.insert(0, str(SRC_DIR))`) against
  the real file before writing it up, but did not independently reproduce the false-red-green
  incident itself (no PR/commit artifact exists for it yet).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
