### PR TITLE
fix(native): report walk errors from the file-collector instead of dropping them (#280 stderr half)

### DIFF
--- a/rust_core/src/gpu_native.rs
+++ b/rust_core/src/gpu_native.rs
@@ -3887,15 +3887,26 @@ fn collect_walked_files(config: &GpuNativeSearchConfig, roots: &[PathBuf]) -> Re
     builder.build_parallel().run(|| {
         let shared_files = Arc::clone(&shared_files);
         Box::new(move |entry| {
-            if let Ok(entry) = entry {
-                if entry
-                    .file_type()
-                    .map(|kind| kind.is_file())
-                    .unwrap_or(false)
-                {
-                    if let Ok(mut guard) = shared_files.lock() {
-                        guard.push(entry.path().to_path_buf());
-                    }
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    // Byte-identical defect to the CPU collector in `native_search.rs`, and
+                    // fixed the same way (task #280): the Err arm used to be dropped with no
+                    // output, so a permission-denied subtree vanished from the file list
+                    // completely silently. Real `rg` prints one stderr line per unreadable
+                    // path and keeps walking. Exit code + JSON envelope marker are still
+                    // unwired here, same as the CPU side -- see the note at that site.
+                    eprintln!("tg: {err}");
+                    return WalkState::Continue;
+                }
+            };
+            if entry
+                .file_type()
+                .map(|kind| kind.is_file())
+                .unwrap_or(false)
+            {
+                if let Ok(mut guard) = shared_files.lock() {
+                    guard.push(entry.path().to_path_buf());
                 }
             }
             WalkState::Continue

--- a/rust_core/src/native_search.rs
+++ b/rust_core/src/native_search.rs
@@ -1628,15 +1628,36 @@ fn collect_walked_files(config: &NativeSearchConfig, roots: &[PathBuf]) -> Resul
     builder.build_parallel().run(|| {
         let shared_files = Arc::clone(&shared_files);
         Box::new(move |entry| {
-            if let Ok(entry) = entry {
-                if entry
-                    .file_type()
-                    .map(|kind| kind.is_file())
-                    .unwrap_or(false)
-                {
-                    if let Ok(mut guard) = shared_files.lock() {
-                        guard.push(entry.path().to_path_buf());
-                    }
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    // Report the per-entry walk error, exactly as the streaming walker in
+                    // `search_walk_roots_parallel` already does (task #263). This collector
+                    // used to drop the Err arm on the floor with NO output at all, so a
+                    // permission-denied subtree vanished from the file list COMPLETELY
+                    // silently -- strictly worse than the streaming path, which at least
+                    // prints one line. Real `rg` prints one stderr line per unreadable path
+                    // and keeps walking every readable file; both tg walkers now match that.
+                    //
+                    // NOTE (task #280): printing is only half the contract. `rg` also exits 2
+                    // on an unreadable path while still emitting its matches, and the JSON
+                    // envelope should carry `result_incomplete` + `incomplete_reason_class`
+                    // the way the Python routes do since #276 slice 1 (c0c3404). Neither is
+                    // wired here yet -- that needs an error count threaded through
+                    // `SearchStats` into `emit_json_matches` and the exit code, and is the
+                    // next slice. Until then this path is honest on stderr but still reports
+                    // success.
+                    eprintln!("tg: {err}");
+                    return WalkState::Continue;
+                }
+            };
+            if entry
+                .file_type()
+                .map(|kind| kind.is_file())
+                .unwrap_or(false)
+            {
+                if let Ok(mut guard) = shared_files.lock() {
+                    guard.push(entry.path().to_path_buf());
                 }
             }
             WalkState::Continue


### PR DESCRIPTION
## Summary

Slice 2a of #276. Both engines' `collect_walked_files` matched only the `Ok` arm of the walk entry (`if let Ok(entry) = entry`), so a permission-denied subtree was dropped from the file list with **no output at all** — strictly worse than the streaming walker beside it, which has printed one stderr line per unreadable path since #263, and a divergence from `rg`.

`collect_walked_files` is live on three call sites: `native_search.rs:874`, `native_search.rs:900`, and `gpu_native.rs:3871`.

## Evidence

Measured on the **checksum-verified** v1.98.11 release asset (SHA256 matched `CHECKSUMS.txt` — a local `tg` on PATH is not the shipped artifact), against a fixture whose unreadable directory was **verified to actually raise** before the probe ran. That precondition matters: earlier `icacls` attempts silently failed to apply, and a fixture that isn't really unreadable makes both arms of the test pass.

| command | stderr | exit | match in readable sibling |
|---|---|---|---|
| `rg needle fx` | `rg: fx\denied: Access is denied.` | **2** | yes |
| `tg search needle fx --json` | same line | **0** | yes |
| `tg search needle fx --cpu --json` | same line | **0** | yes |

Both tg rows route to `NativeCpuBackend` (`routing_reason` `json_output` / `force_cpu`). The payload is never dropped — keep-partial already holds. The defect is that it reports **complete**.

## Scope — deliberately half

This lands the **stderr** half only. Still missing on the native engine, and called out in a comment at both sites so the gap cannot read as closed:

- `rg` exits **2** on an unreadable path; tg exits 0. Per `docs/CONTRACTS.md:115` a SCAN truncation must exit 2.
- Since #276 slice 1 (`c0c3404`) the Python routes carry `result_incomplete` + `incomplete_reason_class` in the JSON envelope. The native engine emits neither.

Wiring those needs an error count threaded through `SearchStats` into `emit_json_matches` and the exit code, changing a signature used at three call sites plus a test. That is a separate slice rather than landed blind — **Rust cannot be compiled in this environment, so CI is the only oracle**, and a large unverifiable change is the wrong shape for that constraint.

## Gates

`rustfmt --check` clean on both files (rustfmt 1.9.0-stable; repo has no `rustfmt.toml`, so local defaults match CI). Compilation and tests are CI's to prove.

Draft until an independent Opus gate returns SHIP.

Refs #280, #276.
