### PR TITLE
fix(gpu): cross the walk-error count to the gpu_native twin (task 316)

### DIFF
--- a/rust_core/src/gpu_native.rs
+++ b/rust_core/src/gpu_native.rs
@@ -3870,6 +3870,11 @@ fn check_gpu_native_implicit_walk_ceiling(
 /// same reason: `collect_walked_files` returned a bare `Vec<PathBuf>`, so it owned NO channel back
 /// to its caller and the walk-error count died at the `eprintln!`. Without this the GPU envelope
 /// could only ever say "complete", which is the silence #276 exists to end.
+/// `Debug` is REQUIRED, not decorative: `collect_search_files`'s walk-ceiling tests call
+/// `Result::expect_err`, which needs `T: Debug` to print the unexpected Ok. Before task 316 that
+/// `T` was a bare `Vec<PathBuf>` (Debug for free), so swapping in a struct broke the tests --
+/// caught by `cuda-feature-check`, the only oracle for this cuda-gated module.
+#[derive(Debug)]
 struct GpuWalkedFiles {
     files: Vec<PathBuf>,
     /// Same `is_io()` filter as both CPU walkers (`native_search.rs:1328`/`:1806`) -- a malformed

--- a/rust_core/src/gpu_native.rs
+++ b/rust_core/src/gpu_native.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::io::Read;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Once;
 use std::time::Instant;
@@ -492,6 +493,12 @@ pub struct GpuNativeSearchStats {
     pub device_stats: Vec<GpuNativeDeviceStats>,
     pub matches: Vec<GpuNativeSearchMatch>,
     pub pipeline: GpuPipelineStats,
+    /// Entries the walk reported an I/O error for (task 316, the GPU twin of
+    /// `native_search::SearchStats::walk_errors`). Non-zero means the file list is INCOMPLETE:
+    /// `main.rs` turns it into the envelope's `result_incomplete` /
+    /// `incomplete_reason_class` / `incomplete_paths_count` triple via the shared
+    /// `incomplete_envelope_fields`, and into exit 2 via `walk_was_incomplete`.
+    pub walk_errors: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -1171,7 +1178,10 @@ fn run_cuda_graph_benchmark_search_paths(
         ));
     }
 
-    let files = collect_search_files(config)?;
+    // Task 316: the walk now returns its error count alongside the paths, so the GPU route
+    // can disclose an incomplete file list instead of silently reporting a short answer.
+    let walked = collect_search_files(config)?;
+    let files = walked.files;
     let pattern_batches = plan_pattern_batches(&config.patterns)?;
     let batch_plans = plan_file_batches(
         &files,
@@ -1492,6 +1502,7 @@ fn run_cuda_graph_benchmark_search_paths(
         device_stats,
         matches,
         pipeline,
+        walk_errors: walked.walk_errors,
     })
 }
 
@@ -1741,7 +1752,10 @@ fn gpu_native_search_paths_multi_with_options(
         ));
     }
 
-    let files = collect_search_files(config)?;
+    // Task 316: the walk now returns its error count alongside the paths, so the GPU route
+    // can disclose an incomplete file list instead of silently reporting a short answer.
+    let walked = collect_search_files(config)?;
+    let files = walked.files;
     let selected_devices = resolve_cuda_devices(device_ids)?;
     let assignments = assign_files_to_devices(&files, &selected_devices)?;
     let device_outcomes = assignments
@@ -1780,6 +1794,7 @@ fn gpu_native_search_paths_multi_with_options(
         device_stats,
         matches,
         pipeline,
+        walk_errors: walked.walk_errors,
     })
 }
 
@@ -3849,9 +3864,23 @@ fn check_gpu_native_implicit_walk_ceiling(
     }
 }
 
