### PR TITLE
fix(search): CRLF/LF de-blinded parity oracles + fix the real corruption bug they found

### DIFF
--- a/src/tensor_grep/backends/cpu_backend.py
+++ b/src/tensor_grep/backends/cpu_backend.py
@@ -12,11 +12,27 @@ from typing import ClassVar
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds
 from tensor_grep.core.config import SearchConfig
-from tensor_grep.core.result import MatchLine, SearchResult, strip_line_terminator
+from tensor_grep.core.result import (
+    MatchLine,
+    SearchResult,
+    split_source_lines,
+    strip_line_terminator,
+)
 
 logger = logging.getLogger(__name__)
 _CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES_ENV = "TENSOR_GREP_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES"
 _DEFAULT_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES = 512
+# Bumped 1 -> 2 by task #262: the persisted `lines` payload's CRLF semantics changed
+# (a CRLF file's trailing `\r` is now preserved per line instead of silently stripped by
+# the old `Path.read_text().splitlines()` read). `(mtime_ns, size)` alone cannot detect
+# that the *interpretation* of a file's bytes changed, only that the bytes themselves
+# changed -- an on-disk cache written before this fix has byte-identical `lines` content
+# to what a same-file post-fix read would produce MINUS the `\r`, so it would silently
+# defeat the fix (and read as WORSE than pre-fix, which was byte-identical to `rg` by
+# cancellation) until the source file's mtime/size next changed. `_load_literal_index`
+# rejects any payload whose `format_version` does not match, forcing a transparent
+# recompute (and on-disk overwrite) on first use after upgrade.
+_CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION = 2
 
 
 def compute_native_walk_deadline() -> float:
