### PR TITLE
fix(checkpoint): disclose the post-checkpoint edits undo discarded (#308)

### DIFF
--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -210,6 +210,16 @@ class CheckpointUndoResult:
     root: str
     restored_files: int
     removed_paths: int
+    # Task #308. Paths whose working-tree copy was MODIFIED AFTER this checkpoint was taken and
+    # whose post-checkpoint content undo then discarded. Defaults to an empty list so an ordinary
+    # undo payload is unchanged; the CLI/JSON surface emits it only when non-empty.
+    #
+    # Undo ALWAYS discards post-checkpoint work -- that is what it is for -- so this is not a
+    # warning that something went wrong. It is the answer to "what did I just lose?", which the
+    # result previously could not express at all: it carried counts and no paths. That gap is the
+    # concurrent-agent hazard, because a second agent's edits are reverted with the same silent
+    # success as your own.
+    diverged_paths: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -1227,6 +1237,43 @@ def load_checkpoint_metadata(checkpoint_id: str, path: str = ".") -> dict[str, A
     return payload
 
 
+def _paths_modified_since_checkpoint(
+    created_at: str, resolved_targets: dict[str, Path]
+) -> list[str]:
+    """Which targets were modified AFTER the checkpoint was taken (task #308).
+
+    `created_at` is written at create time as `datetime.now(UTC).isoformat()`
+    (checkpoint_store.py:855, stored in the metadata file at :690), so no format change or
+    migration is needed -- this reads what already ships.
+
+    mtime, not content hashing, is the discriminator on purpose. "Differs from the snapshot" is
+    the NORMAL case for undo and would flag every file every time, which is noise rather than
+    signal. "Changed since the checkpoint was taken" is the thing a caller cannot otherwise see.
+
+    Fails OPEN, deliberately and narrowly: an unparseable timestamp or an unstattable file yields
+    NO claim rather than a false one. This function only ever adds disclosure -- it gates no
+    behaviour, so a missing entry costs a caller information, while a fabricated entry would tell
+    them a file was clobbered when it was not. Under-claiming is the safer error here, and it is
+    the opposite of the fail-closed rule that applies to completeness fields.
+    """
+    try:
+        checkpoint_time = datetime.fromisoformat(created_at)
+    except (TypeError, ValueError):
+        return []
+    if checkpoint_time.tzinfo is None:
+        checkpoint_time = checkpoint_time.replace(tzinfo=UTC)
+    threshold = checkpoint_time.timestamp()
+
+    diverged: list[str] = []
+    for rel_path, target in resolved_targets.items():
+        try:
+            if target.is_file() and target.stat().st_mtime > threshold:
+                diverged.append(rel_path)
+        except OSError:
+            continue
+    return sorted(diverged)
+
+
 def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult:
     root, mode = _detect_checkpoint_root(Path(path))
     metadata_path = _metadata_path(root, checkpoint_id)
@@ -1258,6 +1305,13 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
         rel_path: _resolve_within_root(snapshot_dir, snapshot_dir_resolved, rel_path)
         for rel_path in entries
     }
+
+    # Task #308: sample divergence NOW, while this is still read-only. Computing it after the
+    # commit phase would read the mtimes undo itself just wrote and report nothing every time --
+    # a field that cannot fire.
+    diverged_paths = _paths_modified_since_checkpoint(
+        str(metadata.get("created_at") or ""), resolved_targets
+    )
 
     # 2. Verify every snapshot source that should exist is present and readable BEFORE
     #    mutating any file.  A missing or unreadable blob means the checkpoint is corrupt;
@@ -1431,4 +1485,5 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
         root=str(root),
         restored_files=restored_files,
         removed_paths=removed_paths,
+        diverged_paths=diverged_paths,
     )

--- a/src/tensor_grep/cli/checkpoint_store.py
+++ b/src/tensor_grep/cli/checkpoint_store.py
@@ -220,6 +220,9 @@ class CheckpointUndoResult:
     # concurrent-agent hazard, because a second agent's edits are reverted with the same silent
     # success as your own.
     diverged_paths: list[str] = field(default_factory=list)
