### PR TITLE
fix(session): disclose files the snapshot could not stat instead of dropping them silently (#288)

### DIFF
--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -22,6 +22,7 @@ from tensor_grep.cli.repo_map import (
     _clear_all_source_caches,
     _is_repo_context_file,
     _iter_repo_files,
+    _UnreadablePathFlag,
     apply_repo_map_output_limits,
     build_context_edit_plan_from_map,
     build_context_pack_from_map,
@@ -472,13 +473,29 @@ def _prune_session_records(
     return retained
 
 
-def _capture_snapshot(file_paths: list[str]) -> list[dict[str, Any]]:
+def _capture_snapshot(
+    file_paths: list[str], *, unreadable_hit: _UnreadablePathFlag | None = None
+) -> list[dict[str, Any]]:
+    """Stat each path into a {path, size, mtime_ns} snapshot, skipping what cannot be stat'd.
+
+    Task #288 -- the SNAPSHOT-side sibling of #286. Skipping is still correct: one unreadable file
+    must never fail session-open. But the skip used to be TOTALLY silent, and a path absent from
+    the snapshot is never compared against anything afterwards, so it stops being staleness-tracked
+    until some later full rebuild happens to re-see it. A transient permission blip at capture time
+    therefore degraded staleness detection DURABLY, blunting the #286 fix on the comparison side.
+
+    `unreadable_hit` is an OPTIONAL mutable out-signal, the same `_UnreadablePathFlag` idiom
+    `_iter_repo_files` uses: passing `None` is a complete no-op, byte-identical to the previous
+    behaviour, so neither existing call site changes until it opts in.
+    """
     snapshot: list[dict[str, Any]] = []
     for current in file_paths:
         path = Path(current)
         try:
             stat = path.stat()
-        except OSError:
+        except OSError as exc:
+            if unreadable_hit is not None:
+                unreadable_hit.record(exc)
             continue
         snapshot.append({
             "path": str(path),
@@ -677,18 +694,31 @@ def open_session(
     session_id = _new_session_id(root)
     changeset = _empty_changeset()
     scan_limit = cast(dict[str, Any] | None, repo_map.get("scan_limit"))
+    # Task #288: capture the snapshot through a flag so files we could not stat are COUNTED
+    # rather than silently absent. Emitted below only when it actually fired.
+    snapshot_unreadable = _UnreadablePathFlag()
     payload = {
         "version": _SESSION_VERSION,
         "session_id": session_id,
         "root": str(root),
         "created_at": created_at,
         "repo_map": repo_map,
-        "snapshot": _capture_snapshot(repo_map["related_paths"]),
+        "snapshot": _capture_snapshot(
+            repo_map["related_paths"], unreadable_hit=snapshot_unreadable
+        ),
         "refresh_type": "full",
         "changeset": changeset,
         "scan_limit": scan_limit,
         "build_seconds": max(0.0, built_at - started_at),
     }
+    if snapshot_unreadable.hit:
+        # Task #288: mirrors `build_repo_map`'s `unreadable_paths = {count, sample}` shape (#276).
+        # Emitted ONLY when it fired, so a clean capture is byte-identical to the old payload and
+        # a reader can trust the key's ABSENCE to mean "the snapshot covered everything".
+        payload["snapshot_unreadable_paths"] = {
+            "count": snapshot_unreadable.count,
+            "sample": list(snapshot_unreadable.sample),
+        }
     # Create the sessions dir up front so _session_payload_path's sessions_dir.resolve() is stable:
     # under concurrent first-time opens, resolving while another writer is still mkdir-ing the dir
     # can transiently mis-resolve and trip the containment guard on a VALID session id (Windows).
@@ -772,6 +802,7 @@ def refresh_session(
         changeset = _empty_changeset()
     refreshed_at = datetime.now(UTC).isoformat()
     created_at = str(existing.get("created_at", refreshed_at))
+    snapshot_unreadable = _UnreadablePathFlag()  # task #288, see open_session
     payload = {
         "version": _SESSION_VERSION,
         "session_id": session_id,
@@ -779,11 +810,21 @@ def refresh_session(
         "created_at": created_at,
         "refreshed_at": refreshed_at,
         "repo_map": repo_map,
-        "snapshot": _capture_snapshot(repo_map["related_paths"]),
+        "snapshot": _capture_snapshot(
+            repo_map["related_paths"], unreadable_hit=snapshot_unreadable
+        ),
         "refresh_type": refresh_type,
         "changeset": changeset,
         "scan_limit": cast(dict[str, Any] | None, repo_map.get("scan_limit")),
     }
+    if snapshot_unreadable.hit:
+        # Task #288: mirrors `build_repo_map`'s `unreadable_paths = {count, sample}` shape (#276).
+        # Emitted ONLY when it fired, so a clean capture is byte-identical to the old payload and
+        # a reader can trust the key's ABSENCE to mean "the snapshot covered everything".
+        payload["snapshot_unreadable_paths"] = {
+            "count": snapshot_unreadable.count,
+            "sample": list(snapshot_unreadable.sample),
+        }
     if refresh_fallback_reason is not None:
         payload["refresh_fallback_reason"] = refresh_fallback_reason
     session_path = _session_payload_path(root, session_id)

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -712,3 +712,109 @@ def test_genuinely_deleted_file_is_still_reported_as_removed(tmp_path: Path) -> 
     assert any("helpers.py" in p for p in changeset["removed"]), (
         f"a genuinely deleted file vanished from `removed`: {changeset['removed']}"
     )
+
+
+# ---------------------------------------------------------------------------
+# (#288) An UNREADABLE file must not vanish from the snapshot without a signal
+# ---------------------------------------------------------------------------
+
+
+def test_capture_snapshot_reports_files_it_could_not_stat(tmp_path: Path, monkeypatch) -> None:
+    """Task #288, the SNAPSHOT-side sibling of #286.
+
+    #286 fixed the COMPARISON side: an unreadable file is no longer misreported as removed. But
+    `_capture_snapshot` wrapped `path.stat()` in a bare `except OSError: continue`, so a file that
+    was unreadable at CAPTURE time never entered the snapshot at all -- and a path absent from the
+    snapshot is not compared against anything, ever. It stops being staleness-tracked entirely
+    until some later full rebuild happens to re-see it. So a transient permission blip at
+    open/refresh time degrades staleness detection DURABLY, which blunts #286's fix.
+
+    Fail-safe direction is unchanged (one unreadable file must never fail session-open) -- what
+    was missing is the SIGNAL, so the caller can tell a complete snapshot from a partial one.
+    Mirrors the `unreadable_paths = {count, sample}` shape `build_repo_map` already ships.
+    """
+    paths = _build_project(tmp_path)
+    targets = [str(paths["core"]), str(paths["service"]), str(paths["helper"])]
+    denied = str(paths["helper"])
+
+    real_stat = Path.stat
+
+    def fake_stat(self: Path, *args: object, **kwargs: object):
+        if str(self) == denied:
+            raise PermissionError(13, "Permission denied", denied)
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    flag = session_store._UnreadablePathFlag()
+    snapshot = session_store._capture_snapshot(targets, unreadable_hit=flag)
+
+    captured = [str(entry["path"]) for entry in snapshot]
+    assert denied not in captured, "precondition: the denied file cannot be stat'd, so it is absent"
+    assert flag.hit is True, (
+        "the file silently vanished from the snapshot with no signal -- it is now untracked for "
+        "staleness and nothing says so"
+    )
+    assert flag.count == 1
+    assert any(denied in s for s in flag.sample)
+
+
+def test_capture_snapshot_on_a_fully_readable_set_is_the_control_arm(tmp_path: Path) -> None:
+    """CONTROL. Without this, the assertion above could pass by flagging EVERY capture."""
+    paths = _build_project(tmp_path)
+    targets = [str(paths["core"]), str(paths["service"]), str(paths["helper"])]
+
+    flag = session_store._UnreadablePathFlag()
+    snapshot = session_store._capture_snapshot(targets, unreadable_hit=flag)
+
+    assert len(snapshot) == 3
+    assert flag.hit is False
+    assert flag.count == 0
+
+
+def test_capture_snapshot_without_a_flag_is_byte_identical(tmp_path: Path) -> None:
+    """The out-param must stay OPTIONAL: `None` is a complete no-op, so the two existing call
+    sites (and any future one) are unaffected until they opt in. Same contract
+    `_UnreadablePathFlag` already carries for `_iter_repo_files`.
+    """
+    paths = _build_project(tmp_path)
+    targets = [str(paths["core"]), str(paths["service"])]
+
+    assert session_store._capture_snapshot(targets) == session_store._capture_snapshot(
+        targets, unreadable_hit=None
+    )
+
+
+def test_open_session_payload_discloses_an_unstattable_file(tmp_path: Path, monkeypatch) -> None:
+    """Task #288, the WIRING arm. The flag is only worth adding if a caller reads it -- a signal
+    with no consumer is the proven-but-not-wired trap. Asserts the OUTCOME (the persisted session
+    payload) rather than the mechanism (the flag object), which is the only thing that proves
+    `open_session` actually threads it.
+    """
+    paths = _build_project(tmp_path)
+    denied = str(paths["helper"])
+    real_stat = Path.stat
+
+    def fake_stat(self: Path, *args: object, **kwargs: object):
+        if str(self) == denied:
+            raise PermissionError(13, "Permission denied", denied)
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    session_id = _open_session(paths["project"])
+    payload = _session_payload(paths["project"], session_id)
+
+    disclosure = payload.get("snapshot_unreadable_paths")
+    assert disclosure, "the session persisted a partial snapshot with no disclosure"
+    assert disclosure["count"] >= 1
+    assert any(denied in s for s in disclosure["sample"])
+
+
+def test_open_session_payload_omits_the_key_on_a_clean_capture(tmp_path: Path) -> None:
+    """CONTROL. The key's ABSENCE must be trustworthy -- if it were always present, a reader could
+    not use absence to mean "the snapshot covered everything", and the arm above would pass for a
+    reason unrelated to the defect.
+    """
+    paths = _build_project(tmp_path)
+    session_id = _open_session(paths["project"])
+
+    assert "snapshot_unreadable_paths" not in _session_payload(paths["project"], session_id)


### PR DESCRIPTION
The **snapshot-side sibling of #286**, and the reason #286 alone wasn't enough.

#286 fixed the *comparison* side — an unreadable file is no longer misreported as removed. But `_capture_snapshot` wrapped `path.stat()` in a bare `except OSError: continue`, so a file unreadable at **capture** time never entered the snapshot at all. A path absent from the snapshot is never compared against anything afterwards: it stops being staleness-tracked entirely until some later full rebuild happens to re-see it.

So a **transient** permission blip at open/refresh time degraded staleness detection **durably** — blunting the fix that had just shipped one layer over.

## The fix

Skipping is still correct; one unreadable file must never fail session-open. What was missing is the **signal**.

`_capture_snapshot` now takes an optional `unreadable_hit` out-param using the existing `_UnreadablePathFlag` idiom that `_iter_repo_files` already uses — so `None` is a complete no-op and nothing changes for a caller until it opts in.

**Wired the same turn, both call sites.** A signal with no consumer is the proven-but-not-wired trap. `open_session` and `refresh_session` pass a flag and, *only when it fires*, emit `snapshot_unreadable_paths = {count, sample}`, mirroring `build_repo_map`'s shape from #276.

Emitting it **conditionally** is deliberate: a clean capture stays byte-identical to the old payload, so a reader can trust the key's **absence** to mean "the snapshot covered everything."

## Tests — five arms

On the helper:
- the defect (a file that can't be stat'd is flagged, not silently gone)
- a clean-set **control**
- a **byte-identical no-flag arm**, proving the out-param is genuinely optional

On the outcome — because the flag alone proves nothing about wiring:
- the persisted session payload carries the disclosure
- a **control that the key is ABSENT** on a clean capture. An always-present key would make absence meaningless and let the first arm pass for an unrelated reason.

**104 passed** across `test_incremental_refresh` + `test_session_cli` + `test_session_containment`; `ruff check` + `ruff format --check --preview` clean.

Task #288.