### PR TITLE
docs(skills): land the 1.101.9 live-dogfood corrections

### DIFF
--- a/.claude/skills/tensor-grep-ledger/SKILL.md
+++ b/.claude/skills/tensor-grep-ledger/SKILL.md
@@ -5,9 +5,8 @@ description: Use when coordinating multiple agents on the same repo with tg ledg
 
 # tensor-grep ledger (EXPERIMENTAL, ADVISORY-tier)
 
-Verified against **tg 1.101.7** (LIVE 2026-07-28 gotcontext-saddle — Slice 1 rollup
-reconfirmed: `claim core/hooks` visible from `list .`, release by claim-id from `.`
-works; record+find fresh PASS; prior 1.95.0 / 1.93.0 #706 notes still accurate).
+Verified against **tg 1.101.9** (LIVE 2026-07-28 gotcontext-saddle — Slice 1 rollup
+reconfirmed; prior 1.101.7 / 1.95.0 / 1.93.0 #706 notes still accurate).
 
 `tg ledger` is **ADVISORY-tier**, not MANDATORY or OPTIONAL, in the vocabulary a multi-agent-coordination
 ecosystem needs to stay legible (the same MANDATORY/OPTIONAL/ADVISORY split the `ruah` coordination

--- a/.claude/skills/tensor-grep-prepare/SKILL.md
+++ b/.claude/skills/tensor-grep-prepare/SKILL.md
@@ -5,8 +5,8 @@ description: Use when an agent needs one-call edit readiness before changing cod
 
 # tensor-grep prepare (one-call edit readiness)
 
-Verified against **tg 1.101.7** (LIVE 2026-07-28 gotcontext-saddle; prior 1.95.0 CLI
-contract / 1.92.1–1.91.0 dogfoods still representative of the core CUJ).
+Verified against **tg 1.101.9** (LIVE 2026-07-28 gotcontext-saddle; prior 1.101.7 /
+1.95.0 CLI contract / 1.92.1–1.91.0 dogfoods still representative of the core CUJ).
 
 ## When to use
 
@@ -33,6 +33,8 @@ Dogfood:
 
 | Case | Result |
 | --- | --- |
+| `prepare … --out` (**1.101.9**) | PASS ~6s — overall 0.9, callers_count=1, file ~8KB |
+| `prepare … --claim` (**1.101.9**) | PASS ~8s — submitted=true + `agent_id_hint` when anonymous |
 | `prepare core/hooks matches_trigger` (**1.101.7**) | PASS ~13s — overall 0.9, callers_count=1, claim.submitted=false |
 | `prepare … --out` / `--claim` (**1.101.7**) | PASS — file ~8KB; submitted=true + `agent_id_hint` when anonymous |
 | `prepare core/hooks matches_trigger` (1.92.1) | PASS ~8s — overall 0.9, callers_count=1, claim.submitted=false |

--- a/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
+++ b/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
@@ -13,7 +13,7 @@ tg doctor --json ROOT
 tg devices
 ```
 
-## Recommended sweep (v1.101.7)
+## Recommended sweep (v1.101.9)
 
 ```bash
 cd /path/to/workspace
@@ -39,33 +39,32 @@ tg agent agent-studio/.claude/lib/routing "task" --json
 tg dogfood --root . --output /tmp/dogfood-ws.json
 ```
 
-## Latest sweep (2026-07-28, tg 1.101.7, gotcontext-saddle)
+## Latest sweep (2026-07-28, tg 1.101.9, gotcontext-saddle)
 
 | Category | Result | Notes |
 | --- | --- | --- |
-| Symbol ladder / blast / orient / map / route-test / evidence / dogfood | ✅ | route `agreement: true` via **`agreement_details`**; trunc hard-stop exit 2 |
-| `tg agent` scoped + root `--deadline 90` | ✅ | scoped ~12s; root ~76s rc 0 non-partial |
-| lexical camelCase → snake | ✅ | `readBlockEnabled` → `read_block_enabled` |
-| **`tg prepare`** / `--out` / `--claim` | ✅ | ~13s; `--out` persists; `agent_id_hint` when anonymous |
-| ledger Slice 1 rollup + Slice 2 record/find | ✅ | `list .` sees `claim core/hooks`; find fresh exit 0 |
-| `tg find` without dense | ✅ | BM25; fallback leads with `` `tg install-dense` `` |
-| GPU | ⚠️ | honest `unsupported` / `gpu-auto-fallback-cpu`; calibrate exit 2 (no CUDA) |
-| Multi-project parent unscoped | ✅ | exit 2 refuse + remediation |
-| Single-repo bare `search --json` (no PATH) | ⚠️ | ~2s exit 1 empty, **no** refuse stderr — always pass PATH |
-| Cold doctor daemon | ✅ | `autostart: on-first-use…`; warm → `running: true` |
+| Symbol ladder / blast / orient / map / route-test / evidence / dogfood | ✅ | `agreement_details` true; evidence `checks.digest_valid` |
+| `tg agent` scoped + root `--deadline 90` | ✅ | scoped ~12s; root ~61s rc 0 non-partial (faster vs 1.101.7) |
+| lexical + trunc hard-stop | ✅ | lexical OK; trunc now honest **conf 0.72** + ask.required (was 0.9) |
+| **`tg prepare`** / `--out` / `--claim` | ✅ | ~6–8s (faster); `agent_id_hint` |
+| ledger Slice 1 rollup + Slice 2 | ✅ | list `.` sees subtree claim; find fresh |
+| `tg find` without dense | ✅ | BM25; install-dense hint; help mentions optional MaxSim |
+| GPU | ⚠️ | `unsupported` / cpu-fallback + explicit “not GPU proof” stderr |
+| Multi-project parent unscoped | ✅ | exit 2 refuse |
+| Bare `search --json` (no PATH) | ⚠️ | still ~1s exit 1 empty, no refuse stderr |
+| Cold doctor daemon | ✅ | autostart hint → warm running |
 
-Artifact: `/tmp/tg-dogfood-11017.json`.
+Artifact: `/tmp/tg-dogfood-11019.json`. Prior same-day 1.101.7: `/tmp/tg-dogfood-11017.json`.
 
 ## Trend
 
 | Version | PASS | TIMEOUT | Notable |
 | --- | ---: | ---: | --- |
-| 1.81.18 | 46 | 2 | deadline symbol flaky |
-| 1.83.0 | 52 | 2 | ledger ships |
 | 1.91.0 | 57 | 2 | prepare + install-dense |
-| 1.92.1 | saddle ✅ | — | prepare solid; ledger PATH footgun documented |
-| 1.93.x–1.95.0 | fixes ship | — | ledger rollup, install-dense hint, prepare `--out`, GPU probe honesty |
-| **1.101.7** | **saddle ✅** | — | live reconfirm; route-test `agreement_details`; bare-json PATH footgun remains |
+| 1.92.1 | saddle ✅ | — | prepare solid; ledger PATH footgun |
+| 1.93.x–1.95.0 | fixes ship | — | ledger rollup, prepare `--out`, GPU probe honesty |
+| 1.101.7 | saddle ✅ | — | agreement_details; bare-json PATH footgun |
+| **1.101.9** | **saddle ✅** | — | faster prepare/agent; trunc conf honesty; MaxSim in find help |
 
 ## Sibling skills
 

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -40,7 +40,7 @@ prefer the canonical path-first form.
    - `tg source REPO_PATH/src SYMBOL`
 4. Symbol navigation — prefer `src/`:
    - `tg callers REPO_PATH/src SYMBOL --deadline 15 --json`
-5. Edit readiness — **prefer `tg prepare REPO/src`** (~13s PASS on gotcontext-saddle hooks @ 1.101.7; ~27s on larger src @ 1.91.0):
+5. Edit readiness — **prefer `tg prepare REPO/src`** (~6s PASS on gotcontext-saddle hooks @ 1.101.9; ~27s on larger src @ 1.91.0):
    - `tg prepare REPO_PATH/src "task" --json`  # primary + blast floor + validation + coordination hooks
    - `tg prepare REPO_PATH/src "task" --out capsule.json --json`  # also persists the full capsule to FILE (byte-identical to stdout JSON; symlink/dangling-symlink/dir refused; feeds `tg evidence emit --capsule FILE` directly, no manual redirect)
    - `tg prepare REPO_PATH/src "task" --claim --json`  # also submit advisory ledger claim; anonymous claims stamp `coordination.claim.agent_id_hint` unless `TG_LEDGER_AGENT_ID` is set


### PR DESCRIPTION
Live-dogfood corrections from the 2026-07-28 sweep on `gotcontext-saddle` against **v1.101.9**, captured before they were lost — they were sitting uncommitted in the working tree, same as the 1.101.7 batch (#841).

## What the sweep recorded

- **Stamps moved to 1.101.9** across the workspace + prepare/ledger/tensor-grep skills.
- **Measured improvements** worth having in the skills rather than only in a chat log: `agent` root `--deadline 90` now ~61s (was ~76s), `prepare --out/--claim` ~6–8s (was ~13s).
- **Truncation honesty**: the hard-stop now reports an honest confidence of **0.72** where it previously reported a misleading **0.9** — that is the kind of number a skill reader will otherwise carry forward wrong.
- **`evidence verify`** digests live under `checks.digest_valid`.
- **MaxSim late-rerank** is mentioned in `--help` but not exercised without dense installed — noted as such rather than implied working.

## Why the stamps say 1.101.9 and not later

The sweep ran against 1.101.9. Stamping forward to whatever is newest would claim a verification that never happened — the repo's pin-each-claim-to-its-source rule. The stamp records what was measured.

Non-releasing (`docs:`). 67 governance tests green (skill-index sync, public docs, enterprise docs); the four edited files are `ruff format --preview --check` clean. Two other skill files show as unformatted repo-wide — pre-existing, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
