### PR TITLE
chore: ignore repo-root pytest basetemp dirs so an unreadable one cannot spam git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ site/
 
 # Pytest / Coverage
 .pytest_cache/
+# Review/dogfood flows drop `basetemp` dirs at the repo root (task #268). On Windows these can
+# land with an ACL that denies the current user, and an UNIGNORED unreadable directory makes git
+# emit `warning: could not open directory ...: Permission denied` on EVERY invocation -- for the
+# operator and for every agent. Ignoring the pattern stops git traversing it at all.
+.pytest_tmp_*/
 .coverage
 htmlcov/
 


### PR DESCRIPTION
Review/dogfood flows drop `basetemp` directories at the repo root. One landed on Windows with an ACL denying the current user, and because the pattern was **unignored**, git traversed it and emitted

```
warning: could not open directory '.pytest_tmp_review_<hash>/': Permission denied
```

on **every** invocation — for the operator and for every agent. The independent gate on #759 hit it too and reported it as noise.

`.pytest_cache/` was already ignored and `/.review_tmp/` was already ignored; the `basetemp` pattern was the gap. Ignoring it stops git traversing the directory at all, so the warning disappears **without needing any permission on the directory itself**.

## Verified, both arms

`git status --short` emitted the warning immediately before this change and emits clean output immediately after. That's a control, not an assumption — the same command, one line apart.

## What this does not do

It does not delete the directory. That still needs one elevated shell: `takeown` and `icacls /reset` both fail unelevated because the DACL belongs to a different SID. (`icacls /reset` *does* work unelevated on a directory this user locked — that's how the different-SID conclusion was established, rather than guessed.)

In the same pass I moved `.review_tmp/` out of the repo entirely into the OS temp dir. A rename needs write on the **parent** only, which we have, and that cleared three of the four locked directories. The fourth denies rename too.

This is the ignorable half of #268; the deletion half stays open there with the exact operator commands.
