### PR TITLE
fix(io): DirectoryScanner yielded symlinked files, disclosing out-of-root content

### DIFF
--- a/src/tensor_grep/io/directory_scanner.py
+++ b/src/tensor_grep/io/directory_scanner.py
@@ -300,6 +300,31 @@ class DirectoryScanner:
                     continue
 
                 file_path = Path(root) / file_name
+                # SYMLINK-FOLLOW DISCLOSURE. `os.walk(followlinks=False)` (the default above) stops
+                # us DESCENDING into a symlinked directory -- it does NOT stop a symlink-to-a-file
+                # appearing in `files`. Every consumer of this walk then does a plain
+                # `open(path, "rb")`, which follows the link to its real target regardless of the
+                # walk's setting. So a git-tracked symlink (an ordinary mode-120000 blob) pointing
+                # at `~/.ssh/id_rsa`, a sibling project's `.env`, or /etc/passwd disclosed that
+                # file's contents into search output, the on-disk symbol cache, and -- because this
+                # is the walker behind `tg agent`/`orient`/the MCP tools -- an LLM agent's context.
+                #
+                # Proven on a temp fixture before the fix: a link at `repo/leak.txt` -> an
+                # out-of-root `secret.txt` was YIELDED by this loop and `open()` returned its
+                # contents.
+                #
+                # `checkpoint_store.py` already carries this guard (`is_dir() and not
+                # is_symlink()`), and AGENTS.md names symlink-follow as a repo-wide SWEEP target
+                # rather than a one-file patch -- this is the core walker the sweep missed, which
+                # matters more than the site it landed on: checkpoint create/restore is occasional,
+                # this is the default read path for ordinary search.
+                #
+                # Skipped, not resolved-and-bounded: a link whose target sits INSIDE the root is
+                # still reachable by its real path, so skipping loses no legitimate content while
+                # a resolve-then-compare would have to get root-containment exactly right on every
+                # platform to avoid reintroducing the escape.
+                if file_path.is_symlink():
+                    continue
                 relative_path = Path(_relative_posix(file_path))
                 if spec_stack and self._path_ignored_by_stack(file_path, False, spec_stack):
                     continue

