### PR TITLE
fix(cli): a --json scan refusal must be parseable, not zero bytes on stdout

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -5158,6 +5158,57 @@ def _format_broad_workspace_scan_error(project_dirs: list[str]) -> str:
     )
 
 
+def _emit_broad_scan_refusal(message: str, *, json_output: bool, path: str) -> None:
+    """Emit a scan-policy refusal on BOTH surfaces, then let the caller exit 2.
+
+    An external dogfood asked for "the same exit-2 refuse for bare `--json` unscoped as the
+    multi-project parent" and it was half-right: the exit code WAS already 2. What was missing is
+    that `--json` printed **zero bytes** to stdout, so a machine consumer got `JSONDecodeError` and
+    had to parse English off stderr to learn why. Measured on the shipped v1.101.9:
+    `tg search PAT --json` on a large implicit root -> exit 2, stdout 0 bytes.
+
+    A refusal is the one answer a `--json` caller most needs machine-readable: it is precisely the
+    case where an empty result must NOT be read as "no matches". Emitting nothing forces the
+    consumer into the inference this whole surface exists to prevent.
+
+    The envelope MIRRORS the MCP `tg_search` refusal payload (`mcp_server.py`) field for field --
+    `truncated` + `result_incomplete` + `incomplete_reason` + `incomplete_reason_class:
+    "scan_limit"` + `error.code: "broad_scan_refused"` + `retryable: false`. Deliberately not a new
+    vocabulary: MCP already settled that a scan-policy ceiling classifies as `scan_limit` and that
+    `error.code` is the sibling signal for WHICH policy refused. Two surfaces refusing the same
+    thing in two different shapes is how CLI and MCP drift into contradicting each other.
+
+    `total_matches: 0` is safe here ONLY because it travels with those flags: the zero is qualified
+    on the same line it appears, which is the difference between a count and an absence claim.
+    """
+    from tensor_grep.cli.formatters.json_fmt import JSON_OUTPUT_VERSION
+
+    typer.echo(message, err=True)
+    if not json_output:
+        return
+    typer.echo(
+        json.dumps(
+            {
+                "version": JSON_OUTPUT_VERSION,
+                "path": path,
+                "total_matches": 0,
+                "total_files": 0,
+                "matches": [],
+                "truncated": True,
+                "result_incomplete": True,
+                "incomplete_reason": message,
+                "incomplete_reason_class": "scan_limit",
+                "error": {
+                    "code": "broad_scan_refused",
+                    "message": message,
+                    "retryable": False,
+                },
+            },
+            indent=2,
+        )
+    )
+
+
 def _format_unbounded_vendored_root_scan_error(vendored_dirs: list[str]) -> str:
     visible_dirs = ", ".join(vendored_dirs[:8])
     if len(vendored_dirs) > 8:
@@ -7694,7 +7745,11 @@ def search_command(
         files_mode=files,
     )
     if refuse_generated_scan:
-        typer.echo(_format_broad_generated_scan_error(generated_scan_dirs), err=True)
+        _emit_broad_scan_refusal(
+            _format_broad_generated_scan_error(generated_scan_dirs),
+            json_output=json,
+            path=str(paths_to_search[0]) if paths_to_search else ".",
+        )
         raise typer.Exit(2)
     refuse_workspace_scan, workspace_project_dirs = _should_refuse_unbounded_workspace_root_scan(
         paths_to_search,
@@ -7703,7 +7758,11 @@ def search_command(
         paths_defaulted=paths_defaulted,
     )
     if refuse_workspace_scan:
-        typer.echo(_format_broad_workspace_scan_error(workspace_project_dirs), err=True)
+        _emit_broad_scan_refusal(
+            _format_broad_workspace_scan_error(workspace_project_dirs),
+            json_output=json,
+            path=str(paths_to_search[0]) if paths_to_search else ".",
+        )
         raise typer.Exit(2)
     refuse_vendored_scan, vendored_root_dirs = _should_refuse_unbounded_vendored_root_scan(
         paths_to_search,
@@ -7712,7 +7771,11 @@ def search_command(
         paths_defaulted=paths_defaulted,
     )
     if refuse_vendored_scan:
-        typer.echo(_format_unbounded_vendored_root_scan_error(vendored_root_dirs), err=True)
+        _emit_broad_scan_refusal(
+            _format_unbounded_vendored_root_scan_error(vendored_root_dirs),
+            json_output=json,
+            path=str(paths_to_search[0]) if paths_to_search else ".",
+        )
         raise typer.Exit(2)
 
     # Bug #88 (dogfood v1.54.1 re-harvest): an implicit-path `--glob`/`--type` search that the

--- a/tests/unit/test_broad_scan_refusal_json_envelope.py
+++ b/tests/unit/test_broad_scan_refusal_json_envelope.py
@@ -1,0 +1,119 @@
+"""A scan-policy REFUSAL must be machine-readable on the `--json` surface.
+
+External dogfood (gotcontext-saddle, v1.101.7 and again on v1.101.9) asked for "the same exit-2
+refuse for bare `--json` unscoped as the multi-project parent". The exit code was already 2 -- what
+was missing is that `--json` printed **zero bytes** to stdout, so a consumer got a
+``JSONDecodeError`` and had to parse English off stderr to learn why. Measured on the shipped
+v1.101.9::
+
+    tg search PAT --json          # large implicit root
+    -> exit 2, stdout 0 bytes, refusal prose on stderr only
+
+A refusal is the one answer a `--json` caller most needs in-band: it is exactly the case where an
+empty result must NOT be read as "no matches found". Emitting nothing forces the consumer into the
+inference this entire surface exists to prevent.
+
+The envelope MIRRORS MCP's `tg_search` refusal payload field for field rather than inventing a
+second shape -- MCP already settled that a scan-policy ceiling classifies as ``scan_limit`` and that
+``error.code`` is the sibling signal for WHICH policy refused. Two surfaces refusing the same thing
+in two different shapes is how CLI and MCP drift into contradicting each other (#293's lesson).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# NOT a module-level `from tensor_grep.cli.main import ...`. Importing `main` at collection time
+# perturbs the lazy-import state four `--help` tests in `test_cli_modes.py` depend on: they passed
+# with that file alone and failed whenever this one was collected first, on snippets that simply
+# were not in the rendered help. The import is deferred into the helper so collection order stops
+# being load-bearing. (A first attempt blamed `redirect_stdout` width-fragility and switching to
+# `capsys` did NOT fix it -- the capsys change is kept anyway, since capturing without swapping
+# the stream is right regardless, but the module-level import was the actual cause.)
+
+_MESSAGE = (
+    "Error: broad root scan refused as a safety guard, not a zero-match result: "
+    "path is a large single-project root (over 1500 files)"
+)
+
+
+def _emit(capsys: pytest.CaptureFixture[str], *, json_output: bool) -> tuple[str, str]:
+    """Capture via pytest's `capsys`, NOT `contextlib.redirect_stdout`.
+
+    The first cut used `redirect_stdout(io.StringIO())` and POISONED four unrelated `--help`
+    tests in `test_cli_modes.py` -- they passed when that file ran alone and failed when this one
+    ran first. Click sizes its help wrapping from the stream it finds at render time, so swapping
+    stdout for a StringIO changes the detected width and re-wraps help text for the rest of the
+    session. Same width-fragility class as the clap help-parse trap, one framework over.
+
+    `capsys` is the fixture pytest provides precisely to capture without disturbing that.
+    """
+    from tensor_grep.cli.main import _emit_broad_scan_refusal
+
+    _emit_broad_scan_refusal(_MESSAGE, json_output=json_output, path=".")
+    captured = capsys.readouterr()
+    return captured.out, captured.err
+
+
+def test_json_refusal_is_a_parseable_document(capsys: pytest.CaptureFixture[str]) -> None:
+    # THE DEFECT: stdout was empty, so this line raised JSONDecodeError.
+    out, _ = _emit(capsys, json_output=True)
+    assert out.strip(), "stdout is empty; a --json consumer gets JSONDecodeError, not a refusal"
+    json.loads(out)
+
+
+def test_the_zero_travels_with_its_qualifiers(capsys: pytest.CaptureFixture[str]) -> None:
+    # `total_matches: 0` is only safe because the incompleteness flags appear beside it. A bare
+    # zero would be an ABSENCE CLAIM over a scan that never ran -- the exact defect this campaign
+    # exists to close. Assert they cannot be separated.
+    payload = json.loads(_emit(capsys, json_output=True)[0])
+    assert payload["total_matches"] == 0
+    assert payload["result_incomplete"] is True
+    assert payload["truncated"] is True
+    assert payload["incomplete_reason_class"] == "scan_limit"
+
+
+def test_the_envelope_names_which_policy_refused_and_that_a_retry_is_futile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = json.loads(_emit(capsys, json_output=True)[0])
+    assert payload["error"]["code"] == "broad_scan_refused"
+    assert payload["error"]["retryable"] is False
+    assert "broad root scan refused" in payload["incomplete_reason"]
+
+
+def test_the_vocabulary_matches_the_mcp_refusal_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    # Cross-surface consistency, pinned. MCP's tg_search refusal carries exactly these keys; if
+    # either side grows a field the other lacks, an agent that learned one surface mis-reads the
+    # other. Kept as a subset check on the CLI side because MCP's payload additionally carries
+    # per-tool keys (lang, rendered_* counts) that have no CLI meaning.
+    payload = json.loads(_emit(capsys, json_output=True)[0])
+    for shared in (
+        "total_matches",
+        "total_files",
+        "matches",
+        "truncated",
+        "result_incomplete",
+        "incomplete_reason",
+        "incomplete_reason_class",
+        "error",
+    ):
+        assert shared in payload, f"CLI refusal envelope is missing MCP's {shared!r}"
+
+
+def test_human_prose_still_goes_to_stderr_in_both_modes(capsys: pytest.CaptureFixture[str]) -> None:
+    # The banner is ADDITIVE. A human running without --json must see exactly what they saw before.
+    _, err_json = _emit(capsys, json_output=True)
+    _, err_text = _emit(capsys, json_output=False)
+    assert "broad root scan refused" in err_json
+    assert "broad root scan refused" in err_text
+    assert err_json == err_text, "stderr must not differ between the two modes"
+
+
+def test_text_mode_stdout_is_byte_identical_to_before(capsys: pytest.CaptureFixture[str]) -> None:
+    # CONTROL ARM: without it, an emitter that always printed the envelope would satisfy every
+    # assertion above while polluting the plain-text surface.
+    out_text, _ = _emit(capsys, json_output=False)
+    assert out_text == "", "text mode must print nothing to stdout"


### PR DESCRIPTION
Closes the external-dogfood ask: *"same exit-2 refuse for bare `--json` unscoped as the multi-project parent"* (reported on v1.101.7, unchanged on v1.101.9).

## The exit code was already right; the payload was empty

Measured on the shipped **v1.101.9**:

```
tg search PAT --json        # large implicit root
-> exit 2, stdout 0 BYTES, refusal prose on stderr only
-> json.loads(stdout) raises JSONDecodeError
```

A refusal is the one answer a `--json` caller most needs in-band: it is exactly the case where an empty result must **not** be read as "no matches found". Emitting nothing forces the consumer into the inference this whole surface exists to prevent.

## Mirrors MCP rather than inventing a second shape

MCP's `tg_search` refusal already settled this vocabulary — a scan-policy ceiling classifies as `scan_limit`, and `error.code` is the sibling signal for *which* policy refused. The CLI envelope now carries the same fields: `truncated` + `result_incomplete` + `incomplete_reason` + `incomplete_reason_class: "scan_limit"` + `error.code: "broad_scan_refused"` + `retryable: false`. Two surfaces refusing the same thing in two shapes is how CLI and MCP drift into contradicting each other (#293's lesson).

`total_matches: 0` is safe **only** because it travels with those flags — the zero is qualified on the same line it appears, which is the difference between a count and an absence claim. Pinned by a test.

Wired at all three refusal sites (generated-scan, workspace-root, vendored-root). Text mode is byte-identical: stderr prose unchanged, stdout still empty.

## Verification

| arm | result |
|---|---|
| treatment | **6 passed** |
| control (envelope suppressed, helper importable) | **4 failed, 2 passed** |

The 2 still passing are the stderr-parity and text-mode controls, which must hold in both arms.

## A test-pollution bug this PR caught in itself

The first cut of the test file **poisoned four unrelated `--help` tests** in `test_cli_modes.py` — they passed with that file alone and failed whenever this one was collected first. Two hypotheses, one wrong:

1. Blamed `redirect_stdout` width-fragility → switched to `capsys` → **still failed**. (Kept anyway; capturing without swapping the stream is right regardless.)
2. Actual cause: the **module-level `from tensor_grep.cli.main import ...`** perturbed lazy-import state the help tests depend on. Deferred into the helper → **533 passed**.

Full original failing order now: **587 passed**. `ruff check` + `ruff format --preview --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
