### PR TITLE
fix(symbols): truncation gates were blind to --deadline, so absence was asserted over an unfinished scan (task 332)

### DIFF
--- a/src/tensor_grep/cli/repo_map.py
+++ b/src/tensor_grep/cli/repo_map.py
@@ -639,6 +639,18 @@ _CALLER_SCAN_CEILING_REMEDIATION = (
     "may be missing. Narrow PATH to a subdirectory containing the symbol for full coverage."
 )
 
+# Task 332: the DEADLINE twin of _SCAN_LIMIT_TRUNCATED_REMEDIATION above. Same fact -- the scan
+# stopped before it finished, so a zero or small count is not trustworthy -- reached by the other
+# cause, and therefore needing a different knob in the advice (--deadline, not --max-repo-files).
+# Kept as its own constant rather than reusing the count-cap string, because telling an agent to
+# "raise --max-repo-files" when the file cap was never the binding constraint sends it to a knob
+# that cannot fix its problem.
+_DEADLINE_TRUNCATED_REMEDIATION = (
+    "The scan stopped at the --deadline before finishing, so a zero or small count is NOT "
+    "trustworthy. Re-run with a larger --deadline, scope to a subdirectory PATH, or warm the "
+    "index with `tg session daemon start`."
+)
+
 
 def _mark_result_incomplete(
     payload: dict[str, Any],
@@ -701,6 +713,39 @@ def _copy_partial_signal(payload: dict[str, Any], source: dict[str, Any]) -> Non
         deadline_limit = source.get("deadline_limit")
         if isinstance(deadline_limit, dict):
             payload["deadline_limit"] = dict(deadline_limit)
+
+
+def _scan_did_not_finish(payload: dict[str, Any]) -> bool:
+    """Whether this payload's SCAN stopped early -- by EITHER truncation cause (task 332).
+
+    The file-count cap (``scan_limit.possibly_truncated``) and the ``--deadline`` cutoff
+    (``partial`` / ``deadline_limit.deadline_exceeded``) are two causes of ONE fact: we stopped
+    looking before we were done, so an empty or small result proves nothing.
+
+    Every gate in this module that asked "was this truncated?" was written when the file cap was
+    the only cause, and none was widened when ``--deadline`` arrived. A mechanical sweep found
+    3 of 3 ``possibly_truncated`` readers here answering the question count-only, so a
+    deadline-truncated scan read as COMPLETE at all three -- an external dogfood of the published
+    1.99.4 wheel caught `tg callers . <symbol> --deadline 0.1 --json` reporting
+    ``files_scanned: 0`` beside a flat "No exact definition found" for a symbol that demonstrably
+    exists.
+
+    This deliberately MIRRORS ``main._scan_incomplete``, which is where the same two-cause
+    contract is already defined for the exit-code gate -- it is not a fourth independent notion.
+    Re-deriving truncation narrowly is the entire defect class; adding another private definition
+    would guarantee the next drift.
+
+    An OUTPUT cap is NOT a scan truncation (a complete analysis capped for display stays
+    complete), so no ``output_limit`` key is consulted here -- same boundary ``_scan_incomplete``
+    draws, and the reason its docstring gives for drawing it.
+    """
+    scan_limit = payload.get("scan_limit")
+    if isinstance(scan_limit, dict) and scan_limit.get("possibly_truncated"):
+        return True
+    deadline_limit = payload.get("deadline_limit")
+    if isinstance(deadline_limit, dict) and deadline_limit.get("deadline_exceeded"):
+        return True
+    return bool(payload.get("partial"))
 
 
 def _deadline_monotonic_from_seconds(deadline_seconds: float | None) -> float | None:
@@ -14084,8 +14129,11 @@ def build_context_render(
     if include_suggested_scope:
         # suggested_scope (audit #93 SUB-2 / #133 dogfood): the SAME centrality-weighted directory
         # rollup `tg orient` emits, computed from the raw map we ALREADY built above -- no second
-        # scan. Gated on the map's OWN `scan_limit.possibly_truncated` (a complete scan has nothing
-        # left to narrow), mirroring orient_capsule's gate. Reuses orient's tested helper; the local
+        # scan. Gated on the map's OWN unfinished-scan state (a complete scan has nothing
+        # left to narrow), mirroring orient_capsule's gate. Task 332: that gate read
+        # `scan_limit.possibly_truncated` directly and so never fired on a --deadline cutoff --
+        # the render that most needs a "narrow to here" hint (the clock ran out) was the one
+        # render that never offered one. Reuses orient's tested helper; the local
         # import avoids the module-level cycle (orient_capsule imports this module), exactly like the
         # `_apply_ignore_globs` reuse above. Additive + conditional: absent unless the scan was
         # truncated AND a clear winner exists, so a non-truncated render stays byte-identical.
@@ -14095,8 +14143,7 @@ def build_context_render(
         # suggested_scope rollup -- otherwise this wrapper (behind `tg context-render`, and any other
         # `include_suggested_scope=True` caller) could point an agent at a tree the sibling commands
         # already know to avoid, on the exact same repo map.
-        scan_limit = repo_map.get("scan_limit")
-        if isinstance(scan_limit, dict) and scan_limit.get("possibly_truncated"):
+        if _scan_did_not_finish(repo_map):
             from tensor_grep.cli.orient_capsule import (
                 _detect_vendored_subtrees,
                 _suggested_scope_from_map,
@@ -16169,6 +16216,19 @@ def build_symbol_defs_from_map(
                 "narrow PATH or raise --max-repo-files."
             )
             _mark_result_incomplete(payload, remediation=_SCAN_LIMIT_TRUNCATED_REMEDIATION)
+        elif _scan_did_not_finish(payload):
+            # Task 332: the DEADLINE arm of the same fact. This branch used to not exist, so a
+            # deadline-truncated defs lookup emitted the BARE sentence above -- a flat "No exact
+            # definition found" over a scan that read 0 files -- and skipped
+            # `_mark_result_incomplete` entirely, because both were gated on the file cap alone.
+            # The count arm above stays first and unchanged: when the cap IS the binding
+            # constraint its message names the right knob, and a shared branch would have to
+            # pick one knob for both causes.
+            payload["message"] += (
+                " The scan stopped at the --deadline before finishing; "
+                "raise --deadline or narrow PATH."
+            )
+            _mark_result_incomplete(payload, remediation=_DEADLINE_TRUNCATED_REMEDIATION)
         # F13 fix: unlike refs/callers (which compute `resolution_gaps` over the files they
         # actually scan), defs' own no_match path used to return bare -- indistinguishable from
         # "the symbol genuinely does not exist" even when the real cause is a grammar-missing
@@ -18209,14 +18269,23 @@ def _blast_radius_no_match_is_possibly_truncated(payload: dict[str, Any]) -> boo
     cold path (task #108, the TRAP A class); and (3) ``main._daemon_blast_radius_no_match_is_
     unreliable`` (the Tier-1 ``blast-radius`` command's own daemon-fallback gate, audit #107).
 
-    Deliberately narrow: only fires on ``no_match`` AND ``possibly_truncated`` together. A
+    Deliberately narrow: only fires on ``no_match`` AND an unfinished scan together. A
     no_match on a COMPLETE map is a real miss -- treating that as untrustworthy too would
     defeat retries/daemon-fallback for every genuine no-match, not just the truncated ones.
+
+    Task 332 widened WHICH truncations count, not how narrow the gate is. The body read
+    ``scan_limit.possibly_truncated`` directly, so it was blind to the ``--deadline`` arm and
+    treated a deadline-truncated no_match as TRUSTWORTHY at all three call sites above --
+    silently skipping the rescue in exactly the case that needs it most (a deadline cutoff can
+    leave ``files_scanned: 0``). The name is kept because three modules import it by that name;
+    the predicate is now ``_scan_did_not_finish``, which covers both causes.
+
+    Direction of the change: this only ever ADDS rescue attempts. Nothing that previously
+    retried stops retrying.
     """
     if not payload.get("no_match"):
         return False
-    scan_limit = payload.get("scan_limit")
-    return isinstance(scan_limit, dict) and bool(scan_limit.get("possibly_truncated"))
+    return _scan_did_not_finish(payload)
 
 
 def build_symbol_blast_radius(

--- a/tests/unit/test_deadline_blind_truncation_gates.py
+++ b/tests/unit/test_deadline_blind_truncation_gates.py
@@ -1,0 +1,139 @@
+"""Task 332: truncation gates must see BOTH truncation causes, not just the file cap.
+
+An external dogfood of the PUBLISHED 1.99.4 wheel found `tg defs/callers/blast-radius` asserting
+absence over a `--deadline`-truncated scan for a symbol that demonstrably exists. A mechanical
+sweep of `repo_map.py` then showed the class: **3 of 3** readers of `scan_limit.possibly_truncated`
+answered "was this truncated?" with "was the FILE CAP hit?", so every one of them read a
+deadline-truncated scan as COMPLETE.
+
+Each test below pairs the treatment arm with a CONTROL that must NOT change, because a gate that
+answered "truncated" unconditionally would satisfy every positive assertion here while making a
+genuine miss unreportable -- which is the failure mode
+`_blast_radius_no_match_is_possibly_truncated`'s own docstring warns about (it would defeat the
+literal-seed retry and both daemon fallbacks for every real no-match).
+
+Bidirectional receipt, measured before the fix landed (pre-fix `repo_map.py` at d3bcb1b):
+    result_incomplete : None                       (now True)
+    message           : "No exact definition found for symbol 'absent_symbol_zzz'."   (bare)
+    trust helper on a deadline no_match -> False   (now True)
+Both controls below were already correct pre-fix and stay correct post-fix -- so these tests
+discriminate the fix, they do not merely restate it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.repo_map import (
+    _blast_radius_no_match_is_possibly_truncated,
+    _scan_did_not_finish,
+    build_repo_map,
+    build_symbol_defs_from_map,
+)
+
+_ABSENT = "absent_symbol_zzz_7f3a9c"
+
+
+def _single_file_map(tmp_path: Path) -> dict:
+    (tmp_path / "a.py").write_text("def present():\n    return 1\n", encoding="utf-8")
+    return build_repo_map(str(tmp_path))
+
+
+class TestScanDidNotFinishPredicate:
+    """The shared predicate mirrors `main._scan_incomplete`'s two-cause contract."""
+
+    def test_file_cap_truncation_counts(self) -> None:
+        assert _scan_did_not_finish({"scan_limit": {"possibly_truncated": True}})
+
+    def test_deadline_truncation_counts(self) -> None:
+        assert _scan_did_not_finish({"deadline_limit": {"deadline_exceeded": True}})
+        assert _scan_did_not_finish({"partial": True})
+
+    def test_complete_scan_is_not_truncated(self) -> None:
+        # CONTROL. Without these, a predicate hardcoded to `return True` passes every
+        # positive assertion in this file.
+        assert not _scan_did_not_finish({})
+        assert not _scan_did_not_finish({"scan_limit": {"possibly_truncated": False}})
+        assert not _scan_did_not_finish({"deadline_limit": {"deadline_exceeded": False}})
+
+    def test_output_cap_alone_is_not_a_scan_truncation(self) -> None:
+        # CONTROL for the boundary `_scan_incomplete` deliberately draws: an OUTPUT cap is a
+        # COMPLETE analysis capped for display. Treating it as a scan truncation would flip
+        # output-cap-only invocations to exit 2 and break the output-cap-stays-0 pins.
+        assert not _scan_did_not_finish({"output_limit": {"primary_truncated": True}})
+
+
+class TestBlastRadiusNoMatchTrust:
+    """The helper gates the literal-seed retry + both daemon fallbacks."""
+
+    def test_deadline_truncated_no_match_is_untrustworthy(self) -> None:
+        # THE FIX. Pre-fix this returned False, so a deadline-truncated no_match -- the case
+        # that can carry `files_scanned: 0` -- skipped the rescue entirely.
+        assert _blast_radius_no_match_is_possibly_truncated({"no_match": True, "partial": True})
+
+    def test_file_cap_truncated_no_match_still_untrustworthy(self) -> None:
+        assert _blast_radius_no_match_is_possibly_truncated({
+            "no_match": True,
+            "scan_limit": {"possibly_truncated": True},
+        })
+
+    def test_no_match_on_a_complete_scan_stays_trustworthy(self) -> None:
+        # CONTROL, and the one the helper's docstring cares most about: a no_match on a COMPLETE
+        # map is a REAL miss. Marking it untrustworthy would fire retries and daemon fallback on
+        # every genuine no-match in the repo.
+        assert not _blast_radius_no_match_is_possibly_truncated({"no_match": True})
+
+    def test_truncation_without_a_no_match_does_not_fire(self) -> None:
+        # CONTROL: the gate is `no_match AND unfinished`, never truncation alone.
+        assert not _blast_radius_no_match_is_possibly_truncated({"partial": True})
+
+
+class TestDefsAbsenceClaimUnderTruncation:
+    """`defs`' no_match branch: the prose and the incompleteness mark, per cause."""
+
+    def test_deadline_truncated_defs_discloses_and_names_the_deadline_knob(
+        self, tmp_path: Path
+    ) -> None:
+        repo_map = _single_file_map(tmp_path)
+        repo_map["partial"] = True
+        repo_map["deadline_limit"] = {
+            "deadline_exceeded": True,
+            "files_scanned": 0,
+            "files_total": 9,
+        }
+
+        payload = build_symbol_defs_from_map(repo_map, _ABSENT)
+
+        assert payload.get("result_incomplete") is True
+        message = payload.get("message") or ""
+        assert "--deadline" in message
+        # It must name the knob that can actually fix it. Sending an agent to
+        # `--max-repo-files` when the clock was the binding constraint is advice it cannot use.
+        assert "--max-repo-files" not in message
+
+    def test_complete_scan_absence_stays_a_clean_miss(self, tmp_path: Path) -> None:
+        # CONTROL. A genuinely absent symbol on a COMPLETE scan must still say so plainly, with
+        # no truncation caveat and no incompleteness mark -- otherwise every honest miss in the
+        # repo starts claiming it might be wrong.
+        repo_map = _single_file_map(tmp_path)
+
+        payload = build_symbol_defs_from_map(repo_map, _ABSENT)
+
+        assert payload.get("no_match") is True
+        assert not payload.get("result_incomplete")
+        message = payload.get("message") or ""
+        assert "--deadline" not in message
+        assert "--max-repo-files" not in message
+
+    def test_file_cap_arm_keeps_its_original_sentence(self, tmp_path: Path) -> None:
+        # CONTROL / refactor regression guard. The count arm was ALREADY honest before task 332.
+        # Routing both causes through one shared branch would have had to pick a single knob for
+        # both, silently degrading this arm's advice -- so pin it verbatim.
+        repo_map = _single_file_map(tmp_path)
+        repo_map["scan_limit"] = {"possibly_truncated": True, "scanned_files": 1}
+
+        payload = build_symbol_defs_from_map(repo_map, _ABSENT)
+
+        message = payload.get("message") or ""
+        assert "--max-repo-files" in message
+        assert "--deadline" not in message


### PR DESCRIPTION
## Found by external dogfood of the **published** 1.99.4 wheel

`tg defs/callers/blast-radius` reported `no_match: true` and *"No exact definition found for
symbol 'collect_walked_files'"* over a `--deadline`-truncated scan — for a symbol the **same
run's complete arm** proved exists (`deadline_limit: {deadline_exceeded: true, files_scanned: 0}`).

## This is a class, and the sweep closed it

I did not fix the one symptom. A mechanical sweep of every `possibly_truncated` reader in
`repo_map.py` found **3 of 3 deadline-blind** — the complete class in that file, not a sample:

| site | effect on the `--deadline` arm |
|---|---|
| `:14099` `build_context_render` | never offered the "narrow your scope" hint — the render that most needs it |
| `:16166` `defs` no_match branch | emitted the **bare** absence sentence **and** skipped `_mark_result_incomplete` |
| `:18219` blast-radius trust helper | treated a deadline `no_match` as **trustworthy**, skipping the literal-seed retry + both daemon fallbacks |

All three were written when the file cap was the only truncation cause, and none was widened
when `--deadline` arrived. Third instance of the widening recorded in task #294.

## The fix

One shared `_scan_did_not_finish` predicate covering both causes, mirroring
`main._scan_incomplete` — which is where that two-cause contract is **already** defined for the
exit-code gate. Not a fourth private notion: re-deriving truncation narrowly *is* the defect class.

## What I deliberately did NOT do

**`no_match` is left alone.** Suppressing it was the reviewer's recommendation and the obvious
fix — and it would have been a regression. `no_match` is control flow across twelve consumers
(literal-seed retry, Tier-2 daemon capsule cold-path fallback per #108, the blast-radius daemon
gate per #107). Nulling it silently disables those rescues, which is precisely what the trust
helper's own docstring warns about.

## Bidirectional receipt — measured, not assumed

| | pre-fix | post-fix |
|---|---|---|
| `result_incomplete` | `None` | `True` |
| message | bare "No exact definition found…" | + caveat naming `--deadline` |
| trust helper on deadline `no_match` | `False` (trusted) | `True` (untrusted) |

**Both controls unchanged in both arms** — that's what makes these tests discriminate rather
than restate:
- a **complete** scan of a genuinely absent symbol stays a clean honest miss (no caveat, no
  incompleteness mark, exit-1 path intact);
- the **count** arm keeps its original `--max-repo-files` sentence verbatim — a shared-branch
  refactor would have had to pick one knob for both causes and silently degraded it.

Advice correctness matters here: sending an agent to `--max-repo-files` when the clock was the
binding constraint is advice it cannot act on, so the two arms keep separate remediation strings.

## Gates

11 new tests pass · 68 neighbouring repo_map/incompleteness tests pass · `ruff check` +
`ruff format --check --preview` clean. Python-only, no Rust.

Closes task 332 in the ledger (not a GitHub issue number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)