### PR TITLE
fix(docs-coverage): report an unreadable subtree instead of claiming full coverage (#284)

### DIFF
--- a/src/tensor_grep/cli/docs_coverage.py
+++ b/src/tensor_grep/cli/docs_coverage.py
@@ -24,6 +24,7 @@ from tensor_grep.cli.repo_map import (
     _DeadlineBreakFlag,
     _iter_repo_files,
     _looks_like_binary_file,
+    _UnreadablePathFlag,
 )
 
 # Path components that are NEVER product source a governing doc documents: tool state (.claude
@@ -199,11 +200,13 @@ def build_docs_coverage(
     walk_deadline_hit = _DeadlineBreakFlag()
     # Thread the cap into the walk (bucketed early-stop); ask for +1 to distinguish exactly-max from
     # more-exist for the truncation notice, matching inventory.
+    walk_unreadable_hit = _UnreadablePathFlag()
     walked = _iter_repo_files(
         root,
         max_files=max_files + 1,
         deadline_monotonic=deadline_monotonic,
         deadline_hit=walk_deadline_hit,
+        unreadable_hit=walk_unreadable_hit,
     )
     possibly_truncated = False
     truncation_cause: str | None = None
@@ -211,6 +214,15 @@ def build_docs_coverage(
         walked = walked[:max_files]
         possibly_truncated = True
         truncation_cause = "project-files"
+    if walk_unreadable_hit.hit:
+        # Task #284. An unreadable subtree made this report SMALLER while still claiming
+        # completeness -- "every source file is documented" when whole directories were invisible.
+        # Overwrites the budget cause deliberately: "project-files" tells the reader to raise
+        # --max-files, which is a real remedy for ITS cause but cannot make a denied path readable.
+        # Ranking the non-remediable cause last-wins is how the single cause field carries the
+        # `budget_remediable: false` information the MCP surface got in #283/#762.
+        possibly_truncated = True
+        truncation_cause = "unreadable-path"
 
     resolved_root = root.resolve()
     doc_paths: list[Path] = []
@@ -331,9 +343,20 @@ def render_docs_coverage_text(payload: dict[str, Any]) -> str:
         f"docs={totals['doc_files']}",
     ]
     if payload["scan_limit"]["possibly_truncated"]:
-        lines.append(
-            f"[!] truncated at max_files={payload['scan_limit']['max_files']} (project-files)"
-        )
+        # Task #284: this line HARDCODED "(project-files)" and named max_files, so an
+        # unreadable-path truncation would have rendered as budget advice that cannot help --
+        # the renderer contradicting its own payload. Read the real cause and, for the one cause
+        # no knob fixes, say so instead of naming a cap.
+        if payload["scan_limit"].get("truncation_cause") == "unreadable-path":
+            lines.append(
+                "[!] skipped unreadable path(s) (unreadable-path); counts are a floor. Raising "
+                "--max-files will NOT help: the path(s) must become readable, or be scoped out."
+            )
+        else:
+            lines.append(
+                f"[!] truncated at max_files={payload['scan_limit']['max_files']} "
+                f"({payload['scan_limit'].get('truncation_cause') or 'project-files'})"
+            )
     uncovered = payload["uncovered_files"]
     if uncovered:
         lines.append(f"\nUndocumented source files ({len(uncovered)}):")
@@ -413,15 +436,23 @@ def build_docs_stale_references(
 
     deadline_monotonic = _deadline_monotonic_from_seconds(deadline_seconds)
     walk_deadline_hit = _DeadlineBreakFlag()
+    walk_unreadable_hit = _UnreadablePathFlag()
     walked = _iter_repo_files(
         root,
         max_files=max_files + 1,
         deadline_monotonic=deadline_monotonic,
         deadline_hit=walk_deadline_hit,
+        unreadable_hit=walk_unreadable_hit,
     )
     possibly_truncated = len(walked) > max_files
     if possibly_truncated:
         walked = walked[:max_files]
+    # Task #284, same as build_docs_coverage above. This builder previously hardcoded its cause
+    # inline in the payload, so it could not express any cause but the file cap.
+    truncation_cause = "project-files" if possibly_truncated else None
+    if walk_unreadable_hit.hit:
+        possibly_truncated = True
+        truncation_cause = "unreadable-path"
     resolved_root = root.resolve()
 
     doc_paths = [
@@ -462,7 +493,7 @@ def build_docs_stale_references(
         "scan_limit": {
             "max_files": max_files,
             "possibly_truncated": possibly_truncated,
-            "truncation_cause": "project-files" if possibly_truncated else None,
+            "truncation_cause": truncation_cause,
         },
     }
     if walk_deadline_hit.hit:

--- a/tests/unit/test_docs_coverage.py
+++ b/tests/unit/test_docs_coverage.py
@@ -306,3 +306,95 @@ def test_cli_accepts_deadline_flag(tmp_path):
     (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
     result = CliRunner().invoke(app, ["docs-coverage", str(tmp_path), "--deadline", "5", "--json"])
     assert result.exit_code == 0, result.output
+
+
+def _deny_scandir_for(monkeypatch, denied_dir):
+    """Make `os.scandir(denied_dir)` raise PermissionError; everything else untouched.
+
+    Deliberately NOT a real chmod/ACL fixture. Task #281 burned a probe on exactly that: the ACL
+    silently failed to apply, so the "hostile" arm was a readable directory and the run would have
+    declared a live defect ABSENT. A monkeypatched raise cannot silently no-op.
+    """
+    import os as _os
+    from pathlib import Path as _Path
+
+    real_scandir = _os.scandir
+    target = str(_Path(denied_dir).resolve())
+
+    def _fake_scandir(path=".", *args, **kwargs):
+        if str(_Path(path).resolve()) == target:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(_os, "scandir", _fake_scandir)
+
+
+def _seed_repo(tmp_path):
+    (tmp_path / "README.md").write_text("# docs\n", encoding="utf-8")
+    (tmp_path / "readable").mkdir()
+    (tmp_path / "readable" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    denied = tmp_path / "denied"
+    denied.mkdir()
+    (denied / "hidden.py").write_text("y = 2\n", encoding="utf-8")
+    return denied
+
+
+def test_docs_coverage_reports_an_unreadable_subtree_as_a_truncation_cause(tmp_path, monkeypatch):
+    """Task #284, same fail-open-by-omission #767 fixed for inventory. `build_docs_coverage`
+    walked with `_iter_repo_files` but never passed `unreadable_hit=`, so a permission-denied
+    subtree produced a SMALLER coverage report that still said `possibly_truncated: False` --
+    "every source file is documented" while whole directories were invisible.
+
+    The cause is NOT budget-remediable, unlike the existing "project-files" (-> raise --max-files).
+    """
+    denied = _seed_repo(tmp_path)
+    _deny_scandir_for(monkeypatch, denied)
+
+    scan = build_docs_coverage(str(tmp_path))["scan_limit"]
+    assert scan["possibly_truncated"] is True, (
+        "an unreadable subtree left the report incomplete but docs-coverage claimed completeness"
+    )
+    assert scan["truncation_cause"] == "unreadable-path"
+
+
+def test_docs_stale_references_reports_an_unreadable_subtree_too(tmp_path, monkeypatch):
+    """Sibling builder in the same module, same omission -- it hardcoded
+    `"project-files" if possibly_truncated else None`, so it could not express any other cause.
+    """
+    denied = _seed_repo(tmp_path)
+    _deny_scandir_for(monkeypatch, denied)
+
+    scan = build_docs_stale_references(str(tmp_path))["scan_limit"]
+    assert scan["possibly_truncated"] is True
+    assert scan["truncation_cause"] == "unreadable-path"
+
+
+def test_docs_coverage_clean_tree_is_the_control_arm(tmp_path):
+    """CONTROL. Without this, both assertions above could pass by marking EVERY scan truncated."""
+    _seed_repo(tmp_path)
+
+    for payload in (build_docs_coverage(str(tmp_path)), build_docs_stale_references(str(tmp_path))):
+        scan = payload["scan_limit"]
+        assert scan["possibly_truncated"] is False
+        assert scan["truncation_cause"] is None
+
+
+def test_docs_coverage_text_render_does_not_give_wrong_knob_advice(tmp_path, monkeypatch):
+    """Task #284, CONSUMER arm -- the worse half of this defect. `render_docs_coverage_text`
+    HARDCODED the string "(project-files)" and named max_files, so even after the payload learned
+    a second cause the human-readable line would still have told the reader to raise a cap that
+    cannot make a denied directory readable. A renderer that contradicts its own payload is still
+    a lie; fixing only the JSON would have left this half broken.
+    """
+    from tensor_grep.cli.docs_coverage import render_docs_coverage_text
+
+    denied = _seed_repo(tmp_path)
+    _deny_scandir_for(monkeypatch, denied)
+
+    text = render_docs_coverage_text(build_docs_coverage(str(tmp_path)))
+
+    assert "unreadable-path" in text
+    assert "must become readable" in text, "the text must name the real remedy"
+    assert "truncated at max_files" not in text, (
+        "the renderer told the reader to raise a cap that cannot fix an unreadable path"
+    )


### PR DESCRIPTION
The next slice after #767 did this for `inventory`. **Both** builders in `docs_coverage.py` walked with `_iter_repo_files` and never passed `unreadable_hit=`, so a permission-denied subtree produced a smaller report that still reported `possibly_truncated: False` — **"every source file is documented"** while whole directories were invisible to the scan.

RED confirmed on both builders; the clean-tree control already passed, so the assertions genuinely discriminate.

## The cause, and why it wins

| cause | remedy | knob-fixable? |
|---|---|---|
| `project-files` | raise `--max-files` | yes |
| **`unreadable-path`** | **make the path readable, or scope it out** | **no** |

Ranking the non-remediable cause last-wins is how a single cause field carries the information the MCP surface got as `budget_remediable: false` in #283/#762.

`build_docs_stale_references` also **hardcoded** its cause inline in the payload — `"project-files" if possibly_truncated else None` — so it could not express any other cause at all. Hoisted to a real variable.

## The consumer was the worse half

`render_docs_coverage_text` hardcoded the literal `"(project-files)"` and named `max_files`. So even with the payload fixed, the **human-readable** line would still have told the reader to raise a cap that cannot make a denied directory readable. Fixing only the JSON would have left the surface a person actually reads still lying.

Same shape as #767, found the same way: trace the consumer instead of stopping at the payload.

## Tests

Four arms — the defect on each builder, a clean-tree control covering both, and a **renderer arm** asserting the rendered text does *not* contain `"truncated at max_files"`.

The deny fixture monkeypatches `os.scandir` rather than applying a real ACL. Task #281 burned a probe on exactly that: the ACL silently failed to apply, the "hostile" arm was a perfectly readable directory, and the test would have declared a real defect **absent**.

**30 passed** in the docs-coverage suite; `ruff check` + `ruff format --check --preview` clean.

#284 census after this: **7 of 15** call sites wired. Remaining: codemap ×2, `repo_map` ×5 (internal helpers — need triage, not blanket wiring), `session_store` ×1 (the walk side, see #288).

Task #284.