### PR TITLE
fix(bench): make the trust benchmark actually measure tg (#307)

### DIFF
--- a/docs/plans/2026-07-26-307-trust-benchmark-lead.md
+++ b/docs/plans/2026-07-26-307-trust-benchmark-lead.md
@@ -1,0 +1,189 @@
+# Task 307: Make the Trust Benchmark Measure Where tg Actually Leads
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Citation convention.** Local task-tracker IDs are written `task NNN` with no `#`, because
+> GitHub auto-links bare `#NNN` and this repo's two numbering spaces overlap. Only genuine
+> GitHub issues/PRs keep the `#`.
+
+**Goal:** Resolve task 307 -- "tg ties rg/GNU grep 2/2/0 on the trust benchmark; find the
+disclosure behaviors that would make it genuinely lead" -- by first establishing whether the tie
+reflects tg's behaviour or the benchmark's blind spot, and then closing whichever is real.
+
+**Status: RESEARCH COMPLETE, DESIGN PROPOSED, NOT YET REVIEWED.**
+
+## What the research established
+
+Exa research on ripgrep's machine-readable contract and on the SARIF standard, then verified
+against the real code in this repo.
+
+**Finding 1 -- rg structurally cannot signal incompleteness in its JSON stream.**
+`rg --json` emits exactly five message types: `begin`, `end`, `match`, `context`, `summary`
+(ripgrep `crates/printer/src/json.rs`, and the rg(1) man page). The terminal `summary` message
+carries `elapsed_total` and `stats` and **no incompleteness field**. rg's soft errors -- "unable
+to read a file" -- reach the user only through **stderr plus exit status 2**
+(`doc/rg.1.txt.tpl`: *"`2` exit status occurs when an error occurred. This is true for both
+catastrophic errors ... and for soft errors (e.g., unable to read a file)"*). A consumer parsing
+only rg's JSON stream cannot distinguish "no matches" from "could not finish looking." This is
+not a defect anyone forgot; it is the shape of the format.
+
+**Finding 2 -- a standard already models this, and it is not tg-invented.**
+SARIF v2.1.0 (OASIS Standard, 27 March 2020) defines `invocations[].executionSuccessful`
+(section 3.20.14) and `invocations[].toolExecutionNotifications` (section 3.20.21), and carries
+an entire **"Appendix I. (Informative) Detecting incomplete result sets."** SARIF's own glossary
+defines a *notification* as "reporting item that describes a condition encountered by a tool
+during its execution" -- exactly an unreadable directory.
+
+**Finding 3 -- tg ALREADY conforms, on a branch that has not merged.**
+Verified against `origin/feat-310-sarif` (PR #796), not assumed:
+- `src/tensor_grep/cli/sarif.py:208` -- `invocation: dict[str, Any] = {"executionSuccessful": not is_partial}`
+- `src/tensor_grep/cli/sarif.py:243` -- `invocation["toolExecutionNotifications"] = notifications`
+- `src/tensor_grep/cli/sarif.py:11` -- the module docstring already states the intent:
+  *"Incompleteness is rendered, not dropped."*
+- `src/tensor_grep/cli/main.py:14181` -- maps `unreadable_paths` onto `executionSuccessful`
+- `tests/unit/test_sarif_output.py:119-136` -- asserts BOTH arms: `executionSuccessful is False`
+  on a partial scan and `is True` on a complete one, with the control explicitly labelled
+
+## The reframe this forces
+
+Task 307 was filed as "find the disclosure behaviors that would make tg lead." The research says
+**tg already has one rg structurally lacks.** So the 2/2/0 tie is not a statement about tg's
+behaviour -- it is a statement about what the benchmark looks at.
+
+This is verification-oracle **Form 7**, already canonical in `AGENTS.md`: *a benchmark column
+tied at the FLOOR for every tool measures nothing.* The same session already hit this once, on
+PR #804, where the payload channel scored **0 for every tool including tg**. A column every
+contestant fails is not evidence of parity; it is evidence the column is not wired to anything.
+
+**So the honest resolution of task 307 is not "add disclosure behaviour to tg." It is "the
+benchmark does not measure the channel where tg leads, and the tie is therefore uninformative."**
+
+## The integrity constraint -- read before Task 2
+
+Adding a column that only tg can score is trivially self-serving, and a benchmark I control
+which concludes I win is worth nothing. Two rules keep this honest, and they are the reason
+Task 2 is gated on review rather than written now:
+
+1. **Name the column for the capability, not the winner.** "Standards-conformant machine-readable
+   incompleteness disclosure (SARIF v2.1.0 Appendix I)" is a capability a consumer can want and
+   any tool could implement. "Disclosure honesty" is not -- tg would be scoring itself on its own
+   feature list under a general-sounding name. The existing 2/2/0 column measured stderr + exit
+   code, a channel all three share; it stays, unchanged, and tg's tie on it stays reported.
+2. **Report the tie and the lead side by side, never merged into one headline.** The CEO-facing
+   sentence must remain "tg ties rg and GNU grep on the shared stderr/exit-code channel, and is
+   the only one of the three that emits a standards-conformant machine-readable incompleteness
+   signal." Collapsing that into "tg leads the trust benchmark" would repeat the exact error this
+   task exists to correct -- the earlier "leads 5/5" claim that reproducibility falsified.
+
+## Dependency reality
+
+- SARIF conformance lives on `origin/feat-310-sarif` (PR #796). **PR #796 is currently RED**
+  on the task 303 large-stdout flake, which PR #802 fixes. Order: #802 -> #796 -> this work.
+- The benchmark harness is `scripts/trust_benchmark.py`, extended on PR #804
+  (`fix-307-benchmark-measures-tg`), which is where the payload-channel columns already live.
+- Nothing here needs Rust compiled locally. `scripts/trust_benchmark.py` is Python; SARIF
+  rendering is Python.
+
+---
+
+### Task 1: pin the "rg cannot do this" premise as an executable check -- do FIRST
+
+Before adding any column, prove the premise the whole reframe rests on. If rg *can* signal
+incompleteness in a machine-readable stream and I simply missed the flag, every task below is
+wrong and must be abandoned.
+
+**Files:**
+- Test: `tests/unit/test_trust_benchmark_premise.py` (create)
+
+- [ ] **Step 1: Write the failing test.** Assert that rg's JSON summary event carries no
+      incompleteness field when a directory is unreadable, and that the same run exits 2.
+
+```python
+def test_rg_json_summary_has_no_incompleteness_field(tmp_path: pathlib.Path) -> None:
+    """PREMISE for task 307. If this ever fails, the whole reframe is void -- rg gained a
+    machine-readable incompleteness channel and tg no longer leads on it.
+
+    Skips (never silently passes) when rg is absent or the OS cannot make a directory
+    unreadable -- a probe that cannot create the condition proves nothing.
+    """
+```
+
+- [ ] **Step 2: Run it and confirm it FAILS before the helper exists.**
+      Run: `python -m pytest tests/unit/test_trust_benchmark_premise.py -v`
+      Expected: FAIL (module/helper not defined).
+
+- [ ] **Step 3: Implement the probe.** Build an unreadable directory, run
+      `rg --json PATTERN <dir>`, parse the JSON Lines, locate the `summary` message, assert no
+      key in it means "incomplete". Assert exit status is 2 -- that is the ONLY channel rg has,
+      and asserting it is what makes the test a statement about rg's *design* rather than a
+      complaint about a missing feature.
+
+- [ ] **Step 4: Assert the PREMISE of the premise.** The unreadable directory must actually be
+      unreadable to the test process. On Windows and when running as root this often silently
+      fails; `pytest.skip` with the observed mode rather than passing vacuously. Receipt: this
+      session already had an escape probe read 4/6 instead of 6/6 because two canary paths were
+      absent, and a UID probe under `/root` that reported DENIED for everything and proved
+      nothing.
+
+- [ ] **Step 5: Run to green, then commit.**
+
+```bash
+git add tests/unit/test_trust_benchmark_premise.py
+git commit -m "test(bench): pin the premise that rg has no machine-readable incompleteness channel"
+```
+
+---
+
+### Task 2: add the SARIF disclosure column to the trust benchmark -- GATED ON REVIEW
+
+**Do not start this task until the thinktank review below has returned and the integrity
+constraint above has been explicitly ratified or amended.** The failure mode here is not a bug;
+it is publishing a benchmark that flatters its author, which is worse than the tie it replaces
+and is the specific thing the CEO statement corrected me on once already.
+
+**Files:**
+- Modify: `scripts/trust_benchmark.py` (the payload-channel scoring added on PR #804)
+- Test: `tests/unit/test_trust_benchmark_premise.py` (extend)
+
+Sketch, deliberately not finalised pending review: score each tool on whether an unreadable
+directory produces a machine-readable artifact in which a consumer can detect an incomplete
+result set without parsing prose. tg via `--sarif`. rg and GNU grep score 0 because no such
+output mode exists -- which the column must state as a *capability absence*, not a failure.
+
+- [ ] **Step 1:** Await review verdict. Record it inline in this document, including any
+      dissent, the way the task 276 plan records its own falsified tasks.
+
+---
+
+### Task 3: correct the CEO-facing sentence -- do LAST
+
+**Files:**
+- Modify: `docs/BACKLOG.md`, and whichever enterprise gap table PR #790 refreshed.
+
+- [ ] **Step 1:** Replace "tg ties rg and GNU grep, it doesn't lead" with the two-clause
+      sentence from the integrity constraint -- tie on the shared channel, sole conformance on
+      the machine-readable one -- **only if** Task 2 shipped and its column is reproducible on
+      both Windows and Linux, the same bar that falsified the original "leads 5/5" claim.
+- [ ] **Step 2:** If Task 2 is rejected on review, write the negative instead: the tie stands,
+      the benchmark's blind spot is documented, and task 307 closes as "measurement was the
+      issue, and the honest read is unchanged." A closed negative is a real outcome here.
+
+---
+
+## Self-review
+
+**Spec coverage.** Task 307 asks for "the disclosure behaviors that would make it genuinely
+lead." Tasks 1-3 answer: the behaviour already exists (SARIF, PR #796); the benchmark cannot
+see it; fixing the measurement is the work. Covered.
+
+**Placeholder scan.** Task 2 is deliberately unfinished and says so, with the reason. That is a
+gate, not a placeholder -- the distinction being that a gate names what unblocks it.
+
+**Type consistency.** No new types. `executionSuccessful` is a bool per SARIF 3.20.14 and
+`sarif.py:208` already emits it as one.
+
+**The thing most likely to be wrong.** That SARIF is the right channel to benchmark at all. A
+reviewer should attack this: SARIF is a *static-analysis* interchange format, and `tg search` is
+not a static analysis tool. If the reviewer concludes SARIF conformance is not a fair proxy for
+"trustworthy machine-readable search output," Task 2 dies and Task 3 takes its negative branch.

--- a/scripts/trust_benchmark.py
+++ b/scripts/trust_benchmark.py
@@ -76,8 +76,18 @@ class Result:
 
 def _tools() -> list[ToolSpec]:
     return [
-        ToolSpec("tg", ["tg", "search", SENTINEL, "."]),
+        # NOTE (2026-07-26, #307): plain `tg search` is NOT tg's own engine. bootstrap.py:1497
+        # forwards it to real rg via `_run_rg_passthrough` whenever no compiled native binary
+        # resolves (bootstrap.py:1264-1272) -- the literal `rg: ` prefix in this row's stderr
+        # appears nowhere in our source, while tg's own walk error is `eprintln!("tg: {err}")`
+        # (native_search.rs:1253). This row is kept because it is what a plain user runs, but a
+        # tie between it and the `rg` row below is DEFINITIONAL, not a result. The `tg --json`
+        # rows are the ones that measure tg.
+        ToolSpec("tg (text; forwards to rg)", ["tg", "search", SENTINEL, "."]),
+        ToolSpec("tg --json", ["tg", "search", "--json", SENTINEL, "."]),
+        ToolSpec("tg --ndjson", ["tg", "search", "--ndjson", SENTINEL, "."]),
         ToolSpec("rg", ["rg", SENTINEL, "."]),
+        ToolSpec("rg --json", ["rg", "--json", SENTINEL, "."]),
         ToolSpec("GNU grep", ["grep", "-r", SENTINEL, "."]),
         ToolSpec("git grep", ["git", "grep", SENTINEL], needs_git=True),
         ToolSpec("ast-grep", ["ast-grep", "run", "-p", SENTINEL, "-l", "python", "."]),
@@ -103,8 +113,21 @@ def _run(argv: list[str], cwd: Path) -> tuple[int, str, str]:
     return (proc.returncode, proc.stdout, proc.stderr)
 
 
-def _score(rc: int, _out: str, err: str, unreadable_name: str) -> tuple[int, str]:
-    """Score one run. A non-zero exit OR a message naming the path is an admission."""
+# The machine-readable incompleteness vocabulary a PAYLOAD consumer can branch on. Mirrors
+# tensor_grep.cli.incompleteness.INCOMPLETENESS_MARKERS; duplicated on purpose because this
+# harness must score COMPETING tools by the same rule, and importing the tool under test would
+# make tg's row depend on tg's own module.
+_PAYLOAD_MARKERS = ("result_incomplete", "incomplete_reason_class", '"errors"', "paths")
+
+
+def _score(rc: int, out: str, err: str, unreadable_name: str) -> tuple[int, str]:
+    """Score one run from the PROCESS channel: exit code + stderr.
+
+    This is what a shell or CI consumer sees. It is deliberately NOT the whole story -- see
+    `_score_payload`, which scores what an agent piping stdout into `jq` sees. Keeping them
+    separate is the point: this scorer alone cannot distinguish "told me on stderr" from "told
+    me in the payload", and that distinction is the entire enterprise thesis (#276).
+    """
     named = unreadable_name and unreadable_name in err
     if rc not in (0, 1):
         return (ADMITS, f"exit {rc}" + (" + names path" if named else ""))
@@ -113,6 +136,25 @@ def _score(rc: int, _out: str, err: str, unreadable_name: str) -> tuple[int, str
     if err.strip():
         return (PARTIAL, f"exit {rc}, unattributed stderr: {err.strip()[:60]!r}")
     return (SILENT, f"exit {rc}, no stderr")
+
+
+def _score_payload(_rc: int, out: str, _err: str, unreadable_name: str) -> tuple[int, str]:
+    """Score STDOUT ALONE -- no exit code, no stderr. The agent's-eye view.
+
+    An agent piping `--json` into `jq` never sees an exit code and never sees stderr. If the
+    payload cannot say "this answer is incomplete", that consumer cannot distinguish "no matches"
+    from "I could not finish looking".
+
+    This column DISCRIMINATES ON DAY ONE and it currently scores AGAINST us: `rg --json` admits
+    via exit 2 on the process channel but is SILENT here, and `tg --json` is SILENT on BOTH --
+    i.e. tg is behind, not tied. That is the honest baseline #276 has to move, and recording the
+    deficit before the fix is what will make the eventual win credible rather than post-hoc.
+    """
+    if any(marker in out for marker in _PAYLOAD_MARKERS):
+        return (ADMITS, "stdout carries a machine-readable incompleteness marker")
+    if unreadable_name and unreadable_name in out:
+        return (PARTIAL, "stdout names the path but carries no structured field")
+    return (SILENT, "stdout indistinguishable from a complete result")
 
 
 def _make_tree(root: Path) -> None:
@@ -238,8 +280,16 @@ def run_condition(
                         "found sentinel, exit 0" if found and rc == 0 else f"rc={rc} found={found}",
                     )
                     continue
+                # TWO channels, deliberately. `_score` is what a shell/CI consumer sees (exit
+                # code + stderr); `_score_payload` is what an agent piping stdout into `jq` sees.
+                # Reporting only the first is what let "tg ties rg" stand for a whole session --
+                # both tools exit 2 and both write stderr, so that channel alone cannot see the
+                # difference #276 is being built to create.
                 score, detail = _score(rc, out, err, hidden_name or "")
                 cell[name] = Cell(score, "ok", detail)
+                pay_score, pay_detail = _score_payload(rc, out, err, hidden_name or "")
+                payload_cell = result.cells.setdefault(f"{tool.name}  [stdout-only]", {})
+                payload_cell[name] = Cell(pay_score, "ok", pay_detail)
         finally:
             cleanup()
     finally:

--- a/scripts/trust_benchmark.py
+++ b/scripts/trust_benchmark.py
@@ -117,7 +117,15 @@ def _run(argv: list[str], cwd: Path) -> tuple[int, str, str]:
 # tensor_grep.cli.incompleteness.INCOMPLETENESS_MARKERS; duplicated on purpose because this
 # harness must score COMPETING tools by the same rule, and importing the tool under test would
 # make tg's row depend on tg's own module.
-_PAYLOAD_MARKERS = ("result_incomplete", "incomplete_reason_class", '"errors"', "paths")
+# EXACTLY the closed incompleteness vocabulary, and nothing looser. The first cut also listed
+# `"errors"` and `paths`, and both were FALSE POSITIVES that flattered the tools:
+#   - `paths` matched `matched_file_paths`, a key present in every COMPLETE `tg --json` directory
+#     envelope, so tg scored ADMITS on a channel where it is in fact silent.
+#   - `"errors"` is always present in semgrep's JSON, so semgrep scored ADMITS unconditionally.
+# A marker that matches complete output cannot distinguish complete from incomplete, which is the
+# only thing this column exists to do. The control arm below now makes that failure self-evident
+# instead of leaving it to be noticed by someone who happens to distrust a good-looking number.
+_PAYLOAD_MARKERS = ("result_incomplete", "incomplete_reason_class")
 
 
 def _score(rc: int, out: str, err: str, unreadable_name: str) -> tuple[int, str]:
@@ -279,6 +287,21 @@ def run_condition(
                         "ok" if (found and rc == 0) else "control-failed",
                         "found sentinel, exit 0" if found and rc == 0 else f"rc={rc} found={found}",
                     )
+                    # THE PAYLOAD CONTROL. Score the payload scorer against a COMPLETE search too.
+                    # A complete result must look complete: anything but SILENT here means a marker
+                    # matches ordinary output, so the incomplete column is measuring nothing. This
+                    # arm is what turns "I noticed a suspicious 2" into an automatic failure --
+                    # the first version of this file had no control and shipped two false-positive
+                    # markers because of it.
+                    pay_score, pay_detail = _score_payload(rc, out, err, "")
+                    control_cell = result.cells.setdefault(f"{tool.name}  [stdout-only]", {})
+                    control_cell[name] = Cell(
+                        pay_score,
+                        "ok" if pay_score == SILENT else "control-failed",
+                        pay_detail
+                        if pay_score == SILENT
+                        else f"BROKEN MARKER: complete output scored {pay_score} -- {pay_detail}",
+                    )
                     continue
                 # TWO channels, deliberately. `_score` is what a shell/CI consumer sees (exit
                 # code + stderr); `_score_payload` is what an agent piping stdout into `jq` sees.
@@ -374,13 +397,23 @@ def main() -> int:
         return 0
 
     cond_names = ["control"] + [n for n, _ in CONDITIONS]
-    width = max(len(t.name) for t in tools) + 2
+    # Render EVERY row that was scored, not just the ToolSpec names. The `[stdout-only]` payload
+    # rows are keyed `f"{tool.name}  [stdout-only]"`, which is not a ToolSpec name -- iterating
+    # `tools` alone computed them, stored them, and printed none of them. A score nobody can see
+    # cannot fail, which is precisely the defect class this benchmark exists to measure (#276).
+    # The JSON output already carried them; only the human-readable table, the thing anyone
+    # actually reads, was blind.
+    row_names = [name for tool in tools for name in (tool.name, f"{tool.name}  [stdout-only]")]
+    row_names = [n for n in row_names if n in result.cells]
+    width = max(len(n) for n in row_names) + 2
     print(f"\nTrust benchmark -- {result.platform}")
-    print("2=ADMITS 1=PARTIAL 0=SILENT -=N/A  (honest == 2)\n")
+    print("2=ADMITS 1=PARTIAL 0=SILENT -=N/A  (honest == 2)")
+    print("`[stdout-only]` rows score STDOUT ALONE -- the agent's-eye view, no exit code,")
+    print("no stderr. That is the channel #276 is about.\n")
     print("tool".ljust(width) + "".join(c.ljust(18) for c in cond_names))
-    for tool in tools:
-        row = result.cells.get(tool.name, {})
-        line = tool.name.ljust(width)
+    for row_name in row_names:
+        row = result.cells.get(row_name, {})
+        line = row_name.ljust(width)
         for c in cond_names:
             cell = row.get(c)
             if cell is None:
@@ -400,10 +433,10 @@ def main() -> int:
         for b in result.broken_fixtures:
             print(f"  - {b}")
     print("\nDetail:")
-    for tool in tools:
-        for c, cell in result.cells.get(tool.name, {}).items():
+    for row_name in row_names:
+        for c, cell in result.cells.get(row_name, {}).items():
             if c != "control" and cell.detail:
-                print(f"  {tool.name:>10} / {c:<16} {cell.detail}")
+                print(f"  {row_name:>26} / {c:<16} {cell.detail}")
     return 0
 
 

--- a/tests/unit/test_trust_benchmark_premise.py
+++ b/tests/unit/test_trust_benchmark_premise.py
@@ -1,0 +1,168 @@
+"""The premise the task 307 reframe rests on: rg has no machine-readable incompleteness channel.
+
+The trust benchmark reports tg, ripgrep and GNU grep tied 2 admits / 2 partial / 0 silent. The
+proposed reading is that the tie is a MEASUREMENT artifact -- rg *structurally cannot* signal an
+incomplete scan inside its JSON stream, so a benchmark that only reads stderr and the exit code
+is looking at the one channel all three share.
+
+That reading is worth nothing unless the premise is executable. If ripgrep ever grows a
+machine-readable incompleteness signal, this test fails and the whole reframe is void -- which is
+exactly what a premise test is for. It is a statement about rg's DESIGN, not a complaint:
+`rg --json` emits begin/end/match/context/summary, and the terminal `summary` message carries
+timing and stats and no incompleteness field (ripgrep `crates/printer/src/json.rs`; rg(1)
+EXIT STATUS: *"2 exit status occurs when an error occurred ... for soft errors (e.g., unable to
+read a file)"*). Both halves are asserted here: nothing in the JSON, and the signal present on
+the exit code.
+
+THE SETUP IS WHAT BREAKS THIS TEST, NOT THE ASSERTION. `os.chmod(d, 0o000)` is a NO-OP on
+Windows -- the directory stays fully listable -- and it is also a no-op for root. Either way the
+scan completes, rg exits 0, and a naive version of this test would pass while proving nothing.
+So the unreadable condition is VERIFIED before anything is asserted, and the test skips with the
+observed state when it cannot be established. Measured on the dev box while writing this:
+chmod 0o000 then os.listdir() succeeded, i.e. LISTABLE anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+# rg's five message types, per the JSON Lines contract. `summary` is the terminal one.
+_TERMINAL_MESSAGE_TYPE = "summary"
+
+# Any of these appearing in rg's summary would mean rg CAN disclose incompleteness in-band, and
+# the task 307 reframe is dead. Deliberately generous -- a near-miss name should still trip it.
+_INCOMPLETENESS_MARKERS = (
+    "incomplete",
+    "partial",
+    "truncated",
+    "unreadable",
+    "error",
+    "skipped",
+    "failed",
+)
+
+
+def _keys_recursive(obj: object) -> set[str]:
+    """Every key anywhere in a nested JSON value."""
+    found: set[str] = set()
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            found.add(key)
+            found |= _keys_recursive(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            found |= _keys_recursive(item)
+    return found
+
+
+def _make_unreadable_tree(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A root holding one readable hit and one directory the process genuinely cannot read.
+
+    Skips -- never returns a half-built tree -- when the OS will not honour the permission
+    change, because a scan that can read everything cannot exercise the behaviour under test.
+    """
+    root = tmp_path / "root"
+    (root / "readable").mkdir(parents=True)
+    (root / "readable" / "hit.txt").write_text("NEEDLE\n", encoding="utf-8")
+
+    locked = root / "locked"
+    locked.mkdir()
+    (locked / "hidden.txt").write_text("NEEDLE\n", encoding="utf-8")
+
+    try:
+        os.chmod(locked, 0o000)
+    except (OSError, NotImplementedError) as exc:  # pragma: no cover - platform dependent
+        pytest.skip(f"cannot chmod a directory on this platform: {exc!r}")
+
+    # PREMISE CHECK. This is the assertion that keeps the test honest on Windows and as root.
+    try:
+        os.listdir(locked)
+    except PermissionError:
+        return root
+    else:
+        os.chmod(locked, 0o700)
+        pytest.skip(
+            "chmod 0o000 did not make the directory unreadable to this process "
+            f"(listdir succeeded; mode is now {oct(locked.stat().st_mode & 0o777)}). "
+            "Expected on Windows and when running as root -- the premise cannot be probed here, "
+            "so passing would prove nothing."
+        )
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _rg() -> str:
+    binary = shutil.which("rg")
+    if binary is None:
+        pytest.skip("ripgrep is not installed; this test is a statement about rg's contract")
+    return binary
+
+
+def test_rg_json_stream_carries_no_incompleteness_signal(tmp_path: pathlib.Path) -> None:
+    """ARM 1: rg's JSON stream stays silent about the directory it could not read."""
+    root = _make_unreadable_tree(tmp_path)
+    try:
+        proc = subprocess.run(
+            [_rg(), "--json", "NEEDLE", str(root)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        os.chmod(root / "locked", 0o700)
+
+    messages = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+    assert messages, f"rg emitted no JSON at all (exit {proc.returncode}): {proc.stderr[:400]}"
+
+    # PREMISE: the scan must have actually found the readable hit, or we are asserting the
+    # absence of a signal in a stream that never searched anything.
+    assert any(m.get("type") == "match" for m in messages), (
+        "rg found no matches -- the readable half of the tree was not searched, so this run "
+        f"cannot show anything about incompleteness reporting. stderr: {proc.stderr[:400]}"
+    )
+
+    summaries = [m for m in messages if m.get("type") == _TERMINAL_MESSAGE_TYPE]
+    assert len(summaries) == 1, f"expected exactly one summary message, got {len(summaries)}"
+
+    keys = {k.lower() for k in _keys_recursive(summaries[0])}
+    leaked = sorted(k for k in keys if any(marker in k for marker in _INCOMPLETENESS_MARKERS))
+    assert not leaked, (
+        "ripgrep's JSON summary now carries what looks like an incompleteness signal "
+        f"({leaked}). If that is real, the task 307 premise is DEAD: rg can disclose an "
+        "incomplete scan in-band, tg no longer leads on that channel, and the plan in "
+        "docs/plans/2026-07-26-307-trust-benchmark-lead.md must be withdrawn."
+    )
+
+
+def test_rg_reports_the_unreadable_directory_on_its_only_available_channel(
+    tmp_path: pathlib.Path,
+) -> None:
+    """ARM 2 -- THE CONTROL, and the half that makes ARM 1 a design claim rather than a smear.
+
+    Without this, ARM 1 is satisfied by an rg that noticed nothing at all, and the test would
+    read as "rg is careless". It is not: rg DOES report the unreadable directory, loudly, on
+    stderr and via exit status 2. The point of task 307 is only that those two channels are not
+    machine-readable output -- a consumer parsing the JSON stream alone cannot see them.
+    """
+    root = _make_unreadable_tree(tmp_path)
+    try:
+        proc = subprocess.run(
+            [_rg(), "--json", "NEEDLE", str(root)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        os.chmod(root / "locked", 0o700)
+
+    assert proc.returncode == 2, (
+        "rg should exit 2 on a soft error (unreadable path) per rg(1) EXIT STATUS; got "
+        f"{proc.returncode}. If this changed, the benchmark's exit-code column is measuring "
+        "something different than it was written for."
+    )
+    assert proc.stderr.strip(), "rg exited 2 but said nothing on stderr"

--- a/tests/unit/test_trust_benchmark_premise.py
+++ b/tests/unit/test_trust_benchmark_premise.py
@@ -104,7 +104,14 @@ def _rg() -> str:
 
 
 def test_rg_json_stream_carries_no_incompleteness_signal(tmp_path: pathlib.Path) -> None:
-    """ARM 1: rg's JSON stream stays silent about the directory it could not read."""
+    """ARM 1: rg's JSON stream stays silent about the directory it could not read.
+
+    Self-contained by design. The first draft asserted only "a match was found" and "no marker
+    keys", and an external audit caught that it could PASS on a COMPLETE scan -- exit 0, nothing
+    incomplete, correctly no marker -- proving nothing. The incompleteness evidence now comes
+    from THIS run's own exit code (PREMISE 1), not from the sibling test. A control that lives
+    in a different subprocess is not this test's control.
+    """
     root = _make_unreadable_tree(tmp_path)
     try:
         proc = subprocess.run(
@@ -119,7 +126,19 @@ def test_rg_json_stream_carries_no_incompleteness_signal(tmp_path: pathlib.Path)
     messages = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
     assert messages, f"rg emitted no JSON at all (exit {proc.returncode}): {proc.stderr[:400]}"
 
-    # PREMISE: the scan must have actually found the readable hit, or we are asserting the
+    # PREMISE 1 -- THIS run must have been incomplete. Without it the test is a SPLIT ORACLE:
+    # it would conclude "rg's JSON hides incompleteness" from a run that was never incomplete,
+    # because a fully readable tree exits 0, emits no marker (correctly), and passes. The
+    # exit-code evidence must come from the SAME subprocess whose JSON is being judged, not
+    # from the sibling test below -- a control in another process controls nothing here.
+    assert proc.returncode == 2, (
+        "this run was NOT incomplete (exit "
+        f"{proc.returncode}, expected 2), so the absence of an incompleteness marker in its "
+        "JSON proves nothing -- rg is correctly silent about a scan that finished. Something "
+        f"made the locked directory readable to rg. stderr: {proc.stderr[:400]}"
+    )
+
+    # PREMISE 2: the scan must have actually found the readable hit, or we are asserting the
     # absence of a signal in a stream that never searched anything.
     assert any(m.get("type") == "match" for m in messages), (
         "rg found no matches -- the readable half of the tree was not searched, so this run "


### PR DESCRIPTION
## The defect

The trust benchmark's `tg` row ran `tg search SENTINEL .`, which is **not tg's own engine**. `bootstrap.py:1497` forwards that to real ripgrep via `_run_rg_passthrough` whenever no compiled native binary resolves (`bootstrap.py:1264-1272`).

The tell is in the output we were scoring: the row's stderr carries a literal `rg: ` prefix, which appears **nowhere in our source** — tg's own walk error is `eprintln!("tg: {err}")` (`native_search.rs:1253`).

So the headline "tg ties ripgrep and GNU grep, 2 admits / 2 partial / 0 silent" was measuring **ripgrep twice**. A tie between that row and the `rg` row is definitional, not a result.

## What changes

- The plain-text row is renamed `tg (text; forwards to rg)` and **kept** — it is what a plain user actually runs — with a comment stating the tie is definitional.
- Adds the rows that measure tg: `tg --json`, `tg --ndjson`, and `rg --json` for comparison.
- Adds a **second scoring channel**. `_score` scores the process channel (exit code + stderr) — what a shell or CI consumer sees. New `_score_payload` scores **stdout alone** — what an agent piping `--json` into `jq` sees, with no exit code and no stderr.

## Why the second channel matters

It discriminates on day one, and **it scores against us**: `rg --json` admits via exit 2 on the process channel but is SILENT in the payload, and `tg --json` is SILENT on **both**. tg is behind, not tied.

That is the honest baseline #276 has to move. Recording the deficit *before* the fix is what will make the eventual win credible instead of post-hoc — a benchmark that only starts measuring once you're winning measures nothing.

## Verification

- Scored columns are computed from the captured process output; the marker list is duplicated from `tensor_grep.cli.incompleteness` on purpose, so tg's row does not depend on tg's own module to score itself.

Refs #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)
