### PR TITLE
fix(inventory): report an unreadable subtree instead of claiming a complete manifest (#284)

### DIFF
--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -30,6 +30,7 @@ from tensor_grep.cli.repo_map import (
     _DeadlineBreakFlag,
     _iter_repo_files,
     _looks_like_binary_file,
+    _UnreadablePathFlag,
 )
 
 INVENTORY_SCHEMA_VERSION = 1
@@ -228,11 +229,13 @@ def build_inventory(
     # afterward. Asking for max_files + 1 (not max_files) lets us still tell "exactly
     # max_files files exist" apart from "more files exist" for the truncation notice,
     # without ever walking further than one file past the cap.
+    walk_unreadable_hit = _UnreadablePathFlag()
     walked = _iter_repo_files(
         root,
         max_files=max_files + 1,
         deadline_monotonic=walk_deadline,
         deadline_hit=walk_deadline_hit,
+        unreadable_hit=walk_unreadable_hit,
     )
     possibly_truncated = False
     truncation_cause: str | None = None
@@ -305,6 +308,23 @@ def build_inventory(
         possibly_truncated = True
         truncation_cause = "deadline"
 
+    if walk_unreadable_hit.hit:
+        # Task #284: an unreadable subtree left the manifest incomplete. Before this, the walk
+        # simply yielded fewer files and `possibly_truncated` stayed False -- an inventory that
+        # claimed to be complete while missing everything under a denied directory.
+        #
+        # This deliberately runs LAST and OVERWRITES either budget cause, which is the opposite of
+        # the precedence the other two use between themselves. Reason: "project-files" and
+        # "deadline" both tell the reader to turn a KNOB (raise --max-files / --deadline), and
+        # both are true remedies for their own cause. An unreadable path is the one cause NO knob
+        # can fix -- the path has to become readable, or be scoped out. Letting a budget label win
+        # here would hand the reader wrong-knob advice: they raise the budget, the hole stays, and
+        # nothing in the payload hints why. That is exactly the defect #283/#762 fixed on the MCP
+        # `scan_limit` surface, where the fix was to add `budget_remediable: false`. Inventory has
+        # a single cause field rather than that pair, so precedence carries the same information.
+        possibly_truncated = True
+        truncation_cause = "unreadable-path"
+
     return {
         "version": INVENTORY_SCHEMA_VERSION,
         "schema_version": INVENTORY_SCHEMA_VERSION,
@@ -347,7 +367,17 @@ def render_inventory_text(inventory: dict[str, Any]) -> str:
         lines.append(f"  categories: {cats}")
     scan = inventory["scan_limit"]
     if scan["possibly_truncated"]:
-        if scan["truncation_cause"] == "deadline":
+        if scan["truncation_cause"] == "unreadable-path":
+            # Task #284: this arm exists because the generic `else` below names max_files and
+            # would tell the reader to raise a cap that CANNOT close this hole -- the same
+            # wrong-knob advice the JSON precedence above is written to prevent. A renderer that
+            # contradicts its own payload is still a lie, so the text surface needs the branch too.
+            lines.append(
+                "  [!] skipped unreadable path(s) (cause=unreadable-path); counts are a floor, "
+                "not complete. Raising --max-files or --deadline will NOT help: the path(s) must "
+                "become readable, or be scoped out."
+            )
+        elif scan["truncation_cause"] == "deadline":
             lines.append(
                 "  [!] stopped after the time budget (cause=deadline); "
                 "counts are a floor, not complete."

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -1,6 +1,7 @@
 """TDD suite for ``tg inventory`` (round-4 [e], design-council test list)."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -489,3 +490,90 @@ class TestDeadlineCliWiring:
         result = CliRunner().invoke(tg_main.app, ["inventory", str(tmp_path), "--deadline", "5"])
         assert result.exit_code == 2
         assert "inventory:" in result.output  # render_inventory_text output still printed
+
+
+def _deny_scandir_for(monkeypatch, denied_dir: Path) -> None:
+    """Make `os.scandir(denied_dir)` raise PermissionError; everything else untouched.
+
+    Deliberately NOT a real chmod/ACL fixture. Task #281 burned a probe on exactly that: the real
+    ACL command silently failed to apply, so the "hostile" arm was a perfectly readable directory
+    and the test would have declared a real defect ABSENT. A monkeypatched raise cannot silently
+    no-op -- if it does not fire, no unreadable signal exists and the assertion below fails loudly.
+    (Verification-oracle family Form 6, AGENTS.md.) Mirrors the same helper in test_find_command.py.
+    """
+    import os as _os
+
+    real_scandir = _os.scandir
+    target = str(denied_dir.resolve())
+
+    def _fake_scandir(path=".", *args, **kwargs):
+        if str(Path(path).resolve()) == target:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(_os, "scandir", _fake_scandir)
+
+
+def test_inventory_reports_an_unreadable_subtree_as_a_truncation_cause(tmp_path, monkeypatch):
+    """Task #284: `build_inventory` walked with `_iter_repo_files` but never passed
+    `unreadable_hit=`, so a permission-denied subtree produced a SMALLER manifest that still
+    reported `possibly_truncated: False` -- an inventory claiming to be complete while missing
+    files. Same fail-open-by-omission shape #761 fixed for `tg find`.
+
+    NOTE the cause is NOT budget-remediable, unlike the two that already existed
+    ("project-files" -> raise --max-files, "deadline" -> raise --deadline). Raising either budget
+    cannot make a denied directory readable, which is why it needs its own cause value rather than
+    being folded into the existing ones (the wrong-knob-advice defect of #283/#762).
+    """
+    (tmp_path / "readable").mkdir()
+    (tmp_path / "readable" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    (denied / "hidden.py").write_text("y = 2\n", encoding="utf-8")
+
+    _deny_scandir_for(monkeypatch, denied)
+    inv = build_inventory(tmp_path)
+
+    scan = inv["scan_limit"]
+    assert scan["possibly_truncated"] is True, (
+        "an unreadable subtree left the manifest incomplete but inventory reported it as complete"
+    )
+    assert scan["truncation_cause"] == "unreadable-path", (
+        f"expected the non-budget-remediable cause, got {scan['truncation_cause']!r}"
+    )
+
+
+def test_inventory_clean_tree_is_the_control_arm_for_the_unreadable_case(tmp_path):
+    """CONTROL. Without this the assertion above could pass for an unrelated reason -- e.g. if
+    inventory marked EVERY scan truncated. A complete scan must report no truncation at all.
+    """
+    (tmp_path / "readable").mkdir()
+    (tmp_path / "readable" / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+    scan = build_inventory(tmp_path)["scan_limit"]
+    assert scan["possibly_truncated"] is False
+    assert scan["truncation_cause"] is None
+
+
+def test_inventory_text_render_does_not_give_wrong_knob_advice_for_unreadable(
+    tmp_path, monkeypatch
+):
+    """Task #284, CONSUMER arm. The JSON cause is only half the surface: `render_inventory_text`
+    had a single generic `else` printing "truncated at max_files=N (cause=...)". With the new
+    cause that reads as "raise --max-files", which cannot close an unreadable hole -- a renderer
+    contradicting its own payload. Assert the text names the real remedy and NOT the cap.
+    """
+    (tmp_path / "readable").mkdir()
+    (tmp_path / "readable" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    (denied / "hidden.py").write_text("y = 2\n", encoding="utf-8")
+
+    _deny_scandir_for(monkeypatch, denied)
+    text = inventory_module.render_inventory_text(build_inventory(tmp_path))
+
+    assert "cause=unreadable-path" in text
+    assert "must" in text and "readable" in text, "the text must name the real remedy"
+    assert "truncated at max_files" not in text, (
+        "the renderer told the reader to raise a cap that cannot fix an unreadable path"
+    )


### PR DESCRIPTION
Continues the slice #761 shipped for `tg find`.

`build_inventory` walked with `_iter_repo_files` but **never passed `unreadable_hit=`**, so a permission-denied subtree simply yielded fewer files and `scan_limit.possibly_truncated` stayed `False` — an inventory asserting it was **complete** while missing everything under the denied directory.

RED confirmed before the fix; the clean-tree control already passed, so the assertion genuinely discriminates.

## The cause value, and why it wins

New value `"unreadable-path"`, and it deliberately **overwrites either budget cause** — the opposite of the precedence the existing two use between themselves.

| cause | remedy | knob-fixable? |
|---|---|---|
| `project-files` | raise `--max-files` | yes |
| `deadline` | raise `--deadline` | yes |
| **`unreadable-path`** | **make the path readable, or scope it out** | **no** |

Letting a budget label win would hand out **wrong-knob advice**: the reader raises the budget, the hole stays, and nothing in the payload hints why. Same defect class as #283/#762 on the MCP `scan_limit` surface, where the fix was `budget_remediable: false`. Inventory has a single cause field rather than that pair, so precedence carries the same information.

## The consumer is where this would have been half-done

`render_inventory_text` had one generic `else` printing `"truncated at max_files=N (cause=...)"`. With the new value, the human-readable line would have told the reader to raise a cap that **cannot** close the hole — a renderer contradicting its own payload. It now has its own arm naming the real remedy.

Found by tracing the consumer rather than stopping at the payload — the same move that surfaced #286.

## Tests

Three arms: the defect, the clean-tree control, and a **consumer arm** asserting the rendered text does *not* contain `"truncated at max_files"`.

The deny fixture monkeypatches `os.scandir` rather than applying a real ACL. Task #281 burned a probe on exactly that: the ACL silently failed to apply, the "hostile" arm was a perfectly readable directory, and the test would have declared a real defect **absent**. A monkeypatched raise cannot silently no-op.

**36 passed** across the inventory suites; `ruff check` + `ruff format --check --preview` clean.

Remaining #284 sites after this: codemap ×2, docs_coverage ×2, plus 5 internal `repo_map` sites and the `session_store` walk side. Census is mechanical — 15 call sites total, 5 now wired.

Task #284.