-fn collect_search_files(config: &GpuNativeSearchConfig) -> Result<Vec<PathBuf>> {
+/// Files the GPU walk collected, plus how many entries it could not read.
+///
+/// Task 316, the GPU twin of `native_search::WalkedFiles` (#276 slice B3) and introduced for the
+/// same reason: `collect_walked_files` returned a bare `Vec<PathBuf>`, so it owned NO channel back
+/// to its caller and the walk-error count died at the `eprintln!`. Without this the GPU envelope
+/// could only ever say "complete", which is the silence #276 exists to end.
+struct GpuWalkedFiles {
+    files: Vec<PathBuf>,
+    /// Same `is_io()` filter as both CPU walkers (`native_search.rs:1328`/`:1806`) -- a malformed
+    /// global gitignore must NOT make a complete walk claim incompleteness.
+    walk_errors: usize,
+}
+
+fn collect_search_files(config: &GpuNativeSearchConfig) -> Result<GpuWalkedFiles> {
     let mut files = Vec::new();
     let mut roots = Vec::new();
+    let mut walk_errors = 0usize;
 
     for path in &config.paths {
         if !path.exists() {
@@ -3868,24 +3897,40 @@ fn collect_search_files(config: &GpuNativeSearchConfig) -> Result<Vec<PathBuf>> 
     }
 
     if !roots.is_empty() {
-        files.extend(collect_walked_files(config, &roots)?);
+        let walked = collect_walked_files(config, &roots)?;
+        files.extend(walked.files);
+        walk_errors += walked.walk_errors;
     }
 
     files.sort_unstable();
     files.dedup();
-    Ok(files)
+    // The count is deliberately NOT deduped alongside the paths: like the CPU side's
+    // `incomplete_paths_count`, it counts walk-error EVENTS, not distinct paths (task 320), so
+    // overlapping roots can raise it more than once for the same directory -- which is exactly
+    // what `rg` does, printing one line per visit.
+    Ok(GpuWalkedFiles { files, walk_errors })
 }
 
-fn collect_walked_files(config: &GpuNativeSearchConfig, roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
+fn collect_walked_files(
+    config: &GpuNativeSearchConfig,
+    roots: &[PathBuf],
+) -> Result<GpuWalkedFiles> {
     if let Some(refusal) = check_gpu_native_implicit_walk_ceiling(config, roots) {
         return Err(anyhow!(refusal));
     }
     let builder = build_walk_builder(config, roots)?;
     let walked_files = Arc::new(std::sync::Mutex::new(Vec::new()));
     let shared_files = Arc::clone(&walked_files);
+    // AtomicUsize rather than a Mutex<usize>, same reasoning as the CPU twin
+    // (`native_search.rs:1767`): a pure counter on the hot walker, incremented under contention by
+    // every worker thread. Relaxed ordering suffices -- no other memory is published through it,
+    // and it is only read after `run()` has joined every worker.
+    let walk_errors = Arc::new(AtomicUsize::new(0));
+    let shared_walk_errors = Arc::clone(&walk_errors);
 
     builder.build_parallel().run(|| {
         let shared_files = Arc::clone(&shared_files);
+        let shared_walk_errors = Arc::clone(&shared_walk_errors);
         Box::new(move |entry| {
             let entry = match entry {
                 Ok(entry) => entry,
@@ -3896,32 +3941,35 @@ fn collect_walked_files(config: &GpuNativeSearchConfig, roots: &[PathBuf]) -> Re
                     // completely silently. Real `rg` prints one stderr line per unreadable
                     // path and keeps walking.
                     //
-                    // THE CPU SIDE IS NOW WIRED; THIS ONE IS NOT. That asymmetry is the whole
-                    // of task 316 and is stated here because the previous version of this
-                    // comment said the exit code and envelope marker were "still unwired here,
-                    // same as the CPU side" -- which stopped being true when task 276 slice A
-                    // landed. A comment asserting a false fact about its twin is worse than no
-                    // comment: it tells the next reader the parity gap does not exist.
+                    // TASK 316 CLOSED THE PARITY GAP. Earlier revisions of this comment said the
+                    // exit code and envelope marker were unwired here, and named two obstacles.
+                    // Both are resolved; the chain now matches the CPU side end to end:
+                    //   :493                    `walk_errors` on GpuNativeSearchStats
+                    //   here                    the increment, behind the same `is_io()` gate
+                    //   main.rs (GPU envelope)  result_incomplete / incomplete_reason_class /
+                    //                           incomplete_paths_count, via the SHARED
+                    //                           `incomplete_envelope_fields` -- not a parallel
+                    //                           copy, so the GPU envelope cannot drift from the
+                    //                           CPU one
+                    //   main.rs (GPU exit arm)  exit 2 via the shared `walk_was_incomplete`
+                    // Obstacle 1 (adding a field to a `Serialize` struct changes JSON shape) is
+                    // answered by the envelope's existing `skip_serializing_if = "Option::is_none"`
+                    // idiom: a complete GPU scan emits none of the three and stays byte-identical.
+                    // Obstacle 2 (this module owns no envelope) is answered by identifying the
+                    // route: `GpuNativeSearchResultJson` / `emit_gpu_native_json_results`.
                     //
-                    // What the CPU side has that this does not (all on `main` today):
-                    //   native_search.rs:91        `walk_errors: usize` on SearchStats
-                    //   native_search.rs:1330/1378 the two increment sites
-                    //   native_search.rs:2436-2438 envelope emits result_incomplete /
-                    //                              incomplete_reason_class="unreadable_path" /
-                    //                              incomplete_paths_count
-                    //   main.rs:8388               `exit(2)` when walk_errors > 0
-                    //
-                    // Closing the gap here is NOT a mechanical port, and the difference is why
-                    // it is a separate slice rather than a line in slice A:
-                    //   1. `GpuNativeSearchStats` (:484) has no `walk_errors` field, and it
-                    //      derives `Serialize` -- adding a field changes emitted JSON shape, so
-                    //      it needs the same omit-when-zero treatment the CPU envelope uses or
-                    //      it breaks byte-identity for complete GPU scans.
-                    //   2. This module emits NO JSON envelope of its own (grep: zero hits for
-                    //      `result_incomplete` in this file). There is no seam here to add the
-                    //      marker to; the count has to reach whichever envelope the GPU route
-                    //      actually renders through, and that route must be identified first.
-                    // Both are CUDA-gated, so CI is the only place either can be exercised.
+                    // Same `is_io()` allow-list as both CPU walkers (`native_search.rs:1328`
+                    // and `:1806`), for the reason recorded there: `ignore::Error` also covers a
+                    // malformed ancestor/global gitignore (Glob / WithLineNumber via `add_parents`),
+                    // plus UnrecognizedFileType / InvalidDefinition / Loop. Counting those would
+                    // label a COMPLETE walk incomplete with a budget-non-remediable cause -- one bad
+                    // glob in ~/.config/git/ignore would make every GPU `--json` search on that
+                    // machine claim it could not finish. A false "incomplete" is worse than the
+                    // silence #276 set out to fix. Non-I/O errors still PRINT (rg-parity, #263);
+                    // they just do not claim the answer is partial.
+                    if err.is_io() {
+                        shared_walk_errors.fetch_add(1, Ordering::Relaxed);
+                    }
                     eprintln!("tg: {err}");
                     return WalkState::Continue;
                 }
@@ -3943,7 +3991,10 @@ fn collect_walked_files(config: &GpuNativeSearchConfig, roots: &[PathBuf]) -> Re
         .lock()
         .map_err(|_| anyhow!("failed to collect GPU native search walk results"))?
         .clone();
-    Ok(files)
+    Ok(GpuWalkedFiles {
+        files,
+        walk_errors: walk_errors.load(Ordering::Relaxed),
+    })
 }
 
 fn build_walk_builder(config: &GpuNativeSearchConfig, roots: &[PathBuf]) -> Result<WalkBuilder> {

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -9177,6 +9177,16 @@ struct GpuNativeSearchResultJson<'a> {
     native_gpu_unavailable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     not_gpu_proof_reason: Option<String>,
+    // Task 316: the same incompleteness triple the CPU envelopes carry, filled by the SHARED
+    // `incomplete_envelope_fields` so the GPU route cannot drift from them. `skip_serializing_if`
+    // keeps a complete GPU scan byte-identical to the pre-316 payload -- the omit-when-complete
+    // convention `result_incomplete` already follows everywhere else.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result_incomplete: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    incomplete_reason_class: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    incomplete_paths_count: Option<usize>,
     pipeline: &'a GpuPipelineStats,
     matches: Vec<SearchMatchJson>,
 }
@@ -12589,14 +12599,27 @@ fn execute_gpu_native_route(
             params.path,
             params.gpu_device_ids,
             gpu_native_match_json_entries(&stats),
-            // Task 276: this route observed no walk of its own, so it cannot report a
-            // count. `None` means "cannot report", NEVER "complete".
-            None,
+            // Task 316: this used to pass `None` with a comment claiming "this route observed no
+            // walk of its own". That was FALSE -- `gpu_native_search_paths_multi` walks via
+            // `collect_search_files` -> `collect_walked_files`; the count simply had nowhere to go.
+            // It does now, and a comment asserting a false fact about its own route is exactly the
+            // failure the gpu_native.rs note warned about. `None` still means "cannot report",
+            // never "complete", so passing the real count is strictly more honest.
+            Some(stats.walk_errors),
         )?;
     } else if params.count {
         emit_gpu_native_count_results(params, &stats)?;
     } else {
         emit_gpu_native_plain_results(params, &stats)?;
+    }
+
+    // Task 316, mirroring #818 on the multi-pattern route: an incomplete walk is checked BEFORE
+    // the no-match branch, because a scan that could not read part of the tree must never report
+    // a confident "0 matches" (exit 1) -- that reads as a genuine absence and is the exact
+    // green-light-to-delete-live-code this campaign exists to prevent. Same shared predicate as
+    // the envelope above, so disclosure and exit code cannot be derived independently.
+    if walk_was_incomplete(Some(stats.walk_errors)) {
+        std::process::exit(2);
     }
 
     if stats.total_matches == 0 {
@@ -13338,6 +13361,13 @@ fn emit_gpu_native_json_results(
         decision.routing_backend(),
         decision.sidecar_used(),
     );
+    // Task 316. Reuse the helper the CPU envelopes use rather than re-deriving the triple here:
+    // re-deriving truncation locally is the exact defect class this campaign closes (task 332
+    // found 3 of 3 repo_map gates deadline-blind for that reason), and `walk_was_incomplete`
+    // below reads the SAME `Some(stats.walk_errors)` so the payload and the exit code cannot
+    // disagree.
+    let (result_incomplete, incomplete_reason_class, incomplete_paths_count) =
+        incomplete_envelope_fields(Some(stats.walk_errors));
     let payload = GpuNativeSearchResultJson {
         version: JSON_OUTPUT_VERSION,
         routing_backend: decision.routing_backend(),
@@ -13357,6 +13387,9 @@ fn emit_gpu_native_json_results(
         gpu_proof: proof_fields.gpu_proof,
         native_gpu_unavailable: proof_fields.native_gpu_unavailable,
         not_gpu_proof_reason: proof_fields.not_gpu_proof_reason,
+        result_incomplete,
+        incomplete_reason_class,
+        incomplete_paths_count,
         pipeline: &stats.pipeline,
         matches: gpu_native_match_json_entries(stats),
     };

--- a/rust_core/src/python_sidecar.rs
+++ b/rust_core/src/python_sidecar.rs
@@ -1103,7 +1103,12 @@ mod tests {
     };
     use serde_json::json;
     use std::env;
-    use std::ffi::{OsStr, OsString};
+    // `OsStr`'s only use in this module is inside a `#[cfg(windows)]` test (:1344), so an
+    // unconditional import is dead on Linux and warns there. `OsString` stays ungated -- the
+    // compiler named only `OsStr`, which is the tell that the other symbol is used on both.
+    #[cfg(windows)]
+    use std::ffi::OsStr;
+    use std::ffi::OsString;
     use std::fs;
     use std::io::Cursor;
     use std::path::Path;


### PR DESCRIPTION
Closes task #316 — the last unbuilt slice of #276.

## The gap

The CPU walkers have carried `walk_errors` → `result_incomplete` /
`incomplete_reason_class` / `incomplete_paths_count` → exit 2 since slice A. The
CUDA twin printed the error to stderr and dropped the count, so a GPU `--json`
search over a partly-unreadable tree reported a short answer as complete and
exited 0.

## Both obstacles answered, not waved past

The in-code note refused a mechanical port and named two blockers:

1. **"adding a field to a `Serialize` struct changes JSON shape"** — the envelope
   already uses `skip_serializing_if = "Option::is_none"` on four fields. The new
   triple uses the same idiom, so a complete GPU scan stays byte-identical.
2. **"this module emits no envelope of its own"** — route identified:
   `GpuNativeSearchResultJson` / `emit_gpu_native_json_results`.

## Shared predicates, not parallel copies

The envelope calls the **shared** `incomplete_envelope_fields` and the exit arm the
**shared** `walk_was_incomplete` (#818), both reading the same
`Some(stats.walk_errors)` — so the payload and the exit code cannot be derived
independently. Re-deriving truncation locally is the exact defect class task 332
found in 3 of 3 repo_map gates. The exit-2 guard runs **before** the no-match
branch, mirroring #818: a scan that could not read part of the tree must never
report a confident "0 matches".

`GpuWalkedFiles` mirrors `native_search::WalkedFiles` (#276 slice B3) so
`collect_walked_files` owns a channel back to its caller. The increment sits behind
the **same `is_io()` allow-list** as both CPU walkers — a malformed global gitignore
must not make a complete walk claim incompleteness.

## Also fixes a false comment on this route

The ndjson arm passed `None` under *"this route observed no walk of its own"*. That
was untrue — `gpu_native_search_paths_multi` walks via `collect_search_files`. It
now passes the real count.

## Census: two of my own expectations were wrong, the code was right

Mechanical census of 13 expected sites, 11 matched. The two mismatches were mine:

- the envelope triple now appears **3×, not 2×** — I under-counted the existing envelopes.
- **4 other** `"observed no walk of its own"` comments survive. I checked each against
  its enclosing route rather than sweeping: `run_index_query` (×2) reads `.tg_index`,
  `handle_ast_run` delegates to the ast wrapper, and `handle_gpu_sidecar_search` shells
  to the Python sidecar via `execute_sidecar_command` and parses its stdout. **None walks
  in-process**, so `None` = "cannot report" is correct there. Only this route's claim was false.

## Noted, deliberately out of scope

The GPU **sidecar** route has a real disclosure gap — the sidecar process *does* walk and
its count never crosses the wire. Closing it needs a sidecar wire-protocol field, not a
comment change, and the existing comment is honest about the limitation.

## Verification

All CUDA-gated (`#[cfg(feature = "cuda")] pub mod gpu_native`), so **`cuda-feature-check`
in CI is the only oracle** — this box is CPU-safe and cannot compile it. `rustfmt --check`
clean on both files locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
