### PR TITLE
fix(rust): cycle guard for pub-use re-export chains in _rust_resolve_use_binding

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -3406,7 +3406,31 @@ def _rust_resolve_use_binding(
     binding: dict[str, Any],
     symbol: str,
     repo_root: Path | str | None = None,
+    _seen: frozenset[tuple[str, str]] | None = None,
 ) -> dict[str, Any] | None:
+    # Cycle guard. This function follows `use` re-export chains by recursing on
+    # the nested binding, and Rust re-exports are a GRAPH, not a tree: a crate
+    # root that does `pub use rules::x::{...}` while a submodule re-exports back
+    # toward the root closes a loop, and the recursion never terminates.
+    #
+    # Receipt: `tg refs . <symbol> --json` on a 594-file Rust workspace
+    # (claude-code-hydron) died with `RecursionError: maximum recursion depth
+    # exceeded`, ~1000 frames of this function, rc=1 and no stdout -- so it took
+    # out EVERY refs query on that repo, not just the cyclic symbol.
+    #
+    # It DOES reproduce on a two-module fixture, but only when the searched
+    # symbol differs from the re-exported name: a matching name hits the early
+    # return above the recursive call. See
+    # test_cyclic_rust_pub_use_reexport_terminates.
+    #
+    # The key is (resolved importer path, imported name): the same file reached
+    # again for the same name is a cycle, while the same file for a DIFFERENT
+    # name is legitimate work and must not be pruned.
+    key = (str(importer_path).casefold(), str(binding.get("imported", "")).casefold())
+    seen = _seen or frozenset()
+    if key in seen:
+        return None
+    seen = seen | {key}
     imported_name = str(binding.get("imported", ""))
     local_name = str(binding.get("local", ""))
     wildcard = bool(binding.get("wildcard"))
@@ -3440,7 +3464,7 @@ def _rust_resolve_use_binding(
                 if imported_name.lower() not in {nested_imported.lower(), nested_local.lower()}:
                     continue
                 nested_resolved = _rust_resolve_use_binding(
-                    candidate_path, nested_binding, symbol, repo_root
+                    candidate_path, nested_binding, symbol, repo_root, seen
                 )
                 if nested_resolved is None:
                     continue

--- a/tests/unit/test_rust_advanced_resolution.py
+++ b/tests/unit/test_rust_advanced_resolution.py
@@ -251,3 +251,65 @@ def test_existing_same_crate_rust_use_alias_resolution_still_works(tmp_path: Pat
     payload = repo_map.build_symbol_callers("issue_invoice", project)
 
     assert any(caller["file"] == str(consumer_path.resolve()) for caller in payload["callers"])
+
+
+def test_cyclic_rust_pub_use_reexport_terminates(tmp_path: Path) -> None:
+    """A `pub use` cycle must not recurse until the stack dies.
+
+    Rust re-exports form a GRAPH, not a tree: two modules that re-export the
+    same name through each other close a loop, and following that chain with no
+    visited-set walks it until the interpreter runs out of stack.
+
+    Two details decide whether this fixture can reproduce the bug at all:
+
+    * The searched symbol must NOT be the re-exported name. A matching name hits
+      the early return before the recursive call is ever reached, so a fixture
+      that searches for `Shared` passes with the guard removed and proves
+      nothing. Every binding in a file is resolved against the searched symbol
+      (see the `_rust_resolve_use_binding` call in the references walk), so an
+      unrelated symbol is the realistic case, not a contrived one.
+    * The cycle needs two hops -- a module re-exporting from itself resolves
+      earlier and never reaches the recursive call.
+
+    Receipt: `tg refs . <symbol> --json` on a 594-file Rust workspace exited 1
+    with `RecursionError: maximum recursion depth exceeded` and no stdout at
+    all, so the crash took out EVERY refs query on that repo.
+    """
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    _write(src_dir / "lib.rs", "pub mod a;\npub mod b;\n")
+    # a re-exports from b, b re-exports from a. Cycle closed.
+    _write(src_dir / "a.rs", "pub use crate::b::Shared;\n")
+    _write(src_dir / "b.rs", "pub use crate::a::Shared;\n")
+
+    binding = repo_map._rust_use_bindings((src_dir / "a.rs").read_text(encoding="utf-8"))[0]
+
+    # Deliberately unrelated to `Shared` -- see the docstring. Reaching the next
+    # line at all is the regression: unpatched this raises RecursionError.
+    resolved = repo_map._rust_resolve_use_binding(
+        src_dir / "a.rs", binding, "totally_unrelated_symbol", project
+    )
+
+    # A cycle resolves to nothing, and saying so is the correct answer.
+    assert resolved is None
+
+
+def test_cycle_guard_does_not_prune_a_legitimate_reexport_chain(tmp_path: Path) -> None:
+    """The control for the guard above: a NON-cyclic chain must still resolve.
+
+    A guard that returned early for everything would also "terminate" and make
+    the cycle test pass while silently breaking real re-export resolution. This
+    pins the other direction.
+    """
+    project = tmp_path / "project"
+    src_dir = project / "src"
+    _write(src_dir / "lib.rs", "pub mod facade;\npub mod inner;\n")
+    _write(src_dir / "facade.rs", "pub use crate::inner::Shared;\n")
+    _write(src_dir / "inner.rs", "pub struct Shared;\n")
+
+    binding = repo_map._rust_use_bindings((src_dir / "facade.rs").read_text(encoding="utf-8"))[0]
+
+    resolved = repo_map._rust_resolve_use_binding(src_dir / "facade.rs", binding, "Shared", project)
+
+    assert resolved is not None
+    assert resolved["definition_file"] == str((src_dir / "inner.rs").resolve())


### PR DESCRIPTION
`_rust_resolve_use_binding` follows `use` re-export chains by recursing on the nested binding, with **no visited-set and no depth cap**. Rust re-exports are a GRAPH, not a tree: two modules that re-export the same name through each other close a loop and the recursion runs until the interpreter's stack dies.

### Receipt

`tg refs . <symbol> --json` on a 594-file Rust workspace exited 1 with `RecursionError: maximum recursion depth exceeded` and produced **no stdout at all** — so this took out *every* refs query on that repo, not just the cyclic symbol.

Measured before/after on the same command, same repo:

| | exit | stdout |
|---|---|---|
| unpatched | 1 | 0 bytes (`RecursionError`) |
| patched | 0 | 7209 bytes of valid JSON |

### The fix

A visited-set keyed on `(resolved importer path, imported name)`. The same file reached again for the **same** name is a cycle; the same file for a **different** name is legitimate work and must not be pruned.

### Behaviour-preserving where no cycle exists

Byte-identical output on three scopes that already worked (`hydron-paths::display_path`, `hydron-tools-agentic::uri_to_path`, `hydron-cli::main`), compared with the session daemon off so both arms took the same code path.

### Tests

Two, both bidirectionally verified against the same file with the guard reverted:

- `test_cyclic_rust_pub_use_reexport_terminates` — fails with `RecursionError` without the guard. **Reproducing it requires the searched symbol to DIFFER from the re-exported name**: a matching name hits the early return above the recursive call, which is why my first fixture passed in both arms and proved nothing.
- `test_cycle_guard_does_not_prune_a_legitimate_reexport_chain` — the control. A guard that returned early for everything would also "terminate", so this pins the other direction.

`tests/unit`: 348 passed. The one pre-existing error (`test_ast_backend.py`, `fixture 'mocker' not found` — no `pytest-mock` in my venv) reproduces identically on pristine `main`.

Draft, so CI is the arbiter — I have not merged.