### PR TITLE
fix(cli): tg scan's text output must say it could not read part of the scope

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -6695,17 +6695,33 @@ def _run_ast_scan_payload(
         # (#276), so a consumer that understands one understands all of them. Emitted ONLY when
         # something was actually skipped: a field that is always present teaches readers to
         # ignore it, and `partial` must mean something when it appears.
+        # `count` counts failed READ ATTEMPTS, not distinct files. `_UnreadablePathFlag.record`
+        # increments per `OSError`, and `scan` runs two backends (the ast-grep wrapper and the
+        # regex leg) that each open the same file -- so ONE unreadable file reports 2. Dogfooded
+        # on an ACL-denied fixture holding exactly one blocked file: count=2, sample=[f, f].
+        #
+        # The event semantics are deliberately NOT changed: other `_UnreadablePathFlag` consumers
+        # count `os.scandir` failures, where per-event IS the right number, and task 320 already
+        # settled that question for the native `incomplete_paths_count` by DOCUMENTING it rather
+        # than deduplicating a hot-path counter. What was wrong is the PROSE, which rendered an
+        # event count as "N file(s) ... could not be read" -- a false statement about the world,
+        # and one the default text output now prints to stdout rather than burying in --json.
+        #
+        # The SAMPLE is de-duplicated because it is a list of PLACES, not a tally: two slots spent
+        # on one path is a sample that names fewer of them. It is already capped, so this is
+        # O(cap) and preserves first-seen order.
+        distinct_unreadable = list(dict.fromkeys(scan_unreadable.sample))
         payload["unreadable_paths"] = {
             "count": scan_unreadable.count,
-            "sample": list(scan_unreadable.sample),
+            "sample": distinct_unreadable,
         }
         payload["partial"] = True
         payload["partial_reason"] = "unreadable_path"
         payload["remediation"] = (
-            f"{scan_unreadable.count} file(s) in scope could not be read (e.g. "
-            f"{', '.join(scan_unreadable.sample) or 'an unreadable path'}), so no rule ran "
-            "against them and this result does NOT prove they are clean. Make them readable, or "
-            "scope the scan away from them."
+            f"{scan_unreadable.count} read attempt(s) in scope failed (e.g. "
+            f"{', '.join(distinct_unreadable) or 'an unreadable path'}), so no rule ran "
+            "against those files and this result does NOT prove they are clean. Make them "
+            "readable, or scope the scan away from them."
         )
     _apply_ruleset_baseline(
         payload,
@@ -14306,6 +14322,31 @@ def scan(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
         return
+
+    # Task #299 gave `scan` a `partial` / `partial_reason` / `remediation` / `unreadable_paths`
+    # payload, and #310's SARIF output carries it in-band -- but the DEFAULT text renderer read
+    # none of them. Measured on the shipped v1.101.4 against an ACL-denied fixture (denial
+    # asserted to bite first): `--json` reported `partial: true` with a 2-path `unreadable_paths`
+    # sample, while the same invocation's stdout printed `Scan completed. total_matches=2` and
+    # exited 0 -- silent about two secrets in a file no rule ever opened. On a SECURITY ruleset
+    # that is the worst shape in the product: an unread file is indistinguishable from a clean one.
+    #
+    # LEADING, not trailing. `codemap` is the sibling that already reads `remediation`, but it
+    # prints its `PARTIAL:` line AFTER the counts -- that ordering is exactly the task #329 defect
+    # and is not the half of the precedent worth copying. A disclosure must be read BEFORE the
+    # total it qualifies, or the reader has already formed the answer.
+    #
+    # The exit code deliberately stays 0; see the SARIF block above. `tg scan` has returned 0 on a
+    # disclosed partial since #299, and flipping it is a contract change with its own consumers,
+    # not a drive-by on a rendering fix.
+    if payload.get("partial"):
+        remediation = str(payload.get("remediation") or "").strip()
+        typer.echo(
+            f"warning: INCOMPLETE SCAN: {remediation}"
+            if remediation
+            else "warning: INCOMPLETE SCAN: part of the scope could not be read, so this result "
+            "does NOT prove those files are clean."
+        )
 
     for finding in cast(list[dict[str, object]], payload["findings"]):
         typer.echo(

--- a/tests/unit/test_scan_text_partial_disclosure.py
+++ b/tests/unit/test_scan_text_partial_disclosure.py
@@ -1,0 +1,156 @@
+"""`tg scan`'s DEFAULT text output must disclose a scope it could not fully read.
+
+`test_scan_unreadable_disclosure.py` (#299) pins the PAYLOAD: `_run_ast_scan_payload` sets
+`partial` / `partial_reason` / `remediation` / `unreadable_paths` when a file in scope cannot be
+opened, and #310's SARIF output carries that in-band. The default TEXT renderer read none of it,
+so the surface most people actually run printed ``Scan completed. total_matches=N`` over files no
+rule ever opened -- a payload-level fix that never reached the default output.
+
+Measured on the SHIPPED v1.101.4 against an ACL-denied fixture (the denial asserted to bite
+first, and a sibling file asserted still readable), one invocation rendered two ways:
+
+    --json   partial=true, partial_reason="unreadable_path",
+             unreadable_paths={"count": 2, "sample": [...]}
+    text     "Scan completed. rules=6 matched_rules=2 total_matches=2"     exit 0
+
+The blocked file held two secrets both rules would have matched. Nothing on stdout said so.
+
+SCOPE: these pin the TEXT path only. The exit code stays 0 by an explicit, cross-referenced
+decision (the SARIF block's exit-code note in `main.py`, and CHANGELOG v1.101.0) -- asserting
+exit 2 here would pin a contract change this commit deliberately did not make.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from tensor_grep.cli import main as main_mod
+from tensor_grep.cli.main import app
+
+runner = CliRunner()
+
+_SUMMARY = "Scan completed."
+_BANNER = "warning: INCOMPLETE SCAN:"
+
+
+def _base_payload() -> dict[str, Any]:
+    return {
+        "findings": [
+            {
+                "rule_id": "python-hardcoded-password",
+                "language": "python",
+                "matches": 1,
+                "files": ["a.py"],
+            }
+        ],
+        "rule_count": 6,
+        "matched_rules": 1,
+        "total_matches": 1,
+        "backends": ["RegexRulesetBackend"],
+    }
+
+
+def _partial_payload() -> dict[str, Any]:
+    """The shape `_run_ast_scan_payload` really builds on an unreadable file.
+
+    Mirrored field-for-field from the writer (`scan_unreadable.hit` in `main.py`) rather than
+    reduced to a bare `partial` flag: the remediation names the paths, and a fixture that dropped
+    it would let a renderer satisfy these tests by printing a marker that tells a reader nothing.
+    """
+    payload = _base_payload()
+    payload.update(
+        partial=True,
+        partial_reason="unreadable_path",
+        unreadable_paths={
+            "count": 2,
+            "sample": ["/repo/blocked.py", "/repo/also_blocked.py"],
+        },
+        remediation=(
+            "2 read attempt(s) in scope failed (e.g. /repo/blocked.py, "
+            "/repo/also_blocked.py), so no rule ran against those files and this result does NOT "
+            "prove they are clean. Make them readable, or scope the scan away from them."
+        ),
+    )
+    return payload
+
+
+def _run_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    payload: dict[str, Any],
+    *extra_args: str,
+):
+    """Drive the REAL `scan` command with the producer stubbed to a known payload.
+
+    The renderer under test is inline in the command body, so there is no helper to call
+    directly -- an earlier draft of this file invented `_emit_scan_text_report`, which does not
+    exist and would have failed on AttributeError as a false red. Stubbing the producer and
+    invoking the command exercises the actual emit block.
+    """
+    monkeypatch.setattr(main_mod, "_run_ast_scan_payload", lambda *a, **k: dict(payload))
+    return runner.invoke(app, ["scan", str(tmp_path), "--ruleset", "secrets", *extra_args])
+
+
+def test_partial_scan_discloses_the_unreadable_scope_in_text_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result = _run_scan(monkeypatch, tmp_path, _partial_payload())
+    out = result.stdout
+    assert _SUMMARY in out  # premise: the renderer really ran
+    assert "INCOMPLETE SCAN" in out
+    assert "does NOT prove they are clean" in out
+    # The paths are what make it actionable; "something was skipped" is not a disclosure.
+    assert "/repo/blocked.py" in out
+
+
+def test_the_disclosure_leads_the_findings_and_the_total(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Task #329's law. The sibling `codemap` prints its `PARTIAL:` line AFTER its counts; that
+    # ordering is the defect, not the half of the precedent worth copying. A reader who has seen
+    # `total_matches=1` has already formed the answer by the time a trailing line lands.
+    out = _run_scan(monkeypatch, tmp_path, _partial_payload()).stdout
+    assert _SUMMARY in out
+    assert "[scan] rule=" in out
+    assert out.index("INCOMPLETE SCAN") < out.index("[scan] rule=")
+    assert out.index("INCOMPLETE SCAN") < out.index(_SUMMARY)
+
+
+def test_a_complete_scan_emits_no_disclosure_at_all(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # CONTROL ARM. Without it, "a warning appeared somewhere" would hold in both arms.
+    out = _run_scan(monkeypatch, tmp_path, _base_payload()).stdout
+    assert _SUMMARY in out  # premise: the renderer really ran
+    assert "INCOMPLETE" not in out
+    assert "warning:" not in out
+
+
+def test_partial_without_a_remediation_string_still_discloses(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Fail-closed: `partial` is the signal and `remediation` is the courtesy. Keying the banner
+    # off the optional field would silence an incomplete scan exactly when its writer was least
+    # careful -- guidance about trust is an allow-list, never a deny-list.
+    bare = _base_payload()
+    bare["partial"] = True
+    out = _run_scan(monkeypatch, tmp_path, bare).stdout
+    assert _BANNER in out
+    assert "does NOT prove those files are clean" in out
+
+
+def test_json_mode_stays_a_single_parseable_document(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The banner is a TEXT-path concern. A stray line on the --json route would break
+    # `json.loads` on stdout, which is the failure this whole campaign exists to prevent.
+    out = _run_scan(monkeypatch, tmp_path, _partial_payload(), "--json").stdout
+    emitted = json.loads(out)
+    assert emitted["partial"] is True
+    assert "remediation" in emitted
+    assert _BANNER not in out

--- a/tests/unit/test_scan_unreadable_disclosure.py
+++ b/tests/unit/test_scan_unreadable_disclosure.py
@@ -40,6 +40,29 @@ def _scan(root: Path) -> dict:
     )
 
 
+def _scan_with_rules(root: Path, rule_count: int) -> dict:
+    """`_scan` with N distinct regex rules, so the leg opens each file N times."""
+    from tensor_grep.cli.main import _run_ast_scan_payload
+
+    rules = []
+    for i in range(rule_count):
+        rule = dict(_REGEX_RULE)
+        rule["id"] = f"{_REGEX_RULE['id']}-{i}"
+        rules.append(rule)
+    return _run_ast_scan_payload(
+        {
+            "config_path": "builtin:auth-safe",
+            "root_dir": root,
+            "rule_dirs": [],
+            "test_dirs": [],
+            "language": "python",
+        },
+        rules,
+        routing_reason="builtin-ruleset-scan",
+        ruleset_name="test-regex",
+    )
+
+
 def _read_text_raiser(canary: str, pristine):
     def fake(self, *args, **kwargs):
         if self.name == canary:
@@ -77,3 +100,45 @@ def test_scan_discloses_a_file_the_rules_could_not_read(tmp_path: Path, monkeypa
     assert payload["partial_reason"] == "unreadable_path"
     # Must not send the reader to a budget knob: no cap increase makes a file readable.
     assert "does NOT prove they are clean" in payload["remediation"]
+
+
+def test_the_unreadable_sample_names_distinct_places_not_repeated_attempts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`scan` runs two backends, so ONE unreadable file raises TWO OSErrors.
+
+    `_UnreadablePathFlag.record` increments per error and appends per error, so the pre-fix
+    sample was `[locked.py, locked.py]` and the prose read "2 file(s) in scope could not be
+    read" -- a false statement about the world, found by dogfooding the real front door against
+    an ACL-denied fixture holding exactly ONE blocked file.
+
+    The event COUNT is deliberately left alone (other `_UnreadablePathFlag` consumers count
+    `os.scandir` failures, where per-event is right, and task 320 settled the same question for
+    the native counter by documenting it). The SAMPLE is a list of PLACES, so it de-duplicates,
+    and the prose no longer claims files.
+    """
+    (tmp_path / "clean.py").write_text("SENTINEL_TOKEN = 1\n", encoding="utf-8")
+    (tmp_path / "locked.py").write_text("SENTINEL_TOKEN = 2\n", encoding="utf-8")
+
+    pristine = Path.read_text
+    monkeypatch.setattr(Path, "read_text", _read_text_raiser("locked.py", pristine))
+    # TWO rules, so the regex leg opens each file twice -- the same double-attempt shape the real
+    # command produces by running the ast-grep wrapper AND the regex leg over one file. With a
+    # single rule only one OSError is raised and the duplicate condition never occurs, which the
+    # premise assertion below would (and did) catch.
+    payload = _scan_with_rules(tmp_path, 2)
+
+    unreadable = payload["unreadable_paths"]
+    # PREMISE: the double-attempt really happened, otherwise this test proves nothing about
+    # de-duplication -- it would just be observing a one-element list that was never at risk.
+    assert unreadable["count"] >= 2, (
+        "premise failed: only one read attempt was recorded, so the duplicate-sample condition "
+        "this test exists for was never reached"
+    )
+    assert len(unreadable["sample"]) == len(set(unreadable["sample"])), (
+        f"sample repeats a path: {unreadable['sample']}"
+    )
+    assert len(unreadable["sample"]) == 1  # exactly one file was ever blocked
+    # And the prose must not render an EVENT count as a FILE count.
+    assert "file(s) in scope could not be read" not in payload["remediation"]
+    assert "read attempt(s) in scope failed" in payload["remediation"]


### PR DESCRIPTION
fix(cli): tg scan's text output must say it could not read part of the scope

`tg scan --ruleset secrets` printed `Scan completed. total_matches=N` and exited 0
over files it could not open. For a SECURITY scanner that is the worst shape in
the product: an unread file is indistinguishable from a clean one.

Task #299 built the payload (`partial`, `partial_reason`, `remediation`,
`unreadable_paths`) and #310's SARIF carries it in-band -- but the DEFAULT text
renderer read none of it. A payload-level fix that never reached the default
output.

## Dogfooded on the shipped v1.101.4, not inferred from a code read

An ACL-denied fixture with ONE blocked file holding two secrets both rules match.
Controls asserted first: the denial bites (UnauthorizedAccessException), and the
sibling file stays readable.

  --json   partial=true, partial_reason="unreadable_path",
           unreadable_paths={"count": 2, "sample": [...]}
  text     "Scan completed. rules=6 matched_rules=2 total_matches=2"    exit 0

Same invocation, same payload. Only the renderer differs.

## LEADING, not trailing

`codemap` is the sibling that already reads `remediation`, but it prints `PARTIAL:`
AFTER its counts. That ordering is the task #329 defect and is not the half of the
precedent worth copying: a reader who has seen `total_matches` has already formed
the answer.

## A second defect, found only by dogfooding

The disclosure said "2 file(s) in scope could not be read" and named the same path
TWICE -- with exactly one file blocked. `_UnreadablePathFlag.record` increments per
`OSError`, and `scan` runs two backends (ast-grep wrapper + regex leg) that each
open the same file. Surfacing that sentence to stdout would have shipped a new lie.

The event COUNT is deliberately unchanged: other `_UnreadablePathFlag` consumers
count `os.scandir` failures where per-event IS right, and task 320 settled the same
event-vs-path question for the native `incomplete_paths_count` by DOCUMENTING it
rather than deduplicating a hot-path counter. What changed is the prose (it no
longer claims files) and the SAMPLE, which de-duplicates because it is a list of
PLACES, not a tally -- two slots spent on one path names fewer of them.

## Exit code deliberately NOT changed

`tg scan` has returned 0 on a disclosed partial since #299; flipping it is a
contract change with its own consumers (the six-consumer surprise #276 slice C0
had to clear), not a drive-by on a rendering fix. SARIF already carries the signal
in-band for CI gates.

## Verification (bidirectional, control arms run)

  treatment                                   7 passed
  control (renderer reverted, git apply -R)   3 failed, 3 passed

The 3 still-passing are the control arms -- a complete scan emits no banner, and
--json stays a single parseable document.

The de-dup regression test needed two attempts: the first used the existing
single-rule `_scan` helper, where only ONE read attempt occurs, so the duplicate
condition it exists for was never reached. Its premise assertion caught that
(`assert count >= 2`); it now drives two rules to force the double attempt.

An earlier draft of the text test invented `_emit_scan_text_report`, which does not
exist -- it would have failed on AttributeError as a false red. The renderer is
inline in the command body, so the test drives the real command with the producer
stubbed.

Re-dogfooded through the real bootstrap front door with the loaded module's source
asserted to be the worktree copy (not a shadowing venv install).

Found by an adversarially-verified census of the incompleteness-envelope campaign;
this is the highest-severity of ~12 surfaces in the same class.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
