### PR TITLE
docs(backlog): reconcile the canonical ledger to v1.101.3

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -34,9 +34,10 @@
 > assertion, and two latency assertions masquerading as hang guards. **#810** stopped the public
 > docs citing local task IDs as though they were GitHub links; **#813** folded in the 8th oracle
 > form and the drain-gate correction.
-> IN FLIGHT (not yet merged, see `gh pr list`): the session-laws capture (**#824**), the
-> `budget_remediable` extension to `repo_map`'s `scan_limit`/`output_limit` (**#826**), and three
-> TorchBackend tests rewritten against a matcher that actually exists (**#827**).
+> LANDING WITH THIS RECONCILE (so this line does not go stale the moment it merges -- `gh pr list`
+> stays the source of truth): the session-laws capture (**#824**), the `budget_remediable`
+> extension to `repo_map`'s `scan_limit`/`output_limit` (**#826**, the only releasing one of the
+> four), and three TorchBackend tests rewritten against a matcher that actually exists (**#827**).
 >
 > Prior refresh 2026-07-26 (post-**v1.98.27**) -- the **trustworthy-tg** wave (#292), continuing
 > the unreadable-path honesty thread below across 14 releases. The through-line: a surface that

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,7 +3,42 @@
 > **Canonical prioritized work list.** Kept in sync with the CLI task store (`TaskUpdate`) and
 > GitHub (`gh pr list` is the source of truth for PRs). **CEO status** = summarize SHIPPING + P0/P1.
 > Update whenever a PR opens/merges or the queue changes. Task-store IDs (`#NNN`) cross-referenced.
-> Last refreshed 2026-07-26 (post-**v1.98.27**) — the **trustworthy-tg** wave (#292), continuing
+> Last refreshed 2026-07-27 (post-**v1.101.3**) — the **incompleteness-envelope** wave, closing
+> the `--json`/`--ndjson` gap that the trustworthy-tg thread below had left as its load-bearing
+> hole. The rule it settles: a machine consumer must be able to tell *truncated* from *absent*
+> without reading stderr, and the exit code must agree with the envelope.
+> **#276 closed across nine PRs**: **#795** gave `SearchStats` a walk-error count and **#808** fed
+> it from the serial walk, so `--json` can no longer claim a complete scan; **#811** put the marker
+> on the `main.rs` `SearchResultJson`/ndjson envelopes and **#818** made the multi-pattern route
+> exit `2` when it discloses an incomplete walk; **#823** crossed the count to the `gpu_native`
+> twin; **#793** gave the benchmarks three-state exit codes and one canonical marker set; **#821**
+> stopped classifying an OUTPUT-write failure as an unreadable path; **#820** wrote down that
+> `incomplete_paths_count` counts EVENTS, not distinct paths; and **#805** added
+> `SearchStats::is_empty()` so the `Drop` guard cannot silently forget a new field — the class fix
+> rather than the instance fix.
+> What an EXTERNAL dogfood caught that our own gates did not: **#814** and **#816** killed two false
+> claims (`not_found` asserted over a scan that read ZERO files, and a guard applied to a SHADOWED
+> function while the real producer went untouched); **#819** found the same shape a third time in
+> the truncation gates, which were blind to `--deadline` and so asserted absence over an unfinished
+> scan; **#815** named the incompleteness fields the contract had never named; **#825** gave every
+> CLI incompleteness cause a machine-branchable `budget_remediable` flag, so "would a bigger budget
+> help?" stops being a guess.
+> New surface: **#796** SARIF v2.1.0 for `tg scan`; **#806** exposed `incomplete_reason_class` over
+> MCP; **#801** surfaced a live foreign ledger claim on `prepare`'s read-only path; **#800** bounded
+> the session rebuild on BOTH refresh branches. Checkpoint honesty: **#785** reports a corrupt
+> checkpoint as corrupt rather than missing; **#799** discloses the post-checkpoint edits `undo`
+> discarded. **#804** fixed the trust benchmark, which had been measuring ripgrep twice and
+> reporting it as tg.
+> Test FORM, not just coverage: **#797** made output determinism a named CI-gated invariant;
+> **#798/#809/#802/#817** retired the last flat wall-clock bounds, an incidental-byproduct
+> assertion, and two latency assertions masquerading as hang guards. **#810** stopped the public
+> docs citing local task IDs as though they were GitHub links; **#813** folded in the 8th oracle
+> form and the drain-gate correction.
+> IN FLIGHT (not yet merged, see `gh pr list`): the session-laws capture (**#824**), the
+> `budget_remediable` extension to `repo_map`'s `scan_limit`/`output_limit` (**#826**), and three
+> TorchBackend tests rewritten against a matcher that actually exists (**#827**).
+>
+> Prior refresh 2026-07-26 (post-**v1.98.27**) -- the **trustworthy-tg** wave (#292), continuing
 > the unreadable-path honesty thread below across 14 releases. The through-line: a surface that
 > cannot complete its work must SAY so, in a field a machine can branch on, and exit accordingly.
 > What shipped: **#767/#768/#769/#770** carried the unreadable-subtree signal into `inventory`,
@@ -22,9 +57,6 @@
 > wall-clock overlap with ones that assert the contract. **#784** committed the trust benchmark
 > harness AND reported what it actually shows — which was NOT a clean lead — and **#789** dropped
 > its vanished-file column for scoring correct behaviour as dishonest.
-> IN FLIGHT (not yet merged, see `gh pr list`): the #276 `--json`/`--ndjson` incompleteness
-> envelope across the native producer (#808) and the second `main.rs` envelope pair (#811), SARIF
-> output (#796), the determinism gate (#797), and the trust-benchmark fix (#804).
 >
 > Prior refresh 2026-07-25b (post-**v1.98.13**, with v1.98.14 releasing) — the **unreadable-path
 > honesty** wave. One question drove it: when tg cannot READ part of a tree, does it say so, or does


### PR DESCRIPTION
## Why

The ledger's newest entry was **v1.98.27** while live was **v1.101.3** — 13 releases and 29 substantive commits unrecorded.

## Two changes, not one

**1. Adds the v1.99.0 → v1.101.3 wave.** The through-line is the incompleteness envelope: a machine consumer must be able to tell *truncated* from *absent* without reading stderr, and the exit code must agree with the envelope.

- **#276 closed across nine PRs** — #795 (walk-error count in `SearchStats`), #808 (fed from the serial walk), #811 (`main.rs` envelope marker), #818 (exit 2 on the multi-pattern route), #823 (`gpu_native` twin), #793 (three-state benchmark exits), #821 (an OUTPUT-write failure is not an unreadable path), #820 (`incomplete_paths_count` counts EVENTS), #805 (`SearchStats::is_empty()` so the `Drop` guard cannot forget a field — the class fix, not the instance fix)
- **What an external dogfood caught that our own gates did not** — #814/#816 (two false claims: `not_found` over a zero-file scan; a guard on a *shadowed* function while the real producer went untouched), #819 (same shape a third time: truncation gates blind to `--deadline`), #815/#825 (the contract gained names it lacked, and a machine-branchable `budget_remediable`)
- **New surface** — #796 SARIF v2.1.0, #806 MCP `incomplete_reason_class`, #801, #800
- **Checkpoint honesty** — #785, #799
- **#804** fixed a trust benchmark that had been measuring ripgrep twice and reporting it as tg
- **Test form** — #797 determinism as a CI-gated invariant; #798/#809/#802/#817 retired flat wall-clock bounds and latency assertions posing as hang guards

**2. Removes a block that had become false.** The header listed #808, #811, #796, #797 and #804 under *"IN FLIGHT (not yet merged)"*. **All five are merged on main** — verified per PR against the commit log before deleting, not inferred from dates. A stale in-flight list is worse than no list: it tells a reader that shipped work is still pending.

The IN FLIGHT line now names what is actually open: #824, #826, #827.

## Verified

- `--json` / `--ndjson` / `--deadline` literals intact after em-dash normalisation (checked explicitly — the normalisation was scoped to ` -- ` with surrounding spaces, so backticked flags could not be caught)
- `ruff format --preview --check` clean — CI formats markdown fences repo-wide and that is a release gate
- The nine #276 PRs each traced back to a #276 slice/finding rather than counted from the prose

Docs-only, non-releasing. Task #337.