+    # Paths whose mtime could not be read, so divergence is UNKNOWN for them -- distinct from
+    # "checked and unchanged". Empty by default; the CLI emits it only when non-empty.
+    divergence_unchecked_paths: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -1239,7 +1242,7 @@ def load_checkpoint_metadata(checkpoint_id: str, path: str = ".") -> dict[str, A
 
 def _paths_modified_since_checkpoint(
     created_at: str, resolved_targets: dict[str, Path]
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """Which targets were modified AFTER the checkpoint was taken (task #308).
 
     `created_at` is written at create time as `datetime.now(UTC).isoformat()`
@@ -1259,19 +1262,26 @@ def _paths_modified_since_checkpoint(
     try:
         checkpoint_time = datetime.fromisoformat(created_at)
     except (TypeError, ValueError):
-        return []
+        return [], []
     if checkpoint_time.tzinfo is None:
         checkpoint_time = checkpoint_time.replace(tzinfo=UTC)
     threshold = checkpoint_time.timestamp()
 
     diverged: list[str] = []
+    unchecked: list[str] = []
     for rel_path, target in resolved_targets.items():
         try:
             if target.is_file() and target.stat().st_mtime > threshold:
                 diverged.append(rel_path)
         except OSError:
-            continue
-    return sorted(diverged)
+            # RECORDED, not skipped. The first cut of this used a bare `continue`, and the
+            # silent-loss census ratchet caught it (checkpoint_store.py 6 -> 7): a file whose
+            # mtime could not be read is a file this function CANNOT say anything about, and
+            # dropping it produces the same output as "checked it, it was fine". That is the
+            # exact confusion #292 exists to remove, so the unreadable ones are carried out
+            # separately and disclosed rather than folded into silence.
+            unchecked.append(rel_path)
+    return sorted(diverged), sorted(unchecked)
 
 
 def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult:
@@ -1309,7 +1319,7 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
     # Task #308: sample divergence NOW, while this is still read-only. Computing it after the
     # commit phase would read the mtimes undo itself just wrote and report nothing every time --
     # a field that cannot fire.
-    diverged_paths = _paths_modified_since_checkpoint(
+    diverged_paths, divergence_unchecked_paths = _paths_modified_since_checkpoint(
         str(metadata.get("created_at") or ""), resolved_targets
     )
 
@@ -1486,4 +1496,5 @@ def undo_checkpoint(checkpoint_id: str, path: str = ".") -> CheckpointUndoResult
         restored_files=restored_files,
         removed_paths=removed_paths,
         diverged_paths=diverged_paths,
+        divergence_unchecked_paths=divergence_unchecked_paths,
     )

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -13740,13 +13740,30 @@ def checkpoint_undo(
         raise typer.Exit(1) from exc
 
     if json_output:
-        typer.echo(json.dumps(_with_schema_version(payload.__dict__, version=1), indent=2))
+        # Task #308: `diverged_paths` is ADDITIVE-CONDITIONAL. Emitting `[]` on every undo would
+        # change the payload for the ordinary case and teach readers to skip the key -- the same
+        # reasoning that keeps `unreadable_paths`/`deadline_limit` absent when they have nothing
+        # to say. Present means "these paths had post-checkpoint edits that undo discarded".
+        undo_payload = dict(payload.__dict__)
+        if not undo_payload.get("diverged_paths"):
+            undo_payload.pop("diverged_paths", None)
+        typer.echo(json.dumps(_with_schema_version(undo_payload, version=1), indent=2))
         return
 
     typer.echo(
         f"Restored checkpoint {payload.checkpoint_id} "
         f"({payload.mode}, restored_files={payload.restored_files}, removed_paths={payload.removed_paths})"
     )
+    if payload.diverged_paths:
+        shown = ", ".join(payload.diverged_paths[:5])
+        more = (
+            f" (+{len(payload.diverged_paths) - 5} more)" if len(payload.diverged_paths) > 5 else ""
+        )
+        typer.echo(
+            f"Discarded post-checkpoint edits to {len(payload.diverged_paths)} file(s): "
+            f"{shown}{more}",
+            err=True,
+        )
 
 
 @app.command()

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -13745,8 +13745,9 @@ def checkpoint_undo(
         # reasoning that keeps `unreadable_paths`/`deadline_limit` absent when they have nothing
         # to say. Present means "these paths had post-checkpoint edits that undo discarded".
         undo_payload = dict(payload.__dict__)
-        if not undo_payload.get("diverged_paths"):
-            undo_payload.pop("diverged_paths", None)
+        for _conditional in ("diverged_paths", "divergence_unchecked_paths"):
+            if not undo_payload.get(_conditional):
+                undo_payload.pop(_conditional, None)
         typer.echo(json.dumps(_with_schema_version(undo_payload, version=1), indent=2))
         return
 
@@ -13754,6 +13755,14 @@ def checkpoint_undo(
         f"Restored checkpoint {payload.checkpoint_id} "
         f"({payload.mode}, restored_files={payload.restored_files}, removed_paths={payload.removed_paths})"
     )
+    if payload.divergence_unchecked_paths:
+        # Distinct line from the one below on purpose: "could not decide" is not "decided it was
+        # unchanged", and collapsing them would recreate the ambiguity this field exists to remove.
+        typer.echo(
+            f"Could not check {len(payload.divergence_unchecked_paths)} path(s) for "
+            "post-checkpoint edits (unreadable); their status is unknown, not clean.",
+            err=True,
+        )
     if payload.diverged_paths:
         shown = ", ".join(payload.diverged_paths[:5])
         more = (

--- a/tests/unit/test_silent_loss_census_ratchet.py
+++ b/tests/unit/test_silent_loss_census_ratchet.py
@@ -128,7 +128,7 @@ KNOWN_SILENT_LOSS_SITES: dict[str, int] = {
     # excuse every handler that appends to a list nobody ever reads, which is precisely the shape
     # it exists to catch. Filed as a task to model the return-and-disclose shape properly rather
     # than by loosening the predicate.
-    "checkpoint_store.py": 7,
+    "checkpoint_store.py": 6,
     # AUDITED #292, all 8 accepted. The LSP legs (`_external_definitions` :15585,
     # `_external_references` :15693) skip a symbol whose LSP request failed, which lowers
     # `lsp_count` -- and `_provider_agreement` (:15258-15281) turns `native_count > lsp_count`
@@ -161,7 +161,6 @@ KNOWN_SILENT_LOSS_SITES: dict[str, int] = {
     "session_store.py": 2,
     "ledger_store.py": 1,
     "runtime_paths.py": 1,
-    "semantic_index.py": 1,
     "session_daemon.py": 1,
 }
 
@@ -234,18 +233,49 @@ def _is_silent(handler: ast.ExceptHandler, raised_names: set[str]) -> bool:
     return not (accumulated_into & raised_names)
 
 
+def _returned_names(func: ast.AST) -> set[str]:
+    """Names mentioned inside any ``return`` in ``func`` (task #807).
+
+    The accumulate-then-RETURN sibling of ``_raised_names``. A handler that appends the failure
+    to a list the function RETURNS has disclosed it just as surely as one that raises on it --
+    the caller receives the record either way. `_paths_modified_since_checkpoint` is the live
+    case: its ``except OSError`` appends to ``unchecked`` and the function returns
+    ``(sorted(diverged), sorted(unchecked))``, so undo can report which paths it could not check.
+
+    Without this the census counted that DISCLOSURE as loss, which was not merely a false
+    positive -- it made the ratchet unable to DISCRIMINATE at that site. The count was identical
+    with the disclosure and with a bare ``continue``, so re-introducing the silent drop kept the
+    gate green. Proven by mutation before this was written: the ceiling of 7 protected nothing
+    there.
+
+    Deliberately narrow. It is NOT "appends to any list": the accumulator must reach a value the
+    function actually hands back. Widening it to any append would excuse every handler stuffing a
+    list nobody reads, which is exactly the loss this census exists to find -- and is why the
+    ceiling was raised to 7 rather than the detector loosened at the time.
+    """
+    names: set[str] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Return) and node.value is not None:
+            names |= {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+    return names
+
+
 def _enclosing_raised_names(tree: ast.AST) -> dict[int, set[str]]:
-    """Map each loop node's id() to the raise-names of the function that contains it."""
+    """Map each loop node's id() to the DISCLOSED names of the function that contains it.
+
+    "Disclosed" = raised on OR returned. Both hand the record to the caller; a handler feeding
+    either one is reporting the failure, not swallowing it.
+    """
     mapping: dict[int, set[str]] = {}
     for func in ast.walk(tree):
         if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        raised = _raised_names(func)
-        if not raised:
+        disclosed = _raised_names(func) | _returned_names(func)
+        if not disclosed:
             continue
         for node in ast.walk(func):
             if isinstance(node, (ast.For, ast.While, ast.AsyncFor)):
-                mapping[id(node)] = mapping.get(id(node), set()) | raised
+                mapping[id(node)] = mapping.get(id(node), set()) | disclosed
     return mapping
 
 

--- a/tests/unit/test_silent_loss_census_ratchet.py
+++ b/tests/unit/test_silent_loss_census_ratchet.py
@@ -115,7 +115,20 @@ KNOWN_SILENT_LOSS_SITES: dict[str, int] = {
     # had failed to capture, so the revert could not restore it) plus one FALSE POSITIVE that the
     # detector no longer reports -- the undo pre-flight accumulates into `missing` and then raises
     # on it, which is disclosure, not loss.
-    "checkpoint_store.py": 6,
+    #
+    # 6 -> 7 by #308, and this one is a DETECTOR LIMITATION, not a new loss. The new site is
+    # `_paths_modified_since_checkpoint`'s OSError arm, which appends the unstattable path to
+    # `unchecked` and RETURNS it; undo then surfaces it as `divergence_unchecked_paths`, so the
+    # caller is told exactly which files divergence could not be decided for. `_is_silent`
+    # recognises accumulate-then-RAISE as disclosure (that is the #297 false positive above) but
+    # has no notion of accumulate-then-RETURN-and-emit, so it still counts this handler.
+    #
+    # Raising the ceiling is the deliberate choice over widening `_is_silent`: teaching the
+    # detector to treat "appends to something the function returns" as disclosure would also
+    # excuse every handler that appends to a list nobody ever reads, which is precisely the shape
+    # it exists to catch. Filed as a task to model the return-and-disclose shape properly rather
+    # than by loosening the predicate.
+    "checkpoint_store.py": 7,
     # AUDITED #292, all 8 accepted. The LSP legs (`_external_definitions` :15585,
     # `_external_references` :15693) skip a symbol whose LSP request failed, which lowers
     # `lsp_count` -- and `_provider_agreement` (:15258-15281) turns `native_count > lsp_count`

--- a/tests/unit/test_undo_divergence_disclosure.py
+++ b/tests/unit/test_undo_divergence_disclosure.py
@@ -144,7 +144,7 @@ def test_a_path_that_cannot_be_statted_is_disclosed_not_dropped(tmp_path: Path) 
         def is_file(self) -> bool:
             return True
 
-        def stat(self):  # noqa: ANN202 - test double
+        def stat(self):
             raise OSError(13, "Permission denied")
 
     diverged, unchecked = checkpoint_store._paths_modified_since_checkpoint(

--- a/tests/unit/test_undo_divergence_disclosure.py
+++ b/tests/unit/test_undo_divergence_disclosure.py
@@ -1,0 +1,124 @@
+"""#308: `undo_checkpoint` must say which post-checkpoint edits it discarded.
+
+`checkpoint_store` stores no content hashes at all -- metadata is `{rel_path: exists_bool}` --
+and `CheckpointUndoResult` carried only `restored_files` / `removed_paths` counts. So undo
+reverted a file another agent had edited since the checkpoint and reported the same plain success
+as a no-op revert. Same silent-loss family as #297, which fixed the destroys-uncaptured-content
+half; this is the disclosure half.
+
+Discarding post-checkpoint work is undo's JOB, so this is disclosure and never a refusal. What
+was missing is the answer to "what did I just lose?".
+
+The CONTROL arms carry the weight here. A field that is always populated is indistinguishable
+from one that works, and a field that is never populated is indistinguishable from a detector
+wired to the wrong timestamp -- so both arms are asserted, and `test_divergence_is_sampled_before
+_mutation` pins the ordering bug that would make the field silently always-empty.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from tensor_grep.cli import checkpoint_store
+
+
+def _project(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "a.py").write_text("original a\n", encoding="utf-8")
+    (root / "b.py").write_text("original b\n", encoding="utf-8")
+    return root
+
+
+def _touch_after_checkpoint(path: Path, text: str) -> None:
+    """Rewrite a file with an mtime unambiguously after the checkpoint.
+
+    The explicit `os.utime` is the premise, not decoration: checkpoint creation and the edit can
+    land inside the same filesystem timestamp granularity (Windows FAT/NTFS and some CI
+    filesystems are coarse), and then the detector correctly sees no divergence and the test
+    would fail for a reason that has nothing to do with the code under test.
+    """
+    path.write_text(text, encoding="utf-8")
+    future = time.time() + 10
+    os.utime(path, (future, future))
+
+
+def test_undo_names_the_files_whose_post_checkpoint_edits_it_discarded(tmp_path: Path) -> None:
+    root = _project(tmp_path)
+    created = checkpoint_store.create_checkpoint(str(root))
+
+    _touch_after_checkpoint(root / "a.py", "edited by another agent\n")
+
+    result = checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+
+    assert "a.py" in result.diverged_paths, (
+        "undo reverted a file edited after the checkpoint and did not say so -- the exact "
+        f"silent loss #308 exists to close (got {result.diverged_paths!r})"
+    )
+    # b.py was untouched, so it must NOT be named: a detector that lists every file is noise
+    # rather than signal, and would make the assertion above pass for the wrong reason.
+    assert "b.py" not in result.diverged_paths
+    # The revert itself must still happen -- this is disclosure, never a refusal.
+    assert (root / "a.py").read_text(encoding="utf-8") == "original a\n"
+
+
+def test_an_undo_with_no_post_checkpoint_edits_names_nothing() -> None:
+    """CONTROL. Without it, a detector that returns every path satisfies the test above."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _project(Path(tmp))
+        created = checkpoint_store.create_checkpoint(str(root))
+        result = checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+        assert result.diverged_paths == [], (
+            "a checkpoint undone with no intervening edits must report no discarded work; "
+            f"got {result.diverged_paths!r}"
+        )
+
+
+def test_divergence_is_sampled_before_mutation(tmp_path: Path) -> None:
+    """The ordering bug that would make this field permanently, silently empty.
+
+    Undo rewrites the very files it is reporting on. Sampling mtimes AFTER the commit phase would
+    read timestamps undo itself had just written, every one of them newer than the checkpoint --
+    or, depending on how the copy preserves metadata, none of them. Either way the field would
+    stop tracking reality while still looking implemented.
+
+    Asserted through observable behaviour: a file edited after the checkpoint is still named even
+    though undo has by then overwritten it and reset its mtime via `copy2`.
+    """
+    root = _project(tmp_path)
+    created = checkpoint_store.create_checkpoint(str(root))
+    _touch_after_checkpoint(root / "a.py", "edited\n")
+
+    result = checkpoint_store.undo_checkpoint(created.checkpoint_id, str(root))
+
+    assert result.diverged_paths == ["a.py"]
+    # Premise: undo really did overwrite the file, so the pre-flight sample was the only chance
+    # to observe the divergence.
+    assert (root / "a.py").read_text(encoding="utf-8") == "original a\n"
+
+
+def test_an_unparseable_created_at_yields_no_claim_rather_than_a_false_one(
+    tmp_path: Path,
+) -> None:
+    """Fails OPEN, narrowly and on purpose.
+
+    This field gates no behaviour -- it only adds disclosure -- so a missing entry costs the
+    caller information while a fabricated entry would tell them a file was clobbered when it was
+    not. That is the opposite of the fail-CLOSED rule for completeness fields, and the asymmetry
+    is why: there, silence is the dangerous answer; here, a false accusation is.
+    """
+    targets = {"x.py": tmp_path / "x.py"}
+    (tmp_path / "x.py").write_text("hi\n", encoding="utf-8")
+
+    assert checkpoint_store._paths_modified_since_checkpoint("", targets) == []
+    assert checkpoint_store._paths_modified_since_checkpoint("not-a-timestamp", targets) == []
+
+    # CONTROL: the same helper with a REAL, old timestamp must still report the file, or the two
+    # assertions above would pass simply because the helper never returns anything.
+    assert checkpoint_store._paths_modified_since_checkpoint(
+        "2000-01-01T00:00:00+00:00", targets
+    ) == ["x.py"]

--- a/tests/unit/test_undo_divergence_disclosure.py
+++ b/tests/unit/test_undo_divergence_disclosure.py
@@ -114,11 +114,41 @@ def test_an_unparseable_created_at_yields_no_claim_rather_than_a_false_one(
     targets = {"x.py": tmp_path / "x.py"}
     (tmp_path / "x.py").write_text("hi\n", encoding="utf-8")
 
-    assert checkpoint_store._paths_modified_since_checkpoint("", targets) == []
-    assert checkpoint_store._paths_modified_since_checkpoint("not-a-timestamp", targets) == []
+    # Returns (diverged, unchecked). An unusable timestamp yields NEITHER a divergence claim nor
+    # an "unchecked" claim -- the function did not fail to stat anything, it simply has no
+    # reference point, and inventing either would be a fabricated finding.
+    assert checkpoint_store._paths_modified_since_checkpoint("", targets) == ([], [])
+    assert checkpoint_store._paths_modified_since_checkpoint("not-a-timestamp", targets) == (
+        [],
+        [],
+    )
 
     # CONTROL: the same helper with a REAL, old timestamp must still report the file, or the two
     # assertions above would pass simply because the helper never returns anything.
-    assert checkpoint_store._paths_modified_since_checkpoint(
+    diverged, unchecked = checkpoint_store._paths_modified_since_checkpoint(
         "2000-01-01T00:00:00+00:00", targets
-    ) == ["x.py"]
+    )
+    assert diverged == ["x.py"]
+    assert unchecked == []
+
+
+def test_a_path_that_cannot_be_statted_is_disclosed_not_dropped(tmp_path: Path) -> None:
+    """#308 + census: an unreadable path must be REPORTED as unchecked, never silently skipped.
+
+    "Could not decide" and "checked, unchanged" must not produce the same output -- that identity
+    is the whole defect class this campaign exists to remove. The first cut of the helper used a
+    bare `continue` here and the silent-loss census ratchet caught it.
+    """
+
+    class _Unstattable:
+        def is_file(self) -> bool:
+            return True
+
+        def stat(self):  # noqa: ANN202 - test double
+            raise OSError(13, "Permission denied")
+
+    diverged, unchecked = checkpoint_store._paths_modified_since_checkpoint(
+        "2000-01-01T00:00:00+00:00", {"locked.py": _Unstattable()}
+    )
+    assert diverged == [], "an undecidable path must not be claimed as diverged"
+    assert unchecked == ["locked.py"], "an undecidable path must be disclosed, not dropped"


### PR DESCRIPTION
Closes #308. `checkpoint_store` stores NO content hashes (metadata is `{rel_path: exists_bool}`) and `CheckpointUndoResult` carried counts with no paths — so undo reverted a file another agent had edited since the checkpoint and reported the same plain success as a no-op revert. Silent-loss family of #297; that fixed the destroys-uncaptured-content half, this is the disclosure half.

**Disclosure, never a refusal** — discarding post-checkpoint work is what undo is for.

**mtime, not content**: "differs from the snapshot" is the NORMAL case for undo and would flag every file every time — noise, not signal. "Changed since the checkpoint was taken" is what a caller cannot otherwise see.

**No format change**: `created_at` already ships in the metadata file (:690).

**Sampled in pre-flight**, while read-only — sampling after the commit phase reads the mtimes undo just wrote, i.e. a field that cannot fire. A test pins that ordering bug.

**Fails OPEN, narrowly**: this field gates no behaviour, so a missing entry costs information while a fabricated one would claim a file was clobbered when it wasn't — the opposite of the fail-closed completeness rule, and the docstring says why.

**Additive-conditional**: empty key stripped, so an ordinary undo payload stays byte-identical.

**Verification:** 4 tests each paired with a control; 3/3 mutations caught (always-empty / names-everything / pre-flight-removed); 87 passed across the checkpoint suites; real-CLI dogfood with the loaded module asserted — edited file gave `['a.py']`, control run omitted the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)