### PR TITLE
fix(cli): the last four disclosures that arrived after the numbers they qualify

### DIFF
--- a/src/tensor_grep/cli/inventory.py
+++ b/src/tensor_grep/cli/inventory.py
@@ -369,10 +369,14 @@ def build_inventory(
 def render_inventory_text(inventory: dict[str, Any]) -> str:
     """One-screen human summary mirroring tg's other summary conventions."""
     totals = inventory["totals"]
-    lines = [
-        f"inventory: {totals['files']} files, {_human_bytes(totals['bytes'])} "
-        f"({inventory['path']})",
-    ]
+    # LEADING (task #329). This block sat BELOW every count it qualifies, so a reader saw
+    # "inventory: 812 files, 4.1 MB" -- a confident total -- and met "counts are a floor" only
+    # after forming an impression of the repo's size. Moved verbatim; the three cause-specific
+    # arms (task #284's wrong-knob guard among them) are unchanged.
+    lines = _inventory_truncation_lines(inventory)
+    lines.append(
+        f"inventory: {totals['files']} files, {_human_bytes(totals['bytes'])} ({inventory['path']})"
+    )
     binary = inventory["binary"]
     if binary["files"]:
         lines.append(f"  binary: {binary['files']} files, {_human_bytes(binary['bytes'])}")
@@ -384,6 +388,12 @@ def render_inventory_text(inventory: dict[str, Any]) -> str:
     if inventory["categories"]:
         cats = ", ".join(f"{rec['category']} {rec['files']}" for rec in inventory["categories"])
         lines.append(f"  categories: {cats}")
+    return "\n".join(lines)
+
+
+def _inventory_truncation_lines(inventory: dict[str, Any]) -> list[str]:
+    """The leading disclosure for a truncated inventory. Empty when the scan finished."""
+    lines: list[str] = []
     scan = inventory["scan_limit"]
     if scan["possibly_truncated"]:
         if scan["truncation_cause"] == "unreadable-path":
@@ -406,7 +416,7 @@ def render_inventory_text(inventory: dict[str, Any]) -> str:
                 f"  [!] truncated at max_files={scan['max_files']} "
                 f"(cause={scan['truncation_cause']}); counts are a floor, not complete."
             )
-    return "\n".join(lines)
+    return lines
 
 
 def _human_bytes(num: int) -> str:

