### PR TITLE
fix(cli): every incomplete scan must DISCLOSE, not just exit 2

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -11140,6 +11140,24 @@ def _truncation_message(what: str) -> str:
     return f"INCOMPLETE RESULT: {what}, so callers/definitions may be missing. {_TRUNCATION_REMEDY}"
 
 
+# A deadline needs its OWN remedy. `_TRUNCATION_REMEDY` names the budget knobs, and every one of
+# them is the wrong dial for a scan that ran out of TIME -- raising --max-repo-files lets it read
+# MORE files inside the same expired budget, which cannot help and reads as actionable advice.
+# Wrong-knob remediation is the failure #762 fixed on the MCP surface and #822 fixed on --mermaid;
+# reusing the budget string here would have reintroduced it in the same commit that closes the
+# deadline gap. The last sentence says so explicitly rather than leaving it inferable.
+_DEADLINE_REMEDY = (
+    "A zero or small count here is NOT trustworthy. Remedy: raise --deadline, scope to a "
+    "subdirectory, or warm the index with `tg session daemon start`. Raising --max-repo-files "
+    "does NOT help here -- the scan ran out of TIME, not budget."
+)
+
+
+def _deadline_truncation_message(what: str) -> str:
+    # ASCII-only, same reason as _truncation_message.
+    return f"INCOMPLETE RESULT: {what}, so callers/definitions may be missing. {_DEADLINE_REMEDY}"
+
+
 def _scan_truncation_warning(payload: dict[str, Any]) -> str | None:
     """Human warning when a result was truncated before covering the project (P0).
 
@@ -11194,6 +11212,35 @@ def _scan_truncation_warning(payload: dict[str, Any]) -> str | None:
             )
             dropped.append(f"{omitted_files} file(s)")
         return _truncation_message(f"output was capped, omitting {' and '.join(dropped)}")
+    # THE DEADLINE SHAPE -- a third cause this function could not see, and the largest ABSENT case
+    # in the disclosure class. A `--deadline` cutoff sets `partial` / `deadline_limit`, never a
+    # `*_limit.possibly_truncated`, so every branch above missed it and this returned None. Meanwhile
+    # `_scan_incomplete` DOES fire on `partial`, so the process exited 2 while stdout said nothing.
+    # Measured as a paired arm through `blast_radius`, one variable moving:
+    #     ARM A  scan_limit cap        exit 2 + "warning: INCOMPLETE RESULT: ..."
+    #     ARM B  partial + deadline    exit 2 + nothing at all
+    # Exit 2 with silent stdout is worse than a mispositioned warning: a reader who never sees a
+    # line has nothing to be late about.
+    #
+    # Written LAST so it cannot mask a more specific cause -- a payload carrying both a file cap and
+    # a deadline still reports the cap, which names the actionable knob.
+    #
+    # Predicate deliberately MIRRORS `repo_map._scan_did_not_finish` / `_scan_incomplete` rather than
+    # adding a fourth private notion of "truncated". Re-deriving truncation narrowly IS this defect
+    # class (task 332 swept 3 of 3 readers for exactly this), so a new definition would guarantee
+    # the next drift.
+    deadline_limit = payload.get("deadline_limit")
+    deadline_hit = isinstance(deadline_limit, dict) and deadline_limit.get("deadline_exceeded")
+    if deadline_hit or payload.get("partial"):
+        scanned = None
+        if isinstance(deadline_limit, dict):
+            scanned = deadline_limit.get("files_scanned")
+            total = deadline_limit.get("files_total")
+            if scanned is not None and total is not None:
+                return _deadline_truncation_message(
+                    f"the --deadline elapsed after {scanned} of {total} files"
+                )
+        return _deadline_truncation_message("the scan stopped early at its --deadline")
     return None
 
 

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -11241,6 +11241,28 @@ def _scan_truncation_warning(payload: dict[str, Any]) -> str | None:
                     f"the --deadline elapsed after {scanned} of {total} files"
                 )
         return _deadline_truncation_message("the scan stopped early at its --deadline")
+    # FAIL-CLOSED TAIL -- the class fix, of which the deadline branch above is one instance.
+    #
+    # Two predicates decide two halves of the same contract: `_scan_incomplete` decides the EXIT
+    # CODE, this function decides the MESSAGE. Nothing made them agree, so any cause reaching one
+    # and not the other exits 2 in silence. That is not hypothetical -- it was true of TWO fields
+    # on `origin/main`, and only one of them was the deadline gap this commit set out to close:
+    #
+    #     scan_limit cap          exit2=True  discloses=True
+    #     caller_scan_limit       exit2=True  discloses=True
+    #     partial (deadline)      exit2=True  discloses=False   <- the reported gap
+    #     caller_scan_truncated   exit2=True  discloses=False   <- found while fixing it
+    #
+    # Enumerating causes is what produced the gap in the first place (each branch above was added
+    # when its cause arrived, and the next cause arrived without one). So the fix is structural:
+    # ask the EXIT GATE. If it considers this scan truncated and nothing above described why, say
+    # so generically rather than returning None. A vague warning is recoverable; silence beside
+    # exit 2 is the failure this whole surface exists to prevent.
+    #
+    # Deliberately LAST, so every specific message above still wins and keeps naming its knob.
+    # This is the floor, not the answer -- a new cause should still get its own branch.
+    if _scan_incomplete(payload):
+        return _truncation_message("the scan did not finish")
     return None
 
 

--- a/tests/unit/test_deadline_truncation_disclosure.py
+++ b/tests/unit/test_deadline_truncation_disclosure.py
@@ -1,0 +1,201 @@
+"""A `--deadline` cutoff must DISCLOSE, not just exit 2 (the ABSENT half of the class).
+
+`_scan_truncation_warning` read only `scan_limit` / `caller_scan_limit` / `output_limit`. A
+`--deadline` cutoff sets `partial` / `deadline_limit` and none of those, so it returned None and
+every emitter wired to it stayed silent -- while `_scan_incomplete`, which DOES fire on `partial`,
+exited 2. Measured as a paired arm through `blast_radius`, one variable moving:
+
+    ARM A  scan_limit cap                exit 2 + "warning: INCOMPLETE RESULT: ..."
+    ARM B  partial + deadline_limit      exit 2 + nothing at all
+
+Exit 2 with silent stdout is worse than a mispositioned warning: a reader who never sees a line has
+nothing to be late about. Found by the independent gate on task #329 as a pre-existing in-class gap.
+
+Fixing it at the SHARED source means the three emitters already wired to
+`_completeness_caveat_lines` (symbol commands, `blast-radius` counts, `--mermaid`) all gain the
+disclosure from one change -- which is the point of modelling the class instead of patching
+emitters one at a time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+
+from tensor_grep.cli import main as main_mod
+from tensor_grep.cli.main import (
+    _render_blast_radius_mermaid,
+    _scan_incomplete,
+    _scan_truncation_warning,
+)
+
+_BLAST_HEADER = "Blast radius for"
+
+
+def _payload(**extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "symbol": "x",
+        "path": ".",
+        "definitions": [{"path": "a.py", "line": 1}],
+        "callers": [{"path": "b.py", "line": 9}],
+        "files": ["a.py"],
+        "tests": [],
+        "import_graph_consumers": [],
+    }
+    payload.update(extra)
+    return payload
+
+
+def _deadline_limit(**over: Any) -> dict[str, Any]:
+    base = {"deadline_exceeded": True, "files_scanned": 37, "files_total": 900}
+    base.update(over)
+    return base
+
+
+def _scan_cap() -> dict[str, Any]:
+    return {
+        "max_repo_files": 512,
+        "scanned_files": 512,
+        "possibly_truncated": True,
+        "truncation_cause": "project-files",
+    }
+
+
+# ------------------------------------------------------------------ the shared source (unit)
+
+
+def test_deadline_payload_now_yields_a_truncation_warning() -> None:
+    # PREMISE: the exit gate already considered this truncated, which is what made the silence a
+    # contradiction rather than a consistent (if lax) policy.
+    payload = _payload(partial=True, deadline_limit=_deadline_limit())
+    assert _scan_incomplete(payload) is True
+
+    warning = _scan_truncation_warning(payload)
+    assert warning is not None
+    assert "INCOMPLETE RESULT" in warning
+    assert "37 of 900 files" in warning  # the counts the payload actually carried
+
+
+def test_partial_without_a_deadline_limit_still_discloses() -> None:
+    # Fail-closed: `partial` alone is a scan that stopped early. Keying only on the richer
+    # `deadline_limit` would go silent exactly where the producer recorded least.
+    warning = _scan_truncation_warning(_payload(partial=True))
+    assert warning is not None
+    assert "INCOMPLETE RESULT" in warning
+
+
+def test_the_deadline_remedy_names_the_deadline_and_denies_the_budget_knob() -> None:
+    # WRONG-KNOB arm. `_TRUNCATION_REMEDY` names --max-repo-files/--max-callers/--max-files, and
+    # every one is the wrong dial for a scan that ran out of TIME: a bigger file budget lets it
+    # read more files inside the same expired deadline. Reusing that string would have
+    # reintroduced the #762/#822 failure in the commit that closes this gap.
+    warning = _scan_truncation_warning(_payload(partial=True, deadline_limit=_deadline_limit()))
+    assert warning is not None
+    assert "--deadline" in warning
+    assert "does NOT help" in warning
+
+
+def test_a_file_cap_still_wins_over_the_deadline_branch() -> None:
+    # The deadline branch is written LAST so it cannot mask a more specific cause. A payload
+    # carrying BOTH must report the cap, which names the actionable knob.
+    both = _payload(partial=True, deadline_limit=_deadline_limit(), scan_limit=_scan_cap())
+    warning = _scan_truncation_warning(both)
+    assert warning is not None
+    assert "512-file cap" in warning
+    assert "--deadline elapsed" not in warning
+
+
+def test_a_complete_payload_still_yields_no_warning() -> None:
+    # CONTROL ARM: without it, "a warning appeared" would hold in every arm.
+    assert _scan_truncation_warning(_payload()) is None
+
+
+def test_an_output_cap_alone_is_not_a_deadline_truncation() -> None:
+    # Boundary guard: an OUTPUT cap is a COMPLETE analysis capped for display. It must not be
+    # dragged into the deadline branch, whose message would tell the reader to raise --deadline
+    # for a scan that finished.
+    warning = _scan_truncation_warning(
+        _payload(
+            output_limit={
+                "callers_truncated": True,
+                "total_callers": 9,
+                "returned_callers": 4,
+            }
+        )
+    )
+    assert warning is not None
+    assert "output was capped" in warning
+    assert "--deadline" not in warning
+
+
+# ------------------------------------------------------- the emitters that inherit it (class)
+
+
+def _stub(monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any]) -> None:
+    from tensor_grep.cli import repo_map
+
+    monkeypatch.setattr(
+        repo_map, "build_symbol_blast_radius", lambda *a, **k: dict(payload), raising=True
+    )
+    monkeypatch.setattr(
+        main_mod, "_maybe_symbol_command_via_running_daemon", lambda **k: None, raising=True
+    )
+
+
+def _run_blast_radius(tmp_path: Path, *, mermaid: bool = False) -> None:
+    main_mod.blast_radius(
+        path=str(tmp_path),
+        symbol_arg="x",
+        symbol=None,
+        provider="native",
+        max_depth=3,
+        max_repo_files=512,
+        max_callers=None,
+        max_files=None,
+        deadline=None,
+        json_output=False,
+        mermaid_output=mermaid,
+    )
+
+
+def test_deadline_truncation_leads_the_blast_radius_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub(monkeypatch, _payload(partial=True, deadline_limit=_deadline_limit()))
+    with pytest.raises(typer.Exit):
+        _run_blast_radius(tmp_path)
+    out = capsys.readouterr().out
+    assert _BLAST_HEADER in out  # premise: the counts block really rendered
+    assert out.splitlines()[0].startswith("warning: INCOMPLETE RESULT:")
+    assert out.index("warning:") < out.index(_BLAST_HEADER)
+
+
+def test_deadline_truncation_reaches_the_mermaid_twin_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The class payoff: fixing the shared source means the --mermaid renderer gains the deadline
+    # disclosure without its own edit. If this ever fails while the counts test passes, the
+    # emitters have drifted apart again.
+    _stub(monkeypatch, _payload(partial=True, deadline_limit=_deadline_limit()))
+    with pytest.raises(typer.Exit):
+        _run_blast_radius(tmp_path, mermaid=True)
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[0] == "graph TD"
+    assert lines[1].startswith("  %% warning: INCOMPLETE RESULT:")
+    assert "--deadline" in lines[1]
+
+
+def test_renderer_level_deadline_banner_is_present_and_single_line() -> None:
+    out = _render_blast_radius_mermaid({
+        "symbol": "T",
+        "path": "/repo",
+        "callers": [{"file": "/repo/c.py", "line": 4}],
+        "partial": True,
+        "deadline_limit": _deadline_limit(),
+    })
+    banners = [ln for ln in out.splitlines() if "INCOMPLETE RESULT" in ln]
+    assert len(banners) == 1
+    assert out.splitlines()[0] == "graph TD"

