### PR TITLE
fix(session): bound the session rebuild with a deadline, on BOTH refresh branches (#304)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -7481,6 +7481,7 @@ def build_repo_map_incremental(
     changeset: dict[str, Any],
     *,
     max_repo_files: int | None = None,
+    deadline_monotonic: float | None = None,
 ) -> dict[str, Any]:
     root = Path(str(previous_map.get("path", "."))).expanduser().resolve()
     if not root.exists():
@@ -7535,13 +7536,33 @@ def build_repo_map_incremental(
     parsed_imports_by_file: dict[str, list[str]] = {}
     parsed_symbols_by_file: dict[str, list[dict[str, Any]]] = {}
 
-    for current_path in sorted(changed_files | (set(current_files_by_path) - previous_paths)):
+    # Task #304: PARSING is bounded here, exactly as `build_repo_map` bounds its own loop -- break
+    # and keep what we have, never raise, never zero the results.
+    #
+    # This builder previously had no `deadline_monotonic` parameter AT ALL while `build_repo_map`
+    # did, so threading a deadline through the session layer would have bounded only the
+    # full-rebuild branch and left THIS one -- the common case for a warm session, and the branch
+    # a refresh takes whenever a changeset exists -- unbounded, while the change looked complete
+    # and the tests looked green. The #284 comment above says the two builders "must not disagree
+    # about whether a scan was complete"; this is that same rule applied to the deadline.
+    #
+    # Unparsed files are NOT dropped from the payload: the assembly loop below falls back to the
+    # PREVIOUS map's imports/symbols for any file this loop did not reach, so a deadline yields a
+    # staler-but-complete map rather than a map with holes in it.
+    deadline_hit = False
+    files_parsed = 0
+    changed_to_parse = sorted(changed_files | (set(current_files_by_path) - previous_paths))
+    for current_path in changed_to_parse:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            deadline_hit = True
+            break
         path_obj = current_files_by_path.get(current_path)
         if path_obj is None:
             continue
         current_imports, current_symbols = _imports_and_symbols_for_path(path_obj)
         parsed_imports_by_file[current_path] = current_imports
         parsed_symbols_by_file[current_path] = current_symbols
+        files_parsed += 1
 
     payload = _envelope(root)
     tests = [str(current) for current in all_files if _is_test_file(current)]
@@ -7588,6 +7609,17 @@ def build_repo_map_incremental(
             "truncation_cause": _cause if _capped else None,
         }
         payload["scan_remediation"] = _SCAN_LIMIT_TRUNCATED_REMEDIATION if _truncated else None
+    # Task #304: same `partial` + `deadline_limit` pair `build_repo_map` emits, and deliberately
+    # the SAME field names -- a consumer cannot tell which builder produced a payload, so a
+    # deadline must look identical from either. Omitted entirely when the parse completed, so a
+    # non-truncated incremental map stays byte-identical to before this parameter existed.
+    if deadline_hit:
+        payload["partial"] = True
+        payload["deadline_limit"] = {
+            "deadline_exceeded": True,
+            "files_scanned": files_parsed,
+            "files_total": len(changed_to_parse),
+        }
     # Task #284: emitted OUTSIDE the `scan_limit` block on purpose, exactly as `build_repo_map`
     # does -- an unreadable path is not a budget cap, and folding it in would give the reader
     # wrong-knob advice ("raise --max-repo-files") for a cause no budget can fix. Omitted

--- a/src/tensor_grep/cli/session_daemon.py
+++ b/src/tensor_grep/cli/session_daemon.py
@@ -31,6 +31,7 @@ from tensor_grep.cli.session_store import (
     _DEFAULT_SESSION_SYMBOL_REPO_MAP_LIMIT,
     _SESSION_SERVE_RESPONSE_CACHE_MAX_BYTES_ENV,
     _SESSION_VERSION,
+    WARM_DAEMON_DEFAULT_DEADLINE_SECONDS,
     _configured_positive_int,
     _ensure_session_not_stale,
     _index_path,
@@ -1933,10 +1934,22 @@ class _SessionDaemonHandler(socketserver.StreamRequestHandler):
                     if not refresh_on_stale:
                         raise
                     load_started_at = monotonic()
+                    # Task #304: bound the staleness-triggered rebuild with the SAME budget the
+                    # warm daemon already applies to `agent`/`orient`/context-render
+                    # (session_store.py:1327, :1349). This was the last unbounded
+                    # `build_repo_map` reachable from a client request: the rebuild ran with no
+                    # time limit, the client gave up at its own 60s, and the cold path then
+                    # anchored a FRESH 60s -- so one stated deadline could be exceeded roughly
+                    # twofold, with the truncation disclosed nowhere.
+                    #
+                    # Reusing the existing constant rather than inventing a second one is the
+                    # point: two independently-chosen daemon budgets would drift, and a reader
+                    # could not tell which one applied to a given request.
                     refresh_session(
                         request_session_id,
                         request_path,
                         payload_cache=server.payload_cache,
+                        deadline_monotonic=(monotonic() + WARM_DAEMON_DEFAULT_DEADLINE_SECONDS),
                     )
                     server.payload_cache.record_refresh()
                     payload, cache_status = _load_payload_with_status_retry(

--- a/src/tensor_grep/cli/session_store.py
+++ b/src/tensor_grep/cli/session_store.py
@@ -729,11 +729,24 @@ def open_session(
     path: str = ".",
     *,
     max_repo_files: int | None = DEFAULT_AGENT_REPO_MAP_LIMIT,
+    deadline_monotonic: float | None = None,
 ) -> SessionOpenResult:
+    """Task #304: `deadline_monotonic` defaults to None, which is exactly today's behaviour.
+
+    It exists because this call and the two in `refresh_session` were the only `build_repo_map`
+    sites in the codebase with no time bound at all, while every symbol command already had one.
+    A daemon serving a stale session therefore rebuilt the whole map unbounded, the client hit its
+    own 60s timeout, and the cold path then anchored a FRESH budget -- so the caller's single
+    stated deadline could be exceeded roughly twofold with no disclosure anywhere.
+    """
     root = _resolve_root(Path(path))
     started_at = monotonic()
     effective_max_repo_files = _effective_session_max_repo_files(max_repo_files)
-    repo_map = build_repo_map(root, max_repo_files=effective_max_repo_files)
+    repo_map = build_repo_map(
+        root,
+        max_repo_files=effective_max_repo_files,
+        deadline_monotonic=deadline_monotonic,
+    )
     built_at = monotonic()
     created_at = datetime.now(UTC).isoformat()
     session_id = _new_session_id(root)
@@ -809,6 +822,7 @@ def refresh_session(
     *,
     max_repo_files: int | None = None,
     payload_cache: _SessionServeCache | None = None,
+    deadline_monotonic: float | None = None,
 ) -> SessionRefreshResult:
     # Fix A / Guard 3: this is the single choke point every refresh path funnels through -- the
     # explicit `tg session refresh` CLI/MCP command, and the daemon's refresh_on_stale recovery
@@ -831,6 +845,7 @@ def refresh_session(
                 cast(dict[str, Any], existing["repo_map"]),
                 changeset,
                 max_repo_files=effective_max_repo_files,
+                deadline_monotonic=deadline_monotonic,
             )
             refresh_type = "incremental"
         except Exception as exc:
@@ -839,11 +854,19 @@ def refresh_session(
                 session_id,
                 exc,
             )
-            repo_map = build_repo_map(root, max_repo_files=effective_max_repo_files)
+            repo_map = build_repo_map(
+                root,
+                max_repo_files=effective_max_repo_files,
+                deadline_monotonic=deadline_monotonic,
+            )
             refresh_type = "full"
             refresh_fallback_reason = "incremental_failed"
     else:
-        repo_map = build_repo_map(root, max_repo_files=effective_max_repo_files)
+        repo_map = build_repo_map(
+            root,
+            max_repo_files=effective_max_repo_files,
+            deadline_monotonic=deadline_monotonic,
+        )
         changeset = _empty_changeset()
     refreshed_at = datetime.now(UTC).isoformat()
     created_at = str(existing.get("created_at", refreshed_at))

--- a/tests/unit/test_incremental_refresh.py
+++ b/tests/unit/test_incremental_refresh.py
@@ -330,18 +330,31 @@ def test_refresh_session_uses_incremental_builder_when_changeset_available(
         changeset: dict[str, list[str]],
         *,
         max_repo_files: int | None = None,
+        deadline_monotonic: float | None = None,
     ) -> dict[str, object]:
+        # Task #304: accepted and forwarded. A test double NARROWER than the function it
+        # replaces turns any new keyword into a spurious TypeError -- and here that error
+        # is swallowed by session_store's incremental-failure fallback (session_store.py:852),
+        # so the test would have reported a WRONG refresh_type rather than an obvious crash.
         incremental_calls["count"] += 1
         assert max_repo_files == session_store.DEFAULT_AGENT_REPO_MAP_LIMIT
-        return original_incremental(previous_map, changeset, max_repo_files=max_repo_files)
+        return original_incremental(
+            previous_map,
+            changeset,
+            max_repo_files=max_repo_files,
+            deadline_monotonic=deadline_monotonic,
+        )
 
     def unexpected_full_build(
         path: str | Path = ".",
         *,
         max_repo_files: int | None = None,
+        deadline_monotonic: float | None = None,
     ) -> dict[str, object]:
         full_calls["count"] += 1
-        return repo_map.build_repo_map(path, max_repo_files=max_repo_files)
+        return repo_map.build_repo_map(
+            path, max_repo_files=max_repo_files, deadline_monotonic=deadline_monotonic
+        )
 
     monkeypatch.setattr(session_store, "build_repo_map_incremental", tracking_incremental)
     monkeypatch.setattr(session_store, "build_repo_map", unexpected_full_build)
@@ -370,6 +383,7 @@ def test_refresh_session_falls_back_to_full_rebuild_when_incremental_fails(
         changeset: dict[str, list[str]],
         *,
         max_repo_files: int | None = None,
+        deadline_monotonic: float | None = None,
     ) -> dict[str, object]:
         assert max_repo_files == session_store.DEFAULT_AGENT_REPO_MAP_LIMIT
         raise RuntimeError("boom")
@@ -378,10 +392,13 @@ def test_refresh_session_falls_back_to_full_rebuild_when_incremental_fails(
         path: str | Path = ".",
         *,
         max_repo_files: int | None = None,
+        deadline_monotonic: float | None = None,
     ) -> dict[str, object]:
         full_calls["count"] += 1
         assert max_repo_files == session_store.DEFAULT_AGENT_REPO_MAP_LIMIT
-        return repo_map.build_repo_map(path, max_repo_files=max_repo_files)
+        return repo_map.build_repo_map(
+            path, max_repo_files=max_repo_files, deadline_monotonic=deadline_monotonic
+        )
 
     monkeypatch.setattr(session_store, "build_repo_map_incremental", failing_incremental)
     monkeypatch.setattr(session_store, "build_repo_map", tracking_full_build)

--- a/tests/unit/test_session_daemon_security.py
+++ b/tests/unit/test_session_daemon_security.py
@@ -472,7 +472,17 @@ def test_write_json_atomic_default_mode_unchanged(tmp_path: Path) -> None:
 
 
 def _stub_repo_map(monkeypatch) -> None:
-    def _fake_build_repo_map(root: Path, *, max_repo_files: int | None = None) -> dict[str, Any]:
+    def _fake_build_repo_map(
+        root: Path,
+        *,
+        max_repo_files: int | None = None,
+        deadline_monotonic: float | None = None,
+    ) -> dict[str, Any]:
+        # `deadline_monotonic` is accepted and ignored on purpose (task #304). This double exists
+        # to make payload PRUNING testable without a real repo scan, so it must tolerate the real
+        # `build_repo_map` signature rather than pin a subset of it -- a stub narrower than the
+        # function it replaces turns any new keyword into a spurious TypeError in a test that has
+        # nothing to do with the change.
         return {
             "related_paths": [],
             "files": [],

--- a/tests/unit/test_session_refresh_deadline.py
+++ b/tests/unit/test_session_refresh_deadline.py
@@ -1,0 +1,150 @@
+"""#304: the session rebuild must honour a deadline -- on BOTH refresh branches.
+
+`session_store`'s three `build_repo_map` calls were the only ones in the codebase with no time
+bound, while every symbol command already had one. A daemon serving a stale session rebuilt the
+whole map unbounded, the client gave up at its own 60s, and the cold path then anchored a FRESH
+budget -- so one stated deadline could be exceeded roughly twofold with the truncation disclosed
+nowhere.
+
+THE TRAP THIS FILE EXISTS TO CATCH: `build_repo_map_incremental` had no `deadline_monotonic`
+parameter at all, so threading a deadline through the session layer bounds only the FULL-rebuild
+branch. A refresh takes the INCREMENTAL branch whenever a changeset exists -- the common case for
+a warm session. Testing only the full path would leave the common case unbounded while every test
+passed. Both branches are asserted here for that reason, and each has its own control.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from time import monotonic
+from typing import Any
+
+from tensor_grep.cli.repo_map import build_repo_map, build_repo_map_incremental
+
+
+def _repo(tmp_path: Path, files: int = 12) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    for i in range(files):
+        (root / f"mod{i}.py").write_text(
+            f"def fn{i}():\n    return {i}\n\n\nclass C{i}:\n    pass\n", encoding="utf-8"
+        )
+    return root
+
+
+# --------------------------------------------------------------------------------------------
+# The INCREMENTAL branch -- the one that had no deadline parameter at all
+# --------------------------------------------------------------------------------------------
+
+
+def test_incremental_rebuild_honours_an_exhausted_deadline(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    previous = build_repo_map(root)
+    changeset: dict[str, Any] = {
+        "added": [],
+        "modified": [str(root / f"mod{i}.py") for i in range(12)],
+        "removed": [],
+    }
+
+    # An ALREADY-PAST deadline: the parse loop must break on its first check. Using a past value
+    # rather than a tiny future one keeps this free of wall-clock racing -- there is no duration
+    # to measure and nothing for a loaded runner to perturb.
+    result = build_repo_map_incremental(previous, changeset, deadline_monotonic=monotonic() - 1.0)
+
+    assert result.get("partial") is True, (
+        "an incremental rebuild that ran out of budget must say so; without this the warm-session "
+        "path returns a silently-stale map at exit 0"
+    )
+    assert result["deadline_limit"]["deadline_exceeded"] is True
+    # Same field names the FULL builder emits -- a consumer cannot tell which builder produced a
+    # payload, so a deadline must look identical from either.
+    assert set(result["deadline_limit"]) == {
+        "deadline_exceeded",
+        "files_scanned",
+        "files_total",
+    }
+
+
+def test_incremental_rebuild_with_an_ample_deadline_is_not_marked_partial(
+    tmp_path: Path,
+) -> None:
+    """CONTROL. Without it, a builder that hardcoded `partial=True` passes the test above."""
+    root = _repo(tmp_path)
+    previous = build_repo_map(root)
+    changeset: dict[str, Any] = {
+        "added": [],
+        "modified": [str(root / "mod0.py")],
+        "removed": [],
+    }
+
+    result = build_repo_map_incremental(previous, changeset, deadline_monotonic=monotonic() + 300.0)
+
+    assert "partial" not in result, f"a completed rebuild must not claim partial: {result.keys()}"
+    assert "deadline_limit" not in result
+
+
+def test_incremental_rebuild_without_a_deadline_is_byte_identical_to_before(
+    tmp_path: Path,
+) -> None:
+    """The backward-compatibility arm: `deadline_monotonic=None` must change nothing.
+
+    This is what makes the parameter safe to add to a load-bearing path -- every existing caller
+    passes nothing and must be unaffected. Compared as whole payloads rather than spot-checked
+    keys, so a stray new field would fail here too.
+    """
+    root = _repo(tmp_path)
+    previous = build_repo_map(root)
+    changeset: dict[str, Any] = {
+        "added": [],
+        "modified": [str(root / "mod0.py")],
+        "removed": [],
+    }
+
+    without = build_repo_map_incremental(previous, changeset)
+    explicit_none = build_repo_map_incremental(previous, changeset, deadline_monotonic=None)
+    assert without == explicit_none
+    assert "partial" not in without
+
+
+# --------------------------------------------------------------------------------------------
+# The FULL branch, through the session layer -- proves the thread actually connects
+# --------------------------------------------------------------------------------------------
+
+
+def test_open_session_threads_its_deadline_into_the_repo_map(tmp_path: Path) -> None:
+    """Seam test: the parameter has to REACH `build_repo_map`, not just exist on the signature.
+
+    Asserted through observable output rather than by inspecting the call, because a signature
+    that accepts `deadline_monotonic` and quietly drops it would satisfy any argument-shape check
+    while leaving the defect exactly where it was.
+    """
+    from tensor_grep.cli import session_store
+
+    root = _repo(tmp_path)
+    result = session_store.open_session(str(root), deadline_monotonic=monotonic() - 1.0)
+    repo_map = result.repo_map if hasattr(result, "repo_map") else None
+    if repo_map is None:  # payload-shaped result
+        import json
+
+        payload = json.loads(
+            session_store._session_payload_path(root, result.session_id).read_text(encoding="utf-8")
+        )
+        repo_map = payload["repo_map"]
+    assert repo_map.get("partial") is True, (
+        "open_session's deadline did not reach build_repo_map -- the parameter exists but is "
+        "dropped, which is the defect wearing a fix's clothes"
+    )
+
+
+def test_open_session_without_a_deadline_still_builds_a_complete_map(tmp_path: Path) -> None:
+    """CONTROL for the seam test: the default path must be unchanged and complete."""
+    from tensor_grep.cli import session_store
+
+    root = _repo(tmp_path)
+    result = session_store.open_session(str(root))
+    import json
+
+    payload = json.loads(
+        session_store._session_payload_path(root, result.session_id).read_text(encoding="utf-8")
+    )
+    assert "partial" not in payload["repo_map"]


### PR DESCRIPTION
Closes #304. `session_store`'s three `build_repo_map` calls were the only ones in the codebase with no time bound. A daemon serving a stale session rebuilt unbounded, the client gave up at its own 60s, and the cold path anchored a FRESH budget — one stated deadline exceeded roughly twofold, disclosed nowhere.

**THE TRAP this is shaped around:** `build_repo_map_incremental` had NO `deadline_monotonic` parameter at all. Threading through the session layer alone bounds only the FULL-rebuild branch and leaves the INCREMENTAL one — the common case for a warm session — unbounded, while the change looks complete and tests look green.

- **A.** incremental gains the parameter and bounds its parse loop as the full builder does. Unparsed files are not dropped (assembly falls back to the previous map), so a deadline yields staler-but-complete rather than holes. Same `partial`/`deadline_limit` field names — a consumer can't tell which builder ran, so a deadline must look identical from either.
- **B.** session layer threads all four sites; the daemon passes the same `WARM_DAEMON_DEFAULT_DEADLINE_SECONDS` already used for agent/orient/context-render rather than a second, driftable constant.

Default `None` == today's behaviour; a test compares whole payloads with/without to pin it.

**Verified:** 5 tests (both branches + controls + a seam test proving the param REACHES the builder); 3/3 mutations caught including the trap itself (revert only Part A → RED); 69 passed across session/daemon/incremental suites.

Widened 4 test doubles that were narrower than the functions they replaced — in the incremental case the TypeError was *swallowed* by the fallback at `session_store.py:852`, reporting a wrong refresh_type rather than crashing. Found by a mechanical monkeypatch-target sweep after the first fix left a second failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)