### PR TITLE
fix(gpu): preserve raw match bytes in gpu_native.rs (no lossy UTF-8 / over-trimmed CRLF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,9 +532,17 @@ jobs:
             echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
           fi
 
+      # `--all-targets` is load-bearing, not tidiness. A bare `cargo check` compiles only the
+      # normal targets, so `#[cfg(test)]` code is never even TYPE-CHECKED -- and because
+      # `gpu_native` is gated behind `#[cfg(feature = "cuda")]` at lib.rs:9-10, `test-rust-core`
+      # (default features) never compiles that module at all. The result was a blind spot where
+      # the entire gpu_native test module could fail to compile and no CI job would notice.
+      # This job is the ONLY oracle for cuda-gated code; `--all-targets` makes it cover the tests
+      # it is the only possible oracle for. It still does not RUN them (checking is not running) --
+      # executing cuda-gated tests needs a cargo test with the feature enabled, tracked separately.
       - name: cargo check --features cuda
         working-directory: rust_core
-        run: cargo check --features cuda
+        run: cargo check --features cuda --all-targets
 
   search-golden-parity:
     name: search-golden-parity (windows-latest)

--- a/rust_core/src/gpu_native.rs
+++ b/rust_core/src/gpu_native.rs
@@ -377,7 +377,21 @@ pub struct GpuNativeSearchConfig {
 pub struct GpuNativeSearchMatch {
     pub path: PathBuf,
     pub line_number: usize,
-    pub text: String,
+    /// Exact matched-line bytes. Never passed through `String::from_utf8_lossy`: genuinely
+    /// invalid-UTF-8 source content (e.g. Latin-1) must survive to JSON/NDJSON output losslessly
+    /// rather than being silently replaced with U+FFFD -- the identical lossy-conversion defect
+    /// class task #266/#746 fixed in the CPU native-search emitter (`NativeSearchMatch::raw`),
+    /// applied here to close the same gap in the CUDA-gated GPU-native path (task #273). Both
+    /// producers (`line_matches_for_file`, `line_matches_for_file_by_scanning`) slice line bytes
+    /// using a boundary that already excludes the line's trailing `\n` (`classify_file_lines`'s
+    /// `LineDescriptor::len` is computed as `newline_index - line_start`; the scanning path's
+    /// `line_end` is the `\n`'s own byte index), so unlike `strip_native_line_terminator`'s "at
+    /// most one trailing `\n`" contract for the CPU emitter, no terminator stripping is needed
+    /// here at all -- a genuine trailing `\r` from a CRLF source line is real line content and
+    /// must never be trimmed. JSON/NDJSON emission derives `text`/`bytes` from this field via
+    /// `native_json_text_fields` (`main.rs::gpu_native_match_json_entries`), mirroring the CPU
+    /// emitter's own `text`-XOR-`bytes` protocol.
+    pub raw: Vec<u8>,
     pub pattern_id: usize,
     pub pattern_text: String,
 }
@@ -1408,14 +1422,14 @@ fn run_cuda_graph_benchmark_search_paths(
             .cmp(&right_index)
             .then(left.line_number.cmp(&right.line_number))
             .then(left.pattern_id.cmp(&right.pattern_id))
-            .then(left.text.cmp(&right.text))
+            .then(left.raw.cmp(&right.raw))
     });
     let mut seen = BTreeSet::new();
     matches.retain(|matched| {
         seen.insert((
             matched.path.clone(),
             matched.line_number,
-            matched.text.clone(),
+            matched.raw.clone(),
             matched.pattern_id,
         ))
     });
@@ -1982,7 +1996,7 @@ fn merge_device_matches(
             .cmp(&right_index)
             .then(left.line_number.cmp(&right.line_number))
             .then(left.pattern_id.cmp(&right.pattern_id))
-            .then(left.text.cmp(&right.text))
+            .then(left.raw.cmp(&right.raw))
     });
 
     let mut seen = BTreeSet::new();
@@ -1992,7 +2006,7 @@ fn merge_device_matches(
             seen.insert((
                 matched.path.clone(),
                 matched.line_number,
-                matched.text.clone(),
+                matched.raw.clone(),
                 matched.pattern_id,
             ))
         })