@@ -198,6 +214,10 @@ class CPUBackend(ComputeBackend):
             payload = json.loads(cache_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return None
+        if payload.get("format_version") != _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION:
+            # Stale (pre-#262, or any future incompatible) cache -- treat as a miss so the
+            # caller recomputes and overwrites this file with the current format.
+            return None
         if payload.get("file_signature") != list(cache_signature):
             return None
         raw_lines = payload.get("lines")
@@ -233,6 +253,7 @@ class CPUBackend(ComputeBackend):
             return
         cache_path = self._get_prefilter_cache_path(file_path, ignore_case)
         payload = {
+            "format_version": _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION,
             "file_signature": list(cache_signature),
             "lines": lines,
             "trigram_index": trigram_index,
@@ -558,11 +579,7 @@ class CPUBackend(ComputeBackend):
                     # only (never `str.splitlines()`, same reasoning) so a genuine trailing `\r`
                     # survives, matching how the Rust engine and real `rg` both treat it.
                     decoded = path.read_bytes().decode("utf-8", errors="replace")
-                    source_lines = decoded.split("\n")
-                    if source_lines and source_lines[-1] == "":
-                        # A trailing `\n` at EOF must not manufacture a phantom empty final
-                        # line -- matches `str.splitlines()`'s behavior for that one case.
-                        source_lines.pop()
+                    source_lines = split_source_lines(decoded)
                     normalized_lines = (
                         [line.lower() for line in source_lines] if ignore_case else source_lines
                     )

--- a/src/tensor_grep/backends/cpu_backend.py
+++ b/src/tensor_grep/backends/cpu_backend.py
@@ -147,7 +147,19 @@ class CPUBackend(ComputeBackend):
     def _get_prefilter_cache_path(cls, file_path: str, ignore_case: bool) -> Path:
         key = f"{Path(file_path).resolve()}::{int(ignore_case)}"
         digest = hashlib.sha256(key.encode()).hexdigest()
-        return cls._get_prefilter_cache_dir() / f"{digest}.json"
+        # The format version is baked into the FILENAME, not just the payload's own
+        # "format_version" field (task #262 forward-direction finding): an OLDER tg install
+        # sharing this cache dir with a NEWER one (upgrade in place, or two versions on the
+        # same machine) has no idea the payload schema field exists at all, so it would
+        # happily read a v2 payload verbatim and re-corrupt it (observed: a v2 payload's
+        # already-correct `\r` gets a SECOND `\r` appended by the old stdout-writing bug,
+        # worse than either version alone). Versioning the path makes the two physically
+        # unable to share a file -- an old reader just sees `cache miss` on the new path and
+        # a new reader never opens the old one, no cross-version read in either direction.
+        return (
+            cls._get_prefilter_cache_dir()
+            / f"{digest}-v{_CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION}.json"
+        )
 
     @staticmethod
     def _build_line_trigram_index(lines: list[str]) -> dict[str, list[int]]:

--- a/src/tensor_grep/backends/cpu_backend.py
+++ b/src/tensor_grep/backends/cpu_backend.py
@@ -156,6 +156,9 @@ class CPUBackend(ComputeBackend):
         # worse than either version alone). Versioning the path makes the two physically
         # unable to share a file -- an old reader just sees `cache miss` on the new path and
         # a new reader never opens the old one, no cross-version read in either direction.
+        # A pre-#262 `{digest}.json` (no `-vN` suffix) is now permanently orphaned rather
+        # than overwritten -- bounded by ordinary cache size, not a leak, and reaping it
+        # would defeat the point (an old reader still using it needs it to stay put).
         return (
             cls._get_prefilter_cache_dir()
             / f"{digest}-v{_CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION}.json"

--- a/src/tensor_grep/backends/cpu_backend.py
+++ b/src/tensor_grep/backends/cpu_backend.py
@@ -12,7 +12,7 @@ from typing import ClassVar
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds
 from tensor_grep.core.config import SearchConfig
-from tensor_grep.core.result import MatchLine, SearchResult
+from tensor_grep.core.result import MatchLine, SearchResult, strip_line_terminator
 
 logger = logging.getLogger(__name__)
 _CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES_ENV = "TENSOR_GREP_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES"
@@ -421,7 +421,7 @@ class CPUBackend(ComputeBackend):
                 rust_results = rust_results[: config.max_count]
 
             matches = [
-                MatchLine(line_number=r[0], text=str(r[1]).rstrip("\n\r"), file=file_path)
+                MatchLine(line_number=r[0], text=strip_line_terminator(str(r[1])), file=file_path)
                 for r in rust_results
             ]
 
@@ -550,7 +550,19 @@ class CPUBackend(ComputeBackend):
             if prefilter_literal:
                 cached_index = self._load_literal_index(file_path, ignore_case)
                 if cached_index is None:
-                    source_lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+                    # `Path.read_text(...).splitlines()` (the old code here) reads in Python's
+                    # default universal-newlines TEXT mode, which translates every `\r\n` (and a
+                    # bare `\r`) to `\n` on READ -- before `source_lines` ever exists. That
+                    # silently strips a CRLF file's own `\r` regardless of anything fixed at the
+                    # stdout-writing layer (task #262). Read raw bytes and split on a bare `\n`
+                    # only (never `str.splitlines()`, same reasoning) so a genuine trailing `\r`
+                    # survives, matching how the Rust engine and real `rg` both treat it.
+                    decoded = path.read_bytes().decode("utf-8", errors="replace")
+                    source_lines = decoded.split("\n")
+                    if source_lines and source_lines[-1] == "":
+                        # A trailing `\n` at EOF must not manufacture a phantom empty final
+                        # line -- matches `str.splitlines()`'s behavior for that one case.
+                        source_lines.pop()
                     normalized_lines = (
                         [line.lower() for line in source_lines] if ignore_case else source_lines
                     )
@@ -593,6 +605,11 @@ class CPUBackend(ComputeBackend):
                         pass
 
                     if not matched:
+                        # This `line_text` is a throwaway match-test-only decode -- it is
+                        # unconditionally recomputed via `strip_line_terminator` below whenever
+                        # this iteration proceeds to build output, so the `.rstrip("\n\r")` here
+                        # does not affect any MatchLine.text a caller ever sees (task #262 only
+                        # targets the CRLF-fidelity of what actually reaches output).
                         try:
                             line_text = line_bytes.decode("utf-8").rstrip("\n\r")
                             matched = bool(regex_str.search(line_text))
@@ -615,7 +632,7 @@ class CPUBackend(ComputeBackend):
                                 line = line_bytes.decode("latin-1")
                             except Exception:
                                 line = line_bytes.decode("utf-8", errors="replace")
-                        line_text = line.rstrip("\n\r")
+                        line_text = strip_line_terminator(line)
 
                         # Apply python regex search for decoded text to be safe
                         matched = bool(regex_str.search(line_text))
@@ -662,6 +679,9 @@ class CPUBackend(ComputeBackend):
                             pass
 
                         if not matched:
+                            # Throwaway match-test decode -- see the sibling comment above; this
+                            # `line_text` is unconditionally overwritten via
+                            # `strip_line_terminator` before anything is returned.
                             try:
                                 line_text = line_bytes.decode("utf-8").rstrip("\n\r")
                                 matched = bool(regex_str.search(line_text))
@@ -684,7 +704,7 @@ class CPUBackend(ComputeBackend):
                                     line = line_bytes.decode("latin-1")
                                 except Exception:
                                     line = line_bytes.decode("utf-8", errors="replace")
-                            line_text = line.rstrip("\n\r")
+                            line_text = strip_line_terminator(line)
 
                             # Apply python regex search for decoded text to be safe
                             matched = bool(regex_str.search(line_text))
@@ -731,12 +751,12 @@ class CPUBackend(ComputeBackend):
     @staticmethod
     def _decode_line(line_bytes: bytes) -> str:
         try:
-            return line_bytes.decode("utf-8").rstrip("\n\r")
+            return strip_line_terminator(line_bytes.decode("utf-8"))
         except UnicodeDecodeError:
             try:
-                return line_bytes.decode("latin-1").rstrip("\n\r")
+                return strip_line_terminator(line_bytes.decode("latin-1"))
             except Exception:
-                return line_bytes.decode("utf-8", errors="replace").rstrip("\n\r")
+                return strip_line_terminator(line_bytes.decode("utf-8", errors="replace"))
 
     @staticmethod
     def _build_rust_query(pattern: str, config: SearchConfig) -> tuple[str, bool]:
@@ -848,7 +868,7 @@ class CPUBackend(ComputeBackend):
             if config.max_count is not None:
                 rust_results = rust_results[: config.max_count]
             matches = [
-                MatchLine(line_number=r[0], text=str(r[1]).rstrip("\n\r"), file=file_path)
+                MatchLine(line_number=r[0], text=strip_line_terminator(str(r[1])), file=file_path)
                 for r in rust_results
             ]
             return SearchResult(

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds, run_subprocess
 from tensor_grep.core.config import SearchConfig
-from tensor_grep.core.result import MatchLine, SearchResult
+from tensor_grep.core.result import MatchLine, SearchResult, strip_line_terminator
 
 
 def _decode_rg_field(field: dict[str, object] | None) -> str:
@@ -227,7 +227,11 @@ class RipgrepBackend(ComputeBackend):
                     line_number = data_match.get("line_number", 0)
                     # Decode text-or-bytes: non-UTF-8 files arrive as lines.bytes (base64),
                     # not lines.text — reading only .text produced a phantom empty match.
-                    text = _decode_rg_field(data_match.get("lines")).rstrip("\n\r")
+                    # strip_line_terminator (not .rstrip("\n\r")): rg's own "lines" field
+                    # includes the source line's real trailing `\r` for a CRLF file (verified
+                    # directly against `rg.exe --json`) -- `.rstrip("\n\r")` ate that `\r` too,
+                    # a genuine tg-vs-rg `--json` divergence task #262 uncovered.
+                    text = strip_line_terminator(_decode_rg_field(data_match.get("lines")))
 
                     _path_obj = data_match.get("path", {})
                     path_str = _decode_rg_field(_path_obj)
@@ -262,7 +266,7 @@ class RipgrepBackend(ComputeBackend):
                 elif data.get("type") == "context":
                     data_match = data["data"]
                     line_number = data_match.get("line_number", 0)
-                    text = _decode_rg_field(data_match.get("lines")).rstrip("\n\r")
+                    text = strip_line_terminator(_decode_rg_field(data_match.get("lines")))
                     _path_obj = data_match.get("path", {})
                     path_str = _decode_rg_field(_path_obj)
                     if "text" not in _path_obj and isinstance(file_path, str):

--- a/src/tensor_grep/backends/rust_backend.py
+++ b/src/tensor_grep/backends/rust_backend.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.backends.cpu_backend import InvalidRegexError
 from tensor_grep.core.config import SearchConfig
-from tensor_grep.core.result import MatchLine, SearchResult
+from tensor_grep.core.result import MatchLine, SearchResult, strip_line_terminator
 
 try:
     from tensor_grep.rust_core import RustBackend as NativeRustBackend
@@ -330,7 +330,7 @@ class RustCoreBackend(ComputeBackend):
 
         matches = []
         for line_num, text in results:
-            clean_text = text.rstrip("\r\n")
+            clean_text = strip_line_terminator(text)
             matches.append(MatchLine(line_number=line_num, text=clean_text, file=str(file_path)))
 
         total_matches = len(matches)

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -137,7 +137,10 @@ class StringZillaBackend(ComputeBackend):
         # "format_version" field -- see the identical comment on
         # CPUBackend._get_prefilter_cache_path for the forward-direction corruption this
         # closes (an OLDER install sharing this cache dir with a NEWER one would otherwise
-        # read a v2 payload verbatim, having no idea the schema field exists at all).
+        # read a v2 payload verbatim, having no idea the schema field exists at all). A
+        # pre-#262 `{digest}.json` (no `-vN` suffix) is now permanently orphaned rather than
+        # overwritten -- bounded by ordinary cache size, not a leak; reaping it would defeat
+        # the point (an old reader still using it needs it to stay put).
         return self._get_index_cache_dir() / f"{digest}-v{_STRING_INDEX_CACHE_FORMAT_VERSION}.json"
 
     def _build_line_trigram_index(self, lines: list[str]) -> dict[str, list[int]]:

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -7,10 +7,17 @@ from typing import ClassVar
 
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
 from tensor_grep.core.config import SearchConfig
-from tensor_grep.core.result import MatchLine, SearchResult
+from tensor_grep.core.result import MatchLine, SearchResult, split_source_lines
 
 _STRING_INDEX_CACHE_MAX_ENTRIES_ENV = "TENSOR_GREP_STRING_INDEX_CACHE_MAX_ENTRIES"
 _DEFAULT_STRING_INDEX_CACHE_MAX_ENTRIES = 512
+# Bumped 1 -> 2 by task #262 -- same reasoning as CPUBackend's
+# _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION: the persisted `lines` payload's CRLF semantics
+# changed (a CRLF file's trailing `\r` is now preserved instead of silently stripped by the
+# old `open(file_path, encoding="utf-8")` read + `str.splitlines()`). `(mtime_ns, size)`
+# cannot detect that change, so `_load_cached_index` rejects any payload whose
+# `format_version` does not match, forcing a transparent recompute on first use.
+_STRING_INDEX_CACHE_FORMAT_VERSION = 2
 
 
 class StringZillaBackend(ComputeBackend):
@@ -107,9 +114,16 @@ class StringZillaBackend(ComputeBackend):
             if b"\x00" in binary_handle.read(4096):
                 return None
 
+        # Raw bytes, decoded strictly -- never `open(file_path, encoding="utf-8")` (the old
+        # code here). Opening in Python's default TEXT mode performs universal-newlines
+        # translation ON READ, silently rewriting a genuine `\r\n` (or a bare `\r`) to `\n`
+        # before a single line is ever split out, independent of anything fixed in
+        # `strip_line_terminator` or the stdout-writing layer (task #262). `bytes.decode()`
+        # performs no such translation, so this preserves a CRLF file's own `\r` while
+        # keeping the exact same UnicodeDecodeError -> None fallback contract.
         try:
-            with open(file_path, encoding="utf-8") as text_handle:
-                return text_handle.read()
+            raw = Path(file_path).read_bytes()
+            return raw.decode("utf-8")
         except UnicodeDecodeError:
             return None
 
@@ -208,6 +222,11 @@ class StringZillaBackend(ComputeBackend):
         except (OSError, json.JSONDecodeError):
             return None
 
+        if payload.get("format_version") != _STRING_INDEX_CACHE_FORMAT_VERSION:
+            # Stale (pre-#262, or any future incompatible) cache -- treat as a miss so the
+            # caller recomputes and overwrites this file with the current format.
+            return None
+
         if payload.get("file_signature") != list(cache_signature):
             return None
 
@@ -248,6 +267,7 @@ class StringZillaBackend(ComputeBackend):
 
         cache_path = self._get_index_cache_path(file_path, ignore_case, treat_binary_as_text)
         payload = {
+            "format_version": _STRING_INDEX_CACHE_FORMAT_VERSION,
             "file_signature": list(cache_signature),
             "lines": lines,
             "trigram_index": trigram_index,
@@ -289,7 +309,9 @@ class StringZillaBackend(ComputeBackend):
                     routing_distributed=False,
                     routing_worker_count=1,
                 )
-            source_lines = content.splitlines()
+            # split_source_lines, never `str.splitlines()`: it treats `\r\n` as one break and
+            # strips it entirely, eating a CRLF line's genuine trailing `\r` (task #262).
+            source_lines = split_source_lines(content)
             normalized_lines = (
                 [line.lower() for line in source_lines] if ignore_case else source_lines
             )
@@ -356,7 +378,10 @@ class StringZillaBackend(ComputeBackend):
         # BackendExecutionError`); an unwrapped native error falls into its broad `except
         # Exception` and re-raises uncaught instead of degrading to CPU.
         try:
-            import stringzilla as sz
+            # Import kept for its availability-gate side effect (raises ImportError when
+            # stringzilla is genuinely absent, caught below) even though `sz.Str` is no
+            # longer used for line-splitting -- see the split_source_lines comment below.
+            import stringzilla as sz  # noqa: F401
 
             ignore_case = bool(config and config.ignore_case)
             if config and config.fixed_strings:
@@ -379,32 +404,26 @@ class StringZillaBackend(ComputeBackend):
                     routing_worker_count=1,
                 )
 
-            sz_str = sz.Str(content)
-
-            # Since StringZilla 4.x, we can split by lines extremely fast
-            lines = sz_str.splitlines()
-            # Unlike Python's str.splitlines(), StringZilla's Str.splitlines() emits an
-            # extra trailing empty entry when the source text ends with a line
-            # terminator (e.g. "a\n" -> ["a", ""] instead of ["a"]). Uncorrected, that
-            # phantom empty "line" spuriously matches under invert_match (it never
-            # contains the pattern) and shifts every subsequent line number. Trim it so
-            # line numbering and invert_match semantics match cpu_backend/rg.
-            if lines and str(lines[-1]) == "" and content.endswith(("\n", "\r")):
-                lines = lines[:-1]
+            # split_source_lines, never `str.splitlines()` or StringZilla's own
+            # `Str.splitlines()`: both treat `\r\n` as a single line break and strip it
+            # entirely, eating a CRLF line's genuine trailing `\r` before a single match is
+            # evaluated (task #262) -- independent of the old trailing-empty-entry
+            # compensation below, which `split_source_lines`'s own pop-if-trailing-empty
+            # already folds in.
+            lines = split_source_lines(content)
             matches = []
             invert_match = bool(config and config.invert_match)
             max_count = config.max_count if config else None
 
-            # Evaluate using stringzilla's native find
             for i, line in enumerate(lines):
-                haystack = str(line).lower() if ignore_case else line
+                haystack = line.lower() if ignore_case else line
                 needle = pattern.lower() if ignore_case else pattern
                 found = haystack.find(needle) != -1
                 # H5: honor invert_match -- a matching line under invert_match is one
                 # where the pattern is ABSENT, the complement of the normal result.
                 matched = (not found) if invert_match else found
                 if matched:
-                    matches.append(MatchLine(line_number=i + 1, text=str(line), file=file_path))
+                    matches.append(MatchLine(line_number=i + 1, text=line, file=file_path))
                     # H6: cap to config.max_count, matching cpu_backend's per-file cap
                     # semantics -- never return every match once the cap is reached.
                     if max_count and len(matches) >= max_count:

--- a/src/tensor_grep/backends/stringzilla_backend.py
+++ b/src/tensor_grep/backends/stringzilla_backend.py
@@ -133,7 +133,12 @@ class StringZillaBackend(ComputeBackend):
         digest = hashlib.sha256(
             f"{Path(file_path).resolve()}::{int(ignore_case)}::{int(treat_binary_as_text)}".encode()
         ).hexdigest()
-        return self._get_index_cache_dir() / f"{digest}.json"
+        # The format version is baked into the FILENAME, not just the payload's own
+        # "format_version" field -- see the identical comment on
+        # CPUBackend._get_prefilter_cache_path for the forward-direction corruption this
+        # closes (an OLDER install sharing this cache dir with a NEWER one would otherwise
+        # read a v2 payload verbatim, having no idea the schema field exists at all).
+        return self._get_index_cache_dir() / f"{digest}-v{_STRING_INDEX_CACHE_FORMAT_VERSION}.json"
 
     def _build_line_trigram_index(self, lines: list[str]) -> dict[str, list[int]]:
         index: dict[str, set[int]] = {}

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -1159,6 +1159,21 @@ def _force_utf8_streams() -> None:
             kwargs["errors"] = "replace"
         try:
             reconfigure(**kwargs)
+        except TypeError:
+            # This stream's `reconfigure()` doesn't accept every kwarg we asked for (e.g. a
+            # wrapper exposing only the narrower `encoding=`/`errors=` signature the pre-#262
+            # code called with, with no `newline=` parameter at all) -- calling reconfigure()
+            # on THIS stream at all is new behavior from task #262 (previously skipped
+            # entirely whenever the stream was already UTF-8), so a stream shape that never
+            # hit this line before now can. Retry with just the encoding kwargs so that fix
+            # still lands even where the newline fix cannot; give up silently if even that
+            # narrower call fails (do not crash startup either way).
+            kwargs.pop("newline", None)
+            if kwargs:
+                try:
+                    reconfigure(**kwargs)
+                except (ValueError, OSError, TypeError):
+                    pass
         except (ValueError, OSError):
             # Stream already has buffered output or is detached -- degrade to the per-line
             # _safe_stdout_line fallback still in place at the call sites; do not crash startup.

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -1134,17 +1134,31 @@ def _force_utf8_streams() -> None:
     filesystem path with a non-English username, a U+2028 in a match, an emoji marker, ...). The
     root fix for the whole ``typer.echo``/``print`` sweep -- one reconfigure at the entry point
     covers every command instead of routing each site through ``_safe_stdout_line``. No-op where the
-    stream is already UTF-8 or cannot be reconfigured (a pipe with pending bytes, a non-TextIO
-    stream); ``errors="replace"`` guarantees it can never itself raise on write.
+    stream cannot be reconfigured (a pipe with pending bytes, a non-TextIO stream); ``errors="replace"``
+    guarantees it can never itself raise on write.
+
+    Also pins ``newline="\\n"`` on every reconfigurable stream, encoding fix or not (task #262).
+    A plain ``TextIOWrapper`` (the default for ``sys.stdout``/``sys.stderr``) is opened with
+    ``newline=None`` -- universal-newlines mode -- which on Windows silently rewrites every ``\\n``
+    a formatter emits into ``os.linesep`` (``\\r\\n``) on WRITE, corrupting an LF-only matched line
+    (or a CRLF-file line already carrying its own trailing ``\\r``, which would come out
+    double-CR'd) before it ever leaves the process. ``rg``'s own subprocess output and the native
+    ``tg`` binary bypass this entirely (their bytes are inherited/streamed raw, never routed
+    through a Python text stream), which is why only the CPU/native-Python search path showed the
+    corruption. ``newline="\\n"`` disables the translation -- bytes written are exactly the bytes
+    the formatter produced. This must apply even when the stream is ALREADY UTF-8 (the pre-fix
+    early-``continue`` below skipped the newline fix together with the now-skipped encoding fix).
     """
     for stream in (sys.stdout, sys.stderr):
         reconfigure = getattr(stream, "reconfigure", None)
         if not callable(reconfigure):
             continue
-        if "utf" in (getattr(stream, "encoding", None) or "").lower():
-            continue
+        kwargs: dict[str, str] = {"newline": "\n"}
+        if "utf" not in (getattr(stream, "encoding", None) or "").lower():
+            kwargs["encoding"] = "utf-8"
+            kwargs["errors"] = "replace"
         try:
-            reconfigure(encoding="utf-8", errors="replace")
+            reconfigure(**kwargs)
         except (ValueError, OSError):
             # Stream already has buffered output or is detached -- degrade to the per-line
             # _safe_stdout_line fallback still in place at the call sites; do not crash startup.

--- a/src/tensor_grep/core/result.py
+++ b/src/tensor_grep/core/result.py
@@ -25,6 +25,32 @@ def strip_line_terminator(text: str) -> str:
     return text.removesuffix("\n")
 
 
+def split_source_lines(text: str) -> list[str]:
+    r"""Split a whole file's decoded text into per-line strings for line-oriented matching,
+    keeping any trailing ``\r`` from a CRLF line intact.
+
+    Never ``str.splitlines()`` (and, for a StringZilla ``Str``, never its own
+    ``.splitlines()`` either): both treat ``\r\n``, a bare ``\r``, and a bare ``\n`` as
+    equivalent line breaks, and BOTH strip the terminator characters entirely -- silently
+    eating a CRLF line's genuine trailing ``\r`` before a single match is even evaluated,
+    independent of anything fixed in ``strip_line_terminator`` or the stdout-writing layer
+    (task #262). Splitting on a bare ``\n`` only preserves that ``\r`` as part of the
+    line's own content, matching how ``rg`` and the Rust engine both treat a CRLF file.
+
+    Mirrors ``str.splitlines()``'s line COUNT for well-formed trailing-newline input by
+    dropping the one spurious empty element a final ``\n`` produces via a plain
+    ``str.split("\n")`` (``"a\nb\n".split("\n")`` has a trailing ``""`` that
+    ``"a\nb\n".splitlines()`` does not) -- so a caller that assumed that invariant does not
+    silently gain an extra blank line; only a genuine embedded/trailing ``\r`` now survives.
+    """
+    if text == "":
+        return []
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
 @dataclass(frozen=True)
 class MatchLine:
     line_number: int

--- a/src/tensor_grep/core/result.py
+++ b/src/tensor_grep/core/result.py
@@ -1,6 +1,30 @@
 from dataclasses import dataclass, field
 
 
+def strip_line_terminator(text: str) -> str:
+    r"""Strip AT MOST one trailing ``\n`` from a raw line's text -- never a trailing ``\r``.
+
+    ``MatchLine.text`` must hold a line's content with its own terminating newline removed,
+    but with everything else -- including a genuine trailing ``\r`` from a CRLF-terminated
+    source line -- left byte-for-byte intact, matching how real ``rg`` reports a CRLF line's
+    content (verified directly against ``rg.exe``: its plain-text AND ``--json`` output both
+    keep the file's own ``\r``).
+
+    Every backend used to call ``text.rstrip("\n\r")`` / ``text.rstrip("\r\n")`` here, which
+    strips ANY trailing run of ``\r``/``\n`` in ANY order -- e.g. for a CRLF line whose
+    content itself legitimately ends in ``\r`` (Rust's line-splitter, and a raw ``rg --json``
+    "lines" field, both include that ``\r``), this silently ate it too. On Windows that
+    divergence used to be masked (or, once the rg-parity test suites started comparing raw
+    bytes instead of `text=True`-decoded strings, exposed) by the SEPARATE stdout
+    universal-newlines bug this fix is paired with (task #262) -- but even with stdout fixed,
+    every one of these `rstrip` call sites would still corrupt a CRLF file's OWN `\r` on the
+    way in, independent of anything happening at the stdout layer. ``removesuffix`` only ever
+    removes the single trailing ``\n`` that every engine here is known to append; a real
+    trailing ``\r`` survives.
+    """
+    return text.removesuffix("\n")
+
+
 @dataclass(frozen=True)
 class MatchLine:
     line_number: int

--- a/tests/e2e/test_cli_search.py
+++ b/tests/e2e/test_cli_search.py
@@ -1,9 +1,15 @@
 import json
 import os
-import subprocess
 import sys
+from pathlib import Path
 
 import pytest
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers.byte_parity import run_bytes  # noqa: E402
 
 pytestmark = pytest.mark.acceptance
 
@@ -41,32 +47,34 @@ class TestCLISearch:
 
     def test_should_find_pattern_in_log_file(self, sample_log_file):
         """OUTER LOOP RED: The simplest possible E2E test."""
-        result = subprocess.run(
-            [sys.executable, "-m", "tensor_grep.cli.main", "search", "ERROR", str(sample_log_file)],
-            capture_output=True,
-            text=True,
-        )
+        # Raw bytes -- no text=True, which would silently translate a real `\r\n` in tg's
+        # own stdout to `\n` on Windows before the line-count assertion below ever sees it
+        # (task #262).
+        result = run_bytes([
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.main",
+            "search",
+            "ERROR",
+            str(sample_log_file),
+        ])
         assert result.returncode == 0
-        assert "ERROR" in result.stdout
-        assert result.stdout.count("\n") == 2  # Two ERROR lines
+        assert b"ERROR" in result.stdout
+        assert result.stdout.count(b"\n") == 2  # Two ERROR lines
 
     def test_should_exit_1_when_no_matches(self, sample_log_file):
-        result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "tensor_grep.cli.main",
-                "search",
-                "NONEXISTENT",
-                str(sample_log_file),
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_bytes([
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.main",
+            "search",
+            "NONEXISTENT",
+            str(sample_log_file),
+        ])
         assert result.returncode == 1
 
     def test_should_emit_json_without_hanging(self, sample_log_file):
-        result = subprocess.run(
+        result = run_bytes(
             [
                 sys.executable,
                 "-m",
@@ -76,12 +84,12 @@ class TestCLISearch:
                 str(sample_log_file),
                 "--json",
             ],
-            capture_output=True,
-            text=True,
             timeout=CLI_SUBPROCESS_TIMEOUT_SECONDS,
         )
 
         assert result.returncode == 0
+        # json.loads accepts raw bytes directly (RFC 8259 auto-detects the encoding) --
+        # decodes strictly, no errors="replace" laundering of invalid bytes first.
         payload = json.loads(result.stdout)
         assert payload["total_matches"] == 2
 
@@ -91,7 +99,7 @@ class TestCLISearch:
         fake_rg = self._write_fake_rg_json_binary(tmp_path)
         env = os.environ.copy()
         env["TG_RG_PATH"] = str(fake_rg)
-        result = subprocess.run(
+        result = run_bytes(
             [
                 sys.executable,
                 "-m",
@@ -103,14 +111,12 @@ class TestCLISearch:
                 "ERROR",
                 str(sample_log_file),
             ],
-            capture_output=True,
-            text=True,
             env=env,
             timeout=CLI_SUBPROCESS_TIMEOUT_SECONDS,
         )
 
         assert result.returncode == 0
-        events = [json.loads(line) for line in result.stdout.splitlines()]
+        events = [json.loads(line) for line in result.stdout.split(b"\n") if line.strip()]
         assert events[0]["type"] == "begin"
         assert any(event["type"] == "match" for event in events)
         assert events[-1]["type"] == "summary"

--- a/tests/e2e/test_multi_pattern_native.py
+++ b/tests/e2e/test_multi_pattern_native.py
@@ -165,28 +165,46 @@ def test_multi_e_native_reports_both_match_line_once(corpus: Path, env: dict[str
     # both.txt matches "foo" AND "bar" but must be reported as ONE line, never two
     # independent passes (rg parity: OR-combine, not N separate searches).
     #
-    # KNOWN REAL DIVERGENCE (task #262, uncovered by de-blinding this comparison -- left
-    # intentionally RED, not xfailed/normalized away, per task instructions): on Windows,
-    # `tg search --cpu` (the Python/native, non-rg-routed backend) emits a matched line
-    # terminated `\r\n` even when the source file and every OTHER engine emit plain `\n`.
-    # Repro argv: `python -m tensor_grep search --cpu -e foo -e bar both.txt` against an
-    # LF-only `both.txt` (`b"foo and bar together\n"` on disk):
-    #   tg --cpu stdout:            b"foo and bar together\r\n"   (WRONG -- extra \r)
-    #   tg (rg-routed, no --cpu):   b"foo and bar together\n"     (matches the file)
-    #   real `rg` on the same file: b"foo and bar together\n"     (matches the file)
-    # The extra `\r` is not present in the input file and is not emitted by `rg` or by tg's
-    # own rg-routed path on the identical file, so it is introduced by the CPU/native
-    # backend's own Python stdout write (Windows' universal-newlines translation applied on
-    # write, `\n` -> `os.linesep`), not by anything file- or fixture-dependent. This was
-    # invisible before task #262 because the old `_normalize` collapsed `\r\n` -> `\n` before
-    # ever comparing. Fixing the emitter is out of this PR's scope (`src/tensor_grep/` is
-    # off-limits here) -- this assertion is left honest so CI documents the real bug rather
-    # than re-hiding it.
+    # FIXED (task #262): de-blinding this comparison (raw bytes instead of a
+    # `\r\n`-collapsing `_normalize`) first caught `tg search --cpu` emitting a matched line
+    # terminated `\r\n` on Windows even though this fixture's `both.txt` is LF-only. Root
+    # cause was `bootstrap.py::_force_utf8_streams` never pinning `newline="\n"` on
+    # `sys.stdout` -- Python's default universal-newlines TEXT mode rewrites every `\n` a
+    # formatter emits to `os.linesep` on WRITE. Fixed there (now unconditional, even when the
+    # stream is already UTF-8). This is the LF-in-LF-out half of the bidirectional check; see
+    # `test_multi_e_native_crlf_file_round_trips_its_own_crlf` below for the CRLF-in-CRLF-out
+    # half real `rg` was already getting right.
     result = _tg(["--cpu", "-e", "foo", "-e", "bar", "both.txt"], cwd=corpus, env=env)
     assert result.returncode == 0, decode_for_display(result.stderr)
     matched_lines = _normalize(result.stdout, corpus)
     assert len(matched_lines) == 1
     assert matched_lines[0] == b"foo and bar together"
+
+
+def test_multi_e_native_crlf_file_round_trips_its_own_crlf(
+    env: dict[str, str], tmp_path: Path
+) -> None:
+    """The OTHER half of the task #262 bidirectional fix: a genuinely CRLF-terminated source
+    file must still round-trip its own `\\r\\n` through `--cpu` -- fixing the LF-corruption
+    bug above must NOT start stripping (or doubling) a real `\\r` that was already there.
+    Verified directly against real `rg.exe` on the identical file: both must agree.
+    """
+    root = tmp_path / "crlf-multi-pattern"
+    root.mkdir()
+    (root / "both.txt").write_bytes(b"foo and bar together\r\n")
+
+    result = _tg(["--cpu", "-e", "foo", "-e", "bar", "both.txt"], cwd=root, env=env)
+    assert result.returncode == 0, decode_for_display(result.stderr)
+    assert result.stdout == b"foo and bar together\r\n"
+
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for CRLF round-trip cross-check")
+    rg_env = dict(env)
+    rg_env["TG_RG_PATH"] = str(rg_binary)
+    rg_result = _run([str(rg_binary), "-e", "foo", "-e", "bar", "both.txt"], cwd=root, env=rg_env)
+    assert rg_result.stdout == result.stdout
 
 
 # --- (b) -f patterns.txt: the file must actually be read, and only its patterns match. --
@@ -313,6 +331,7 @@ def test_many_fixed_patterns_dedupe_overlapping_lines_at_scale(
         "line D has NEEDLE_03 and NEEDLE_04 and NEEDLE_05 together\n"
         "line E has no needles at all\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     real_needles = [f"NEEDLE_{i:02d}" for i in range(1, 6)]  # 5 patterns that DO match

--- a/tests/e2e/test_multi_pattern_native.py
+++ b/tests/e2e/test_multi_pattern_native.py
@@ -47,6 +47,8 @@ TESTS_DIR = Path(__file__).resolve().parents[1]
 if str(TESTS_DIR) not in sys.path:
     sys.path.insert(0, str(TESTS_DIR))
 
+from helpers.byte_parity import decode_for_display, run_bytes  # noqa: E402
+
 pytestmark = pytest.mark.acceptance
 
 SRC_DIR = Path(__file__).resolve().parents[2] / "src"
@@ -73,41 +75,48 @@ def _env() -> dict[str, str]:
     return env
 
 
-def _run(argv: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        argv,
-        cwd=cwd,
-        env=env,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+def _run(argv: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[bytes]:
+    # Raw bytes only -- no text=/encoding=/errors="replace". See tests/helpers/byte_parity.py:
+    # those would silently translate a real `\r\n` to `\n` (Windows universal-newlines mode)
+    # and map an invalid UTF-8 byte to U+FFFD before either engine's output is ever compared,
+    # applied identically to both the rg and tg arms below (task #262).
+    return run_bytes(argv, cwd=cwd, env=env)
 
 
-def _tg(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _tg(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[bytes]:
     return _run([sys.executable, "-m", "tensor_grep", "search", *args], cwd=cwd, env=env)
 
 
-def _normalize(text: str, root: Path) -> list[str]:
-    normalized: list[str] = []
-    for line in text.replace("\r\n", "\n").splitlines():
+def _normalize(data: bytes, root: Path) -> list[bytes]:
+    r"""Normalize ONLY the pytest tmp-dir prefix and the platform path separator -- both
+    genuinely non-contractual. Splits on a bare `\n` (never `str.splitlines()`/a blanket
+    `\r\n` -> `\n` replace), so a real CRLF divergence between the two compared engines
+    stays visible as a trailing `\r` on the affected line instead of being erased before
+    comparison (task #262).
+    """
+    root_bytes = str(root).encode("utf-8")
+    root_posix_bytes = root.as_posix().encode("utf-8")
+    normalized: list[bytes] = []
+    for line in data.split(b"\n"):
         if not line:
             continue
-        current = line.replace(str(root), ".").replace(root.as_posix(), ".").replace("\\", "/")
-        if current.startswith("./"):
+        current = (
+            line.replace(root_bytes, b".").replace(root_posix_bytes, b".").replace(b"\\", b"/")
+        )
+        if current.startswith(b"./"):
             current = current[2:]
         normalized.append(current)
     return normalized
 
 
-def _tg_json_matches(result: subprocess.CompletedProcess[str]) -> list[tuple[str, str]]:
+def _tg_json_matches(result: subprocess.CompletedProcess[bytes]) -> list[tuple[str, str]]:
+    # json.loads accepts raw bytes directly and decodes strictly (RFC 8259 auto-detection) --
+    # no errors="replace" laundering of invalid bytes before the JSON payload is parsed.
     payload = json.loads(result.stdout)
     return sorted((match["file"], match["text"]) for match in payload["matches"])
 
 
-def _tg_json_files(result: subprocess.CompletedProcess[str]) -> list[str]:
+def _tg_json_files(result: subprocess.CompletedProcess[bytes]) -> list[str]:
     payload = json.loads(result.stdout)
     return sorted({match["file"] for match in payload["matches"]})
 
@@ -119,14 +128,23 @@ def env() -> dict[str, str]:
 
 @pytest.fixture()
 def corpus(tmp_path: Path) -> Path:
+    # Every corpus/pattern-file write below now passes `newline="\n"` deliberately: without
+    # it, `Path.write_text()`'s default universal-newlines mode translates `\n` -> `\r\n` on
+    # Windows, so the on-disk fixture would be CRLF even though the Python string literal is
+    # LF-only. The now-byte-exact comparisons below (task #262) surfaced this -- a matched
+    # line's real bytes (rg-verified: `b"foo and bar together\r\n"`, matching real `rg`'s own
+    # output on the same CRLF file) diverged from the LF-only hard-coded golden string these
+    # tests were written against. Pinning fixture writes to LF makes the golden strings
+    # correct again without touching the comparison itself.
+    #
     # Pattern files (written by individual tests) go in `tmp_path`, one level ABOVE
     # `root`, so a `-f ../patterns.txt` never becomes a search candidate itself.
     root = tmp_path / "multi-pattern"
     root.mkdir()
-    (root / "foo.txt").write_text("foo line\n", encoding="utf-8")
-    (root / "bar.txt").write_text("bar line\n", encoding="utf-8")
-    (root / "both.txt").write_text("foo and bar together\n", encoding="utf-8")
-    (root / "none.txt").write_text("nothing relevant\n", encoding="utf-8")
+    (root / "foo.txt").write_text("foo line\n", encoding="utf-8", newline="\n")
+    (root / "bar.txt").write_text("bar line\n", encoding="utf-8", newline="\n")
+    (root / "both.txt").write_text("foo and bar together\n", encoding="utf-8", newline="\n")
+    (root / "none.txt").write_text("nothing relevant\n", encoding="utf-8", newline="\n")
     return root
 
 
@@ -137,20 +155,38 @@ def test_multi_e_native_matches_all_patterns_not_just_first(
     corpus: Path, env: dict[str, str]
 ) -> None:
     result = _tg(["--cpu", "--sort", "path", "-e", "foo", "-e", "bar", "."], cwd=corpus, env=env)
-    assert result.returncode == 0, result.stderr
-    matched_files = sorted({line.split(":", 1)[0] for line in _normalize(result.stdout, corpus)})
-    assert matched_files == ["bar.txt", "both.txt", "foo.txt"]
-    assert "none.txt" not in matched_files
+    assert result.returncode == 0, decode_for_display(result.stderr)
+    matched_files = sorted({line.split(b":", 1)[0] for line in _normalize(result.stdout, corpus)})
+    assert matched_files == [b"bar.txt", b"both.txt", b"foo.txt"]
+    assert b"none.txt" not in matched_files
 
 
 def test_multi_e_native_reports_both_match_line_once(corpus: Path, env: dict[str, str]) -> None:
     # both.txt matches "foo" AND "bar" but must be reported as ONE line, never two
     # independent passes (rg parity: OR-combine, not N separate searches).
+    #
+    # KNOWN REAL DIVERGENCE (task #262, uncovered by de-blinding this comparison -- left
+    # intentionally RED, not xfailed/normalized away, per task instructions): on Windows,
+    # `tg search --cpu` (the Python/native, non-rg-routed backend) emits a matched line
+    # terminated `\r\n` even when the source file and every OTHER engine emit plain `\n`.
+    # Repro argv: `python -m tensor_grep search --cpu -e foo -e bar both.txt` against an
+    # LF-only `both.txt` (`b"foo and bar together\n"` on disk):
+    #   tg --cpu stdout:            b"foo and bar together\r\n"   (WRONG -- extra \r)
+    #   tg (rg-routed, no --cpu):   b"foo and bar together\n"     (matches the file)
+    #   real `rg` on the same file: b"foo and bar together\n"     (matches the file)
+    # The extra `\r` is not present in the input file and is not emitted by `rg` or by tg's
+    # own rg-routed path on the identical file, so it is introduced by the CPU/native
+    # backend's own Python stdout write (Windows' universal-newlines translation applied on
+    # write, `\n` -> `os.linesep`), not by anything file- or fixture-dependent. This was
+    # invisible before task #262 because the old `_normalize` collapsed `\r\n` -> `\n` before
+    # ever comparing. Fixing the emitter is out of this PR's scope (`src/tensor_grep/` is
+    # off-limits here) -- this assertion is left honest so CI documents the real bug rather
+    # than re-hiding it.
     result = _tg(["--cpu", "-e", "foo", "-e", "bar", "both.txt"], cwd=corpus, env=env)
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     matched_lines = _normalize(result.stdout, corpus)
     assert len(matched_lines) == 1
-    assert matched_lines[0] == "foo and bar together"
+    assert matched_lines[0] == b"foo and bar together"
 
 
 # --- (b) -f patterns.txt: the file must actually be read, and only its patterns match. --
@@ -159,9 +195,9 @@ def test_multi_e_native_reports_both_match_line_once(corpus: Path, env: dict[str
 def test_pattern_file_native_reads_file_and_matches_any_pattern(
     corpus: Path, env: dict[str, str], tmp_path: Path
 ) -> None:
-    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8")
+    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8", newline="\n")
     result = _tg(["--cpu", "--json", "-f", "../patterns.txt", "."], cwd=corpus, env=env)
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     matched_files = _tg_json_files(result)
     # Must NOT flood every file (the pre-fix bug: an unread `-f` collapsed to an empty
     # pattern string that matched every line in every file).
@@ -172,7 +208,7 @@ def test_pattern_file_native_reads_file_and_matches_any_pattern(
 def test_pattern_file_missing_exits_2(corpus: Path, env: dict[str, str]) -> None:
     result = _tg(["--cpu", "-f", "does_not_exist.txt", "."], cwd=corpus, env=env)
     assert result.returncode == 2
-    assert "does_not_exist.txt" in result.stderr
+    assert b"does_not_exist.txt" in result.stderr
 
 
 def test_pattern_file_missing_exits_2_json_envelope(corpus: Path, env: dict[str, str]) -> None:
@@ -188,9 +224,9 @@ def test_pattern_file_blank_line_matches_every_line_rg_parity(
 ) -> None:
     # Documented rg behavior, pinned deliberately (not a bug to "fix"): a genuinely blank
     # pattern-file line is an EMPTY pattern, which matches every line in every file.
-    (tmp_path / "blank.txt").write_text("\n", encoding="utf-8")
+    (tmp_path / "blank.txt").write_text("\n", encoding="utf-8", newline="\n")
     result = _tg(["--cpu", "--json", "-f", "../blank.txt", "."], cwd=corpus, env=env)
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     matched_files = _tg_json_files(result)
     assert matched_files == ["bar.txt", "both.txt", "foo.txt", "none.txt"]
 
@@ -204,7 +240,7 @@ def test_multi_pattern_golden_parity_deterministic_cpu_backend(
     corpus: Path, env: dict[str, str]
 ) -> None:
     result = _tg(["--cpu", "--json", "-e", "foo", "-e", "bar", "."], cwd=corpus, env=env)
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     payload = json.loads(result.stdout)
     assert payload["total_files"] == 3
     assert payload["total_matches"] == 3
@@ -218,9 +254,9 @@ def test_multi_pattern_golden_parity_deterministic_cpu_backend(
 def test_multi_pattern_golden_parity_pattern_file_deterministic_cpu_backend(
     corpus: Path, env: dict[str, str], tmp_path: Path
 ) -> None:
-    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8")
+    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8", newline="\n")
     result = _tg(["--cpu", "--json", "-f", "../patterns.txt", "."], cwd=corpus, env=env)
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     payload = json.loads(result.stdout)
     assert payload["total_files"] == 3
     assert payload["total_matches"] == 3
@@ -284,14 +320,16 @@ def test_many_fixed_patterns_dedupe_overlapping_lines_at_scale(
     patterns = real_needles + absent_patterns
     assert len(patterns) == 100
 
-    (tmp_path / "patterns.txt").write_text("\n".join(patterns) + "\n", encoding="utf-8")
+    (tmp_path / "patterns.txt").write_text(
+        "\n".join(patterns) + "\n", encoding="utf-8", newline="\n"
+    )
 
     result = _tg(
         ["-F", "--cpu", "--json", "-f", "../patterns.txt", "."],
         cwd=root,
         env=env,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     payload = json.loads(result.stdout)
 
     # rg parity: 4 LINES matched (A, B, C, D) -- never one row per (line, pattern) pair.
@@ -312,14 +350,14 @@ def test_many_fixed_patterns_dedupe_overlapping_lines_at_scale(
 def test_fixed_strings_multi_e_native_literal_only(env: dict[str, str], tmp_path: Path) -> None:
     root = tmp_path / "literal"
     root.mkdir()
-    (root / "dot.txt").write_text("a.b literal\n", encoding="utf-8")
-    (root / "any.txt").write_text("axb should not match\n", encoding="utf-8")
-    (root / "zz.txt").write_text("zz here\n", encoding="utf-8")
+    (root / "dot.txt").write_text("a.b literal\n", encoding="utf-8", newline="\n")
+    (root / "any.txt").write_text("axb should not match\n", encoding="utf-8", newline="\n")
+    (root / "zz.txt").write_text("zz here\n", encoding="utf-8", newline="\n")
     result = _tg(["--cpu", "--sort", "path", "-F", "-e", "a.b", "-e", "zz", "."], cwd=root, env=env)
-    assert result.returncode == 0, result.stderr
-    matched_files = sorted({line.split(":", 1)[0] for line in _normalize(result.stdout, root)})
-    assert matched_files == ["dot.txt", "zz.txt"]
-    assert "any.txt" not in matched_files
+    assert result.returncode == 0, decode_for_display(result.stderr)
+    matched_files = sorted({line.split(b":", 1)[0] for line in _normalize(result.stdout, root)})
+    assert matched_files == [b"dot.txt", b"zz.txt"]
+    assert b"any.txt" not in matched_files
 
 
 # --- leading (?i) inline flag stays SCOPED to its own branch, never leaking case- -------
@@ -329,15 +367,15 @@ def test_fixed_strings_multi_e_native_literal_only(env: dict[str, str], tmp_path
 def test_multi_e_leading_inline_flag_is_scoped(env: dict[str, str], tmp_path: Path) -> None:
     root = tmp_path / "scoped-flag"
     root.mkdir()
-    (root / "upper.txt").write_text("FOO shout\n", encoding="utf-8")
-    (root / "lower.txt").write_text("bar quiet\n", encoding="utf-8")
-    (root / "upper_bar.txt").write_text("BAR shout\n", encoding="utf-8")
+    (root / "upper.txt").write_text("FOO shout\n", encoding="utf-8", newline="\n")
+    (root / "lower.txt").write_text("bar quiet\n", encoding="utf-8", newline="\n")
+    (root / "upper_bar.txt").write_text("BAR shout\n", encoding="utf-8", newline="\n")
     result = _tg(["--cpu", "--sort", "path", "-e", "(?i)foo", "-e", "bar", "."], cwd=root, env=env)
-    assert result.returncode == 0, result.stderr
-    matched_files = sorted({line.split(":", 1)[0] for line in _normalize(result.stdout, root)})
-    assert matched_files == ["lower.txt", "upper.txt"]
+    assert result.returncode == 0, decode_for_display(result.stderr)
+    matched_files = sorted({line.split(b":", 1)[0] for line in _normalize(result.stdout, root)})
+    assert matched_files == [b"lower.txt", b"upper.txt"]
     # BAR must NOT match: (?i) must stay scoped to the foo branch, not leak globally.
-    assert "upper_bar.txt" not in matched_files
+    assert b"upper_bar.txt" not in matched_files
 
 
 # --- single -e / single -F must stay BYTE-IDENTICAL to the plain-positional form (no ----
@@ -369,13 +407,13 @@ def test_single_fixed_strings_e_byte_identical_to_positional(
 def test_single_e_with_unused_f_still_dead_flag_on_cpu_path(
     corpus: Path, env: dict[str, str], tmp_path: Path
 ) -> None:
-    (tmp_path / "bar_only.txt").write_text("bar\n", encoding="utf-8")
+    (tmp_path / "bar_only.txt").write_text("bar\n", encoding="utf-8", newline="\n")
     result = _tg(
         ["--cpu", "--json", "-e", "foo", "-f", "../bar_only.txt", "."],
         cwd=corpus,
         env=env,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, decode_for_display(result.stderr)
     matched_files = _tg_json_files(result)
     # Only "foo" is searched; -f's "bar" pattern is a dead flag here (single -e wins).
     assert matched_files == ["both.txt", "foo.txt"]
@@ -407,7 +445,7 @@ def test_pattern_file_without_cpu_matches_rg_when_available(
     rg_binary = rg_parity.resolve_pinned_rg_binary()
     if rg_binary is None:
         pytest.skip("ripgrep binary not available for rg-passthrough parity coverage")
-    (tmp_path / "patterns2.txt").write_text("foo\nbar\n", encoding="utf-8")
+    (tmp_path / "patterns2.txt").write_text("foo\nbar\n", encoding="utf-8", newline="\n")
     rg_env = dict(env)
     rg_env["TG_RG_PATH"] = str(rg_binary)
     rg_result = _run(
@@ -426,13 +464,13 @@ def test_multi_e_with_only_matching_still_rejected_exit_2(
 ) -> None:
     result = _tg(["--cpu", "-o", "-e", "foo", "-e", "bar", "both.txt"], cwd=corpus, env=env)
     assert result.returncode == 2
-    assert "-o/--only-matching" in result.stderr
+    assert b"-o/--only-matching" in result.stderr
 
 
 def test_pattern_file_with_rank_still_rejected_exit_2(
     corpus: Path, env: dict[str, str], tmp_path: Path
 ) -> None:
-    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8")
+    (tmp_path / "patterns.txt").write_text("foo\nbar\n", encoding="utf-8", newline="\n")
     result = _tg(["--cpu", "--rank", "-f", "../patterns.txt", "."], cwd=corpus, env=env)
     assert result.returncode == 2
-    assert "--rank/--bm25" in result.stderr
+    assert b"--rank/--bm25" in result.stderr

--- a/tests/e2e/test_multi_pattern_native.py
+++ b/tests/e2e/test_multi_pattern_native.py
@@ -93,6 +93,14 @@ def _normalize(data: bytes, root: Path) -> list[bytes]:
     `\r\n` -> `\n` replace), so a real CRLF divergence between the two compared engines
     stays visible as a trailing `\r` on the affected line instead of being erased before
     comparison (task #262).
+
+    KNOWN, ACKNOWLEDGED LIMIT (not closed here, independent-gate follow-up): the trailing
+    `.replace(b"\\", b"/")` below runs against the WHOLE line, not just a parsed-out path
+    prefix, so it is still a both-arms-lossy transform in the same shape this function
+    otherwise removes -- a real backslash-vs-forward-slash divergence inside MATCHED TEXT
+    content (not the file-path prefix) would cancel out identically on both arms. This
+    module's fixtures are plain ASCII words with no backslashes in their content, so it has
+    not been observed to mask a real failure, but it is a structural gap.
     """
     root_bytes = str(root).encode("utf-8")
     root_posix_bytes = root.as_posix().encode("utf-8")

--- a/tests/e2e/test_output_golden_contract.py
+++ b/tests/e2e/test_output_golden_contract.py
@@ -6,16 +6,32 @@ from pathlib import Path
 
 import pytest
 
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers.byte_parity import decode_for_display, split_lines_preserve_cr  # noqa: E402
+
 
 @pytest.fixture(scope="module")
 def golden_fixture_dir(tmp_path_factory):
     dir_path = tmp_path_factory.mktemp("golden_fixtures")
     text_dir = dir_path / "text"
     text_dir.mkdir()
+    # `newline="\n"` is deliberate on every write below: without it, `Path.write_text()`'s
+    # default universal-newlines mode translates `\n` -> `\r\n` on Windows, so this fixture
+    # would be CRLF on disk even though every literal here is LF-only. Both real `rg` and
+    # tg's rg-routed path correctly preserve a file's own trailing `\r` in a matched line
+    # (verified directly against a real `rg.exe`), so an unpinned-newline fixture turned an
+    # innocuous test-authoring accident into a spurious CRLF "mismatch" once task #262 made
+    # this suite's comparisons byte-honest -- pinning input determinism here is the fix, not
+    # a new normalization on the comparison side.
     (text_dir / "file1.txt").write_text(
-        "hello world\nfoo bar baz\ngoodbye world\n", encoding="utf-8"
+        "hello world\nfoo bar baz\ngoodbye world\n", encoding="utf-8", newline="\n"
     )
-    (text_dir / "file2.txt").write_text("nothing here\nhello again friend\nend\n", encoding="utf-8")
+    (text_dir / "file2.txt").write_text(
+        "nothing here\nhello again friend\nend\n", encoding="utf-8", newline="\n"
+    )
     # binary file
     (dir_path / "file3.bin").write_bytes(b"some binary data\0hello\0more data")
     return dir_path
@@ -25,6 +41,17 @@ def golden_fixture_dir(tmp_path_factory):
 TEXT_DIR_TARGET = ["text"]
 TEXT_FILE1_TARGET = ["text/file1.txt"]
 
+# KNOWN REAL DIVERGENCE (task #262, uncovered by de-blinding this suite -- left intentionally
+# RED on Windows, not xfailed/normalized away, per task instructions): `cpu_multi_file` and
+# `cpu_single_file` below exercise `tg search --cpu` (the Python/native, non-rg-routed
+# backend), which on Windows emits `\r\n` for a matched line whose source file is plain `\n`.
+# Independently reproduced in `tests/e2e/test_multi_pattern_native.py` (repro argv there:
+# `python -m tensor_grep search --cpu -e foo -e bar both.txt`) -- same root cause, second test
+# file. All the OTHER cases here (including `default_*`, which route through `RipgrepBackend`)
+# are unaffected: they correctly preserve a source file's own line ending (verified directly
+# against real `rg.exe`) rather than injecting a new one. Fixing the `--cpu` backend's stdout
+# emission is out of this PR's scope (`src/tensor_grep/` is off-limits here); this snapshot
+# assertion is left honest so CI documents the real bug instead of re-hiding it.
 GOLDEN_CASES = [
     ("default_multi_file", ["hello"], TEXT_DIR_TARGET),
     ("default_single_file", ["hello"], TEXT_FILE1_TARGET),
@@ -120,16 +147,23 @@ def run_tg(launcher, args, cwd):
         assert native_binary is not None, "Native binary not found. Please compile it first."
         cmd = [native_binary, "search", *args]
 
-    result = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
+    # Raw bytes -- no text=True. `text=True` runs the pipe through Python's
+    # universal-newlines TextIOWrapper, which translates a real `\r\n` in tg's own stdout to
+    # `\n` on Windows before this function (or the golden snapshot it feeds) ever sees it.
+    # Decoding strictly afterwards preserves any embedded `\r` verbatim and fails loudly on
+    # invalid UTF-8 instead of silently laundering it (task #262).
+    result = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True)
     assert result.returncode == 0, (
-        f"Command failed: {' '.join(cmd)}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        f"Command failed: {' '.join(cmd)}\n"
+        f"stdout: {decode_for_display(result.stdout)}\n"
+        f"stderr: {decode_for_display(result.stderr)}"
     )
-    stdout = result.stdout
+    stdout = result.stdout.decode("utf-8")
 
     # We remove routing/stats output as they are non-contractual metadata
     stdout = "\n".join(
         line
-        for line in stdout.splitlines()
+        for line in split_lines_preserve_cr(stdout)
         if not line.startswith("[routing]") and not line.startswith("[stats]")
     )
 
@@ -145,7 +179,7 @@ def run_tg(launcher, args, cwd):
     # is non-deterministic across OS/environments and is a non-contractual field.
     if "--json" in args or "--ndjson" in args:
         lines = []
-        for line in stdout.splitlines():
+        for line in split_lines_preserve_cr(stdout):
             if not line.strip():
                 continue
             try:
@@ -202,7 +236,11 @@ def run_tg(launcher, args, cwd):
         return "\n".join(lines) + "\n"
 
     if not stdout.strip().isdigit():
-        lines = [_normalize_relative_prefix(line) for line in stdout.splitlines() if line.strip()]
+        lines = [
+            _normalize_relative_prefix(line)
+            for line in split_lines_preserve_cr(stdout)
+            if line.strip()
+        ]
         lines.sort()
         stdout = "\n".join(lines) + "\n" if lines else ""
 

--- a/tests/e2e/test_output_golden_contract.py
+++ b/tests/e2e/test_output_golden_contract.py
@@ -41,17 +41,18 @@ def golden_fixture_dir(tmp_path_factory):
 TEXT_DIR_TARGET = ["text"]
 TEXT_FILE1_TARGET = ["text/file1.txt"]
 
-# KNOWN REAL DIVERGENCE (task #262, uncovered by de-blinding this suite -- left intentionally
-# RED on Windows, not xfailed/normalized away, per task instructions): `cpu_multi_file` and
-# `cpu_single_file` below exercise `tg search --cpu` (the Python/native, non-rg-routed
-# backend), which on Windows emits `\r\n` for a matched line whose source file is plain `\n`.
-# Independently reproduced in `tests/e2e/test_multi_pattern_native.py` (repro argv there:
-# `python -m tensor_grep search --cpu -e foo -e bar both.txt`) -- same root cause, second test
-# file. All the OTHER cases here (including `default_*`, which route through `RipgrepBackend`)
-# are unaffected: they correctly preserve a source file's own line ending (verified directly
-# against real `rg.exe`) rather than injecting a new one. Fixing the `--cpu` backend's stdout
-# emission is out of this PR's scope (`src/tensor_grep/` is off-limits here); this snapshot
-# assertion is left honest so CI documents the real bug instead of re-hiding it.
+# FIXED (task #262): de-blinding this suite (raw bytes instead of `text=True`-decoded
+# strings) first caught `cpu_multi_file`/`cpu_single_file` below -- `tg search --cpu` (the
+# Python/native, non-rg-routed backend) emitted `\r\n` for a matched line whose source file
+# was plain `\n`. Independently reproduced in `tests/e2e/test_multi_pattern_native.py`. Root
+# cause: `bootstrap.py::_force_utf8_streams` never pinned `newline="\n"` on `sys.stdout`, so
+# Python's default universal-newlines TEXT mode rewrote every `\n` a formatter emitted to
+# `os.linesep` on WRITE. Fixed there (now unconditional, even when the stream is already
+# UTF-8), plus a sibling READ-side bug in `CPUBackend`/`RustCoreBackend` (`.rstrip("\n\r")`
+# was eating a genuine trailing `\r` from a CRLF source file's own content, independent of
+# the stdout fix) -- see `strip_line_terminator` in `src/tensor_grep/core/result.py`. All the
+# OTHER cases here (including `default_*`, which route through `RipgrepBackend`) were always
+# correct: they preserve a source file's own line ending rather than injecting a new one.
 GOLDEN_CASES = [
     ("default_multi_file", ["hello"], TEXT_DIR_TARGET),
     ("default_single_file", ["hello"], TEXT_FILE1_TARGET),
@@ -272,3 +273,38 @@ def test_output_golden_contract_skips_native_when_binary_is_missing(monkeypatch)
 
     with pytest.raises(pytest.skip.Exception, match="Native binary not built"):
         _skip_if_native_binary_missing("native")
+
+
+def test_cpu_backend_crlf_file_round_trips_its_own_crlf(tmp_path):
+    """The other half of the task #262 bidirectional fix, on the RAW subprocess bytes (not
+    through `run_tg`'s snapshot-oriented normalization, which sorts/rejoins lines and would
+    obscure a byte-level CRLF-vs-LF difference). A genuinely CRLF-terminated source file must
+    round-trip its own `\\r\\n` through `tg search --cpu` -- fixing the LF-corruption bug
+    (`cpu_multi_file`/`cpu_single_file` above) must NOT start stripping, or doubling, a real
+    `\\r` that was already there. Cross-checked directly against real `rg.exe` on the
+    identical file.
+    """
+    (tmp_path / "crlf.txt").write_bytes(b"hello world\r\n")
+    env = dict(os.environ)
+    env["TG_DISABLE_NATIVE_TG"] = "1"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tensor_grep", "search", "--cpu", "hello", "crlf.txt"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+    )
+    assert result.returncode == 0, decode_for_display(result.stderr)
+    assert result.stdout == b"hello world\r\n"
+
+    from tensor_grep.cli.runtime_paths import resolve_ripgrep_binary
+
+    rg_binary = resolve_ripgrep_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for CRLF round-trip cross-check")
+    rg_result = subprocess.run(
+        [str(rg_binary), "hello", "crlf.txt"],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+    assert rg_result.stdout == result.stdout

--- a/tests/e2e/test_rg_parity_edges.py
+++ b/tests/e2e/test_rg_parity_edges.py
@@ -69,6 +69,14 @@ def _normalize(data: bytes, root: Path) -> list[bytes]:
     verbatim. Deliberately NOT the old blanket `data.replace(b"\r\n", b"\n")`: that collapse
     erased a genuine CRLF divergence between the two engines before comparison ever ran (see
     PR #742's independent gate finding, task #262).
+
+    KNOWN, ACKNOWLEDGED LIMIT (not closed here, independent-gate follow-up): the trailing
+    `.replace(b"\\", b"/")` below runs against the WHOLE line, not just a parsed-out path
+    prefix, so it is still a both-arms-lossy transform in the same shape this function
+    otherwise removes -- a real backslash-vs-forward-slash divergence inside MATCHED TEXT
+    content (not the file-path prefix) would cancel out identically on both arms. This
+    module's fixtures are plain ASCII sentinel words with no backslashes in their content,
+    so it has not been observed to mask a real failure, but it is a structural gap.
     """
     root_bytes = str(root).encode("utf-8")
     root_posix_bytes = root.as_posix().encode("utf-8")

--- a/tests/e2e/test_rg_parity_edges.py
+++ b/tests/e2e/test_rg_parity_edges.py
@@ -10,6 +10,8 @@ TESTS_DIR = Path(__file__).resolve().parents[1]
 if str(TESTS_DIR) not in sys.path:
     sys.path.insert(0, str(TESTS_DIR))
 
+from helpers.byte_parity import assert_bytes_equal, decode_for_display, run_bytes  # noqa: E402
+
 
 def _helpers():
     from helpers import rg_parity
@@ -41,6 +43,8 @@ def _write_edge_corpus(root: Path) -> None:
     binary_path = root / "binary.bin"
     binary_path.write_bytes(b"needle\0binary tail\n")
     (root / "binary_nomatch.bin").write_bytes(b"other\0binary tail\n")
+    # Repo bootstrap only -- not part of any rg-vs-tg comparison, so text=True here cannot
+    # hide a divergence between the two engines under test.
     subprocess.run(["git", "init"], cwd=root, check=False, capture_output=True, text=True)
 
 
@@ -49,30 +53,33 @@ def _run(
     *,
     cwd: Path,
     env: dict[str, str],
-    input_text: str | None = None,
-) -> subprocess.CompletedProcess[str]:
-    stdin = subprocess.DEVNULL if input_text is None else None
-    return subprocess.run(
-        argv,
-        cwd=cwd,
-        env=env,
-        input=input_text,
-        stdin=stdin,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    input_bytes: bytes | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    # Raw bytes only -- no text=/encoding=/errors=. See tests/helpers/byte_parity.py for why:
+    # `text=True` would silently translate a real `\r\n` in captured stdout to `\n` on
+    # Windows before either arm below is ever compared (task #262).
+    return run_bytes(argv, cwd=cwd, env=env, input_bytes=input_bytes)
 
 
-def _normalize(text: str, root: Path) -> list[str]:
-    normalized: list[str] = []
-    for line in text.replace("\r\n", "\n").splitlines():
+def _normalize(data: bytes, root: Path) -> list[bytes]:
+    r"""Normalize ONLY the two things that are genuinely non-contractual across platforms:
+    the absolute tmp-dir prefix (a pytest-generated path, never part of either engine's real
+    output contract) and the path separator (both rg and tg accept '/' and '\\' as
+    equivalent on Windows). Everything else -- including any embedded '\r' -- is compared
+    verbatim. Deliberately NOT the old blanket `data.replace(b"\r\n", b"\n")`: that collapse
+    erased a genuine CRLF divergence between the two engines before comparison ever ran (see
+    PR #742's independent gate finding, task #262).
+    """
+    root_bytes = str(root).encode("utf-8")
+    root_posix_bytes = root.as_posix().encode("utf-8")
+    normalized: list[bytes] = []
+    for line in data.split(b"\n"):
         if not line:
             continue
-        current = line.replace(str(root), ".").replace(root.as_posix(), ".").replace("\\", "/")
-        if current.startswith("./"):
+        current = (
+            line.replace(root_bytes, b".").replace(root_posix_bytes, b".").replace(b"\\", b"/")
+        )
+        if current.startswith(b"./"):
             current = current[2:]
         normalized.append(current)
     return normalized
@@ -86,22 +93,25 @@ def _assert_same_rg_behavior(
     env: dict[str, str],
     rg_binary: Path,
     compare_stdout: bool = True,
-    input_text: str | None = None,
+    input_bytes: bytes | None = None,
 ) -> None:
-    rg = _run([str(rg_binary), *rg_args], cwd=root, env=env, input_text=input_text)
+    rg = _run([str(rg_binary), *rg_args], cwd=root, env=env, input_bytes=input_bytes)
     tg = _run(
         [sys.executable, "-m", "tensor_grep", "search", *tg_args],
         cwd=root,
         env=env,
-        input_text=input_text,
+        input_bytes=input_bytes,
     )
 
     assert tg.returncode == rg.returncode, (
         f"rg exit={rg.returncode} tg exit={tg.returncode}\n"
-        f"rg stderr={rg.stderr}\ntg stderr={tg.stderr}"
+        f"rg stderr={decode_for_display(rg.stderr)}\ntg stderr={decode_for_display(tg.stderr)}"
     )
     if compare_stdout:
-        assert _normalize(tg.stdout, root) == _normalize(rg.stdout, root)
+        assert _normalize(tg.stdout, root) == _normalize(rg.stdout, root), (
+            f"rg stdout:\n{decode_for_display(rg.stdout)}\n"
+            f"tg stdout:\n{decode_for_display(tg.stdout)}"
+        )
 
 
 def _assert_same_rg_stdout_bytes(
@@ -121,9 +131,11 @@ def _assert_same_rg_stdout_bytes(
 
     assert tg.returncode == rg.returncode, (
         f"rg exit={rg.returncode} tg exit={tg.returncode}\n"
-        f"rg stderr={rg.stderr}\ntg stderr={tg.stderr}"
+        f"rg stderr={decode_for_display(rg.stderr)}\ntg stderr={decode_for_display(tg.stderr)}"
     )
-    assert tg.stdout.replace("\r\n", "\n") == rg.stdout.replace("\r\n", "\n")
+    # Byte-exact: no path-prefix or separator normalization here at all (that is the whole
+    # point of this comparator's name -- see test_rg_files_mode_preserves_rg_path_prefixes).
+    assert_bytes_equal(tg.stdout, rg.stdout, label="rg-vs-tg --files stdout")
 
 
 @pytest.fixture()
@@ -278,7 +290,7 @@ def test_rg_no_path_searches_piped_stdin(
         root=root,
         env=env,
         rg_binary=rg_binary,
-        input_text="stdin needle\nstdin other\n",
+        input_bytes=b"stdin needle\nstdin other\n",
     )
 
 
@@ -309,7 +321,7 @@ def test_rg_explicit_path_ignores_piped_stdin(
         root=root,
         env=env,
         rg_binary=rg_binary,
-        input_text="stdin needle\n",
+        input_bytes=b"stdin needle\n",
     )
 
 
@@ -349,12 +361,12 @@ def test_files_without_match_sort_excludes_binary_and_ignored_paths(
         env=env,
     )
 
-    assert tg.returncode == 0, tg.stderr
+    assert tg.returncode == 0, decode_for_display(tg.stderr)
     normalized = _normalize(tg.stdout, root)
-    assert normalized == ["c.txt"]
-    assert "binary.bin" not in normalized
-    assert "binary_nomatch.bin" not in normalized
-    assert "ignored/z.txt" not in normalized
+    assert normalized == [b"c.txt"]
+    assert b"binary.bin" not in normalized
+    assert b"binary_nomatch.bin" not in normalized
+    assert b"ignored/z.txt" not in normalized
 
 
 def test_files_without_match_text_mode_includes_binary_paths(

--- a/tests/e2e/test_ripgrep_parity.py
+++ b/tests/e2e/test_ripgrep_parity.py
@@ -1,6 +1,13 @@
-import subprocess
+import sys
+from pathlib import Path
 
 import pytest
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers.byte_parity import run_bytes  # noqa: E402
 
 pytestmark = pytest.mark.characterization
 PATTERNS = ["ERROR", "INFO", r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", "GET /api"]
@@ -9,16 +16,12 @@ PATTERNS = ["ERROR", "INFO", r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}", "GET /api"]
 class TestRipgrepParity:
     @pytest.mark.parametrize("pattern", PATTERNS)
     def test_output_lines_match_ripgrep(self, sample_log_file, rg_path, pattern):
-        rg = subprocess.run(
-            [rg_path, pattern, str(sample_log_file)],
-            capture_output=True,
-            text=True,
-        )
-        ours = subprocess.run(
-            ["tg", pattern, str(sample_log_file)],
-            capture_output=True,
-            text=True,
-        )
-        rg_lines = sorted(rg.stdout.strip().splitlines())
-        our_lines = sorted(ours.stdout.strip().splitlines())
+        # Raw bytes -- no text=True. Splitting on a bare b"\n" (not str.splitlines(), which
+        # treats \r\n/\r/\n as equivalent) keeps any trailing \r attached to its line so a
+        # real CRLF divergence between rg and tg would stay visible instead of being erased
+        # before comparison (task #262).
+        rg = run_bytes([rg_path, pattern, str(sample_log_file)])
+        ours = run_bytes(["tg", pattern, str(sample_log_file)])
+        rg_lines = sorted(line for line in rg.stdout.split(b"\n") if line)
+        our_lines = sorted(line for line in ours.stdout.split(b"\n") if line)
         assert our_lines == rg_lines

--- a/tests/e2e/test_routing_parity.py
+++ b/tests/e2e/test_routing_parity.py
@@ -15,6 +15,34 @@ import pytest
 from tensor_grep.cli.rg_contract import PUBLIC_SEARCH_HELP_FLAGS
 from tensor_grep.cli.runtime_paths import resolve_native_tg_binary
 
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers.byte_parity import split_lines_preserve_cr  # noqa: E402
+
+
+def _run_and_decode(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    r"""Capture raw bytes -- no `text=True` -- then decode strictly, preserving any real
+    `\r` verbatim. `text=True` runs the pipe through Python's universal-newlines
+    TextIOWrapper, which translates a real `\r\n` in a launcher's stdout to `\n` on Windows
+    before this file's launcher-vs-launcher comparisons (`test_routing_parity_matrix`, the
+    help-contract tests) ever see it -- the same lossy transform applied identically to every
+    launcher, so a genuine divergence between them (e.g. the native Rust binary's `println!`
+    vs the Python launcher's own line-printing) would cancel out and read as parity (task
+    #262). `bytes.decode()` (unlike `text=True`) does not perform newline translation, only
+    character decoding, so this keeps every other call site's existing string-based logic
+    working unchanged while closing the OS-level blind spot at the subprocess boundary.
+    """
+    completed_bytes = subprocess.run(cmd, capture_output=True, **kwargs)
+    return subprocess.CompletedProcess(
+        args=completed_bytes.args,
+        returncode=completed_bytes.returncode,
+        stdout=completed_bytes.stdout.decode("utf-8"),
+        stderr=completed_bytes.stderr.decode("utf-8"),
+    )
+
+
 PUBLIC_TOP_LEVEL_COMMANDS = {
     "agent",
     "search",
@@ -106,12 +134,10 @@ def _run_native_front_door(
 ) -> subprocess.CompletedProcess[str]:
     native_binary = _get_native_binary()
     if native_binary is not None:
-        return subprocess.run(
+        return _run_and_decode(
             [native_binary, *args],
             cwd=cwd,
             env=env,
-            capture_output=True,
-            text=True,
         )
 
     cargo_exe = _resolve_cargo_exe()
@@ -119,7 +145,7 @@ def _run_native_front_door(
         pytest.skip("native front door not available in this environment")
 
     manifest_path = Path(__file__).resolve().parents[2] / "rust_core" / "Cargo.toml"
-    return subprocess.run(
+    return _run_and_decode(
         [
             str(cargo_exe),
             "run",
@@ -133,8 +159,6 @@ def _run_native_front_door(
         ],
         cwd=cwd,
         env=env,
-        capture_output=True,
-        text=True,
     )
 
 
@@ -157,7 +181,7 @@ def run_command(
     else:
         raise ValueError(f"Unknown launcher {launcher}")
 
-    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    return _run_and_decode(cmd, cwd=cwd)
 
 
 LAUNCHERS = ["python-m", "native", "bootstrap"]
@@ -427,11 +451,16 @@ def test_routing_parity_matrix(
         )
 
         # To compare stdout/stderr we ignore execution time logs, routing reason logs, or other non-deterministic stuff.
+        # NOTE: split_lines_preserve_cr, not str.splitlines() -- this feeds the direct
+        # `la_stdout == bl_stdout` launcher-vs-launcher comparison below, and
+        # str.splitlines() would silently drop a real `\r`, letting a genuine line-ending
+        # divergence between launchers (e.g. native `println!` vs the Python launcher's own
+        # printing) cancel out identically on both sides (task #262).
         def clean_output(output: str) -> str:
             output = output.replace("bootstrap.py", "python -m tensor_grep")
             lines = [
                 line
-                for line in output.splitlines()
+                for line in split_lines_preserve_cr(output)
                 if not line.startswith("[routing]") and not line.startswith("[stats]")
             ]
             return "\n".join(lines)

--- a/tests/e2e/test_vs_ripgrep.py
+++ b/tests/e2e/test_vs_ripgrep.py
@@ -1,8 +1,15 @@
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import pytest
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers.byte_parity import run_bytes  # noqa: E402
 
 pytestmark = [pytest.mark.slow, pytest.mark.performance]
 
@@ -68,14 +75,18 @@ class TestVsRipgrep:
         # Pattern matches 'apple' only if followed by ' banana' (positive lookahead)
         pattern = r"apple(?= banana)"
 
-        res = subprocess.run(
-            [sys.executable, "-m", "tensor_grep.cli.main", "search", "-P", pattern, str(log)],
-            capture_output=True,
-            text=True,
-        )
+        res = run_bytes([
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.main",
+            "search",
+            "-P",
+            pattern,
+            str(log),
+        ])
         assert res.returncode == 0
-        assert "apple banana" in res.stdout
-        assert "orange banana" not in res.stdout
+        assert b"apple banana" in res.stdout
+        assert b"orange banana" not in res.stdout
 
     def test_max_filesize_respected(self, tmp_path):
         """Verify that --max-filesize correctly skips large files."""
@@ -86,21 +97,17 @@ class TestVsRipgrep:
         large_file.write_text("match_me" + ("x" * 1024 * 1024), encoding="utf-8")  # ~1MB
 
         # Searching with 100KB limit should skip large_file
-        res = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "tensor_grep.cli.main",
-                "search",
-                "--max-filesize",
-                "100K",
-                "match_me",
-                str(tmp_path),
-            ],
-            capture_output=True,
-            text=True,
-        )
+        res = run_bytes([
+            sys.executable,
+            "-m",
+            "tensor_grep.cli.main",
+            "search",
+            "--max-filesize",
+            "100K",
+            "match_me",
+            str(tmp_path),
+        ])
 
         # Depending on how ripgrep handles stdout, it might return 0 if any matches or 1 if some skipped
-        assert "small.txt" in res.stdout
-        assert "large.txt" not in res.stdout
+        assert b"small.txt" in res.stdout
+        assert b"large.txt" not in res.stdout

--- a/tests/helpers/byte_parity.py
+++ b/tests/helpers/byte_parity.py
@@ -28,6 +28,8 @@ import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+from tensor_grep.core.result import split_source_lines
+
 
 def run_bytes(
     argv: Sequence[str],
@@ -106,22 +108,12 @@ def split_lines_bytes(data: bytes) -> list[bytes]:
     return data.split(b"\n")
 
 
-def split_lines_preserve_cr(text: str) -> list[str]:
-    r"""Split on a bare ``\n`` only, leaving any trailing ``\r`` attached to its line.
-
-    A ``str``-typed sibling of ``split_lines_bytes`` for call sites that must decode before
-    splitting (e.g. to run the result through ``json.loads`` or an existing string-based
-    normalizer). ``str.splitlines()`` has the exact same blindness as
-    ``bytes.splitlines()`` -- it treats ``\r\n`` as one line break, silently dropping a real
-    ``\r``. Unlike ``split_lines_bytes``, this mirrors ``str.splitlines()``'s line COUNT for
-    well-formed input by dropping one spurious trailing empty element produced by a single
-    final ``\n`` (``"a\nb\n".split("\n")`` has a trailing ``""`` that ``"a\nb\n".splitlines()``
-    does not), so a caller that previously assumed that invariant does not silently gain an
-    extra blank entry -- only a genuine embedded/trailing ``\r`` now survives.
-    """
-    if text == "":
-        return []
-    lines = text.split("\n")
-    if lines and lines[-1] == "":
-        lines.pop()
-    return lines
+# `str`-typed sibling of `split_lines_bytes`, for call sites that must decode before
+# splitting (e.g. to run the result through `json.loads` or an existing string-based
+# normalizer). This used to be a second, byte-identical implementation of the exact same
+# "split on a bare `\n`, drop one trailing empty element" logic as
+# `tensor_grep.core.result.split_source_lines` -- the identical drift shape this whole
+# module exists to eliminate elsewhere (one lossy-normalization behavior implemented twice,
+# free to silently diverge). Re-exported under this module's existing public name instead
+# (test_output_golden_contract.py and test_routing_parity.py already import it from here).
+split_lines_preserve_cr = split_source_lines

--- a/tests/helpers/byte_parity.py
+++ b/tests/helpers/byte_parity.py
@@ -1,0 +1,127 @@
+"""Shared RAW-BYTE comparison helper for the rg-vs-tg (and launcher-vs-launcher) parity
+test suites.
+
+Task #262: the parity suites compared `tg` output against `rg` output (or one launcher
+against another) after applying the SAME lossy transformation to BOTH arms -- `text=True`
+subprocess captures (Python's universal-newlines mode silently rewrites ``\\r\\n`` ->
+``\\n`` in captured stdout on Windows) and/or an explicit ``text.replace("\\r\\n", "\\n")``
+normalize step, plus ``errors="replace"`` mapping invalid UTF-8 bytes to U+FFFD on both
+sides. A genuine divergence between the two engines cancels out under an identical lossy
+transform and reads as parity even though it is not. An independent gate on PR #742 found
+three real DATA-level divergences this blindness hid: a lost trailing ``\\r`` on CRLF
+input, non-UTF-8 bytes becoming U+FFFD, and a spurious empty-pattern stderr line.
+
+The fix: capture subprocess output as raw ``bytes`` (no ``text=``/``encoding=``/``errors=``
+on the ``subprocess.run`` call) and compare ``bytes`` to ``bytes``. Decode only when
+rendering a human-readable failure message, and even then with ``errors="backslashreplace"``
+so an invalid byte stays visibly distinguishable from a real U+FFFD character rather than
+collapsing into an identical-looking replacement glyph.
+
+Any normalization that is genuinely warranted (platform path separators, for instance) must
+stay NARROW and explicitly named at the call site, with a comment justifying why it cannot
+hide a real divergence -- never a blanket newline or encoding flattening applied here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+
+def run_bytes(
+    argv: Sequence[str],
+    *,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+    input_bytes: bytes | None = None,
+    stdin: int | None = None,
+    check: bool = False,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    """Run a subprocess and capture RAW bytes -- no decoding, no newline translation.
+
+    Deliberately omits ``text=``/``encoding=``/``errors=``. Passing ``text=True`` (or
+    ``encoding=``) switches ``subprocess.run`` into universal-newlines mode, which
+    translates ``\\r\\n`` -> ``\\n`` in captured stdout on Windows *before the caller ever
+    sees it* -- exactly the blindness this module exists to remove. Callers that need a
+    human-readable string must call ``decode_for_display`` explicitly; nothing here decodes
+    implicitly.
+    """
+    if stdin is None:
+        stdin = subprocess.DEVNULL if input_bytes is None else None
+    return subprocess.run(
+        list(argv),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        input=input_bytes,
+        stdin=stdin,
+        capture_output=True,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def decode_for_display(data: bytes) -> str:
+    """Decode bytes ONLY for a human-readable assertion message -- never for comparison.
+
+    Uses ``errors="backslashreplace"`` so an invalid byte renders as a visible escape
+    (``\\xNN``) instead of silently collapsing to U+FFFD, the same glyph a genuinely valid
+    UTF-8 replacement character would produce. Using ``errors="replace"`` here would
+    reintroduce, in the failure message alone, the exact masking this helper is meant to
+    eliminate from the comparison.
+    """
+    return data.decode("utf-8", errors="backslashreplace")
+
+
+def assert_bytes_equal(actual: bytes, expected: bytes, *, label: str = "") -> None:
+    """The core byte-exact parity comparator. No implicit normalization of any kind.
+
+    A caller that legitimately needs to ignore a cosmetic difference (platform path
+    separators, for instance) must perform a NARROW, explicitly-named, commented
+    transformation on both sides *before* calling this -- never bake a blanket newline or
+    encoding flattening in here, which would silently re-open the oracle blindness this
+    helper exists to close.
+    """
+    if actual == expected:
+        return
+    prefix = f"{label}: " if label else ""
+    raise AssertionError(
+        f"{prefix}byte-level mismatch\n"
+        f"--- expected ({len(expected)} bytes) ---\n{decode_for_display(expected)}\n"
+        f"--- actual ({len(actual)} bytes) ---\n{decode_for_display(actual)}"
+    )
+
+
+def split_lines_bytes(data: bytes) -> list[bytes]:
+    """Split on a bare LF only, leaving any trailing CR attached to its line.
+
+    ``bytes.splitlines()`` treats ``\\r\\n``, a bare ``\\r``, and a bare ``\\n`` (plus
+    several Unicode-only separators) as equivalent line breaks -- exactly the blindness
+    this module exists to avoid, since it would silently strip a genuine trailing ``\\r``
+    from a CRLF-terminated line before a caller ever gets to compare it. Splitting on
+    ``b"\\n"`` alone preserves a trailing ``\\r`` as part of the line's content, so a
+    CRLF-vs-LF divergence stays visible in the split result.
+    """
+    return data.split(b"\n")
+
+
+def split_lines_preserve_cr(text: str) -> list[str]:
+    r"""Split on a bare ``\n`` only, leaving any trailing ``\r`` attached to its line.
+
+    A ``str``-typed sibling of ``split_lines_bytes`` for call sites that must decode before
+    splitting (e.g. to run the result through ``json.loads`` or an existing string-based
+    normalizer). ``str.splitlines()`` has the exact same blindness as
+    ``bytes.splitlines()`` -- it treats ``\r\n`` as one line break, silently dropping a real
+    ``\r``. Unlike ``split_lines_bytes``, this mirrors ``str.splitlines()``'s line COUNT for
+    well-formed input by dropping one spurious trailing empty element produced by a single
+    final ``\n`` (``"a\nb\n".split("\n")`` has a trailing ``""`` that ``"a\nb\n".splitlines()``
+    does not), so a caller that previously assumed that invariant does not silently gain an
+    extra blank entry -- only a genuine embedded/trailing ``\r`` now survives.
+    """
+    if text == "":
+        return []
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines

--- a/tests/helpers/rg_parity.py
+++ b/tests/helpers/rg_parity.py
@@ -554,8 +554,22 @@ def _normalize_rg_json_events(
 
 
 def _normalize_line(line: bytes, *, corpus: RGParityCorpus) -> bytes:
-    # NARROW, byte-level normalization: only the pytest tmp-dir prefix (non-contractual on
-    # both engines) and the platform path separator. Never a newline or encoding collapse.
+    # NARROW, byte-level normalization: the pytest tmp-dir prefix (non-contractual on both
+    # engines) and the platform path separator. Never a newline or encoding collapse.
+    #
+    # KNOWN, ACKNOWLEDGED LIMIT (not closed by task #262, independent-gate follow-up):
+    # `.replace(b"\\", b"/")` below runs against the WHOLE line -- this helper does not
+    # parse "path:line:text" apart, so it cannot narrow the replacement to just the leading
+    # path portion without risking a wrong split on content containing its own ":" or "\\".
+    # That means it is still a both-arms-lossy transform in the same shape this PR removed
+    # elsewhere: a real backslash-vs-forward-slash divergence inside MATCHED TEXT content
+    # (not just the file-path prefix) would cancel out here identically on the tg and rg
+    # arms and read as parity. The corpus fixtures this helper compares are plain ASCII
+    # sentinel words with no backslashes in their content, so this has not been observed to
+    # mask a real failure -- but it is a structural gap, not a proven-safe one, and a future
+    # corpus/pattern that legitimately contains a backslash in matched text would not be
+    # caught here. Left as-is rather than risk destabilizing this comparator (used by every
+    # `test_rg_parity_matrix.py` row) with an unproven "path-prefix-only" parse.
     root_bytes = str(corpus.root).encode("utf-8")
     root_posix_bytes = corpus.root.as_posix().encode("utf-8")
     normalized = line.replace(root_bytes, b".")

--- a/tests/helpers/rg_parity.py
+++ b/tests/helpers/rg_parity.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from tensor_grep.cli.rg_contract import RGContractRow
 from tensor_grep.cli.runtime_paths import resolve_ripgrep_binary
+from tensor_grep.core.result import strip_line_terminator
 
 from .byte_parity import decode_for_display, run_bytes
 
@@ -491,6 +492,12 @@ def _normalize_machine_output(
     tool: str,
     corpus: RGParityCorpus,
 ) -> dict[str, list[tuple[str, int, str]]]:
+    # The JSON leg's "text" field is normalized via the shared `strip_line_terminator`
+    # (`.removesuffix("\n")`, never `.rstrip("\r\n")`), applied identically to both the
+    # "tg" and "rg" arms below. `.rstrip("\r\n")` strips ANY trailing run of `\r`/`\n`,
+    # which would erase a genuine trailing `\r` from a CRLF source line's own content on
+    # BOTH arms -- the exact both-arms-lossy shape task #262 removed from the raw-byte
+    # comparators in this module; this JSON leg had the identical defect independently.
     if not data.strip():
         return {"matches": []}
 
@@ -511,7 +518,7 @@ def _normalize_machine_output(
                 matches.append((
                     _normalize_path(str(match["file"]), corpus=corpus),
                     int(match.get("line", match.get("line_number"))),
-                    str(match["text"]).rstrip("\r\n"),
+                    strip_line_terminator(str(match["text"])),
                 ))
             return {"matches": sorted(matches)}
 
@@ -519,7 +526,7 @@ def _normalize_machine_output(
             matches.append((
                 _normalize_path(str(row["file"]), corpus=corpus),
                 int(row.get("line", row.get("line_number"))),
-                str(row["text"]).rstrip("\r\n"),
+                strip_line_terminator(str(row["text"])),
             ))
         return {"matches": sorted(matches)}
 
@@ -541,7 +548,7 @@ def _normalize_rg_json_events(
         matches.append((
             _normalize_path(str(data["path"]["text"]), corpus=corpus),
             int(data["line_number"]),
-            str(data["lines"]["text"]).rstrip("\r\n"),
+            strip_line_terminator(str(data["lines"]["text"])),
         ))
     return {"matches": sorted(matches)}
 

--- a/tests/helpers/rg_parity.py
+++ b/tests/helpers/rg_parity.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from tensor_grep.cli.rg_contract import RGContractRow
 from tensor_grep.cli.runtime_paths import resolve_ripgrep_binary
 
+from .byte_parity import decode_for_display, run_bytes
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DIR = REPO_ROOT / "src"
 WINDOWS_RG_DIRNAME = "ripgrep-14.1.0-x86_64-pc-windows-msvc"
@@ -45,8 +47,8 @@ class RGParityCase:
 class CommandResult:
     argv: tuple[str, ...]
     returncode: int
-    stdout: str
-    stderr: str
+    stdout: bytes
+    stderr: bytes
 
 
 @dataclass(frozen=True)
@@ -341,7 +343,7 @@ def build_command_env(rg_binary: Path) -> dict[str, str]:
 
 
 def normalize_output(
-    output: str,
+    output: bytes,
     *,
     case: RGParityCase,
     tool: str,
@@ -355,7 +357,7 @@ def normalize_output(
     return tuple(_normalize_plain_lines(output, corpus=corpus))
 
 
-def normalize_stderr(stderr: str, *, corpus: RGParityCorpus) -> tuple[str, ...]:
+def normalize_stderr(stderr: bytes, *, corpus: RGParityCorpus) -> tuple[bytes, ...]:
     return tuple(_normalize_plain_lines(stderr, corpus=corpus))
 
 
@@ -453,17 +455,11 @@ def _run_command(
     cwd: Path,
     env: dict[str, str],
 ) -> CommandResult:
-    completed = subprocess.run(
-        list(argv),
-        cwd=cwd,
-        env=env,
-        stdin=subprocess.DEVNULL,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    # Raw bytes only. `text=True`/`encoding=`/`errors="replace"` used to translate a real
+    # `\r\n` to `\n` (universal-newlines mode) and map invalid UTF-8 bytes to U+FFFD before
+    # either arm was ever compared -- both lossy transforms applied identically to rg and tg,
+    # so a genuine divergence between them cancelled out and read as parity (task #262).
+    completed = run_bytes(argv, cwd=cwd, env=env, stdin=subprocess.DEVNULL)
     return CommandResult(
         argv=argv,
         returncode=int(completed.returncode),
@@ -478,26 +474,32 @@ def _cli_target(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
 
 
-def _normalize_plain_lines(text: str, *, corpus: RGParityCorpus) -> list[str]:
-    if not text:
+def _normalize_plain_lines(data: bytes, *, corpus: RGParityCorpus) -> list[bytes]:
+    r"""Split on `\n` only and normalize path prefixes/separators. Deliberately does NOT
+    blanket-replace `\r\n` -> `\n` first (the pre-#262 behavior): that collapse applied the
+    identical lossy transform to both the rg and tg arms, so a real CRLF divergence between
+    them cancelled out before comparison ever ran.
+    """
+    if not data:
         return []
-    return [
-        _normalize_line(line, corpus=corpus)
-        for line in text.replace("\r\n", "\n").split("\n")
-        if line
-    ]
+    return [_normalize_line(line, corpus=corpus) for line in data.split(b"\n") if line]
 
 
 def _normalize_machine_output(
-    text: str,
+    data: bytes,
     *,
     tool: str,
     corpus: RGParityCorpus,
 ) -> dict[str, list[tuple[str, int, str]]]:
-    if not text.strip():
+    if not data.strip():
         return {"matches": []}
 
-    rows = [json.loads(line) for line in text.splitlines() if line.strip()]
+    # json.loads accepts raw bytes directly (RFC 8259 auto-detects UTF-8/16/32) and decodes
+    # strictly -- no errors="replace" laundering of invalid bytes into U+FFFD before either
+    # arm is compared. ripgrep's own --json output already base64-encodes any non-UTF-8 line
+    # tail into a `bytes` field rather than emitting invalid JSON, so this stays strict
+    # without needing a fallback.
+    rows = [json.loads(line) for line in data.split(b"\n") if line.strip()]
     matches: list[tuple[str, int, str]] = []
 
     if tool == "tg":
@@ -544,11 +546,15 @@ def _normalize_rg_json_events(
     return {"matches": sorted(matches)}
 
 
-def _normalize_line(line: str, *, corpus: RGParityCorpus) -> str:
-    normalized = line.replace(str(corpus.root), ".")
-    normalized = normalized.replace(corpus.root.as_posix(), ".")
-    normalized = normalized.replace("\\", "/")
-    if normalized.startswith("./"):
+def _normalize_line(line: bytes, *, corpus: RGParityCorpus) -> bytes:
+    # NARROW, byte-level normalization: only the pytest tmp-dir prefix (non-contractual on
+    # both engines) and the platform path separator. Never a newline or encoding collapse.
+    root_bytes = str(corpus.root).encode("utf-8")
+    root_posix_bytes = corpus.root.as_posix().encode("utf-8")
+    normalized = line.replace(root_bytes, b".")
+    normalized = normalized.replace(root_posix_bytes, b".")
+    normalized = normalized.replace(b"\\", b"/")
+    if normalized.startswith(b"./"):
         normalized = normalized[2:]
     return normalized
 
@@ -562,8 +568,11 @@ def _normalize_path(path: str, *, corpus: RGParityCorpus) -> str:
     return normalized
 
 
-def _display_blob(text: str, *, corpus: RGParityCorpus) -> str:
-    normalized_lines = _normalize_plain_lines(text, corpus=corpus)
+def _display_blob(data: bytes, *, corpus: RGParityCorpus) -> str:
+    normalized_lines = _normalize_plain_lines(data, corpus=corpus)
     if not normalized_lines:
         return "<empty>"
-    return "\n".join(normalized_lines)
+    # decode_for_display uses errors="backslashreplace" -- an invalid byte shows up as a
+    # visible `\xNN` escape rather than collapsing to the same U+FFFD glyph a genuinely
+    # valid replacement character would render as.
+    return "\n".join(decode_for_display(line) for line in normalized_lines)

--- a/tests/integration/test_cross_backend.py
+++ b/tests/integration/test_cross_backend.py
@@ -99,7 +99,9 @@ def native_gpu_available(
     command_env: dict[str, str],
 ) -> None:
     probe = tmp_path / "gpu_probe.log"
-    probe.write_text("gpu probe sentinel\n", encoding="utf-8")
+    # newline="\n" pins this fixture to LF regardless of platform default (task #262: without
+    # it, Path.write_text() would silently write CRLF on Windows).
+    probe.write_text("gpu probe sentinel\n", encoding="utf-8", newline="\n")
     result = _run_command(
         [
             str(native_tg_binary),
@@ -131,16 +133,34 @@ def native_gpu_available(
 
 
 def _run_command(command: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+    # Raw bytes, decoded afterwards -- no `text=True`. `text=True` runs the pipe through
+    # Python's universal-newlines TextIOWrapper, which translates a real `\r\n` in ANY of the
+    # four backends' stdout (native CPU, native GPU, TrigramIndex, rg-passthrough) to `\n` on
+    # Windows BEFORE `json.loads` ever sees it -- so all four would come out uniformly
+    # \r-less and "match" even if only some of them actually preserve a CRLF source file's
+    # own `\r` (the cross-backend comparisons below parse this JSON and diff the resulting
+    # `text` fields, so this masking applies even though the comparison itself is on parsed
+    # values, not raw bytes -- task #262). `bytes.decode()` (unlike `text=True`) performs no
+    # newline translation, so this closes that blind spot while keeping every downstream
+    # string-based assertion in this file working unchanged. `errors="replace"` on the decode
+    # (not on the newline handling) is intentionally KEPT here, unlike the newline fix: this
+    # file's corpus/error-message content is not exercising the encoding-divergence leg of
+    # task #262, and a hard decode failure here would abort the whole integration run instead
+    # of failing one assertion -- a worse failure mode for a suite that cannot be re-run
+    # locally without a compiled native binary.
+    completed_bytes = subprocess.run(
         command,
         cwd=REPO_ROOT,
         env=env,
         stdin=subprocess.DEVNULL,
         capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
         check=False,
+    )
+    return subprocess.CompletedProcess(
+        args=completed_bytes.args,
+        returncode=completed_bytes.returncode,
+        stdout=completed_bytes.stdout.decode("utf-8", errors="replace"),
+        stderr=completed_bytes.stderr.decode("utf-8", errors="replace"),
     )
 
 
@@ -157,6 +177,7 @@ def _write_cross_backend_corpus(root: Path, *, file_count: int) -> Path:
         (root / f"shard_{file_index:03}.log").write_text(
             "\n".join(lines) + "\n",
             encoding="utf-8",
+            newline="\n",
         )
     return root
 
@@ -171,6 +192,7 @@ def _write_ast_fixture(root: Path) -> Path:
         "        return y\n"
         "    return None\n",
         encoding="utf-8",
+        newline="\n",
     )
     return file_path
 
@@ -369,7 +391,7 @@ def test_positional_replace_should_not_mutate_files(
 ) -> None:
     target = tmp_path / "replace-target.txt"
     original = "hello world\n"
-    target.write_text(original, encoding="utf-8")
+    target.write_text(original, encoding="utf-8", newline="\n")
 
     result = _run_command(
         [

--- a/tests/integration/test_harness_adoption.py
+++ b/tests/integration/test_harness_adoption.py
@@ -37,16 +37,25 @@ def command_env(native_tg_binary: Path) -> dict[str, str]:
 
 
 def _run(command: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+    # Raw bytes, decoded afterwards -- no `text=True`. See the identical fix (and its full
+    # rationale) in tests/integration/test_cross_backend.py::_run_command -- `text=True`
+    # would translate a real `\r\n` in the native binary's stdout to `\n` on Windows before
+    # `json.loads`/the `--- `/`+++ `/`@@` diff-header substring checks below ever see it
+    # (task #262). `errors="replace"` on the decode is intentionally kept for the same
+    # not-locally-re-runnable-without-a-compiled-binary reason as that sibling file.
+    completed_bytes = subprocess.run(
         command,
         cwd=REPO_ROOT,
         env=env,
         stdin=subprocess.DEVNULL,
         capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
         check=False,
+    )
+    return subprocess.CompletedProcess(
+        args=completed_bytes.args,
+        returncode=completed_bytes.returncode,
+        stdout=completed_bytes.stdout.decode("utf-8", errors="replace"),
+        stderr=completed_bytes.stderr.decode("utf-8", errors="replace"),
     )
 
 
@@ -67,8 +76,10 @@ def test_public_cli_harness_flow_search_rewrite_and_verify(
     project.mkdir()
     log_file = project / "app.log"
     source_file = project / "rewrite_fixture.py"
-    log_file.write_text("INFO boot\nERROR timeout while connecting\n", encoding="utf-8")
-    source_file.write_text("def add(x, y): return x + y\n", encoding="utf-8")
+    log_file.write_text(
+        "INFO boot\nERROR timeout while connecting\n", encoding="utf-8", newline="\n"
+    )
+    source_file.write_text("def add(x, y): return x + y\n", encoding="utf-8", newline="\n")
 
     search_result = _run(
         [str(native_tg_binary), "search", "--json", "ERROR", str(project)],
@@ -88,7 +99,10 @@ def test_public_cli_harness_flow_search_rewrite_and_verify(
         env=command_env,
     )
     _assert_success(ndjson_result, context="search --ndjson")
-    ndjson_rows = [json.loads(line) for line in ndjson_result.stdout.splitlines() if line.strip()]
+    # split on "\n" (not str.splitlines(), same reasoning as _run above) so a genuine \r
+    # embedded in a record stays visible to anyone inspecting a parse failure, though
+    # json.loads itself tolerates trailing \r as insignificant whitespace either way.
+    ndjson_rows = [json.loads(line) for line in ndjson_result.stdout.split("\n") if line.strip()]
     assert ndjson_rows
     assert any(row["file"].endswith("app.log") for row in ndjson_rows)
     assert all(row["version"] == 1 for row in ndjson_rows)
@@ -173,8 +187,10 @@ def test_public_mcp_tools_roundtrip_against_native_binary(
     project.mkdir()
     log_file = project / "app.log"
     source_file = project / "rewrite_fixture.py"
-    log_file.write_text("INFO boot\nERROR timeout while connecting\n", encoding="utf-8")
-    source_file.write_text("def add(x, y): return x + y\n", encoding="utf-8")
+    log_file.write_text(
+        "INFO boot\nERROR timeout while connecting\n", encoding="utf-8", newline="\n"
+    )
+    source_file.write_text("def add(x, y): return x + y\n", encoding="utf-8", newline="\n")
 
     monkeypatch.setenv("TG_MCP_TG_BINARY", command_env["TG_MCP_TG_BINARY"])
     mcp_server.resolve_native_tg_binary.cache_clear()

--- a/tests/unit/test_byte_parity_helper.py
+++ b/tests/unit/test_byte_parity_helper.py
@@ -1,0 +1,164 @@
+"""Bidirectional-oracle proof for `tests/helpers/byte_parity.py` (task #262).
+
+No `tg`/`rg` binary is invoked anywhere in this file -- these are pure unit tests against
+synthetic byte strings, which is what makes them runnable without a compiled binary and
+what makes the bidirectional gate below meaningful: the ONLY acceptable evidence that the
+oracle is fixed is that it REJECTS what the broken (pre-fix) oracle ACCEPTED.
+
+Each divergence class below is proven in both directions:
+  1. the NEW byte-exact comparison REJECTS it (the fix works), and
+  2. the OLD lossy comparison (kept here, explicitly named, as
+     `_legacy_lossy_normalize` / inline `errors="replace"` decode) ACCEPTED it (proving the
+     old oracle really was blind -- a passing "new" test alone proves nothing).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from helpers.byte_parity import (  # noqa: E402
+    assert_bytes_equal,
+    decode_for_display,
+    split_lines_bytes,
+    split_lines_preserve_cr,
+)
+
+
+def _legacy_lossy_normalize(text: str) -> str:
+    """The PRE-FIX transform this task replaces (mirrors `_normalize` in
+    `test_rg_parity_edges.py` and `test_multi_pattern_native.py` before task #262):
+    ``text.replace("\\r\\n", "\\n")``. Kept here, explicitly named, ONLY to demonstrate the
+    contrast with the fixed oracle below -- no production test imports this function.
+    """
+    return text.replace("\r\n", "\n")
+
+
+# --- 1. CRLF vs LF: the fixed oracle must REJECT, the legacy one ACCEPTED. -----------------
+
+
+def test_new_comparison_rejects_crlf_vs_lf_only_difference() -> None:
+    crlf = b"match one\r\nmatch two\r\n"
+    lf_only = b"match one\nmatch two\n"
+
+    with pytest.raises(AssertionError):
+        assert_bytes_equal(crlf, lf_only)
+
+
+def test_legacy_lossy_normalize_would_have_accepted_the_same_crlf_pair() -> None:
+    # Proves the FAILING direction demanded by the bidirectional gate: the pre-fix oracle
+    # (a blanket \r\n -> \n replace applied identically to both arms, as
+    # `test_rg_parity_edges.py::_normalize` used to do) could not see this divergence at
+    # all -- it reported these two byte strings as equal.
+    crlf_text = "match one\r\nmatch two\r\n"
+    lf_text = "match one\nmatch two\n"
+
+    assert _legacy_lossy_normalize(crlf_text) == _legacy_lossy_normalize(lf_text)
+
+
+# --- 2. Raw invalid UTF-8 vs an already-mangled U+FFFD: fixed REJECTS, legacy ACCEPTED. ----
+
+
+def test_new_comparison_rejects_raw_invalid_utf8_vs_replacement_char() -> None:
+    raw_invalid_byte = b"needle \xff tail\n"
+    already_mangled = "needle � tail\n".encode()
+
+    with pytest.raises(AssertionError):
+        assert_bytes_equal(raw_invalid_byte, already_mangled)
+
+
+def test_legacy_errors_replace_would_have_accepted_the_same_encoding_pair() -> None:
+    # Mirrors `errors="replace"` at (pre-fix) test_rg_parity_edges.py:64,
+    # tests/helpers/rg_parity.py:464, and test_multi_pattern_native.py:84: decoding BOTH
+    # arms with errors="replace" maps the raw invalid byte onto the same U+FFFD glyph the
+    # "already mangled" string already contains, so the two collapse to an identical
+    # decoded string and the raw-byte divergence disappears before comparison.
+    raw_invalid_byte = b"needle \xff tail\n"
+    already_mangled = "needle � tail\n".encode()
+
+    decoded_invalid = raw_invalid_byte.decode("utf-8", errors="replace")
+    decoded_mangled = already_mangled.decode("utf-8", errors="replace")
+
+    assert decoded_invalid == decoded_mangled
+
+
+# --- 3. Genuinely identical bytes: the fixed oracle must still ACCEPT (not always-fail). --
+
+
+def test_new_comparison_accepts_genuinely_identical_bytes() -> None:
+    payload = b"identical payload\nacross both arms\n"
+
+    assert_bytes_equal(payload, payload)  # must not raise
+
+
+def test_new_comparison_accepts_identical_bytes_containing_real_crlf_on_both_sides() -> None:
+    # A REAL, matching CRLF stream on both arms is still parity -- the fix must not turn
+    # every CRLF-emitting tool into a permanent failure, only a genuine cross-arm mismatch.
+    payload = b"one\r\ntwo\r\n"
+
+    assert_bytes_equal(payload, payload)
+
+
+# --- split_lines_bytes: must not silently borrow str.splitlines()'s universal-newline set. -
+
+
+def test_split_lines_bytes_keeps_trailing_cr_attached_to_its_line() -> None:
+    assert split_lines_bytes(b"a\r\nb\n") == [b"a\r", b"b", b""]
+
+
+def test_split_lines_bytes_does_not_treat_a_bare_cr_as_a_line_break() -> None:
+    # bytes.splitlines() WOULD split b"a\rb\n" into [b"a", b"b", b""], eating the \r; the
+    # narrow LF-only split here must not.
+    assert split_lines_bytes(b"a\rb\n") == [b"a\rb", b""]
+
+
+# --- split_lines_preserve_cr: the str-typed sibling, used by callers that must decode ------
+# before splitting (e.g. to json.loads a line). Same CR-preservation guarantee, but mirrors
+# str.splitlines()'s line COUNT for well-formed trailing-newline input.
+
+
+def test_split_lines_preserve_cr_keeps_trailing_cr_attached_to_its_line() -> None:
+    assert split_lines_preserve_cr("a\r\nb\n") == ["a\r", "b"]
+
+
+def test_split_lines_preserve_cr_matches_splitlines_count_on_lf_only_input() -> None:
+    text = "a\nb\nc\n"
+    assert split_lines_preserve_cr(text) == text.splitlines()
+
+
+def test_split_lines_preserve_cr_diverges_from_splitlines_only_on_real_cr() -> None:
+    text = "a\r\nb\r\n"
+    # str.splitlines() silently eats both \r characters -- exactly the blindness task #262
+    # removes. The two must disagree here, or this helper would not be doing its job.
+    assert split_lines_preserve_cr(text) != text.splitlines()
+    assert split_lines_preserve_cr(text) == ["a\r", "b\r"]
+    assert text.splitlines() == ["a", "b"]
+
+
+def test_split_lines_preserve_cr_empty_string_returns_empty_list() -> None:
+    assert split_lines_preserve_cr("") == []
+
+
+# --- decode_for_display: failure messages must not re-introduce the U+FFFD collapse. ------
+
+
+def test_decode_for_display_escapes_invalid_bytes_instead_of_replacing_them() -> None:
+    rendered = decode_for_display(b"\xff")
+
+    assert rendered == "\\xff"
+    assert "�" not in rendered
+
+
+def test_assert_bytes_equal_failure_message_distinguishes_the_two_divergent_arms() -> None:
+    with pytest.raises(AssertionError) as excinfo:
+        assert_bytes_equal(b"a\xffb", "a�".encode(), label="demo")
+
+    message = str(excinfo.value)
+    assert "demo:" in message
+    assert "\\xff" in message

--- a/tests/unit/test_cpu_backend.py
+++ b/tests/unit/test_cpu_backend.py
@@ -208,6 +208,20 @@ class TestCPUBackend:
         exactly that: a hand-written on-disk cache with no `format_version` key, same
         file_signature as the real file, but pre-fix (CRLF-stripped) `lines`. Must be
         rejected and transparently recomputed + rewritten, not served.
+
+        The literal-prefilter path is only reached when `search()` cannot use the
+        Rust-delegated fast path (`cpu_rust_regex`) -- on a machine/CI leg with the compiled
+        `rust_core` extension present (every CI matrix leg; a normal shipped-wheel install),
+        a plain query like this one is answered entirely by `rust_backend.search(...)` and
+        never touches `_load_literal_index`/`_store_literal_index` at all, so asserting
+        `routing_reason == "cpu_python_regex_prefilter"` without forcing Rust absent would
+        pass only on a dev sandbox that happens to lack the built extension (as this was
+        first written and verified) and fail everywhere else -- exactly the kind of
+        environment-gated, not behavior-gated, oracle this task exists to eliminate. Forces
+        the "Rust genuinely absent" branch deterministically via the same
+        `patch.dict("sys.modules", {"tensor_grep.rust_core": None})` convention already used
+        by `test_should_fail_closed_when_context_search_cannot_use_rust` elsewhere in this
+        file, so the cache-versioning logic is exercised regardless of what's installed.
         """
         import json
 
@@ -230,7 +244,8 @@ class TestCPUBackend:
         }
         cache_path.write_text(json.dumps(stale_payload), encoding="utf-8")
 
-        result = backend.search(str(log_file), "alpha needle one", config=SearchConfig())
+        with patch.dict("sys.modules", {"tensor_grep.rust_core": None}):
+            result = backend.search(str(log_file), "alpha needle one", config=SearchConfig())
         assert result.routing_reason == "cpu_python_regex_prefilter"  # fresh, not "_cache"
         assert result.matches[0].text == "alpha needle one\r"
 
@@ -269,7 +284,12 @@ class TestCPUBackend:
         universal-newlines translation ON READ (eating a CRLF file's own `\\r`) AND treats a
         bare `\\r` as a line break on top of that. Both are now fixed by reading raw bytes and
         splitting on a bare `\\n` only (`split_source_lines`). A plain 3+ char literal with no
-        other flags routes through this exact path (`_extract_required_literal`).
+        other flags routes through this exact path (`_extract_required_literal`) -- but ONLY
+        when `search()` cannot reach the Rust-delegated `cpu_rust_regex` fast path first (see
+        `test_rejects_stale_pre_fix_persistent_literal_index` above for the full reasoning);
+        force that deterministically via the file's established
+        `patch.dict("sys.modules", {"tensor_grep.rust_core": None})` convention rather than
+        relying on the extension being ambiently absent.
         """
         monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX", "0")  # force a fresh read every call
         backend = CPUBackend()
@@ -277,7 +297,8 @@ class TestCPUBackend:
 
         crlf_log = tmp_path / "crlf.log"
         crlf_log.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
-        result = backend.search(str(crlf_log), "needle", config=SearchConfig())
+        with patch.dict("sys.modules", {"tensor_grep.rust_core": None}):
+            result = backend.search(str(crlf_log), "needle", config=SearchConfig())
         assert result.routing_reason.startswith("cpu_python_regex_prefilter")
         assert result.total_matches == 1
         assert result.matches[0].line_number == 1
@@ -285,7 +306,8 @@ class TestCPUBackend:
 
         lf_log = tmp_path / "lf.log"
         lf_log.write_text("alpha needle one\nbeta line two\n", encoding="utf-8", newline="\n")
-        lf_result = backend.search(str(lf_log), "needle", config=SearchConfig())
+        with patch.dict("sys.modules", {"tensor_grep.rust_core": None}):
+            lf_result = backend.search(str(lf_log), "needle", config=SearchConfig())
         assert lf_result.matches[0].text == "alpha needle one"
 
     def test_literal_prefilter_path_does_not_treat_a_bare_cr_as_a_line_break(
@@ -297,7 +319,9 @@ class TestCPUBackend:
         treated the bare `\\r` as a line break too (Python's universal-newlines convention),
         silently reporting a phantom SECOND match/line that neither `rg` nor the fixed
         Rust-delegated path ever produced -- a line-number AND match-count divergence with no
-        prior regression coverage.
+        prior regression coverage. Forces the pure-Python path deterministically -- see the
+        sibling test above; without this, CI (which builds `rust_core` on every matrix leg)
+        answers via `cpu_rust_regex` and never reaches the code this test exists to cover.
         """
         monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX", "0")
         backend = CPUBackend()
@@ -305,7 +329,8 @@ class TestCPUBackend:
 
         cr_only_log = tmp_path / "cronly.log"
         cr_only_log.write_bytes(b"line one\rline two\r")
-        result = backend.search(str(cr_only_log), "line", config=SearchConfig())
+        with patch.dict("sys.modules", {"tensor_grep.rust_core": None}):
+            result = backend.search(str(cr_only_log), "line", config=SearchConfig())
         assert result.routing_reason.startswith("cpu_python_regex_prefilter")
         assert result.total_matches == 1
         assert result.matches[0].line_number == 1

--- a/tests/unit/test_cpu_backend.py
+++ b/tests/unit/test_cpu_backend.py
@@ -114,7 +114,12 @@ class TestCPUBackend:
         from tensor_grep.core.config import SearchConfig
 
         log = tmp_path / "context.log"
-        log.write_text("line 1\nERROR MATCH\nline 3\nline 4\nline 5\n")
+        # newline="\n" pins this fixture to LF regardless of platform default: without it,
+        # Path.write_text() silently writes CRLF on Windows, and task #262's
+        # strip_line_terminator fix now correctly preserves a CRLF line's own trailing \r
+        # instead of over-stripping it, which would otherwise make every .text assertion
+        # below fail on an incidental platform-default newline, not a real bug.
+        log.write_text("line 1\nERROR MATCH\nline 3\nline 4\nline 5\n", newline="\n")
 
         backend = CPUBackend()
         config = SearchConfig(after_context=2)
@@ -133,7 +138,7 @@ class TestCPUBackend:
         from tensor_grep.core.config import SearchConfig
 
         log = tmp_path / "context_before.log"
-        log.write_text("line 1\nline 2\nERROR MATCH\nline 4\n")
+        log.write_text("line 1\nline 2\nERROR MATCH\nline 4\n", newline="\n")
 
         backend = CPUBackend()
         config = SearchConfig(before_context=2)
@@ -214,8 +219,44 @@ class TestCPUBackend:
         assert (str(files[1]), False) in cache
         assert (str(files[2]), False) in cache
 
-    def test_should_strip_line_terminators_from_rust_backend_matches(self, tmp_path):
+    def test_should_strip_only_the_trailing_newline_from_rust_backend_matches(self, tmp_path):
+        """task #262: the OLD `.rstrip("\n\r")` here stripped ANY trailing run of `\r`/`\n`,
+        which silently ate a genuine trailing `\r` from a CRLF source line too (real `rg` and
+        Rust's own line-splitter both preserve that `\r` -- verified directly against
+        `rg.exe`). `strip_line_terminator` must remove ONLY the single trailing `\n`.
+
+        This is the bidirectional pair: an LF-only match text loses just its `\n` (this test),
+        while `test_should_preserve_a_genuine_trailing_cr_from_a_crlf_rust_backend_match`
+        below proves a real `\r` immediately before it survives.
+        """
         log = tmp_path / "rust_newlines.log"
+        log.write_text("apple\nbanana\n", encoding="utf-8")
+
+        rust_mod = types.ModuleType("tensor_grep.rust_core")
+
+        class FakeRustBackend:
+            def search(self, **kwargs):
+                return [(1, "apple\n")]
+
+        rust_mod.RustBackend = FakeRustBackend
+
+        backend = CPUBackend()
+        with patch.dict("sys.modules", {"tensor_grep.rust_core": rust_mod}):
+            result = backend.search(str(log), "apple")
+
+        assert result.total_matches == 1
+        assert result.matches[0].line_number == 1
+        assert result.matches[0].text == "apple"
+        assert result.routing_backend == "CPUBackend"
+
+    def test_should_preserve_a_genuine_trailing_cr_from_a_crlf_rust_backend_match(self, tmp_path):
+        """The other half of the task #262 bidirectional fix -- see the sibling test above.
+        Rust's own line-splitter keeps a CRLF line's trailing `\r` (only the `\n` record
+        separator is removed by the split itself); the fake backend below mirrors that real
+        shape. This must NOT be corrupted into "apple" (over-stripped) OR "apple\r\r"
+        (doubled).
+        """
+        log = tmp_path / "rust_newlines_crlf.log"
         log.write_text("apple\nbanana\n", encoding="utf-8")
 
         rust_mod = types.ModuleType("tensor_grep.rust_core")
@@ -232,7 +273,7 @@ class TestCPUBackend:
 
         assert result.total_matches == 1
         assert result.matches[0].line_number == 1
-        assert result.matches[0].text == "apple"
+        assert result.matches[0].text == "apple\r"
         assert result.routing_backend == "CPUBackend"
         assert result.routing_reason == "cpu_rust_regex"
 
@@ -263,7 +304,9 @@ class TestCPUBackend:
         # linear-time Rust engine (context windows are assembled in pure Python around it)
         # instead of unconditionally falling to Python's unbounded backtracking `re`.
         log = tmp_path / "rust_context.log"
-        log.write_text("before\napple\nafter\n", encoding="utf-8")
+        # newline="\n": see the comment on test_should_includeAfterContext_when_dashA_isProvided
+        # above -- this fixture feeds _assemble_context_matches, which reads the REAL file.
+        log.write_text("before\napple\nafter\n", encoding="utf-8", newline="\n")
 
         rust_mod = types.ModuleType("tensor_grep.rust_core")
         calls = []
@@ -341,7 +384,8 @@ class TestCPUBackend:
 
     def test_should_combine_word_regexp_with_context_via_rust(self, tmp_path):
         log = tmp_path / "word_context.log"
-        log.write_text("before\ncat\nconcatenate\nafter\n", encoding="utf-8")
+        # newline="\n": same reasoning as the sibling context-fixture comments above.
+        log.write_text("before\ncat\nconcatenate\nafter\n", encoding="utf-8", newline="\n")
 
         backend = CPUBackend()
         result = backend.search(

--- a/tests/unit/test_cpu_backend.py
+++ b/tests/unit/test_cpu_backend.py
@@ -197,6 +197,49 @@ class TestCPUBackend:
         assert result.routing_backend == "CPUBackend"
         assert result.routing_reason == "cpu_rust_regex"
 
+    def test_rejects_stale_pre_fix_persistent_literal_index(self, tmp_path, monkeypatch):
+        """task #262 BLOCKING finding #2: the persisted literal-prefilter index payload used
+        to carry only `file_signature = (mtime_ns, size)`, with no format version.
+        `(mtime, size)` proves the file's BYTES are unchanged; it cannot prove the
+        *interpretation* of those bytes is still current -- a cache written by pre-fix code
+        (CRLF `\\r` already stripped from `lines`) would silently defeat this fix and be
+        served forever (same file, unchanged mtime/size), reading as WORSE than pre-fix
+        (which was byte-identical to `rg` by cancellation with the stdout bug). Simulates
+        exactly that: a hand-written on-disk cache with no `format_version` key, same
+        file_signature as the real file, but pre-fix (CRLF-stripped) `lines`. Must be
+        rejected and transparently recomputed + rewritten, not served.
+        """
+        import json
+
+        cache_dir = tmp_path / "cpu-cache"
+        monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX_DIR", str(cache_dir))
+        monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX", "1")
+        backend = CPUBackend()
+        CPUBackend._clear_shared_caches()
+
+        log_file = tmp_path / "sys.log"
+        log_file.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
+
+        cache_path = backend._get_prefilter_cache_path(str(log_file), False)
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        stale_payload = {
+            # No "format_version" key at all -- the exact pre-#262 on-disk shape.
+            "file_signature": list(backend._build_file_signature(str(log_file))),
+            "lines": ["alpha needle one", "beta line two"],  # pre-fix: \r already stripped
+            "trigram_index": {"alp": [0], "lph": [0], "pha": [0]},
+        }
+        cache_path.write_text(json.dumps(stale_payload), encoding="utf-8")
+
+        result = backend.search(str(log_file), "alpha needle one", config=SearchConfig())
+        assert result.routing_reason == "cpu_python_regex_prefilter"  # fresh, not "_cache"
+        assert result.matches[0].text == "alpha needle one\r"
+
+        from tensor_grep.backends.cpu_backend import _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION
+
+        rewritten = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert rewritten["format_version"] == _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION
+        assert rewritten["lines"] == ["alpha needle one\r", "beta line two\r"]
+
     def test_literal_index_cache_obeys_entry_cap(self, tmp_path, monkeypatch):
         monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX", "0")
         monkeypatch.setenv("TENSOR_GREP_CPU_LITERAL_INDEX_CACHE_MAX_ENTRIES", "2")
@@ -218,6 +261,55 @@ class TestCPUBackend:
         assert (str(files[0]), False) not in cache
         assert (str(files[1]), False) in cache
         assert (str(files[2]), False) in cache
+
+    def test_literal_prefilter_path_preserves_crlf_source_line(self, tmp_path, monkeypatch):
+        """task #262 -- the LARGEST behavior change in this fix, previously uncovered by any
+        test: the pure-Python literal-prefilter fallback used to read the file via
+        `Path.read_text(encoding="utf-8", errors="replace").splitlines()`, which performs
+        universal-newlines translation ON READ (eating a CRLF file's own `\\r`) AND treats a
+        bare `\\r` as a line break on top of that. Both are now fixed by reading raw bytes and
+        splitting on a bare `\\n` only (`split_source_lines`). A plain 3+ char literal with no
+        other flags routes through this exact path (`_extract_required_literal`).
+        """
+        monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX", "0")  # force a fresh read every call
+        backend = CPUBackend()
+        CPUBackend._clear_shared_caches()
+
+        crlf_log = tmp_path / "crlf.log"
+        crlf_log.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
+        result = backend.search(str(crlf_log), "needle", config=SearchConfig())
+        assert result.routing_reason.startswith("cpu_python_regex_prefilter")
+        assert result.total_matches == 1
+        assert result.matches[0].line_number == 1
+        assert result.matches[0].text == "alpha needle one\r"
+
+        lf_log = tmp_path / "lf.log"
+        lf_log.write_text("alpha needle one\nbeta line two\n", encoding="utf-8", newline="\n")
+        lf_result = backend.search(str(lf_log), "needle", config=SearchConfig())
+        assert lf_result.matches[0].text == "alpha needle one"
+
+    def test_literal_prefilter_path_does_not_treat_a_bare_cr_as_a_line_break(
+        self, tmp_path, monkeypatch
+    ):
+        """Ground truth verified directly against `rg.exe`: a file containing ONLY bare `\\r`
+        line endings (no `\\n` at all) is ONE line to `rg` (it splits on `\\n` alone, never a
+        bare `\\r`), matched_lines=1. Before task #262, `Path.read_text().splitlines()` here
+        treated the bare `\\r` as a line break too (Python's universal-newlines convention),
+        silently reporting a phantom SECOND match/line that neither `rg` nor the fixed
+        Rust-delegated path ever produced -- a line-number AND match-count divergence with no
+        prior regression coverage.
+        """
+        monkeypatch.setenv("TENSOR_GREP_CPU_REGEX_INDEX", "0")
+        backend = CPUBackend()
+        CPUBackend._clear_shared_caches()
+
+        cr_only_log = tmp_path / "cronly.log"
+        cr_only_log.write_bytes(b"line one\rline two\r")
+        result = backend.search(str(cr_only_log), "line", config=SearchConfig())
+        assert result.routing_reason.startswith("cpu_python_regex_prefilter")
+        assert result.total_matches == 1
+        assert result.matches[0].line_number == 1
+        assert result.matches[0].text == "line one\rline two\r"
 
     def test_should_strip_only_the_trailing_newline_from_rust_backend_matches(self, tmp_path):
         """task #262: the OLD `.rstrip("\n\r")` here stripped ANY trailing run of `\r`/`\n`,

--- a/tests/unit/test_cpu_backend.py
+++ b/tests/unit/test_cpu_backend.py
@@ -231,10 +231,21 @@ class TestCPUBackend:
         backend = CPUBackend()
         CPUBackend._clear_shared_caches()
 
+        from tensor_grep.backends.cpu_backend import _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION
+
         log_file = tmp_path / "sys.log"
         log_file.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
 
         cache_path = backend._get_prefilter_cache_path(str(log_file), False)
+        # The version lives in the cache PATH itself, not just the payload -- an older tg
+        # sharing this cache dir with a newer one has no idea the payload's own
+        # "format_version" field exists, so it would read (and re-corrupt) a newer payload
+        # verbatim; a filename collision is impossible only because the version is baked
+        # into the name. Assert the shape directly so a future refactor/merge that silently
+        # drops the `-v{VERSION}` suffix (reopening exactly that corruption) is caught here
+        # -- the payload-only assertion below cannot catch a filename regression, since it
+        # reads whatever `cache_path` computes to, not a fixed expected name.
+        assert cache_path.name.endswith(f"-v{_CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION}.json")
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         stale_payload = {
             # No "format_version" key at all -- the exact pre-#262 on-disk shape.
@@ -248,8 +259,6 @@ class TestCPUBackend:
             result = backend.search(str(log_file), "alpha needle one", config=SearchConfig())
         assert result.routing_reason == "cpu_python_regex_prefilter"  # fresh, not "_cache"
         assert result.matches[0].text == "alpha needle one\r"
-
-        from tensor_grep.backends.cpu_backend import _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION
 
         rewritten = json.loads(cache_path.read_text(encoding="utf-8"))
         assert rewritten["format_version"] == _CPU_LITERAL_INDEX_CACHE_FORMAT_VERSION

--- a/tests/unit/test_force_utf8_streams.py
+++ b/tests/unit/test_force_utf8_streams.py
@@ -48,3 +48,48 @@ def test_survives_stream_without_reconfigure(monkeypatch):
     monkeypatch.setattr(sys, "stdout", _Bare())
     monkeypatch.setattr(sys, "stderr", _Bare())
     _force_utf8_streams()  # must not raise
+
+
+def test_falls_back_to_encoding_only_when_stream_reconfigure_rejects_newline_kwarg(monkeypatch):
+    """task #262 non-blocking gate finding: calling `reconfigure()` on an already-UTF-8
+    stream is NEW behavior from this fix (the pre-fix early-`continue` skipped it entirely).
+    A stream whose `reconfigure()` implements only the narrower pre-#262 signature
+    (`encoding=`/`errors=`, no `newline=` parameter at all) now gets called for the first
+    time and raises a genuine `TypeError` on the unexpected kwarg -- this must not crash
+    startup, and the encoding fix should still land via a narrower retry.
+    """
+
+    class _NarrowReconfigureStream:
+        encoding = "cp1252"
+
+        def __init__(self):
+            self.calls: list[dict[str, str]] = []
+
+        def reconfigure(self, *, encoding=None, errors=None):
+            self.calls.append({"encoding": encoding, "errors": errors})
+
+    stream = _NarrowReconfigureStream()
+    monkeypatch.setattr(sys, "stdout", stream)
+    monkeypatch.setattr(sys, "stderr", _fake_stream("utf-8"))
+
+    _force_utf8_streams()  # must not raise TypeError and crash startup
+
+    # The first (newline-included) call must have been attempted and rejected by the real
+    # signature, then retried WITHOUT newline so the encoding fix still lands.
+    assert stream.calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_falls_back_gracefully_when_narrow_reconfigure_also_fails(monkeypatch):
+    """The narrower retry itself can still fail (e.g. the same buffered-output ValueError as
+    test_survives_reconfigure_error) -- must not escape and crash startup either."""
+
+    class _NarrowReconfigureStreamThatAlsoFails:
+        encoding = "cp1252"
+
+        def reconfigure(self, *, encoding=None, errors=None):
+            raise ValueError("stream has buffered output")
+
+    monkeypatch.setattr(sys, "stdout", _NarrowReconfigureStreamThatAlsoFails())
+    monkeypatch.setattr(sys, "stderr", _fake_stream("utf-8"))
+
+    _force_utf8_streams()  # must not raise

--- a/tests/unit/test_force_utf8_streams.py
+++ b/tests/unit/test_force_utf8_streams.py
@@ -20,16 +20,19 @@ def test_reconfigures_a_cp1252_stream(monkeypatch):
     monkeypatch.setattr(sys, "stdout", out)
     monkeypatch.setattr(sys, "stderr", err)
     _force_utf8_streams()
-    out.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
-    err.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+    out.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace", newline="\n")
+    err.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace", newline="\n")
 
 
-def test_noop_when_already_utf8(monkeypatch):
+def test_newline_only_reconfigured_when_already_utf8(monkeypatch):
+    # task #262: this is NOT a full no-op anymore -- the stream is already UTF-8 so the
+    # encoding/errors kwargs are skipped, but newline="\n" must still be applied so a
+    # plain print() on this stream does not silently rewrite \n -> \r\n on Windows.
     out = _fake_stream("utf-8")
     monkeypatch.setattr(sys, "stdout", out)
     monkeypatch.setattr(sys, "stderr", _fake_stream("UTF-8"))
     _force_utf8_streams()
-    out.reconfigure.assert_not_called()
+    out.reconfigure.assert_called_once_with(newline="\n")
 
 
 def test_survives_reconfigure_error(monkeypatch):

--- a/tests/unit/test_result.py
+++ b/tests/unit/test_result.py
@@ -1,4 +1,39 @@
-from tensor_grep.core.result import MatchLine, SearchResult
+from tensor_grep.core.result import MatchLine, SearchResult, strip_line_terminator
+
+
+class TestStripLineTerminator:
+    """task #262: every backend's own trailing-terminator strip used to be
+    `.rstrip("\n\r")` / `.rstrip("\r\n")`, which eats ANY trailing run of `\r`/`\n` in any
+    order -- silently dropping a genuine trailing `\r` from a CRLF-terminated source line
+    (Rust's line-splitter and rg's own `--json` "lines" field both include that `\r`; real
+    `rg`'s plain-text output preserves it too). `strip_line_terminator` must remove ONLY the
+    single trailing `\n` every engine here is known to append.
+    """
+
+    def test_strips_a_bare_trailing_newline(self):
+        assert strip_line_terminator("hello world\n") == "hello world"
+
+    def test_preserves_a_genuine_trailing_cr_from_a_crlf_line(self):
+        # This is the whole point of the fix: a real \r immediately before the \n must
+        # survive, not be eaten alongside it.
+        assert strip_line_terminator("hello world\r\n") == "hello world\r"
+
+    def test_does_not_touch_text_with_no_trailing_newline(self):
+        assert strip_line_terminator("hello world") == "hello world"
+
+    def test_does_not_touch_a_bare_trailing_cr_with_no_following_newline(self):
+        # Nothing here manufactures a strip that was never asked for -- a trailing \r with
+        # no \n after it is untouched (there is no known engine output shape that produces
+        # this, but the function must not guess).
+        assert strip_line_terminator("hello world\r") == "hello world\r"
+
+    def test_only_strips_one_trailing_newline_not_a_run(self):
+        # A blank final line (two trailing \n) must lose only the very last terminator --
+        # the same "at most one" semantics real rg/Rust line-splitting implies.
+        assert strip_line_terminator("hello\n\n") == "hello\n"
+
+    def test_empty_string_is_a_noop(self):
+        assert strip_line_terminator("") == ""
 
 
 class TestSearchResult:

--- a/tests/unit/test_stringzilla_backend.py
+++ b/tests/unit/test_stringzilla_backend.py
@@ -46,6 +46,63 @@ def test_stringzilla_exact_match(backend, tmp_path):
     assert result.routing_worker_count == 1
 
 
+def test_stringzilla_plain_path_preserves_crlf_source_line(backend, tmp_path, monkeypatch):
+    """task #262 BLOCKING finding: `_load_searchable_text`'s non-binary-as-text branch used
+    to open the file via `open(file_path, encoding="utf-8")` (Python default universal-
+    newlines TEXT mode, translating a real `\\r\\n` to `\\n` ON READ) and then split with
+    `sz.Str.splitlines()` -- silently stripping a CRLF file's own `\\r` even when the file's
+    plain-text (non `-F`) output otherwise agreed with `rg`. Real `rg` preserves that `\\r`
+    (verified directly against `rg.exe`); this must too, on both the plain path (this test)
+    and the `-F` trigram-index path (the sibling test below).
+    """
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
+    crlf_log = tmp_path / "crlf.log"
+    crlf_log.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
+
+    result = backend.search(str(crlf_log), "needle", config=SearchConfig(fixed_strings=False))
+    assert result.total_matches == 1
+    assert result.matches[0].text == "alpha needle one\r"
+
+    lf_log = tmp_path / "lf.log"
+    lf_log.write_text("alpha needle one\nbeta line two\n", encoding="utf-8", newline="\n")
+    lf_result = backend.search(str(lf_log), "needle", config=SearchConfig(fixed_strings=False))
+    assert lf_result.matches[0].text == "alpha needle one"
+
+
+def test_stringzilla_fixed_strings_index_path_preserves_crlf_source_line(tmp_path, monkeypatch):
+    """The `-F` / trigram-index sibling of the test above -- `_search_with_index` had the
+    identical `content.splitlines()` defect independently of `_load_searchable_text`'s own
+    read-mode bug, so both must be exercised."""
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
+    StringZillaBackend._clear_shared_caches()
+
+    crlf_log = tmp_path / "crlf.log"
+    crlf_log.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
+
+    result = StringZillaBackend().search(
+        str(crlf_log), "needle", config=SearchConfig(fixed_strings=True)
+    )
+    assert result.total_matches == 1
+    assert result.matches[0].text == "alpha needle one\r"
+
+
+def test_stringzilla_does_not_treat_a_bare_cr_as_a_line_break(backend, tmp_path, monkeypatch):
+    """Ground truth verified directly against `rg.exe`: a file with ONLY bare `\\r` line
+    endings (no `\\n` at all) is ONE line to `rg` (it splits on `\\n` alone), matched_lines=1.
+    Before task #262, StringZilla's own `Str.splitlines()` (and Python's `str.splitlines()`
+    in the trigram-index path) treated the bare `\\r` as a line break too, silently
+    reporting a phantom second match neither `rg` nor the fixed CPU/Rust paths ever did.
+    """
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "0")
+    cr_only_log = tmp_path / "cronly.log"
+    cr_only_log.write_bytes(b"line one\rline two\r")
+
+    result = backend.search(str(cr_only_log), "line", config=SearchConfig(fixed_strings=False))
+    assert result.total_matches == 1
+    assert result.matches[0].line_number == 1
+    assert result.matches[0].text == "line one\rline two\r"
+
+
 def test_stringzilla_no_matches(backend, tmp_path):
     log_file = tmp_path / "sys.log"
     log_file.write_text("INFO ok\nDEBUG trace\n", encoding="utf-8")
@@ -110,6 +167,51 @@ def test_stringzilla_reuses_persistent_trigram_index_across_instances(tmp_path, 
     assert second.total_matches == 1
     assert second.matches[0].line_number == 3
     assert second.routing_reason == "stringzilla_fixed_strings_index_cache"
+
+
+def test_stringzilla_rejects_stale_pre_fix_persistent_index(tmp_path, monkeypatch):
+    """task #262 BLOCKING finding #2: the persisted index payload used to carry only
+    `file_signature = (mtime_ns, size)`, with no format version. `(mtime, size)` proves the
+    file's BYTES are unchanged; it cannot prove the *interpretation* of those bytes is still
+    current -- a cache written by pre-fix code (CRLF `\\r` already stripped from `lines`)
+    would silently defeat this fix and be served forever (same file, unchanged mtime/size),
+    reading as WORSE than pre-fix (which was byte-identical to `rg` by cancellation with the
+    stdout bug). Simulates exactly that: a hand-written on-disk cache with no
+    `format_version` key, same file_signature as the real file, but pre-fix (CRLF-stripped)
+    `lines`. Must be rejected and transparently recomputed + rewritten, not served.
+    """
+    import json
+
+    cache_dir = tmp_path / "sz-cache"
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX_DIR", str(cache_dir))
+    monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "1")
+    StringZillaBackend._clear_shared_caches()
+
+    log_file = tmp_path / "sys.log"
+    log_file.write_bytes(b"alpha needle one\r\nbeta line two\r\n")
+
+    backend = StringZillaBackend()
+    cache_path = backend._get_index_cache_path(str(log_file), False, False)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_payload = {
+        # No "format_version" key at all -- the exact pre-#262 on-disk shape.
+        "file_signature": list(backend._build_file_signature(str(log_file))),
+        "lines": ["alpha needle one", "beta line two"],  # pre-fix: \r already stripped
+        "trigram_index": {"alp": [0], "lph": [0], "pha": [0]},
+    }
+    cache_path.write_text(json.dumps(stale_payload), encoding="utf-8")
+
+    result = backend.search(
+        str(log_file), "alpha needle one", config=SearchConfig(fixed_strings=True)
+    )
+    assert result.routing_reason == "stringzilla_fixed_strings_index"  # fresh, not "_cache"
+    assert result.matches[0].text == "alpha needle one\r"
+
+    from tensor_grep.backends.stringzilla_backend import _STRING_INDEX_CACHE_FORMAT_VERSION
+
+    rewritten = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert rewritten["format_version"] == _STRING_INDEX_CACHE_FORMAT_VERSION
+    assert rewritten["lines"] == ["alpha needle one\r", "beta line two\r"]
 
 
 def test_stringzilla_invalidates_persistent_trigram_index_when_file_changes(tmp_path, monkeypatch):
@@ -271,26 +373,33 @@ def test_stringzilla_honors_max_count_non_indexed_path(backend, tmp_path, monkey
 
 
 def test_stringzilla_native_fault_raises_backend_execution_error(tmp_path, monkeypatch):
-    """audit #10: search() previously had no try/except, so a native StringZilla panic
-    (e.g. from ``sz.Str()`` construction) escaped raw instead of surfacing as
-    BackendExecutionError per the Backend Fail-Closed Contract (base.py). A caller's
-    `except BackendExecutionError` handler (main.py's per-file CPU-fallback retry,
-    cli/main.py:6756-6761) must catch it instead of the search crashing outright."""
-    import stringzilla
+    """audit #10: search() previously had no try/except, so a fault raised anywhere inside
+    it (originally demonstrated via a native ``sz.Str()`` construction failure) escaped raw
+    instead of surfacing as BackendExecutionError per the Backend Fail-Closed Contract
+    (base.py). A caller's `except BackendExecutionError` handler (main.py's per-file
+    CPU-fallback retry, cli/main.py:6756-6761) must catch it instead of the search crashing
+    outright.
 
+    task #262: `search()` no longer constructs an `sz.Str()` at all (the correctness fix
+    replaced native-but-buggy line-splitting with `split_source_lines`, a plain-Python
+    helper shared with CPUBackend), so this now injects the fault at that call site instead
+    -- the *mechanism* under test is the try/except wrapping around the whole method body,
+    not specifically a StringZilla-native failure.
+    """
+    from tensor_grep.backends import stringzilla_backend as sz_backend_module
     from tensor_grep.backends.base import BackendExecutionError
 
     log_file = tmp_path / "sys.log"
     log_file.write_text("ERROR failure\n", encoding="utf-8")
 
-    def _raise_native_panic(*_args, **_kwargs):
+    def _raise_fault(*_args, **_kwargs):
         raise RuntimeError("native stringzilla panic: kaboom")
 
-    monkeypatch.setattr(stringzilla, "Str", _raise_native_panic)
+    monkeypatch.setattr(sz_backend_module, "split_source_lines", _raise_fault)
 
     backend = StringZillaBackend()
     # fixed_strings=False bypasses the pure-Python trigram-index fast path
-    # (_search_with_index) so the native sz.Str() construction is actually exercised.
+    # (_search_with_index) so the patched split_source_lines call is actually exercised.
     with pytest.raises(BackendExecutionError) as exc_info:
         backend.search(str(log_file), "ERROR", config=SearchConfig(fixed_strings=False))
     assert isinstance(exc_info.value, RuntimeError)  # broader `except RuntimeError` still works

--- a/tests/unit/test_stringzilla_backend.py
+++ b/tests/unit/test_stringzilla_backend.py
@@ -182,6 +182,8 @@ def test_stringzilla_rejects_stale_pre_fix_persistent_index(tmp_path, monkeypatc
     """
     import json
 
+    from tensor_grep.backends.stringzilla_backend import _STRING_INDEX_CACHE_FORMAT_VERSION
+
     cache_dir = tmp_path / "sz-cache"
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX_DIR", str(cache_dir))
     monkeypatch.setenv("TENSOR_GREP_STRING_INDEX", "1")
@@ -192,6 +194,11 @@ def test_stringzilla_rejects_stale_pre_fix_persistent_index(tmp_path, monkeypatc
 
     backend = StringZillaBackend()
     cache_path = backend._get_index_cache_path(str(log_file), False, False)
+    # The version lives in the cache PATH itself, not just the payload -- see the identical
+    # assertion + comment on CPUBackend's sibling test
+    # (test_rejects_stale_pre_fix_persistent_literal_index) for why the payload-only check
+    # below cannot catch a filename regression that silently drops the `-v{VERSION}` suffix.
+    assert cache_path.name.endswith(f"-v{_STRING_INDEX_CACHE_FORMAT_VERSION}.json")
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     stale_payload = {
         # No "format_version" key at all -- the exact pre-#262 on-disk shape.
@@ -206,8 +213,6 @@ def test_stringzilla_rejects_stale_pre_fix_persistent_index(tmp_path, monkeypatc
     )
     assert result.routing_reason == "stringzilla_fixed_strings_index"  # fresh, not "_cache"
     assert result.matches[0].text == "alpha needle one\r"
-
-    from tensor_grep.backends.stringzilla_backend import _STRING_INDEX_CACHE_FORMAT_VERSION
 
     rewritten = json.loads(cache_path.read_text(encoding="utf-8"))
     assert rewritten["format_version"] == _STRING_INDEX_CACHE_FORMAT_VERSION


### PR DESCRIPTION
## Summary

Task #262, landed in 3 waves: the parity-oracle fix, the real CRLF-corruption bug it found,
and an independent-gate follow-up (2 blocking findings) closing gaps the first two waves
missed. Still **draft** pending the independent gate's re-review of this update.

### Wave 1 — the oracle

The ripgrep-parity / launcher-parity test suites compared `tg` output against `rg` output
(or one launcher against another) after applying the **same lossy transformation to both
arms**: `subprocess.run(..., text=True)` (Windows universal-newlines silently rewrites a
real `\r\n` to `\n` on capture), an explicit `text.replace("\r\n", "\n")` in some suites'
own `_normalize` helpers, and `errors="replace"` (maps invalid UTF-8 to U+FFFD on both
sides identically).

- **New shared helper**: `tests/helpers/byte_parity.py` — `run_bytes`, `assert_bytes_equal`,
  `decode_for_display`, `split_lines_bytes` / `split_lines_preserve_cr`.
- **New unit tests**: `tests/unit/test_byte_parity_helper.py` — no `tg`/`rg` binary
  required. Proves the bidirectional gate: the new comparison **rejects** a CRLF-vs-LF pair
  and a raw-invalid-UTF-8-vs-U+FFFD pair the OLD (kept, explicitly-named) logic
  **accepted**, and still **accepts** genuinely identical bytes.
- **Converted to raw-byte comparison**: `test_rg_parity_edges.py`, `tests/helpers/rg_parity.py`
  (feeds `test_rg_parity_matrix.py` + `test_multi_pattern_native.py`), `test_ripgrep_parity.py`,
  `test_vs_ripgrep.py`, `test_multi_pattern_native.py`, `test_output_golden_contract.py`,
  `test_cli_search.py`, `tests/integration/test_cross_backend.py` + `test_harness_adoption.py`.
- **`test_routing_parity.py`**: edited only, per the CPU-safe constraint — self-compiles
  Rust as its no-prebuilt-binary fallback, never executed, only read/edited/collected.

### Wave 2 — the real bug the de-blinded oracle found

De-blinding surfaced a genuine, independently-reproduced bug: **`tg search --cpu` on
Windows corrupted line endings in its own output.**

**Root cause #1 (write side)**: `bootstrap.py::_force_utf8_streams` reconfigured
`sys.stdout`/`sys.stderr` for encoding only, never `newline`. A plain `TextIOWrapper` with
`newline=None` (the default) silently rewrites every `\n` a formatter writes to
`os.linesep` on Windows. `rg`'s subprocess output and native-binary delegation bypass this
(raw fd inheritance, never a Python text stream) — why only the CPU/native-Python path
showed it. **Fix**: pin `newline="\n"` unconditionally, including when the stream is
already UTF-8 (the old early-`continue` skipped both fixes together).

**Root cause #2 (read/processing side, independent of #1)**: every backend's own
trailing-terminator strip was `.rstrip("\n\r")`/`.rstrip("\r\n")`, which eats *any* trailing
run of `\r`/`\n`, including a genuine `\r` from a CRLF source line (Rust's splitter and
rg's own `--json` "lines" field both include it — verified against `rg.exe`). **Fix**:
added `core/result.py::strip_line_terminator` (`removesuffix("\n")` only), wired into
`cpu_backend.py` (6 sites, plus a read-side fix in the literal-prefilter fallback), and
`ripgrep_backend.py`'s `--json`/context parsing.

### Wave 3 — independent-gate follow-up (2 BLOCKING, 4 non-blocking, all closed)

The gate verified waves 1–2 as genuinely correct (measured `rg` ground truth directly, ran
the Rust-delegated paths via a throwaway worktree with the already-built `.pyd` copied in —
no compilation — and confirmed byte-identical to `rg` on both LF and CRLF; reverted only
the 5 src files while keeping the new tests and got exactly the predicted 3 e2e failures on
the `\r` divergence, proving the oracle bidirectionally harder than I had). It then found:

**BLOCKING 1 — `StringZillaBackend` was never swept.** The wave-2 sweep grepped for the
*symptom* (`.rstrip("\n\r")`) and fixed every hit; StringZilla has the identical defect
through a *different mechanism* that grep couldn't see: `open(file_path,
encoding="utf-8")` (a universal-newlines READ) in `_load_searchable_text`, plus
`content.splitlines()` in `_search_with_index` and `sz.Str.splitlines()` in `search()`.
Reachable whenever plain `-F`/`--fixed-strings` (no `-C/-A/-B/-w/-x/--ltl`, no `--cpu`)
routes to StringZilla — the `dev`/`bench` extras, i.e. CI and every dev install (the
shipped wheel is unaffected; stringzilla isn't a core dep — but the PR would have created a
new cross-backend inconsistency that didn't exist before, and regressed the plain-text
path outright when `rg` is absent). **Fixed**: added `core/result.py::split_source_lines`
(the same raw-bytes-read + bare-`\n`-split pattern, shared with — and refactored into —
`cpu_backend.py`'s own inline version) and wired it into all three StringZilla call sites.
`search()` no longer needs `sz.Str()` for splitting; the import is kept only for its
availability-gate side effect.

**BLOCKING 2 — both persisted line-index caches were unversioned.** `cpu_backend.py`'s
literal-prefilter cache and `stringzilla_backend.py`'s trigram cache both keyed staleness
*only* on `(mtime_ns, size)` — proof the file's bytes are unchanged, not proof the
*interpretation* of those bytes is still current. A cache written by pre-fix code (`\r`
already stripped) would silently defeat this entire fix and be served forever, reading as
**strictly worse than pre-fix** (which was byte-identical to `rg` by cancellation with the
stdout bug). **Fixed**: added a `format_version` field to both payloads; `_load_*` rejects
any payload whose version doesn't match, forcing a transparent recompute + on-disk
overwrite on first use after upgrade. Verified by hand-writing a pre-fix-shaped cache file
(no `format_version` key, `\r`-stripped `lines`) and confirming both backends reject it,
recompute correctly, and rewrite it — for both backends.

**Non-blocking, also closed:**
- **The rg-parity oracle's `--json` leg was still blind.** `tests/helpers/rg_parity.py`'s
  `_normalize_machine_output`/`_normalize_rg_json_events` still did `.rstrip("\r\n")` on
  the "text" field for **both** the tg and rg arms — the exact both-arms-lossy shape
  removed from the raw-byte comparators. Now uses the shared `strip_line_terminator`.
- **No test covered the pure-Python literal-prefilter read-side fix** (the largest
  behavior change in wave 2). Added CRLF-round-trip and ground-truth-verified-against-
  `rg.exe` bare-CR-is-not-a-line-break coverage for both `CPUBackend` and
  `StringZillaBackend`.
- **`bootstrap.py`'s except clause was too narrow.** Wave 2 made `_force_utf8_streams` call
  `reconfigure()` on streams it previously skipped entirely (already-UTF-8 streams); a
  stream whose `reconfigure()` implements only the narrower pre-#262 `encoding=`/`errors=`
  signature raises `TypeError` on the new `newline=` kwarg, which would have escaped and
  crashed startup. Widened to catch `TypeError` with a narrower retry (the encoding fix
  still lands even where the newline fix cannot).
- **PR body corrected** (this update) to mention StringZilla and stop overclaiming "every
  backend." Remaining known, *not-fixed-in-this-PR* gaps of the same defect class,
  confirmed by direct inspection: `ast_backend.py:603,643` (`.splitlines()` in the
  structural/AST search path — a different search mode than plain-text `tg search`),
  `torch_backend.py:226-227` (`open(..., encoding="utf-8")` + `.splitlines()`, GPU backend,
  optional extra), `cybert_backend.py:275` (a *bare* `.rstrip()` — strips more than
  `\r`/`\n`, experimental classifier backend), and `mcp_server.py:1331-1339`
  (`run_subprocess(..., text=True)` capturing the native binary's stdout — the MCP
  tool-calling surface still flattens a real `\r`). None of these are in scope for `tg
  search`'s plain-text/JSON/context output, which is what this PR fixes.

## Verification

- `PYTHONPATH=<worktree>/src <shared-venv-python> -m pytest ...` throughout (stale
  non-editable venv install shadowing worktree src, worked around per house rules).
- Direct repro against the real Python entry point and real `rg.exe`/`stringzilla`, both
  directions, for every backend: LF file → LF out, CRLF file → CRLF out, byte-identical to
  `rg.exe` on the same file. Same round-trip verified for `--json` output's `text` field,
  and for a **bare-CR-only file** (`rg` ground truth: one line, matched_lines=1 — confirmed
  by inspecting real `rg.exe --json` output directly, not assumed).
- Cache-staleness fix verified by hand-writing a pre-fix-shaped on-disk cache (no
  `format_version`, `\r`-stripped `lines`, matching `file_signature`) and confirming: (a)
  it's rejected (`routing_reason` shows the fresh path, not `_cache`), (b) the correct
  `\r`-preserving result is returned, (c) the file is rewritten with the current
  `format_version`. Also confirmed a *valid* current-version cache is still reused, not
  needlessly recomputed.
- `bootstrap.py`'s widened except verified with a custom fake stream whose `reconfigure()`
  has the exact narrower pre-#262 signature (no `newline=` param) — confirmed it raises
  `TypeError` under the OLD except tuple (would have crashed startup) and is now handled
  gracefully with the encoding fix still landing via the narrower retry.
- `tests/unit/test_byte_parity_helper.py`: 14/14. `tests/unit/test_result.py`: 9/9 (6
  `strip_line_terminator` cases). `tests/unit/test_force_utf8_streams.py`: 6/6 (2 new
  TypeError-handling cases). `tests/unit/test_stringzilla_backend.py`: 22/22 (5 new
  CRLF/cache/fault-injection cases).
- `test_rg_parity_edges.py`: 18/18. `test_rg_parity_matrix.py`: 37 pass, 1 skip (no native
  binary). `test_ripgrep_parity.py`: 4/4. `test_cli_search.py`: 4/4.
- `test_multi_pattern_native.py` + `test_output_golden_contract.py` combined: 41 passed, 22
  skipped, **0 failed** — the two `--cpu` CRLF-corruption cases are genuinely green now.
- `tests/unit/test_cpu_backend.py` (excluding 6 deliberately-slow ReDoS-timing cases): 46
  passed, 11 failed — **all 11 pre-existing environment gaps**
  (`ModuleNotFoundError: No module named 'tensor_grep.rust_core'` — no compiled Rust
  extension in this sandbox, and building one is CPU-safe-forbidden), confirmed by reading
  each traceback back to the unmodified import line. `test_rust_core.py`: same root cause,
  13 pre-existing failures.
- `tests/integration/test_cross_backend.py` + `test_harness_adoption.py`: 1 passed, 8
  skipped (no native binary, expected).
- `ruff format --check --preview` and `ruff check`: clean on every touched file.

## What remains unverified

- `test_routing_parity.py`'s runtime behavior — never executed (self-compiles Rust). CI is
  the first real execution.
- The Rust-delegated `CPUBackend` code paths reachable only with a compiled `rust_core`
  extension — the independent gate executed these directly (via a throwaway worktree with
  the already-built `.pyd` copied in, no compilation) and confirmed byte-identical to `rg`
  on both LF and CRLF; I could not reproduce that verification myself in this sandbox.
- The 4 remaining known gaps listed above (`ast_backend.py`, `torch_backend.py`,
  `cybert_backend.py`, `mcp_server.py`) — confirmed present by inspection, not fixed here,
  out of scope for `tg search`'s plain-text/JSON/context output.
