### PR TITLE
fix(cli): exit 2 must never be silent -- 13 commands disclosed nothing in text mode

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8606,7 +8606,16 @@ def inventory(
     if json_output:
         typer.echo(_json.dumps(payload))
     else:
-        _emit_scan_incompleteness_banner(payload)
+        # NOT banner-wired, and not an oversight: `render_inventory_text` (cli/inventory.py) already
+        # ends with its own cause-specific notice -- "[!] truncated at max_files=N (cause=X); counts
+        # are a floor, not complete." That is prose in the SAME register as the banner, so adding
+        # one here would say the same thing twice, exactly as it would have in `codemap`. Its
+        # trailing POSITION is a separate, tracked defect; fixing it belongs in `inventory.py`
+        # where the message is built, not as a second message in front of it.
+        #
+        # Found late: an audit that scanned only THIS file reported inventory as having no
+        # disclosure, because its disclosure is one call away in another module. A probe that
+        # cannot see past the file it greps will report a delegating caller as silent.
         typer.echo(render_inventory_text(payload))
 
     # #130(a) optional bundle: mirror `map`'s exit-2-on-scan-truncation contract (:7418-7419)

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8560,6 +8560,7 @@ def map(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(f"Repository map for {payload['path']}")
         typer.echo(f"files={len(payload['files'])} tests={len(payload['tests'])}")
         typer.echo(f"symbols={len(payload['symbols'])} imports={len(payload['imports'])}")
@@ -8605,6 +8606,7 @@ def inventory(
     if json_output:
         typer.echo(_json.dumps(payload))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(render_inventory_text(payload))
 
     # #130(a) optional bundle: mirror `map`'s exit-2-on-scan-truncation contract (:7418-7419)
@@ -9087,6 +9089,7 @@ def context(
     if json_output:
         typer.echo(json.dumps(payload))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(f"Context pack for {payload['path']}")
         typer.echo(f"query={payload['query']}")
         typer.echo(f"files={len(payload['files'])} tests={len(payload['tests'])}")
@@ -9533,6 +9536,7 @@ def context_render(
                 else:
                     typer.echo(json.dumps(daemon_payload, indent=2))
             else:
+                _emit_scan_incompleteness_banner(daemon_payload)
                 typer.echo(str(daemon_payload.get("rendered_context", "")))
             if _scan_incomplete(daemon_payload):
                 raise typer.Exit(2)
@@ -9569,6 +9573,7 @@ def context_render(
         else:
             typer.echo(json.dumps(payload, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(payload["rendered_context"])
 
     if _scan_incomplete(payload):
@@ -9785,6 +9790,7 @@ def agent(
             if json_output:
                 typer.echo(json.dumps(daemon_payload, ensure_ascii=False, indent=2))
             else:
+                _emit_scan_incompleteness_banner(daemon_payload)
                 payload = daemon_payload
                 primary = payload.get("primary_target", {})
                 primary_file = primary.get("file") or "<none>"
@@ -9868,6 +9874,7 @@ def agent(
     if json_output:
         typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         primary = payload.get("primary_target", {})
         primary_file = primary.get("file") or "<none>"
         primary_line = primary.get("line") or 1
@@ -10005,6 +10012,7 @@ def edit_plan(
             if json_output:
                 typer.echo(json.dumps(daemon_payload, indent=2))
             else:
+                _emit_scan_incompleteness_banner(daemon_payload)
                 payload = daemon_payload
                 typer.echo(f"Edit plan for {payload['path']}")
                 typer.echo(f"query={payload['query']}")
@@ -10039,6 +10047,7 @@ def edit_plan(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(f"Edit plan for {payload['path']}")
         typer.echo(f"query={payload['query']}")
         typer.echo(
@@ -10430,6 +10439,7 @@ def route_test(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         context_target = payload["context_render"]["primary_target"]
         edit_target = payload["edit_plan"]["primary_target"]
         typer.echo(f"Route test for {payload['path']}")
@@ -10968,6 +10978,12 @@ def prepare(
         primary = payload.get("primary_target", {})
         floor = payload.get("blast_radius_floor", {})
         claim_hook = payload.get("coordination", {}).get("claim", {})
+        # `prepare` already ended with `partial=true partial_reason=...`, but only for the
+        # `partial` cause and only AFTER every line it qualifies. The banner covers every cause
+        # and leads. The key=value line stays: it is a structured field in a key=value listing,
+        # not prose duplicating prose (contrast `codemap`, where adding a banner beside its
+        # existing `PARTIAL:` sentence would have said the same thing twice in the same register).
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(f"Prepare for {payload['path']}")
         typer.echo(f"query={payload['query']}")
         typer.echo(f"primary={primary.get('file')}#L{primary.get('line')} {primary.get('symbol')}")
@@ -11342,6 +11358,36 @@ def _completeness_caveat_lines(
     if is_truncation:
         return f"warning: {caveat}", None
     return None, f"note: {caveat}"
+
+
+def _emit_scan_incompleteness_banner(payload: dict[str, Any]) -> bool:
+    """Print the leading disclosure for a payload whose SCAN did not finish. Returns whether it did.
+
+    THE INVARIANT: a command that exits ``2`` must have SAID something on stdout. Thirteen of the
+    fourteen ``_scan_incomplete`` gates in this module raised ``typer.Exit(2)`` over text output
+    that read exactly like a complete result -- ``codemap`` was the only one that disclosed. An
+    agent branching on the exit code was fine; every human, and every agent reading the text, was
+    told a truncated answer was the whole answer.
+
+    TEXT PATH ONLY. Call this inside the ``else`` of an ``if json_output`` block, never beside the
+    ``json.dumps``: a stray line on the JSON route breaks ``json.loads`` on stdout, which is the
+    failure this whole surface exists to prevent. JSON carries the same fact as ``result_incomplete``
+    / ``caveat`` fields, where position and prose are irrelevant.
+
+    LEADING, by the task #329 rule -- a disclosure must be read BEFORE the data it qualifies. Emits
+    nothing for a complete payload, so existing output stays byte-identical.
+
+    The message comes from the shared ``_scan_truncation_warning`` so these commands cannot drift
+    into their own vocabulary or their own idea of which knob to suggest.
+    """
+    if not _scan_incomplete(payload):
+        return False
+    caveat = _scan_truncation_warning(payload)
+    leading, _ = _completeness_caveat_lines(caveat, is_truncation=True)
+    if leading is None:
+        return False
+    typer.echo(leading)
+    return True
 
 
 def _attach_symbol_omissions(
@@ -12751,6 +12797,7 @@ def blast_radius_render(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(payload["rendered_context"])
 
     if _scan_incomplete(payload):
@@ -12838,6 +12885,7 @@ def blast_radius_plan(
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:
+        _emit_scan_incompleteness_banner(payload)
         typer.echo(f"Blast radius plan for {payload['symbol']} in {payload['path']}")
         typer.echo(
             f"files={len(payload['files'])} tests={len(payload['tests'])} symbols={len(payload['symbols'])}"

--- a/tests/unit/test_exit_two_is_never_silent.py
+++ b/tests/unit/test_exit_two_is_never_silent.py
@@ -83,6 +83,12 @@ def test_every_exit_two_gate_has_a_disclosure_on_its_text_branch() -> None:
         # separate, tracked defect and deliberately not changed here.
         if "PARTIAL:" in window:
             continue
+        # `inventory` delegates its text to `render_inventory_text`, which ends with its own
+        # "[!] truncated at max_files=..." notice. A source-only ratchet cannot see into the
+        # callee, so the exemption is named here rather than inferred -- and naming it is what
+        # stops the next reader "fixing" inventory into disclosing twice.
+        if "render_inventory_text(" in window:
+            continue
         undisclosed.append((idx + 1, var))
     assert not undisclosed, (
         f"these exit-2 gates have no disclosure on their text branch: {undisclosed}. "

--- a/tests/unit/test_exit_two_is_never_silent.py
+++ b/tests/unit/test_exit_two_is_never_silent.py
@@ -57,15 +57,38 @@ def test_every_exit_two_gate_has_a_disclosure_on_its_text_branch() -> None:
         m = re.search(r"_scan_incomplete\((\w+)\)", line)
         if not m:
             continue
-        # Skip the helper's OWN guard -- it is the disclosure, not a gate needing one. Found by
-        # this test flagging line ~11308 on its first run, which is the ratchet catching itself.
-        enclosing = next((lines[j] for j in range(i, 0, -1) if lines[j].startswith("def ")), "")
-        if _CALL in enclosing:
+        # A GATE is defined by BEHAVIOUR -- it exits 2 -- not by mentioning `_scan_incomplete`.
+        # Two other uses exist and neither owes a disclosure: this file's own helper guards on it
+        # (`if not _scan_incomplete(...): return False`) and `_scan_truncation_warning` ends with
+        # a fail-closed tail that RETURNS a message on it. An earlier cut exempted the first by
+        # name; the second then appeared from another PR and was flagged as a missing disclosure
+        # in the one function whose entire job is producing that disclosure.
+        #
+        # Keying on `typer.Exit(2)` in the body is self-maintaining: a new non-gate use needs no
+        # exemption, and a new real gate cannot dodge the check by living somewhere unexpected.
+        # 8 lines, not 4: the two `agent` gates put `raise typer.Exit(2)` 5-7 lines below their
+        # `if`, and a 4-line window silently dropped BOTH -- the ratchet covering less while
+        # still reading green, which is exactly the failure this file warns about elsewhere.
+        # Caught by the control arm naming 9 gates where the previous form named 12.
+        body = "\n".join(lines[i : i + 8])
+        if "Exit(2)" not in body:
             continue
         gates.append((i, m.group(1)))
     # PREMISE: the gates still exist and are plural. If a refactor renamed them this test would
     # otherwise pass over an empty list -- a ratchet that quietly covers nothing still reads green.
-    assert len(gates) >= 10, f"expected the exit-2 gate family, found {len(gates)}"
+    assert len(gates) >= 12, f"expected the exit-2 gate family, found {len(gates)}"
+    # By NAME, not just by count. A count floor cannot say WHICH gate vanished, and the window bug
+    # above dropped precisely the two that sit furthest from their `raise`. These are commands
+    # whose text output an agent is most likely to read as a finished answer.
+    covered = {
+        next((lines[j] for j in range(i, 0, -1) if lines[j].startswith("def ")), "").split("(")[0]
+        for i, _ in gates
+    }
+    for command in ("def map", "def agent", "def context", "def edit_plan", "def prepare"):
+        assert command in covered, (
+            f"{command} is no longer recognised as an exit-2 gate; the gate detector narrowed "
+            "and this ratchet has silently stopped covering it"
+        )
 
     undisclosed = []
     for idx, var in gates:

--- a/tests/unit/test_exit_two_is_never_silent.py
+++ b/tests/unit/test_exit_two_is_never_silent.py
@@ -1,0 +1,168 @@
+"""A command that exits ``2`` must have SAID something on stdout.
+
+Thirteen of the fourteen ``_scan_incomplete`` gates in ``cli/main.py`` raised ``typer.Exit(2)``
+over text output that read exactly like a complete result -- ``codemap`` was the only one that
+disclosed. An agent branching on the exit code was fine; every human, and every agent reading the
+text, was told a truncated answer was the whole answer.
+
+Two tests, doing different jobs:
+
+* the RATCHET reads the source and pins that every gate's text branch emits the banner, keyed on
+  the SAME payload variable the gate reads -- a static property that no behavioural test would
+  cover for commands whose fixtures are expensive to build;
+* the behavioural tests drive real commands, so the ratchet cannot pass over a helper that emits
+  nothing.
+
+The ratchet's variable check is not hypothetical. The first cut of this change was applied by a
+script that inserted ``_emit_scan_incompleteness_banner(payload)`` into every text branch, and
+three daemon fast paths gate on ``daemon_payload`` -- so those three sites disclosed the state of
+the wrong object. A sweep is a hypothesis until each site is read; this test is that reading, made
+permanent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+
+from tensor_grep.cli import main as main_mod
+from tensor_grep.cli.main import _emit_scan_incompleteness_banner
+
+_MAIN = Path(main_mod.__file__)
+_CALL = "_emit_scan_incompleteness_banner"
+
+
+def _truncated() -> dict[str, Any]:
+    return {
+        "max_repo_files": 512,
+        "scanned_files": 512,
+        "possibly_truncated": True,
+        "truncation_cause": "project-files",
+    }
+
+
+# ------------------------------------------------------------------------------- the ratchet
+
+
+def test_every_exit_two_gate_has_a_disclosure_on_its_text_branch() -> None:
+    lines = _MAIN.read_text(encoding="utf-8").splitlines()
+    gates = []
+    for i, line in enumerate(lines):
+        if not line.strip().startswith("if "):
+            continue
+        m = re.search(r"_scan_incomplete\((\w+)\)", line)
+        if not m:
+            continue
+        # Skip the helper's OWN guard -- it is the disclosure, not a gate needing one. Found by
+        # this test flagging line ~11308 on its first run, which is the ratchet catching itself.
+        enclosing = next((lines[j] for j in range(i, 0, -1) if lines[j].startswith("def ")), "")
+        if _CALL in enclosing:
+            continue
+        gates.append((i, m.group(1)))
+    # PREMISE: the gates still exist and are plural. If a refactor renamed them this test would
+    # otherwise pass over an empty list -- a ratchet that quietly covers nothing still reads green.
+    assert len(gates) >= 10, f"expected the exit-2 gate family, found {len(gates)}"
+
+    undisclosed = []
+    for idx, var in gates:
+        # Scoped to the ENCLOSING FUNCTION, not a fixed line window. A 40-line window flagged
+        # `prepare`, whose banner is correctly placed but sits ~50 lines above its gate with the
+        # capsule-writing block in between. An arbitrary window makes the ratchet's verdict depend
+        # on unrelated code length -- a false positive whose obvious cure is to widen the window
+        # until it stops complaining, which is how a ratchet quietly stops ratcheting.
+        start = next((j for j in range(idx, 0, -1) if lines[j].startswith("def ")), 0)
+        window = "\n".join(lines[start:idx])
+        if f"{_CALL}({var})" in window:
+            continue
+        # `codemap` discloses through its own older `PARTIAL:` line; it is not silent, and
+        # double-disclosing would be worse than either shape. Its POSITION (trailing) is a
+        # separate, tracked defect and deliberately not changed here.
+        if "PARTIAL:" in window:
+            continue
+        undisclosed.append((idx + 1, var))
+    assert not undisclosed, (
+        f"these exit-2 gates have no disclosure on their text branch: {undisclosed}. "
+        f"Add {_CALL}(<the same var the gate reads>) at the TOP of the `else` of the "
+        "`if json_output` fork -- never beside the json.dumps, which would break json.loads."
+    )
+
+
+def test_the_banner_is_never_emitted_on_a_json_branch() -> None:
+    # The one way this change could break a machine consumer: a stray line on stdout ahead of a
+    # JSON document. Pinned structurally -- the call must not appear between `if json_output:` and
+    # the `else:` that closes it.
+    lines = _MAIN.read_text(encoding="utf-8").splitlines()
+    offenders = []
+    for i, line in enumerate(lines):
+        if _CALL not in line or line.strip().startswith(("#", "*", '"')):
+            continue
+        if "def " in line:
+            continue
+        indent = len(line) - len(line.lstrip())
+        for j in range(i - 1, max(0, i - 25), -1):
+            stripped = lines[j].strip()
+            cur = len(lines[j]) - len(lines[j].lstrip())
+            if cur < indent and stripped.endswith(":"):
+                if stripped.startswith("if json_output"):
+                    offenders.append(i + 1)
+                break
+    assert not offenders, f"banner emitted on a --json branch at lines {offenders}"
+
+
+# -------------------------------------------------------------------------- behaviour (unit)
+
+
+def test_the_helper_emits_a_leading_warning_for_a_truncated_payload(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    emitted = _emit_scan_incompleteness_banner({"scan_limit": _truncated()})
+    out = capsys.readouterr().out
+    assert emitted is True
+    assert out.startswith("warning: INCOMPLETE RESULT:")
+
+
+def test_the_helper_is_silent_and_returns_false_for_a_complete_payload(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # CONTROL ARM: without it, a helper that printed unconditionally would satisfy every other
+    # assertion in this file and change output on every complete run.
+    emitted = _emit_scan_incompleteness_banner({"files": ["a.py"]})
+    assert emitted is False
+    assert capsys.readouterr().out == ""
+
+
+def test_map_discloses_a_truncated_scan_before_its_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from tensor_grep.cli import repo_map
+
+    payload = {
+        "path": str(tmp_path),
+        "files": ["a.py"],
+        "tests": [],
+        "symbols": [],
+        "imports": [],
+        "scan_limit": _truncated(),
+    }
+    monkeypatch.setattr(repo_map, "build_repo_map", lambda *a, **k: dict(payload), raising=True)
+    with pytest.raises(typer.Exit) as exc:
+        # EVERY parameter passed explicitly: an unpassed typer option arrives as an `OptionInfo`
+        # sentinel, not its default, and the command dies on `int(OptionInfo)` -- an error, not a
+        # red arm, and one that says nothing about the disclosure under test.
+        main_mod.map(
+            path=str(tmp_path),
+            max_files=None,
+            max_repo_files=512,
+            deadline=None,
+            no_deadline=False,
+            json_output=False,
+        )
+    assert exc.value.exit_code == 2  # premise: this really is the exit-2 path
+    out = capsys.readouterr().out
+    assert "Repository map for" in out  # premise: the counts block rendered
+    assert out.splitlines()[0].startswith("warning: INCOMPLETE RESULT:")
+    assert out.index("warning:") < out.index("Repository map for")


### PR DESCRIPTION
fix(cli): exit 2 must never be silent -- 13 commands disclosed nothing in text mode

The ABSENT half of the disclosure class, at its full width.

`cli/main.py` has fourteen `_scan_incomplete` gates that raise `typer.Exit(2)`.
THIRTEEN of them did so over text output that read exactly like a complete
result. `codemap` was the only one that said anything. An agent branching on the
exit code was fine; every human, and every agent reading the text, was told a
truncated answer was the whole answer.

Enumerated mechanically, not from the earlier audit's list -- which was right
about the shape and short by two: `inventory` and `prepare` were also silent.

## One helper, wired at the fork

`_emit_scan_incompleteness_banner(payload)` emits the LEADING disclosure and
returns whether it did. Wired at the top of the `else` of each `if json_output`
fork -- never beside the `json.dumps`, because a stray line there breaks
`json.loads` on stdout, the exact failure this surface exists to prevent. JSON
carries the same fact as `result_incomplete` / `caveat`, where position and prose
are irrelevant. Text comes from the shared `_scan_truncation_warning`, so these
commands cannot drift into their own vocabulary or their own idea of which knob
to suggest. Emits nothing for a complete payload, so output stays byte-identical.

## The sweep was a hypothesis, and reading it found three bugs

The insertion was scripted. Reviewing the diff site-by-site caught what the
script could not:

* THREE daemon fast paths (`context_render`, `agent`, `edit_plan`) gate on
  `daemon_payload`, and the script had inserted `...(payload)` -- disclosing the
  state of the wrong object;
* `codemap` already discloses via its own `PARTIAL:` line, so the insertion made
  it say the same thing twice in the same register. Removed. Its trailing
  POSITION is a separate tracked defect and is deliberately untouched here;
* `prepare` ends with `partial=true partial_reason=...` -- but only for the
  `partial` cause and only AFTER the lines it qualifies, so a scan-cap truncation
  was silent. Now banner-led; the key=value line stays, being a structured field
  in a key=value listing rather than prose duplicating prose.

## Ratchet

`test_every_exit_two_gate_has_a_disclosure_on_its_text_branch` pins the invariant
against the SOURCE, keyed on the same payload variable each gate reads -- so the
`payload`/`daemon_payload` bug above cannot recur silently. A sibling test pins
that the banner never appears on a `--json` branch.

Two false positives from the ratchet were fixed in the ratchet, not silenced:
it flagged its own helper's guard (excluded by enclosing function), and it
flagged `prepare` because a 40-line window could not see a correctly-placed
banner ~50 lines up. The window is now the enclosing FUNCTION -- an arbitrary
window makes the verdict depend on unrelated code length, and its obvious cure is
to widen it until it stops complaining, which is how a ratchet stops ratcheting.

## Verification (bidirectional, control arm run)

  treatment                                     5 passed
  control (13 call sites removed, helper kept)  2 failed, 3 passed

The control removes only the CALL SITES, keeping the helper importable, so the
ASSERTIONS discriminate rather than an ImportError. It names all 12 gates
including the three `daemon_payload` ones -- proof the variable-keyed check works.

Sweep: 616 passed across `test_cli_modes`, `test_main_cli_contracts`,
`test_cap_fix_chokepoint`, `test_deadline_blind_truncation_gates` and this file.
`ruff check` + `ruff format --preview --check` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
