### PR TITLE
fix(docs-coverage): --stale claimed absence over a scan it never finished

### DIFF
--- a/src/tensor_grep/cli/docs_coverage.py
+++ b/src/tensor_grep/cli/docs_coverage.py
@@ -355,30 +355,53 @@ def render_docs_coverage_fix_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_docs_coverage_text(payload: dict[str, Any]) -> str:
-    """ASCII-only text rendering (typer.echo crashes on non-ASCII on cp1252 Windows consoles)."""
-    totals = payload["totals"]
-    lines = [
-        f"Docs coverage for {payload['path']}",
-        f"source_files={totals['source_files']}  covered={totals['covered']}  "
-        f"uncovered={totals['uncovered']}  coverage={totals['coverage_pct']}%  "
-        f"docs={totals['doc_files']}",
-    ]
-    if payload["scan_limit"]["possibly_truncated"]:
-        # Task #284: this line HARDCODED "(project-files)" and named max_files, so an
-        # unreadable-path truncation would have rendered as budget advice that cannot help --
-        # the renderer contradicting its own payload. Read the real cause and, for the one cause
-        # no knob fixes, say so instead of naming a cap.
-        if payload["scan_limit"].get("truncation_cause") == "unreadable-path":
+def docs_scan_incompleteness_lines(payload: dict[str, Any]) -> list[str]:
+    """The LEADING disclosure for a docs scan that did not finish. Empty when it did.
+
+    Defined once and shared by BOTH renderers in this module. `--stale` previously read neither
+    `scan_limit` nor `partial`, so a truncated run could print "No stale references found (every
+    cited path still exists)" -- an ABSENCE claim over a doc set that was never fully read, which
+    is the worst shape this surface has. `--check` did disclose, but only AFTER its counts.
+
+    Task #284's cause-awareness is preserved verbatim: an `unreadable-path` truncation must NOT be
+    answered with budget advice, because no `--max-files` value makes a denied path readable.
+    `partial` (a `--deadline` cutoff) is a THIRD cause that neither renderer read at all.
+    """
+    scan_limit = payload.get("scan_limit") or {}
+    lines: list[str] = []
+    if scan_limit.get("possibly_truncated"):
+        if scan_limit.get("truncation_cause") == "unreadable-path":
             lines.append(
                 "[!] skipped unreadable path(s) (unreadable-path); counts are a floor. Raising "
                 "--max-files will NOT help: the path(s) must become readable, or be scoped out."
             )
         else:
             lines.append(
-                f"[!] truncated at max_files={payload['scan_limit']['max_files']} "
-                f"({payload['scan_limit'].get('truncation_cause') or 'project-files'})"
+                f"[!] truncated at max_files={scan_limit.get('max_files')} "
+                f"({scan_limit.get('truncation_cause') or 'project-files'})"
             )
+    elif payload.get("partial"):
+        # Deadline: named separately because raising --max-files is the wrong knob for a scan that
+        # ran out of TIME, and because the builder sets `partial` WITHOUT `possibly_truncated`.
+        lines.append(
+            "[!] the scan stopped early at its --deadline; counts are a floor. Raise --deadline "
+            "or narrow the PATH -- raising --max-files will NOT help."
+        )
+    return lines
+
+
+def render_docs_coverage_text(payload: dict[str, Any]) -> str:
+    """ASCII-only text rendering (typer.echo crashes on non-ASCII on cp1252 Windows consoles)."""
+    totals = payload["totals"]
+    # LEADING, per task #329: a reader who has seen `coverage=87%` has already formed the answer by
+    # the time a trailing `[!]` lands. This block used to sit BELOW the counts it qualifies.
+    lines = [*docs_scan_incompleteness_lines(payload)]
+    lines += [
+        f"Docs coverage for {payload['path']}",
+        f"source_files={totals['source_files']}  covered={totals['covered']}  "
+        f"uncovered={totals['uncovered']}  coverage={totals['coverage_pct']}%  "
+        f"docs={totals['doc_files']}",
+    ]
     uncovered = payload["uncovered_files"]
     if uncovered:
         lines.append(f"\nUndocumented source files ({len(uncovered)}):")
