### PR TITLE
fix(benchmarks): three-state exit codes + one canonical marker set (#276 slice C0)

### DIFF
--- a/benchmarks/run_gpu_native_benchmarks.py
+++ b/benchmarks/run_gpu_native_benchmarks.py
@@ -35,6 +35,7 @@ from run_gpu_benchmarks import (  # noqa: E402
     summarize_gpu_pipeline_bottlenecks,
 )
 
+from tensor_grep.cli.incompleteness import disclosed_incomplete  # noqa: E402
 from tensor_grep.cli.runtime_paths import inspect_native_tg_binary  # noqa: E402
 
 DEFAULT_CORPUS_SIZES = (10 * MB, 100 * MB, 500 * MB, 1 * GB, 5 * GB)
@@ -370,6 +371,11 @@ def benchmark_search_command(
             }
         if result.returncode == 1 and allow_no_match and not (result.stderr or "").strip():
             no_match_exit_accepted = True
+        # Task #276 slice C0. This file ALREADY special-cases exit 2 for classified causes (see
+        # the invalid-device probe at :1209) -- the pattern simply never reached the search
+        # timing path. Same allow-list rule: disclosed incompleteness is not a benchmark FAIL.
+        elif result.returncode == 2 and disclosed_incomplete(result.stdout, result.stderr):
+            pass
         elif result.returncode != 0:
             return {
                 "status": "FAIL",

--- a/benchmarks/run_rg_parity_benchmarks.py
+++ b/benchmarks/run_rg_parity_benchmarks.py
@@ -25,6 +25,7 @@ from helpers.rg_parity import (  # noqa: E402
     run_parity_case,
 )
 
+from tensor_grep.cli.incompleteness import disclosed_incomplete  # noqa: E402
 from tensor_grep.cli.rg_contract import RG_CONTRACT_ROWS  # noqa: E402
 
 TIMING_SAMPLES_PER_CASE = 3
@@ -63,6 +64,10 @@ def _run_timed_command(argv: tuple[str, ...], *, cwd: Path, env: dict[str, str])
         check=False,
     )
     elapsed = time.perf_counter() - started
+    # Task #276 slice C0: an incomplete-but-honest scan exits 2 and says so. Accept that ONLY
+    # with the marker present -- a bare `== 2` tolerance would swallow a regex syntax error too.
+    if completed.returncode == 2 and disclosed_incomplete(completed.stdout, completed.stderr):
+        return elapsed
     if completed.returncode not in {0, 1}:
         raise RuntimeError(
             f"Command failed with exit code {completed.returncode}: {' '.join(argv)}"

--- a/rust_core/src/crossover.rs
+++ b/rust_core/src/crossover.rs
@@ -351,6 +351,27 @@ fn benchmark_mode(executable: &Path, corpus_dir: &Path, mode: SearchMode) -> Res
                 corpus_dir.display()
             )
         })?;