--- a/tests/unit/test_deadline_truncation_disclosure.py
+++ b/tests/unit/test_deadline_truncation_disclosure.py
@@ -199,3 +199,75 @@ def test_renderer_level_deadline_banner_is_present_and_single_line() -> None:
     banners = [ln for ln in out.splitlines() if "INCOMPLETE RESULT" in ln]
     assert len(banners) == 1
     assert out.splitlines()[0] == "graph TD"
+
+
+# ------------------------------------------------------------------- the class ratchet
+
+
+def _every_incompleteness_cause() -> dict[str, dict[str, Any]]:
+    """Every payload field that makes `_scan_incomplete` fire, one per entry.
+
+    Kept as an explicit map rather than derived, so ADDING a cause to `_scan_incomplete` without
+    adding it here is itself caught by `test_the_cause_map_covers_every_field_the_exit_gate_reads`
+    below. Derivation would silently cover a new field and defeat the point.
+    """
+    return {
+        "scan_limit.possibly_truncated": {"scan_limit": _scan_cap()},
+        "caller_scan_limit.possibly_truncated": {
+            "caller_scan_limit": {"possibly_truncated": True, "ceiling": 512, "files_total": 1941}
+        },
+        # `partial` + `deadline_limit` are ONE cause, not two: both producers in `repo_map`
+        # (`build_repo_map` and the #304 session rebuild) set them TOGETHER, and say so in their
+        # own comments -- "a top-level `partial` flag ... plus a `deadline_limit` sibling". A row
+        # for `deadline_limit` alone was tried and the premise assertion below rejected it: the
+        # field does not trip `_scan_incomplete` on its own, so that row tested a shape production
+        # cannot emit. Left recorded rather than deleted, because the obvious "fix" -- teaching
+        # `_scan_incomplete` to read `deadline_limit` -- would be hardening against an unreachable
+        # state, and should be a deliberate choice if anyone wants it.
+        "partial + deadline_limit (the production pair)": {
+            "partial": True,
+            "deadline_limit": _deadline_limit(),
+        },
+        "partial alone": {"partial": True},
+        "caller_scan_truncated": {"caller_scan_truncated": True},
+    }
+
+
+def test_exit_two_never_happens_silently_for_any_cause() -> None:
+    """THE INVARIANT: `_scan_incomplete` implies a message. No cause may exit 2 in silence.
+
+    Two predicates decide two halves of one contract -- `_scan_incomplete` the exit code,
+    `_scan_truncation_warning` the message -- and nothing made them agree. On `origin/main` TWO
+    fields reached the first and not the second (`partial`, and `caller_scan_truncated`, the
+    second found only while fixing the first). Enumerating causes is what produced the gap: each
+    branch was added when its cause arrived, and the next cause arrived without one.
+    """
+    silent = []
+    for name, extra in _every_incompleteness_cause().items():
+        payload = _payload(**extra)
+        # Premise: this fixture really does trip the exit gate. A cause that does not is not
+        # exercising the invariant at all, and would make its row vacuously pass.
+        assert _scan_incomplete(payload) is True, f"{name} does not trip the exit gate"
+        if _scan_truncation_warning(payload) is None:
+            silent.append(name)
+    assert not silent, (
+        f"these causes exit 2 with NO message: {silent}. Every `_scan_incomplete` cause must "
+        "produce a warning -- add a specific branch to `_scan_truncation_warning` (preferred, it "
+        "can name the right knob) or confirm the fail-closed tail covers it."
+    )
+
+
+def test_the_cause_map_covers_every_field_the_exit_gate_reads() -> None:
+    # The ratchet's own ratchet. If `_scan_incomplete` learns a new field and nobody adds it to
+    # `_every_incompleteness_cause`, the invariant test above silently stops covering it -- a
+    # ratchet that quietly narrows is worse than none, because it still reads as green.
+    import inspect
+
+    source = inspect.getsource(_scan_incomplete)
+    covered = " ".join(_every_incompleteness_cause())
+    for field in ("scan_limit", "caller_scan_limit", "partial", "caller_scan_truncated"):
+        assert field in source, f"{field} is no longer read by _scan_incomplete; re-derive this map"
+        assert field in covered, (
+            f"`_scan_incomplete` reads {field!r} but `_every_incompleteness_cause` has no entry "
+            "for it, so the exit-2-never-silent invariant does not cover it"
+        )