@@ -549,7 +572,13 @@ def build_docs_stale_references(
 def render_docs_stale_text(payload: dict[str, Any]) -> str:
     """ASCII-only text render of the --stale report."""
     totals = payload["totals"]
-    lines = [
+    # This renderer read NEITHER `scan_limit` NOR `partial`, so a truncated run printed
+    # "No stale references found (every cited path still exists)" -- an ABSENCE claim over a doc
+    # set that was never fully read. `--json` carried the truncation the whole time; only the
+    # default output dropped it. Leading, and via the shared helper so the two renderers in this
+    # module cannot drift into different vocabulary or different advice.
+    lines = [*docs_scan_incompleteness_lines(payload)]
+    lines += [
         f"Stale doc references for {payload['path']}",
         f"docs={totals['doc_files']}  references_checked={totals['references_checked']}  "
         f"stale={totals['stale']}",

--- a/tests/unit/test_docs_coverage_disclosure_position.py
+++ b/tests/unit/test_docs_coverage_disclosure_position.py
@@ -1,0 +1,155 @@
+"""Both `docs-coverage` renderers must LEAD with an incomplete-scan disclosure.
+
+Two defects, one shared cause -- each renderer decided for itself what counts as truncation:
+
+* ``--stale`` read NEITHER ``scan_limit`` NOR ``partial``. A truncated run printed
+  "No stale references found (every cited path still exists)" -- an ABSENCE claim over a doc set
+  that was never fully read. ``--json`` carried the truncation the whole time; only the default
+  output dropped it.
+* ``--check`` did disclose, but BELOW the counts it qualifies. A reader who has seen
+  ``coverage=87%`` has already formed the answer by the time a trailing ``[!]`` lands (task #329).
+
+Neither read ``partial``, so a ``--deadline`` cutoff was invisible on both.
+
+The fix is one shared ``docs_scan_incompleteness_lines`` helper, so the two cannot drift into
+different vocabulary or different advice -- and so a THIRD renderer added later inherits it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tensor_grep.cli.docs_coverage import (
+    docs_scan_incompleteness_lines,
+    render_docs_coverage_text,
+    render_docs_stale_text,
+)
+
+_BANNER = "[!]"
+
+
+def _scan_limit(**over: Any) -> dict[str, Any]:
+    base = {"max_files": 512, "possibly_truncated": False, "truncation_cause": None}
+    base.update(over)
+    return base
+
+
+def _coverage_payload(**extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "path": "/repo",
+        "totals": {
+            "source_files": 10,
+            "covered": 9,
+            "uncovered": 1,
+            "coverage_pct": 90.0,
+            "doc_files": 4,
+        },
+        "uncovered_files": ["src/a.py"],
+        "scan_limit": _scan_limit(),
+    }
+    payload.update(extra)
+    return payload
+
+
+def _stale_payload(**extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "path": "/repo",
+        "totals": {"doc_files": 4, "references_checked": 20, "stale": 0},
+        "stale_references": [],
+        "scan_limit": _scan_limit(),
+    }
+    payload.update(extra)
+    return payload
+
+
+# ------------------------------------------------------------------ the ABSENT case (--stale)
+
+
+def test_stale_report_discloses_a_truncated_scan_at_all() -> None:
+    out = render_docs_stale_text(
+        _stale_payload(
+            scan_limit=_scan_limit(possibly_truncated=True, truncation_cause="project-files")
+        )
+    )
+    # Premise: the report really rendered its "nothing found" claim, which is what makes the
+    # missing disclosure dangerous rather than merely untidy.
+    assert "No stale references found" in out
+    assert _BANNER in out, "a truncated --stale run claims absence with no disclosure at all"
+
+
+def test_stale_report_disclosure_leads_the_absence_claim() -> None:
+    out = render_docs_stale_text(
+        _stale_payload(
+            scan_limit=_scan_limit(possibly_truncated=True, truncation_cause="project-files")
+        )
+    )
+    assert out.splitlines()[0].startswith(_BANNER)
+    assert out.index(_BANNER) < out.index("No stale references found")
+
+
+def test_a_complete_stale_report_is_unchanged() -> None:
+    # CONTROL ARM: without it, a renderer that always printed a banner would pass every test above.
+    out = render_docs_stale_text(_stale_payload())
+    assert "Stale doc references for" in out  # premise: it rendered
+    assert _BANNER not in out
+
+
+# -------------------------------------------------------------- the POSITION case (--check)
+
+
+def test_coverage_report_disclosure_leads_the_counts() -> None:
+    out = render_docs_coverage_text(
+        _coverage_payload(
+            scan_limit=_scan_limit(possibly_truncated=True, truncation_cause="project-files")
+        )
+    )
+    assert "coverage=90.0%" in out  # premise: the counts block rendered
+    assert out.splitlines()[0].startswith(_BANNER)
+    assert out.index(_BANNER) < out.index("coverage=")
+
+
+def test_a_complete_coverage_report_is_unchanged() -> None:
+    out = render_docs_coverage_text(_coverage_payload())
+    assert out.splitlines()[0].startswith("Docs coverage for")
+    assert _BANNER not in out
+
+
+# --------------------------------------------------------------------- causes and their knobs
+
+
+def test_an_unreadable_path_is_not_answered_with_budget_advice() -> None:
+    # Task #284's cause-awareness, preserved through the extraction. No --max-files value makes a
+    # denied path readable, so naming the cap would be advice that cannot work.
+    lines = docs_scan_incompleteness_lines(
+        _coverage_payload(
+            scan_limit=_scan_limit(possibly_truncated=True, truncation_cause="unreadable-path")
+        )
+    )
+    assert len(lines) == 1
+    assert "will NOT help" in lines[0]
+    assert "truncated at max_files" not in lines[0]
+
+
+def test_a_deadline_cutoff_is_disclosed_and_names_the_right_knob() -> None:
+    # THIRD cause, read by neither renderer before: the builder sets `partial` WITHOUT
+    # `possibly_truncated`, so every branch above it missed a --deadline cutoff entirely.
+    lines = docs_scan_incompleteness_lines(_coverage_payload(partial=True))
+    assert len(lines) == 1
+    assert "--deadline" in lines[0]
+    assert "--max-files will NOT help" in lines[0]
+
+
+def test_a_file_cap_wins_over_the_deadline_branch() -> None:
+    # A payload carrying both must name the cap, which is the actionable knob.
+    lines = docs_scan_incompleteness_lines(
+        _coverage_payload(
+            partial=True,
+            scan_limit=_scan_limit(possibly_truncated=True, truncation_cause="project-files"),
+        )
+    )
+    assert len(lines) == 1
+    assert "truncated at max_files" in lines[0]
+
+
+def test_a_complete_payload_yields_no_lines() -> None:
+    assert docs_scan_incompleteness_lines(_coverage_payload()) == []


### PR DESCRIPTION
Two defects, one cause: each renderer decided for itself what counts as truncation.

## The ABSENT case

`--stale` read **neither** `scan_limit` **nor** `partial`, so a truncated run printed:

```
No stale references found (every cited path still exists).
```

An **absence claim over a doc set that was never fully read**. `--json` carried the truncation the whole time; only the default output dropped it — the same shape as `tg scan` reporting a clean security scan over a file it could not open (#831).

## The POSITION case

`--check` did disclose, but *below* the counts it qualifies. A reader who has seen `coverage=90%` has already formed the answer by the time a trailing `[!]` lands (task #329).

## The third cause both missed

Neither read `partial`, so a `--deadline` cutoff was invisible on both — the builder sets `partial` **without** `possibly_truncated`, so every existing branch missed it.

## Fix

One shared `docs_scan_incompleteness_lines` helper feeds both renderers, leading. They cannot drift into different vocabulary or different advice, and a third renderer added later inherits it rather than re-deriving truncation narrowly — which is the defect class itself.

Task #284's cause-awareness is preserved verbatim and pinned by its own test: an `unreadable-path` truncation must not be answered with budget advice, since no `--max-files` value makes a denied path readable.

## Verification

| arm | result |
|---|---|
| treatment | **9 passed** |
| control (both call sites reverted, helper kept importable) | **3 failed, 6 passed** |

The control reverts only the call sites — reverting the whole diff makes the module die on `ImportError`, and a file that cannot be collected is not a red arm. The 6 still passing are helper-behaviour tests and complete-payload controls.

63 passed across the docs-coverage + governance suites; `ruff check` + `ruff format --preview --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
