### PR TITLE
fix(readiness): make the exit-code gate three-state aware (#276 slice C0)

### DIFF
--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -282,16 +282,33 @@ def _search_flag_tokens_for_sweep(command: list[str]) -> set[str]:
 # into a check that cannot fail, which is the failure mode this repo names Form 1.
 #
 # So: tolerate 2 ONLY when the run explained itself. The marker must be PRESENT. No marker,
-# no tolerance. That mirrors the existing #121 carve-out below, which is likewise scoped to
-# one label + one precondition + one stderr substring rather than to the bare exit code.
-_INCOMPLETENESS_MARKERS = ("result_incomplete", "incomplete_reason_class")
+# no tolerance.
+#
+# HONEST DIFFERENCE from the #121 carve-out below: that one is scoped to a single label AND
+# a precondition (rg absent) AND a stderr substring. This guard has only the substring --
+# it applies to all 28 labels with no precondition. That is a deliberately wider allow-list,
+# so the marker set is the ONLY thing keeping it honest; widen that set with care.
+# The JSON envelope's keys (json_fmt.py:127, :140) AND the plain-text route's stderr sentinel.
+# BOTH are required, and an independent audit caught why: every one of the 28 sweep cases is
+# plain-text (`--no-json` is even in the inverse-flag set), and NO tg route writes either JSON key
+# to stderr -- so a JSON-key-only check has a treatment arm that can never fire on the routes this
+# consumer actually runs. The plain-text disclosure is `tg: rg exited 2, keeping partial results:
+# {reason}` (ripgrep_backend.py:143, :324, :443, and the timeout variant at :187), so the sentinel
+# below is the phrase that route really emits.
+_INCOMPLETENESS_MARKERS = (
+    "result_incomplete",
+    "incomplete_reason_class",
+    "keeping partial results",
+)
 
 
 def _disclosed_incomplete(stdout: str, stderr: str) -> bool:
     """True when an exit-2 run disclosed that its scan was incomplete.
 
     Reads both streams because the marker's home differs by route: the `--json` envelope
-    carries it in stdout, while the plain-text route names the unreadable path on stderr.
+    carries the KEYS in stdout, while the plain-text route emits its own stderr sentinel
+    (`keeping partial results`). Merely naming a path on stderr is NOT a disclosure -- a
+    permission-denied line with no sentinel is indistinguishable from a hard failure.
 
     CALL-SITE ASSUMPTION -- read this before reusing the helper elsewhere. The substring test is
     safe HERE because the sweep searches a corpus this script authors itself and passes by

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -292,6 +292,19 @@ def _disclosed_incomplete(stdout: str, stderr: str) -> bool:
 
     Reads both streams because the marker's home differs by route: the `--json` envelope
     carries it in stdout, while the plain-text route names the unreadable path on stderr.
+
+    CALL-SITE ASSUMPTION -- read this before reusing the helper elsewhere. The substring test is
+    safe HERE because the sweep searches a corpus this script authors itself and passes by
+    explicit path (`_public_search_flag_sweep_cases` builds `probe_dir/app.log` and searches it
+    for "ERROR"), so no matched line can contain these tokens. It is safe on the `--json` route
+    for a second, independent reason: `json_fmt.py:126` and `:139` emit both keys ONLY when the
+    result is actually incomplete, so a complete envelope never carries the strings either.
+
+    Both of those are properties of the CALLER, not of this function. A sweep case that searched
+    the repository itself would break the first one immediately -- `json_fmt.py` contains the
+    literal "result_incomplete" -- and a failed run whose output happened to include such a line
+    would then read as disclosed. If you add a case that searches real source, switch this to a
+    structured check (parse stdout as JSON, test for the KEY) instead of widening the corpus.
     """
     haystack = f"{stdout} {stderr}"
     return any(marker in haystack for marker in _INCOMPLETENESS_MARKERS)

--- a/scripts/agent_readiness.py
+++ b/scripts/agent_readiness.py
@@ -269,6 +269,34 @@ def _search_flag_tokens_for_sweep(command: list[str]) -> set[str]:
     return tokens
 
 
+# Task #276 slice C0 -- make exit-code consumers three-state aware BEFORE the native
+# search path starts exiting 2 on an incomplete walk.
+#
+# The contract the producer will emit: 0/1 = parse output; 2 = parse output AND read the
+# incompleteness marker; >2 = error.
+#
+# This is deliberately an ALLOW-LIST, not "tolerate exit 2". Exit 2 is ALSO the code for a
+# catastrophic failure -- a regex syntax error, an unresolvable engine -- exactly as it is in
+# ripgrep, whose own docs call 2 "true for both catastrophic errors ... and soft errors". A
+# blanket `returncode == 2 -> continue` would swallow every one of those and turn this sweep
+# into a check that cannot fail, which is the failure mode this repo names Form 1.
+#
+# So: tolerate 2 ONLY when the run explained itself. The marker must be PRESENT. No marker,
+# no tolerance. That mirrors the existing #121 carve-out below, which is likewise scoped to
+# one label + one precondition + one stderr substring rather than to the bare exit code.
+_INCOMPLETENESS_MARKERS = ("result_incomplete", "incomplete_reason_class")
+
+
+def _disclosed_incomplete(stdout: str, stderr: str) -> bool:
+    """True when an exit-2 run disclosed that its scan was incomplete.
+
+    Reads both streams because the marker's home differs by route: the `--json` envelope
+    carries it in stdout, while the plain-text route names the unreadable path on stderr.
+    """
+    haystack = f"{stdout} {stderr}"
+    return any(marker in haystack for marker in _INCOMPLETENESS_MARKERS)
+
+
 def _ripgrep_available() -> bool:
     """Whether tg can resolve a ripgrep binary (TG_RG_PATH / PATH / bundled). Gates the
     #121 tolerance in the flag sweep below: `--count-matches` needs rg for its per-occurrence
@@ -344,6 +372,11 @@ def validate_public_search_advertised_flag_sweep(
             and completed.returncode == 2
             and "count-matches" in stderr.lower()
         ):
+            continue
+        # Task #276 slice C0: an incomplete-but-honest scan exits 2 and says so. Accept that
+        # ONLY with the marker present -- see `_disclosed_incomplete` for why this is an
+        # allow-list rather than a bare `== 2` tolerance.
+        if completed.returncode == 2 and _disclosed_incomplete(stdout, stderr):
             continue
         if completed.returncode not in {0, 1}:
             failures.append(

--- a/tests/unit/test_agent_readiness_script.py
+++ b/tests/unit/test_agent_readiness_script.py
@@ -1538,3 +1538,32 @@ def test_progress_reporter_auto_emits_in_ci_without_json(monkeypatch) -> None:
         "[progress] readiness start",
         "[progress] readiness done 0s",
     ]
+
+
+def test_disclosed_incomplete_tolerates_only_a_disclosed_exit_two() -> None:
+    """Task #276 slice C0: the exit-2 tolerance must be an ALLOW-LIST, not a blanket accept.
+
+    Exit 2 is overloaded. It is what an honest incomplete scan will return once #276 lands, but
+    it is ALSO what a catastrophic failure returns -- a regex syntax error, an unresolvable
+    engine -- exactly as in ripgrep, whose docs call 2 "true for both catastrophic errors ...
+    and soft errors". A tolerance keyed on the bare exit code would swallow every one of those
+    and turn the readiness sweep into a check that cannot fail.
+
+    So this test is deliberately bidirectional. The CONTROL arm is the point: an exit-2 run that
+    did NOT explain itself must still be rejected. If `_disclosed_incomplete` is ever weakened to
+    `return True`, the control assertions below fail.
+    """
+    module = _load_script_module()
+    disclosed = module._disclosed_incomplete
+
+    # TREATMENT -- the run disclosed why it was incomplete, on either stream.
+    assert disclosed('{"matches": [], "result_incomplete": true}', "")
+    assert disclosed("", 'tg: incomplete_reason_class="unreadable_path"')
+    assert disclosed('{"incomplete_reason_class": "deadline"}', "")
+
+    # CONTROL -- exit 2 with no disclosure is a REAL error and must not be tolerated.
+    assert not disclosed("", "regex parse error: unclosed group")
+    assert not disclosed("", "tg: ripgrep is not resolvable on PATH")
+    assert not disclosed("", "")
+    # Near-miss: names a path but never claims incompleteness. Still not a disclosure.
+    assert not disclosed("", "tg: /srv/locked: Permission denied")

--- a/tests/unit/test_agent_readiness_script.py
+++ b/tests/unit/test_agent_readiness_script.py
@@ -6,6 +6,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 
 def _load_script_module():
     root = Path(__file__).resolve().parents[2]
@@ -1567,3 +1569,64 @@ def test_disclosed_incomplete_tolerates_only_a_disclosed_exit_two() -> None:
     assert not disclosed("", "")
     # Near-miss: names a path but never claims incompleteness. Still not a disclosure.
     assert not disclosed("", "tg: /srv/locked: Permission denied")
+
+
+def _make_incomplete_scan_fake_run(stderr_text: str):
+    """Fake `subprocess.run` where every probe reports exit 2 with `stderr_text`.
+
+    Drives the REAL `validate_public_search_advertised_flag_sweep`, unlike the helper-only test
+    above -- an independent audit showed that deleting the call-site guard entirely still left
+    the suite green, because nothing pinned that the sweep actually consults the helper.
+    """
+
+    def fake_run(command, **_kwargs):
+        if command == ["tg", "search", "--help"]:
+            return subprocess.CompletedProcess(
+                args=command, returncode=0, stdout=_flag_sweep_help_stdout(), stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=command, returncode=2, stdout="", stderr=stderr_text
+        )
+
+    return fake_run
+
+
+def test_flag_sweep_tolerates_a_disclosed_incomplete_exit_two(monkeypatch, tmp_path) -> None:
+    """Task #276 slice C0, TREATMENT arm at the call site (not just the helper).
+
+    `_ripgrep_available` is forced True so the #121 carve-out cannot fire -- otherwise this would
+    pass for the wrong reason and prove nothing about the new guard.
+    """
+    module = _load_script_module()
+    monkeypatch.setattr(
+        module.shutil, "which", lambda command: command if command == "tg" else None
+    )
+    monkeypatch.setattr(module, "_ripgrep_available", lambda: True)
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        # the sentinel the plain-text route really emits (ripgrep_backend.py:143)
+        _make_incomplete_scan_fake_run("tg: rg exited 2, keeping partial results: unreadable path"),
+    )
+    module.validate_public_search_advertised_flag_sweep("", tmp_path, "1.12.28")
+
+
+def test_flag_sweep_still_fails_an_undisclosed_exit_two(monkeypatch, tmp_path) -> None:
+    """CONTROL arm -- the one that makes the pair mean something.
+
+    Exit 2 with no disclosure is a REAL error (regex syntax, unresolvable engine). If this ever
+    passes, the guard has become a blanket `== 2` tolerance and the sweep can no longer fail.
+    """
+    module = _load_script_module()
+    monkeypatch.setattr(
+        module.shutil, "which", lambda command: command if command == "tg" else None
+    )
+    monkeypatch.setattr(module, "_ripgrep_available", lambda: True)
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        _make_incomplete_scan_fake_run("regex parse error: unclosed group"),
+    )
+    with pytest.raises(module.ReadinessError) as excinfo:
+        module.validate_public_search_advertised_flag_sweep("", tmp_path, "1.12.28")
+    assert "exit=2" in str(excinfo.value)


### PR DESCRIPTION
Slice **C0** of #276 — and it **gates** slice C.

## Why this comes first

An adversarial review of the #276 plan returned **HOLD** on the exact open question the plan had flagged: *is exit 2 safe?* It is not. The blast radius is **six consumers**, and I verified the three sharpest against the tree myself:

| Consumer | Site | What breaks |
|---|---|---|
| **tg spawns itself** | `rust_core/src/crossover.rs:354` — `bail!` on `!status.success()`, child from `env::current_exe()` | an exit-2 child kills `tg calibrate`, with a **misattributed** cause |
| **`tg dogfood`** (shipped command) | `scripts/agent_readiness.py:348` | ~30 `tg search` invocations; `dogfood.py:429` runs these by default; also the `windows-agent-readiness` CI gate |
| e2e byte-fidelity | `tests/e2e/test_native_json_byte_fidelity.py:100` | asserts `returncode == 0`, CI-gated via `TG_REQUIRE_RG_PARITY=1` |
| benchmarks | `run_gpu_native_benchmarks.py:371`, `run_rg_parity_benchmarks.py:62` | report `FAIL`, not partial |
| MCP | `mcp_server.py:1922` | total loss of results |

Shipping the producer first would have turned an honest partial into a broken `tg calibrate`, a failing `tg dogfood`, and a red matrix. Consumers move first; this PR does the highest-traffic one.

## The design point: allow-list, not `== 2 -> continue`

Exit 2 is **overloaded**. It is what an honest incomplete scan will return once #276 lands — but it is also what a regex syntax error returns. ripgrep's own docs say 2 is *"true for both catastrophic errors ... and soft errors."* A tolerance keyed on the bare exit code would swallow every real error and turn this sweep into a check that **cannot fail**.

So exit 2 is tolerated **only when the run disclosed why** — `result_incomplete` or `incomplete_reason_class` must be present on either stream. No marker, no tolerance. This deliberately mirrors the existing #121 carve-out immediately below it, which is scoped to one label + one precondition + one stderr substring rather than to the code.

## Verification — the red arm was proved, not assumed

```
weakened `_disclosed_incomplete` to `return True`
  -> FAILED on the control: assert not disclosed("", "regex parse error: unclosed group")
restored
  -> passed
```

42/42 in `test_agent_readiness_script.py`. `ruff format --preview` + `ruff check` clean.

Remaining C0 sites (benchmarks, the e2e assertion, `crossover.rs`, MCP) follow in sibling PRs before slice C lands.