### PR TITLE
fix(cli): make the --mermaid truncation disclosure survive RENDERING

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -12264,6 +12264,34 @@ def _mermaid_label(text: str) -> str:
     return text.replace("\\", "/").replace('"', "'")
 
 
+_MERMAID_INCOMPLETE_LABEL_LIMIT = 110
+
+
+def _mermaid_incomplete_label(banner: str) -> str:
+    """The disclosure banner reduced to something a DIAGRAM BOX can carry.
+
+    A node label is read in a picture, not a terminal, so it needs the CAUSE and nothing else:
+    the ``warning:`` prefix is a log convention that means nothing inside a box, and the remedy
+    sentence is long enough to distort the graph it is warning about. Both stay one line up in
+    the ``%%`` comment, which is where a source reader looks and where the full text belongs.
+
+    Bounded deliberately. The cause clause is producer-controlled (a caller-scan message names two
+    counts and a path-narrowing hint) and an unbounded label would let the worst-truncated graph
+    render worst -- the incompleteness signal degrading exactly when it matters most, which is the
+    defect inverted. Yes, this truncates a truncation notice; the ellipsis says so, and the
+    untruncated text is one line above.
+    """
+    cause = " ".join(banner.split())
+    for prefix in ("warning: ", "note: "):
+        if cause.startswith(prefix):
+            cause = cause[len(prefix) :]
+            break
+    cause = cause.split(", so ", 1)[0].split(". ", 1)[0]
+    if len(cause) > _MERMAID_INCOMPLETE_LABEL_LIMIT:
+        cause = cause[: _MERMAID_INCOMPLETE_LABEL_LIMIT - 3].rstrip() + "..."
+    return cause
+
+
 def _mermaid_relpath(file_path: str, root: str) -> str:
     """A short forward-slashed path for a Mermaid node (relative to root when it stays inside)."""
     forward = file_path.replace("\\", "/")
@@ -12329,6 +12357,19 @@ def _render_blast_radius_mermaid(payload: dict[str, Any]) -> str:
         # field typing, so this is cheap fail-closed hardening rather than a proven vector, and
         # `_mermaid_label` already sanitizes node text on exactly this reasoning.
         lines.append(f"  %% {' '.join(leading.split())}")
+        # AND a real NODE, because the comment above is invisible in a RENDERED diagram.
+        # Mermaid's own flowchart docs say comments "will be ignored by the parser", so `%%`
+        # serves the agent reading the source and nobody looking at the picture -- who is
+        # precisely the reader most likely to trust a caller graph at a glance. Verified against
+        # the upstream docs rather than assumed; the earlier fix that moved this disclosure to
+        # LEAD improved the source-reading case only.
+        #
+        # Declared with no edge, so `-->` counts and the "no invented edges" guard are untouched;
+        # emitted only when incomplete, so a complete graph stays byte-identical. The node carries
+        # the CAUSE clause (up to the first sentence break) rather than the full text -- the
+        # remedy sentence is long enough to distort a diagram, and it remains one line up in the
+        # comment for whoever is reading the source.
+        lines.append(f'  tg_incomplete["{_mermaid_label(_mermaid_incomplete_label(leading))}"]')
     lines.append(f'  target["{_mermaid_label(symbol)}"]')
     for idx, rel in enumerate(sorted(grouped)):
         node = f"n{idx}"

--- a/tests/unit/test_leading_truncation_banner.py
+++ b/tests/unit/test_leading_truncation_banner.py
@@ -354,14 +354,26 @@ def test_mermaid_banner_is_one_line_so_it_cannot_inject_graph_statements() -> No
     # interpolates payload-derived values, so a newline reaching the banner would close the
     # comment and turn the rest into live graph statements. No reachable cold path types these as
     # anything but int -- this pins the flattening so that stays true regardless.
+    #
+    # There are now TWO disclosure lines -- the comment and the rendered `tg_incomplete` node --
+    # so this no longer counts "lines mentioning INCOMPLETE RESULT" and expects one. That count
+    # was the MECHANISM; the intent is that neither disclosure can be SPLIT by an injected
+    # newline. Each is asserted to be exactly one line, which is the same property stated against
+    # the shape the renderer actually has.
     hostile = _truncated_scan_limit()
     hostile["max_repo_files"] = 'BAD\n  evil["pwn"]\n  evil --> target'
     out = _render_blast_radius_mermaid(_mermaid_payload(scan_limit=hostile, result_incomplete=True))