@@ -4019,13 +4033,10 @@ fn line_matches_for_file(
             .saturating_add(line_len)
             .min(file_bytes.len());
         let line_bytes = &file_bytes[relative_start..relative_end];
-        let text = String::from_utf8_lossy(line_bytes)
-            .trim_end_matches('\r')
-            .to_string();
         matches.push(GpuNativeSearchMatch {
             path: file.path.clone(),
             line_number: line.line_number,
-            text,
+            raw: line_bytes.to_vec(),
             pattern_id: offset.pattern_id,
             pattern_text: all_patterns[offset.pattern_id].clone(),
         });
@@ -4060,13 +4071,10 @@ fn line_matches_for_file_by_scanning(
             .copied()
             .unwrap_or(file_bytes.len());
         let line_bytes = &file_bytes[line_start..line_end];
-        let text = String::from_utf8_lossy(line_bytes)
-            .trim_end_matches('\r')
-            .to_string();
         matches.push(GpuNativeSearchMatch {
             path: path.to_path_buf(),
             line_number: newline_index + 1,
-            text,
+            raw: line_bytes.to_vec(),
             pattern_id: offset.pattern_id,
             pattern_text: all_patterns[offset.pattern_id].clone(),
         });
@@ -4344,10 +4352,13 @@ mod tests {
     use super::{
         cached_search_kernel_ptx_path, check_gpu_native_implicit_walk_ceiling,
         collect_search_files, kernel_compile_options_for_compute_capability, line_matches_for_file,
-        load_file_batch_into_pinned_slice, resolve_adaptive_match_capacity,
-        resolve_max_match_capacity, validate_requested_cuda_device_ids, BatchedFile, FileBatchPlan,
-        GpuNativeSearchConfig, LineDescriptor, PatternMatchPosition,
+        line_matches_for_file_by_scanning, load_file_batch_into_pinned_slice,
+        resolve_adaptive_match_capacity, resolve_max_match_capacity,
+        validate_requested_cuda_device_ids, BatchedFile, FileBatchPlan, GpuNativeSearchConfig,
+        LineDescriptor, PatternMatchPosition,
     };
+    use base64::engine::general_purpose::STANDARD as TEST_BASE64_STANDARD;
+    use base64::Engine as _;
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -4599,7 +4610,7 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].path, path);
         assert_eq!(matches[0].line_number, 2);
-        assert_eq!(matches[0].text, "ERROR target");
+        assert_eq!(matches[0].raw, b"ERROR target");
     }
 
     #[test]
@@ -4634,7 +4645,175 @@ mod tests {
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].path, path);
         assert_eq!(matches[0].line_number, 3);