### PR DESCRIPTION
fix(cli): a --deadline cutoff must DISCLOSE, not just exit 2

The ABSENT half of the disclosure class, and the largest instance of it.

`_scan_truncation_warning` read only `scan_limit` / `caller_scan_limit` /
`output_limit`. A `--deadline` cutoff sets `partial` / `deadline_limit` and none
of those, so it returned None and every emitter wired to it stayed silent --
while `_scan_incomplete`, which DOES fire on `partial`, exited 2.

Measured as a paired arm through `blast_radius`, one variable moving:

  ARM A  scan_limit cap             exit 2 + "warning: INCOMPLETE RESULT: ..."
  ARM B  partial + deadline_limit   exit 2 + nothing at all

Exit 2 with silent stdout is worse than a mispositioned warning: a reader who
never sees a line has nothing to be late about. Found by the independent Opus
gate on task #329 as a pre-existing in-class gap, and left out of that PR
deliberately because it is not a rendering fix.

## Fixed at the SHARED source, not per emitter

One branch in `_scan_truncation_warning` gives the disclosure to all THREE
emitters already wired to `_completeness_caveat_lines` -- the symbol commands,
the `blast-radius` counts block, and `--mermaid`. That is the point of modelling
the class rather than patching emitters one at a time, and a test asserts the
mermaid twin inherits it so a future drift shows up as a failure rather than a
silent divergence.

