### PR TITLE
docs(backlog): reconcile to v1.98.13 — the unreadable-path honesty wave

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -17,13 +17,32 @@
 > the Rust-side `.filter_map(|e| e.ok())` walk-error-discard class (10 sites, mechanically censused —
 > a prose note had said 6) so it cannot grow while #276's slices land.
 >
-> **Process receipts from this wave, both costly:** (1) PR #764 was NO-SHIPed TWICE by independent
-> gates, both times for a false MECHANISM attached to a correct one-line fix — draft 1 claimed repo-map
-> eviction (`build_repo_map_incremental` ignores `removed`; the cited line says so verbatim), draft 2
-> claimed a persisted list was re-served (it has no reader; health RECOMPUTES). **A disproved claim's
-> replacement needs the same verification the original failed.** (2) `tag == PyPI` is NOT a sufficient
-> drain gate — a `fix:` commit sitting on main with CI still queued is a release IN FLIGHT even though
-> the tag has not moved yet. Check for an unreleased release-triggering commit, not just tag equality.
+> **Process receipts from this wave, all four costly:**
+>
+> (1) **PR #764 was NO-SHIPed THREE times by independent gates — every time for a false MECHANISM
+> attached to a correct one-line fix, and every time by naming a consumer without checking it.**
+> Draft 1 claimed repo-map eviction (`build_repo_map_incremental` ignores `removed`; the line cited
+> as evidence says so verbatim). Draft 2 claimed a persisted list was re-served (it has no reader;
+> health RECOMPUTES). Draft 3 named **`tg session health`**, which does not exist — there is no
+> `@session_app.command("health")` and no `tg_session_health` MCP tool; `health` is only a request
+> kind on the session serve/daemon protocol. **A disproved claim's replacement needs the same
+> verification the original failed** — plausibility is not evidence. **GREP THE NAME FIRST.**
+>
+> (2) **Line numbers in prose about a file the PR EDITS rot by construction.** #764's citations went
+> stale twice; the second time the very commit that fixed them shifted 10 of 12 by 16 lines. Fixing
+> the instance a third time would have guaranteed a fourth, so the body now cites **SYMBOLS**, which
+> do not drift. Line numbers are fine for files a change does not touch.
+>
+> (3) **`tag == PyPI` is NOT a sufficient drain gate.** A release-triggering commit sitting on main
+> with CI still queued is a release IN FLIGHT even though the tag has not moved. And once the tag HAS
+> moved, the publish may still be running — merging then can cancel it via the branch concurrency
+> group and strand a tagged version with no artifact on PyPI. Check the release RUN's jobs.
+>
+> (4) **A subagent gate's result is EPHEMERAL** (#285, closed as an unrecoverable loss). Acting on a
+> gate's blockers feels like discharging it, but silently drops everything it classified
+> non-blocking — those items exist only in the returned text, not on the PR (`gh pr view --json
+> reviews` on #757 shows only Codex boilerplate). Transcribe NON-BLOCKING items into a task or the PR
+> body in the same turn the notification is read; the blockers self-record by being fixed.
 >
 > Prior refresh 2026-07-25 (post-**v1.98.11** — reconciling the v1.98.3 baseline forward across 8
 > releases and 16 merged PRs. Headline: **the `--json` bug family is CLOSED** (#264/#266/#267/#269/

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,29 @@
 > **Canonical prioritized work list.** Kept in sync with the CLI task store (`TaskUpdate`) and
 > GitHub (`gh pr list` is the source of truth for PRs). **CEO status** = summarize SHIPPING + P0/P1.
 > Update whenever a PR opens/merges or the queue changes. Task-store IDs (`#NNN`) cross-referenced.
-> Last refreshed 2026-07-25 (post-**v1.98.11** — reconciling the v1.98.3 baseline forward across 8
+> Last refreshed 2026-07-25b (post-**v1.98.13**, with v1.98.14 releasing) — the **unreadable-path
+> honesty** wave. One question drove it: when tg cannot READ part of a tree, does it say so, or does
+> it report success over a silently smaller result set? Answers shipped: **#757/#761** thread the
+> existing `unreadable_paths` signal into `tg find`/`codemap`/incremental refresh and pin
+> `incomplete_reason_class` in `CONTRACTS.md`; **#762** (v1.98.14) makes MCP `tg_search`'s
+> `scan_limit` say WHY a scan truncated and whether raising the budget would even help —
+> `budget_remediable: false` on an unreadable dir, contract 1.4.0→1.5.0, because the old payload gave
+> WRONG-KNOB advice; **#763** stops an ACL-locked pytest basetemp from spamming every `git status`.
+> Two defects found by tracing CONSUMERS rather than fixing the named site: **#286** (`session_store`
+> reported a permission-denied file as DELETED — PR #764) and **#288** (`_capture_snapshot` drops
+> unreadable files from the snapshot entirely, so they stop being tracked at all). **#765** ratchets
+> the Rust-side `.filter_map(|e| e.ok())` walk-error-discard class (10 sites, mechanically censused —
+> a prose note had said 6) so it cannot grow while #276's slices land.
+>
+> **Process receipts from this wave, both costly:** (1) PR #764 was NO-SHIPed TWICE by independent
+> gates, both times for a false MECHANISM attached to a correct one-line fix — draft 1 claimed repo-map
+> eviction (`build_repo_map_incremental` ignores `removed`; the cited line says so verbatim), draft 2
+> claimed a persisted list was re-served (it has no reader; health RECOMPUTES). **A disproved claim's
+> replacement needs the same verification the original failed.** (2) `tag == PyPI` is NOT a sufficient
+> drain gate — a `fix:` commit sitting on main with CI still queued is a release IN FLIGHT even though
+> the tag has not moved yet. Check for an unreleased release-triggering commit, not just tag equality.
+>
+> Prior refresh 2026-07-25 (post-**v1.98.11** — reconciling the v1.98.3 baseline forward across 8
 > releases and 16 merged PRs. Headline: **the `--json` bug family is CLOSED** (#264/#266/#267/#269/
 > #272/#273 were ONE defect — a renderer flag silently choosing the ENGINE and thus the FILE SET),
 > with three ratchets so it stays closed: #752 the renderer/file-set invariant in both git and


### PR DESCRIPTION
Anchors `docs/BACKLOG.md` forward from **v1.98.11** to **v1.98.13** (with v1.98.14 releasing).

The wave is organised around one question: **when tg cannot READ part of a tree, does it say so, or does it report success over a silently smaller result set?**

| item | answer shipped |
|---|---|
| #757 / #761 | thread the existing `unreadable_paths` signal into `tg find` / `codemap` / incremental refresh; pin `incomplete_reason_class` in `CONTRACTS.md` |
| #762 (v1.98.14) | MCP `tg_search`'s `scan_limit` now says **why** a scan truncated and whether raising the budget would even help — `budget_remediable: false` on an unreadable dir. Contract 1.4.0→1.5.0. The old payload gave **wrong-knob advice**. |
| #763 | an ACL-locked pytest basetemp no longer spams every `git status` |
| #765 | ratchets the Rust `.filter_map(\|e\| e.ok())` walk-error-discard class — 10 sites, mechanically censused (a prose note had said 6) — so it cannot grow while #276's slices land |

Two defects came from **tracing consumers rather than fixing the named site**: #286 (`session_store` reported a permission-denied file as *deleted*) and #288 (`_capture_snapshot` drops unreadable files from the snapshot entirely, so they stop being tracked at all).

## Two process receipts, both of which cost cycles

1. **PR #764 was NO-SHIPed twice by independent gates** — both times for a false *mechanism* attached to a correct one-line fix. Draft 1 claimed repo-map eviction (`build_repo_map_incremental` ignores `removed`, and the line cited as evidence says so verbatim). Draft 2 claimed a persisted list was re-served (it has no reader; health *recomputes*). The lesson worth keeping: **a disproved claim's replacement needs the same verification the original failed** — plausibility is not enough.
2. **`tag == PyPI` is not a sufficient drain gate.** A `fix:` commit sitting on main with CI still queued is a release *in flight* even though the tag has not moved yet. The check must be "is there an unreleased release-triggering commit", not tag equality.

Docs-only. `ruff format --check --preview` clean; `test_public_docs_governance.py` **43 passed**.