### PR TITLE
fix(test): de-flake large-stdout guard whose clock bound contradicted its own timeout

### DIFF
--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -3840,7 +3840,20 @@ mod tests {
         // process_control's drain-while-timing-out wait), the child would block writing to a
         // full, undrained pipe and this call would hit the timeout and report failure instead of
         // completing quickly -- this is a regression guard, not just a happy-path check.
-        let timeout_ms = 15_000;
+        //
+        // #303: the wall-clock bound below is DERIVED from this timeout rather than being an
+        // independent constant. The two were previously 15s and 10s, which left a 5s window where
+        // a merely-slow runner produced a fully correct result (success + >1MB captured, i.e. the
+        // pipes demonstrably drained) that still failed the clock -- a false red, twice observed
+        // on windows CI. A deadlock cannot land in that window: it exhausts the time limit and
+        // `terminate_for_timeout` kills the child, so `result.success` is false and the FIRST
+        // assertion fires. The clock is therefore not what catches a deadlock; it catches the
+        // weaker "drains, but pathologically slowly" regression (e.g. a hand-rolled poll loop
+        // reading a tiny buffer at a low duty cycle), which is why it is kept rather than deleted.
+        let timeout_ms = 60_000;
+        // Half the timeout: comfortably above any legitimate spawn-plus-2.6MB cost on a loaded
+        // runner, and comfortably below the limit, so the two bounds can never contradict.
+        let slow_drain_bound = Duration::from_millis(timeout_ms / 2);
 
         let started = Instant::now();
         let result = run_validation_command(
@@ -3863,8 +3876,10 @@ mod tests {
             result.stdout.len()
         );
         assert!(
-            elapsed < Duration::from_secs(10),
-            "expected the large-output command to finish well under the timeout (no deadlock), took {elapsed:?}"
+            elapsed < slow_drain_bound,
+            "expected the large-output command to finish well under the {timeout_ms}ms timeout \
+             (drain is pathologically slow, though not deadlocked -- a deadlock would have failed \
+             the success assertion above); took {elapsed:?}, bound {slow_drain_bound:?}"
         );
     }
 


### PR DESCRIPTION
## The defect

`run_validation_command_captures_large_stdout_without_deadlock` set `timeout_ms = 15_000` but asserted `elapsed < Duration::from_secs(10)`.

Those two bounds contradict each other. There is a 5-second window where the command **succeeds**, >1MB of stdout is captured, the pipes demonstrably drained — and the test fails anyway on the clock. Observed twice on windows CI (first nightly, then stable), where spawning PowerShell to write 2.6MB on a loaded runner is legitimately slow.

## Why the clock never guarded what it claimed

The comment cites the pipe-fill deadlock footgun (rust-lang#45572). But a real deadlock **cannot** land in that window:

- the child blocks writing to a full, undrained pipe
- `controlled_with_output` exhausts its time limit
- `terminate_for_timeout` kills the child
- `result.success` is `false` → the **first** assertion fires

So the clock only ever fires where the property under test *holds*. It had no discriminating power against the defect it named — [oracle-family Form 7](../blob/main/AGENTS.md): *a measurement that cannot discriminate measures nothing.*

## Why it is kept, not deleted

It does catch a weaker regression `result.success` cannot see: a drain that works but is **pathologically slow** (e.g. a hand-rolled poll loop reading a tiny buffer at a low duty cycle). That is worth a guard.

The fix makes the bound **derive from the timeout** (`timeout_ms / 2`) so the two can never contradict again, and raises the timeout to 60s so runner slowness is not mistaken for a code defect.

## Production code is untouched and was never at fault

`run_validation_command` already uses `process_control`'s `controlled_with_output`, which drains the pipes *while* timing out. `rust_core/src/main.rs:10458-10463` documents exactly why a hand-rolled `spawn` + `wait_timeout` + `wait_with_output` must not replace it — and cites the same upstream issue. Research confirmed the class is real and documented upstream; our production path is already immune to it.

## Verification

- `rustfmt --check --edition 2021` clean.
- Rust compilation/test is **CI-only** here (CPU-safe policy); the windows leg is the oracle for this change.
- Bidirectional note: this change *widens* an over-tight bound, so it cannot mask a real deadlock — a deadlock still fails `assert!(result.success)` first, which is untouched.

Refs #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
