### PR TITLE
chore(hygiene): ignore generated tool output at any depth (.tensor-grep/, docs/code-map/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,16 @@ npm/node_modules/
 # (`src/tensor_grep/.tensor-grep/`, created by running tg from inside the package dir) went
 # untracked-but-not-ignored and polluted `git status`. Match the CLASS at any depth instead.
 .tensor-grep/
+# `tg codemap`'s default output dir (main.rs/codemap.py: `--out` defaults to <root>/docs/code-map).
+# Generated, not authored: 190 pages plus a `_coverage.json` carrying a `generated_at` timestamp
+# AND an absolute machine-local path ("C:\\dev\\projects\\..."), so committing it would bake one
+# developer's filesystem into the repo and churn on every regeneration. Never tracked on main.
+# Ignoring it is a supported configuration, not a workaround: `check_codemap_freshness`'s
+# output-dir exclusion already handles the committed, never-committed, and untracked cases
+# (tests/unit/test_codemap_freshness.py), so this does not affect tg's own freshness oracle.
+# Whether to PUBLISH a code map as docs stays a separate product decision -- use an explicit
+# `--out` outside this path when that is the intent.
+docs/code-map/
 # .factory/ is Factory-AI/droid local tool state (contains machine-specific paths) -- never track any of it.
 /.factory/
 /_archive/

--- a/.gitignore
+++ b/.gitignore
@@ -48,12 +48,16 @@ npm/node_modules/
 /*.patch
 /*.txt
 /.tmp*/
-/.tensor-grep/
+# tg writes its own session/index state into a `.tensor-grep/` dir at whatever root it is
+# scoped to -- which is NOT always the repo root. Two root-anchored entries (`/.tensor-grep/`
+# and `/src/.tensor-grep/`) used to enumerate the places it had been observed, so a real one
+# (`src/tensor_grep/.tensor-grep/`, created by running tg from inside the package dir) went
+# untracked-but-not-ignored and polluted `git status`. Match the CLASS at any depth instead.
+.tensor-grep/
 # .factory/ is Factory-AI/droid local tool state (contains machine-specific paths) -- never track any of it.
 /.factory/
 /_archive/
 /agent_out.json
-/src/.tensor-grep/
 /src/tensor_grep/cli/commands.txt
 /src/tensor_grep/core/import_trace.txt
 stream_test.py


### PR DESCRIPTION
## What

Two instances of one class: **generated tool output sitting untracked-but-not-ignored**, polluting `git status` on every checkout.

1. **`.tensor-grep/`** — `.gitignore` carried two *root-anchored* entries (`/.tensor-grep/`, `/src/.tensor-grep/`) enumerating the two places tg's state dir had been *observed*. tg writes it at whatever root it is scoped to, so `src/tensor_grep/.tensor-grep/` (note `tensor_grep`, the package, not `src/`) matched **neither** and had been accumulating session JSONs since 2026-07-13. Replaced both with an unanchored `.tensor-grep/`.
2. **`docs/code-map/`** — `tg codemap`'s default `--out` (`codemap.py:994,1214`). 190 generated pages; `_coverage.json` carries a `generated_at` timestamp **and an absolute machine-local path** (`C:\dev\projects\...`), so committing it would bake one developer's filesystem into the repo and churn on every regeneration. Never tracked on main.

This is the #745 shape: enumerating observed cases instead of modelling the class, so case N+1 slips through. A third anchored path would have been the wrong fix.

## Why `docs/code-map/` is safe to ignore

Ignoring it is a **supported configuration, not a workaround**. `check_codemap_freshness`'s output-dir exclusion already covers the committed, never-committed, and untracked cases, and the freshness suite's own `git_fixture_repo` gitignores exactly this directory — with a comment naming "did you commit the regenerated pages" as *a real, separate product question* (`tests/unit/test_codemap_freshness.py:126,228,245`). So this does not touch tg's own freshness oracle.

Publishing a code map as documentation remains a separate product decision; that intent is served by an explicit `--out` outside this path.

## Verification — and why the obvious check is a tautology

My first control arm reported "ignored" in **both** arms. Cause: `git check-ignore` reads the in-tree `.gitignore` regardless of `core.excludesFile`, so pointing it at the old blob still evaluated the new file. A check that passes in both arms is not verification.

Re-run out-of-process against the two real checkouts:

| path | control (`origin/main`) | treatment (this branch) |
|---|---|---|
| `src/tensor_grep/.tensor-grep/sessions/index.json` | **NOT ignored** | ignored |
| `docs/code-map/_coverage.json` | **NOT ignored** | ignored |

`.tensor-grep/` also confirmed at repo root and at `deep/nested/` depth. `git ls-files` shows **0** tracked files under either path, so broadening cannot shadow committed content.

## Scope

`.gitignore` only. No code. `chore:` — non-releasing.