### PR TITLE
fix(cli): give every CLI incompleteness cause a machine-branchable remediability flag (task 307-C)

### DIFF
--- a/src/tensor_grep/cli/docs_coverage.py
+++ b/src/tensor_grep/cli/docs_coverage.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from tensor_grep.cli.incompleteness import budget_remediable
 from tensor_grep.cli.inventory import DEFAULT_MAX_INVENTORY_FILES, _is_test_path
 from tensor_grep.cli.repo_map import (
     _deadline_monotonic_from_seconds,
@@ -306,6 +307,15 @@ def build_docs_coverage(
             "max_files": max_files,
             "possibly_truncated": possibly_truncated,
             "truncation_cause": truncation_cause,
+            # Task #307-C: the machine-branchable "is a retry worth it?" flag. Emitted ONLY
+            # when the scan was actually truncated, so a complete scan stays byte-identical.
+            # Same allow-list the MCP `scan_limit` surface uses (#283) -- one definition in
+            # `cli/incompleteness.py`, so CLI and MCP cannot drift into different advice.
+            **(
+                {"budget_remediable": budget_remediable(truncation_cause)}
+                if possibly_truncated
+                else {}
+            ),
         },
         "coverage": {
             "match": "path-or-basename",
@@ -519,6 +529,15 @@ def build_docs_stale_references(
             "max_files": max_files,
             "possibly_truncated": possibly_truncated,
             "truncation_cause": truncation_cause,
+            # Task #307-C: the machine-branchable "is a retry worth it?" flag. Emitted ONLY
+            # when the scan was actually truncated, so a complete scan stays byte-identical.
+            # Same allow-list the MCP `scan_limit` surface uses (#283) -- one definition in
+            # `cli/incompleteness.py`, so CLI and MCP cannot drift into different advice.
+            **(
+                {"budget_remediable": budget_remediable(truncation_cause)}
+                if possibly_truncated
+                else {}
+            ),
         },
     }
     if walk_deadline_hit.hit:

--- a/src/tensor_grep/cli/incompleteness.py
+++ b/src/tensor_grep/cli/incompleteness.py
@@ -34,6 +34,39 @@ INCOMPLETENESS_MARKERS: tuple[str, ...] = (
 )
 
 
+# Causes a bigger budget CAN fix, in BOTH spellings the product ships. The two vocabularies are
+# deliberately NOT unified (#293): `truncation_cause` is hyphenated, `incomplete_reason_class` /
+# `partial_reason` are underscored, each is internally consistent, and renaming either breaks a
+# documented contract for no correctness gain. So this maps both rather than normalising.
+_BUDGET_REMEDIABLE_CAUSES: frozenset[str] = frozenset({
+    "project-files",  # the --max-files/--max-repo-files count cap -- raise it
+    "max-scan-entries",  # DirectoryScanner's own entry budget -- raise it
+    "scan_limit",  # underscored sibling of the above
+    "deadline",  # the --deadline wall-clock bound -- raise it
+    "timeout",  # a per-file/subprocess wall-clock bound -- raise it
+})
+
+
+def budget_remediable(cause: str | None) -> bool:
+    """Can a BIGGER budget fix this truncation cause? Fail-closed.
+
+    Task #307-C. The knowledge this encodes already existed -- but only inside
+    `tests/unit/test_truncation_cause_vocabulary_ratchet.py`, which meant CI could branch on it and
+    the shipped CLI could not. `budget_remediable` was emitted by exactly ONE surface (the MCP
+    `scan_limit` object, `mcp_server.py`, task #283) while every CLI route stamped a cause with no
+    machine-branchable "is a retry worth it?" flag. A consumer that cannot tell
+    `raise --max-repo-files` from `you will never read that directory` retries forever or gives up
+    on a fixable scan.
+
+    ALLOW-LIST, never a deny-list (#282). ``unreadable-path``/``unreadable_path`` is the value that
+    must return False, but enumerating the *unsafe* cases fails OPEN on any cause a future author
+    adds and this function has not been taught -- an unrecognised cause would be advertised as
+    "just raise the limit", which is the wrong-knob advice #283 exists to prevent. So: name the
+    SAFE causes, and return False for everything else including ``None`` and ``"unknown"``.
+    """
+    return cause in _BUDGET_REMEDIABLE_CAUSES
+
+
 def disclosed_incomplete(stdout: str | None, stderr: str | None) -> bool:
     """True when an exit-2 run DISCLOSED that its scan was incomplete.
 

--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -26,6 +26,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from tensor_grep.cli.incompleteness import budget_remediable
 from tensor_grep.cli.repo_map import (
     _DeadlineBreakFlag,
     _iter_repo_files,
@@ -352,6 +353,15 @@ def build_inventory(
             "scanned_files": total_files,
             "possibly_truncated": possibly_truncated,
             "truncation_cause": truncation_cause,
+            # Task #307-C: the machine-branchable "is a retry worth it?" flag. Emitted ONLY
+            # when the scan was actually truncated, so a complete scan stays byte-identical.
+            # Same allow-list the MCP `scan_limit` surface uses (#283) -- one definition in
+            # `cli/incompleteness.py`, so CLI and MCP cannot drift into different advice.
+            **(
+                {"budget_remediable": budget_remediable(truncation_cause)}
+                if possibly_truncated
+                else {}
+            ),
         },
     }
 

--- a/tests/unit/test_budget_remediable_cli_parity.py
+++ b/tests/unit/test_budget_remediable_cli_parity.py
@@ -1,0 +1,119 @@
+"""Task #307-C: every CLI incompleteness cause carries a machine-branchable remediability flag.
+
+The knowledge already existed -- but only inside
+`tests/unit/test_truncation_cause_vocabulary_ratchet.py`, so CI could branch on it and the SHIPPED
+CLI could not. `budget_remediable` was emitted by exactly ONE surface (the MCP `scan_limit` object,
+task #283) while every CLI route stamped a cause with no "is a retry worth it?" signal. A consumer
+that cannot tell `raise --max-repo-files` from `you will never read that directory` either retries
+forever or gives up on a fixable scan.
+
+Every assertion here is paired with its opposite arm -- an allow-list that returns True for
+everything, or False for everything, is a brick, and a brick passes a one-sided test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tensor_grep.cli.incompleteness import budget_remediable
+
+
+def test_budget_remediable_discriminates_between_the_two_cause_families() -> None:
+    # TREATMENT: a budget cap or a clock -- raising the knob genuinely fixes these.
+    assert budget_remediable("project-files") is True
+    assert budget_remediable("max-scan-entries") is True
+    assert budget_remediable("deadline") is True
+    assert budget_remediable("timeout") is True
+    assert budget_remediable("scan_limit") is True
+
+    # CONTROL: no budget value makes a permission-denied path readable. If this arm ever returns
+    # True the helper has become a brick that says "just raise the limit" to everything, which is
+    # the wrong-knob advice #283 exists to prevent.
+    assert budget_remediable("unreadable-path") is False
+    assert budget_remediable("unreadable_path") is False
+
+
+def test_budget_remediable_fails_closed_on_anything_it_was_not_taught() -> None:
+    """ALLOW-LIST, not deny-list (#282).
+
+    A deny-list ("return False only for unreadable-path") fails OPEN on every cause a future
+    author adds -- the new value would be advertised as budget-remediable purely because nobody
+    updated this function. These arms pin the safe direction.
+    """
+    assert budget_remediable(None) is False
+    assert budget_remediable("unknown") is False
+    assert budget_remediable("self_verify") is False
+    assert budget_remediable("a-cause-nobody-has-invented-yet") is False
+    assert budget_remediable("") is False
+
+
+def _scan_limit(payload: dict[str, Any]) -> dict[str, Any]:
+    scan = payload["scan_limit"]
+    assert isinstance(scan, dict)
+    return scan
+
+
+def test_inventory_emits_the_flag_only_when_truncated() -> None:
+    from tensor_grep.cli import inventory as inventory_mod
+
+    source = inventory_mod.__file__
+    assert source is not None
+    text = open(source, encoding="utf-8").read()
+
+    # PREMISE: the emitter still gates the flag on `possibly_truncated`. If that gate is removed,
+    # a COMPLETE inventory starts carrying the key and the byte-identity promise below is void --
+    # so this must fail loudly rather than let the claim rot.
+    assert '"budget_remediable": budget_remediable(truncation_cause)' in text
+    assert "if possibly_truncated" in text
+
+    # CLAIM: the helper is imported from the ONE shared definition, not re-implemented locally.
+    # A second copy is how CLI and MCP drift into giving opposite advice for the same cause.
+    assert "from tensor_grep.cli.incompleteness import budget_remediable" in text
+
+
+def test_docs_coverage_emits_the_flag_at_both_scan_limit_sites() -> None:
+    from tensor_grep.cli import docs_coverage as docs_mod
+
+    source = docs_mod.__file__
+    assert source is not None
+    text = open(source, encoding="utf-8").read()
+
+    # docs-coverage builds a scan_limit in TWO places (the coverage report and --stale mode). A
+    # fix applied to one arm and not its twin is the recurring defect of this whole campaign, so
+    # the count is the assertion.
+    assert text.count('"budget_remediable": budget_remediable(truncation_cause)') == 2
+    assert "from tensor_grep.cli.incompleteness import budget_remediable" in text
+
+
+def test_the_ratchet_and_the_product_agree_on_which_causes_are_remediable() -> None:
+    """The ratchet test owned this fact; the product now does. Pin them together.
+
+    Before #307-C the mapping lived ONLY in the ratchet module, which is why the CLI could not
+    branch on it. Now that the product owns it, the ratchet's copy must agree -- otherwise we have
+    re-created the drift in the opposite direction.
+    """
+    # Loaded by PATH, not by `from tests.unit...` -- `tests/` is not a package, so the import form
+    # raises ModuleNotFoundError and the cross-check would be quietly lost to a skip or an error.
+    import importlib.util
+    from pathlib import Path
+
+    ratchet_path = Path(__file__).with_name("test_truncation_cause_vocabulary_ratchet.py")
+    assert ratchet_path.is_file(), f"ratchet module moved: {ratchet_path}"
+    spec = importlib.util.spec_from_file_location("_ratchet_for_parity", ratchet_path)
+    assert spec is not None and spec.loader is not None
+    ratchet = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(ratchet)
+
+    known = ratchet.KNOWN_TRUNCATION_CAUSES
+    non_remediable = ratchet.NON_BUDGET_REMEDIABLE
+    # PREMISE: both sets are non-empty and the non-remediable set is a real subset. A vacuous loop
+    # over an empty set would pass this test while checking nothing.
+    assert known, "ratchet's KNOWN_TRUNCATION_CAUSES is empty -- the loop below would be vacuous"
+    assert non_remediable and non_remediable < known
+
+    for cause in known:
+        expected = cause not in non_remediable
+        assert budget_remediable(cause) is expected, (
+            f"{cause!r}: ratchet says budget_remediable={expected}, product says "
+            f"{budget_remediable(cause)} -- the two definitions have drifted"
+        )


### PR DESCRIPTION
Closes the C-leg of task #307 (trust-benchmark: what would make tg genuinely lead rg/GNU grep).

## The gap

`budget_remediable` shipped on exactly **one** surface — the MCP `scan_limit` object (#283). Every
CLI route stamped a `truncation_cause` with no machine-branchable "is a retry worth it?" signal, so
a consumer could not tell `raise --max-repo-files` (fixable) from `you will never read that
directory` (not). It either retries forever or abandons a fixable scan.

The knowledge **already existed** — inside `tests/unit/test_truncation_cause_vocabulary_ratchet.py`,
as `KNOWN_TRUNCATION_CAUSES` / `NON_BUDGET_REMEDIABLE`. CI could branch on it; the shipped CLI could
not. This moves it into the product and has the ratchet cross-check the product rather than own a
second copy.

## The fix

`budget_remediable(cause)` lives in `cli/incompleteness.py` — the module that already owns this
vocabulary and already states the allow-list design point.

- **Allow-list, not deny-list (#282).** Naming the SAFE causes means an unrecognised value returns
  `False`. A deny-list ("False only for unreadable-path") fails **open** on every cause a future
  author adds — the new value would be advertised as "just raise the limit", which is exactly the
  wrong-knob advice #283 fixed.
- **Maps both spellings without unifying them (#293).** `truncation_cause` is hyphenated,
  `incomplete_reason_class`/`partial_reason` underscored; each is internally consistent and renaming
  either breaks a documented contract.
- Wired at all 3 `scan_limit` emitters — inventory (1) and docs-coverage (2: the coverage report and
  `--stale` mode). Emitted **only** when `possibly_truncated`, so a complete scan stays byte-identical.

## Verification

**Bidirectional.** Mutating the allow-list into the deny-list shape (mutation asserted applied, not
assumed) fails `test_budget_remediable_fails_closed_on_anything_it_was_not_taught`; restored and
re-run green. Both arms are pinned — budget causes `True`, unreadable-path `False` — because a helper
that returns `True` for everything is a brick and a one-sided test cannot tell.

The ratchet cross-check loads the ratchet module **by path**: `tests/` is not a package, so
`from tests.unit...` raises `ModuleNotFoundError` and the check would have been silently lost. It
also asserts both sets are non-empty first, so the loop cannot pass vacuously.

**78 passed** across the new parity suite + inventory + docs-coverage + ratchet. `ruff check` and
`ruff format --preview` clean.

## Scope note

The census behind this was re-run after discovering the shared checkout was 28 commits stale. On the
current tree the finding **holds and widened** — the new `cli/sarif.py` is a 10th cause-emitting
surface without the flag. Wiring the remaining 7 (`agent_capsule`, `codemap`, `formatters/json_fmt`,
`main`, `repo_map`, `orient_capsule`, `sarif`) is a follow-up: they stamp causes through different
shapes than `scan_limit` and each needs its own emit-only-when-truncated gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