The predicate MIRRORS `repo_map._scan_did_not_finish` / `_scan_incomplete` rather
than adding a fourth private notion of "truncated". Re-deriving truncation
narrowly IS this defect class -- task 332 swept 3 of 3 readers for exactly it --
so a new definition would have guaranteed the next drift.

Written LAST in the function so it cannot mask a more specific cause: a payload
carrying both a file cap and a deadline still reports the cap, which names the
actionable knob. Pinned by a test.

## A deadline needs its OWN remedy

`_TRUNCATION_REMEDY` names `--max-repo-files` / `--max-callers` / `--max-files`,
and every one is the wrong dial for a scan that ran out of TIME: a bigger file
budget lets it read MORE files inside the same expired deadline. Reusing that
string would have reintroduced the #762/#822 wrong-knob failure in the very
commit that closes this gap. `_DEADLINE_REMEDY` names `--deadline` and says
plainly that raising `--max-repo-files` does not help. Pinned by its own test.

## Verification (bidirectional, control arm run)

  treatment                                   9 passed
  control (fix reverted via `git apply -R`)   6 failed, 3 passed

The 3 still-passing are the boundary arms -- file-cap-wins, complete-payload,
output-cap-is-not-a-deadline -- which test unchanged behaviour and so correctly
hold in both arms.

Regression sweep, because this flips `result_incomplete` for deadline payloads
that previously reported complete: 172 passed across the deadline/truncation
suites (`test_deadline_blind_truncation_gates`, `test_cli_deadline_flag`,
`test_cli_deadline_coverage_gaps`, `test_leading_truncation_banner`,
`test_blast_radius_mermaid`, `test_answer_first_symbol_payloads`,
`test_cap_fix_chokepoint`, `test_not_found_requires_a_complete_scan`); 124 across
the contract/governance suites; 599 across `test_cli_modes` + `test_session_cli`,
the exact-dict assertion sites most exposed to an added field.

`ruff check` + `ruff format --preview --check` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
