### PR TITLE
test(sidecar): make the sidecar timeout a hang guard, not a latency assertion (task 331)

### DIFF
--- a/rust_core/tests/test_sidecar_ipc.rs
+++ b/rust_core/tests/test_sidecar_ipc.rs
@@ -123,11 +123,30 @@ fn configure_classify_env(command: &mut Command) {
     configure_repo_python_env(command);
 }
 
+/// HANG GUARD, not a latency assertion (task 331).
+///
+/// `run_with_timeout` PANICS when this expires, and a panic is a test failure — so this value was
+/// silently acting as "the sidecar must answer within 15s on Windows" for tests whose actual
+/// invariant is the CONTENT of an error message. On a loaded windows-nightly runner the sidecar
+/// spawn plus a Python interpreter start exceeded it, and two GPU-error-message tests failed with
+/// nothing wrong in the product. That is the wall-clock-assertion form task 309 retired elsewhere
+/// in this suite, and it has now cost two separate red CI runs (task 167 was the first).
+///
+/// This is deliberately NOT the ceiling-raising that failed twice on task 259. There the ceiling
+/// WAS the assertion — a perf test asserting a duration, where a bigger number erases the signal.
+/// Here the timeout asserts nothing anyone cares about; its only job is to stop a wedged
+/// subprocess from hanging CI forever (the anti-hang-test-protocol requirement). A hang guard and
+/// a latency bound are different instruments, and 15s is far too tight to serve as the former on a
+/// contended runner. The number below is chosen to be unreachable by a merely SLOW start while
+/// still bounding a genuine wedge well inside the job timeout.
+///
+/// If these tests fail again after this change, the cause is NOT scheduling latency and must be
+/// diagnosed as a real defect rather than re-tuned.
 fn sidecar_test_timeout() -> Duration {
     if cfg!(windows) {
-        Duration::from_secs(15)
+        Duration::from_secs(120)
     } else {
-        Duration::from_secs(5)
+        Duration::from_secs(60)
     }
 }
 


### PR DESCRIPTION
Two GPU-error-message tests failed on `test-rust-core (windows-latest, nightly)` in run `30235825250`, blocking PR #815 — whose **entire diff is `docs/CONTRACTS.md`** and therefore cannot reach a Rust IPC test. The re-run passed with no code change, confirming an environmental flake.

## Mechanism, not a guess

- `run_with_timeout` **panics** on expiry (`test_sidecar_ipc.rs:70`) — and a panic *is* a test failure.
- `sidecar_test_timeout()` returned **15s on Windows** (`:127`).

So that constant was silently acting as *"the sidecar must answer within 15s"* for two tests whose actual invariant is the **content of an error message**:

```
test_gpu_search_cuda_visible_devices_empty_reports_clear_error_without_traceback
test_gpu_search_invalid_device_id_reports_clear_error_without_traceback
```

Both spawn `tg`, which spawns a Python sidecar. On a contended windows-nightly runner that start exceeded 15s and the tests reported a product defect that did not exist.

This is the wall-clock-assertion form **#309** retired elsewhere in this suite, and it has now cost two separate red CI runs — **#167** de-flaked two siblings for v1.74.2 and did not cover these.

## Why this is not the ceiling-raising that failed twice on #259

There, the ceiling **was** the assertion: a perf test asserting a duration, where a bigger number erases the very signal the test exists to produce.

Here the timeout asserts nothing anyone cares about. Its only job is to stop a wedged subprocess from hanging CI forever — the anti-hang-test-protocol requirement. **A hang guard and a latency bound are different instruments**, and 15s is far too tight to serve as the former on a shared runner. Raising it removes a false signal rather than suppressing a true one.

The value is chosen so a merely *slow* start cannot reach it while a genuine wedge stays bounded well inside the job timeout. The doc comment states this outright so the next reader needn't re-derive it — and records that a failure **after** this change is not scheduling latency and must be diagnosed as a real defect rather than re-tuned.

## Verification

CPU-SAFE binds this box: `cargo` is forbidden, so `rustfmt --edition 2021 --check` is the local oracle and is **clean**. Compilation and execution are CI's call. The change is one constant plus a comment, in a test file — no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
