### PR TITLE
fix(session): never report an UNREADABLE file as removed (it caused false-stale errors and needless rebuilds)

### DIFF
--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -548,8 +548,30 @@ def _stale_changeset(
     for current_path, snapshot_entry in snapshot_by_path.items():
         try:
             stat = os.stat(current_paths.get(current_path) or current_path)
-        except OSError:
+        except (FileNotFoundError, NotADirectoryError):
+            # The file is genuinely GONE (or a parent stopped being a directory). This is the
+            # only failure that means "removed".
             removed.append(current_path)
+            continue
+        except OSError:
+            # Task #286: a bare `except OSError` here previously reported ANY stat failure as a
+            # deletion -- including PermissionError. That is not an under-report, it is data loss:
+            # `removed` is consumed by `build_repo_map_incremental` (repo_map.py, see its
+            # `normalized_changeset["removed"]` comment), so a TRANSIENT permission problem
+            # silently EVICTED real files from the repo map. Measured: denying read on one
+            # subdirectory reported every file under it as removed. Reachable from MCP on every
+            # `tg_session_*` call with `refresh_on_stale=True`.
+            #
+            # Fail SAFE in the direction that cannot destroy data: an indeterminate file is left
+            # OUT of all three buckets, so it is treated as unchanged. The opposite error (a real
+            # deletion we failed to notice) merely leaves a stale entry the next successful scan
+            # corrects; reporting a false deletion is unrecoverable from here.
+            #
+            # NOT YET SURFACED as an explicit signal: the changeset vocabulary is
+            # {added, modified, removed} with no way to say "I could not tell". Adding that
+            # fourth state is a consumer-contract change (the same closed-vocabulary problem
+            # #276/#283 solved on other surfaces) and is tracked separately -- do not conflate it
+            # into `removed` to make the signal visible.
             continue
         if int(stat.st_size) != int(snapshot_entry["size"]) or int(stat.st_mtime_ns) != int(
             snapshot_entry["mtime_ns"]

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -545,6 +545,13 @@ def _stale_changeset(
 
     removed: list[str] = []
     modified: list[str] = []
+    # Accumulate indeterminate paths and emit ONE warning after the loop. Logging per file would
+    # be unbounded-ish spam: `_stale_changeset` runs on EVERY session-serving request (both
+    # `_load_session_payload` and `_session_health_payload`), the snapshot is capped only by
+    # DEFAULT_AGENT_REPO_MAP_LIMIT (2000), and no handler is configured in this package -- so
+    # Python's lastResort would put up to ~2000 lines on stderr per request.
+    indeterminate: list[str] = []
+    indeterminate_kinds: set[str] = set()
     for current_path, snapshot_entry in snapshot_by_path.items():
         try:
             stat = os.stat(current_paths.get(current_path) or current_path)
@@ -563,11 +570,15 @@ def _stale_changeset(
             # ignores `removed` entirely today, see repo_map.py's `normalized_changeset["removed"]`
             # D2 comment, and a probe passing a false `removed` evicted nothing):
             #   1. `_changeset_has_entries` -> `_ensure_session_not_stale` raises SessionStaleError
-            #      naming files nobody touched.
-            #   2. The false list is PERSISTED into the session payload (`"changeset"` below) and
-            #      re-served by `_session_health_payload` -- an agent reads "deleted" for files
-            #      that exist.
-            #   3. On MCP `refresh_on_stale=True` that false-stale forces a needless rebuild.
+            #      whose message names files nobody touched.
+            #   2. `_session_health_payload` RECOMPUTES this same changeset and serves it with
+            #      `stale: true` -- so `tg session health` tells an agent those files were deleted.
+            #      (It does NOT re-serve the copy persisted under the payload's `"changeset"` key;
+            #      that copy currently has no reader in `src/` at all. A second draft of this
+            #      comment claimed it did -- asserting a consumer without checking it, which is
+            #      the very mistake the first draft made about `build_repo_map_incremental`.)
+            #   3. On MCP `refresh_on_stale=True` that false-stale forces a needless rebuild,
+            #      which also flushes the process-global source caches via `_clear_all_source_caches`.
             # So: false reporting + wasted work, not data loss.
             #
             # Fail SAFE anyway: an indeterminate file is left OUT of all three buckets and treated
@@ -581,17 +592,22 @@ def _stale_changeset(
             # make it visible; that is exactly the bug above.
             # Also unhandled: a disconnected Windows UNC share raises FileNotFoundError for every
             # file, so a dropped network mount still reports the whole tree as removed.
-            logger.warning(
-                "session staleness check could not stat %s (%s); treating it as unchanged rather "
-                "than removed -- the changeset for this session is incomplete",
-                current_path,
-                type(exc).__name__,
-            )
+            indeterminate.append(current_path)
+            indeterminate_kinds.add(type(exc).__name__)
             continue
         if int(stat.st_size) != int(snapshot_entry["size"]) or int(stat.st_mtime_ns) != int(
             snapshot_entry["mtime_ns"]
         ):
             modified.append(current_path)
+
+    if indeterminate:
+        logger.warning(
+            "session staleness check could not stat %d file(s) (%s); they are treated as "
+            "unchanged rather than removed, so this changeset may be incomplete. Sample: %s",
+            len(indeterminate),
+            ", ".join(sorted(indeterminate_kinds)),
+            ", ".join(indeterminate[:3]),
+        )
 
     return {
         "added": added,

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -558,6 +558,15 @@ def _stale_changeset(
         except (FileNotFoundError, NotADirectoryError):
             # The file is genuinely GONE (or a parent stopped being a directory). This is the
             # only failure that means "removed".
+            #
+            # KNOWN GAP, and it lives HERE rather than in the OSError arm below: a disconnected
+            # Windows UNC share raises FileNotFoundError (winerror 53) for EVERY file under it, so
+            # a dropped network mount lands in this arm and reports the whole tree as removed --
+            # the same false-deletion class task #286 fixed, arriving through the one arm that is
+            # supposed to mean "really gone". Not fixable by widening the OSError split: at the
+            # single-file level winerror 53 is indistinguishable from a real deletion. The
+            # discriminator has to be at the TREE level (e.g. every entry under a root resolving
+            # to removed is likelier a mount drop than a mass delete). Tracked as task #287.
             removed.append(current_path)
             continue
         except OSError as exc:
@@ -594,8 +603,6 @@ def _stale_changeset(
             # (`payload["unreadable_paths"] = {count, sample}`, the #276 pattern) -- but that is a
             # consumer-contract change, tracked separately. Do NOT conflate it into `removed` to
             # make it visible; that is exactly the bug above.
-            # Also unhandled: a disconnected Windows UNC share raises FileNotFoundError for every
-            # file, so a dropped network mount still reports the whole tree as removed.
             indeterminate.append(current_path)
             indeterminate_kinds.add(type(exc).__name__)
             continue

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -553,25 +553,40 @@ def _stale_changeset(
             # only failure that means "removed".
             removed.append(current_path)
             continue
-        except OSError:
+        except OSError as exc:
             # Task #286: a bare `except OSError` here previously reported ANY stat failure as a
-            # deletion -- including PermissionError. That is not an under-report, it is data loss:
-            # `removed` is consumed by `build_repo_map_incremental` (repo_map.py, see its
-            # `normalized_changeset["removed"]` comment), so a TRANSIENT permission problem
-            # silently EVICTED real files from the repo map. Measured: denying read on one
-            # subdirectory reported every file under it as removed. Reachable from MCP on every
-            # `tg_session_*` call with `refresh_on_stale=True`.
+            # deletion -- including PermissionError. Measured: denying read on one subdirectory
+            # reported every file under it as removed.
             #
-            # Fail SAFE in the direction that cannot destroy data: an indeterminate file is left
-            # OUT of all three buckets, so it is treated as unchanged. The opposite error (a real
-            # deletion we failed to notice) merely leaves a stale entry the next successful scan
-            # corrects; reporting a false deletion is unrecoverable from here.
+            # What that actually breaks (verified by execution -- an earlier version of this
+            # comment claimed repo-map EVICTION and was WRONG; `build_repo_map_incremental`
+            # ignores `removed` entirely today, see repo_map.py's `normalized_changeset["removed"]`
+            # D2 comment, and a probe passing a false `removed` evicted nothing):
+            #   1. `_changeset_has_entries` -> `_ensure_session_not_stale` raises SessionStaleError
+            #      naming files nobody touched.
+            #   2. The false list is PERSISTED into the session payload (`"changeset"` below) and
+            #      re-served by `_session_health_payload` -- an agent reads "deleted" for files
+            #      that exist.
+            #   3. On MCP `refresh_on_stale=True` that false-stale forces a needless rebuild.
+            # So: false reporting + wasted work, not data loss.
             #
-            # NOT YET SURFACED as an explicit signal: the changeset vocabulary is
-            # {added, modified, removed} with no way to say "I could not tell". Adding that
-            # fourth state is a consumer-contract change (the same closed-vocabulary problem
-            # #276/#283 solved on other surfaces) and is tracked separately -- do not conflate it
-            # into `removed` to make the signal visible.
+            # Fail SAFE anyway: an indeterminate file is left OUT of all three buckets and treated
+            # as unchanged. A real deletion we failed to notice leaves a stale entry that the next
+            # successful scan corrects; a false deletion is unrecoverable from here.
+            #
+            # Log it rather than degrade in total silence. A structured signal in the changeset
+            # itself would be better -- `build_repo_map` already ships the right shape
+            # (`payload["unreadable_paths"] = {count, sample}`, the #276 pattern) -- but that is a
+            # consumer-contract change, tracked separately. Do NOT conflate it into `removed` to
+            # make it visible; that is exactly the bug above.
+            # Also unhandled: a disconnected Windows UNC share raises FileNotFoundError for every
+            # file, so a dropped network mount still reports the whole tree as removed.
+            logger.warning(
+                "session staleness check could not stat %s (%s); treating it as unchanged rather "
+                "than removed -- the changeset for this session is incomplete",
+                current_path,
+                type(exc).__name__,
+            )
             continue
         if int(stat.st_size) != int(snapshot_entry["size"]) or int(stat.st_mtime_ns) != int(
             snapshot_entry["mtime_ns"]

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -572,11 +572,15 @@ def _stale_changeset(
             #   1. `_changeset_has_entries` -> `_ensure_session_not_stale` raises SessionStaleError
             #      whose message names files nobody touched.
             #   2. `_session_health_payload` RECOMPUTES this same changeset and serves it with
-            #      `stale: true` -- so `tg session health` tells an agent those files were deleted.
-            #      (It does NOT re-serve the copy persisted under the payload's `"changeset"` key;
-            #      that copy currently has no reader in `src/` at all. A second draft of this
-            #      comment claimed it did -- asserting a consumer without checking it, which is
-            #      the very mistake the first draft made about `build_repo_map_incremental`.)
+            #      `stale: true`, so the `health` request on the session serve/daemon protocol
+            #      (the `command == "health"` arms in this module and in `session_daemon.py`)
+            #      reports live files as deleted. NOTE there is no `tg session health` CLI command
+            #      and no `tg_session_health` MCP tool -- two earlier drafts of this comment named
+            #      one. It also does NOT re-serve the copy persisted under the payload's
+            #      `"changeset"` key; that copy has no reader in `src/` at all.
+            #      Three drafts of this comment each named a consumer without checking it
+            #      (`build_repo_map_incremental`, then the persisted key, then a CLI command that
+            #      does not exist). If you edit this comment, GREP FOR THE NAME FIRST.
             #   3. On MCP `refresh_on_stale=True` that false-stale forces a needless rebuild,
             #      which also flushes the process-global source caches via `_clear_all_source_caches`.
             # So: false reporting + wasted work, not data loss.

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -10060,7 +10060,17 @@ def test_cli_does_not_treat_default_json_as_rg_json_passthrough() -> None:
     )
 
 
-def test_cli_uses_implicit_rg_root_for_no_path_files_with_matches(monkeypatch):
+def test_cli_uses_implicit_rg_root_for_no_path_files_with_matches(monkeypatch, tmp_path):
+    """Asserts a no-path search forwards an EMPTY `paths` list (the implicit-root contract).
+
+    Runs from an ISOLATED cwd. It used to run from whatever directory pytest was launched in --
+    i.e. the real repo root -- which made the assertion depend on ambient filesystem state. A
+    permission-denied directory at the repo root (task #268) makes the implicit-root walk report
+    INCOMPLETE, so `tg` correctly exits 2 per the three-state contract (0 complete / 1 not-found /
+    2 incomplete) and this test false-failed on `assert 2 == 0`. The product was right and the test
+    was wrong: nothing here is about the repo's contents, so it must not read them.
+    """
+    monkeypatch.chdir(tmp_path)
     calls: dict[str, object] = {}
 
     def _fake_passthrough(self, paths, pattern, config=None):

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -614,3 +614,75 @@ def test_incremental_map_omits_unreadable_paths_on_a_clean_walk(tmp_path: Path) 
 
     assert "unreadable_paths" not in incremental_map
     assert "unreadable_paths" not in repo_map.build_repo_map(paths["project"])
+# (#286) An UNREADABLE file must never be reported as REMOVED
+# ---------------------------------------------------------------------------
+
+
+def _deny_stat_under(monkeypatch, denied_dir: Path) -> None:
+    """Make `os.stat` raise PermissionError for anything under `denied_dir`.
+
+    Patched NARROWLY on purpose: an earlier probe patched `os.stat` globally and broke pytest's
+    OWN failure reporting -- the instrument took down the harness. Scoping the raise to one
+    subtree keeps pytest able to report a failure if this test fails.
+    """
+    import os as _os
+
+    real_stat = _os.stat
+    # Normalize with PURE STRING ops only. A first version called `Path(...).resolve()` inside the
+    # fake, and `resolve()` itself calls `os.stat` -- instant RecursionError. The instrument ate
+    # itself. `os.path.normpath`/`abspath` touch no filesystem.
+    target = _os.path.normcase(_os.path.normpath(_os.path.abspath(str(denied_dir))))
+
+    def _fake_stat(path, *args, **kwargs):
+        candidate = _os.path.normcase(_os.path.normpath(_os.path.abspath(str(path))))
+        if candidate.startswith(target):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(_os, "stat", _fake_stat)
+
+
+def test_unreadable_file_is_not_reported_as_removed(tmp_path: Path, monkeypatch) -> None:
+    """Task #286, MEASURED defect. `_stale_changeset` wrapped `os.stat` in a bare `except OSError`
+    and appended to `removed`, so it could not tell "the file is gone" (FileNotFoundError) from
+    "I am not allowed to look at it" (PermissionError).
+
+    That matters because `removed` is consumed by `build_repo_map_incremental`
+    (repo_map.py:7422), so a TRANSIENT permission problem silently EVICTED real files from the
+    repo map -- data-loss-shaped, not merely an under-report. Reachable from MCP on every
+    `tg_session_*` call with `refresh_on_stale=True`.
+    """
+    paths = _build_project(tmp_path)
+    session_id = _open_session(paths["project"])
+    denied_dir = paths["project"] / "src"
+
+    _deny_stat_under(monkeypatch, denied_dir)
+    changeset = session_store._stale_changeset(
+        _session_payload(paths["project"], session_id), detect_added_files=False
+    )
+
+    assert changeset is not None
+    unreadable_reported_as_removed = [p for p in changeset["removed"] if "src" in p]
+    assert unreadable_reported_as_removed == [], (
+        "a permission-denied file was reported as REMOVED; that eviction propagates into "
+        f"build_repo_map_incremental: {unreadable_reported_as_removed}"
+    )
+
+
+def test_genuinely_deleted_file_is_still_reported_as_removed(tmp_path: Path) -> None:
+    """CONTROL ARM. Without this, the fix above could be "never report removals" -- which
+    satisfies the first assertion while destroying the feature entirely. A real deletion must
+    still land in `removed`.
+    """
+    paths = _build_project(tmp_path)
+    session_id = _open_session(paths["project"])
+    paths["helper"].unlink()
+
+    changeset = session_store._stale_changeset(
+        _session_payload(paths["project"], session_id), detect_added_files=False
+    )
+
+    assert changeset is not None
+    assert any("helpers.py" in p for p in changeset["removed"]), (
+        f"a genuinely deleted file vanished from `removed`: {changeset['removed']}"
+    )

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -621,6 +621,8 @@ def test_incremental_map_omits_unreadable_paths_on_a_clean_walk(tmp_path: Path) 
 
     assert "unreadable_paths" not in incremental_map
     assert "unreadable_paths" not in repo_map.build_repo_map(paths["project"])
+
+
 # (#286) An UNREADABLE file must never be reported as REMOVED
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -647,25 +647,35 @@ def test_unreadable_file_is_not_reported_as_removed(tmp_path: Path, monkeypatch)
     and appended to `removed`, so it could not tell "the file is gone" (FileNotFoundError) from
     "I am not allowed to look at it" (PermissionError).
 
-    That matters because `removed` is consumed by `build_repo_map_incremental`
-    (repo_map.py:7422), so a TRANSIENT permission problem silently EVICTED real files from the
-    repo map -- data-loss-shaped, not merely an under-report. Reachable from MCP on every
-    `tg_session_*` call with `refresh_on_stale=True`.
+    What that breaks: a false `removed` entry reaches `_changeset_has_entries` ->
+    `_ensure_session_not_stale`, which raises SessionStaleError naming files nobody touched; the
+    false list is then PERSISTED into the session payload and re-served by
+    `_session_health_payload`; and on MCP `refresh_on_stale=True` it forces a needless rebuild.
+    NOTE: it does NOT evict anything from the repo map -- `build_repo_map_incremental` ignores
+    `removed` entirely (see its D2 comment), which an earlier version of this docstring got wrong.
     """
     paths = _build_project(tmp_path)
     session_id = _open_session(paths["project"])
     denied_dir = paths["project"] / "src"
 
-    _deny_stat_under(monkeypatch, denied_dir)
-    changeset = session_store._stale_changeset(
-        _session_payload(paths["project"], session_id), detect_added_files=False
+    # PRECONDITION: without this the test can go inert. If `_build_project`'s layout ever stops
+    # putting files under src/, the "in p" filter below matches nothing and the assertion passes
+    # vacuously -- declaring the defect absent instead of testing for it.
+    payload = _session_payload(paths["project"], session_id)
+    snapshot_src_entries = [e for e in payload["snapshot"] if "src" in str(e["path"])]
+    assert len(snapshot_src_entries) == 3, (
+        "fixture drift: expected 3 snapshot entries under src/ for the deny-stat arm to bite, "
+        f"got {len(snapshot_src_entries)}"
     )
+
+    _deny_stat_under(monkeypatch, denied_dir)
+    changeset = session_store._stale_changeset(payload, detect_added_files=False)
 
     assert changeset is not None
     unreadable_reported_as_removed = [p for p in changeset["removed"] if "src" in p]
     assert unreadable_reported_as_removed == [], (
-        "a permission-denied file was reported as REMOVED; that eviction propagates into "
-        f"build_repo_map_incremental: {unreadable_reported_as_removed}"
+        "a permission-denied file was reported as REMOVED; that false report raises "
+        f"SessionStaleError and is persisted into the session payload: {unreadable_reported_as_removed}"
     )
 
 

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -251,6 +251,13 @@ def test_build_repo_map_incremental_only_reparses_changed_files(
 
 
 def test_build_repo_map_incremental_removes_deleted_entries_from_payload(tmp_path: Path) -> None:
+    """NOTE for future readers: the pruning asserted here does NOT come from `changeset["removed"]`
+    being consumed. The files are unlinked from disk BEFORE the call, so they disappear simply
+    because `_iter_repo_files` only yields files that still exist. `build_repo_map_incremental`
+    ignores `removed` entirely (its D2 comment says so, and a probe passing a false `removed` for
+    files still on disk evicts nothing). Without this note the test reads like a contradiction of
+    that fact -- which is exactly the wrong inference task #286 was fixed on.
+    """
     paths = _build_project(tmp_path)
     previous_map = repo_map.build_repo_map(paths["project"])
     paths["helper"].unlink()
@@ -648,11 +655,15 @@ def test_unreadable_file_is_not_reported_as_removed(tmp_path: Path, monkeypatch)
     "I am not allowed to look at it" (PermissionError).
 
     What that breaks: a false `removed` entry reaches `_changeset_has_entries` ->
-    `_ensure_session_not_stale`, which raises SessionStaleError naming files nobody touched; the
-    false list is then PERSISTED into the session payload and re-served by
-    `_session_health_payload`; and on MCP `refresh_on_stale=True` it forces a needless rebuild.
-    NOTE: it does NOT evict anything from the repo map -- `build_repo_map_incremental` ignores
-    `removed` entirely (see its D2 comment), which an earlier version of this docstring got wrong.
+    `_ensure_session_not_stale`, which raises SessionStaleError naming files nobody touched;
+    `_session_health_payload` RECOMPUTES the same changeset and serves it with `stale: true`, so
+    `tg session health` reports those files as deleted; and on MCP `refresh_on_stale=True` it
+    forces a needless rebuild.
+
+    TWO THINGS EARLIER DRAFTS OF THIS DOCSTRING GOT WRONG, both by naming a consumer without
+    checking it: (1) it does NOT evict anything from the repo map -- `build_repo_map_incremental`
+    ignores `removed` entirely (see its D2 comment); (2) health does NOT re-serve the `changeset`
+    key persisted in the session payload -- that copy has no reader in `src/` at all.
     """
     paths = _build_project(tmp_path)
     session_id = _open_session(paths["project"])

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -657,13 +657,15 @@ def test_unreadable_file_is_not_reported_as_removed(tmp_path: Path, monkeypatch)
     What that breaks: a false `removed` entry reaches `_changeset_has_entries` ->
     `_ensure_session_not_stale`, which raises SessionStaleError naming files nobody touched;
     `_session_health_payload` RECOMPUTES the same changeset and serves it with `stale: true`, so
-    `tg session health` reports those files as deleted; and on MCP `refresh_on_stale=True` it
-    forces a needless rebuild.
+    the `health` request on the session serve/daemon protocol reports live files as deleted; and
+    on MCP `refresh_on_stale=True` it forces a needless rebuild.
 
-    TWO THINGS EARLIER DRAFTS OF THIS DOCSTRING GOT WRONG, both by naming a consumer without
-    checking it: (1) it does NOT evict anything from the repo map -- `build_repo_map_incremental`
-    ignores `removed` entirely (see its D2 comment); (2) health does NOT re-serve the `changeset`
-    key persisted in the session payload -- that copy has no reader in `src/` at all.
+    THREE THINGS EARLIER DRAFTS OF THIS DOCSTRING GOT WRONG, every one by naming a consumer
+    without checking it: (1) it does NOT evict anything from the repo map --
+    `build_repo_map_incremental` ignores `removed` entirely (see its D2 comment); (2) health does
+    NOT re-serve the `changeset` key persisted in the session payload -- that copy has no reader
+    in `src/`; (3) there is no `tg session health` CLI command and no `tg_session_health` MCP tool
+    -- `health` is only a request kind on the serve/daemon protocol. GREP THE NAME FIRST.
     """
     paths = _build_project(tmp_path)
     session_id = _open_session(paths["project"])
@@ -686,7 +688,7 @@ def test_unreadable_file_is_not_reported_as_removed(tmp_path: Path, monkeypatch)
     unreadable_reported_as_removed = [p for p in changeset["removed"] if "src" in p]
     assert unreadable_reported_as_removed == [], (
         "a permission-denied file was reported as REMOVED; that false report raises "
-        f"SessionStaleError and is persisted into the session payload: {unreadable_reported_as_removed}"
+        f"SessionStaleError and is re-served by the health request: {unreadable_reported_as_removed}"
     )
 
 

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -688,7 +688,8 @@ def test_unreadable_file_is_not_reported_as_removed(tmp_path: Path, monkeypatch)
     unreadable_reported_as_removed = [p for p in changeset["removed"] if "src" in p]
     assert unreadable_reported_as_removed == [], (
         "a permission-denied file was reported as REMOVED; that false report raises "
-        f"SessionStaleError and is re-served by the health request: {unreadable_reported_as_removed}"
+        "SessionStaleError and is recomputed and served again by the health request: "
+        f"{unreadable_reported_as_removed}"
     )
 
 


### PR DESCRIPTION
`_stale_changeset` wrapped `os.stat` in a bare `except OSError` and appended to `removed`. That cannot distinguish **"the file is gone"** (`FileNotFoundError`) from **"I am not allowed to look at it"** (`PermissionError`), so a permission-denied subtree reported every file under it as **deleted**.

## Severity: false reporting + wasted work — NOT data loss

**Three earlier drafts of this PR each named a consumer without checking it. All three were disproved.** Recording that here because the wrong mechanism had been written into the code comment and the test docstring too, and a merged-in wrong mechanism misleads every later reader.

- **Draft 1 claimed repo-map eviction.** `build_repo_map_incremental` **ignores `removed` entirely** — `repo_map.py:7421` builds `changed_files` from `added | modified` only, the D2 comment at `:7422-7427` says so verbatim, and `normalized_changeset["removed"]` has no reader anywhere in `src/`. A probe passing a deliberately false `removed` for files still on disk evicted nothing.
- **Draft 2 claimed the persisted list is re-served by health.** It is not. The `changeset` key written into the session payload has **zero readers in `src/`** — it is currently inert. `_session_health_payload` *recomputes* the changeset itself and serves that.
- **Draft 3 named `tg session health` as the harmed surface. That command does not exist** — there is no `@session_app.command("health")` and no `tg_session_health` MCP tool. `health` is only a request kind on the session serve/daemon JSON-lines protocol. The harm is real; the front door named for it was invented.

**Why this kept happening, and what changed:** every draft cited `session_store.py:NNN` line numbers — inside the very file this PR edits. Each fix commit shifted the file and silently invalidated its own citations (the last one moved 10 of 12 by 16 lines). Line numbers in prose about a file you are editing are structurally guaranteed to rot, so **this body now cites SYMBOLS**, which do not drift. Line numbers survive only for `repo_map.py`, which this PR does not touch.

The harm is real, just via a different route than either draft said. Verified hop by hop:

1. `_changeset_has_entries` → `_ensure_session_not_stale` raises `SessionStaleError`, whose message names files nobody touched.
2. `_session_health_payload` recomputes the same false changeset and serves it with `stale: true` — so **the `health` request on the session serve/daemon protocol reports live files as deleted**.
3. On MCP `refresh_on_stale=True` (`_load_session_payload`, param `refresh_on_stale`) the false-stale forces a `refresh_session` rebuild, which also flushes the process-global source caches via `_clear_all_source_caches`.

A correctness/honesty bug on a surface agents read, and wasted work on a warm daemon. Not catastrophic, not cosmetic.

Measured before the fix (one denied subdirectory): the test's RED run reported **three** real source files as removed.

## How this was found

While wiring `unreadable_hit=` into `session_store.py` for #284, I traced what consumes the result and asked whether a denied subtree could produce a *false* removal. **Wiring the kwarg would not have caught this** — the walk-side gap makes `added` under-report; this defect is in the stat classifier on the snapshot side. Two different bugs in one function, and only one is a missing parameter.

## Fix

`FileNotFoundError` / `NotADirectoryError` → genuine removal. Any other `OSError` → **indeterminate**, left out of all three buckets, treated as unchanged.

The direction is deliberate: missing a real deletion leaves a stale entry the next successful scan corrects, while a **false** deletion is unrecoverable from here. Fail safe toward the recoverable mistake.

Checked against real error shapes on both platforms: the residual non-`FileNotFoundError` deletion cases are NFS `ESTALE` and Windows delete-pending → `PermissionError`, both genuinely ambiguous and both self-correcting on the next scan (they become `ENOENT`). No common deletion path is silently dropped.

## Logging, bounded on purpose

One **aggregated** warning after the loop — count, error kinds, and a 3-path sample — not one line per file. `_stale_changeset` runs on *every* session-serving request, the snapshot is capped only by `DEFAULT_AGENT_REPO_MAP_LIMIT` (2000), and this package configures no log handler, so a per-file warning would put up to ~2000 lines on stderr **per request** via Python's `lastResort`. The message says the changeset *may* be incomplete, since an indeterminate file may well be unchanged.

A structured signal in the changeset itself would beat a log line; `build_repo_map` already ships the right shape (`unreadable_paths = {count, sample}`, the #276 pattern). That's a consumer-contract change, tracked separately. My earlier claim that "no vocabulary exists" was wrong — it does, one layer over. What must NOT happen is folding it into `removed` to make it visible; that is exactly the bug above.

## Known gap, documented at the site

A **disconnected Windows UNC share raises `FileNotFoundError` for every file**, so a dropped network mount still reports the whole tree as removed — arriving through the arm that means "really gone." Out of this PR's reach; filed as task #287 with an acceptance test.

## Tests — both arms, mutation-verified

- unreadable file must **not** appear in `removed` (RED pre-fix: 3 files did)
- **control**: a genuinely deleted file **must** still appear. Independently confirmed to FAIL against a "never report removals" mutant, so it genuinely kills the degenerate fix.
- **precondition assert**: the positive test asserts 3 snapshot entries exist under `src/` *before* the deny is installed. Without it, a fixture-layout change would make the `"src" in p` filter match nothing and the test would pass **vacuously** — declaring the defect absent instead of testing for it.
- a note added to `test_build_repo_map_incremental_removes_deleted_entries_from_payload`, which prunes deleted files only because they are gone from disk — it reads like a contradiction of the "removed is unread" fact otherwise.

The fixture patches `os.stat` **narrowly**, under one subtree. Two instrument failures got us here, both recorded in the helper: patching `os.stat` globally under pytest breaks pytest's own failure reporting, and calling `Path.resolve()` inside a fake `os.stat` recurses infinitely because `resolve()` calls `os.stat`.

Local: **91 passed** across `test_incremental_refresh.py` + `test_session_cli.py` (run with `-o addopts=""`, since the repo's `-x` fail-fast would otherwise leave later tests unverified), `ruff check` + `ruff format --check --preview` clean.

Task #286.
