### PR TITLE
fix(refs): guard the alias-call producers that actually answer (task 326, REOPENED)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -5564,7 +5564,17 @@ def _js_ts_provider_alias_calls(
     for line_number, line in enumerate(lines, start=1):
         sanitized_line = _strip_js_ts_string_and_comment_noise(line)
         for alias_name in sorted(alias_names):
-            if not re.search(rf"\b{re.escape(alias_name)}\s*\(", sanitized_line):
+            alias_match = re.search(rf"\b{re.escape(alias_name)}\s*\(", sanitized_line)
+            if alias_match is None:
+                continue
+            # Task 326 (REOPENED): `\bNAME\s*\(` also matches `fn NAME(` / `function NAME(` -- a
+            # DECLARATION, not a call site. The first fix for this put the guard in
+            # `_regex_references_and_calls`, which sits LATER in the fallback chain and is never
+            # reached on a wheel install (no tree-sitter grammar -> the AST arm returns nothing ->
+            # THIS arm answers and stops the chain), so the defect shipped in v1.99.1 with green
+            # unit tests. Reuses the one shared `_DEFINITION_KEYWORD_BEFORE_SYMBOL` constant
+            # rather than a second regex, so the arms cannot drift apart again.
+            if _DEFINITION_KEYWORD_BEFORE_SYMBOL.search(sanitized_line[: alias_match.start()]):
                 continue
             alias_resolution = alias_resolution_by_name.get(alias_name, {})
             calls.append({
@@ -5894,7 +5904,17 @@ def _rust_provider_alias_calls(
     for line_number, line in enumerate(lines, start=1):
         sanitized_line = _strip_rust_string_and_comment_noise(line)
         for alias_name in sorted(alias_names):
-            if not re.search(rf"\b{re.escape(alias_name)}\s*\(", sanitized_line):
+            alias_match = re.search(rf"\b{re.escape(alias_name)}\s*\(", sanitized_line)
+            if alias_match is None:
+                continue
+            # Task 326 (REOPENED): `\bNAME\s*\(` also matches `fn NAME(` / `function NAME(` -- a
+            # DECLARATION, not a call site. The first fix for this put the guard in
+            # `_regex_references_and_calls`, which sits LATER in the fallback chain and is never
+            # reached on a wheel install (no tree-sitter grammar -> the AST arm returns nothing ->
+            # THIS arm answers and stops the chain), so the defect shipped in v1.99.1 with green
+            # unit tests. Reuses the one shared `_DEFINITION_KEYWORD_BEFORE_SYMBOL` constant
+            # rather than a second regex, so the arms cannot drift apart again.
+            if _DEFINITION_KEYWORD_BEFORE_SYMBOL.search(sanitized_line[: alias_match.start()]):
                 continue
             alias_resolution = alias_resolution_by_name.get(alias_name, {})
             calls.append({

--- a/tests/unit/test_alias_calls_exclude_declarations.py
+++ b/tests/unit/test_alias_calls_exclude_declarations.py
@@ -1,0 +1,98 @@
+"""The provider-alias call producers must not report a DECLARATION as a call (task 326, REOPENED).
+
+Task 326 was "fixed" once in `_regex_references_and_calls`, shipped in v1.99.1 with green unit
+tests, and the defect survived. The patched function was correct and never ran: the Rust chain is
+
+    _rust_references_and_calls   -> ([], []) with no tree-sitter grammar (any wheel install)
+    _rust_provider_alias_calls   -> RETURNS ROWS, so the chain stops here
+    _regex_references_and_calls  -> never reached  <- the one that was patched
+
+so the guard lived in a shadowed arm. This file pins the arm that actually answers.
+
+WHY IT USES THE REPO'S OWN SOURCE. Four synthetic fixtures were built and each failed to
+reproduce, for a different reason every time (measured, not guessed):
+  1. one declaration -> the symbol becomes THE definition and never enters `references`
+  2. the dev venv HAS the tree-sitter grammar, so the AST arm answers and this arm is skipped --
+     a synthetic end-to-end test PASSES ON A BROKEN BUILD unless the grammar is stubbed out
+  3. `alias_names` is populated only from `use` statements that RESOLVE to the symbol, so files
+     without a resolving `use` make the producer emit nothing at all
+  4. resolution needs a plausible crate layout
+Rather than keep approximating, this calls the producer directly on the two real files that are
+PROVEN to reproduce it. The coupling is deliberate and the premise assertions below make a
+content drift fail loudly as a SKIP-worthy premise failure, not as a silent pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli.repo_map import _rust_provider_alias_calls
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SYMBOL = "collect_walked_files"
+# Both files DECLARE `collect_walked_files`; one becomes the definition and the other's
+# declaration leaks into `references`, where this producer labels it a call.
+_SOURCES = (
+    _REPO_ROOT / "rust_core" / "src" / "gpu_native.rs",
+    _REPO_ROOT / "rust_core" / "src" / "native_search.rs",
+)
+
+
+def _declaration_lines(path: Path) -> set[int]:
+    """Line numbers whose text is a `fn <SYMBOL>(` declaration."""
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return {
+        number
+        for number, text in enumerate(lines, start=1)
+        if text.lstrip().startswith(("fn " + _SYMBOL, "pub fn " + _SYMBOL))
+        and _SYMBOL + "(" in text
+    }
+
+
+@pytest.mark.parametrize("source", _SOURCES, ids=lambda p: p.name)
+def test_alias_producer_does_not_report_declarations_as_calls(source: Path) -> None:
+    if not source.exists():  # pragma: no cover - repo layout guard
+        pytest.skip(f"{source} absent; this test is coupled to the repo's own Rust sources")
+
+    declarations = _declaration_lines(source)
+    calls = _rust_provider_alias_calls(source, _SYMBOL, str(_REPO_ROOT))
+    call_lines = {int(row["line"]) for row in calls}
+
+    # PREMISE 1 -- the file must still contain a declaration, or the assertion below is vacuous.
+    assert declarations, (
+        f"{source.name} no longer declares `{_SYMBOL}`; this test is coupled to repo content "
+        "and must be re-pointed rather than silently passing"
+    )
+    # PREMISE 2 -- the producer must still emit SOMETHING here. It emits only when a `use`
+    # binding resolves to the symbol; if that stops holding, an empty result would satisfy the
+    # negative assertion while proving nothing.
+    assert calls, (
+        f"{source.name}: `_rust_provider_alias_calls` returned NO rows, so this test cannot "
+        "discriminate. Re-check the `use`-binding precondition before trusting a pass."
+    )
+
+    leaked = sorted(declarations & call_lines)
+    assert not leaked, (
+        f"{source.name}: declaration line(s) {leaked} reported as calls. "
+        f"declarations={sorted(declarations)} call_lines={sorted(call_lines)}"
+    )
+
+
+@pytest.mark.parametrize("source", _SOURCES, ids=lambda p: p.name)
+def test_alias_producer_still_reports_genuine_call_sites(source: Path) -> None:
+    """CONTROL ARM. A guard that suppressed every row would satisfy the test above while
+    destroying the feature, so a real call site must survive."""
+    if not source.exists():  # pragma: no cover - repo layout guard
+        pytest.skip(f"{source} absent; this test is coupled to the repo's own Rust sources")
+
+    declarations = _declaration_lines(source)
+    calls = _rust_provider_alias_calls(source, _SYMBOL, str(_REPO_ROOT))
+    call_lines = {int(row["line"]) for row in calls}
+
+    genuine = call_lines - declarations
+    assert genuine, (
+        f"{source.name}: NO non-declaration call site survived -- the guard over-fired and "
+        f"suppressed real calls. call_lines={sorted(call_lines)} declarations={sorted(declarations)}"
+    )


### PR DESCRIPTION
Fixes the regression codex round 3 found in **published v1.99.1** — a defect my own earlier "fix" (#814) claimed to have closed.

## #814 was correct, shipped correctly, and never ran

```
tg refs . collect_walked_files --json
-> line 3879, "fn collect_walked_files(config: &GpuNativeSearchConfig...)", ref_kind: "call"
```

I verified the guard **is** in the 1.99.1 wheel and that the function it guards **does** exclude declarations. It's just not the function that answers. The Rust fallback chain:

| step | result |
|---|---|
| `_rust_references_and_calls` | `([], [])` with no tree-sitter grammar — i.e. **every** pip/uvx wheel |
| `_rust_provider_alias_calls` | **returns rows, chain stops here** |
| `_regex_references_and_calls` | never reached ← what #814 patched |

Classic test-the-mechanism-not-the-outcome: 6/6 green on a shadowed arm.

## Twin fixed in the same change

The offending line is byte-identical in `_rust_provider_alias_calls` and `_js_ts_provider_alias_calls`, so this is one `replace_all` against the existing shared `_DEFINITION_KEYWORD_BEFORE_SYMBOL` constant — not a second regex. Fixing Rust alone would have made this the **third** one-arm fix of the same defect.

## Why the test targets the repo's own sources

Four synthetic fixtures were built; every one failed to reproduce, each for a different **measured** reason:

1. One declaration → the symbol becomes *the* definition and never enters `references`.
2. The dev venv **has** the tree-sitter grammar, so the AST arm answers and this arm is skipped — a synthetic end-to-end test **passes on a broken build** unless the grammar is stubbed.
3. `alias_names` is populated only from `use` statements that *resolve* to the symbol; files without one make the producer emit nothing.
4. Resolution needs a plausible crate layout.

Rather than keep approximating, the test calls the producer on `rust_core/src/{gpu_native,native_search}.rs`, which are proven to reproduce. The coupling is deliberate and **guarded**: two premise assertions fail loudly if those files stop declaring the symbol or the producer stops emitting, so drift can't become a silent pass.

## Evidence

Observed **RED** before the fix — leaked declaration lines `3879` and `1760`. **GREEN** after, with the producer output re-measured end to end:

```
gpu_native.rs     calls=[3871]           declarations=[3879]  leaked=[]
native_search.rs  calls=[915,941,2781]   declarations=[1709]  leaked=[]
```

Both arms asserted. The control — a genuine call site must *still* classify as a call — is what stops an over-firing guard from reading as a fix, since that failure looks identical to success.

81 adjacent tests green (`typed_ref_kinds`, `cross_lang_resolution`, `lang_go`, `regex_reference_call_classification`, `cap_fix_chokepoint`). ruff clean.

## Not closing the task on merge

Task 326 stays open until re-verified against a **published wheel** (codex round 4, task 330). Shipping on green unit tests is precisely how the first attempt shipped broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
