### PR TITLE
fix(edit-plan): report an unreadable subtree during validation-test discovery (#291)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -4237,6 +4237,7 @@ def _discover_validation_tests_for_primary_file(
     precomputed_file_paths: list[str | Path] | None = None,
     deadline_monotonic: float | None = None,
     deadline_hit: _DeadlineBreakFlag | None = None,
+    unreadable_hit: _UnreadablePathFlag | None = None,
 ) -> list[str]:
     if not primary_file:
         return []
@@ -4278,6 +4279,14 @@ def _discover_validation_tests_for_primary_file(
             max_files=_VALIDATION_RUNNER_SCAN_LIMIT,
             deadline_monotonic=deadline_monotonic,
             deadline_hit=deadline_hit,
+            # Task #291: this walk feeds the VALIDATION PLAN -- the answer to "what should I run
+            # to validate this edit?". Unwired, a permission-denied subtree simply yielded fewer
+            # discovered tests and the plan was emitted with no hint it was built over a partial
+            # scan, so an agent runs a shorter suite and believes it validated. Strictly worse
+            # than the search surfaces (#761/#767/#768): there the user sees fewer results and
+            # can notice; here they get a confident INSTRUCTION. Not budget-remediable -- raising
+            # _VALIDATION_RUNNER_SCAN_LIMIT cannot make a denied directory readable.
+            unreadable_hit=unreadable_hit,
         )
     for current in candidate_files:
         # #639 Opus-gate nit 1: the resolve loop above can be bounded and still hand back a

--- a/tests/unit/test_edit_plan_seed.py
+++ b/tests/unit/test_edit_plan_seed.py
@@ -915,3 +915,84 @@ def test_symbol_callers_provider_results_respect_capped_repo_map_file_universe(
     assert str(outside_cap.resolve()) not in {
         str(current["file"]) for current in refs_payload["references"]
     }
+
+
+# ---------------------------------------------------------------------------
+# (#291) The validation plan must not be built silently over a partial scan
+# ---------------------------------------------------------------------------
+
+
+def _deny_scandir_for(monkeypatch, denied_dir: Path) -> None:
+    """Make `os.scandir(denied_dir)` raise PermissionError; everything else untouched.
+
+    Never a real chmod/ACL (#281: an ACL that silently failed to apply left a "hostile" arm that
+    was a perfectly readable directory, nearly declaring a live defect ABSENT).
+    """
+    import os as _os
+
+    real_scandir = _os.scandir
+    target = str(denied_dir.resolve())
+
+    def _fake_scandir(path=".", *args, **kwargs):
+        if str(Path(path).resolve()) == target:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_scandir(path, *args, **kwargs)
+
+    monkeypatch.setattr(_os, "scandir", _fake_scandir)
+
+
+def test_validation_test_discovery_reports_an_unreadable_subtree(tmp_path: Path, monkeypatch):
+    """Task #291. `_discover_validation_tests_for_primary_file` walks with `_iter_repo_files` but
+    never passed `unreadable_hit=`, so a permission-denied subtree simply yielded FEWER discovered
+    tests and the plan was emitted with no hint it was built over a partial scan.
+
+    This is worse than the search surfaces #761/#767/#768 fixed. There a user gets fewer results
+    and can notice. Here the user gets a CONFIDENT INSTRUCTION -- "run these to validate your
+    edit" -- computed from a scan that silently skipped part of the tree. The agent runs a shorter
+    suite and believes it validated the change.
+
+    The cause is NOT budget-remediable: raising `_VALIDATION_RUNNER_SCAN_LIMIT` cannot make a
+    denied directory readable.
+    """
+    project = tmp_path / "proj"
+    _write(project / "src" / "core.py", "def create_invoice(total):\n    return total + 1\n")
+    denied = project / "src" / "hidden_tests"
+    denied.mkdir(parents=True, exist_ok=True)
+    _write(denied / "test_core.py", "def test_create_invoice():\n    assert True\n")
+
+    _deny_scandir_for(monkeypatch, denied)
+    flag = repo_map._UnreadablePathFlag()
+    repo_map._discover_validation_tests_for_primary_file(
+        str(project),
+        str(project / "src" / "core.py"),
+        primary_symbol_name="create_invoice",
+        query="create invoice",
+        limit=3,
+        unreadable_hit=flag,
+    )
+
+    assert flag.hit is True, (
+        "validation-test discovery skipped an unreadable subtree with no signal -- the plan it "
+        "feeds would claim to be the validation set while part of the tree was never scanned"
+    )
+    assert flag.count >= 1
+
+
+def test_validation_test_discovery_clean_tree_is_the_control_arm(tmp_path: Path):
+    """CONTROL. Without this the assertion above could pass by flagging EVERY discovery run."""
+    project = tmp_path / "proj"
+    _write(project / "src" / "core.py", "def create_invoice(total):\n    return total + 1\n")
+    _write(project / "tests" / "test_core.py", "def test_create_invoice():\n    assert True\n")
+
+    flag = repo_map._UnreadablePathFlag()
+    repo_map._discover_validation_tests_for_primary_file(
+        str(project),
+        str(project / "src" / "core.py"),
+        primary_symbol_name="create_invoice",
+        query="create invoice",
+        limit=3,
+        unreadable_hit=flag,
+    )
+
+    assert flag.hit is False
+    assert flag.count == 0


### PR DESCRIPTION
First slice of #291. `_discover_validation_tests_for_primary_file` walks with `_iter_repo_files` and **never passed `unreadable_hit=`**, so a permission-denied subtree yielded fewer discovered tests and the validation plan was emitted with no hint it was built over a partial scan.

**This is worse than the search surfaces #761/#767/#768 fixed.** There a user gets fewer results and can notice. Here they get a **confident instruction** — *"run these to validate your edit"* — computed from a scan that silently skipped part of the tree. An agent runs a shorter suite and believes it validated.

Not budget-remediable: raising `_VALIDATION_RUNNER_SCAN_LIMIT` cannot make a denied directory readable.

The param is **optional, defaulting to `None`** (a complete no-op) — exactly like the `deadline_hit` this function already accepts and threads into the same walk. No caller changes until it opts in.

## The fixture topology is not the obvious shape

Recording this because it cost three wrong guesses before I stopped theorising and measured:

- `_validation_repo_root(source.parent)` returns the file's **own parent** (`proj/src`), **not** the project root — so the fallback walk scans `proj/src`.
- A denied dir placed as a **sibling** of `src/` is therefore never visited, and the flag can never fire — a repro whose topology deletes the mechanism it tests.
- The function also early-returns `[]` when `validation_root == scoped_path`, so `scoped_root` must stay the project root to clear that guard.

An instrumented probe — count `scandir` calls, print the directories visited — settled it in one run after three hypotheses had failed. **Measure the harness before theorising about the code.**

## Verification

**Mutation-verified**: dropping `unreadable_hit=` from the walk fails the defect arm while the control still passes; restoring it passes both. That's the proof the assertion can discriminate.

**42 passed** in the edit-plan suite; `ruff check` + `ruff format --check --preview` clean.

## Scope

Three sites remain in the #291 family and are **not** in this slice — they are multi-hop from the payload and need their own threading: `_detect_validation_runners_from_root`, `_has_python_validation_fallback_evidence`, `_raw_validation_plan_for_tests`.

Task #291.