--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -9008,14 +9008,19 @@ def codemap(
     if json_output:
         typer.echo(json.dumps(payload, indent=2, sort_keys=True))
     else:
+        # LEADING (task #329). This block used to sit BELOW the counts, which is the position
+        # defect: a reader who has seen `symbols=1204` has already formed the answer by the time a
+        # trailing PARTIAL line lands. `codemap` was the ONE command in this family that disclosed
+        # at all, which is exactly why its ordering went unexamined for so long -- "it discloses"
+        # read as "it is fine".
+        if payload.get("partial"):
+            _safe_stdout_line(f"PARTIAL: {payload.get('remediation', '')}")
         _safe_stdout_line(f"Code map for {payload['path']}")
         _safe_stdout_line(f"out={payload['out']} index={payload['index']}")
         _safe_stdout_line(
             f"folders={payload['folders_total']} files={payload['files_total']} "
             f"symbols={payload['symbols_total']}"
         )
-        if payload.get("partial"):
-            _safe_stdout_line(f"PARTIAL: {payload.get('remediation', '')}")
 
     if _scan_incomplete(payload):
         raise typer.Exit(2)
@@ -10463,11 +10468,17 @@ def route_test(
             f"{edit_target.get('file')}#L{edit_target.get('line')} "
             f"{edit_target.get('symbol')}"
         )
+        # `agreement=` is a VERDICT, and a verdict computed from a truncated scan is the single
+        # most over-readable line this command emits -- so the qualifier leads it (task #329).
+        # The key=value form is kept rather than converted to a `warning:` banner: this whole
+        # block is a key=value listing and something may parse `partial=true`. Same call made for
+        # `prepare`, and the opposite call for `codemap`/`inventory`, whose trailing lines are
+        # prose in the same register as a banner and would have said it twice.
+        if payload.get("partial"):
+            typer.echo(f"partial=true agreement_basis={payload.get('agreement_basis')}")
         typer.echo(f"agreement={payload['agreement']}")
         for warning in payload["warnings"]:
             typer.echo(f"warning={warning}")
-        if payload.get("partial"):
-            typer.echo(f"partial=true agreement_basis={payload.get('agreement_basis')}")
 
     if _scan_incomplete(payload):
         raise typer.Exit(2)
@@ -12931,14 +12942,17 @@ def session_open(
         typer.echo(json.dumps(_with_schema_version(payload.__dict__, version=1), indent=2))
         return
 
-    typer.echo(
-        f"Opened session {payload.session_id} "
-        f"(files={payload.file_count}, symbols={payload.symbol_count})"
-    )
+    # LEADING (task #329): `files=`/`symbols=` are the numbers the cap qualifies, and a session is
+    # opened once and then trusted for its whole lifetime -- a caveat read after the counts is a
+    # caveat read after the decision to trust them.
     if isinstance(payload.scan_limit, dict) and payload.scan_limit.get("possibly_truncated"):
         typer.echo(
             "Session repo map is capped; reopen with a larger --max-repo-files for full coverage."
         )
+    typer.echo(
+        f"Opened session {payload.session_id} "
+        f"(files={payload.file_count}, symbols={payload.symbol_count})"
+    )
 
 
 @session_daemon_app.command("start")

--- a/tests/unit/test_trailing_disclosures_now_lead.py
+++ b/tests/unit/test_trailing_disclosures_now_lead.py
@@ -1,0 +1,76 @@
+"""Four emitters that DID disclose, but AFTER the numbers they qualify (task #329).
+
+These are the mild half of the disclosure class -- unlike the thirteen silent commands (#837) or
+``docs-coverage --stale`` (#840), each of these already told the truth. It just arrived late:
+
+* ``codemap``      -- ``PARTIAL:`` printed below ``folders=/files=/symbols=``
+* ``inventory``    -- ``[!] truncated ...`` printed below ``inventory: N files, X MB``
+* ``route-test``   -- ``partial=true`` printed below the ``agreement=`` VERDICT
+* ``session open`` -- the cap notice printed below ``files=/symbols=``
+
+``codemap`` is the instructive one: it was the ONLY command in its family that disclosed at all,
+and that is exactly why its ordering went unexamined. "It discloses" read as "it is fine".
+
+REGISTER decides whether the old line moves or stays. ``codemap`` and ``inventory`` emit PROSE --
+same register as a leading banner -- so those move. ``route-test`` emits ``partial=true
+agreement_basis=...``, a structured field in a key=value listing that something may parse, so it
+moves POSITION but keeps its FORM. Same call made for ``prepare``; the opposite call was made for
+``inventory`` in #837, where adding a banner beside its prose would have said it twice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tensor_grep.cli.inventory import render_inventory_text
+
+
+def _inventory(**scan: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "path": "/repo",
+        "totals": {"files": 812, "bytes": 4_300_000},
+        "binary": {"files": 0, "bytes": 0},
+        "languages": [],
+        "categories": [],
+        "scan_limit": {"possibly_truncated": False, "truncation_cause": None, "max_files": 512},
+    }
+    if scan:
+        base["scan_limit"].update(scan)
+    return base
+
+
+_TOTALS = "inventory: 812 files"
+
+
+def test_inventory_truncation_leads_its_totals() -> None:
+    out = render_inventory_text(
+        _inventory(possibly_truncated=True, truncation_cause="project-files")
+    )
+    # Premise: the totals really rendered, so the ordering assertion is not vacuous.
+    assert _TOTALS in out
+    assert out.splitlines()[0].lstrip().startswith("[!]")
+    assert out.index("[!]") < out.index(_TOTALS)
+
+
+def test_inventory_unreadable_path_still_refuses_budget_advice_after_the_move() -> None:
+    # Task #284's wrong-knob guard must survive the extraction: no --max-files value makes a
+    # denied path readable, so this arm must not name a cap.
+    out = render_inventory_text(
+        _inventory(possibly_truncated=True, truncation_cause="unreadable-path")
+    )
+    assert "will NOT help" in out
+    assert "truncated at max_files" not in out
+
+
+def test_inventory_deadline_cause_survives_the_move() -> None:
+    out = render_inventory_text(_inventory(possibly_truncated=True, truncation_cause="deadline"))
+    assert "cause=deadline" in out
+    assert out.index("[!]") < out.index(_TOTALS)
+
+
+def test_a_complete_inventory_is_byte_identical_to_before() -> None:
+    # CONTROL ARM: without it, a renderer that always led with a banner would satisfy every
+    # assertion above while changing output on every healthy run.
+    out = render_inventory_text(_inventory())
+    assert out.splitlines()[0].startswith(_TOTALS)
+    assert "[!]" not in out


### PR DESCRIPTION
The last four emitters in the disclosure class. Unlike the thirteen silent commands (#837) or `docs-coverage --stale` (#840), **each of these already told the truth** — it just arrived after the numbers it qualifies (task #329).

| command | was | now |
|---|---|---|
| `codemap` | `PARTIAL:` below `folders=/files=/symbols=` | leads |
| `inventory` | `[!] truncated ...` below `inventory: N files, X MB` | leads |
| `route-test` | `partial=true` below the `agreement=` **verdict** | leads |
| `session open` | cap notice below `files=/symbols=` | leads |

## `codemap` is the instructive one

It was the **only** command in its family that disclosed at all — which is exactly why its ordering went unexamined. *"It discloses"* read as *"it is fine"*, and the position defect hid behind the presence of a correct line.

## REGISTER decides whether the old line moves or stays

`codemap` and `inventory` emit **prose** — same register as a leading banner — so those move outright. `route-test` emits `partial=true agreement_basis=...`, a structured field in a key=value listing that something may parse, so it moves POSITION but keeps its FORM. Same call made for `prepare`; the opposite call was made for `inventory` in #837, where adding a banner beside its prose would have said it twice.

`session open` matters more than its size suggests: a session is opened once and then trusted for its whole lifetime, so a caveat read after the counts is a caveat read after the decision to trust them.

## `inventory` extraction

Its three cause-specific arms (including task #284's wrong-knob guard — no `--max-files` value makes a denied path readable) moved **verbatim** into `_inventory_truncation_lines`, each pinned by its own test so the extraction cannot have quietly flattened them.

## Verification

| arm | result |
|---|---|
| treatment | **4 passed** |
| control (leading call removed, helper kept importable) | **3 failed, 1 passed** |

The control reverts only the call site — reverting the whole diff makes the module unimportable, and a file that cannot be collected is not a red arm. The 1 still passing is the complete-inventory control, which must stay byte-identical.

**640 passed** across `test_inventory*`, `test_session_cli`, `test_cli_modes` and this file; `ruff check` + `ruff format --preview --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