-        assert_eq!(matches[0].text, "ERROR target");
+        assert_eq!(matches[0].raw, b"ERROR target");
+    }
+
+    // --- Task #273: GpuNativeSearchMatch.raw byte-fidelity (mirrors task #266/#746's fix in
+    // native_search.rs's NativeSearchMatch::raw / strip_native_line_terminator) ----------------
+    //
+    // Before this fix, both `line_matches_for_file` and `line_matches_for_file_by_scanning` built
+    // `GpuNativeSearchMatch.text: String` via
+    // `String::from_utf8_lossy(line_bytes).trim_end_matches('\r').to_string()`, which (a) silently
+    // replaced any genuinely invalid-UTF-8 byte with U+FFFD, and (b) unconditionally stripped a
+    // trailing `\r` even though `line_bytes` never includes the line's `\n` terminator (both
+    // producers slice up to but excluding the `\n`), so a trailing `\r` is always genuine CRLF
+    // content, never a terminator artifact to strip. Each test below asserts the specific byte
+    // sequence that only the buggy `from_utf8_lossy`/`trim_end_matches('\r')` pipeline would
+    // corrupt -- reintroducing that pipeline on `raw` (e.g.
+    // `raw: String::from_utf8_lossy(line_bytes).trim_end_matches('\r').to_string().into_bytes()`)
+    // fails every test in this group.
+
+    #[test]
+    fn line_match_materialization_preserves_invalid_utf8_bytes_losslessly() {
+        // 'E', 0xFF (not a valid UTF-8 lead/continuation byte on its own), 'R', 'O', 'R'.
+        let mut bytes = b"INFO start\n".to_vec();
+        let invalid_line: &[u8] = &[b'E', 0xFF, b'R', b'O', b'R'];
+        bytes.extend_from_slice(invalid_line);
+        bytes.push(b'\n');
+
+        let path = PathBuf::from("invalid-utf8.log");
+        let file = BatchedFile {
+            path: path.clone(),
+            start: 100,
+            end: 100 + bytes.len(),
+            line_descriptors: vec![
+                LineDescriptor {
+                    start: 100,
+                    len: 10,
+                    line_number: 1,
+                },
+                LineDescriptor {
+                    start: 111,
+                    len: invalid_line.len() as u32,
+                    line_number: 2,
+                },
+            ],
+        };
+        let offsets = vec![PatternMatchPosition {
+            byte_offset: 11,
+            pattern_id: 0,
+        }];
+        let patterns = vec!["ERROR".to_string()];
+
+        let matches = line_matches_for_file(&file, &bytes, &offsets, &patterns);
+
+        assert_eq!(matches.len(), 1);
+        // The old `String::from_utf8_lossy` path would have replaced the 0xFF byte with the
+        // 3-byte UTF-8 encoding of U+FFFD, changing both the content AND the length. Assert the
+        // exact original bytes survive, unchanged.
+        assert_eq!(matches[0].raw, invalid_line);
+        assert_ne!(
+            matches[0].raw,
+            String::from_utf8_lossy(invalid_line).as_bytes(),
+            "raw must not have been run through a lossy UTF-8 conversion"
+        );
+
+        // Full pipeline: `native_json_text_fields` (the shared JSON/NDJSON emitter helper this
+        // producer now feeds, task #271) must route genuinely invalid UTF-8 through the
+        // `bytes`/base64 side of its `text`-XOR-`bytes` contract, never `text`.
+        let (text, encoded_bytes) = crate::native_search::native_json_text_fields(&matches[0].raw);
+        assert_eq!(text, None);
+        let encoded_bytes =
+            encoded_bytes.expect("invalid UTF-8 must produce a base64 `bytes` field");
+        assert_eq!(
+            TEST_BASE64_STANDARD
+                .decode(encoded_bytes)
+                .expect("base64 payload must decode"),
+            invalid_line
+        );
+    }
+
+    #[test]
+    fn line_match_materialization_preserves_trailing_carriage_return() {
+        // A genuine CRLF source line: "ERROR target\r" followed by the `\n` terminator that the
+        // line-descriptor slicing already excludes. The pre-fix `.trim_end_matches('\r')` would
+        // wrongly eat the trailing `\r`, producing "ERROR target" (12 bytes) instead of the
+        // correct 13-byte "ERROR target\r".
+        let bytes = b"INFO start\r\nERROR target\r\n";
+        let path = PathBuf::from("crlf.log");
+        let file = BatchedFile {
+            path: path.clone(),
+            start: 100,
+            end: 100 + bytes.len(),
+            line_descriptors: vec![
+                LineDescriptor {
+                    start: 100,
+                    len: 11, // "INFO start\r"
+                    line_number: 1,
+                },
+                LineDescriptor {
+                    start: 112,
+                    len: 13, // "ERROR target\r"
+                    line_number: 2,
+                },
+            ],
+        };
+        let offsets = vec![PatternMatchPosition {
+            byte_offset: 12,
+            pattern_id: 0,
+        }];
+        let patterns = vec!["ERROR".to_string()];
+
+        let matches = line_matches_for_file(&file, bytes, &offsets, &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].raw, b"ERROR target\r");
+    }
+
+    #[test]
+    fn line_match_materialization_by_scanning_preserves_trailing_carriage_return() {
+        // Same CRLF regression as above, but through the fallback `line_matches_for_file_by_scanning`
+        // path (taken whenever `line_descriptors` is empty) -- the two producers had the identical
+        // `.trim_end_matches('\r')` bug independently and both must be fixed.
+        let bytes: &[u8] = b"INFO start\r\nERROR target\r\n";
+        let path = PathBuf::from("crlf-scanned.log");
+        let offsets = vec![PatternMatchPosition {
+            byte_offset: 12,
+            pattern_id: 0,
+        }];
+        let patterns = vec!["ERROR".to_string()];
+
+        let matches = line_matches_for_file_by_scanning(&path, bytes, &offsets, &patterns);
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].line_number, 2);
+        assert_eq!(matches[0].raw, b"ERROR target\r");
+    }
+
+    #[test]
+    fn line_match_materialization_valid_utf8_round_trips_through_text() {
+        // The `text` side of the `native_json_text_fields` contract for a plain valid-UTF-8 line.
+        let path = PathBuf::from("sample.log");
+        let bytes = b"INFO start\nERROR target\n";
+        let file = BatchedFile {
+            path: path.clone(),
+            start: 100,
+            end: 100 + bytes.len(),
+            line_descriptors: vec![
+                LineDescriptor {
+                    start: 100,
+                    len: 10,
+                    line_number: 1,
+                },
+                LineDescriptor {
+                    start: 111,
+                    len: 12,
+                    line_number: 2,
+                },
+            ],
+        };
+        let offsets = vec![PatternMatchPosition {
+            byte_offset: 11,
+            pattern_id: 0,
+        }];
+        let patterns = vec!["ERROR".to_string()];
+
+        let matches = line_matches_for_file(&file, bytes, &offsets, &patterns);
+
+        assert_eq!(matches.len(), 1);
+        let (text, encoded_bytes) = crate::native_search::native_json_text_fields(&matches[0].raw);
+        assert_eq!(text, Some("ERROR target"));
+        assert_eq!(encoded_bytes, None);
     }
 }
 

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -13104,11 +13104,21 @@ fn gpu_native_match_json_entries(stats: &GpuNativeSearchStats) -> Vec<SearchMatc
     // sidecar). `GpuNativeSearchMatch` now carries `raw: Vec<u8>` instead, produced without any
     // lossy conversion in `gpu_native.rs`, so this mirrors the multi-pattern native path's own
     // `native_json_text_fields(&matched.raw)` call below (task #271) rather than