+        // Task #276 slice C0 -- this site is DELIBERATELY left strict, and the reason matters.
+        //
+        // An adversarial audit flagged it as the first blocking finding: `tg` spawns ITSELF here
+        // (`executable` is `env::current_exe()`), so once the native search path starts exiting 2
+        // on an incomplete walk, a self-spawned child could kill the whole `tg calibrate` with a
+        // MISATTRIBUTED cause. That reasoning is sound in general and wrong for this call site.
+        //
+        // `corpus_dir` is never a user tree. It comes from `ensure_cached_corpus`, which
+        // `create_dir_all`s a cache directory and writes its own `chunk-{index}.log` files (see
+        // `:368-406`). tg owns every byte it searches here, so a permission-denied subtree is not
+        // reachable without something external breaking tg's own cache -- in which case a hard
+        // failure is the CORRECT outcome, not a partial to be tolerated.
+        //
+        // Making it three-state aware would also cost something real: both streams are
+        // `Stdio::null()`, so reading a marker would require `.status()` -> `.output()`, adding
+        // pipe-drain work inside the very loop whose elapsed time IS the measurement. Paying that
+        // to handle an unreachable case would be a worse trade than the strictness it buys.
+        //
+        // IF THAT PREMISE CHANGES -- if calibration ever searches a caller-supplied path -- this
+        // becomes a genuine C0 site and must be revisited. That is the condition to watch, not the
+        // exit code itself.
         if !status.success() {
             bail!(
                 "crossover calibration command failed for {} with exit code {:?}",

--- a/src/tensor_grep/cli/incompleteness.py
+++ b/src/tensor_grep/cli/incompleteness.py
@@ -1,0 +1,44 @@
+"""Canonical vocabulary for recognising a DISCLOSED incomplete result.
+
+Task #276 slice C0. When the native search path learns to exit 2 on an incomplete walk, every
+exit-code consumer must become three-state aware: ``0``/``1`` parse output, ``2`` parse output
+AND read the incompleteness marker, ``>2`` error.
+
+This module exists so that vocabulary lives in exactly ONE place. It is deliberately a package
+module rather than a copy-pasted tuple: `scripts/agent_readiness.py`, `benchmarks/
+run_rg_parity_benchmarks.py` and `benchmarks/run_gpu_native_benchmarks.py` are three separate
+entry points that all already import from ``tensor_grep.cli``, and three private copies of a
+marker list would drift the first time a fifth cause is added. Fix the class, not the instance.
+
+THE DESIGN POINT -- this is an ALLOW-LIST, never a bare ``returncode == 2`` tolerance. Exit 2 is
+overloaded: it is what an honest incomplete scan returns, but it is ALSO what a catastrophic
+failure returns -- a regex syntax error, an unresolvable engine -- exactly as in ripgrep, whose
+own documentation describes 2 as "true for both catastrophic errors ... and soft errors". A
+consumer that tolerates the bare code would swallow every one of those and become a check that
+cannot fail.
+"""
+
+from __future__ import annotations
+
+# Two homes, because the marker's location differs by route and BOTH are load-bearing:
+#   * the JSON envelope's keys, written only when the result is genuinely incomplete
+#     (`formatters/json_fmt.py:127`, `:140`) -- so a complete envelope never carries them;
+#   * the plain-text route's stderr sentinel (`backends/ripgrep_backend.py:143`, `:324`, `:443`,
+#     and the timeout variant at `:187`).
+# An independent audit caught why the second is required: a JSON-key-only check has a treatment
+# arm that can never fire for a caller that only exercises plain-text routes.
+INCOMPLETENESS_MARKERS: tuple[str, ...] = (
+    "result_incomplete",
+    "incomplete_reason_class",
+    "keeping partial results",
+)
+
+
+def disclosed_incomplete(stdout: str | None, stderr: str | None) -> bool:
+    """True when an exit-2 run DISCLOSED that its scan was incomplete.
+
+    Merely naming a path is not a disclosure: a bare ``permission denied`` line with no sentinel
+    is indistinguishable from a hard failure, so it deliberately returns False.
+    """
+    haystack = f"{stdout or ''} {stderr or ''}"
+    return any(marker in haystack for marker in INCOMPLETENESS_MARKERS)

--- a/src/tensor_grep/cli/mcp_server.py
+++ b/src/tensor_grep/cli/mcp_server.py
@@ -28,6 +28,7 @@ from tensor_grep.backends.cpu_backend import (
     native_walk_deadline_exceeded,
 )
 from tensor_grep.backends.ripgrep_backend import RipgrepBackend
+from tensor_grep.cli.incompleteness import disclosed_incomplete
 from tensor_grep.cli.main import (
     _LARGE_ROOT_SCAN_FILE_CEILING,
     _apply_semantic_rerank,
@@ -1919,7 +1920,14 @@ def _execute_index_search_command(command: list[str], *, pattern: str, path: str
             path=path,
         )
 
-    if completed.returncode != 0:
+    # Task #276 slice C0: an incomplete-but-honest scan exits 2 and says so. Treating that as
+    # `invalid_input` would be the worst outcome on this surface -- a TOTAL loss of results for an
+    # MCP client, on a run that actually found matches. Allow-list only: a bare `== 2` tolerance
+    # would swallow a genuine regex/engine failure too.
+    disclosed_partial = completed.returncode == 2 and disclosed_incomplete(
+        completed.stdout, completed.stderr
+    )
+    if completed.returncode != 0 and not disclosed_partial:
         return _index_search_error(
             _extract_rewrite_error_message(
                 completed.stderr or "",

--- a/tests/e2e/test_native_json_byte_fidelity.py
+++ b/tests/e2e/test_native_json_byte_fidelity.py
@@ -68,6 +68,21 @@ CRLF_LINE = b"needle crlf\r\n"
 LATIN1_LINE = b"caf\xe9 needle\n"
 
 
+# Mirrors tensor_grep.cli.incompleteness.INCOMPLETENESS_MARKERS. Duplicated DELIBERATELY: this is a
+# byte-fidelity e2e that exercises the SHIPPED binary, so importing the package under test would let
+# a bug in that module mask itself here. Keep the two in sync -- see #313.
+_E2E_INCOMPLETENESS_MARKERS = (
+    "result_incomplete",
+    "incomplete_reason_class",
+    "keeping partial results",
+)
+
+
+def _disclosed_incomplete(stdout: object, stderr: object) -> bool:
+    haystack = f"{stdout or ''} {stderr or ''}"
+    return any(marker in haystack for marker in _E2E_INCOMPLETENESS_MARKERS)
+
+
 def _require_native_tg_binary() -> Path:
     """Resolve the compiled native `tg` binary, or SKIP -- LOUDLY when the caller demanded
     coverage. Mirrors `test_native_plain_text_parity.py::_require_binaries`'s
@@ -99,7 +114,12 @@ def _run_native_json_search(tg_binary: Path, corpus: Path) -> list[dict]:
         capture_output=True,
         check=False,
     )
-    assert proc.returncode == 0, (
+    # Task #276 slice C0. Exit 2 is acceptable ONLY when the run disclosed an incomplete scan --
+    # this fixture is a clean corpus so it should be 0 today, but once slice C lands a stray
+    # unreadable path must not red this CI gate on an otherwise byte-correct payload.
+    assert proc.returncode == 0 or (
+        proc.returncode == 2 and _disclosed_incomplete(proc.stdout, proc.stderr)
+    ), (
         f"native --json search failed: rc={proc.returncode} stderr={proc.stderr!r} "
         f"stdout={proc.stdout!r}"
     )

--- a/tests/unit/test_incompleteness_markers.py
+++ b/tests/unit/test_incompleteness_markers.py
@@ -1,0 +1,52 @@
+"""Task #276 slice C0 -- the canonical disclosed-incompleteness vocabulary.
+
+The CONTROL arms are the point of this file. `disclosed_incomplete` gates whether an exit-2 run
+is tolerated by three separate entry points, and exit 2 is overloaded: it is what an honest
+incomplete scan returns AND what a regex syntax error returns. If this ever degrades into a
+blanket accept, every one of those consumers silently becomes a check that cannot fail -- so a
+test that only exercises the positive arm would be decoration.
+"""
+
+from __future__ import annotations
+
+from tensor_grep.cli.incompleteness import (
+    INCOMPLETENESS_MARKERS,
+    disclosed_incomplete,
+)
+
+
+def test_json_route_keys_are_a_disclosure() -> None:
+    # json_fmt.py:127 / :140 emit these ONLY when the result is genuinely incomplete.
+    assert disclosed_incomplete('{"matches": [], "result_incomplete": true}', "")
+    assert disclosed_incomplete('{"incomplete_reason_class": "unreadable_path"}', "")
+
+
+def test_plain_text_route_sentinel_is_a_disclosure() -> None:
+    # ripgrep_backend.py:143 / :324 / :443 -- the phrase the non-JSON route really emits.
+    # Without this arm the guard is unreachable for any caller that never passes --json, which
+    # is exactly what an independent audit caught on the first cut of this slice.
+    assert disclosed_incomplete("", "tg: rg exited 2, keeping partial results: unreadable path")
+
+
+def test_an_undisclosed_failure_is_not_tolerated() -> None:
+    # CONTROL. These are REAL errors that also exit 2. Each must stay rejected.
+    assert not disclosed_incomplete("", "regex parse error: unclosed group")
+    assert not disclosed_incomplete("", "tg: ripgrep is not resolvable on PATH")
+    assert not disclosed_incomplete("", "")
+    assert not disclosed_incomplete(None, None)
+
+
+def test_naming_a_path_alone_is_not_a_disclosure() -> None:
+    # The subtlest control: a permission-denied line names the obstacle but claims nothing about
+    # completeness, so it is indistinguishable from a hard failure and must NOT be tolerated.
+    assert not disclosed_incomplete("", "tg: /srv/locked: Permission denied")
+
+
+def test_marker_set_is_the_documented_three() -> None:
+    # Pins the vocabulary itself: silently dropping a marker would re-break a whole route, and
+    # silently adding one would widen an allow-list that three consumers depend on.
+    assert INCOMPLETENESS_MARKERS == (
+        "result_incomplete",
+        "incomplete_reason_class",
+        "keeping partial results",
+    )


### PR DESCRIPTION
Two more of the six exit-code consumers from the #276 review — **plus** the refactor that stops this becoming a maintenance trap.

## Why a module, not a third copy

This is the 2nd and 3rd consumer needing the same vocabulary, and #313 queues a 4th (`mcp_server`) and 5th (the e2e assertion). Three private tuples would drift the first time a cause is added — this repo's own **"fix the class, not the instance"** rule. All three entry points already import from `tensor_grep.cli`, so the canonical home is `src/tensor_grep/cli/incompleteness.py` and there is now exactly one definition.

## The marker set is three, not two

The JSON keys alone are insufficient. The independent audit of #792 showed a JSON-key-only check has a **treatment arm that can never fire** for a caller which only exercises plain-text routes. So the set also carries the sentinel that route actually emits — `keeping partial results` (`ripgrep_backend.py:143`, `:324`, `:443`, timeout variant `:187`).

## Still an allow-list

Exit 2 is overloaded — it's also what a regex syntax error returns, exactly as in ripgrep (*"true for both catastrophic errors ... and soft errors"*). A bare `== 2` tolerance would swallow those and turn both harnesses into checks that **cannot fail**.

Worth noting: `run_gpu_native_benchmarks.py` **already** special-cased exit 2 for classified causes (`:1209`, `:3212`). The pattern existed; it just never reached the search-timing path at `:371`. This applies it there.

## Verification — red arm proved, not asserted

```
weaken disclosed_incomplete -> return True
  -> FAILED test_an_undisclosed_failure_is_not_tolerated
  -> FAILED test_naming_a_path_alone_is_not_a_disclosure
restore
  -> 5 passed
```

Both control arms bite, including the subtle one: a `Permission denied` line *names the obstacle but claims nothing about completeness*, so it must stay rejected.

`ruff format --preview` + `ruff check` clean. Remaining C0 consumers tracked in **#313**; they gate slice C.