-    banner_lines = [ln for ln in out.splitlines() if "INCOMPLETE RESULT" in ln]
-    assert len(banner_lines) == 1, f"banner spans multiple lines: {banner_lines}"
-    assert 'evil["pwn"]' not in out.replace(banner_lines[0], "")
-    # Premise: the hostile value really did reach the banner, or this proves nothing.
-    assert "BAD" in banner_lines[0]
+    lines = out.splitlines()
+    comment_lines = [ln for ln in lines if ln.lstrip().startswith("%% warning:")]
+    node_lines = [ln for ln in lines if "tg_incomplete[" in ln]
+    assert len(comment_lines) == 1, f"comment spans multiple lines: {comment_lines}"
+    assert len(node_lines) == 1, f"node spans multiple lines: {node_lines}"
+    # Premise: the hostile value really did reach BOTH disclosures, or this proves nothing.
+    assert "BAD" in comment_lines[0]
+    assert "BAD" in node_lines[0]
+    # And nothing it carried became a live graph statement on a line of its own.
+    residue = [ln for ln in lines if ln not in comment_lines + node_lines]
+    assert not any("evil" in ln for ln in residue), f"injected statement survived: {residue}"
 
 
 def test_mermaid_upstream_result_incomplete_still_gets_a_leading_disclosure() -> None:

--- a/tests/unit/test_mermaid_visible_incomplete_node.py
+++ b/tests/unit/test_mermaid_visible_incomplete_node.py
@@ -1,0 +1,121 @@
+"""A `--mermaid` truncation disclosure must survive RENDERING, not just source-reading.
+
+Task #329 moved this disclosure to LEAD its graph, which fixed the reader who consumes the raw
+text. It did nothing for the reader looking at the picture: Mermaid's own flowchart documentation
+states that comments "will be ignored by the parser", so a `%%` line is absent from every rendered
+diagram. That reader -- a human glancing at a caller graph -- is precisely the one most likely to
+trust it at a glance, and `--mermaid` exists to serve them.
+
+So the disclosure is now BOTH: the `%%` comment (machine-greppable, carries the full remedy) and a
+real node (renders, carries the cause). The node is declared with no edge, so the "no invented
+edges" guard and every `-->` count stay untouched, and it is emitted only when incomplete, so a
+complete graph stays byte-identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tensor_grep.cli.main import (
+    _MERMAID_INCOMPLETE_LABEL_LIMIT,
+    _mermaid_incomplete_label,
+    _render_blast_radius_mermaid,
+)
+
+_NODE = "tg_incomplete["
+
+
+def _payload(**extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "symbol": "Target",
+        "path": "/repo",
+        "callers": [{"file": "/repo/pkg/caller.py", "line": 12}],
+    }
+    payload.update(extra)
+    return payload
+
+
+def _scan_cap() -> dict[str, Any]:
+    return {
+        "max_repo_files": 512,
+        "scanned_files": 512,
+        "possibly_truncated": True,
+        "truncation_cause": "project-files",
+    }
+
+
+def test_a_truncated_graph_carries_a_node_not_only_a_comment() -> None:
+    out = _render_blast_radius_mermaid(_payload(scan_limit=_scan_cap(), result_incomplete=True))
+    # Premise: the graph really rendered, so the assertions below are not vacuous.
+    assert "pkg/caller.py" in out
+    assert _NODE in out, "the disclosure exists only as a %% comment, which no renderer shows"
+    assert "512-file cap" in out.split(_NODE, 1)[1], "the node must carry the CAUSE"
+
+
+def test_the_comment_is_kept_alongside_the_node() -> None:
+    # Not either/or. The comment carries the full remedy and is what a grep over the source finds;
+    # dropping it to "clean up" would trade one audience for the other.
+    out = _render_blast_radius_mermaid(_payload(scan_limit=_scan_cap(), result_incomplete=True))
+    assert "%% warning: INCOMPLETE RESULT:" in out
+    assert "--max-repo-files" in out  # the remedy survives, in the comment
+
+
+def test_the_node_leads_the_graph_content() -> None:
+    out = _render_blast_radius_mermaid(_payload(scan_limit=_scan_cap(), result_incomplete=True))
+    lines = out.splitlines()
+    assert lines[0] == "graph TD"  # the diagram-type declaration still opens the block
+    assert lines[1].startswith("  %% warning:")
+    assert lines[2].startswith(f"  {_NODE}")
+    assert out.index(_NODE) < out.index("pkg/caller.py")
+
+
+def test_the_node_adds_no_edge() -> None:
+    # The existing contract: `--mermaid` never invents edges. A disclosure that fabricated one
+    # would be a lie in the shape of a warning.
+    out = _render_blast_radius_mermaid(_payload(scan_limit=_scan_cap(), result_incomplete=True))
+    assert out.count("-->") == 1  # only the real caller edge
+    assert "tg_incomplete -->" not in out
+    assert "--> tg_incomplete" not in out
+
+
+def test_a_complete_graph_is_byte_identical_to_no_disclosure_at_all() -> None:
+    # CONTROL ARM. Without it, "a node appeared" would be true in every arm.
+    out = _render_blast_radius_mermaid(_payload())
+    assert "-->" in out  # premise: the graph rendered
+    assert _NODE not in out
+    assert "%%" not in out
+    assert "INCOMPLETE" not in out
+
+
+def test_a_zero_caller_graph_keeps_its_own_trailing_advisory() -> None:
+    # The advisory half of the split is untouched: that scan COMPLETED and found nothing, so its
+    # note still trails and no incomplete node is added.
+    out = _render_blast_radius_mermaid(_payload(callers=[]))
+    assert out.splitlines()[-1].strip().startswith("%% no callers found")
+    assert _NODE not in out
+
+
+def test_the_label_drops_the_log_prefix_and_the_remedy() -> None:
+    label = _mermaid_incomplete_label(
+        "warning: INCOMPLETE RESULT: the scan stopped at a 9-file cap, so callers/definitions "
+        "may be missing. A zero or small count here is NOT trustworthy. Remedy: raise things."
+    )
+    assert label == "INCOMPLETE RESULT: the scan stopped at a 9-file cap"
+    assert "warning:" not in label  # a log convention, meaningless inside a box
+    assert "Remedy" not in label  # long enough to distort the graph it warns about
+
+
+def test_a_pathological_cause_cannot_distort_the_diagram() -> None:
+    # The cause clause is producer-controlled. An unbounded label would make the WORST-truncated
+    # graph render worst -- the signal degrading exactly where it matters most.
+    label = _mermaid_incomplete_label("warning: INCOMPLETE RESULT: " + "x" * 5000)
+    assert len(label) <= _MERMAID_INCOMPLETE_LABEL_LIMIT
+    assert label.endswith("...")  # the truncation is disclosed, not silent
+
+
+def test_the_label_is_always_one_line() -> None:
+    # A newline would close the node declaration and inject live graph statements.
+    label = _mermaid_incomplete_label(
+        'warning: INCOMPLETE RESULT: bad\n  evil["pwn"]\n  evil --> x'
+    )
+    assert "\n" not in label


### PR DESCRIPTION
fix(cli): make the --mermaid truncation disclosure survive RENDERING

Task #329 moved this disclosure to LEAD its graph. That fixed the reader who
consumes the raw text and did nothing for the reader looking at the picture.

Mermaid's own flowchart documentation states that comments "will be ignored by
the parser", so a `%%` line is absent from every rendered diagram. Verified
against the upstream docs rather than assumed -- the premise is a claim about an
external parser, and #329's own review explicitly declined to assert it without
running one.

That reader is the one who matters most here: `--mermaid` exists to produce a
picture, and a human glancing at a caller graph is far likelier to trust it at a
glance than someone reading the source. A truncated graph looked exactly like a
complete one.

## Both, not either

- the `%%` comment stays -- machine-greppable, and it carries the full remedy;
- a real `tg_incomplete[...]` node is added -- it renders, and it carries the CAUSE.

Dropping the comment to "clean up" would trade one audience for the other; a test
pins that both survive.

## The node cannot damage what it warns about

- **No edge.** Declared standalone, so the "never invent edges" contract and every
  `-->` count are untouched. A disclosure that fabricated an edge would be a lie in
  the shape of a warning.
- **Emitted only when incomplete**, so a complete graph stays byte-identical.
- **Label bounded** at 110 chars. The cause clause is producer-controlled (the
  caller-scan message names two counts and a path hint), and an unbounded label
  would make the WORST-truncated graph render worst -- the signal degrading exactly
  where it matters most. Yes, that truncates a truncation notice; the ellipsis says
  so and the untruncated text is one line above.
- **Label stripped** of the `warning:` prefix (a log convention, meaningless inside
  a box) and of the remedy sentence (long enough to distort the diagram).

## One existing test UPDATED, not loosened

`test_mermaid_banner_is_one_line_so_it_cannot_inject_graph_statements` counted
lines mentioning `INCOMPLETE RESULT` and expected exactly one. There are now
legitimately two disclosure lines. That count was the MECHANISM; the intent is
that neither disclosure can be SPLIT by an injected newline. It now asserts each
is exactly one line and that nothing the hostile value carried became a live graph
statement -- the same property against the shape the renderer actually has.

## Verification (bidirectional, control arm run)

  treatment                       9 passed (33 across all three mermaid suites)
  control (node emission removed) 2 failed, 7 passed

The control was run a SECOND time to be worth anything: reverting the whole diff
removes `_mermaid_incomplete_label`, so the test module dies on ImportError and
the file ERRORS rather than failing -- and a file that cannot be collected is not
a red arm. Reverting only the emission line, keeping the helper importable, makes
the ASSERTIONS the discriminator. The 7 that still pass are genuine controls
(complete graph, zero-caller advisory, the label helper's own behaviour).

Regression sweep: 96 passed across `test_main_cli_contracts`,
`test_answer_first_symbol_payloads`, `test_cap_fix_chokepoint`,
`test_incompleteness_markers`. `ruff check` + `ruff format --preview --check` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
