### PR TITLE
fix(repo-map): stop _path_is_relative_to crashing on OSError; disclose dropped validation files (#291)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -1256,9 +1256,26 @@ def _is_repo_context_file(path: Path, root: Path) -> bool:
 
 
 def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    """Is ``path`` inside ``parent``? Answers False rather than raising when it cannot tell.
+
+    Task #291. This caught ``ValueError`` only -- the "different drive / not a subpath" answer --
+    while both ``resolve()`` calls can also raise ``OSError`` (permission denied, a vanished
+    component, a disconnected share). That escaped through all 9 call sites and CRASHED the
+    command with an unhandled traceback, which is strictly worse than the silent-loss class this
+    module has been hardening against: the caller gets no answer at all, not a partial one.
+
+    Found while testing the #291 fix, which made it reachable in an ordinary way -- that fix hands
+    this function a path whose ``resolve()`` ALREADY failed once, so the retry here was guaranteed
+    to raise on exactly the input the fix exists to handle.
+
+    Fails CLOSED (False = treat as outside the root). That matches the existing ValueError arm and
+    is the safe direction: an unverifiable path is excluded from a scope-limited set rather than
+    silently admitted into one. Callers that need to know a file was DROPPED for this reason
+    record it separately -- see ``_precomputed_validation_files_for_root``.
+    """
     try:
         path.resolve().relative_to(parent.resolve())
-    except ValueError:
+    except (ValueError, OSError):
         return False
     return True
 
@@ -1269,6 +1286,7 @@ def _precomputed_validation_files_for_root(
     *,
     deadline_monotonic: float | None = None,
     deadline_hit: _DeadlineBreakFlag | None = None,
+    unreadable_hit: _UnreadablePathFlag | None = None,
 ) -> list[Path] | None:
     """#639 Opus-gate nit 1 (dogfood #1 RESIDUAL): this loop does one filesystem ``Path.resolve()``
     syscall per entry in ``file_paths`` -- on a large repo map's ``related_paths``/``files``+
@@ -1295,11 +1313,31 @@ def _precomputed_validation_files_for_root(
         current = Path(str(raw_path)).expanduser()
         if not current.is_absolute():
             current = normalized_root / current
+        resolve_error: OSError | None = None
         try:
             resolved = current.resolve()
-        except OSError:
+        except OSError as exc:
+            # The `absolute()` fallback keeps this loop from crashing, but MEASURED: it does not
+            # save the entry. `_path_is_relative_to` below re-resolves the path, hits the same
+            # OSError, and fails closed -- so a resolve failure here ALWAYS costs the file.
+            #
+            # An earlier draft of this comment claimed the fallback was usually harmless and that
+            # only a boundary-crossing symlink lost anything. The control-arm test falsified that
+            # in one run. Do not restore that reasoning without re-running it.
             resolved = current.absolute()
+            resolve_error = exc
         if not _path_is_relative_to(resolved, normalized_root):
+            if resolve_error is not None and unreadable_hit is not None:
+                # Task #291. THIS is the only branch where the resolve failure actually costs a
+                # file. `absolute()` skipped symlink resolution, so a link crossing the root
+                # boundary is judged on its unresolved form and dropped here -- silently, from a
+                # list that feeds the agent's "run these to validate your edit" plan. An agent
+                # then runs a SHORTER suite and believes it validated.
+                #
+                # Recorded HERE rather than in the except arm on purpose: recording at the except
+                # would flag every benign resolve failure as data loss and drown the real signal.
+                # The distinction is what the control arm in the test pins.
+                unreadable_hit.record(resolve_error)
             continue
         key = str(resolved)
         if key in seen:

--- a/tests/unit/test_edit_plan_seed.py
+++ b/tests/unit/test_edit_plan_seed.py
@@ -978,6 +978,91 @@ def test_validation_test_discovery_reports_an_unreadable_subtree(tmp_path: Path,
     assert flag.count >= 1
 
 
+def _deny_resolve_for(monkeypatch, denied: Path) -> None:
+    """Make `Path.resolve()` raise for one exact path; everything else untouched.
+
+    `abspath` not `resolve()` for the comparison -- resolve would re-enter this patch and recurse.
+    """
+    import os as _os
+
+    real_resolve = Path.resolve
+    target = _os.path.abspath(_os.fspath(denied))
+
+    def _fake_resolve(self, *args, **kwargs):
+        if _os.path.abspath(_os.fspath(self)) == target:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _fake_resolve)
+
+
+def test_precomputed_validation_files_records_a_resolve_failure_that_costs_a_file(
+    tmp_path: Path, monkeypatch
+):
+    """Task #291. A resolve failure only costs a file when containment then drops it.
+
+    The validation-file list feeds the agent's "run these to validate your edit" plan. An entry
+    dropped here means the agent runs a SHORTER suite and believes it validated.
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    outside = tmp_path / "outside" / "stray.py"
+    outside.parent.mkdir()
+    outside.write_text("x = 1\n", encoding="utf-8")
+
+    _deny_resolve_for(monkeypatch, outside)
+    flag = repo_map._UnreadablePathFlag()
+    selected = repo_map._precomputed_validation_files_for_root(
+        project, [outside], unreadable_hit=flag
+    )
+
+    assert selected == [], "precondition: the entry must actually have been dropped"
+    assert flag.hit is True, (
+        "a resolve failure caused an entry to fall out of the validation-file list with no signal"
+    )
+
+
+def test_precomputed_validation_files_clean_tree_is_the_control_arm(tmp_path: Path):
+    """CONTROL. Without it, the assertion above could pass by flagging EVERY call.
+
+    Note what this arm is NOT. A first draft asserted that a resolve failure on a path UNDER the
+    root was harmless -- that `absolute()` saved it. Running it falsified that immediately: the
+    entry was dropped anyway, because `_path_is_relative_to` re-resolves and now fails closed. So
+    a resolve failure in this loop ALWAYS costs the file, and the honest control is simply "no
+    resolve failure at all".
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    inside = project / "kept.py"
+    inside.write_text("x = 1\n", encoding="utf-8")
+
+    flag = repo_map._UnreadablePathFlag()
+    selected = repo_map._precomputed_validation_files_for_root(
+        project, [inside], unreadable_hit=flag
+    )
+
+    assert selected and selected[0].name == "kept.py"
+    assert flag.hit is False, "a clean run reported data loss"
+    assert flag.count == 0
+
+
+def test_path_is_relative_to_answers_false_instead_of_crashing_on_oserror(
+    tmp_path: Path, monkeypatch
+):
+    """Task #291, the higher-severity find: this used to raise through all 9 call sites.
+
+    It caught `ValueError` only, so an `OSError` from either `resolve()` escaped and killed the
+    command with an unhandled traceback -- strictly worse than the silent-loss class, since the
+    caller gets no answer at all rather than a partial one.
+    """
+    target = tmp_path / "thing.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    _deny_resolve_for(monkeypatch, target)
+
+    # Must not raise. Fails CLOSED: an unverifiable path is treated as outside the root.
+    assert repo_map._path_is_relative_to(target, tmp_path) is False
+
+
 def test_validation_test_discovery_clean_tree_is_the_control_arm(tmp_path: Path):
     """CONTROL. Without this the assertion above could pass by flagging EVERY discovery run."""
     project = tmp_path / "proj"


### PR DESCRIPTION
## Two findings — the second more severe than the task that led to it

### 1. `_path_is_relative_to` crashed instead of degrading (higher severity)

It caught `ValueError` only. Both of its `resolve()` calls can also raise **`OSError`** — permission
denied, vanished component, disconnected share — which escaped through **all 9 call sites** and killed
the command with an unhandled traceback.

That is *worse* than the silent-loss class this module has been hardening against: the caller gets
**no** answer, not a partial one. Now fails **closed** (`False` = outside the root), matching the
existing `ValueError` arm — an unverifiable path is excluded from a scope-limited set, never silently
admitted.

**Found only because the #291 fix made it reachable in an ordinary way**: that fix hands this function
a path whose `resolve()` already failed, so the retry inside was guaranteed to raise on exactly the
input the fix exists to handle.

### 2. Dropped validation files are now disclosed

`_precomputed_validation_files_for_root` records into an optional `_UnreadablePathFlag`. It feeds the
agent's *"run these to validate your edit"* plan across **four** call sites — an entry lost here means
the agent runs a **shorter suite and believes it validated**.

## A correction I had to make mid-fix

An earlier draft asserted the `absolute()` fallback was usually harmless — that only a
boundary-crossing symlink lost anything — **and the code comment said so.** The control-arm test
falsified it in one run: `_path_is_relative_to` re-resolves and now fails closed, so a resolve failure
here **always** costs the file. Comment and test both rewritten, with the wrong reasoning recorded at
the code site so it isn't restored.

## Also: #291 itself was mis-scoped

The task listed three functions as separate remaining sites. They are all **callers of one helper**,
plus a fourth the hand-derived list never mentioned. One fix, not three slices — the census caught
that.

## Census note (honest, because the number did NOT move)

`repo_map.py` stays at **8**. Two detector limitations, neither a correctness problem:

- it counts a handler **once per enclosing accumulating loop**, so 6 distinct handlers score 8;
- it **cannot see disclosure performed outside the handler** — exactly where this fix records, at the
  containment drop. That placement is deliberate: recording in the `except` arm would flag failures
  before knowing whether they cost anything.

Both are precision issues; the ratchet still does its one job — the count cannot grow.

## Verification

- 45 tests in `test_edit_plan_seed.py` pass; census ratchet green; ruff clean.
- Three arms: treatment (entry dropped → flag fires), control (clean run → flag silent), and a direct
  test that `_path_is_relative_to` **returns False instead of raising**.
