### PR TITLE
docs(support): denominate the deprecation window in time, not just minor versions

### DIFF
--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -33,5 +33,18 @@ This document distinguishes CI-tested environments from best-effort compatibilit
 `tensor-grep` follows Semantic Versioning (SemVer) 2.0.0.
 - **Major versions** may introduce breaking changes to CLI flags, `sgconfig.yml` schemas, or machine-readable outputs.
 - **Minor versions** add features in a backward-compatible manner.
-- **Deprecation Policy:** stable features, flags, or fields scheduled for removal will be marked as `DEPRECATED` for at least 2 minor versions before removal.
+- **Deprecation Policy:** stable features, flags, or fields scheduled for removal are marked
+  `DEPRECATED` for at least **90 days AND 2 minor versions** -- whichever is longer.
+
+  The time floor is the load-bearing half. This project releases on merge via semantic-release,
+  and the measured cadence is **a median of 0 days between minor bumps** (v1.95, v1.96, v1.97 and
+  v1.98 all shipped on 2026-07-24). A version-only window is therefore not a window: read
+  literally, "2 minor versions" can elapse in an afternoon, while a reader reasonably infers
+  months. If you are pinning `tensor-grep` in a managed environment, 90 days is the number to
+  plan against.
+- **Supported versions / security patches:** the **latest released version only**. There are no
+  maintenance branches -- every fix ships forward from `main` -- so a security fix arrives as a new
+  release, never as a backport to an older line. Upgrade is the patch path. Air-gapped or
+  version-pinned deployments should budget for this explicitly rather than assume an LTS line
+  exists; there isn't one.
 - **Experimental Surface:** items documented in [docs/EXPERIMENTAL.md](EXPERIMENTAL.md) are outside the stable compatibility guarantees and may change in minor releases.


### PR DESCRIPTION
## The finding

`docs/SUPPORT_MATRIX.md` promised stable flags/fields stay `DEPRECATED` **"for at least 2 minor versions before removal."** That reads like months. Measured against this repo's actual cadence:

```
median days between MINOR bumps: 0
v1.95, v1.96, v1.97, v1.98  -> all shipped 2026-07-24
```

semantic-release publishes on merge, so two minor versions can elapse in an **afternoon**. The policy wasn't missing — it was *misleading*, which is worse for the audience it exists to serve.

## Changes

- Deprecation window is now **90 days AND 2 minor versions, whichever is longer**, with the cadence measurement stated inline so a future editor can see why the time floor is load-bearing.
- Adds the **support/EOL statement**, previously absent entirely: latest released version only, no maintenance branches, no backports — upgrade is the patch path. Named explicitly so air-gapped and version-pinned deployments budget for it instead of assuming an LTS line.

The 90-day figure is a proposal, not a derivation — industry range is 4–12 months (Salesforce CLI 4mo, Mesos 6mo, Tanzu 6–12mo) and 90 days is the honest short end for a tool that ships this fast. Easy to change; the important part is that a time floor exists at all.

Closes the C2/C3 rows of the enterprise-readiness scorecard (task #312). Docs-only, non-releasing.