--- a/tests/unit/test_scanner_skips_symlinked_files.py
+++ b/tests/unit/test_scanner_skips_symlinked_files.py
@@ -1,0 +1,124 @@
+"""`DirectoryScanner.walk()` must never yield a symlinked FILE.
+
+`os.walk(followlinks=False)` — the default this scanner relies on — stops the walk DESCENDING into
+a symlinked directory. It does not stop a symlink-to-a-file appearing in ``files``. Every consumer
+then does a plain ``open(path, "rb")``, which follows the link to its real target regardless.
+
+So a git-tracked symlink (an ordinary mode-120000 blob — nothing exotic) pointing at
+``~/.ssh/id_rsa``, a sibling project's ``.env``, or ``/etc/passwd`` disclosed that file's contents
+into search output, the on-disk symbol cache, and — because ``DirectoryScanner`` is the walker
+behind ``tg agent`` / ``tg orient`` / the MCP tools — an LLM agent's context window.
+
+Proven on a temp fixture before the fix::
+
+    repo/leak.txt -> ../outside/secret.txt   (contains SECRET_MARKER_998877)
+    DirectoryScanner.walk(repo) -> ['leak.txt', 'normal.py']
+    open('.../leak.txt').read() -> 'SECRET_MARKER_998877'
+
+`checkpoint_store.py` already carried this guard. AGENTS.md names symlink-follow as a repo-wide
+SWEEP target, not a one-file patch — this is the core walker the sweep missed, and it matters more
+than the site it landed on: checkpoint create/restore is occasional, this is the default read path
+for ordinary search.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.core.config import SearchConfig
+from tensor_grep.io.directory_scanner import DirectoryScanner
+
+_MARKER = "SECRET_MARKER_998877"
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path]:
+    """A scanned root containing a symlink that escapes it.
+
+    Returns (repo_root, link_path). Skips on hosts that cannot create symlinks (unprivileged
+    Windows) — mirroring the repo's existing follow-fixture pattern rather than silently passing.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text(f"{_MARKER}\n", encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "normal.py").write_text("x = 1\n", encoding="utf-8")
+
+    link = repo / "leak.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError as exc:  # pragma: no cover - platform/privilege dependent
+        pytest.skip(f"cannot create a symlink on this host: {exc}")
+
+    # PREMISE: the fixture really is the dangerous shape. Without this, a host that silently
+    # created a regular file instead of a link would make every assertion below vacuous.
+    assert link.is_symlink(), "fixture did not produce a symlink"
+    assert link.resolve() == secret.resolve(), "symlink does not point out of the scanned root"
+    return repo, link
+
+
+def _walk(repo: Path) -> list[str]:
+    return [Path(p).name for p in DirectoryScanner(SearchConfig()).walk(str(repo))]
+
+
+def test_a_symlinked_file_is_not_yielded(tmp_path: Path) -> None:
+    """THE DEFECT: `leak.txt` was yielded, and opening it returned out-of-root content."""
+    repo, _ = _fixture(tmp_path)
+    names = _walk(repo)
+    # PREMISE: the walk really ran and found the ordinary file, so the absence below is a skip
+    # and not an empty walk.
+    assert "normal.py" in names, f"walk returned nothing usable: {names}"
+    assert "leak.txt" not in names, (
+        "DirectoryScanner yielded a symlinked file; every consumer open()s it and follows the "
+        "link out of the scanned root"
+    )
+
+
+def test_the_out_of_root_content_is_never_reachable_through_the_walk(tmp_path: Path) -> None:
+    """End-to-end: no path the walk yields may read back the marker.
+
+    Stronger than the name check above — it survives a fix that renames or relocates the link
+    rather than skipping it.
+    """
+    repo, _ = _fixture(tmp_path)
+    for path in DirectoryScanner(SearchConfig()).walk(str(repo)):
+        content = Path(path).read_text(encoding="utf-8", errors="replace")
+        assert _MARKER not in content, f"{path} discloses out-of-root content"
+
+
+def test_ordinary_files_are_still_walked(tmp_path: Path) -> None:
+    """CONTROL ARM: without it, a scanner that yielded NOTHING would pass both tests above."""
+    repo, _ = _fixture(tmp_path)
+    (repo / "second.py").write_text("y = 2\n", encoding="utf-8")
+    names = _walk(repo)
+    assert "normal.py" in names
+    assert "second.py" in names
+
+
+def test_a_symlink_whose_target_is_inside_the_root_is_also_skipped(tmp_path: Path) -> None:
+    """Skipped, not resolved-and-bounded — and deliberately so.
+
+    A link pointing INSIDE the root loses no content by being skipped: the real file is walked by
+    its own path. Resolving-then-comparing would have to get root containment exactly right on
+    every platform (case-insensitive FS, UNC paths, junctions) to avoid reintroducing the escape,
+    for zero gain. This test pins the simpler contract so a later "improvement" to resolve-and-
+    allow has to argue with it.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    real = repo / "real.py"
+    real.write_text("z = 3\n", encoding="utf-8")
+    inner = repo / "alias.py"
+    try:
+        inner.symlink_to(real)
+    except OSError as exc:  # pragma: no cover
+        pytest.skip(f"cannot create a symlink on this host: {exc}")
+    assert inner.is_symlink()
+
+    names = _walk(repo)
+    assert "real.py" in names, "the real file must still be walked"
+    assert "alias.py" not in names, "an in-root symlink is skipped; its target is walked directly"


### PR DESCRIPTION
`DirectoryScanner` — the single Python file-enumeration primitive behind `tg search`'s CPU path, `tg agent`, `tg orient`, every AST workflow (`defs`/`refs`/`callers`/`blast-radius`/`scan`), and the MCP server's directory scan — **yielded symlinked files**, and every consumer `open()`s what it yields.

## Proven, not inferred

```
repo/leak.txt -> ../outside/secret.txt      (contains SECRET_MARKER_998877)

DirectoryScanner.walk(repo)  ->  ['leak.txt', 'normal.py']
open('.../leak.txt').read()  ->  'SECRET_MARKER_998877'
```

`os.walk(followlinks=False)` — which this scanner relies on — stops the walk **descending into** a symlinked *directory*. It does not stop a symlink-to-a-*file* appearing in `files`, and `open()` follows the link regardless of the walk's setting.

## Why it matters more than the site the original fix landed on

A git-tracked symlink is an ordinary mode-120000 blob — nothing exotic. One pointing at `~/.ssh/id_rsa`, a sibling project's `.env`, or `/etc/passwd` disclosed that file into search output, the on-disk symbol cache, and — because this is the walker behind `tg agent` and the MCP tools — **an LLM agent's context window**.

`checkpoint_store.py` already carried this guard, and `AGENTS.md` names symlink-follow as a repo-wide **sweep target**, not a one-file patch. This is the walker the sweep missed. Checkpoint create/restore is occasional; this is the default read path for ordinary search.

## Skipped, not resolved-and-bounded

A link whose target sits *inside* the root loses nothing by being skipped — the real file is walked by its own path. Resolving-then-comparing would have to get root containment exactly right on every platform (case-insensitive FS, UNC paths, junctions) to avoid reintroducing the escape, for zero gain. A test pins that contract so a later "improvement" has to argue with it.

## Verification

| arm | result |
|---|---|
| treatment | **4 passed** |
| control (guard removed) | **3 failed, 1 passed** |

The 1 still passing is the "ordinary files are still walked" control — without it, a scanner that yielded **nothing** would satisfy every other assertion. The fixture asserts its own premises (the link really is a symlink, and it really points out of the root) and skips rather than silently passing on hosts that can't create symlinks.

**580 passed** across the scanner, CLI-modes and CLI-contracts suites; `ruff check` + `ruff format --preview --check` clean.

Found by a six-lens adversarially-verified audit; the verifier independently re-derived the reachability chain and caught a path typo in the original report (`cpu_backend.py` is under `backends/`, not `core/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
