### PR TITLE
fix(search): honor root .gitignore in both Python rg-passthrough paths outside git repos (#269)

### DIFF
--- a/.claude/rg_argv_differential_fuzz.py
+++ b/.claude/rg_argv_differential_fuzz.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Differential fuzz: `bootstrap._search_path_args_raw` vs an independent model of rg's grammar.
+
+WHY THIS EXISTS
+---------------
+Task #269 (root-`.gitignore` honoring on the Python-only rg-passthrough paths) went through FOUR
+rounds in which every round found an argv form nobody had enumerated by hand:
+
+  1. `-u`/`-uu`/`--unrestricted` ungated  -> `-u` became STRICTER than no flag
+  2. `-f`/`--file`/`-e<attached>` not treated as pattern sources -> wrong root's ignore file
+  3. `-ieneedle` (mid-bundle attached)    -> same, introduced by round 2's own fix
+  4. `PATH -eneedle` (positional BEFORE the flag) -> same, introduced by round 3's own fix
+
+Hand-written enumerations kept missing a dimension. This harness replaces the enumeration with a
+whole-grammar model: it parses argv the way rg 15.1.0 documents itself to (via `rg --help`'s own
+flag tables), computes the PATH positionals rg would search, and compares that against what
+`_search_path_args_raw` computes. Every disagreement is a candidate wrong-root -> wrong
+`--ignore-file` injection -> silently wrong file set.
+
+The reference model here is deliberately the ONLY grammar model in the repo. Do not write a
+second one: two independently-written models disagree with each other and neither is
+authoritative. If rg's grammar changes, update `SHORT_VALUE` / `LONG_VALUE` below from
+`rg --help` and re-run.
+
+USAGE
+-----
+    python .claude/rg_argv_differential_fuzz.py
+    python .claude/rg_argv_differential_fuzz.py --seed 20260725 --iterations 60000
+    python .claude/rg_argv_differential_fuzz.py --src path/to/src   # test another checkout
+
+Exit code 0 = zero disagreements (the closing gate). Exit code 1 = disagreements, printed with
+a minimal reproducer per distinct shape so a failure is actionable, not just a count.
+
+The run is deterministic for a given `--seed`, so a reported failure reproduces exactly.
+
+REFRESHING THE FLAG TABLES (do this when bumping the pinned rg)
+--------------------------------------------------------------
+    rg --help | grep -oE "^\\s+-[a-zA-Z] [A-Z<]"          # -> SHORT_VALUE
+    rg --help | grep -oE "^\\s+(-[a-zA-Z], )?--[a-z0-9-]+=" # -> LONG_VALUE
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import itertools
+import random
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------------------
+# rg 15.1.0 grammar tables, taken from `rg --help`'s own output (see module docstring).
+# --------------------------------------------------------------------------------------
+
+#: Short flags that take a value. `rg --help` prints these as `-X ARG, --long=ARG`.
+#: A value-taking short flag inside a cluster SWALLOWS the remainder of the token as its value
+#: (`-ite` == `-i -t e`, verified live: `rg -ite needle .` -> "unrecognized file type: e"), or,
+#: when it is the token's LAST character, consumes the NEXT argv token (`-ie needle`).
+SHORT_VALUE = set("ABCEMdefgjmrtT")
+
+#: Long flags that take a value. `rg --help` prints these with an `=ARG` suffix.
+LONG_VALUE = {
+    "--after-context",
+    "--before-context",
+    "--color",
+    "--colors",
+    "--context",
+    "--context-separator",
+    "--dfa-size-limit",
+    "--encoding",
+    "--engine",
+    "--field-context-separator",
+    "--field-match-separator",
+    "--file",
+    "--generate",
+    "--glob",
+    "--hostname-bin",
+    "--hyperlink-format",
+    "--iglob",
+    "--ignore-file",
+    "--max-columns",
+    "--max-count",
+    "--max-depth",
+    "--max-filesize",
+    "--path-separator",
+    "--pre",
+    "--pre-glob",
+    "--regex-size-limit",
+    "--regexp",
+    "--replace",
+    "--sort",
+    "--sortr",
+    "--threads",
+    "--type",
+    "--type-add",
+    "--type-clear",
+    "--type-not",
+}
+
+#: Flags that SUPPLY THE PATTERN. If any of these appears in the option region, rg does NOT
+#: treat the first bare positional as the pattern -- every bare positional is a PATH. rg's
+#: grammar is ORDER-INDEPENDENT here: `rg sub -eneedle` == `rg -eneedle sub` (verified live).
+PATTERN_SOURCE_SHORT = set("ef")
+PATTERN_SOURCE_LONG = {"--regexp", "--file"}
+
+
+def rg_roots(argv: list[str]) -> list[str]:
+    """Return the PATH positionals rg would search. Empty list == implicit cwd root."""
+    positionals: list[str] = []
+    pattern_from_flag = False
+    end_of_opts = False
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if end_of_opts:
+            positionals.append(arg)
+            i += 1
+            continue
+        if arg == "--":
+            end_of_opts = True
+            i += 1
+            continue
+        if arg.startswith("--"):
+            name, sep, _value = arg.partition("=")
+            if name in PATTERN_SOURCE_LONG:
+                pattern_from_flag = True
+            if not sep and name in LONG_VALUE:
+                i += 1  # value lives in the next argv token
+            i += 1
+            continue
+        if arg.startswith("-") and len(arg) > 1:
+            cluster = arg[1:]
+            for offset, char in enumerate(cluster):
+                if char in SHORT_VALUE:
+                    if char in PATTERN_SOURCE_SHORT:
+                        pattern_from_flag = True
+                    if offset == len(cluster) - 1:
+                        i += 1  # value lives in the next argv token
+                    break  # the remainder of the token is this flag's value
+            i += 1
+            continue
+        positionals.append(arg)
+        i += 1
+    if pattern_from_flag:
+        return positionals
+    return positionals[1:]  # the first bare positional is the PATTERN
+
+
+# --------------------------------------------------------------------------------------
+# Corpus
+# --------------------------------------------------------------------------------------
+
+BOOL_SHORTS = list("inFvswxaqlcHINopzSPULb")
+VALUES = ["5", "needle", "pats.txt", "*.py", "py", "utf-8", "-weird"]
+PATTERNS = ["needle", "unwrap", "u", "g*.py"]
+PATHS = [".", "otherdir", "sub", "--"]
+CLUSTER_PREFIXES = ["", "i", "n", "iv", "vF", "zi", "s", "in", "wxa"]
+
+
+def build_corpus(seed: int, iterations: int) -> list[list[str]]:
+    """Systematic sweep (every prefix x value-flag x attach/separate x tail) + seeded fuzz."""
+    cases: list[list[str]] = []
+    for prefix, flag in itertools.product(CLUSTER_PREFIXES, sorted(SHORT_VALUE)):
+        for value in ("needle", "5", "*.py", "py", "utf-8"):
+            cases.append([f"-{prefix}{flag}{value}", "otherdir"])
+            cases.append([f"-{prefix}{flag}", value, "otherdir"])
+            cases.append([f"-{prefix}{flag}{value}"])
+            cases.append([f"-{prefix}{flag}", value])
+            cases.append([f"-{prefix}{flag}", value, "needle", "otherdir"])
+            cases.append([f"-{prefix}{flag}", value, "needle", "--", "otherdir"])
+            # ORDERING dimension (round 4): the PATH ahead of the pattern-source flag.
+            cases.append(["otherdir", f"-{prefix}{flag}{value}"])
+            cases.append(["otherdir", f"-{prefix}{flag}", value])
+
+    rnd = random.Random(seed)
+    alphabet = (
+        [f"-{c}" for c in sorted(SHORT_VALUE) + BOOL_SHORTS]
+        + [f"-{a}{b}" for a in "invFszwx" for b in sorted(SHORT_VALUE) + BOOL_SHORTS]
+        + [f"-{a}{v}" for a in sorted(SHORT_VALUE) for v in VALUES]
+        + [f"-{p}{a}{v}" for p in "inz" for a in sorted(SHORT_VALUE) for v in ("needle", "5", "py")]
+        + sorted(LONG_VALUE)
+        + [f"{k}={v}" for k in sorted(LONG_VALUE) for v in ("needle", "py", "5")]
+        + ["--no-ignore", "--unrestricted", "--files", "--json", "--", "--hidden"]
+        + PATTERNS
+        + PATHS
+        + VALUES
+    )
+    for _ in range(iterations):
+        cases.append([rnd.choice(alphabet) for _ in range(rnd.randint(1, 6))])
+    return cases
+
+
+# --------------------------------------------------------------------------------------
+
+
+def load_bootstrap(src: Path):
+    sys.path.insert(0, str(src))
+    spec = importlib.util.spec_from_file_location(
+        "_fuzz_bootstrap", src / "tensor_grep" / "cli" / "bootstrap.py"
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise SystemExit(f"cannot import bootstrap.py from {src}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def shape_of(argv: list[str]) -> tuple[str, ...]:
+    return tuple(
+        "TOK" if not a.startswith("-") else ("LONG" if a.startswith("--") else a) for a in argv
+    )
+
+
+def main() -> int:
+    default_src = Path(__file__).resolve().parent.parent / "src"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src", type=Path, default=default_src, help="path to the src/ tree")
+    parser.add_argument("--seed", type=int, default=20260725, help="fuzz seed (reproducible)")
+    parser.add_argument("--iterations", type=int, default=60000, help="random cases to generate")
+    parser.add_argument("--max-report", type=int, default=25, help="distinct shapes to print")
+    args = parser.parse_args()
+
+    bootstrap = load_bootstrap(args.src)
+    cases = build_corpus(args.seed, args.iterations)
+
+    disagreements: list[tuple[list[str], list[str], list[str]]] = []
+    for argv in cases:
+        expected = rg_roots(argv)
+        actual = bootstrap._search_path_args_raw(argv)
+        if expected != actual:
+            disagreements.append((argv, expected, actual))
+
+    print(f"src        : {args.src}")
+    print(f"seed       : {args.seed}")
+    print(f"cases      : {len(cases)}")
+    print(f"disagreements: {len(disagreements)}")
+
+    if not disagreements:
+        print("\nPASS -- _search_path_args_raw agrees with the rg grammar model on every case.")
+        return 0
+
+    by_shape: dict[tuple[str, ...], tuple[list[str], list[str], list[str]]] = {}
+    for argv, expected, actual in disagreements:
+        by_shape.setdefault(shape_of(argv), (argv, expected, actual))
+    print(f"distinct shapes: {len(by_shape)}\n")
+    # shortest reproducers first -- they are the ones worth reading
+    ordered = sorted(by_shape.values(), key=lambda row: (len(row[0]), len("".join(row[0]))))
+    for argv, expected, actual in ordered[: args.max_report]:
+        print(f"  argv      : {argv}")
+        print(f"    rg roots: {expected}")
+        print(f"    tg roots: {actual}")
+    if len(ordered) > args.max_report:
+        print(f"  ... {len(ordered) - args.max_report} more distinct shapes")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,23 @@ jobs:
             echo "no .tg-registration.toml present; skipping registration check"
           fi
 
+      # rg-argv-grammar differential fuzz (task #269): five rounds of the #264-class root-
+      # `.gitignore` fix each found "an argv form nobody enumerated" in
+      # `bootstrap._search_path_args_raw` (the Python-only rg-passthrough's positional-path
+      # extraction, whenever no compiled native `tg` binary is discoverable). Hand-written
+      # enumerations kept missing a dimension (flag spelling, mid-bundle attachment, and
+      # crucially argv ORDERING — rg's own grammar is order-independent, a single left-to-right
+      # parse pass is not). This gate replaces enumeration with an independent whole-grammar
+      # model of rg 15.1.0 (built from `rg --help`'s own flag tables, kept deliberately as the
+      # ONLY such model in the repo — do not add a second one) and differential-fuzzes it
+      # against the real function over 65k+ argv cases in ~3 seconds. Self-contained (only
+      # needs `src/`, no dev deps), so it runs here rather than in `test-python` below. A future
+      # rg upgrade must refresh `SHORT_VALUE`/`LONG_VALUE` in the script from the new
+      # `rg --help` output (see the script's own docstring) — this gate is what catches a
+      # missed refresh, not a substitute for doing it.
+      - name: "rg argv grammar differential fuzz (task #269)"
+        run: python .claude/rg_argv_differential_fuzz.py --seed 20260725 --iterations 65000
+
   test-python:
     name: test-python (${{ matrix.os }}, py${{ matrix.python-version }})
     needs: smoke

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -510,6 +510,14 @@ class RipgrepBackend(ComputeBackend):
             cmd.append("--json")
 
         # We enforce JSON output so we can seamlessly parse it back into our SearchResult dataclasses
+        # Task #269 non-blocking note (independent gate, Part B): every flag in this block --
+        # including the root-ignore-file injection below -- is gated on `config` being truthy.
+        # `search_passthrough(file_path, pattern)` (no third arg) defaults `config` to `None`,
+        # so a caller using that form gets ZERO of these flags, not just no ignore-file
+        # injection. Not a regression (this is pre-existing behavior for every other flag here
+        # too, and both real call sites, `cli/main.py:7768`/`:7843`, always pass a real
+        # `config`), but worth flagging so `config=None` is never mistaken for "injection
+        # covered" -- it means "no SearchConfig-derived flags at all were forwarded".
         if config:
             if config.ignore_case:
                 cmd.append("-i")

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -610,6 +610,12 @@ class RipgrepBackend(ComputeBackend):
             # function's own `args.paths`); a pre-enumerated FILE list (the rare
             # `--files-without-match` branch in `cli/main.py`) safely no-ops via the helper's
             # own `Path.is_file()` existence check rather than emitting a wrong flag.
+            # `config.unrestricted` (rg's `-u`/`-uu`/`-uuu`) is a documented ALIAS for
+            # `--no-ignore` (+`--hidden`/+`--binary`) that rg's own parser expands -- NOT
+            # observed by `config.no_ignore` -- so it must gate this injection too (independent
+            # gate finding, task #269): without it `-u` came out STRICTER than no flag at all,
+            # since the emitted `--ignore-file` below (line ~648) survives `--no-ignore` by
+            # design and silently resurrected the very rules `-u` asked to disable.
             cmd.extend(
                 root_ignore_file_args(
                     file_path if isinstance(file_path, list) else [file_path],
@@ -617,6 +623,7 @@ class RipgrepBackend(ComputeBackend):
                     no_ignore_files=config.no_ignore_files,
                     no_ignore_vcs=config.no_ignore_vcs,
                     no_ignore_dot=config.no_ignore_dot,
+                    unrestricted=config.unrestricted,
                 )
             )
             if config.ignore_file_case_insensitive:

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from tensor_grep.backends.base import BackendExecutionError, ComputeBackend
+from tensor_grep.cli.rg_root_ignore import root_ignore_file_args
 from tensor_grep.cli.subprocess_policy import configured_ripgrep_timeout_seconds, run_subprocess
 from tensor_grep.core.config import SearchConfig
 from tensor_grep.core.result import MatchLine, SearchResult
@@ -597,6 +598,27 @@ class RipgrepBackend(ComputeBackend):
             if config.ignore_file:
                 for ignore_path in config.ignore_file:
                     cmd.extend(["--ignore-file", ignore_path])
+            # Task #269: this is the second of two Python-only real-`rg` forwarding paths
+            # (the other is `bootstrap.py::_run_rg_passthrough`), reachable via every entry
+            # point built on `_build_cmd` (`search`, `search_passthrough`, `_search_counts`,
+            # `_search_files_with_matches`) whenever no compiled native `tg` binary is
+            # discoverable. Real rg's own `.gitignore` auto-discovery requires
+            # `require_git=true` by default, so a root `.gitignore` is silently a no-op outside
+            # a git repo -- the same #264 defect already fixed for the compiled native binary's
+            # rg-passthrough (`rust_core/src/rg_passthrough.rs::root_ignore_file_args`).
+            # `file_path` here is the same root(s) real rg is about to walk (mirrors that
+            # function's own `args.paths`); a pre-enumerated FILE list (the rare
+            # `--files-without-match` branch in `cli/main.py`) safely no-ops via the helper's
+            # own `Path.is_file()` existence check rather than emitting a wrong flag.
+            cmd.extend(
+                root_ignore_file_args(
+                    file_path if isinstance(file_path, list) else [file_path],
+                    no_ignore=config.no_ignore,
+                    no_ignore_files=config.no_ignore_files,
+                    no_ignore_vcs=config.no_ignore_vcs,
+                    no_ignore_dot=config.no_ignore_dot,
+                )
+            )
             if config.ignore_file_case_insensitive:
                 cmd.append("--ignore-file-case-insensitive")
             if config.no_ignore_file_case_insensitive:

--- a/src/tensor_grep/backends/ripgrep_backend.py
+++ b/src/tensor_grep/backends/ripgrep_backend.py
@@ -622,8 +622,12 @@ class RipgrepBackend(ComputeBackend):
             # `--no-ignore` (+`--hidden`/+`--binary`) that rg's own parser expands -- NOT
             # observed by `config.no_ignore` -- so it must gate this injection too (independent
             # gate finding, task #269): without it `-u` came out STRICTER than no flag at all,
-            # since the emitted `--ignore-file` below (line ~648) survives `--no-ignore` by
-            # design and silently resurrected the very rules `-u` asked to disable.
+            # since the `--ignore-file` operands emitted here survive `--no-ignore` by design
+            # (see this function's own `cmd.append("-" + "u" * config.unrestricted)` further
+            # below, which forwards the raw token to rg -- referenced by SHAPE, not a line
+            # number, per the NB-2 lesson from this task's independent gate: a raw line-number
+            # citation drifted stale within the SAME commit that added it) and would otherwise
+            # silently resurrect the very rules `-u` asked to disable.
             cmd.extend(
                 root_ignore_file_args(
                     file_path if isinstance(file_path, list) else [file_path],

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -1086,8 +1086,28 @@ def _run_native_tg_command(binary_name: str, argv: list[str]) -> int:
 
 
 def _run_rg_passthrough(binary_name: str, search_args: list[str]) -> int:
+    # Task #269: this is one of two Python-only real-`rg` forwarding paths (the other is
+    # `RipgrepBackend._build_cmd`), reachable whenever no compiled native `tg` binary is
+    # discoverable. Real rg's own `.gitignore` auto-discovery requires `require_git=true` by
+    # default, so a root `.gitignore` is silently a no-op outside a git repo -- the same #264
+    # defect already fixed for the compiled native binary's rg-passthrough
+    # (`rust_core/src/rg_passthrough.rs::root_ignore_file_args`). `_search_path_args` gives the
+    # same raw-argv positional-path extraction already used throughout this module (e.g.
+    # `_search_args_paths_defaulted`), so the roots this computes always match what real rg
+    # will actually search. The emitted `--ignore-file <path>` operands are PREPENDED (not
+    # appended) so they land before any `--` end-of-options sentinel the user's own argv might
+    # contain -- inserting after it would misparse them as positional paths.
+    from tensor_grep.cli.rg_root_ignore import root_ignore_file_args
+
+    ignore_file_ops = root_ignore_file_args(
+        _search_path_args(search_args),
+        no_ignore="--no-ignore" in search_args,
+        no_ignore_files="--no-ignore-files" in search_args,
+        no_ignore_vcs="--no-ignore-vcs" in search_args,
+        no_ignore_dot="--no-ignore-dot" in search_args,
+    )
     return _streaming_passthrough_returncode(
-        [binary_name, *search_args], timeout_env_var="TG_RG_TIMEOUT_SECONDS"
+        [binary_name, *ignore_file_ops, *search_args], timeout_env_var="TG_RG_TIMEOUT_SECONDS"
     )
 
 

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -612,8 +612,11 @@ def _search_args_include_generated_scan_bound(
 # Task #269 independent-gate finding: the naive `arg.startswith("-u")` this replaced only
 # matched `-u`/`-uu`/`-uuu` as the WHOLE token -- it missed the bundled/clustered short-flag
 # form (`-iu`, `-nu`, ...), which rg's own clap-style parser accepts identically to `-i -u` /
-# `-n -u`. Walks the cluster the same way `_requires_full_cli`'s bundled-scan does (lines
-# ~369-374 above): the first ATTACHED-VALUE short flag in a cluster swallows the remainder of
+# `-n -u`. Walks the cluster the same way `_requires_full_cli`'s bundled-scan does (above in
+# this same module -- referenced by NAME, not a line number, per the NB-2 lesson from this
+# task's independent gate: a raw line-number citation drifted stale within days of being
+# written, when later edits to this file shifted every line below it): the first
+# ATTACHED-VALUE short flag in a cluster swallows the remainder of
 # that token as its own value, so a `u` appearing after it is DATA, not a flag -- `-tu` means
 # `--type u`, not `-t -u`. Extracted to one named helper (rather than two separately-maintained
 # copies of the same rule) so `_search_args_request_unrestricted_generated_scan` (the broad-scan
@@ -643,16 +646,92 @@ def _search_args_request_unrestricted_generated_scan(search_args: list[str]) -> 
     return _search_args_request_unrestricted(search_args)
 
 
+def _attached_cluster_value_offset(arg: str) -> int | None:
+    """For a bundled/clustered short-flag token (`-ieneedle`, `-tpy`, a plain boolean cluster
+    like `-in`, ...), return the index INTO `arg` of the first ATTACHED-VALUE short-flag
+    character in the cluster, or `None` if the token carries no attached-value flag at all (a
+    plain boolean cluster, or not a dash-prefixed multi-char token to begin with). Shared by
+    `_search_args_contains_pattern_source_flag`'s pre-pass and `_search_path_args_raw`'s
+    extraction walk below so the two passes cannot silently diverge on which characters count
+    (task #269 independent-gate BLOCKING-1's own root cause was two separate passes computing
+    the same thing differently)."""
+    if arg.startswith("--") or len(arg) <= 2 or not arg.startswith("-"):
+        return None
+    for offset, ch in enumerate(arg[1:], start=1):
+        if f"-{ch}" in _SEARCH_ATTACHED_VALUE_SHORT_FLAGS:
+            return offset
+    return None
+
+
+def _search_args_contains_pattern_source_flag(search_args: list[str]) -> bool:
+    """Pre-pass: does ANY pattern-source flag (`-e`/`--regexp`/`-f`/`--file`, in every accepted
+    spelling -- exact, `--flag=value`, attached short (`-eVAL`), and mid-bundle attached short
+    (`-ieVAL`)) appear anywhere in `search_args` BEFORE a `--` end-of-options sentinel?
+
+    Task #269 independent-gate BLOCKING-1: rg's own grammar is ORDER-INDEPENDENT -- a pattern
+    can be supplied via a flag either before OR after the positional PATH
+    (`rg sub -eneedle` == `rg -eneedle sub`) -- but `_search_path_args_raw`'s extraction walk
+    is a single left-to-right pass whose `regexp_pattern_seen` state used to start `False` and
+    only flip `True` at the MOMENT it encountered the flag. A PATH positional occurring BEFORE
+    that flag in argv (`tg search otherdir -eneedle`) was therefore silently misread as the
+    bare pattern under the "first non-flag token is the pattern" rule, `_search_path_args_raw`
+    returned the wrong (empty) root list, and `_run_rg_passthrough` injected the WRONG root's
+    ignore file -- reproducing the #264 signature (`--json` landed on the correct engine,
+    plain text did not) A FOURTH time, inside this same PR. This pre-pass supplies the correct
+    STARTING value for `regexp_pattern_seen` instead, so a PATH appearing anywhere relative to
+    the flag is handled identically.
+
+    Deliberately mirrors ONLY the flag-classification portion of `_search_path_args_raw`'s
+    walk (not positional extraction, which this function does not need) -- and shares
+    `_attached_cluster_value_offset` with it rather than re-deriving the same cluster logic a
+    second time, so the two passes cannot drift apart on which argv shapes count.
+    """
+    skip_next = False
+    for arg in search_args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--":
+            break
+        if arg in _SEARCH_PATTERN_SOURCE_FLAGS:
+            return True
+        if any(arg.startswith(f"{flag}=") for flag in _SEARCH_PATTERN_SOURCE_FLAGS):
+            return True
+        offset = _attached_cluster_value_offset(arg)
+        if offset is not None:
+            if arg[offset] in ("e", "f"):
+                return True
+            # Consumed as a non-pattern-source attached value (e.g. `-tpy`, `-im5`) -- nothing
+            # more to classify for this token; it carries no separate-token value to skip
+            # either way (attached values live inside the same token by definition).
+            continue
+        if arg in _SEARCH_FLAGS_WITH_VALUES:
+            skip_next = True
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in _SEARCH_FLAGS_WITH_VALUES):
+            continue
+        # A bare boolean flag (no value) or a genuine positional needs no further handling
+        # here -- this pre-pass only answers "does a pattern-source flag appear anywhere
+        # before `--`", not where positionals fall; that is the extraction walk's job below.
+    return False
+
+
 def _search_path_args_raw(search_args: list[str]) -> list[str]:
     """Same walk as ``_search_path_args`` but WITHOUT its ``paths or ["."]`` fallback --
     an empty return means the caller supplied no explicit PATH positional at all
     (``paths_defaulted``), which the fallback-collapsed public helper cannot
     distinguish from an explicit ``.`` (both become ``["."]`` there).
     ``_search_args_paths_defaulted`` below is the only reason this is split out; keep
-    both derived from one walk so they can never drift out of sync with each other."""
+    both derived from one walk so they can never drift out of sync with each other.
+
+    Task #269 independent-gate BLOCKING-1: `regexp_pattern_seen` is seeded from
+    `_search_args_contains_pattern_source_flag`'s pre-pass (a TWO-pass walk) rather than
+    starting `False` and flipping mid-walk -- see that function's docstring for why a
+    single-pass walk silently misread a PATH positional occurring BEFORE the pattern-source
+    flag in argv as the bare pattern instead."""
     paths: list[str] = []
     bare_pattern_seen = False
-    regexp_pattern_seen = False
+    regexp_pattern_seen = _search_args_contains_pattern_source_flag(search_args)
     skip_next = False
     parse_options = True
     for index, arg in enumerate(search_args):
@@ -677,37 +756,18 @@ def _search_path_args_raw(search_args: list[str]) -> list[str]:
             # within the SAME commit that added it): scan past leading BOOLEAN short flags
             # (e.g. `-i`, `-n`) until the first ATTACHED-VALUE short flag, which swallows the
             # remainder of the token -- or, if it is the token's LAST character, the NEXT argv
-            # token -- as its own value.
-            #
-            # Task #269 independent-gate BLOCKING-3 (re-gate on the FIX-1 round itself): the
-            # prior version of this branch only matched `-e`/`-f` as literally the FIRST
-            # character of the token (a plain `arg.startswith(("-e", "-f"))` check), so
-            # rg's own accepted MID-BUNDLE form -- `-ieneedle` == `-i -e needle`, `-ie needle`
-            # == `-i -e` <value in the next arg> -- fell through to the generic dash-skip below
-            # unrecognized: the token was dropped as opaque, the REAL PATH after it got
-            # silently misread as the bare pattern, and the wrong (cwd's) root ignore file got
-            # injected -- the exact "an argv form nobody enumerated" bug this whole PR closes,
-            # reproduced a third time by machinery that was already sitting in this same file.
-            # `-e`/`-f` specifically are PATTERN-SOURCE flags (mark `regexp_pattern_seen`);
-            # every OTHER attached-value short flag bundled the same way (`-im 5 needle
-            # otherdir` == `-i -m 5 needle otherdir`) needs the identical value-consumption
-            # handling even though it is not a pattern source -- independent-gate NB-1, closed
-            # in this same walk rather than as a second special case.
-            if not arg.startswith("--") and len(arg) > 2 and arg.startswith("-"):
-                consumed_as_attached_value = False
-                for offset, ch in enumerate(arg[1:], start=1):
-                    if f"-{ch}" not in _SEARCH_ATTACHED_VALUE_SHORT_FLAGS:
-                        continue
-                    consumed_as_attached_value = True
-                    if ch in ("e", "f"):
-                        regexp_pattern_seen = True
-                    if offset == len(arg) - 1:
-                        # The attached-value flag is the LAST character of this token -- its
-                        # value is the NEXT argv token, not attached (`-ie needle` / `-im 5`).
-                        skip_next = index + 1 < len(search_args)
-                    break
-                if consumed_as_attached_value:
-                    continue
+            # token -- as its own value. Shares `_attached_cluster_value_offset` with the
+            # pre-pass above rather than re-deriving the same cluster logic a second time.
+            offset = _attached_cluster_value_offset(arg)
+            if offset is not None:
+                ch = arg[offset]
+                if ch in ("e", "f"):
+                    regexp_pattern_seen = True
+                if offset == len(arg) - 1:
+                    # The attached-value flag is the LAST character of this token -- its
+                    # value is the NEXT argv token, not attached (`-ie needle` / `-im 5`).
+                    skip_next = index + 1 < len(search_args)
+                continue
             if arg in _SEARCH_FLAGS_WITH_VALUES:
                 skip_next = index + 1 < len(search_args)
                 continue
@@ -1185,9 +1245,16 @@ def _run_rg_passthrough(binary_name: str, search_args: list[str]) -> int:
     # (`rust_core/src/rg_passthrough.rs::root_ignore_file_args`). `_search_path_args` gives the
     # same raw-argv positional-path extraction already used throughout this module (e.g.
     # `_search_args_paths_defaulted`), so the roots this computes always match what real rg
-    # will actually search. The emitted `--ignore-file <path>` operands are PREPENDED (not
-    # appended) so they land before any `--` end-of-options sentinel the user's own argv might
-    # contain -- inserting after it would misparse them as positional paths. `-u`/`-uu`/`-uuu`/
+    # will actually search -- this claim held only from BLOCKING-1's fix onward
+    # (`_search_path_args_raw` is now a genuine two-pass walk via
+    # `_search_args_contains_pattern_source_flag`'s pre-pass; earlier rounds of this same PR
+    # computed the wrong roots whenever a pattern-source flag followed the PATH positional in
+    # argv, since rg's own grammar is order-independent but a single left-to-right pass is
+    # not -- independent-gate finding, task #269).
+    #
+    # The emitted `--ignore-file <path>` operands are PREPENDED (not appended) so they land
+    # before any `--` end-of-options sentinel the user's own argv might contain -- inserting
+    # after it would misparse them as positional paths. `-u`/`-uu`/`-uuu`/
     # `--unrestricted` (rg's documented `--no-ignore` alias) is checked via
     # `_search_args_request_unrestricted` -- the SAME helper
     # `_search_args_request_unrestricted_generated_scan` (the broad-scan guardrail) uses --

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -186,7 +186,11 @@ _SEARCH_PCRE2_FLAGS = {"-P", "--pcre2"}
 # not pattern text, so folding it in there would feed a filename string into invalid-regex
 # validation. This is a narrower, `_search_path_args_raw`-only concern.
 _SEARCH_PATTERN_SOURCE_FLAGS = _SEARCH_PATTERN_FLAGS | {"-f", "--file"}
-_SEARCH_PATTERN_SOURCE_ATTACHED_SHORT_FLAGS = ("-e", "-f")
+# NOTE: the attached/bundled short forms of `-e`/`-f` (`-eVAL`, `-fVAL`, and mid-bundle forms
+# like `-ieVAL`) are handled by `_search_path_args_raw`'s own general cluster walk (below,
+# independent-gate BLOCKING-3), not by a separate constant here -- a prior round's
+# `arg.startswith((...))` check using a tuple like this one only matched `-e`/`-f` as the
+# token's FIRST character and missed the mid-bundle form real rg accepts.
 _SEARCH_FLAGS_WITH_VALUES = {
     "-A",
     "-B",
@@ -666,20 +670,44 @@ def _search_path_args_raw(search_args: list[str]) -> list[str]:
             if any(arg.startswith(f"{flag}=") for flag in _SEARCH_PATTERN_SOURCE_FLAGS):
                 regexp_pattern_seen = True
                 continue
-            # Attached short-flag pattern-source form (`-eneedle` == `-e needle`,
-            # `-fpats.txt` == `-f pats.txt`). Must be checked BEFORE the generic
-            # `_is_short_flag_with_attached_value` branch below, which recognizes the same
-            # tokens as attached-value flags but does not mark a pattern as already supplied --
-            # letting them fall through there reproduces this exact bug (task #269
-            # independent-gate FIX-1: the first REAL positional, the PATH, gets silently
-            # misread as the bare pattern, and `_search_path_args` falls back to `["."]`).
-            if (
-                not arg.startswith("--")
-                and len(arg) > 2
-                and arg.startswith(_SEARCH_PATTERN_SOURCE_ATTACHED_SHORT_FLAGS)
-            ):
-                regexp_pattern_seen = True
-                continue
+            # Bundled/clustered short-flag walk (mirrors `_requires_full_cli`'s bundled scan
+            # and `_search_args_request_unrestricted`'s cluster walk, both above in this same
+            # module -- cited by NAME rather than a line range on purpose, per the NB-2 lesson
+            # from this task's independent gate: a raw line-number citation drifted stale
+            # within the SAME commit that added it): scan past leading BOOLEAN short flags
+            # (e.g. `-i`, `-n`) until the first ATTACHED-VALUE short flag, which swallows the
+            # remainder of the token -- or, if it is the token's LAST character, the NEXT argv
+            # token -- as its own value.
+            #
+            # Task #269 independent-gate BLOCKING-3 (re-gate on the FIX-1 round itself): the
+            # prior version of this branch only matched `-e`/`-f` as literally the FIRST
+            # character of the token (a plain `arg.startswith(("-e", "-f"))` check), so
+            # rg's own accepted MID-BUNDLE form -- `-ieneedle` == `-i -e needle`, `-ie needle`
+            # == `-i -e` <value in the next arg> -- fell through to the generic dash-skip below
+            # unrecognized: the token was dropped as opaque, the REAL PATH after it got
+            # silently misread as the bare pattern, and the wrong (cwd's) root ignore file got
+            # injected -- the exact "an argv form nobody enumerated" bug this whole PR closes,
+            # reproduced a third time by machinery that was already sitting in this same file.
+            # `-e`/`-f` specifically are PATTERN-SOURCE flags (mark `regexp_pattern_seen`);
+            # every OTHER attached-value short flag bundled the same way (`-im 5 needle
+            # otherdir` == `-i -m 5 needle otherdir`) needs the identical value-consumption
+            # handling even though it is not a pattern source -- independent-gate NB-1, closed
+            # in this same walk rather than as a second special case.
+            if not arg.startswith("--") and len(arg) > 2 and arg.startswith("-"):
+                consumed_as_attached_value = False
+                for offset, ch in enumerate(arg[1:], start=1):
+                    if f"-{ch}" not in _SEARCH_ATTACHED_VALUE_SHORT_FLAGS:
+                        continue
+                    consumed_as_attached_value = True
+                    if ch in ("e", "f"):
+                        regexp_pattern_seen = True
+                    if offset == len(arg) - 1:
+                        # The attached-value flag is the LAST character of this token -- its
+                        # value is the NEXT argv token, not attached (`-ie needle` / `-im 5`).
+                        skip_next = index + 1 < len(search_args)
+                    break
+                if consumed_as_attached_value:
+                    continue
             if arg in _SEARCH_FLAGS_WITH_VALUES:
                 skip_next = index + 1 < len(search_args)
                 continue

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -578,16 +578,38 @@ def _search_args_include_generated_scan_bound(
     return False
 
 
+# Task #269 independent-gate finding: the naive `arg.startswith("-u")` this replaced only
+# matched `-u`/`-uu`/`-uuu` as the WHOLE token -- it missed the bundled/clustered short-flag
+# form (`-iu`, `-nu`, ...), which rg's own clap-style parser accepts identically to `-i -u` /
+# `-n -u`. Walks the cluster the same way `_requires_full_cli`'s bundled-scan does (lines
+# ~369-374 above): the first ATTACHED-VALUE short flag in a cluster swallows the remainder of
+# that token as its own value, so a `u` appearing after it is DATA, not a flag -- `-tu` means
+# `--type u`, not `-t -u`. Extracted to one named helper (rather than two separately-maintained
+# copies of the same rule) so `_search_args_request_unrestricted_generated_scan` (the broad-scan
+# guardrail) and `_run_rg_passthrough` (task #269 root-ignore-file gating) cannot silently drift
+# out of parity with each other -- the exact "one rule, two implementations" trap this whole PR
+# exists to close for `.gitignore` honoring.
+def _search_args_request_unrestricted(search_args: list[str]) -> bool:
+    for arg in search_args:
+        if arg == "--unrestricted":
+            return True
+        if not arg.startswith("-") or arg.startswith("--"):
+            continue
+        for ch in arg[1:]:
+            if ch == "u":
+                return True
+            if f"-{ch}" in _SEARCH_ATTACHED_VALUE_SHORT_FLAGS:
+                break
+    return False
+
+
 def _search_args_request_unrestricted_generated_scan(search_args: list[str]) -> bool:
     files_mode = "--files" in search_args
     if files_mode and any(arg in _SEARCH_HIDDEN_FLAGS for arg in search_args):
         return True
     if any(arg in _SEARCH_NO_IGNORE_FLAGS for arg in search_args):
         return True
-    return any(
-        arg == "--unrestricted" or (arg.startswith("-u") and not arg.startswith("--"))
-        for arg in search_args
-    )
+    return _search_args_request_unrestricted(search_args)
 
 
 def _search_path_args_raw(search_args: list[str]) -> list[str]:
@@ -1096,7 +1118,13 @@ def _run_rg_passthrough(binary_name: str, search_args: list[str]) -> int:
     # `_search_args_paths_defaulted`), so the roots this computes always match what real rg
     # will actually search. The emitted `--ignore-file <path>` operands are PREPENDED (not
     # appended) so they land before any `--` end-of-options sentinel the user's own argv might
-    # contain -- inserting after it would misparse them as positional paths.
+    # contain -- inserting after it would misparse them as positional paths. `-u`/`-uu`/`-uuu`/
+    # `--unrestricted` (rg's documented `--no-ignore` alias) is checked via
+    # `_search_args_request_unrestricted` -- the SAME helper
+    # `_search_args_request_unrestricted_generated_scan` (the broad-scan guardrail) uses --
+    # rather than a second hand-rolled predicate (independent-gate finding: without it
+    # `-u` came out STRICTER than no flag at all, since the emitted `--ignore-file` survives
+    # `--no-ignore` by design and would silently resurrect the rules `-u` asked to disable).
     from tensor_grep.cli.rg_root_ignore import root_ignore_file_args
 
     ignore_file_ops = root_ignore_file_args(
@@ -1105,6 +1133,7 @@ def _run_rg_passthrough(binary_name: str, search_args: list[str]) -> int:
         no_ignore_files="--no-ignore-files" in search_args,
         no_ignore_vcs="--no-ignore-vcs" in search_args,
         no_ignore_dot="--no-ignore-dot" in search_args,
+        unrestricted=int(_search_args_request_unrestricted(search_args)),
     )
     return _streaming_passthrough_returncode(
         [binary_name, *ignore_file_ops, *search_args], timeout_env_var="TG_RG_TIMEOUT_SECONDS"

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -191,6 +191,16 @@ _SEARCH_PATTERN_SOURCE_FLAGS = _SEARCH_PATTERN_FLAGS | {"-f", "--file"}
 # independent-gate BLOCKING-3), not by a separate constant here -- a prior round's
 # `arg.startswith((...))` check using a tuple like this one only matched `-e`/`-f` as the
 # token's FIRST character and missed the mid-bundle form real rg accepts.
+# Independent-gate final-gate finding (differential fuzz against `.claude/
+# rg_argv_differential_fuzz.py`'s rg-grammar model, task #269): `--generate` takes a value in
+# real rg but was previously listed ONLY in `_TG_ONLY_SEARCH_FLAGS` above (which gates ROUTING
+# -- forcing full-CLI dispatch), never here (which gates VALUE CONSUMPTION in the positional
+# walk below). The two sets answer different questions and one flag can need to be in both;
+# `--generate`'s absence here made `_search_path_args_raw(["--generate", "py", ...])` treat
+# "py" as a positional/pattern instead of `--generate`'s own value -- unreachable through
+# `_run_rg_passthrough` today (routing already forces full-CLI first), but this function is
+# shared by several broad-scan guards that run BEFORE that routing decision, so a real grammar
+# gap here is not automatically inert. Found by exhaustive differential fuzzing, not by hand.
 _SEARCH_FLAGS_WITH_VALUES = {
     "-A",
     "-B",
@@ -213,6 +223,7 @@ _SEARCH_FLAGS_WITH_VALUES = {
     "--field-match-separator",
     "--file",
     "-f",
+    "--generate",
     "--glob",
     "--gpu-device-ids",
     "--hostname-bin",
@@ -701,9 +712,21 @@ def _search_args_contains_pattern_source_flag(search_args: list[str]) -> bool:
         if offset is not None:
             if arg[offset] in ("e", "f"):
                 return True
-            # Consumed as a non-pattern-source attached value (e.g. `-tpy`, `-im5`) -- nothing
-            # more to classify for this token; it carries no separate-token value to skip
-            # either way (attached values live inside the same token by definition).
+            # Independent-gate re-gate BLOCKING-2: a non-pattern-source attached-value flag
+            # (e.g. `-tpy`, `-im5`) is only self-contained when its value is ATTACHED within
+            # the same token. When the value char is the token's LAST character (`-ir`, `-ig`
+            # -- a bundled `-i` plus `-r`/`-g` with the value in the NEXT argv token, `-ir
+            # needle`), that next token is the flag's VALUE, not a genuine positional -- it
+            # must be skipped here too, exactly like the extraction walk below already does,
+            # or a value that happens to look like a pattern-source flag gets misclassified.
+            # The prior version of this pre-pass shared `_attached_cluster_value_offset` (the
+            # OFFSET) with the extraction walk but let each pass decide `skip_next`
+            # independently -- the offset was unified, the CONSUMPTION was not, and that
+            # asymmetry (`-r -e needle` correctly not a pattern source; `-ir -e needle`
+            # wrongly WAS, because the un-skipped "-e" got read as its own flag) is exactly
+            # the "one rule, two implementations" trap this whole PR exists to close.
+            if offset == len(arg) - 1:
+                skip_next = True
             continue
         if arg in _SEARCH_FLAGS_WITH_VALUES:
             skip_next = True

--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -175,6 +175,18 @@ _BROAD_GENERATED_SCAN_DIR_NAMES = {
 _SEARCH_PATTERN_FLAGS = {"-e", "--regexp"}
 _SEARCH_LITERAL_FLAGS = {"-F", "--fixed-strings"}
 _SEARCH_PCRE2_FLAGS = {"-P", "--pcre2"}
+# Task #269 independent-gate FIX-1: `-f`/`--file`/`--file=` supply pattern(s) FROM A FILE, same
+# as `-e`/`--regexp` supply the pattern text directly -- both are PATTERN-SOURCE flags whose
+# presence means the bare positional pattern slot is already filled, so `_search_path_args_raw`
+# below must treat the token immediately following either as ALREADY the pattern, not skip past
+# it into misreading the next positional (the actual PATH) as a bare pattern. Kept as its own
+# set/tuple rather than folding `-f`/`--file` into `_SEARCH_PATTERN_FLAGS` itself:
+# `_regex_patterns_from_search_args` also consumes `_SEARCH_PATTERN_FLAGS` to EXTRACT the
+# literal pattern TEXT from a flag's value for regex validation -- `-f`'s value is a FILENAME,
+# not pattern text, so folding it in there would feed a filename string into invalid-regex
+# validation. This is a narrower, `_search_path_args_raw`-only concern.
+_SEARCH_PATTERN_SOURCE_FLAGS = _SEARCH_PATTERN_FLAGS | {"-f", "--file"}
+_SEARCH_PATTERN_SOURCE_ATTACHED_SHORT_FLAGS = ("-e", "-f")
 _SEARCH_FLAGS_WITH_VALUES = {
     "-A",
     "-B",
@@ -225,6 +237,20 @@ _SEARCH_FLAGS_WITH_VALUES = {
     "-t",
     "-T",
 }
+# Task #269 independent-gate FIX-2: `-e` (pattern, e.g. `-eunwrap` == `-e unwrap`) was missing
+# here even though it IS an attached-value short flag in real rg. The omission produced a
+# false positive in `_search_args_request_unrestricted`'s cluster walk (below): `-eunwrap`
+# would scan past the `e` (not recognized as attached-value) and hit the `u` in "unwrap",
+# reporting "unrestricted requested" for a pattern that merely happens to contain the letter
+# `u` -- forcing `guarded_broad_root` and misrouting a perfectly valid rg-passthrough search
+# into the full Python CLI, which then rejects rg-only flags like `--no-heading`. Verified
+# strictly improving at all three consumers of this tuple: `_requires_full_cli`'s bundled scan
+# (removes a SYMMETRICAL false positive -- `-eg*.py` is `-e "g*.py"`, not `-g`, and stopping
+# the scan at `-e` now correctly treats the rest of the token as that flag's value rather than
+# more flags); `_is_short_flag_with_attached_value` (a no-op there, since `_search_path_args_raw`
+# below intercepts `-e<val>`/`-f<val>` as pattern-source flags before this generic check is
+# ever reached); and `_search_args_request_unrestricted` (the actual FIX-2 regression this
+# closes).
 _SEARCH_ATTACHED_VALUE_SHORT_FLAGS = (
     "-A",
     "-B",
@@ -232,6 +258,7 @@ _SEARCH_ATTACHED_VALUE_SHORT_FLAGS = (
     "-E",
     "-M",
     "-d",
+    "-e",
     "-f",
     "-g",
     "-j",
@@ -632,11 +659,25 @@ def _search_path_args_raw(search_args: list[str]) -> list[str]:
             parse_options = False
             continue
         if parse_options:
-            if arg in _SEARCH_PATTERN_FLAGS:
+            if arg in _SEARCH_PATTERN_SOURCE_FLAGS:
                 regexp_pattern_seen = True
                 skip_next = index + 1 < len(search_args)
                 continue
-            if any(arg.startswith(f"{flag}=") for flag in _SEARCH_PATTERN_FLAGS):
+            if any(arg.startswith(f"{flag}=") for flag in _SEARCH_PATTERN_SOURCE_FLAGS):
+                regexp_pattern_seen = True
+                continue
+            # Attached short-flag pattern-source form (`-eneedle` == `-e needle`,
+            # `-fpats.txt` == `-f pats.txt`). Must be checked BEFORE the generic
+            # `_is_short_flag_with_attached_value` branch below, which recognizes the same
+            # tokens as attached-value flags but does not mark a pattern as already supplied --
+            # letting them fall through there reproduces this exact bug (task #269
+            # independent-gate FIX-1: the first REAL positional, the PATH, gets silently
+            # misread as the bare pattern, and `_search_path_args` falls back to `["."]`).
+            if (
+                not arg.startswith("--")
+                and len(arg) > 2
+                and arg.startswith(_SEARCH_PATTERN_SOURCE_ATTACHED_SHORT_FLAGS)
+            ):
                 regexp_pattern_seen = True
                 continue
             if arg in _SEARCH_FLAGS_WITH_VALUES:

--- a/src/tensor_grep/cli/rg_root_ignore.py
+++ b/src/tensor_grep/cli/rg_root_ignore.py
@@ -1,0 +1,82 @@
+"""Task #269: shared root-ignore-file discovery for the Python-only real-`rg` forwarding paths.
+
+Both `bootstrap.py::_run_rg_passthrough` and `backends/ripgrep_backend.py::RipgrepBackend.
+_build_cmd` shell out to a real `rg` binary and are reachable whenever no compiled native `tg`
+binary is discoverable (the pip/uvx pure-Python install channel). Real `rg`'s own automatic
+`.gitignore` discovery requires `require_git=true` by default, so a root `.gitignore` is silently
+a no-op OUTSIDE a git repository -- the exact defect task #264 fixed for the COMPILED native
+binary's rg-passthrough (`rust_core/src/rg_passthrough.rs::root_ignore_file_args`), but which was
+deliberately left open on both Python-only paths (see that PR's outcome test docstring). This
+module ports that Rust function's shape verbatim for Python so all THREE implementations
+(compiled-native Rust, this module's two Python call sites) cannot silently diverge -- two
+implementations that disagree would recreate the very bug class this closes.
+
+Root-only, exactly matching the native engine's scope (`native_search.rs::build_walk_builder` /
+`index.rs::collect_file_entries`'s unconditional `add_ignore` trio): no parent-directory ascent,
+no nested-directory walk. NOT `--no-require-git`: that would additionally pull in nested and
+global gitignores via rg's normal parent-ascending discovery, diverging from tg's deliberately
+root-only scope (`docs/BACKLOG.md:154`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Root-only ignore filenames tg treats as ignore sources, in ASCENDING precedence order (rg
+#: docs: "When specifying multiple ignore files, earlier files have lower precedence than later
+#: files") -- exactly mirroring `rust_core/src/rg_passthrough.rs::ROOT_IGNORE_FILENAMES`.
+ROOT_IGNORE_FILENAMES: tuple[str, str, str] = (".ignore", ".gitignore", ".rgignore")
+
+
+def root_ignore_file_args(
+    roots: list[str] | None,
+    *,
+    no_ignore: bool,
+    no_ignore_files: bool,
+    no_ignore_vcs: bool,
+    no_ignore_dot: bool,
+) -> list[str]:
+    """Return `["--ignore-file", path, ...]` operands for every discovered root ignore file.
+
+    SECURITY / correctness (verified live against the shipped rg 15.1.0 during #744, reused
+    here rather than re-derived): an explicit `--ignore-file <path>` is NOT cancelled by
+    `--no-ignore` or `--no-ignore-vcs` -- rg's own `--no-ignore` help text says so verbatim
+    ("This does not imply --no-ignore-files, since --ignore-file is specified explicitly as a
+    command line argument"). Blindly emitting `--ignore-file` would therefore silently
+    RESURRECT ignore rules the user explicitly asked to disable, so every flag that can disable
+    root-ignore honoring is checked BEFORE emitting the matching `--ignore-file`, matching rg's
+    own documented per-flag scope:
+      - ``no_ignore``       -- matches the native engine's own single-flag gate; skip all three.
+      - ``no_ignore_files``  -- rg cancels any ``--ignore-file`` regardless of argv order per its
+        own docs ("even ones that come after this flag, are ignored"); short-circuited here too
+        so nothing is emitted at all.
+      - ``no_ignore_vcs``   -- rg's docs restrict this to source-control ignore files ("only
+        respect rules in .ignore or .rgignore"); skip only ``.gitignore``.
+      - ``no_ignore_dot``   -- rg's docs restrict this to ``.ignore``/``.rgignore`` ("Don't
+        respect filter rules from .ignore or .rgignore files ... does not impact whether filter
+        rules from .gitignore files are respected"); skip only those two.
+    ``no_ignore_exclude``/``no_ignore_global``/``no_ignore_parent`` are deliberately NOT
+    parameters: none of them govern a root ``.ignore``/``.gitignore``/``.rgignore`` file (they
+    gate ``.git/info/exclude``, the global git ignore config, and parent-directory ignore-file
+    ascent respectively), so they have no bearing on what this function emits.
+
+    ``roots`` mirrors rg's own ``args.paths``: an empty/``None`` list defaults to a single ``.``
+    root (an implicit search still has an implicit cwd root to check).
+    """
+    if no_ignore or no_ignore_files:
+        return []
+
+    effective_roots = roots or ["."]
+    operands: list[str] = []
+    for root in effective_roots:
+        root_path = Path(root)
+        for ignore_name in ROOT_IGNORE_FILENAMES:
+            if ignore_name == ".gitignore" and no_ignore_vcs:
+                continue
+            if ignore_name != ".gitignore" and no_ignore_dot:
+                continue
+            ignore_path = root_path / ignore_name
+            if ignore_path.is_file():
+                operands.append("--ignore-file")
+                operands.append(str(ignore_path))
+    return operands

--- a/src/tensor_grep/cli/rg_root_ignore.py
+++ b/src/tensor_grep/cli/rg_root_ignore.py
@@ -35,6 +35,7 @@ def root_ignore_file_args(
     no_ignore_files: bool,
     no_ignore_vcs: bool,
     no_ignore_dot: bool,
+    unrestricted: int = 0,
 ) -> list[str]:
     """Return `["--ignore-file", path, ...]` operands for every discovered root ignore file.
 
@@ -55,15 +56,34 @@ def root_ignore_file_args(
       - ``no_ignore_dot``   -- rg's docs restrict this to ``.ignore``/``.rgignore`` ("Don't
         respect filter rules from .ignore or .rgignore files ... does not impact whether filter
         rules from .gitignore files are respected"); skip only those two.
+      - ``unrestricted``    -- rg's `-u`/`-uu`/`-uuu` is a documented ALIAS: `-u` expands to
+        `--no-ignore` (`-uu` additionally implies `--hidden`, `-uuu` additionally implies
+        `--binary`), so any count > 0 already implies `--no-ignore` and must gate exactly like
+        it (independent-gate finding on task #269: this was originally missed because
+        ``ripgrep_backend.py``'s ``config.no_ignore`` and clap's own `-u` expansion are two
+        separate code paths -- neither call site alone observes both. Without this, `-u` would
+        become STRICTER than no flag at all: the emitted `--ignore-file` survives `-u`, per the
+        `no_ignore` bullet above, and silently re-applies rules `-u` asked to disable).
     ``no_ignore_exclude``/``no_ignore_global``/``no_ignore_parent`` are deliberately NOT
     parameters: none of them govern a root ``.ignore``/``.gitignore``/``.rgignore`` file (they
     gate ``.git/info/exclude``, the global git ignore config, and parent-directory ignore-file
     ascent respectively), so they have no bearing on what this function emits.
 
+    KNOWN GAP, low priority, flagged not fixed (independent-gate non-blocking note, task #269):
+    rg's `--ignore`/`--ignore-vcs`/`--ignore-dot`/`--ignore-files` RE-ENABLE flags are not
+    parameters either. rg is last-wins on repeated ignore flags, so e.g. `--no-ignore
+    --ignore-vcs` (disable everything, then re-enable VCS-scoped honoring) should behave like a
+    bare search for `.gitignore` -- but a caller that passes only the raw `no_ignore=True`
+    booleans this function takes cannot distinguish that from a bare `--no-ignore` with no
+    re-enable, so this function returns `[]` for both. Same raw-token-vs-parsed-bool class as
+    the `unrestricted` gap above, but the failure direction is the SAFE one: under-EMITTING
+    (falling back to whatever rg's own auto-discovery does, i.e. nothing outside a git repo) is
+    a missed convenience, not a resurrected-ignore-rule regression, so it is not gated here.
+
     ``roots`` mirrors rg's own ``args.paths``: an empty/``None`` list defaults to a single ``.``
     root (an implicit search still has an implicit cwd root to check).
     """
-    if no_ignore or no_ignore_files:
+    if no_ignore or no_ignore_files or unrestricted > 0:
         return []
 
     effective_roots = roots or ["."]

--- a/src/tensor_grep/cli/rg_root_ignore.py
+++ b/src/tensor_grep/cli/rg_root_ignore.py
@@ -78,13 +78,18 @@ def root_ignore_file_args(
     booleans, it returns `[]` for both that case and a bare `--no-ignore` with no re-enable.
     This is NOT because a caller cannot tell the difference -- `RipgrepBackend`'s own
     `SearchConfig` carries `ignore`/`ignore_dot`/`ignore_files`/`ignore_vcs` and forwards them
-    to rg directly elsewhere in `_build_cmd` (`ripgrep_backend.py:562/566/574/586`), and
-    `bootstrap.py`'s raw-argv caller could detect the same long-flag tokens via the identical
-    `in search_args` style already used for `no_ignore`/`no_ignore_files`/etc. It is that
-    neither call site currently THREADS that signal into this function's gating -- a scope
-    decision, not an inherent inability. The failure direction is the SAFE one: under-EMITTING
-    (falling back to whatever rg's own auto-discovery does, i.e. nothing outside a git repo) is
-    a missed convenience, not a resurrected-ignore-rule regression, so it is not gated here.
+    to rg directly elsewhere in `_build_cmd` (each guarded by its own `if config.ignore:` /
+    `if config.ignore_dot:` / `if config.ignore_files:` / `if config.ignore_vcs:` check in
+    `ripgrep_backend.py` -- cited by SHAPE rather than a line number on purpose, per the NB-2
+    lesson from this task's independent gate: a raw line-number citation drifted stale within
+    the SAME commit that added it, when an unrelated comment inserted earlier in the file
+    shifted every line below it), and `bootstrap.py`'s raw-argv caller could detect the same
+    long-flag tokens via the identical `in search_args` style already used for
+    `no_ignore`/`no_ignore_files`/etc. It is that neither call site currently THREADS that
+    signal into this function's gating -- a scope decision, not an inherent inability. The
+    failure direction is the SAFE one: under-EMITTING (falling back to whatever rg's own
+    auto-discovery does, i.e. nothing outside a git repo) is a missed convenience, not a
+    resurrected-ignore-rule regression, so it is not gated here.
 
     ``roots`` mirrors rg's own ``args.paths``: an empty/``None`` list defaults to a single ``.``
     root (an implicit search still has an implicit cwd root to check).

--- a/src/tensor_grep/cli/rg_root_ignore.py
+++ b/src/tensor_grep/cli/rg_root_ignore.py
@@ -69,14 +69,20 @@ def root_ignore_file_args(
     gate ``.git/info/exclude``, the global git ignore config, and parent-directory ignore-file
     ascent respectively), so they have no bearing on what this function emits.
 
-    KNOWN GAP, low priority, flagged not fixed (independent-gate non-blocking note, task #269):
-    rg's `--ignore`/`--ignore-vcs`/`--ignore-dot`/`--ignore-files` RE-ENABLE flags are not
-    parameters either. rg is last-wins on repeated ignore flags, so e.g. `--no-ignore
+    KNOWN GAP, low priority, flagged not fixed (independent-gate non-blocking note, task #269;
+    correction applied on re-gate -- the original wording here overstated it): rg's
+    `--ignore`/`--ignore-vcs`/`--ignore-dot`/`--ignore-files` RE-ENABLE flags are not parameters
+    of THIS function. rg is last-wins on repeated ignore flags, so e.g. `--no-ignore
     --ignore-vcs` (disable everything, then re-enable VCS-scoped honoring) should behave like a
-    bare search for `.gitignore` -- but a caller that passes only the raw `no_ignore=True`
-    booleans this function takes cannot distinguish that from a bare `--no-ignore` with no
-    re-enable, so this function returns `[]` for both. Same raw-token-vs-parsed-bool class as
-    the `unrestricted` gap above, but the failure direction is the SAFE one: under-EMITTING
+    bare search for `.gitignore`, but since this function only receives the `no_ignore*`
+    booleans, it returns `[]` for both that case and a bare `--no-ignore` with no re-enable.
+    This is NOT because a caller cannot tell the difference -- `RipgrepBackend`'s own
+    `SearchConfig` carries `ignore`/`ignore_dot`/`ignore_files`/`ignore_vcs` and forwards them
+    to rg directly elsewhere in `_build_cmd` (`ripgrep_backend.py:562/566/574/586`), and
+    `bootstrap.py`'s raw-argv caller could detect the same long-flag tokens via the identical
+    `in search_args` style already used for `no_ignore`/`no_ignore_files`/etc. It is that
+    neither call site currently THREADS that signal into this function's gating -- a scope
+    decision, not an inherent inability. The failure direction is the SAFE one: under-EMITTING
     (falling back to whatever rg's own auto-discovery does, i.e. nothing outside a git repo) is
     a missed convenience, not a resurrected-ignore-rule regression, so it is not gated here.
 

--- a/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
+++ b/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
@@ -308,3 +308,79 @@ def test_git_repo_cell_does_not_regress_via_python_bootstrap_passthrough(tmp_pat
         f"git-repo cell must stay correct (no regression): got {matched_files}\n"
         f"stdout={result.stdout!r}\nstderr={result.stderr}"
     )
+
+
+# --- Task #269 independent-gate re-gate FIX-1 (BLOCKING, SILENT): a pattern-source flag
+# (`--file`/`-f`/attached `-e<val>`) made `_search_path_args_raw` misread the real search
+# target PATH as the bare pattern, so `_run_rg_passthrough` silently injected CWD's root
+# `.gitignore` instead of the actual target directory's. Reproduces the independent gate's
+# exact measured table shape: cwd holds a root ignore file that must NOT apply; the real
+# target (an explicit PATH positional elsewhere) has its own ignore file that MUST.
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--file", "pats.txt"],
+        ["-f", "pats.txt"],
+        ["-fpats.txt"],
+        ["-eneedle"],
+    ],
+    ids=["--file", "-f", "-fpats.txt-attached", "-eneedle-attached"],
+)
+def test_pattern_source_flag_injects_the_targets_ignore_file_not_cwds(
+    tmp_path: Path, extra_args: list[str]
+) -> None:
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    cwd_root = tmp_path / "task-269-wrong-root"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    # cwd's OWN root ignore file must NOT apply -- it excludes a name that isn't even present,
+    # so its presence alone (mis-applied) wouldn't be visible; what actually distinguishes a
+    # regression is that `otherdir`'s ignore file (which excludes b.log) gets bypassed instead.
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("b.log\n", encoding="utf-8")
+    (other_dir / "a.txt").write_text("needle\n", encoding="utf-8")
+    (other_dir / "b.log").write_text("needle\n", encoding="utf-8")
+    (cwd_root / "pats.txt").write_text("needle\n", encoding="utf-8")
+    env = _force_no_native_binary_env(rg_binary)
+
+    args = ["--no-heading", *extra_args, "otherdir"]
+    result = _run_tg_search(args, cwd=cwd_root, env=env)
+
+    assert result.returncode == 0, f"argv={args}\nstdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}
+    assert matched_files == {"a.txt"}, (
+        f"{extra_args}: must honor otherdir's own .gitignore (excluding b.log), not cwd's "
+        f"(which would leave both present): got {matched_files}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )
+
+
+def test_dash_e_unattached_control_still_honors_the_targets_ignore_file(tmp_path: Path) -> None:
+    """Control for the parametrized regression above: the un-attached `-e needle` form already
+    worked before this fix (it was already recognized as a pattern-source flag) -- pins that
+    this fix did not change its behavior."""
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    cwd_root = tmp_path / "task-269-wrong-root-control"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("b.log\n", encoding="utf-8")
+    (other_dir / "a.txt").write_text("needle\n", encoding="utf-8")
+    (other_dir / "b.log").write_text("needle\n", encoding="utf-8")
+    env = _force_no_native_binary_env(rg_binary)
+
+    result = _run_tg_search(["--no-heading", "-e", "needle", "otherdir"], cwd=cwd_root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}
+    assert matched_files == {"a.txt"}

--- a/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
+++ b/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
@@ -215,7 +215,7 @@ def test_plain_text_and_json_agree_on_the_same_one_file_set(
 
 @pytest.mark.parametrize(
     "flag",
-    ["--no-ignore", "--no-ignore-vcs", "--no-ignore-files"],
+    ["--no-ignore", "--no-ignore-vcs", "--no-ignore-files", "-u"],
 )
 def test_ignore_disabling_flag_restores_the_gitignored_file_via_python_bootstrap_passthrough(
     non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
@@ -228,7 +228,14 @@ def test_ignore_disabling_flag_restores_the_gitignored_file_via_python_bootstrap
     `root_ignore_file_args` gating is load-bearing end-to-end through the real CLI, not just at
     the unit-test level -- without it, an explicit `--ignore-file` would silently resurrect the
     rule the user asked to disable (verified live against rg 15.1.0 in the #264 PR; reused, not
-    re-derived, per this task's brief)."""
+    re-derived, per this task's brief).
+
+    `-u` (rg's documented `--no-ignore` alias) is included here as the independent-gate
+    BLOCKING finding from this task's first pass: it was not observed by either call site's
+    gating at all, so the injected `--ignore-file` (immune to `--no-ignore` by design) silently
+    resurrected the ignored file under `-u` -- making `-u` STRICTER than passing no flag at
+    all. Measured pre-fix (this exact regression, `TG_DISABLE_NATIVE_TG=1`, `tg 1.98.3`):
+    `-u needle .` returned only the non-ignored file, identical to a bare search with no flag."""
     root, env = non_git_root_gitignore_corpus
 
     result = _run_tg_search(["--no-heading", flag, "needle", "."], cwd=root, env=env)
@@ -238,6 +245,34 @@ def test_ignore_disabling_flag_restores_the_gitignored_file_via_python_bootstrap
     assert matched_files == {"a.txt", "skipme.txt"}, (
         f"{flag} must restore the gitignored file: got {matched_files}\n"
         f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("flag", ["--no-ignore", "-u"])
+def test_ignore_disabling_flag_restores_the_gitignored_file_via_python_ripgrep_backend_json(
+    non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
+    flag: str,
+) -> None:
+    """The `--json` counterpart of the escape-hatch control above, on the SECOND Python
+    implementation (`RipgrepBackend._build_cmd`, via `cli/main.py`'s full CLI): a bare `--json`
+    is one of bootstrap's `_TG_ONLY_SEARCH_FLAGS`, so `--json -u` and `--json --no-ignore` both
+    land on `RipgrepBackend.search()`, never on `_run_rg_passthrough`. Independent-gate
+    non-blocking finding: this file previously only asserted `--json` was CORRECT (the
+    excludes-gitignored-file tests above), never that its escape hatches worked -- an
+    argv-construction-only check (`test_ripgrep_backend.py`'s unit coverage) is not the same as
+    an OUTCOME check through the real CLI + real rg (the exact standard #744's gate held the
+    plain-text side to)."""
+    root, env = non_git_root_gitignore_corpus
+
+    result = _run_tg_search(["--json", flag, "needle", "."], cwd=root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    payload = json.loads(result.stdout)
+    assert payload["routing_backend"] == "RipgrepBackend", payload
+    basenames = {Path(_normalize_path_str(str(p))).name for p in payload["matched_file_paths"]}
+    assert basenames == {"a.txt", "skipme.txt"}, (
+        f"{flag} must restore the gitignored file via --json too: got {basenames}\n"
+        f"stdout={result.stdout!r}"
     )
 
 

--- a/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
+++ b/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
@@ -14,17 +14,21 @@ identical pre-#264-fix defect and were explicitly out of scope for that PR.
 This file closes that gap for the Python channel: unlike the compiled-native test, the
 no-native-binary condition can be FORCED deterministically here (`TG_DISABLE_NATIVE_TG=1`)
 rather than merely hoped for, so this suite never needs to skip on that account -- it always
-exercises `bootstrap.py:1088` (plain-text) and `ripgrep_backend.py`'s `_build_cmd` (via
-`cli/main.py`'s full CLI, `--json`) for real, over a real non-git fixture directory and a real
-`rg` binary.
+exercises `bootstrap.py::_run_rg_passthrough` (plain-text; referenced by NAME, not a line
+number, per the NB-2 lesson from this task's independent gate -- an earlier version of this
+citation drifted stale when later edits to `bootstrap.py` shifted every line below it) and
+`ripgrep_backend.py`'s `_build_cmd` (via `cli/main.py`'s full CLI, `--json`) for real, over a
+real non-git fixture directory and a real `rg` binary.
 
 WHY PLAIN-TEXT AND `--json` DIVERGE AT ALL (the actual mechanism behind the whole #264/#269 bug
 family, independently confirmed here and by the sibling #744 fix on PR c597b85): bootstrap's
-own native-delegation gate, `_can_delegate_to_native_tg_search` (`bootstrap.py:456-464`), only
-forwards a search to the compiled native binary when argv contains one of a fixed
+own native-delegation gate, `_can_delegate_to_native_tg_search` (referenced by NAME, not a
+line number, per the NB-2 lesson from this task's independent gate -- an earlier version of
+this citation drifted stale when later edits to `bootstrap.py` shifted every line below it),
+only forwards a search to the compiled native binary when argv contains one of a fixed
 `supported_trigger` set -- `{--cpu, --force-cpu, --json, --ndjson, --gpu-device-ids}` -- or
-`TG_RUST_FIRST_SEARCH=1` is set (`_prefer_rust_first_search`, `bootstrap.py:292-294`, default
-off). A bare plain-text `tg search PATTERN .` has none of those triggers, so bootstrap ALWAYS
+`TG_RUST_FIRST_SEARCH=1` is set (`_prefer_rust_first_search`, default off). A bare plain-text
+`tg search PATTERN .` has none of those triggers, so bootstrap ALWAYS
 falls through to its own `_run_rg_passthrough` REGARDLESS of whether a native binary is
 discoverable (see `tests/unit/test_cli_bootstrap.py::
 test_main_entry_bare_plain_text_search_bypasses_native_delegation_even_when_native_binary_present`
@@ -154,7 +158,7 @@ def non_git_root_gitignore_corpus(tmp_path: Path) -> tuple[Path, dict[str, str]]
 def test_plain_text_search_excludes_gitignored_file_via_python_bootstrap_passthrough(
     non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
 ) -> None:
-    """Exercises `bootstrap.py::_run_rg_passthrough` (bootstrap.py:1088) directly: a bare
+    """Exercises `bootstrap.py::_run_rg_passthrough` directly: a bare
     `tg search` with no complicating flags stays on bootstrap's own fast path and never reaches
     `cli/main.py`'s full CLI."""
     root, env = non_git_root_gitignore_corpus
@@ -380,6 +384,86 @@ def test_dash_e_unattached_control_still_honors_the_targets_ignore_file(tmp_path
     env = _force_no_native_binary_env(rg_binary)
 
     result = _run_tg_search(["--no-heading", "-e", "needle", "otherdir"], cwd=cwd_root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}
+    assert matched_files == {"a.txt"}
+
+
+# --- Task #269 independent-gate re-gate BLOCKING-3 (introduced by the FIX-1 round itself) +
+# NB-1: the FIX-1 round's `arg.startswith(("-e", "-f"))` check only matched `-e`/`-f` as
+# literally the first character of the token, missing rg's own accepted MID-BUNDLE form
+# (`-ieneedle` == `-i -e needle`). `-ie needle otherdir` / `-if pats.txt otherdir` are pinned
+# explicitly here (not just their attached siblings) because they produced the right answer BY
+# ACCIDENT under the bug -- the un-consumed value token got swept up as the bare pattern
+# instead of a path, which happened to still leave the real PATH correctly identified. Without
+# pinning them, a fix that only closed the attached form would leave this class silently open.
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["-ieneedle"],
+        ["-ie", "needle"],
+        ["-ifpats.txt"],
+        ["-if", "pats.txt"],
+    ],
+    ids=["-ieneedle-attached", "-ie-separate-value", "-ifpats.txt-attached", "-if-separate-value"],
+)
+def test_mid_bundle_pattern_source_flag_injects_the_targets_ignore_file_not_cwds(
+    tmp_path: Path, extra_args: list[str]
+) -> None:
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    cwd_root = tmp_path / "task-269-wrong-root-mid-bundle"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("b.log\n", encoding="utf-8")
+    (other_dir / "a.txt").write_text("needle\n", encoding="utf-8")
+    (other_dir / "b.log").write_text("needle\n", encoding="utf-8")
+    (cwd_root / "pats.txt").write_text("needle\n", encoding="utf-8")
+    env = _force_no_native_binary_env(rg_binary)
+
+    args = ["--no-heading", *extra_args, "otherdir"]
+    result = _run_tg_search(args, cwd=cwd_root, env=env)
+
+    assert result.returncode == 0, f"argv={args}\nstdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}
+    assert matched_files == {"a.txt"}, (
+        f"{extra_args}: must honor otherdir's own .gitignore (excluding b.log), not cwd's "
+        f"(which would leave both present): got {matched_files}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )
+
+
+def test_nb1_mid_bundle_non_pattern_source_flag_does_not_misread_pattern_as_path(
+    tmp_path: Path,
+) -> None:
+    """NB-1: `-im 5 needle otherdir` (`-i -m 5`) is not a pattern-source form -- "needle" is
+    the real bare pattern, "otherdir" the real path. Outcome-level pin that the fix did not
+    just avoid a wrong file set (root_ignore_file_args already no-ops on a nonexistent
+    "needle" root either way) but that the search itself still finds the right file under the
+    real target's own ignore rules."""
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    cwd_root = tmp_path / "task-269-nb1"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (other_dir / ".gitignore").write_text("b.log\n", encoding="utf-8")
+    (other_dir / "a.txt").write_text("needle\n", encoding="utf-8")
+    (other_dir / "b.log").write_text("needle\n", encoding="utf-8")
+    env = _force_no_native_binary_env(rg_binary)
+
+    result = _run_tg_search(
+        ["--no-heading", "-im", "5", "needle", "otherdir"], cwd=cwd_root, env=env
+    )
 
     assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
     matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}

--- a/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
+++ b/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
@@ -468,3 +468,75 @@ def test_nb1_mid_bundle_non_pattern_source_flag_does_not_misread_pattern_as_path
     assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
     matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}
     assert matched_files == {"a.txt"}
+
+
+# --- Task #269 independent-gate FINAL-GATE BLOCKING-1: rg's grammar is ORDER-INDEPENDENT (a
+# pattern-source flag may appear before OR after the positional PATH), but
+# `_search_path_args_raw` was a single left-to-right pass that only learned "a pattern is
+# already supplied" at the MOMENT it encountered the flag -- a PATH positional occurring
+# BEFORE the flag in argv was silently misread as the bare pattern, and the WRONG root's
+# `.gitignore` got injected. This is the independent gate's own measured repro, reproduced
+# here at the outcome level: `sub` (the real search target, appearing FIRST) has its own
+# `.gitignore`; cwd's `.gitignore` must NOT apply. Plain-text and `--json` are both asserted so
+# a regression confined to only one Python implementation cannot hide behind the other.
+
+
+def test_path_before_pattern_source_flag_honors_the_targets_own_ignore_file(
+    tmp_path: Path,
+) -> None:
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    cwd_root = tmp_path / "task-269-blocking1"
+    sub = cwd_root / "sub"
+    sub.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (sub / ".gitignore").write_text("d.log\n", encoding="utf-8")
+    (sub / "c.txt").write_text("needle\n", encoding="utf-8")
+    (sub / "d.log").write_text("needle\n", encoding="utf-8")
+    env = _force_no_native_binary_env(rg_binary)
+
+    plain = _run_tg_search(["--no-heading", "sub", "-eneedle"], cwd=cwd_root, env=env)
+    as_json = _run_tg_search(["--json", "sub", "-eneedle"], cwd=cwd_root, env=env)
+
+    assert plain.returncode == 0, f"stdout={plain.stdout!r}\nstderr={plain.stderr}"
+    assert as_json.returncode == 0, f"stdout={as_json.stdout!r}\nstderr={as_json.stderr}"
+    plain_files = {Path(f).name for f in _matched_files_from_plain_text(plain.stdout)}
+    payload = json.loads(as_json.stdout)
+    json_files = {Path(_normalize_path_str(str(p))).name for p in payload["matched_file_paths"]}
+
+    assert plain_files == json_files == {"c.txt"}, (
+        f"PATH-before-flag ordering must honor sub's own .gitignore on both surfaces: "
+        f"plain={plain_files} json={json_files}\n"
+        f"plain stdout={plain.stdout!r}\njson stdout={as_json.stdout!r}"
+    )
+
+
+def test_path_before_pattern_source_flag_injects_nothing_when_target_has_no_ignore_file(
+    tmp_path: Path,
+) -> None:
+    """The independent gate's other measured row: `otherdir` has NO ignore file of its own --
+    cwd's `.gitignore` must not leak in, so nothing should be filtered at all."""
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    cwd_root = tmp_path / "task-269-blocking1-no-ignore"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (other_dir / "a.txt").write_text("needle\n", encoding="utf-8")
+    (other_dir / "b.log").write_text("needle\n", encoding="utf-8")
+    env = _force_no_native_binary_env(rg_binary)
+
+    result = _run_tg_search(["--no-heading", "otherdir", "-eneedle"], cwd=cwd_root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = {Path(f).name for f in _matched_files_from_plain_text(result.stdout)}
+    assert matched_files == {"a.txt", "b.log"}, (
+        f"cwd's *.log rule must NOT leak into a search rooted at otherdir: got {matched_files}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )

--- a/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
+++ b/tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py
@@ -1,0 +1,275 @@
+"""Task #269: assert the real SEARCH OUTCOME (which files get matched) through the two
+Python-only real-`rg` forwarding paths, forcing the no-native-binary channel deterministically.
+
+`tests/e2e/test_search_root_ignore_file_outcome.py` (task #264 / PR #744) pins the identical
+outcome contract for the COMPILED native `tg` binary's rg-passthrough
+(`rust_core/src/rg_passthrough.rs`), and deliberately SKIPS whenever no native `tg` binary is
+discoverable -- because while writing that test, the author found `python -m tensor_grep search`
+falls back to TWO separate, Python-only rg-passthrough implementations
+(`tensor_grep.cli.bootstrap._run_rg_passthrough` and
+`tensor_grep.backends.ripgrep_backend.RipgrepBackend._build_cmd`, the latter reached via
+`cli/main.py`'s full-CLI search command for both plain-text and `--json`) that shared the
+identical pre-#264-fix defect and were explicitly out of scope for that PR.
+
+This file closes that gap for the Python channel: unlike the compiled-native test, the
+no-native-binary condition can be FORCED deterministically here (`TG_DISABLE_NATIVE_TG=1`)
+rather than merely hoped for, so this suite never needs to skip on that account -- it always
+exercises `bootstrap.py:1088` (plain-text) and `ripgrep_backend.py`'s `_build_cmd` (via
+`cli/main.py`'s full CLI, `--json`) for real, over a real non-git fixture directory and a real
+`rg` binary.
+
+WHY PLAIN-TEXT AND `--json` DIVERGE AT ALL (the actual mechanism behind the whole #264/#269 bug
+family, independently confirmed here and by the sibling #744 fix on PR c597b85): bootstrap's
+own native-delegation gate, `_can_delegate_to_native_tg_search` (`bootstrap.py:456-464`), only
+forwards a search to the compiled native binary when argv contains one of a fixed
+`supported_trigger` set -- `{--cpu, --force-cpu, --json, --ndjson, --gpu-device-ids}` -- or
+`TG_RUST_FIRST_SEARCH=1` is set (`_prefer_rust_first_search`, `bootstrap.py:292-294`, default
+off). A bare plain-text `tg search PATTERN .` has none of those triggers, so bootstrap ALWAYS
+falls through to its own `_run_rg_passthrough` REGARDLESS of whether a native binary is
+discoverable (see `tests/unit/test_cli_bootstrap.py::
+test_main_entry_bare_plain_text_search_bypasses_native_delegation_even_when_native_binary_present`
+for the routing-only proof, which pins this even with a native binary resolvable -- not merely
+absent). `--json` IS a supported trigger, so it can reach the native engine (which already
+honors root ignore files correctly per #127) whenever a native binary exists; the output-format
+flag doesn't change ignore-handling directly, it changes WHICH ENGINE runs. That is the real
+generator of "an output-format flag changes the file set" -- flagged here for visibility, not
+fixed (a delegation gate keyed on output-format flags is a broader design question, out of
+scope for this task).
+
+This file forces the no-native-binary cell specifically (the pip/uvx pure-Python channel this
+task's bug lives in) via `TG_DISABLE_NATIVE_TG=1`, so it is not sensitive to whether a native
+binary happens to be discoverable on the machine running it.
+
+Skipped only when a real `rg` binary cannot be resolved (mirrors
+`tests/e2e/test_search_root_ignore_file_outcome.py` and the `rg_path` fixture in
+`tests/conftest.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "src"
+
+
+def _helpers():
+    from helpers import rg_parity
+
+    return rg_parity
+
+
+def _write_non_git_root_gitignore_corpus(root: Path) -> None:
+    root.mkdir(parents=True)
+    # Deliberately NOT `git init`: task #264/#269 is specifically about a NON-git directory,
+    # where real rg's own `.gitignore` auto-discovery is a no-op by default
+    # (`require_git=true`). A `.git` marker anywhere in an ancestor of `root` would mask the
+    # exact bug this file pins.
+    (root / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (root / "a.txt").write_text("needle\n", encoding="utf-8")
+    (root / "skipme.txt").write_text("needle\n", encoding="utf-8")
+
+
+def _force_no_native_binary_env(rg_binary: Path) -> dict[str, str]:
+    """Build a subprocess env that forces the Python-only channel deterministically:
+    `TG_DISABLE_NATIVE_TG=1` short-circuits `resolve_native_tg_binary()` to `None`
+    (`runtime_paths.py:282-283`) regardless of what happens to be on this machine, so this
+    suite never needs to skip (or worse, silently exercise the wrong implementation) based on
+    native-binary discoverability."""
+    env = os.environ.copy()
+    pythonpath_entries = [str(SRC_DIR)]
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    if existing_pythonpath:
+        pythonpath_entries.extend(
+            entry
+            for entry in existing_pythonpath.split(os.pathsep)
+            if entry and entry != str(SRC_DIR)
+        )
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env["TG_RG_PATH"] = str(rg_binary)
+    env["TG_DISABLE_NATIVE_TG"] = "1"
+    env.pop("TG_NATIVE_TG_BINARY", None)
+    env.pop("TG_MCP_TG_BINARY", None)
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env
+
+
+def _run_tg_search(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tensor_grep", "search", *args],
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _matched_files_from_plain_text(stdout: str) -> set[str]:
+    files: set[str] = set()
+    for line in stdout.replace("\r\n", "\n").splitlines():
+        if not line:
+            continue
+        path = line.split(":", 1)[0]
+        files.add(_normalize_path_str(path))
+    return files
+
+
+def _normalize_path_str(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+@pytest.fixture()
+def non_git_root_gitignore_corpus(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    root = tmp_path / "task-269-root-ignore"
+    _write_non_git_root_gitignore_corpus(root)
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+    return root, _force_no_native_binary_env(rg_binary)
+
+
+def test_plain_text_search_excludes_gitignored_file_via_python_bootstrap_passthrough(
+    non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
+) -> None:
+    """Exercises `bootstrap.py::_run_rg_passthrough` (bootstrap.py:1088) directly: a bare
+    `tg search` with no complicating flags stays on bootstrap's own fast path and never reaches
+    `cli/main.py`'s full CLI."""
+    root, env = non_git_root_gitignore_corpus
+
+    result = _run_tg_search(["--no-heading", "needle", "."], cwd=root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = _matched_files_from_plain_text(result.stdout)
+    assert matched_files == {"a.txt"}, (
+        "plain-text `tg search` (bootstrap._run_rg_passthrough) must exclude the gitignored "
+        f"file in a non-git directory (task #269): got {matched_files}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )
+
+
+def test_json_search_excludes_gitignored_file_via_python_ripgrep_backend(
+    non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
+) -> None:
+    """Exercises `RipgrepBackend._build_cmd` (via `cli/main.py`'s full CLI): a bare `--json`
+    is one of bootstrap's `_TG_ONLY_SEARCH_FLAGS`, so it routes to the full CLI, where
+    `RipgrepBackend.search()` (json_mode=True) is the engine actually invoked whenever no
+    native binary is discoverable."""
+    root, env = non_git_root_gitignore_corpus
+
+    result = _run_tg_search(["--json", "needle", "."], cwd=root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    payload = json.loads(result.stdout)
+    assert payload["routing_backend"] == "RipgrepBackend", payload
+    json_files = {_normalize_path_str(str(p)) for p in payload["matched_file_paths"]}
+    json_basenames = {Path(p).name for p in json_files}
+    assert json_basenames == {"a.txt"}, (
+        "`tg search --json` (RipgrepBackend._build_cmd) must exclude the gitignored file: "
+        f"got {json_files}\nstdout={result.stdout!r}"
+    )
+
+
+def test_plain_text_and_json_agree_on_the_same_one_file_set(
+    non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
+) -> None:
+    """The core #264/#269 claim ported to the Python-only channel: an output-format flag must
+    never change WHICH FILES are searched. A test that only checks parity (not the absolute
+    correct set) would have passed BEFORE this fix too, since both Python implementations
+    shared the identical defect -- so this is deliberately a THIRD assertion alongside the two
+    single-surface tests above, never a substitute for them."""
+    root, env = non_git_root_gitignore_corpus
+
+    plain = _run_tg_search(["--no-heading", "needle", "."], cwd=root, env=env)
+    as_json = _run_tg_search(["--json", "needle", "."], cwd=root, env=env)
+
+    assert plain.returncode == 0 and as_json.returncode == 0
+    plain_files = _matched_files_from_plain_text(plain.stdout)
+    payload = json.loads(as_json.stdout)
+    json_files = {Path(_normalize_path_str(str(p))).name for p in payload["matched_file_paths"]}
+
+    assert plain_files == json_files == {"a.txt"}
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--no-ignore", "--no-ignore-vcs", "--no-ignore-files"],
+)
+def test_ignore_disabling_flag_restores_the_gitignored_file_via_python_bootstrap_passthrough(
+    non_git_root_gitignore_corpus: tuple[Path, dict[str, str]],
+    flag: str,
+) -> None:
+    """Regression control for the fix's escape hatches, ported from PR #744's outcome test:
+    each of `--no-ignore` / `--no-ignore-vcs` / `--no-ignore-files` must still search BOTH
+    files (only `.gitignore` exists in this fixture, so `--no-ignore-vcs` and
+    `--no-ignore-files` behave identically to `--no-ignore` here). Proves the shared
+    `root_ignore_file_args` gating is load-bearing end-to-end through the real CLI, not just at
+    the unit-test level -- without it, an explicit `--ignore-file` would silently resurrect the
+    rule the user asked to disable (verified live against rg 15.1.0 in the #264 PR; reused, not
+    re-derived, per this task's brief)."""
+    root, env = non_git_root_gitignore_corpus
+
+    result = _run_tg_search(["--no-heading", flag, "needle", "."], cwd=root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = _matched_files_from_plain_text(result.stdout)
+    assert matched_files == {"a.txt", "skipme.txt"}, (
+        f"{flag} must restore the gitignored file: got {matched_files}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )
+
+
+def test_git_repo_cell_does_not_regress_via_python_bootstrap_passthrough(tmp_path: Path) -> None:
+    """Inside a real git repo, real rg's own auto-discovery already honors the root
+    `.gitignore` (require_git defaults true and is satisfied) -- this fix must not add a
+    SECOND, redundant `--ignore-file` that changes behavior there. `--ignore-file` ranks below
+    rg's auto-discovered rules, so redundant-not-harmful is the expected shape (reused from the
+    #264 PR's live verification), but this test pins the OUTCOME regardless of mechanism."""
+    rg_parity = _helpers()
+    rg_binary = rg_parity.resolve_pinned_rg_binary()
+    if rg_binary is None:
+        pytest.skip("ripgrep binary not available for #269 root-ignore-file outcome coverage")
+
+    root = tmp_path / "task-269-git-repo"
+    _write_non_git_root_gitignore_corpus(root)
+    init = subprocess.run(
+        ["git", "init", "-q"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if init.returncode != 0:
+        pytest.skip(f"git init unavailable for the control cell: {init.stderr}")
+    env = _force_no_native_binary_env(rg_binary)
+
+    result = _run_tg_search(["--no-heading", "needle", "."], cwd=root, env=env)
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    matched_files = _matched_files_from_plain_text(result.stdout)
+    assert matched_files == {"a.txt"}, (
+        f"git-repo cell must stay correct (no regression): got {matched_files}\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr}"
+    )

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -411,7 +411,7 @@ def test_main_entry_bare_plain_text_search_bypasses_native_delegation_even_when_
     monkeypatch,
 ) -> None:
     """Task #269 map finding, independently confirmed (also root-caused by the sibling #744
-    fix on PR c597b85): `_can_delegate_to_native_tg_search` (`bootstrap.py:456-464`) only
+    fix on PR c597b85): `_can_delegate_to_native_tg_search` only
     forwards a search to the compiled native binary when argv contains one of
     `{--cpu, --force-cpu, --json, --ndjson, --gpu-device-ids}`, or `TG_RUST_FIRST_SEARCH=1`
     (default off). A bare `tg search PATTERN .` has none of those triggers, so bootstrap ALWAYS
@@ -702,7 +702,8 @@ def test_requires_full_cli_does_not_misread_dash_e_glob_looking_pattern_as_glob_
 # `[]`, `_search_path_args` fell back to `["."]`, and `_run_rg_passthrough` injected the ROOT
 # `.gitignore` for the WRONG directory (cwd, not the actual search target) -- a silent
 # wrong-file-set, the exact class this whole PR family exists to close. Fixed via
-# `_SEARCH_PATTERN_SOURCE_FLAGS`/`_SEARCH_PATTERN_SOURCE_ATTACHED_SHORT_FLAGS`.
+# `_SEARCH_PATTERN_SOURCE_FLAGS` plus the bundled/clustered cluster walk further below (which
+# also closes the mid-bundle attached form -- see the BLOCKING-3 test block after this one).
 
 
 def test_search_path_args_raw_treats_file_flag_as_pattern_source_not_a_path() -> None:
@@ -716,6 +717,103 @@ def test_search_path_args_raw_treats_attached_dash_e_as_pattern_source_not_a_pat
     assert bootstrap._search_path_args_raw(["-eneedle", "otherdir"]) == ["otherdir"]
     # Control: the un-attached form already worked before this fix.
     assert bootstrap._search_path_args_raw(["-e", "needle", "otherdir"]) == ["otherdir"]
+
+
+# --- Task #269 independent-gate re-gate BLOCKING-3 (introduced by the FIX-1 round itself) +
+# NB-1: `-e`/`-f` mid-BUNDLE with a leading boolean short flag (`-ieneedle` == `-i -e needle`,
+# `-ie needle` == `-i -e` <value in next arg>) was NOT caught by the FIX-1 round's
+# `arg.startswith(("-e", "-f"))` check (which only matches `-e`/`-f` as literally the first
+# character), so the token fell through as opaque, the real PATH after it was misread as the
+# bare pattern, and the WRONG root's `.gitignore` got injected -- same failure shape as FIX-1,
+# and origin/main was correct, so this was a genuine regression introduced by this PR. Fixed by
+# replacing the narrow `startswith` check with the general cluster walk `_requires_full_cli`
+# and `_search_args_request_unrestricted` already use elsewhere in this file. NB-1 (`-im 5
+# needle otherdir` misreading the PATTERN "needle" as a PATH) is the exact same underlying
+# defect for a NON-pattern-source attached flag (`-m`) and is closed by the same walk.
+#
+# `-ie needle otherdir` / `-if pats.txt otherdir` are explicitly pinned here because they
+# produced the RIGHT ANSWER BY ACCIDENT under the BLOCKING-3 bug (the un-consumed value token
+# got swept up as the bare pattern instead of a path, which happened to leave the real PATH
+# correctly identified) -- without a test pinning the CORRECT MECHANISM (regexp_pattern_seen
+# set via the flag, not via an accidental bare-pattern misread), a future change could
+# reintroduce BLOCKING-3 for the "value in a separate token" shape while this suite stayed
+# green.
+
+
+def test_search_path_args_raw_treats_mid_bundle_attached_dash_e_as_pattern_source() -> None:
+    # -ieneedle == -i -e needle (attached, mid-bundle).
+    assert bootstrap._search_path_args_raw(["-ieneedle", "otherdir"]) == ["otherdir"]
+    # -ifpats.txt == -i -f pats.txt (attached, mid-bundle).
+    assert bootstrap._search_path_args_raw(["-ifpats.txt", "otherdir"]) == ["otherdir"]
+
+
+def test_search_path_args_raw_treats_mid_bundle_dash_e_with_separate_value_as_pattern_source() -> (
+    None
+):
+    """Pins the CORRECT MECHANISM for the "value in the next token" bundled form, not just the
+    right final answer -- see the module comment above for why the by-accident form is
+    insufficient on its own."""
+    raw = bootstrap._search_path_args_raw(["-ie", "needle", "otherdir"])
+    assert raw == ["otherdir"], raw
+    raw = bootstrap._search_path_args_raw(["-if", "pats.txt", "otherdir"])
+    assert raw == ["otherdir"], raw
+
+
+def test_search_path_args_paths_defaulted_is_false_for_mid_bundle_attached_forms() -> None:
+    assert bootstrap._search_args_paths_defaulted(["-ieneedle", "otherdir"]) is False
+    assert bootstrap._search_args_paths_defaulted(["-ie", "needle", "otherdir"]) is False
+
+
+def test_search_path_args_raw_closes_nb1_non_pattern_source_mid_bundle_value() -> None:
+    """NB-1: `-im 5 needle otherdir` (`-i -m 5`, i.e. ignore-case + max-count=5) is NOT a
+    pattern-source flag -- "needle" is the real bare pattern, "otherdir" the real path. Before
+    this fix, "5" (which should be consumed as `-m`'s value) was silently misread as the bare
+    pattern instead, cascading "needle" into `paths` alongside "otherdir"."""
+    assert bootstrap._search_path_args_raw(["-im", "5", "needle", "otherdir"]) == ["otherdir"]
+
+
+def test_run_rg_passthrough_mid_bundle_attached_dash_e_injects_the_correct_roots_ignore_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cwd_root = tmp_path / "wrongroot3"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(cwd_root)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["-ieneedle", "otherdir"])
+
+    argv = seen["argv"]
+    flag_index = argv.index("--ignore-file")
+    injected_path = (cwd_root / argv[flag_index + 1]).resolve()
+    assert injected_path == (other_dir / ".gitignore").resolve(), (
+        f"must inject otherdir's .gitignore, not cwd's: got {injected_path}"
+    )
+
+
+def test_run_rg_passthrough_mid_bundle_dash_e_separate_value_injects_the_correct_roots_ignore_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Pins the `-ie needle otherdir` by-accident form's CORRECT MECHANISM through the real
+    `_run_rg_passthrough` entry point -- not just `_search_path_args_raw` in isolation."""
+    cwd_root = tmp_path / "wrongroot4"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(cwd_root)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["-ie", "needle", "otherdir"])
+
+    argv = seen["argv"]
+    flag_index = argv.index("--ignore-file")
+    injected_path = (cwd_root / argv[flag_index + 1]).resolve()
+    assert injected_path == (other_dir / ".gitignore").resolve(), (
+        f"must inject otherdir's .gitignore, not cwd's: got {injected_path}"
+    )
 
 
 def test_search_path_args_paths_defaulted_is_false_for_file_flag_with_explicit_path() -> None:

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -564,6 +564,95 @@ def test_run_rg_passthrough_no_ignore_dot_skips_ignore_and_rgignore_not_gitignor
     assert not any(v.endswith(".rgignore") for v in values), values
 
 
+# --- Task #269 independent-gate finding (BLOCKING on first pass): `-u`/`-uu`/`-uuu`/
+# `--unrestricted` is rg's documented alias for `--no-ignore` (`-uu` additionally implies
+# `--hidden`, `-uuu` additionally implies `--binary`), forwarded raw to real rg
+# (`_streaming_passthrough_returncode` just hands argv straight through). Neither the original
+# fix nor its tests observed it: only the four literal `--no-ignore*` long tokens were checked,
+# so `-u` left the injected `--ignore-file` in place -- and since `--ignore-file` survives
+# `--no-ignore` by design, `-u` came out STRICTER than passing no flag at all. Fixed via
+# `_search_args_request_unrestricted`, shared with the pre-existing
+# `_search_args_request_unrestricted_generated_scan` broad-scan guardrail so the two cannot
+# silently drift out of parity with each other.
+
+
+def test_run_rg_passthrough_unrestricted_suppresses_injection(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["-u", "needle", str(tmp_path)])
+
+    assert "--ignore-file" not in seen["argv"]
+
+
+def test_run_rg_passthrough_unrestricted_double_and_triple_suppress_injection(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    for flag in ("-uu", "-uuu"):
+        seen = _capture_streaming_passthrough_argv(monkeypatch)
+        bootstrap._run_rg_passthrough("rg", [flag, "needle", str(tmp_path)])
+        assert "--ignore-file" not in seen["argv"], (flag, seen["argv"])
+
+
+def test_run_rg_passthrough_unrestricted_long_form_suppresses_injection(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["--unrestricted", "needle", str(tmp_path)])
+
+    assert "--ignore-file" not in seen["argv"]
+
+
+def test_run_rg_passthrough_clustered_unrestricted_short_flag_suppresses_injection(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """`-iu` (ignore-case + unrestricted bundled into one token) is what the naive
+    `arg.startswith("-u")` predicate this replaced would have missed entirely -- `"-iu"` does
+    not start with `"-u"`. rg's own clap-style parser accepts this cluster identically to
+    `-i -u`."""
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["-iu", "needle", str(tmp_path)])
+
+    assert "--ignore-file" not in seen["argv"]
+
+
+def test_search_args_request_unrestricted_matches_bare_short_flags() -> None:
+    assert bootstrap._search_args_request_unrestricted(["-u"]) is True
+    assert bootstrap._search_args_request_unrestricted(["-uu"]) is True
+    assert bootstrap._search_args_request_unrestricted(["-uuu"]) is True
+    assert bootstrap._search_args_request_unrestricted(["--unrestricted"]) is True
+
+
+def test_search_args_request_unrestricted_matches_clustered_short_flags() -> None:
+    # -iu == -i -u; -nu == -n -u (n is not an attached-value flag, so u is still reachable).
+    assert bootstrap._search_args_request_unrestricted(["-iu"]) is True
+    assert bootstrap._search_args_request_unrestricted(["-nu"]) is True
+
+
+def test_search_args_request_unrestricted_does_not_false_positive_on_attached_value_flags() -> None:
+    # -t is an ATTACHED-VALUE short flag (file type): "-tu" means `--type u`, i.e. a file type
+    # literally named "u" -- not `-t -u`. The `u` here is DATA, not a flag, and must not trip
+    # the unrestricted gate (a false positive here would UNDER-emit --ignore-file, not
+    # over-emit -- still a correctness bug, just the safer direction than the BLOCKING one).
+    assert bootstrap._search_args_request_unrestricted(["-tu"]) is False
+    # A bare, unrelated flag/pattern must not match.
+    assert bootstrap._search_args_request_unrestricted(["-i", "needle", "."]) is False
+    assert bootstrap._search_args_request_unrestricted(["needle", "."]) is False
+
+
+def test_search_args_request_unrestricted_generated_scan_shares_the_same_helper() -> None:
+    """The pre-existing broad-scan guardrail must widen identically to the new gate -- both
+    call `_search_args_request_unrestricted` rather than maintaining separate predicates."""
+    assert bootstrap._search_args_request_unrestricted_generated_scan(["-iu", "needle"]) is True
+    assert bootstrap._search_args_request_unrestricted_generated_scan(["needle", "."]) is False
+
+
 def test_main_entry_should_not_passthrough_unbounded_generated_root_search(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -935,14 +935,37 @@ def test_search_args_contains_pattern_source_flag_stops_at_end_of_options_sentin
     assert bootstrap._search_args_contains_pattern_source_flag(["sub", "--", "-eneedle"]) is False
 
 
-def test_search_args_contains_pattern_source_flag_does_not_count_a_consumed_flag_value() -> None:
+# Independent-gate final-gate BLOCKING-2 (re-gate on the BLOCKING-1 round itself): the shared
+# `_attached_cluster_value_offset` helper unifies which OFFSET a mid-bundle attached-value flag
+# sits at, but the pre-pass previously decided `skip_next` INDEPENDENTLY of the extraction
+# walk -- and decided it wrong, never setting it at all. A mid-bundle value flag ending a token
+# (`-ir`, `-ig` -- `-i` plus `-r`/`-g`, whose value is the NEXT argv token) therefore failed to
+# consume its own value in the pre-pass, so a value that happens to look like a pattern-source
+# flag (`-e needle`, `-fpats.txt`) got misread as a SEPARATE, genuine flag instead of data.
+# `["--replace", "-eattached", "otherdir"]` alone did not catch this: `--replace` is the LONG
+# separated form, handled by the `_SEARCH_FLAGS_WITH_VALUES` arm, which already worked --
+# a negative control that only exercises the working arm proves nothing about the broken
+# mid-bundle short-flag arm. `-r` and `-g` are the only two value-taking short flags that
+# actually accept a `-e`-shaped value in real rg (verified live: `-t`/`-T` reject it as an
+# unrecognized file type, `-m`/`-A`/`-B`/`-C`/`-M`/`-d`/`-j`/`-E` reject it as a parse error) --
+# `-r` (`--replace`) and `-g` (`--glob`) both happily accept an arbitrary string.
+@pytest.mark.parametrize(
+    "search_args",
+    [
+        ["--replace", "-eattached", "otherdir"],
+        ["-ir", "-e", "needle"],
+        ["-ig", "-fpats.txt", "sub"],
+    ],
+    ids=["--replace-long-separated", "-ir-mid-bundle-r", "-ig-mid-bundle-g"],
+)
+def test_search_args_contains_pattern_source_flag_does_not_count_a_consumed_flag_value(
+    search_args: list[str],
+) -> None:
     """A token that LOOKS like a pattern-source flag but is actually another flag's VALUE
-    (e.g. `--replace -eattached`, where `-eattached` is `--replace`'s replacement string) must
-    not be misdetected as a real pattern-source flag."""
-    assert (
-        bootstrap._search_args_contains_pattern_source_flag(["--replace", "-eattached", "otherdir"])
-        is False
-    )
+    (e.g. `--replace -eattached`, where `-eattached` is `--replace`'s replacement string, or
+    the mid-bundle `-ir -e needle`/`-ig -fpats.txt sub`, where `-e`/`-f` are `-r`'s/`-g`'s own
+    value) must not be misdetected as a real pattern-source flag."""
+    assert bootstrap._search_args_contains_pattern_source_flag(search_args) is False, search_args
 
 
 def test_run_rg_passthrough_path_before_dash_e_injects_the_correct_roots_ignore_file(

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -653,6 +653,131 @@ def test_search_args_request_unrestricted_generated_scan_shares_the_same_helper(
     assert bootstrap._search_args_request_unrestricted_generated_scan(["needle", "."]) is False
 
 
+# --- Task #269 independent-gate re-gate FIX-2 (BLOCKING, introduced by the FIX-1 round's own
+# extraction): `-e` was missing from `_SEARCH_ATTACHED_VALUE_SHORT_FLAGS`, so `-eunwrap`
+# (== `-e unwrap`, a pattern that merely happens to contain the letter `u`) walked past `e` and
+# matched the `u` in "unwrap", reporting a false "unrestricted requested". That forced
+# `guarded_broad_root` and misrouted a valid rg-passthrough search into the full Python CLI,
+# which then rejected the rg-only `--no-heading` flag with exit 2. `-e` is now in
+# `_SEARCH_ATTACHED_VALUE_SHORT_FLAGS`, matching real rg's own attached-value semantics.
+
+
+def test_search_args_request_unrestricted_does_not_false_positive_on_pattern_containing_u() -> None:
+    # The exact regression: a pattern attached to -e that happens to contain the letter "u"
+    # must not be misread as -u (unrestricted).
+    assert bootstrap._search_args_request_unrestricted(["-eunwrap"]) is False
+    assert bootstrap._search_args_request_unrestricted(["-eunicorn"]) is False
+    # Control: the same pattern minus any "u" must also be False (was already False pre-fix;
+    # pins that this fix did not change the no-match case).
+    assert bootstrap._search_args_request_unrestricted(["-enicorn"]) is False
+    # A GENUINE -u after a real -e-consumed value is still correctly detected as two separate
+    # tokens (not attached) -- -e consumes its own token via skip_next elsewhere, this helper
+    # only sees raw argv, so an actual "-e", "pattern", "-u" sequence must still trip True.
+    assert bootstrap._search_args_request_unrestricted(["-e", "pattern", "-u"]) is True
+
+
+def test_search_args_request_unrestricted_e_flag_does_not_regress_clustered_forms() -> None:
+    """Parity check requested by the independent gate: `-iu`/`-nu`/`-au` must remain True after
+    adding `-e` to the attached-value tuple (this fix only changes how `-e<val>` clusters are
+    scanned, not `-i`/`-n`/`-a`-led ones)."""
+    assert bootstrap._search_args_request_unrestricted(["-iu"]) is True
+    assert bootstrap._search_args_request_unrestricted(["-nu"]) is True
+    assert bootstrap._search_args_request_unrestricted(["-au"]) is True
+
+
+def test_requires_full_cli_does_not_misread_dash_e_glob_looking_pattern_as_glob_flag() -> None:
+    """The independent gate's cited symmetrical false positive: `-eg*.py` means `-e "g*.py"`
+    (a literal pattern), not `-g *.py` (a glob walk-scope flag) -- `_requires_full_cli`'s
+    bundled-short-flag scan (~line 369) must not force full-CLI routing for it now that `-e` is
+    a recognized attached-value flag (the scan stops at `e`, never reaching the `g`)."""
+    assert bootstrap._requires_full_cli(["-eg*.py", "."]) is False
+
+
+# --- Task #269 independent-gate re-gate FIX-1 (BLOCKING, and SILENT): `-f`/`--file`/`-fVAL`/
+# `-eVAL` supply a PATTERN (from a file, or attached), but `_search_path_args_raw` only
+# recognized the bare `-e`/`--regexp` forms as "a pattern is already supplied" -- `-f`/`--file`
+# fell into the generic "flag with a value" bucket, which does NOT mark a pattern as seen. The
+# consequence: the REAL positional PATH immediately after got silently misread as the bare
+# pattern (the "first non-flag token is the pattern" rule), `_search_path_args_raw` returned
+# `[]`, `_search_path_args` fell back to `["."]`, and `_run_rg_passthrough` injected the ROOT
+# `.gitignore` for the WRONG directory (cwd, not the actual search target) -- a silent
+# wrong-file-set, the exact class this whole PR family exists to close. Fixed via
+# `_SEARCH_PATTERN_SOURCE_FLAGS`/`_SEARCH_PATTERN_SOURCE_ATTACHED_SHORT_FLAGS`.
+
+
+def test_search_path_args_raw_treats_file_flag_as_pattern_source_not_a_path() -> None:
+    assert bootstrap._search_path_args_raw(["--file", "pats.txt", "otherdir"]) == ["otherdir"]
+    assert bootstrap._search_path_args_raw(["-f", "pats.txt", "otherdir"]) == ["otherdir"]
+    assert bootstrap._search_path_args_raw(["-fpats.txt", "otherdir"]) == ["otherdir"]
+    assert bootstrap._search_path_args_raw(["--file=pats.txt", "otherdir"]) == ["otherdir"]
+
+
+def test_search_path_args_raw_treats_attached_dash_e_as_pattern_source_not_a_path() -> None:
+    assert bootstrap._search_path_args_raw(["-eneedle", "otherdir"]) == ["otherdir"]
+    # Control: the un-attached form already worked before this fix.
+    assert bootstrap._search_path_args_raw(["-e", "needle", "otherdir"]) == ["otherdir"]
+
+
+def test_search_path_args_paths_defaulted_is_false_for_file_flag_with_explicit_path() -> None:
+    """The `_search_args_paths_defaulted` predicate (used to decide whether a walk-scope flag
+    like `-g`/`-t` counts as a genuine bound, and by the broad-scan guardrails) derives from
+    `_search_path_args_raw` and shares the exact same bug: pre-fix, `-f pats.txt otherdir` read
+    as paths-defaulted (no explicit path) even though `otherdir` WAS an explicit path -- just
+    misclassified as the bare pattern."""
+    assert bootstrap._search_args_paths_defaulted(["--file", "pats.txt", "otherdir"]) is False
+    assert bootstrap._search_args_paths_defaulted(["-eneedle", "otherdir"]) is False
+
+
+def test_run_rg_passthrough_file_flag_injects_the_correct_roots_ignore_file_not_cwds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The measured regression table's shape: cwd holds a root `.gitignore` that must NOT be
+    consulted; the real search target (`otherdir`, an explicit PATH positional) has its OWN
+    `.gitignore` that MUST be. Pre-fix, `_run_rg_passthrough` silently injected cwd's file
+    instead (or, depending on exact walk state, injected nothing useful) -- either way, the
+    WRONG root's ignore file, not `otherdir`'s."""
+    cwd_root = tmp_path / "wrongroot"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(cwd_root)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["--file", "pats.txt", "otherdir"])
+
+    argv = seen["argv"]
+    flag_index = argv.index("--ignore-file")
+    # The injected path is emitted relative to the passed root ("otherdir"), matching real rg's
+    # own relative-argv convention -- resolve against cwd (which this test pinned via
+    # monkeypatch.chdir) before comparing, rather than expecting an absolute path verbatim.
+    injected_path = (cwd_root / argv[flag_index + 1]).resolve()
+    assert injected_path == (other_dir / ".gitignore").resolve(), (
+        f"must inject otherdir's .gitignore, not cwd's: got {injected_path}"
+    )
+
+
+def test_run_rg_passthrough_attached_dash_e_injects_the_correct_roots_ignore_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cwd_root = tmp_path / "wrongroot2"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (other_dir / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(cwd_root)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["-eneedle", "otherdir"])
+
+    argv = seen["argv"]
+    flag_index = argv.index("--ignore-file")
+    injected_path = (cwd_root / argv[flag_index + 1]).resolve()
+    assert injected_path == (other_dir / ".gitignore").resolve(), (
+        f"must inject otherdir's .gitignore, not cwd's: got {injected_path}"
+    )
+
+
 def test_main_entry_should_not_passthrough_unbounded_generated_root_search(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -407,6 +407,163 @@ def test_main_entry_should_passthrough_search_subcommand_to_rg(monkeypatch):
     assert seen == {"binary_name": "rg", "search_args": ["-i", "ERROR", "."]}
 
 
+def test_main_entry_bare_plain_text_search_bypasses_native_delegation_even_when_native_binary_present(
+    monkeypatch,
+) -> None:
+    """Task #269 map finding, independently confirmed (also root-caused by the sibling #744
+    fix on PR c597b85): `_can_delegate_to_native_tg_search` (`bootstrap.py:456-464`) only
+    forwards a search to the compiled native binary when argv contains one of
+    `{--cpu, --force-cpu, --json, --ndjson, --gpu-device-ids}`, or `TG_RUST_FIRST_SEARCH=1`
+    (default off). A bare `tg search PATTERN .` has none of those triggers, so bootstrap ALWAYS
+    falls through to its own `_run_rg_passthrough` -- REGARDLESS of whether a native `tg`
+    binary is discoverable. This is the actual mechanism behind the #264/#269 "an output-format
+    flag changes the file set" bug family: the flag doesn't touch ignore-handling directly, it
+    changes WHICH ENGINE runs (native, which already honored root ignore files correctly via
+    #127, vs. Python's own naive passthrough). Unlike the sibling test above (which patches
+    `resolve_native_tg_binary` to `None`), this test proves the SAME routing decision holds when
+    a native binary IS resolvable -- the trigger-set gate is what refuses delegation, not binary
+    absence."""
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(sys, "argv", ["tg", "search", "needle", "."])
+    monkeypatch.setattr(bootstrap, "resolve_native_tg_binary", lambda: "tg.exe")
+    monkeypatch.setattr(bootstrap, "resolve_ripgrep_binary", lambda: "rg")
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_native_tg_search",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a bare plain-text search must never delegate to the native binary"
+        ),
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "_run_rg_passthrough",
+        lambda binary_name, search_args: (
+            seen.update({"binary_name": binary_name, "search_args": list(search_args)}) or 0
+        ),
+    )
+    monkeypatch.setattr(bootstrap, "_run_full_cli", lambda: pytest.fail("full cli should not run"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bootstrap.main_entry()
+
+    assert excinfo.value.code == 0
+    assert seen == {"binary_name": "rg", "search_args": ["needle", "."]}
+
+
+# --- Task #269: bootstrap._run_rg_passthrough root-ignore-file injection ----------------------
+# Mirrors rust_core/src/rg_passthrough.rs's own `root_ignore_file_args` unit tests (task #264 /
+# PR #744): this is the Python-only rg-passthrough path reached whenever no compiled native `tg`
+# binary is discoverable, which shares the identical pre-#264-fix defect the Rust side already
+# closed. See `tensor_grep.cli.rg_root_ignore.root_ignore_file_args` for the shared helper both
+# this module and `RipgrepBackend._build_cmd` call.
+
+
+def _capture_streaming_passthrough_argv(monkeypatch) -> dict[str, object]:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        bootstrap,
+        "_streaming_passthrough_returncode",
+        lambda argv, timeout_env_var=None: (
+            seen.update({"argv": list(argv), "timeout_env_var": timeout_env_var}) or 0
+        ),
+    )
+    return seen
+
+
+def test_run_rg_passthrough_injects_root_gitignore_outside_git_repo(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    rc = bootstrap._run_rg_passthrough("rg", ["needle", str(tmp_path)])
+
+    assert rc == 0
+    argv = seen["argv"]
+    assert argv[0] == "rg"
+    flag_index = argv.index("--ignore-file")
+    assert argv[flag_index + 1] == str(tmp_path / ".gitignore")
+    # The injected operands must precede the user's own search_args so a `--` sentinel the user
+    # supplied (if any) still applies only to their own positionals.
+    assert argv.index("needle") > flag_index + 1
+
+
+def test_run_rg_passthrough_defaults_root_to_dot_when_path_omitted(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["needle"])
+
+    argv = seen["argv"]
+    assert "--ignore-file" in argv
+    value = argv[argv.index("--ignore-file") + 1]
+    assert Path(value).resolve() == (tmp_path / ".gitignore").resolve()
+
+
+def test_run_rg_passthrough_empty_when_no_ignore_files_present(monkeypatch, tmp_path: Path) -> None:
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["needle", str(tmp_path)])
+
+    assert seen["argv"] == ["rg", "needle", str(tmp_path)]
+
+
+def test_run_rg_passthrough_no_ignore_suppresses_injection(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".rgignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["--no-ignore", "needle", str(tmp_path)])
+
+    assert "--ignore-file" not in seen["argv"]
+
+
+def test_run_rg_passthrough_no_ignore_files_suppresses_injection(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["--no-ignore-files", "needle", str(tmp_path)])
+
+    assert "--ignore-file" not in seen["argv"]
+
+
+def test_run_rg_passthrough_no_ignore_vcs_skips_only_gitignore(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["--no-ignore-vcs", "needle", str(tmp_path)])
+
+    argv = seen["argv"]
+    values = [argv[i + 1] for i, tok in enumerate(argv) if tok == "--ignore-file"]
+    assert not any(v.endswith(".gitignore") for v in values), values
+    assert any(v.endswith(".ignore") for v in values), values
+
+
+def test_run_rg_passthrough_no_ignore_dot_skips_ignore_and_rgignore_not_gitignore(
+    monkeypatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".rgignore").write_text("skipme.txt\n", encoding="utf-8")
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["--no-ignore-dot", "needle", str(tmp_path)])
+
+    argv = seen["argv"]
+    values = [argv[i + 1] for i, tok in enumerate(argv) if tok == "--ignore-file"]
+    assert any(v.endswith(".gitignore") for v in values), values
+    assert not any(v.endswith(".ignore") and not v.endswith(".rgignore") for v in values), values
+    assert not any(v.endswith(".rgignore") for v in values), values
+
+
 def test_main_entry_should_not_passthrough_unbounded_generated_root_search(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_cli_bootstrap.py
+++ b/tests/unit/test_cli_bootstrap.py
@@ -687,8 +687,8 @@ def test_search_args_request_unrestricted_e_flag_does_not_regress_clustered_form
 
 def test_requires_full_cli_does_not_misread_dash_e_glob_looking_pattern_as_glob_flag() -> None:
     """The independent gate's cited symmetrical false positive: `-eg*.py` means `-e "g*.py"`
-    (a literal pattern), not `-g *.py` (a glob walk-scope flag) -- `_requires_full_cli`'s
-    bundled-short-flag scan (~line 369) must not force full-CLI routing for it now that `-e` is
+    (a literal pattern), not `-g *.py` (a glob walk-scope flag) -- `_requires_full_cli`'s own
+    bundled-short-flag scan must not force full-CLI routing for it now that `-e` is
     a recognized attached-value flag (the scan stops at `e`, never reaching the `g`)."""
     assert bootstrap._requires_full_cli(["-eg*.py", "."]) is False
 
@@ -873,6 +873,120 @@ def test_run_rg_passthrough_attached_dash_e_injects_the_correct_roots_ignore_fil
     injected_path = (cwd_root / argv[flag_index + 1]).resolve()
     assert injected_path == (other_dir / ".gitignore").resolve(), (
         f"must inject otherdir's .gitignore, not cwd's: got {injected_path}"
+    )
+
+
+# --- Task #269 independent-gate FINAL-GATE BLOCKING-1 (a different DIMENSION than rounds 1-3,
+# each of which enumerated HOW a pattern-source flag is spelled): rg's grammar is
+# ORDER-INDEPENDENT -- a pattern-source flag can appear BEFORE or AFTER the positional PATH
+# (`rg sub -eneedle` produces the same output as `rg -eneedle sub`) -- but
+# `_search_path_args_raw` was a single left-to-right pass whose `regexp_pattern_seen` state
+# only flipped True at the MOMENT it encountered the flag. `tg search otherdir -eneedle` (PATH
+# first) silently misread "otherdir" as the bare pattern, `_search_path_args_raw` returned an
+# empty root list, and `_run_rg_passthrough` injected the WRONG root's `.gitignore` --
+# reproducing the #264 signature (plain-text and `--json` disagreeing on the file set) a FOURTH
+# time, inside this same PR, with zero prior test coverage (no test among the prior 205 put a
+# positional before the pattern-source flag). Fixed via a genuine two-pass walk: a pre-pass
+# (`_search_args_contains_pattern_source_flag`) determines whether ANY pattern-source flag
+# appears anywhere before `--`, seeding `regexp_pattern_seen`'s STARTING value instead of
+# letting the extraction walk discover it mid-stream.
+
+
+@pytest.mark.parametrize(
+    "search_args",
+    [
+        ["otherdir", "-eneedle"],
+        ["otherdir", "-e", "needle"],
+        ["otherdir", "-fpats.txt"],
+        ["otherdir", "-f", "pats.txt"],
+        ["otherdir", "--regexp=needle"],
+        ["otherdir", "--file=pats.txt"],
+    ],
+    ids=["-eVAL", "-e VAL", "-fFILE", "-f FILE", "--regexp=VAL", "--file=FILE"],
+)
+def test_search_path_args_raw_path_before_pattern_source_flag_all_six_spellings(
+    search_args: list[str],
+) -> None:
+    """All six rg-accepted pattern-source spellings, with the PATH positional appearing FIRST
+    -- the exact dimension BLOCKING-1 found uncovered. Every one of these previously returned
+    `[]` (the PATH silently misread as the bare pattern) instead of `["otherdir"]`."""
+    assert bootstrap._search_path_args_raw(search_args) == ["otherdir"], search_args
+
+
+def test_search_path_args_raw_path_before_mid_bundle_pattern_source_flag() -> None:
+    """Mid-bundle spelling (BLOCKING-3's dimension) combined with PATH-first ordering
+    (BLOCKING-1's dimension) -- both must compose correctly."""
+    assert bootstrap._search_path_args_raw(["otherdir", "-ieneedle"]) == ["otherdir"]
+    assert bootstrap._search_path_args_raw(["otherdir", "-ie", "needle"]) == ["otherdir"]
+
+
+def test_search_path_args_paths_defaulted_is_false_when_path_precedes_pattern_source_flag() -> None:
+    assert bootstrap._search_args_paths_defaulted(["otherdir", "-eneedle"]) is False
+    assert bootstrap._search_args_paths_defaulted(["otherdir", "-e", "needle"]) is False
+
+
+def test_search_args_contains_pattern_source_flag_stops_at_end_of_options_sentinel() -> None:
+    """`-e needle -- sub` (pattern-source flag BEFORE `--`) already worked correctly before
+    this fix and must stay that way; a hypothetical pattern-source-shaped token appearing AFTER
+    `--` is a literal positional, not a flag, and must not be misdetected by the pre-pass."""
+    assert bootstrap._search_args_contains_pattern_source_flag(["-e", "needle", "--", "sub"]) is (
+        True
+    )
+    assert bootstrap._search_args_contains_pattern_source_flag(["sub", "--", "-eneedle"]) is False
+
+
+def test_search_args_contains_pattern_source_flag_does_not_count_a_consumed_flag_value() -> None:
+    """A token that LOOKS like a pattern-source flag but is actually another flag's VALUE
+    (e.g. `--replace -eattached`, where `-eattached` is `--replace`'s replacement string) must
+    not be misdetected as a real pattern-source flag."""
+    assert (
+        bootstrap._search_args_contains_pattern_source_flag(["--replace", "-eattached", "otherdir"])
+        is False
+    )
+
+
+def test_run_rg_passthrough_path_before_dash_e_injects_the_correct_roots_ignore_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Outcome-level pin through the real `_run_rg_passthrough` entry point, mirroring the
+    independent gate's own measured repro: `otherdir` (no ignore file of its own) must get
+    NOTHING injected -- not cwd's `.gitignore` -- when the pattern-source flag comes after it
+    in argv."""
+    cwd_root = tmp_path / "wrongroot5"
+    other_dir = cwd_root / "otherdir"
+    other_dir.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    monkeypatch.chdir(cwd_root)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["otherdir", "-eneedle"])
+
+    argv = seen["argv"]
+    assert "--ignore-file" not in argv, (
+        f"otherdir has no ignore file of its own -- nothing must be injected: {argv}"
+    )
+
+
+def test_run_rg_passthrough_path_before_dash_e_still_finds_the_correct_roots_own_ignore_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The positive-injection counterpart: when the PATH-first target DOES have its own
+    ignore file, that file (not cwd's) must be injected."""
+    cwd_root = tmp_path / "wrongroot6"
+    sub = cwd_root / "sub"
+    sub.mkdir(parents=True)
+    (cwd_root / ".gitignore").write_text("should-not-apply.log\n", encoding="utf-8")
+    (sub / ".gitignore").write_text("d.log\n", encoding="utf-8")
+    monkeypatch.chdir(cwd_root)
+    seen = _capture_streaming_passthrough_argv(monkeypatch)
+
+    bootstrap._run_rg_passthrough("rg", ["sub", "-eneedle"])
+
+    argv = seen["argv"]
+    flag_index = argv.index("--ignore-file")
+    injected_path = (cwd_root / argv[flag_index + 1]).resolve()
+    assert injected_path == (sub / ".gitignore").resolve(), (
+        f"must inject sub's .gitignore, not cwd's: got {injected_path}"
     )
 
 

--- a/tests/unit/test_rg_root_ignore.py
+++ b/tests/unit/test_rg_root_ignore.py
@@ -177,3 +177,59 @@ def test_no_ignore_files_wins_over_explicit_root_even_with_files_present(tmp_pat
     )
 
     assert operands == []
+
+
+# --- Task #269 independent-gate finding: rg's `-u`/`-uu`/`-uuu` alias for `--no-ignore` -------
+# Confirmed BLOCKING on the first pass of this task: `-u` is rg's documented alias for
+# `--no-ignore` (`-uu` additionally implies `--hidden`, `-uuu` additionally implies `--binary`),
+# but neither call site observed it, so the emitted `--ignore-file` (which survives
+# `--no-ignore` by design -- see the module docstring) silently resurrected the ignored files
+# under `-u`, making `-u` STRICTER than passing no flag at all.
+
+
+def test_unrestricted_suppresses_injection_even_when_no_ignore_flags_are_false(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+        unrestricted=1,
+    )
+
+    assert operands == []
+
+
+def test_unrestricted_zero_is_a_no_op(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+        unrestricted=0,
+    )
+
+    assert operands == ["--ignore-file", str(tmp_path / ".gitignore")]
+
+
+def test_unrestricted_default_parameter_does_not_change_existing_callers(tmp_path: Path) -> None:
+    """Callers written before `unrestricted` existed (i.e. every pre-existing call in this
+    file) must keep working unchanged -- the parameter must default to the no-op value."""
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands == ["--ignore-file", str(tmp_path / ".gitignore")]

--- a/tests/unit/test_rg_root_ignore.py
+++ b/tests/unit/test_rg_root_ignore.py
@@ -1,0 +1,179 @@
+"""Task #269: unit tests for the shared Python `root_ignore_file_args` helper.
+
+Mirrors `rust_core/src/rg_passthrough.rs`'s own `root_ignore_file_args` unit tests (task #264 /
+PR #744) so the Rust and Python implementations of the same root-only ignore-file discovery
+cannot silently diverge. This module is called by both `bootstrap.py::_run_rg_passthrough` and
+`backends/ripgrep_backend.py::RipgrepBackend._build_cmd` -- see `tests/unit/test_cli_bootstrap.py`
+and `tests/unit/test_ripgrep_backend.py` for the call-site-level coverage; this file pins the
+shared helper's own contract in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.rg_root_ignore import root_ignore_file_args
+
+
+def _values(operands: list[str]) -> list[str]:
+    return [operands[i + 1] for i, tok in enumerate(operands) if tok == "--ignore-file"]
+
+
+def test_emits_ignore_file_for_root_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands.count("--ignore-file") == 1
+    assert _values(operands) == [str(tmp_path / ".gitignore")]
+
+
+def test_empty_when_no_ignore_files_present(tmp_path: Path) -> None:
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands == []
+
+
+def test_defaults_root_to_dot_when_roots_empty(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    operands = root_ignore_file_args(
+        [],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands == ["--ignore-file", ".gitignore"]
+
+
+def test_defaults_root_to_dot_when_roots_none(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    operands = root_ignore_file_args(
+        None,
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands == ["--ignore-file", ".gitignore"]
+
+
+def test_no_ignore_suppresses_all_three(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".rgignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=True,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands == []
+
+
+def test_no_ignore_files_suppresses_all_three(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".rgignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=True,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands == []
+
+
+def test_no_ignore_vcs_skips_only_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=True,
+        no_ignore_dot=False,
+    )
+
+    values = _values(operands)
+    assert not any(v.endswith(".gitignore") for v in values), values
+    assert any(v.endswith(".ignore") for v in values), values
+
+
+def test_no_ignore_dot_skips_ignore_and_rgignore_not_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".rgignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=True,
+    )
+
+    values = _values(operands)
+    assert any(v.endswith(".gitignore") for v in values), values
+    assert not any(v.endswith(".ignore") and not v.endswith(".rgignore") for v in values), values
+    assert not any(v.endswith(".rgignore") for v in values), values
+
+
+def test_covers_every_explicit_root(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    (root_a / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (root_b / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(root_a), str(root_b)],
+        no_ignore=False,
+        no_ignore_files=False,
+        no_ignore_vcs=False,
+        no_ignore_dot=False,
+    )
+
+    assert operands.count("--ignore-file") == 2
+
+
+def test_no_ignore_files_wins_over_explicit_root_even_with_files_present(tmp_path: Path) -> None:
+    """rg's own docs: --no-ignore-files cancels any --ignore-file "regardless of argv order,
+    even ones that come after this flag" -- short-circuit before any filesystem probing."""
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+
+    operands = root_ignore_file_args(
+        [str(tmp_path)],
+        no_ignore=False,
+        no_ignore_files=True,
+        no_ignore_vcs=True,
+        no_ignore_dot=True,
+    )
+
+    assert operands == []

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -47,6 +48,117 @@ def test_should_forward_no_ignore_flag():
 
     cmd = run.call_args[0][0]
     assert "--no-ignore" in cmd
+
+
+# --- Task #269: RipgrepBackend._build_cmd root-ignore-file injection --------------------------
+# Mirrors rust_core/src/rg_passthrough.rs's own `root_ignore_file_args` unit tests (task #264 /
+# PR #744): `_build_cmd` is the second of two Python-only rg-passthrough implementations
+# reachable whenever no compiled native `tg` binary is discoverable, and shares the same
+# `.gitignore`-outside-git-repo defect the compiled binary's rg-passthrough already closed.
+
+
+def test_build_cmd_injects_root_gitignore_outside_git_repo(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig()
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    flag_index = cmd.index("--ignore-file")
+    assert cmd[flag_index + 1] == str(tmp_path / ".gitignore")
+
+
+def test_build_cmd_empty_when_no_ignore_files_present(tmp_path: Path) -> None:
+    backend = RipgrepBackend()
+    config = SearchConfig()
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    assert "--ignore-file" not in cmd
+
+
+def test_build_cmd_no_ignore_suppresses_root_ignore_injection(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig(no_ignore=True)
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    assert "--ignore-file" not in cmd
+
+
+def test_build_cmd_no_ignore_files_suppresses_root_ignore_injection(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig(no_ignore_files=True)
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    assert "--ignore-file" not in cmd
+
+
+def test_build_cmd_no_ignore_vcs_skips_only_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig(no_ignore_vcs=True)
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    values = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "--ignore-file"]
+    assert not any(v.endswith(".gitignore") for v in values), values
+    assert any(v.endswith(".ignore") for v in values), values
+
+
+def test_build_cmd_no_ignore_dot_skips_ignore_and_rgignore_not_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".ignore").write_text("skipme.txt\n", encoding="utf-8")
+    (tmp_path / ".rgignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig(no_ignore_dot=True)
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    values = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "--ignore-file"]
+    assert any(v.endswith(".gitignore") for v in values), values
+    assert not any(v.endswith(".ignore") and not v.endswith(".rgignore") for v in values), values
+    assert not any(v.endswith(".rgignore") for v in values), values
+
+
+def test_build_cmd_covers_every_explicit_root(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    (root_a / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    (root_b / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig()
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(root_a), str(root_b)], pattern="needle", config=config, json_mode=True
+        )
+
+    assert sum(1 for tok in cmd if tok == "--ignore-file") == 2
 
 
 def test_json_context_events_do_not_inflate_match_totals():

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -161,6 +161,43 @@ def test_build_cmd_covers_every_explicit_root(tmp_path: Path) -> None:
     assert sum(1 for tok in cmd if tok == "--ignore-file") == 2
 
 
+# Task #269 independent-gate finding (BLOCKING on first pass): `config.unrestricted` (rg's
+# `-u`/`-uu`/`-uuu`, forwarded verbatim at line ~648 below via `cmd.append("-" + "u" *
+# config.unrestricted)`) is a documented ALIAS for `--no-ignore`, but `_build_cmd` only checked
+# `config.no_ignore` when gating the new root-ignore-file injection -- so `-u` alone left the
+# injected `--ignore-file` in place, and since `--ignore-file` is NOT cancelled by `--no-ignore`
+# (see `rg_root_ignore.py`'s docstring), `-u` silently resurrected the ignored files. `-u` must
+# return the SAME cmd shape as `--no-ignore` with respect to this injection.
+def test_build_cmd_unrestricted_suppresses_root_ignore_injection(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+    config = SearchConfig(unrestricted=1)
+
+    with patch.object(backend, "_get_binary_name", return_value="rg"):
+        cmd = backend._build_cmd(
+            file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+        )
+
+    assert "--ignore-file" not in cmd
+    assert "-u" in cmd
+
+
+def test_build_cmd_unrestricted_double_and_triple_suppress_root_ignore_injection(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".gitignore").write_text("skipme.txt\n", encoding="utf-8")
+    backend = RipgrepBackend()
+
+    for level, flag in ((2, "-uu"), (3, "-uuu")):
+        config = SearchConfig(unrestricted=level)
+        with patch.object(backend, "_get_binary_name", return_value="rg"):
+            cmd = backend._build_cmd(
+                file_path=[str(tmp_path)], pattern="needle", config=config, json_mode=True
+            )
+        assert "--ignore-file" not in cmd, (level, cmd)
+        assert flag in cmd, (level, cmd)
+
+
 def test_json_context_events_do_not_inflate_match_totals():
     backend = RipgrepBackend()
     config = SearchConfig(context=1)

--- a/tests/unit/test_ripgrep_backend.py
+++ b/tests/unit/test_ripgrep_backend.py
@@ -162,8 +162,10 @@ def test_build_cmd_covers_every_explicit_root(tmp_path: Path) -> None:
 
 
 # Task #269 independent-gate finding (BLOCKING on first pass): `config.unrestricted` (rg's
-# `-u`/`-uu`/`-uuu`, forwarded verbatim at line ~648 below via `cmd.append("-" + "u" *
-# config.unrestricted)`) is a documented ALIAS for `--no-ignore`, but `_build_cmd` only checked
+# `-u`/`-uu`/`-uuu`, forwarded verbatim further below in `_build_cmd` via
+# `cmd.append("-" + "u" * config.unrestricted)` -- referenced by SHAPE, not a line number, per
+# the NB-2 lesson from this task's independent gate: a raw line-number citation drifted stale
+# within days of being written) is a documented ALIAS for `--no-ignore`, but `_build_cmd` only checked
 # `config.no_ignore` when gating the new root-ignore-file injection -- so `-u` alone left the
 # injected `--ignore-file` in place, and since `--ignore-file` is NOT cancelled by `--no-ignore`
 # (see `rg_root_ignore.py`'s docstring), `-u` silently resurrected the ignored files. `-u` must


### PR DESCRIPTION
## Summary

Task #269: the third implementation of the #264 defect. Real `rg`'s own `.gitignore`
auto-discovery requires `require_git=true` by default, so a root `.gitignore` is silently a
no-op outside a git repository. PR #744 fixed this for the **compiled native** `tg` binary's
rg-passthrough (`rust_core/src/rg_passthrough.rs`), but explicitly left the **Python-only**
channel (pip/uvx installs with no native binary) unfixed and out of scope -- this PR closes
that gap.

## Step 1 -- the map (every Python rg-forwarding path)

Confirmed by direct tracing (monkeypatched both candidates and ran real invocations), not
assumed:

| # | `file:line` | Reached when | Pre-fix defect |
|---|---|---|---|
| 1 | `src/tensor_grep/cli/bootstrap.py:1088` (`_run_rg_passthrough`, via the forward-branch at `bootstrap.py:1256-1260`) | A bare plain-text `tg search PATTERN [.]` with no complicating flags. Confirmed this fires regardless of native-binary presence -- see the mechanism note below. | Yes -- raw argv forwarded to real `rg` verbatim, zero `--ignore-file` injection. |
| 2 | `src/tensor_grep/backends/ripgrep_backend.py` (`RipgrepBackend._build_cmd`, shared by `.search()`, `.search_passthrough()`, `._search_counts()`, `._search_files_with_matches()`) | Any search that bootstrap punts to `cli/main.py`'s full CLI (e.g. bare `--json`, since `--json` is in bootstrap's `_TG_ONLY_SEARCH_FLAGS`) and lands on `RipgrepBackend`, i.e. whenever no native binary is discoverable. | Yes -- same missing injection; only the pre-existing *explicit* `config.ignore_file` (`--ignore-file` CLI flag) was forwarded. |

Both were empirically confirmed broken with the same live repro:
non-git dir, root `.gitignore` excluding `skipme.txt`, both files containing `needle`,
`TG_DISABLE_NATIVE_TG=1`:
- `python -m tensor_grep search needle .` -> both files (bug)
- `python -m tensor_grep search --json needle .` -> both files (bug, `routing_backend: "RipgrepBackend"`)

**No third Python-only path exists.** `_build_cmd` is shared by every `RipgrepBackend` entry
point, so fixing it once covers `.search()`, `.search_passthrough()`, `._search_counts()`, and
`._search_files_with_matches()` uniformly.

### The mechanism behind the whole bug family (independently confirmed, matches sibling #744/c597b85)

`_can_delegate_to_native_tg_search` (`bootstrap.py:456-464`) only forwards a search to the
compiled native binary when argv contains one of `{--cpu, --force-cpu, --json, --ndjson,
--gpu-device-ids}`, or `TG_RUST_FIRST_SEARCH=1` (default off, `bootstrap.py:292-294`). A bare
plain-text search has none of those triggers, so bootstrap **always** falls through to
`_run_rg_passthrough` -- regardless of whether a native binary is discoverable. Proven with a
native binary present (not just absent) in
`tests/unit/test_cli_bootstrap.py::test_main_entry_bare_plain_text_search_bypasses_native_delegation_even_when_native_binary_present`.

`--json` **is** a supported trigger, so with a native binary present it reaches the native
engine directly (already correct per #127, not via rg-passthrough at all). That's the real
generator of "an output-format flag changes the file set": the flag doesn't touch
ignore-handling, it changes **which engine runs**. Flagging this for visibility per the
coordinator's request -- **not fixing it here**; whether a delegation gate should be keyed on
output-format flags at all is a separate design question.

## Step 2 -- the fix

New shared helper `src/tensor_grep/cli/rg_root_ignore.py::root_ignore_file_args()`, ported in
shape from `rust_core/src/rg_passthrough.rs::root_ignore_file_args` (branch
`fix/rg-passthrough-root-ignore-264`) rather than reinvented, so all three implementations
(Rust, and these two Python call sites) cannot silently diverge:
- Root-only scope (mirrors the native engine's `add_ignore` trio) -- no parent/nested walk.
- `.ignore` / `.gitignore` / `.rgignore`, ascending precedence order.
- `no_ignore` / `no_ignore_files` suppress all three (rg cancels `--ignore-file` outright on
  `--no-ignore-files`, so this short-circuits before any filesystem check).
- `no_ignore_vcs` skips only `.gitignore`; `no_ignore_dot` skips only `.ignore`/`.rgignore`
  (rg's own documented per-flag scope, reused from #744's live verification against rg 15.1.0,
  not re-derived).
- Existence-checked (`Path.is_file()`) before emitting `--ignore-file`, so rg never errors on a
  missing file and a pre-enumerated file list (the rare `--files-without-match` case) safely
  no-ops instead of emitting a wrong flag.

Wired into both call sites:
- `bootstrap.py::_run_rg_passthrough` -- roots come from `_search_path_args(search_args)` (the
  module's own existing raw-argv positional-path extractor, already used by
  `_search_args_paths_defaulted`), flags detected via simple `in search_args` membership
  (matching the existing style throughout this module). The emitted `--ignore-file <path>`
  operands are **prepended**, not appended, so they land before any `--` end-of-options
  sentinel the user's own argv might contain.
- `ripgrep_backend.py::RipgrepBackend._build_cmd` -- roots come from `file_path` (the same value
  real rg is about to walk), flags from the existing `SearchConfig` fields.

**Argv safety**: `--ignore-file <path>` is emitted as two adjacent argv tokens (never `=`-joined
or shell-interpolated), the same convention the pre-existing explicit `config.ignore_file`
handling in `ripgrep_backend.py` and the Rust reference already use -- a flag-value pair is
unambiguous to rg's parser regardless of what the value starts with, unlike a bare trailing
positional (which is what the codebase's `--` sentinel convention specifically protects
against elsewhere, e.g. `RipgrepBackend._append_search_paths`).

**No behavior change inside a git repo** -- verified live: real rg already auto-discovers the
same root `.gitignore` there, so the addition is redundant-not-harmful (ranks below rg's own
auto-discovered rules).

## Step 3 -- bidirectional tests

Unit (`tests/unit/test_rg_root_ignore.py`, `test_cli_bootstrap.py`, `test_ripgrep_backend.py`)
and e2e (`tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py`) coverage mirroring
#744's Rust-side test matrix (injection, empty-when-absent, `no_ignore`/`no_ignore_files`/
`no_ignore_vcs`/`no_ignore_dot` gating, multi-root coverage).

**Measured pre-fix baseline** (`git stash` on just the two source fixes, tests kept): of the
new discriminating assertions, **8 unit-test failures** (4 in each of `test_cli_bootstrap.py`
and `test_ripgrep_backend.py` -- every assertion checking `--ignore-file` is *present*) and
**3 e2e failures** (`test_plain_text_search_excludes_gitignored_file_via_python_bootstrap_passthrough`,
`test_json_search_excludes_gitignored_file_via_python_ripgrep_backend`,
`test_plain_text_and_json_agree_on_the_same_one_file_set`) -- all confirmed to return both files
including `skipme.txt`. The negative-control tests (`--no-ignore*` escape hatches, the
no-ignore-files-present empty case, the git-repo cell) correctly passed in **both** arms, as
expected -- they pin pre-existing, unrelated-to-this-fix behavior, not this fix's discriminating
claim. All tests pass post-fix; fix restored and re-verified.

## Skip-removal status

`tests/e2e/test_search_root_ignore_file_outcome.py` (the file whose native-binary skip
documents this exact gap) lives on **PR #744's branch**, not yet merged to `main` as of this
PR -- it does not exist on this branch. Per the task brief, rather than editing across branches,
this PR adds a **parallel Python-path case**:
`tests/e2e/test_python_rg_passthrough_root_ignore_outcome.py`, which forces the no-native-binary
condition deterministically (`TG_DISABLE_NATIVE_TG=1`) rather than skipping -- it never needs to
skip on that account. **Dependency note for reviewers**: once #744 merges, its outcome test's
docstring (which references this exact gap by name) should be revisited to point at this PR's
closure; no direct file conflict expected since the two test files are independent.

## Coordination

- Stayed entirely inside `bootstrap.py` (search-passthrough function only) and
  `ripgrep_backend.py`; did not touch `_force_utf8_streams` (#743's area) or `rust_core/`
  (#742/#744's area).
- New file `src/tensor_grep/cli/rg_root_ignore.py` has no other owners in flight.

Generated with Claude Code
