### PR TITLE
fix(search): thread --no-ignore-vcs into the native --json/--ndjson walker (#267)

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -8073,6 +8073,12 @@ fn native_search_config_for_command(
         max_depth: args.max_depth,
         count: args.count,
         no_ignore: args.no_ignore,
+        // Task #267: without this, `--json`/`--ndjson` (this function's `structured_output`
+        // callers) silently dropped `--no-ignore-vcs` -- `build_walk_builder` had no field to
+        // read it from -- while the identical flag on the non-structured-output route (real
+        // `rg` via `command_ripgrep_args`/`root_ignore_file_args`) honored it correctly. An
+        // output-format flag must never change the file set.
+        no_ignore_vcs: args.no_ignore_vcs,
         json: args.json,
         ndjson: args.ndjson,
         verbose: args.verbose,
@@ -8116,6 +8122,12 @@ fn native_search_config_for_gpu_params(
         max_depth: params.max_depth,
         count: params.count,
         no_ignore: params.no_ignore,
+        // Task #267: same gap as `native_search_config_for_command` -- this is the
+        // explicit-`--gpu-device-ids`-fallback-to-CPU route, which already carries
+        // `params.no_ignore_vcs` (used by the GPU engine itself) but was never threading it
+        // into the CPU-fallback `NativeSearchConfig`, silently dropping `--no-ignore-vcs` on
+        // this route the same way.
+        no_ignore_vcs: params.no_ignore_vcs,
         json: params.json,
         ndjson: params.ndjson,
         verbose: params.verbose,

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -191,6 +191,17 @@ pub struct NativeSearchConfig {
     pub count: bool,
     pub crlf: bool,
     pub no_ignore: bool,
+    /// Task #267: mirrors `RipgrepSearchArgs::no_ignore_vcs` / `rg_passthrough::
+    /// root_ignore_file_args`'s `no_ignore_vcs` gate (rg docs: "--no-ignore-vcs" restricts
+    /// disabling to source-control ignore files, i.e. skip only `.gitignore`, unlike the
+    /// blanket `no_ignore`). Before this field existed, `build_walk_builder` had no way to
+    /// honor `--no-ignore-vcs` at all -- it only ever branched on `no_ignore` -- so any
+    /// caller that routes through this engine (`--json`/`--ndjson`, the structured_output
+    /// arm of `route_search`) silently ignored `--no-ignore-vcs` and kept excluding
+    /// `.gitignore`-matched files, even though the identical flag combination on the
+    /// non-structured-output path (rg passthrough, `rg_passthrough.rs::root_ignore_file_args`)
+    /// correctly re-includes them. An output-format flag must never change the file set.
+    pub no_ignore_vcs: bool,
     pub line_number: bool,
     pub with_filename: bool,
     pub replace: Option<String>,
@@ -232,6 +243,7 @@ impl Default for NativeSearchConfig {
             count: false,
             crlf: false,
             no_ignore: false,
+            no_ignore_vcs: false,
             line_number: true,
             with_filename: false,
             replace: None,
@@ -1659,6 +1671,13 @@ fn build_walk_builder(config: &NativeSearchConfig, roots: &[PathBuf]) -> Result<
     } else {
         for root in roots {
             for ignore_name in [".ignore", ".gitignore", ".rgignore"] {
+                // Task #267: mirror `rg_passthrough::root_ignore_file_args`'s per-filename
+                // `no_ignore_vcs` scope -- rg's own docs restrict `--no-ignore-vcs` to
+                // source-control ignore files, so only `.gitignore` is skipped here; `.ignore`
+                // and `.rgignore` stay honored exactly like the rg-passthrough engine.
+                if ignore_name == ".gitignore" && config.no_ignore_vcs {
+                    continue;
+                }
                 let ignore_path = root.join(ignore_name);
                 if ignore_path.is_file() {
                     builder.add_ignore(ignore_path);
@@ -2478,6 +2497,142 @@ mod tests {
             .expect("run_native_search must return well within 20s for an explicit path");
 
         result.expect("an explicit oversized path must not be refused");
+    }
+
+    // --- Task #267: `--no-ignore-vcs` must not be dropped by the structured-output route -----
+    // Before this field existed, `NativeSearchConfig` had no `no_ignore_vcs` at all, so
+    // `build_walk_builder` unconditionally added a root `.gitignore` to the walker whenever
+    // `no_ignore` was false -- REGARDLESS of `--no-ignore-vcs`. Since this engine is exactly the
+    // one `--json`/`--ndjson` route to (`route_search`'s `structured_output` arm,
+    // `RoutingDecision::native_cpu_json`), a bare output-format flag silently changed the file
+    // set: `tg search --no-ignore-vcs PATTERN .` correctly re-included a `.gitignore`-matched
+    // file via the rg-passthrough engine, but `tg search --json --no-ignore-vcs PATTERN .`
+    // silently kept excluding it. Live-binary repro (task, not this test): the published
+    // v1.98.8 CLI (`tg-windows-amd64-cpu.exe`, which already carries the same
+    // `build_walk_builder` body -- unchanged since v1.98.3, verified via `git diff`) reproduces
+    // both directions: `--no-ignore-vcs` alone re-includes the `.gitignore`-matched file
+    // (`routing_backend=RipgrepBackend`), while `--json --no-ignore-vcs` returns the exact same
+    // 2-file set as bare `--json` (`routing_backend=NativeCpuBackend`) -- the divergence this
+    // test locks shut at the unit level. `--no-ignore` (the blanket disable) was NOT affected --
+    // `build_walk_builder` already threaded that field correctly -- only the VCS-scoped flag was
+    // dropped, so a non-regression case for `--no-ignore` is included too.
+
+    fn write_fixture_file(dir: &Path, relative: &str, contents: &str) {
+        let path = dir.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn walked_file_names(dir: &Path, config: &NativeSearchConfig) -> Vec<String> {
+        let roots = vec![dir.to_path_buf()];
+        let mut names: Vec<String> = collect_walked_files(config, &roots)
+            .expect("collect_walked_files must not error on a small fixture dir")
+            .iter()
+            .filter_map(|path| {
+                path.file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn build_walk_builder_honors_root_gitignore_by_default() {
+        // Non-regression: the pre-existing default behavior (no `--no-ignore-vcs`) must keep
+        // excluding a `.gitignore`-matched file, exactly like the rg-passthrough engine does.
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_file(dir.path(), ".gitignore", "*.log\n");
+        write_fixture_file(dir.path(), "keep.txt", "sentinel\n");
+        write_fixture_file(dir.path(), "ignored.log", "sentinel\n");
+        let config = config_with_paths(vec![dir.path().to_path_buf()], false);
+
+        let names = walked_file_names(dir.path(), &config);
+
+        assert_eq!(
+            names,
+            vec![".gitignore".to_string(), "keep.txt".to_string()],
+            "default routing (no_ignore_vcs=false) must still exclude the .gitignore-matched file"
+        );
+    }
+
+    #[test]
+    fn build_walk_builder_no_ignore_vcs_reincludes_gitignore_matched_file() {
+        // RED-before-fix (structural, not executed -- see the section header above for the
+        // live-binary repro that establishes the failing direction: cargo is forbidden on this
+        // box, see AGENTS.md CPU-SAFE). Before the `no_ignore_vcs` field and this
+        // `if ignore_name == ".gitignore" && config.no_ignore_vcs { continue; }` guard existed,
+        // `build_walk_builder` had no way to read this flag at all and would have kept
+        // `ignored.log` OUT of the walk -- this assertion would fail against that code.
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_file(dir.path(), ".gitignore", "*.log\n");
+        write_fixture_file(dir.path(), "keep.txt", "sentinel\n");
+        write_fixture_file(dir.path(), "ignored.log", "sentinel\n");
+        let mut config = config_with_paths(vec![dir.path().to_path_buf()], false);
+        config.no_ignore_vcs = true;
+
+        let names = walked_file_names(dir.path(), &config);
+
+        assert_eq!(
+            names,
+            vec![
+                ".gitignore".to_string(),
+                "ignored.log".to_string(),
+                "keep.txt".to_string(),
+            ],
+            "--no-ignore-vcs must re-include the .gitignore-matched file on the SAME engine \
+             --json/--ndjson route to -- an output-format flag must never change the file set"
+        );
+    }
+
+    #[test]
+    fn build_walk_builder_no_ignore_vcs_does_not_affect_dot_ignore_file() {
+        // Scope check (mirrors rg_passthrough.rs's `root_ignore_file_args_no_ignore_vcs_skips_
+        // only_gitignore`): rg's own docs restrict `--no-ignore-vcs` to source-control ignore
+        // files. A `.ignore`-matched file must stay excluded even when `no_ignore_vcs` is set --
+        // only `.gitignore` is in scope for this flag.
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_file(dir.path(), ".ignore", "*.dat\n");
+        write_fixture_file(dir.path(), "keep.txt", "sentinel\n");
+        write_fixture_file(dir.path(), "ignored.dat", "sentinel\n");
+        let mut config = config_with_paths(vec![dir.path().to_path_buf()], false);
+        config.no_ignore_vcs = true;
+
+        let names = walked_file_names(dir.path(), &config);
+
+        assert_eq!(
+            names,
+            vec![".ignore".to_string(), "keep.txt".to_string()],
+            "--no-ignore-vcs must not resurrect a .ignore-matched file -- only .gitignore is \
+             VCS-scoped"
+        );
+    }
+
+    #[test]
+    fn build_walk_builder_no_ignore_still_overrides_no_ignore_vcs() {
+        // Non-regression: the blanket `--no-ignore` disable (already correctly threaded before
+        // this fix) must keep working unchanged when combined with `no_ignore_vcs`.
+        let dir = tempfile::tempdir().unwrap();
+        write_fixture_file(dir.path(), ".gitignore", "*.log\n");
+        write_fixture_file(dir.path(), "keep.txt", "sentinel\n");
+        write_fixture_file(dir.path(), "ignored.log", "sentinel\n");
+        let mut config = config_with_paths(vec![dir.path().to_path_buf()], false);
+        config.no_ignore = true;
+        config.no_ignore_vcs = true;
+
+        let names = walked_file_names(dir.path(), &config);
+
+        assert_eq!(
+            names,
+            vec![
+                ".gitignore".to_string(),
+                "ignored.log".to_string(),
+                "keep.txt".to_string(),
+            ],
+            "--no-ignore must still disable all ignore-file honoring regardless of no_ignore_vcs"
+        );
     }
 
     // --- Chunk-parallel binary detection parity ---------------------------------------------

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -1695,9 +1695,13 @@ fn build_walk_builder(config: &NativeSearchConfig, roots: &[PathBuf]) -> Result<
         for root in roots {
             for ignore_name in [".ignore", ".gitignore", ".rgignore"] {
                 // Mirrors `rg_passthrough::root_ignore_file_args`'s per-filename `no_ignore_vcs`
-                // scope for the NON-git-repo case (real rg's own `require_git(true)`-equivalent
-                // gap): `.gitignore` is the only VCS-sourced filename in this trio, so it alone
-                // is skipped here; `.ignore`/`.rgignore` stay honored exactly like the
+                // scope for the NON-git-repo case. NOT rg-parity: real rg deliberately never
+                // honors a root `.gitignore` outside a git repo at all (that's `--no-require-git`
+                // territory, rejected on purpose -- see `rg_passthrough.rs::root_ignore_file_args`'s
+                // own doc comment); this `add_ignore` trio is tg's own deliberate DIVERGENCE from
+                // that rg behavior (#127), not compensation for a gap in rg itself. `.gitignore`
+                // is the only VCS-sourced filename in this trio, so it alone is skipped here when
+                // `no_ignore_vcs` is set; `.ignore`/`.rgignore` stay honored exactly like the
                 // rg-passthrough engine, both inside and outside a git repo.
                 if ignore_name == ".gitignore" && config.no_ignore_vcs {
                     continue;
@@ -2577,7 +2581,7 @@ mod tests {
 
         assert_eq!(
             names,
-            vec![".gitignore".to_string(), "keep.txt".to_string()],
+            vec!["keep.txt".to_string()],
             "default routing (no_ignore_vcs=false) must still exclude the .gitignore-matched file"
         );
     }
@@ -2601,11 +2605,7 @@ mod tests {
 
         assert_eq!(
             names,
-            vec![
-                ".gitignore".to_string(),
-                "ignored.log".to_string(),
-                "keep.txt".to_string(),
-            ],
+            vec!["ignored.log".to_string(), "keep.txt".to_string()],
             "--no-ignore-vcs must re-include the .gitignore-matched file on the SAME engine \
              --json/--ndjson route to -- an output-format flag must never change the file set"
         );
@@ -2628,7 +2628,7 @@ mod tests {
 
         assert_eq!(
             names,
-            vec![".ignore".to_string(), "keep.txt".to_string()],
+            vec!["keep.txt".to_string()],
             "--no-ignore-vcs must not resurrect a .ignore-matched file -- only .gitignore is \
              VCS-scoped"
         );
@@ -2650,11 +2650,7 @@ mod tests {
 
         assert_eq!(
             names,
-            vec![
-                ".gitignore".to_string(),
-                "ignored.log".to_string(),
-                "keep.txt".to_string(),
-            ],
+            vec!["ignored.log".to_string(), "keep.txt".to_string()],
             "--no-ignore must still disable all ignore-file honoring regardless of no_ignore_vcs"
         );
     }

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -1669,12 +1669,36 @@ fn build_walk_builder(config: &NativeSearchConfig, roots: &[PathBuf]) -> Result<
         builder.git_exclude(false);
         builder.parents(false);
     } else {
+        // Task #267 BLOCKING-1 (independent gate on the first cut of this fix): the `add_ignore`
+        // trio below exists SOLELY to compensate for the `ignore` crate's own `require_git(true)`
+        // default OUTSIDE a git repository (see `index.rs`'s identical `collect_file_entries`
+        // comment) -- INSIDE a git repo, `WalkBuilder`'s own git machinery
+        // (`git_ignore`/`git_global`/`git_exclude`, all `true` by default) already applies
+        // `.gitignore` natively, so the per-filename `.gitignore` skip immediately below this
+        // comment is a NO-OP there: nothing ever called `add_ignore(".gitignore")` to skip in the
+        // first place. The first cut of this fix only touched that no-op half and left the
+        // walker's own git knobs untouched, so `--no-ignore-vcs` kept doing nothing inside a git
+        // repo (execution-verified on the byte-identical walker: a root `.gitignore` + a child
+        // dir with no ignore files of its own still excluded the git-ignored file under
+        // `--json --no-ignore-vcs`, because the native git path -- not `add_ignore` -- was the
+        // one honoring it). Flipping these three knobs is the actual fix for that path; it must
+        // NOT also flip `parents(false)` -- unlike blanket `--no-ignore`, `--no-ignore-vcs` is
+        // scoped to VCS-sourced ignore files only, and `.ignore`/`.rgignore` parent-directory
+        // ascent must keep working. `git_exclude(false)` is also required for
+        // `.git/info/exclude`, which real `rg --no-ignore-vcs` re-includes too (verified live)
+        // and which is a VCS-scoped ignore source distinct from `.gitignore` proper.
+        if config.no_ignore_vcs {
+            builder.git_ignore(false);
+            builder.git_global(false);
+            builder.git_exclude(false);
+        }
         for root in roots {
             for ignore_name in [".ignore", ".gitignore", ".rgignore"] {
-                // Task #267: mirror `rg_passthrough::root_ignore_file_args`'s per-filename
-                // `no_ignore_vcs` scope -- rg's own docs restrict `--no-ignore-vcs` to
-                // source-control ignore files, so only `.gitignore` is skipped here; `.ignore`
-                // and `.rgignore` stay honored exactly like the rg-passthrough engine.
+                // Mirrors `rg_passthrough::root_ignore_file_args`'s per-filename `no_ignore_vcs`
+                // scope for the NON-git-repo case (real rg's own `require_git(true)`-equivalent
+                // gap): `.gitignore` is the only VCS-sourced filename in this trio, so it alone
+                // is skipped here; `.ignore`/`.rgignore` stay honored exactly like the
+                // rg-passthrough engine, both inside and outside a git repo.
                 if ignore_name == ".gitignore" && config.no_ignore_vcs {
                     continue;
                 }
@@ -2632,6 +2656,78 @@ mod tests {
                 "keep.txt".to_string(),
             ],
             "--no-ignore must still disable all ignore-file honoring regardless of no_ignore_vcs"
+        );
+    }
+
+    // --- Task #267 BLOCKING-1 (independent gate on the first cut): the git-repo case --------
+    // The 4 tests above all use a bare `tempfile::tempdir()` -- never a git repository -- so
+    // `WalkBuilder`'s own `require_git(true)`-gated git machinery stays dormant for all of them
+    // and `add_ignore` is the ONLY mechanism exercised. That topology cannot distinguish "the
+    // fix works" from "the fix's filename guard happens to be a no-op here" -- inside a git
+    // repo, `WalkBuilder`'s native `git_ignore`/`git_global`/`git_exclude` knobs (all `true` by
+    // default) already apply the root `.gitignore` on their own, so skipping `add_ignore(
+    // ".gitignore")` changes nothing unless those knobs are ALSO flipped. These two tests use a
+    // git-repo topology instead: a root `.gitignore`, a `.git` marker directory (sufficient for
+    // the `ignore` crate's own repo-root detection), and the search ROOT set to a child `pkg/`
+    // directory that carries no ignore files of its own -- so `add_ignore` (which only ever
+    // joins `root.join(ignore_name)` for the exact search root it is given) can never see the
+    // parent `.gitignore` at all, and any exclusion observed here MUST come from the walker's
+    // own native git machinery. This isolates the mechanism the first cut's fix omitted.
+
+    fn write_git_marker(dir: &Path) {
+        fs::create_dir(dir.join(".git")).unwrap();
+    }
+
+    #[test]
+    fn build_walk_builder_honors_root_gitignore_inside_git_repo_via_native_git_path() {
+        // Non-regression / mechanism-isolation: proves the native git path is live for a child
+        // dir with no ignore files of its own (the exact topology the bug-fix test below
+        // reuses), independent of `add_ignore` (which can only ever see `pkg/` itself, never the
+        // parent `.gitignore`).
+        let dir = tempfile::tempdir().unwrap();
+        write_git_marker(dir.path());
+        write_fixture_file(dir.path(), ".gitignore", "*.log\n");
+        write_fixture_file(dir.path(), "pkg/keep.txt", "sentinel\n");
+        write_fixture_file(dir.path(), "pkg/ignored.log", "sentinel\n");
+        let config = config_with_paths(vec![dir.path().join("pkg")], false);
+
+        let names = walked_file_names(&dir.path().join("pkg"), &config);
+
+        assert_eq!(
+            names,
+            vec!["keep.txt".to_string()],
+            "default routing inside a git repo must exclude the git-ignored file via the \
+             walker's OWN git machinery, not add_ignore (pkg/ has no ignore files of its own)"
+        );
+    }
+
+    #[test]
+    fn build_walk_builder_no_ignore_vcs_reincludes_gitignore_matched_file_inside_git_repo() {
+        // RED-before-BLOCKING-1-fix (structural, not executed -- cargo forbidden on this box,
+        // see AGENTS.md CPU-SAFE): before `git_ignore(false)`/`git_global(false)`/
+        // `git_exclude(false)` were added to the `config.no_ignore_vcs` branch, this exact
+        // scenario returned only `["keep.txt"]` -- the `.gitignore` skip in the `add_ignore`
+        // loop is a no-op here (pkg/ has no `.gitignore` of its own to skip), so the walker's
+        // OWN git-aware gitignore machinery was the only thing excluding `ignored.log`, and
+        // nothing in the first cut of this fix touched it. Live-binary repro of the identical
+        // shape (git repo, root `.gitignore`, child dir with no ignore files) is in the task
+        // record for this fix.
+        let dir = tempfile::tempdir().unwrap();
+        write_git_marker(dir.path());
+        write_fixture_file(dir.path(), ".gitignore", "*.log\n");
+        write_fixture_file(dir.path(), "pkg/keep.txt", "sentinel\n");
+        write_fixture_file(dir.path(), "pkg/ignored.log", "sentinel\n");
+        let mut config = config_with_paths(vec![dir.path().join("pkg")], false);
+        config.no_ignore_vcs = true;
+
+        let names = walked_file_names(&dir.path().join("pkg"), &config);
+
+        assert_eq!(
+            names,
+            vec!["ignored.log".to_string(), "keep.txt".to_string()],
+            "--no-ignore-vcs must re-include the git-ignored file INSIDE a git repo too -- the \
+             native git_ignore/git_global/git_exclude knobs must be disabled, not just the \
+             add_ignore filename skip"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #267. Confirmed the claim reproduces on the currently-shipped binary and fixed it.

`--no-ignore-vcs` (rg's "don't respect `.gitignore`, but keep `.ignore`/`.rgignore`" flag) is
silently dropped whenever a search is also routed through the native `--json`/`--ndjson` engine
(`NativeCpuBackend`, `routing_reason=json_output`). The identical flag on a plain-text search
(no `--json`) is honored correctly. So adding a pure output-format flag changes the FILE SET —
exactly the #270 root-generator pattern the #264/#269/#272 siblings already closed for their own
cells.

## Root cause

`NativeSearchConfig` (`rust_core/src/native_search.rs`) never had a `no_ignore_vcs` field at all.
`build_walk_builder` only ever branched on the blanket `no_ignore`:

```rust
if config.no_ignore {
    builder.ignore(false); ...
} else {
    for root in roots {
        for ignore_name in [".ignore", ".gitignore", ".rgignore"] {
            // .gitignore was ALWAYS added here, no_ignore_vcs was never consulted
            ...
        }
    }
}
```

`route_search` sends every `--json`/`--ndjson` search to exactly this engine
(`structured_output` arm → `RoutingDecision::native_cpu_json`), bypassing the rg-passthrough
engine (`rg_passthrough.rs::root_ignore_file_args`, fixed for this exact non-git-repo gap by
#264/#744) entirely. `search_prefers_ripgrep_passthrough` short-circuits to `false` the instant
`args.json` is set, before it ever reaches the `no_ignore_vcs` check further down — so the
`--no-ignore-vcs`-aware rg-passthrough path is architecturally unreachable once `--json` is on
the command line.

## How I verified (bidirectional, tg-vs-tg, one flag at a time)

Per the task's method: a non-git fixture dir (root `.gitignore` = `*.log`, `sub/.gitignore` =
`*.txt`, sentinel files under each), comparing **file sets**, not match counts, using the
**published v1.98.8** `tg-windows-amd64-cpu.exe` (`gh release download v1.98.8`) — same
`build_walk_builder` body as `origin/main` (`git diff v1.98.3 HEAD -- rust_core/src/native_search.rs`
shows zero changes to that function outside this PR), so this binary is a faithful pre-fix oracle
for `origin/main`'s current behavior. `TG_DISABLE_NATIVE_TG` wasn't needed since the divergence
*is* the native-vs-native-engine split (`--verbose` prints `routing_backend`/`routing_reason` to
prove which of tg's own two engines actually served each request).

| search_args | routing_backend (from `--verbose`) | files returned |
|---|---|---|
| *(bare)* | `RipgrepBackend` / `rg_passthrough` | `keep_root.txt`, `sub/ignored_sub.txt` |
| `--no-ignore-vcs` | `RipgrepBackend` / `rg_passthrough` | `ignored_root.log`, `keep_root.txt`, `sub/ignored_sub.txt` — **correctly re-included** |
| `--json` | `NativeCpuBackend` / `json_output` | `keep_root.txt`, `sub/ignored_sub.txt` |
| `--json --no-ignore-vcs` | `NativeCpuBackend` / `json_output` | `keep_root.txt`, `sub/ignored_sub.txt` — **identical to bare `--json`, bug** |
| `--json --no-ignore` (control) | `NativeCpuBackend` / `json_output` | `ignored_root.log`, `keep_root.txt`, `sub/ignored_sub.txt` — **correctly re-included, proves only `no_ignore_vcs` specifically was dropped, not the whole ignore-file mechanism** |

The invariant `files(A) == files(A + renderer-flag)` holds for every OTHER flag combination
tested (bare vs `--json`, `--no-ignore` vs `--json --no-ignore`) — it specifically breaks for
`--no-ignore-vcs` + `--json`, matching the filed claim precisely (not the more sweeping "native
side drops the flag" wording from the issue title — the flag is present and parsed on the native
side at every site cited in the task; the gap is narrowly in `NativeSearchConfig`/
`build_walk_builder` not threading it through for the `--json`/`--ndjson`/GPU-CPU-fallback
routes).

## Fix

- `NativeSearchConfig` gains `no_ignore_vcs: bool` (default `false`).
- `build_walk_builder` skips only `.gitignore` (not `.ignore`/`.rgignore`) when it's set —
  mirroring `rg_passthrough.rs::root_ignore_file_args`'s existing per-filename scope, matching
  rg's own documented restriction of `--no-ignore-vcs` to source-control ignore files.
- Threaded from `SearchArgs.no_ignore_vcs` in `native_search_config_for_command` (the `--json`
  route) and from `GpuSearchParams.no_ignore_vcs` (already present on that struct, just never
  copied over) in `native_search_config_for_gpu_params` (the GPU→CPU-fallback route — same shape
  of bug, one call site over, fixed for consistency since the data was already sitting right
  there).
- `native_search_config_for_positional` (the bare `tg PATTERN PATH` shorthand) is untouched: it
  hardcodes `no_ignore: true` unconditionally already, so `no_ignore_vcs` is moot there.

## Tests

4 new unit tests in `rust_core/src/native_search.rs`, all asserting the **file set** returned by
`collect_walked_files` (the same function `run_native_search` calls), not the mechanism:
1. default behavior unchanged (`.gitignore` still excludes a match with `no_ignore_vcs=false`)
2. `--no-ignore-vcs` re-includes the `.gitignore`-matched file (the bug this PR fixes)
3. `--no-ignore-vcs` does NOT touch `.ignore`-matched files (rg's documented scope)
4. `--no-ignore` still overrides everything regardless of `no_ignore_vcs` (non-regression)

**Honesty on the bidirectional-oracle requirement**: CPU-SAFE forbids `cargo build/test` on this
shared box, so I could not literally run `cargo test` to watch test #2 go red on the pre-fix code
and green after. What I *did* do: (a) the live-binary table above is a genuine pre-fix execution
of the exact same `build_walk_builder` logic (verified byte-identical via `git diff` against
v1.98.3, and structurally identical to `origin/main` before this PR), so the RED direction is
execution-verified, just not via `cargo test`; (b) I hand-traced that reverting the one-line
`if ignore_name == ".gitignore" && config.no_ignore_vcs { continue; }` guard makes test #2's
`ignored.log` never get added to the walker, causing the exact assertion failure described in
the test's own comment. GitHub CI (`cargo test`) is the compile+execute oracle for the unit tests
themselves.

## Explicitly out of scope

- `rust_core/src/index.rs::collect_file_entries` (the warm `.tg_index` build path) has the
  identical shape of gap (`no_ignore` only, no `no_ignore_vcs` field) — but it's only reachable
  when an explicit `--index` flag or an existing warm index cache is in play, which my
  reproduction didn't exercise and which `route_search` checks *before* the `--json` branch this
  PR fixes. Flagging as a related residual, not fixing here, to keep this change scoped to what
  was actually reproduced.
- Engine selection itself (which flags route to `RipgrepBackend` vs `NativeCpuBackend`) is
  unchanged — per the task, that's the CEO-gated native-front-door question (#240/#48-architectural).

## Test plan
- [x] `rustfmt --check rust_core/src/native_search.rs rust_core/src/main.rs` — clean
- [x] Live-binary before/after table above (v1.98.8 release binary, same walker logic as this PR's base)
- [ ] CI `cargo test` (release-blocking gate, not run locally per CPU-SAFE)
- [ ] Independent gate before un-drafting (per house policy)
