### PR TITLE
fix(symbols): stop two false claims an external dogfood caught (definition-as-call, not_found over a truncated scan)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -11080,6 +11080,30 @@ def _symbol_payload_has_no_results(payload: dict[str, Any], result_key: str) -> 
     return not payload.get(result_key)
 
 
+def _symbol_not_found_claim(payload: dict[str, Any], result_key: str) -> bool:
+    """Whether the payload may affirmatively claim the symbol is ABSENT (task 327).
+
+    ``not_found`` is a positive claim -- "we looked and it is not there" -- and rg's exit-1
+    convention is built on it. A scan cut short by ``--deadline`` or a ``--max-repo-files`` cap
+    never finished looking, so an empty result from it proves nothing. An external dogfood of
+    v1.98.27 caught ``tg refs ... --deadline 0.1 --json`` reporting ``files_scanned: 0`` and
+    ``not_found: true`` in the same payload: the confident false zero this command's own emitter
+    docstring exists to prevent, surviving in the one field the completeness machinery never
+    covered.
+
+    The truncation predicate is ``_scan_incomplete`` -- NOT a fresh check -- because that gate is
+    already where "the scan-vs-output-cap contract is defined exactly once". A second notion of
+    incompleteness here could drift from the exit-code gate and reintroduce exactly the
+    inconsistency this fixes. It also gets the OUTPUT-cap boundary right for free: an output cap
+    is a complete analysis capped for display, so it must NOT suppress ``not_found``.
+
+    Exit codes are unaffected: ``_scan_incomplete``-true payloads already exit 2 on a branch
+    evaluated before ``not_found`` is consulted, so this only changes what the FIELD says to a
+    caller reading the JSON.
+    """
+    return _symbol_payload_has_no_results(payload, result_key) and not _scan_incomplete(payload)
+
+
 _ZERO_CALLERS_CAVEAT = (
     "0 callers in the static call graph does not mean this symbol is dead code. Dynamic "
     "dispatch (getattr / decorators / string-keyed registries), test files, re-exports, and "
@@ -11294,7 +11318,7 @@ def _emit_symbol_command_result(
 
     The truncation warning supersedes the generic caveat (incompleteness is the real story).
     """
-    not_found = _symbol_payload_has_no_results(payload, result_key)
+    not_found = _symbol_not_found_claim(payload, result_key)
     payload["not_found"] = not_found
     caveat, is_truncation = _annotate_result_completeness(payload, result_key=result_key)
     if json_output:
@@ -12381,7 +12405,7 @@ def blast_radius(
     # 0 with an empty callers list -- on a refactor-safety command that reads as "resolved, zero
     # impact" instead of "never found". Compute + stamp BEFORE any output path (mirrors
     # _emit_symbol_command_result) so json/text/mermaid all see the same additive `not_found` field.
-    not_found = _symbol_payload_has_no_results(payload, "callers")
+    not_found = _symbol_not_found_claim(payload, "callers")
     payload["not_found"] = not_found
     # Annotate completeness BEFORE any output path so mermaid/json/text all see result_incomplete and
     # honor the shared exit contract (cursor review 1.40.0): a --deadline partial or output-cap

--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -5067,6 +5067,24 @@ def _python_provider_alias_calls(path: Path, symbol: str) -> list[dict[str, Any]
     return deduped
 
 
+# Task 326: `fn NAME(` / `function NAME(` is a DECLARATION, not a call site. The tree-sitter arm
+# of this same feature already refuses to count it -- `_is_definition_identifier` below excludes
+# `function_item`/`struct_item`/`enum_item`/`trait_item` -- but this regex fallback did not, so a
+# published wheel (which ships no tree-sitter Rust grammar, making THIS the arm real users reach)
+# reported every declaration as a call at `resolution_confidence: 1.0`. Found by an external
+# dogfood of v1.98.27; the guard existing on one arm and not the other is what made it survive.
+#
+# Deliberately a NARROW deny-list of unambiguous declaration keywords, NOT an allow-list of call
+# shapes. The usual fail-closed rule (enumerate the safe cases, reject the rest) inverts here
+# because the two error directions are not symmetric: over-suppressing DROPS real call sites, and
+# a missing caller silently understates impact, which is worse than a rare surplus row a reader
+# can see and dismiss. Anything this pattern does not recognise therefore stays a call.
+#
+# `\b` anchors `fn` as a whole token so an identifier merely ENDING in those letters
+# (`spawn_fn collect(...)`) is not mistaken for a declaration; `\*?` admits `function* name(`.
+_DEFINITION_KEYWORD_BEFORE_SYMBOL = re.compile(r"\b(?:fn|function)\s*\*?\s*$")
+
+
 def _regex_references_and_calls(
     path: Path, symbol: str
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -5150,7 +5168,13 @@ def _regex_references_and_calls(
         sanitized_line = _strip_line_string_and_comment_noise(
             line, supports_template_strings=supports_template_strings
         )
-        if call_pattern.search(sanitized_line):
+        # Task 326: keep the historical "at most one call row per line" shape (downstream dedupe
+        # keys on file+line), but require at least one occurrence on the line that is NOT a
+        # declaration before emitting it.
+        if any(
+            _DEFINITION_KEYWORD_BEFORE_SYMBOL.search(sanitized_line[: call_match.start()]) is None
+            for call_match in call_pattern.finditer(sanitized_line)
+        ):
             calls.append({
                 "name": symbol,
                 "kind": "call",

--- a/tests/unit/test_not_found_requires_a_complete_scan.py
+++ b/tests/unit/test_not_found_requires_a_complete_scan.py
@@ -1,0 +1,92 @@
+"""`not_found` must not assert absence over a scan that never finished (task 327).
+
+Found by an external codex dogfood of the published v1.98.27 wheel:
+
+    tg refs . collect_walked_files --deadline 0.1 --json
+    -> {"deadline_limit": {"deadline_exceeded": true, "files_scanned": 0, "files_total": 209},
+        "partial": true, "references": [], "not_found": true}   EXIT=2
+
+Zero files were read, and the payload still claimed the symbol was not found. `not_found` answers
+"we looked and it is absent"; a scan that was cut off never looked, so it cannot support the
+claim. This is the same confident-false-zero class the #276 campaign is about -- surviving in a
+field the completeness machinery never covered. The docstring on the stamp site says in as many
+words that its purpose is preventing "the dangerous 'confident false zero'".
+
+Exit 2 already fired, so an agent obeying the documented exit-code contract was safe; an agent
+reading the field was not. The fix reuses `_scan_incomplete` -- the gate the repo already calls
+the place where "the scan-vs-output-cap contract is defined exactly once" -- rather than adding a
+second notion of incompleteness that could drift from it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tensor_grep.cli.main import _symbol_not_found_claim
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"references": []}
+    payload.update(overrides)
+    return payload
+
+
+def test_a_complete_scan_finding_nothing_still_reports_not_found() -> None:
+    """CONTROL ARM. Runs first: a guard that suppressed `not_found` unconditionally would pass
+    every truncation assertion below while destroying the genuine-absence signal (exit 1), so
+    this must hold before any of them count as evidence."""
+    assert _symbol_not_found_claim(_payload(), "references") is True
+
+
+def test_a_deadline_truncated_scan_does_not_claim_not_found() -> None:
+    """The exact shape codex reported: nothing read, nothing found, absence asserted."""
+    payload = _payload(
+        partial=True,
+        deadline_limit={"deadline_exceeded": True, "files_scanned": 0, "files_total": 209},
+    )
+
+    assert _symbol_not_found_claim(payload, "references") is False
+
+
+def test_a_scan_cap_truncated_scan_does_not_claim_not_found() -> None:
+    payload = _payload(
+        scan_limit={"max_repo_files": 10, "scanned_files": 10, "possibly_truncated": True}
+    )
+
+    assert _symbol_not_found_claim(payload, "references") is False
+
+
+def test_a_caller_scan_ceiling_truncated_scan_does_not_claim_not_found() -> None:
+    payload = _payload(
+        callers=[],
+        caller_scan_limit={"ceiling": 512, "files_total": 2000, "possibly_truncated": True},
+    )
+
+    assert _symbol_not_found_claim(payload, "callers") is False
+
+
+def test_an_output_cap_alone_still_reports_not_found() -> None:
+    """BOUNDARY, pinned deliberately. An OUTPUT cap is a COMPLETE analysis capped for display
+    (docs/CONTRACTS.md: it "stays exit 0; only a SCAN truncation exits 2"), and `_scan_incomplete`
+    excludes it on purpose. So the scan DID finish looking and `not_found` remains meaningful.
+
+    Widening the guard to output caps here would silently flip output-cap-only invocations and
+    break the output-cap-stays-exit-0 pins. The separate discoverability problem with output-cap
+    disclosure is tracked as task 328, and is a docs fix, not a change to this predicate."""
+    payload = _payload(output_limit={"possibly_truncated": True})
+
+    assert _symbol_not_found_claim(payload, "references") is True
+
+
+def test_a_resolver_no_match_on_a_complete_scan_still_reports_not_found() -> None:
+    payload = _payload(no_match=True)
+
+    assert _symbol_not_found_claim(payload, "references") is True
+
+
+def test_a_truncated_scan_that_DID_find_results_reports_not_found_false() -> None:
+    """Both inputs point the same way here; included so the truthy-results path is covered and
+    the guard cannot be read as "truncation forces False regardless of results"."""
+    payload = _payload(references=[{"file": "a.rs", "line": 1}], partial=True)
+
+    assert _symbol_not_found_claim(payload, "references") is False

--- a/tests/unit/test_regex_reference_call_classification.py
+++ b/tests/unit/test_regex_reference_call_classification.py
@@ -1,0 +1,154 @@
+"""The regex reference fallback must not classify a DEFINITION line as a call (task 326).
+
+Found by an external codex dogfood of the published v1.98.27 wheel:
+
+    tg refs . collect_walked_files --json
+    -> {"line": 3879,
+        "text": "fn collect_walked_files(config: &GpuNativeSearchConfig, ...) -> ... {",
+        "ref_kind": "call", "provenance": "regex-heuristic", "resolution_confidence": 1.0}
+
+That line is the declaration, not a call site. The tree-sitter Rust path already refuses to
+count it -- ``_is_definition_identifier`` (``repo_map.py``) excludes ``function_item`` /
+``struct_item`` / ``enum_item`` / ``trait_item``. The regex fallback had no such guard, so this
+is a TWIN GAP: one arm of the same feature carried the check and the other did not.
+
+Reachability is not theoretical. ``_rust_references_and_calls`` returns ``([], [])`` when no
+tree-sitter Rust grammar is installed, and the caller then falls through to
+``_regex_references_and_calls`` and promotes every ``call`` row to a reference with
+``ref_kind="call"``. A plain ``pip``/``uvx`` install ships no Rust grammar, so the regex arm is
+what real users hit -- which is exactly how the external reviewer reached it.
+
+Each test below asserts BOTH arms. A guard that suppressed everything would pass a
+definition-only assertion just as happily as a correct one, so every definition case is paired
+with a real call site that MUST still be classified as a call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.repo_map import _regex_references_and_calls
+
+
+def _call_lines(tmp_path: Path, filename: str, source: str, symbol: str) -> set[int]:
+    """Line numbers ``_regex_references_and_calls`` classified as CALLS."""
+    path = tmp_path / filename
+    path.write_text(source, encoding="utf-8")
+    _references, calls = _regex_references_and_calls(path, symbol)
+    return {int(call["line"]) for call in calls}
+
+
+def _reference_lines(tmp_path: Path, filename: str, source: str, symbol: str) -> set[int]:
+    path = tmp_path / filename
+    path.write_text(source, encoding="utf-8")
+    references, _calls = _regex_references_and_calls(path, symbol)
+    return {int(reference["line"]) for reference in references}
+
+
+def test_rust_fn_definition_is_not_a_call_but_the_real_call_site_still_is(
+    tmp_path: Path,
+) -> None:
+    source = "\n".join((
+        "fn collect_walked_files(config: &Config) -> Result<Vec<PathBuf>> {",  # 1: definition
+        "    Ok(Vec::new())",  # 2
+        "}",  # 3
+        "fn caller(config: &Config) {",  # 4
+        "    let files = collect_walked_files(config);",  # 5: real call
+        "}",  # 6
+    ))
+
+    calls = _call_lines(tmp_path, "walk.rs", source, "collect_walked_files")
+
+    # Control arm FIRST: if the guard over-fires and suppresses everything, this fails and the
+    # definition assertion below stops being evidence of anything.
+    assert 5 in calls, f"the real call site must still be classified as a call; got {calls}"
+    assert 1 not in calls, f"`fn NAME(` is a declaration, not a call; got {calls}"
+
+
+def test_rust_definition_modifiers_do_not_smuggle_a_definition_past_the_guard(
+    tmp_path: Path,
+) -> None:
+    """Only the token immediately before the symbol is inspected, so every `fn` modifier
+    combination collapses to the same check."""
+    source = "\n".join((
+        "pub fn collect_walked_files(c: &C) -> R {}",  # 1
+        "pub(crate) fn collect_walked_files(c: &C) -> R {}",  # 2
+        "async fn collect_walked_files(c: &C) -> R {}",  # 3
+        "pub async unsafe fn collect_walked_files(c: &C) -> R {}",  # 4
+        "const fn collect_walked_files(c: &C) -> R {}",  # 5
+        'pub extern "C" fn collect_walked_files(c: &C) -> R {}',  # 6
+        "    let files = collect_walked_files(config);",  # 7: real call
+    ))
+
+    calls = _call_lines(tmp_path, "modifiers.rs", source, "collect_walked_files")
+
+    assert calls == {7}, f"only line 7 is a call site; got {sorted(calls)}"
+
+
+def test_js_ts_function_definition_is_not_a_call_but_the_real_call_site_still_is(
+    tmp_path: Path,
+) -> None:
+    """`_regex_references_and_calls` gates on `_JS_TS_SUFFIXES | _RUST_SUFFIXES`, so the same
+    defect reached JS/TS via `function NAME(`. Fixing only the Rust spelling would have left
+    the twin live."""
+    source = "\n".join((
+        "function collectWalkedFiles(config) {",  # 1: definition
+        "  return [];",  # 2
+        "}",  # 3
+        "export function collectWalkedFiles2(config) {}",  # 4
+        "async function collectWalkedFiles3(config) {}",  # 5
+        "const files = collectWalkedFiles(config);",  # 6: real call
+    ))
+
+    calls = _call_lines(tmp_path, "walk.js", source, "collectWalkedFiles")
+
+    assert 6 in calls, f"the real call site must still be classified as a call; got {calls}"
+    assert 1 not in calls, f"`function NAME(` is a declaration, not a call; got {calls}"
+
+
+def test_js_generator_function_definition_is_not_a_call(tmp_path: Path) -> None:
+    source = "\n".join((
+        "function* collectWalkedFiles(config) {",  # 1: generator definition
+        "  yield 1;",  # 2
+        "}",  # 3
+        "const files = collectWalkedFiles(config);",  # 4: real call
+    ))
+
+    calls = _call_lines(tmp_path, "gen.js", source, "collectWalkedFiles")
+
+    assert calls == {4}, f"only line 4 is a call site; got {sorted(calls)}"
+
+
+def test_the_definition_line_is_still_reported_as_a_REFERENCE(tmp_path: Path) -> None:
+    """The fix narrows CALL classification only. A declaration is a legitimate reference to the
+    symbol and `tg refs` must keep reporting it -- dropping it would trade a mislabel for a
+    missing row, which is strictly worse for impact analysis."""
+    source = "\n".join((
+        "fn collect_walked_files(config: &Config) -> R {",  # 1: definition
+        "}",  # 2
+        "    let files = collect_walked_files(config);",  # 3: real call
+    ))
+
+    references = _reference_lines(tmp_path, "refs.rs", source, "collect_walked_files")
+
+    assert references == {1, 3}, (
+        f"the declaration must remain a reference row, not be dropped; got {sorted(references)}"
+    )
+
+
+def test_a_call_whose_name_merely_ends_in_fn_is_not_mistaken_for_a_definition(
+    tmp_path: Path,
+) -> None:
+    """A textual `fn`/`function` check that is not token-anchored would swallow a real call to a
+    symbol preceded by an identifier ending in those letters."""
+    source = "\n".join((
+        "    let files = spawn_fn collect_walked_files(config);",  # 1: not a definition
+        "    other.collect_walked_files(config);",  # 2: method call
+        "    Self::collect_walked_files(config);",  # 3: path call
+    ))
+
+    calls = _call_lines(tmp_path, "boundary.rs", source, "collect_walked_files")
+
+    assert calls == {1, 2, 3}, (
+        f"`fn` must match as a whole token, not a suffix; got {sorted(calls)}"
+    )


### PR DESCRIPTION
## What an external reviewer found

An independent codex dogfood of the **published v1.98.27 wheel** (not a dev build) reported three items. Triaged: **two are real defects, one is contracted behaviour**.

| # | Reported | Verdict |
|---|---|---|
| D3 | `refs` labels a `fn NAME(` declaration as `ref_kind: "call"`, confidence `1.0` | **REAL** — fixed here (task 326) |
| D2b | `not_found: true` on a scan that read **0 files** | **REAL** — fixed here (task 327) |
| D1 | `callers --json` returns 1 of 4 with `result_incomplete: false`, exit 0 | **CONTRACTED** — not changed, see below |

## 326 — the guard existed on one arm and not its twin

`_regex_references_and_calls` matched `\bNAME\s*\(`, which a declaration line satisfies. The **tree-sitter arm of the same feature already refuses to count it** (`_is_definition_identifier` excludes `function_item`/`struct_item`/`enum_item`/`trait_item`).

Reachability is not theoretical. The tree-sitter arm returns `([], [])` when no Rust grammar is installed, and **a pip/uvx wheel ships none** — so the regex arm is what real users reach. That is exactly how the reviewer hit it on the shipped artifact.

It also crossed languages: the fallback gates on JS/TS suffixes too, so `function NAME(` mislabelled identically. Fixing only the Rust spelling would have left the twin live.

The guard is a **narrow deny-list of declaration keywords, not an allow-list of call shapes**. The usual fail-closed rule inverts here because the error directions are not symmetric — over-suppressing *drops real call sites*, and a missing caller silently understates impact, which is worse than a surplus row a reader can see and dismiss.

## 327 — a confident false zero in the one field nobody checked

```
tg refs . collect_walked_files --deadline 0.1 --json
-> deadline_exceeded: true, files_scanned: 0, references: [], not_found: true
```

`not_found` claims *"we looked and it is absent."* A truncated scan never looked. This is the same class the whole task-276 campaign is about — surviving in the one field the completeness machinery never covered, while the emitter docstring six lines above the stamp site states its purpose is preventing exactly that.

The predicate **reuses `_scan_incomplete`** rather than adding a new check, because that gate is already where *"the scan-vs-output-cap contract is defined exactly once"*. A second notion of incompleteness could drift from the exit-code gate and reintroduce the inconsistency being fixed. It also gets the output-cap boundary right for free.

**Exit codes are unchanged** — `_scan_incomplete` payloads already exit 2 on a branch evaluated before `not_found` is read. This only changes what the field tells a caller parsing the JSON.

## Why D1 is not fixed

`CONTRACTS.md:156`: *"An OUTPUT-only cap … is a COMPLETE analysis capped only for display and stays exit `0`; only a SCAN truncation exits `2`."* The omission **is** machine-branchable via `token_budget.truncated` / `primary_truncated` / `primary_omitted` / `omissions.omitted_sections`.

Flipping `result_incomplete` or the exit code would relitigate a settled contract and break the pins holding it. But the reviewer's reaction is still evidence: someone with full repo access and the JSON in hand concluded the tool claimed completeness. That is *defensible but not discoverable* — filed as task 328, a docs fix naming the field to branch on.

## Verification

Both test files assert **both arms, controls first**:
- a real call site must still classify as a call;
- a complete scan finding nothing must still report `not_found` (exit 1).

A guard that suppressed everything would satisfy every positive assertion, so without the controls these tests would prove nothing. The old-vs-new predicate was additionally run side by side: three truncation shapes flip `True -> False`, both control shapes unchanged.

```
6/6   new regex-classification tests
7/7   new not_found tests
527   test_cli_modes.py
243   deadline / not_found pinning suites
242   language suites
```

One process note: the `not_found` fix was written before its test was run, so it was never observed RED. Rather than assume, the pre-fix predicate was executed against the same payloads to prove the change discriminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