-    // `guaranteed_utf8_match_fields`. VERIFIED: `cuda-feature-check` (.github/workflows/ci.yml)
-    // runs only `cargo check --features cuda` -- no `--tests`/`--all-targets` -- so this file's
-    // `#[cfg(test)]` module (including the tests added for this fix) is never even type-checked
-    // in CI, let alone executed. No CI job currently exercises this file at all beyond that bare
-    // `cargo check`.
+    // `guaranteed_utf8_match_fields`.
+    //
+    // CI COVERAGE, precisely: `cuda-feature-check` (.github/workflows/ci.yml) runs
+    // `cargo check --features cuda --all-targets`. `test-rust-core` builds DEFAULT features and
+    // never compiles `gpu_native` at all (it is gated at lib.rs by `#[cfg(feature = "cuda")]`),
+    // so this job is the ONLY oracle for cuda-gated code. `--all-targets` is LOAD-BEARING, not
+    // tidiness: a bare `cargo check` compiles only normal targets, leaving `gpu_native.rs`'s
+    // `#[cfg(test)]` module and the `tests/test_gpu_native_*.rs` integration targets entirely
+    // un-type-checked -- which is exactly how eight `.text` reads survived this PR's first cut
+    // and surfaced only as `E0609` once `--all-targets` was added. Do not drop it.
+    //
+    // What that still does NOT buy: those tests are type-checked but NEVER EXECUTED anywhere in
+    // CI -- checking is not running, and no CUDA runner exists. Task #279 tracks whether
+    // `cargo test --features cuda` can link on a GPU-less runner; until it is answered, treat
+    // cuda-gated tests as compile-time protection only.
     stats
         .matches
         .iter()

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -13005,10 +13005,11 @@ fn unique_line_matches(matches: &[SearchMatchJson]) -> Vec<SearchMatchJson> {
 }
 
 /// Writes each matched line's raw bytes directly to stdout (never through `println!`/`Display`
-/// on `matched.text`), so a genuinely non-UTF-8 match -- currently only reachable via the
-/// multi-pattern native path -- prints byte-for-byte instead of via a lossy `Option<String>`
-/// unwrap (task #266: the same byte-fidelity guarantee `append_standard_match_bytes` gives the
-/// single-pattern native emitter, extended to this shared plain-text writer).
+/// on `matched.text`), so a genuinely non-UTF-8 match -- reachable via the multi-pattern native
+/// path and, since task #273, the CUDA-gated GPU-native path -- prints byte-for-byte instead of
+/// via a lossy `Option<String>` unwrap (task #266: the same byte-fidelity guarantee
+/// `append_standard_match_bytes` gives the single-pattern native emitter, extended to this shared
+/// plain-text writer).
 ///
 /// A closed output pipe (`tg ... | head -1`) is a normal, expected termination and returns
 /// `Ok(())` quietly; any OTHER write failure (disk full, I/O error) is a real error and is
@@ -13094,29 +13095,32 @@ fn emit_count_search_matches(path: &str, matches: &[SearchMatchJson]) -> anyhow:
 
 #[cfg(feature = "cuda")]
 fn gpu_native_match_json_entries(stats: &GpuNativeSearchStats) -> Vec<SearchMatchJson> {
-    // NOT exempt the way TrigramIndex/AST/the GPU sidecar are (those three have a real, cited
-    // guarantee their source text is always valid UTF-8). `GpuNativeSearchMatch.text` is built
-    // in `gpu_native.rs` via `String::from_utf8_lossy(line_bytes).trim_end_matches('\r')` -- the
-    // IDENTICAL lossy-conversion + over-trim defect class task #266 fixes in the CPU emitter.
-    // Left unfixed here deliberately: this is the CUDA-gated, experimental GPU-native search
-    // path (not the "shared native emitter" #266/#263 name), off by default
-    // (`cuda-feature-check` CI only `cargo check`s it, never runs it), and per this repo's own
-    // GPU program notes, not a currently-viable production path. `guaranteed_utf8_match_fields`
-    // here is a straight type-compatibility wrap of whatever `matched.text` already is -- it
-    // does NOT certify losslessness for this producer the way it does for the other three.
-    // Fixing gpu_native.rs's own conversion is a disclosed, separate follow-up, not silently
-    // dropped.
+    // task #273: this used to be the one remaining NOT-exempt-but-treated-as-exempt producer --
+    // `GpuNativeSearchMatch.text` was built in `gpu_native.rs` via
+    // `String::from_utf8_lossy(line_bytes).trim_end_matches('\r')`, the identical
+    // lossy-conversion + over-trim defect class task #266/#746 fixed in the CPU native-search
+    // emitter, then routed through `guaranteed_utf8_match_fields` (a straight type-compatibility
+    // wrap that does NOT certify losslessness the way it does for TrigramIndex/AST/the GPU
+    // sidecar). `GpuNativeSearchMatch` now carries `raw: Vec<u8>` instead, produced without any
+    // lossy conversion in `gpu_native.rs`, so this mirrors the multi-pattern native path's own
+    // `native_json_text_fields(&matched.raw)` call below (task #271) rather than
+    // `guaranteed_utf8_match_fields`. VERIFIED: `cuda-feature-check` (.github/workflows/ci.yml)
+    // runs only `cargo check --features cuda` -- no `--tests`/`--all-targets` -- so this file's
+    // `#[cfg(test)]` module (including the tests added for this fix) is never even type-checked
+    // in CI, let alone executed. No CI job currently exercises this file at all beyond that bare
+    // `cargo check`.
     stats
         .matches
         .iter()
         .map(|matched| {
-            let (text, bytes, raw) = guaranteed_utf8_match_fields(matched.text.clone());
+            let (text, bytes) = native_json_text_fields(&matched.raw);
+            let text = text.map(str::to_string);
             SearchMatchJson {
                 file: matched.path.to_string_lossy().into_owned(),
                 line: matched.line_number,
                 text,
                 bytes,
-                raw,
+                raw: matched.raw.clone(),
                 range: None,
                 meta_variables: None,
                 pattern_id: (stats.pattern_count > 1).then_some(matched.pattern_id),

--- a/rust_core/tests/test_gpu_native_integration.rs
+++ b/rust_core/tests/test_gpu_native_integration.rs
@@ -792,7 +792,16 @@ fn test_gpu_native_multi_pattern_falls_back_to_batched_passes_for_large_pattern_
             (
                 matched.path.to_string_lossy().into_owned(),
                 matched.line_number,
-                matched.text,
+                // `cpu_union_pattern_tuples` (below) and `parse_match_tuple`/`parse_json_tuples`
+                // are shared across ~15 call sites in this file that compare `tg`'s own JSON
+                // stdout text-vs-text (unaffected by `GpuNativeSearchMatch`'s `raw: Vec<u8>`
+                // shape) -- widening their return type to `Vec<u8>` would ripple far past what
+                // this fix touches. `String::from_utf8` fails loudly (not lossily) rather than
+                // going through `from_utf8_lossy`, so this large-pattern-fallback corpus (pure
+                // ASCII by construction, `write_large_pattern_fallback_corpus` above) keeps the
+                // same byte-fidelity guarantee as a `Vec<u8>` comparison would, without touching
+                // the shared helpers.
+                String::from_utf8(matched.raw).expect("test corpus is valid UTF-8"),
                 matched.pattern_id,
                 matched.pattern_text,
             )

--- a/rust_core/tests/test_gpu_native_long_lines.rs
+++ b/rust_core/tests/test_gpu_native_long_lines.rs
@@ -60,17 +60,44 @@ fn write_short_vs_long_perf_corpora(dir: &Path, pattern: &str) -> (PathBuf, Path
     (short, long)
 }
 
-fn cpu_expected_matches(corpus: &Path, pattern: &str) -> Vec<(String, usize, String)> {
+/// Splits `body` into lines the same way the GPU-native producers do (`classify_file_lines`,
+/// `line_matches_for_file_by_scanning`): boundaries are `\n` bytes, exactly one trailing `\n` is
+/// excluded, and everything else -- including a genuine trailing `\r` from a CRLF source line --
+/// is kept as real line content. Unlike `str::lines()` (which additionally normalizes away a
+/// trailing `\r` immediately before `\n`), this must NOT special-case `\r\n`: task #273 fixed the
+/// GPU-native emitter to retain that `\r`, so the CPU oracle here has to retain it too, or a
+/// future CRLF corpus would compare a `\r`-stripped oracle against a `\r`-preserving producer and
+/// the two would spuriously diverge on the CRLF case this whole fix is about.
+fn split_lines_keep_cr(body: &[u8]) -> Vec<&[u8]> {
+    let mut lines = Vec::new();
+    let mut start = 0usize;
+    for (index, &byte) in body.iter().enumerate() {
+        if byte == b'\n' {
+            lines.push(&body[start..index]);
+            start = index + 1;
+        }
+    }
+    if start < body.len() {
+        lines.push(&body[start..]);
+    }
+    lines
+}
+
+fn cpu_expected_matches(corpus: &Path, pattern: &str) -> Vec<(String, usize, Vec<u8>)> {
     let path = corpus.join("corpus.log");
-    let body = fs::read_to_string(path).unwrap();
-    body.lines()
+    let body = fs::read(path).unwrap();
+    split_lines_keep_cr(&body)
+        .into_iter()
         .enumerate()
         .filter_map(|(index, line)| {
-            line.contains(pattern).then(|| {
+            // These corpora are built from Rust `String`s (`build_line_with_pattern` etc.), so
+            // every line is valid UTF-8 by construction; only the pattern *search* needs `&str`.
+            let line_text = std::str::from_utf8(line).expect("test corpus lines are valid UTF-8");
+            line_text.contains(pattern).then(|| {
                 (
                     corpus.join("corpus.log").to_string_lossy().into_owned(),
                     index + 1,
-                    line.to_string(),
+                    line.to_vec(),
                 )
             })
         })
@@ -80,7 +107,7 @@ fn cpu_expected_matches(corpus: &Path, pattern: &str) -> Vec<(String, usize, Str
 fn gpu_match_tuples(
     config: &GpuNativeSearchConfig,
     device_id: i32,
-) -> Vec<(String, usize, String)> {
+) -> Vec<(String, usize, Vec<u8>)> {
     let mut tuples = gpu_native_search_paths(config, device_id)
         .unwrap()
         .matches
@@ -89,7 +116,7 @@ fn gpu_match_tuples(
             (
                 matched.path.to_string_lossy().into_owned(),
                 matched.line_number,
-                matched.text,
+                matched.raw,
             )
         })
         .collect::<Vec<_>>();
@@ -130,7 +157,7 @@ fn test_gpu_native_adaptive_dispatch_matches_cpu_for_ten_kib_lines() {
             (
                 matched.path.to_string_lossy().into_owned(),
                 matched.line_number,
-                matched.text.clone(),
+                matched.raw.clone(),
             )
         })
         .collect::<Vec<_>>();
@@ -173,7 +200,7 @@ fn test_gpu_native_adaptive_dispatch_matches_cpu_for_hundred_kib_lines() {
             (
                 matched.path.to_string_lossy().into_owned(),
                 matched.line_number,
-                matched.text.clone(),
+                matched.raw.clone(),
             )
         })
         .collect::<Vec<_>>();
@@ -221,28 +248,32 @@ fn test_gpu_native_adaptive_dispatch_classifies_mixed_short_medium_and_long_line
             (
                 matched.path.to_string_lossy().into_owned(),
                 matched.line_number,
-                matched.text,
+                matched.raw,
             )
         })
         .collect::<Vec<_>>();
     actual.sort();
     let expected_path = corpus.join("mixed.log").to_string_lossy().into_owned();
     let expected = vec![
-        (expected_path.clone(), 1, format!("short {pattern}")),
+        (
+            expected_path.clone(),
+            1,
+            format!("short {pattern}").into_bytes(),
+        ),
         (
             expected_path.clone(),
             2,
-            build_line_with_pattern(512, pattern, 1),
+            build_line_with_pattern(512, pattern, 1).into_bytes(),
         ),
         (
             expected_path.clone(),
             3,
-            build_line_with_pattern(10 * 1024, pattern, 2),
+            build_line_with_pattern(10 * 1024, pattern, 2).into_bytes(),
         ),
         (
             expected_path,
             4,
-            build_line_with_pattern(100 * 1024, pattern, 3),
+            build_line_with_pattern(100 * 1024, pattern, 3).into_bytes(),
         ),
     ];
     assert_eq!(actual, expected);

--- a/rust_core/tests/test_gpu_native_streams.rs
+++ b/rust_core/tests/test_gpu_native_streams.rs
@@ -16,7 +16,7 @@ fn first_device_id() -> Option<i32> {
         .and_then(|devices| devices.first().map(|device| device.device_id))
 }
 
-fn write_overlap_corpus(dir: &Path) -> (PathBuf, Vec<(PathBuf, usize, String)>) {
+fn write_overlap_corpus(dir: &Path) -> (PathBuf, Vec<(PathBuf, usize, Vec<u8>)>) {
     let corpus = dir.join("overlap-corpus");
     fs::create_dir(&corpus).unwrap();
 
@@ -29,7 +29,11 @@ fn write_overlap_corpus(dir: &Path) -> (PathBuf, Vec<(PathBuf, usize, String)>) 
             "ERROR overlap sentinel".repeat(128)
         );
         fs::write(&path, &body).unwrap();
-        expected.push((path.clone(), 4, "ERROR overlap sentinel".repeat(128)));
+        expected.push((
+            path.clone(),
+            4,
+            "ERROR overlap sentinel".repeat(128).into_bytes(),
+        ));
     }
 
     (corpus, expected)
@@ -115,7 +119,7 @@ fn test_gpu_native_overlap_matches_expected_results_without_races() {
         .unwrap()
         .matches
         .into_iter()
-        .map(|matched| (matched.path, matched.line_number, matched.text))
+        .map(|matched| (matched.path, matched.line_number, matched.raw))
         .collect::<Vec<_>>();
     actual.sort();
 
@@ -226,7 +230,7 @@ fn test_gpu_native_multi_gpu_balances_distribution_and_matches_single_gpu_result
             (
                 matched.path.clone(),
                 matched.line_number,
-                matched.text.clone(),
+                matched.raw.clone(),
             )
         })
         .collect::<Vec<_>>();
@@ -237,7 +241,7 @@ fn test_gpu_native_multi_gpu_balances_distribution_and_matches_single_gpu_result
             (
                 matched.path.clone(),
                 matched.line_number,
-                matched.text.clone(),
+                matched.raw.clone(),
             )
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

Build task #273. Two live sites in the CUDA-gated GPU-native search engine (`rust_core/src/gpu_native.rs`) lossily mangled match bytes — the exact defect family task #266/#746 fixed in `native_search.rs` (the CPU emitter):

- `line_matches_for_file` and `line_matches_for_file_by_scanning` built `GpuNativeSearchMatch.text: String` via `String::from_utf8_lossy(line_bytes).trim_end_matches('\r').to_string()`.
- Invalid UTF-8 silently became U+FFFD.
- A genuine trailing `\r` from a CRLF source line was stripped even though `line_bytes` in both producers already excludes the line's `\n` terminator — so a trailing `\r` present in that slice is always real content, never a terminator artifact.

## Scope decision (cited)

Changed `GpuNativeSearchMatch.text: String` → `raw: Vec<u8>`, mirroring `NativeSearchMatch::raw`'s shape from task #746 (`rust_core/src/native_search.rs:56`) rather than patching the two sites in place. Justification: a shape *divergence* between the CPU and GPU-native engines is exactly how this defect family survived independently in two places — keeping the shapes aligned means the next audit sees one contract, not two.

## Mechanical consumer census — round 1 was incomplete, corrected in round 2

Round 1 grepped `grep -rn "GpuNativeSearchMatch" rust_core/src/*.rs` and found 3 consumers inside `gpu_native.rs`/`main.rs`. **That query was wrong on two axes: scope (`src/` only, excluding `tests/`) and predicate (the type NAME, not the FIELD)** — every real consumer in the integration test suite reaches `.text` through `stats.matches` without ever naming `GpuNativeSearchMatch`, so the type-name grep was structurally blind to them. The independent Opus gate caught this: `cuda-feature-check` (ubuntu) failed at `tests/test_gpu_native_long_lines.rs:92` with `E0609: no field 'text'`. Round 2 found all 8 real sites across 3 files by grepping the field, not the type, and including `tests/`:

- `rust_core/src/gpu_native.rs` — 2 sort comparators + 2 dedup-key tuples (the per-file path and `merge_device_matches`'s multi-device merge path) — `.text` → `.raw`.
- `rust_core/src/gpu_native.rs` — 2 pre-existing unit-test assertions — updated to compare `.raw` against byte literals.
- `rust_core/src/main.rs:13096` `gpu_native_match_json_entries` (`#[cfg(feature = "cuda")]`) — the **single JSON/plain/count emission point**: `emit_gpu_native_json_results`, `emit_gpu_native_plain_results`, and `emit_gpu_native_count_results` all funnel through it. This function already had an 11-line comment explicitly documenting the defect as a disclosed, deliberately-deferred follow-up.
- `rust_core/tests/test_gpu_native_long_lines.rs` — 4 sites (`cpu_expected_matches`, `gpu_match_tuples`, and the 3 tests that call them).
- `rust_core/tests/test_gpu_native_integration.rs:795` — 1 site (`test_gpu_native_multi_pattern_falls_back_to_batched_passes_for_large_pattern_sets`).
- `rust_core/tests/test_gpu_native_streams.rs` — 3 sites (`write_overlap_corpus`'s expected tuples, and the single-GPU/multi-GPU consistency check).
- Confirmed clean (field-level grep, not type-name grep): `test_gpu_native.rs`, `test_gpu_native_error_handling.rs`, `test_gpu_native_graphs.rs` reference neither `.text` nor `GpuNativeSearchMatch`.

## Fix shape reused, not reinvented

`main.rs::gpu_native_match_json_entries` now calls `native_json_text_fields(&matched.raw)` (`native_search.rs:381`, already `pub` and already imported in `main.rs`) instead of `guaranteed_utf8_match_fields`, mirroring the multi-pattern native path's own identical call at `main.rs:8191`/`8220` (task #271). No second implementation of the text/bytes split was written. `gpu_native.rs` itself needed no new `use` — the byte→text/bytes split happens in `main.rs`, which already had the import; only `gpu_native.rs`'s producers changed (they now emit raw bytes with no conversion at all).

`strip_native_line_terminator` was **not** reused: it strips "at most one trailing `\n`" for the CPU emitter's byte-scanning path, which can include a `\n` in its raw slice. Both GPU-native producers already exclude `\n` by construction (`LineDescriptor::len = newline_index - line_start`; the scanning path's `line_end` is the `\n`'s own index), so no terminator stripping is needed at all — the fix is simply to stop trimming `\r`.

### Test-fixture remedy for the 8 integration-test sites

Not a mechanical `.text`→`.raw` rename — the test sites compare against `String`-typed CPU expectations that needed their own fix:

- `test_gpu_native_long_lines.rs`'s `cpu_expected_matches` derived lines via `body.lines()`, which normalizes away a trailing `\r` before `\n` — exactly the byte this PR stops discarding. Replaced with `split_lines_keep_cr`, a byte-level splitter mirroring `gpu_native.rs`'s own line-boundary math, so the CPU oracle and the GPU-native producer agree on CRLF content instead of the oracle silently normalizing it away. Both sides now compare as `Vec<u8>` (the **preferred** remedy per the gate).
- `test_gpu_native_streams.rs`'s 3 sites: also moved to `Vec<u8>` on both sides (`.raw` / `.into_bytes()`) — trivial since none of them route through a `String`-based CPU oracle.
- `test_gpu_native_integration.rs:795`: used the **acceptable fallback** instead — `String::from_utf8(matched.raw).expect(...)` (fails loudly on invalid UTF-8, never lossily) rather than widening `cpu_union_pattern_tuples`/`parse_match_tuple`/`parse_json_tuples`, which are shared by ~15 *other* call sites in that file that compare `tg`'s own JSON stdout text-vs-text and never touch `GpuNativeSearchMatch` at all. Widening those helpers to `Vec<u8>` would have rippled far past what this fix needs to touch. This test's corpus (`write_large_pattern_fallback_corpus`) is pure ASCII by construction, so no byte-fidelity is actually lost by staying at the `String` level here.

## Tests

5 new unit tests added to `gpu_native.rs`'s existing `#[cfg(test)]` module, **3 of which are genuinely discriminating** — correcting an overclaim in this PR's first draft, which is worth stating plainly rather than quietly fixing:

- **Discriminating** (fail if reverted to `String::from_utf8_lossy(line_bytes).trim_end_matches('\r').to_string().into_bytes()`): `line_match_materialization_preserves_invalid_utf8_bytes_losslessly` (gpu_native.rs:4667), `line_match_materialization_preserves_trailing_carriage_return` (:4727), `line_match_materialization_by_scanning_preserves_trailing_carriage_return` (:4764) — the CRLF tests fail on length/content (missing `\r`), the invalid-UTF-8 test fails because the U+FFFD-replaced bytes differ from the original 0xFF byte.
- **Characterization only, NOT discriminating** (would still pass against a revert — LF fixture, valid UTF-8, no `\r`): `line_match_materialization_valid_utf8_round_trips_through_text` (:4784), and the 2 updated pre-existing assertions at :4613/:4648. These document the `native_json_text_fields` baseline contract but do not, by themselves, prove the fix. Flagging this explicitly rather than letting "5 new tests" read as "5 discriminating tests."

Plus the 8-site integration-test fix above, which restores `cuda-feature-check --all-targets` (added in this PR by the gate) to green.

## Two additional, previously-undocumented effects of this fix

1. **Equality/ordering delta.** The sort comparators and dedup keys at `gpu_native.rs:1425`/`1432` and `1999`/`2009` are unchanged in *ordering* for valid UTF-8 (both byte-lexicographic before and after). But two distinct invalid-UTF-8 lines that previously both lossily converted to the same U+FFFD-containing `String` compared **equal** and could be silently deduped into one match. Post-fix they compare on their real (distinct) byte content and are correctly kept as separate matches. Desirable, previously undocumented.
2. **Plain-text output is now byte-correct too, not just `--json`.** `emit_plain_search_matches_with_line_number` (`main.rs:13034-13035`) writes `SearchMatchJson.raw` directly. Pre-fix, `raw` was derived from the already-lossy `text` String (`guaranteed_utf8_match_fields`), so a CRLF line printed as `ERROR target\n` (missing `\r`). Post-fix it prints `ERROR target\r\n`, byte-identical to `rg`. This PR was scoped around `--json`/`--ndjson` output but the plain-text and `--count` code paths get the same correctness fix for free, since all three funnel through `gpu_native_match_json_entries`.

## CI coverage gap — stated plainly

Verified by reading `.github/workflows/ci.yml`'s `cuda-feature-check` job (`ubuntu-latest` + `windows-latest` matrix): it originally ran only `cargo check --features cuda`, with no `--tests`/`--all-targets` flag — meaning `#[cfg(test)]` code was never even type-checked, let alone executed. **The independent gate added `--all-targets` directly to this branch** (kept in this PR), which is what surfaced the 8-site test breakage in the first place — it is the highest-value line in this PR. Even with `--all-targets`, `cargo check` still only type-checks; it does not run any test. Executing cuda-gated tests would need a `cargo test --features cuda` job, which does not exist today — tracked as a separate, real gap, not silently glossed over.

## rustfmt

`rustfmt --edition 2021 --check` on all 5 touched `.rs` files (`gpu_native.rs`, `main.rs`, `test_gpu_native_long_lines.rs`, `test_gpu_native_integration.rs`, `test_gpu_native_streams.rs`): clean. Also re-checked the 3 gpu_native test files this PR does *not* touch (`test_gpu_native.rs`, `test_gpu_native_error_handling.rs`, `test_gpu_native_graphs.rs`): also clean, and confirmed via the field-level grep above that they need no changes.

## What I could not verify (no compiler access, CPU-SAFE)

- Does not compile at all under `--features cuda` — `cargo check`/`build`/`test`/`clippy`, `rustc`, and `maturin` are all forbidden on this shared desktop. Every claim above is from reading the code and hand-deriving byte offsets/line-boundary math, not from a compiler or test run. **`cuda-feature-check` on this push (now with `--all-targets`) is the only oracle that can prove the 8-site test fix actually compiles** — round 1 of this PR shipped with an incomplete census precisely because I could not compile to catch it myself; watch that job on this push before trusting the fix is complete.
- Whether `Vec<u8>` vs `&[u8; N]` byte-literal `assert_eq!`/`assert_ne!` comparisons type-check as written — **now closed**: the gate confirmed the lib-test target compiled cleanly in the round-1 CI run (before the test-crate failures), so `assert_eq!(Vec<u8>, b"…")`, the base64 imports, and `native_json_text_fields`'s reachability from `gpu_native.rs`'s test module are all proven to type-check.
- Whether the 3 untouched test files (`test_gpu_native.rs`, `test_gpu_native_error_handling.rs`, `test_gpu_native_graphs.rs`) compile cleanly under `--all-targets` — grepped clean of any `.text`/`GpuNativeSearchMatch` reference, but not compiler-proven; only the next `cuda-feature-check` run settles this.

## Lineage

Task #273 (this fix) mirrors #266/#746 (the CPU-emitter defect) and reuses #271's shared JSON helper. These are internal task-tracker labels used as commit-message convention in this repo; GitHub issue/PR numbers 266/271/273 currently point to unrelated, already-merged work (numbers were recycled over time), so please read them as prose references, not GitHub auto-links to this defect's actual history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
