### PR TITLE
ci: the PyPI artifact smoke test must report why it failed, not just that it did

### DIFF
--- a/scripts/smoke_test_pypi_artifacts.py
+++ b/scripts/smoke_test_pypi_artifacts.py
@@ -31,6 +31,47 @@ def _project_dependencies() -> list[str]:
     return list(metadata["project"].get("dependencies", []))
 
 
+_SOURCE = "def add(x, y): return x + y\n"
+_REWRITTEN = "lambda x, y: x + y"
+_PATTERN = "def $F($$$ARGS): return $EXPR"
+_REPLACEMENT = "lambda $$$ARGS: $EXPR"
+
+
+def _run_checked(command: list[str], *, what: str) -> subprocess.CompletedProcess[str]:
+    """Run a command; on failure print the output that explains the failure.
+
+    `subprocess.run(..., capture_output=True, check=True)` raises a `CalledProcessError` whose
+    string form carries the argv and the exit status and nothing else. The captured streams hang
+    off the exception and are never printed, so a failure here reports THAT the artifact is bad
+    while withholding WHY.
+
+    Receipt: `validate-pypi-artifacts` failed on the v1.101.10 release run (30363114542). The log
+    contains exactly `... 'run', '--lang', 'python', '--rewrite', ... returned non-zero exit
+    status 1` -- `tg`'s own stderr, the one thing that would have named the cause, was captured and
+    discarded. The failure was neither diagnosable from the log nor reproducible off it, and it
+    blocked the PyPI publish for that version.
+
+    A smoke test exists to explain a bad artifact. Swallowing the artifact's error message is the
+    one thing it must not do.
+    """
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"SMOKE FAILURE: {what}", file=sys.stderr)
+        print(f"  command:     {command}", file=sys.stderr)
+        print(f"  exit status: {result.returncode}", file=sys.stderr)
+        print(f"  --- stdout ---\n{result.stdout or '(empty)'}", file=sys.stderr)
+        print(f"  --- stderr ---\n{result.stderr or '(empty)'}", file=sys.stderr)
+        raise SystemExit(1)
+    return result
+
+
+def _fail(what: str, *, detail: str) -> None:
+    """A wrong-output failure, reported with the output rather than as a bare AssertionError."""
+    print(f"SMOKE FAILURE: {what}", file=sys.stderr)
+    print(detail, file=sys.stderr)
+    raise SystemExit(1)
+
+
 def run_smoke_test(*, dist_dir: Path, version: str, work_dir: Path) -> None:
     resolved_dist = dist_dir.resolve()
     venv_dir = work_dir / ".pypi-smoke-venv"
@@ -42,17 +83,11 @@ def run_smoke_test(*, dist_dir: Path, version: str, work_dir: Path) -> None:
     python_exe = _venv_python(venv_dir)
     dependencies = _project_dependencies()
     if dependencies:
-        subprocess.run(
-            [
-                str(python_exe),
-                "-m",
-                "pip",
-                "install",
-                *dependencies,
-            ],
-            check=True,
+        _run_checked(
+            [str(python_exe), "-m", "pip", "install", *dependencies],
+            what="install project dependencies into the smoke venv",
         )
-    subprocess.run(
+    _run_checked(
         [
             str(python_exe),
             "-m",
@@ -64,9 +99,9 @@ def run_smoke_test(*, dist_dir: Path, version: str, work_dir: Path) -> None:
             "--no-deps",
             f"tensor-grep=={version}",
         ],
-        check=True,
+        what=f"install the built tensor-grep=={version} artifact",
     )
-    subprocess.run(
+    _run_checked(
         [
             str(python_exe),
             "-c",
@@ -76,57 +111,61 @@ def run_smoke_test(*, dist_dir: Path, version: str, work_dir: Path) -> None:
                 "import tensor_grep"
             ),
         ],
-        check=True,
+        what=f"import tensor_grep and confirm it reports version {version}",
     )
-    subprocess.run(
-        [
-            str(_venv_tg(venv_dir)),
-            "--version",
-        ],
-        check=True,
-    )
+    tg_exe = str(_venv_tg(venv_dir))
+    _run_checked([tg_exe, "--version"], what="tg --version")
+
     rewrite_smoke_dir = work_dir / "rewrite-smoke"
     rewrite_smoke_dir.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            str(python_exe),
-            "-c",
-            (
-                "import subprocess, sys; "
-                "from pathlib import Path; "
-                "source = Path(sys.argv[2]); "
-                "source.write_text('def add(x, y): return x + y\\n', encoding='utf-8'); "
-                "result = subprocess.run([sys.argv[1], 'run', '--lang', 'python', "
-                "'--rewrite', 'lambda $$$ARGS: $EXPR', "
-                "'def $F($$$ARGS): return $EXPR', str(source)], "
-                "capture_output=True, text=True, check=True); "
-                "assert 'lambda x, y: x + y' in result.stdout"
-            ),
-            str(_venv_tg(venv_dir)),
-            str(rewrite_smoke_dir / "plan.py"),
-        ],
-        check=True,
+
+    # Run the probes from this process rather than through a nested `python -c`. The nesting bought
+    # nothing -- the inner interpreter only wrote a file and shelled out to `tg` -- while putting a
+    # second CalledProcessError between the real failure and the log.
+    plan_source = rewrite_smoke_dir / "plan.py"
+    plan_source.write_text(_SOURCE, encoding="utf-8")
+    plan = _run_checked(
+        [tg_exe, "run", "--lang", "python", "--rewrite", _REPLACEMENT, _PATTERN, str(plan_source)],
+        what="tg run --rewrite (plan mode)",
     )
-    subprocess.run(
-        [
-            str(python_exe),
-            "-c",
-            (
-                "import subprocess, sys; "
-                "from pathlib import Path; "
-                "source = Path(sys.argv[2]); "
-                "source.write_text('def add(x, y): return x + y\\n', encoding='utf-8'); "
-                "subprocess.run([sys.argv[1], 'run', '--lang', 'python', "
-                "'--rewrite', 'lambda $$$ARGS: $EXPR', '--apply', "
-                "'def $F($$$ARGS): return $EXPR', str(source)], "
-                "capture_output=True, text=True, check=True); "
-                "assert source.read_text(encoding='utf-8') == 'lambda x, y: x + y\\n'"
+    if _REWRITTEN not in plan.stdout:
+        _fail(
+            "tg run --rewrite planned no usable edit",
+            detail=(
+                f"  expected {_REWRITTEN!r} in stdout\n"
+                f"  --- stdout ---\n{plan.stdout or '(empty)'}\n"
+                f"  --- stderr ---\n{plan.stderr or '(empty)'}"
             ),
-            str(_venv_tg(venv_dir)),
-            str(rewrite_smoke_dir / "apply.py"),
+        )
+
+    apply_source = rewrite_smoke_dir / "apply.py"
+    apply_source.write_text(_SOURCE, encoding="utf-8")
+    applied = _run_checked(
+        [
+            tg_exe,
+            "run",
+            "--lang",
+            "python",
+            "--rewrite",
+            _REPLACEMENT,
+            "--apply",
+            _PATTERN,
+            str(apply_source),
         ],
-        check=True,
+        what="tg run --rewrite --apply",
     )
+    final = apply_source.read_text(encoding="utf-8")
+    expected = f"{_REWRITTEN}\n"
+    if final != expected:
+        _fail(
+            "tg run --rewrite --apply did not rewrite the file on disk",
+            detail=(
+                f"  expected: {expected!r}\n"
+                f"  actual:   {final!r}\n"
+                f"  --- stdout ---\n{applied.stdout or '(empty)'}\n"
+                f"  --- stderr ---\n{applied.stderr or '(empty)'}"
+            ),
+        )
 
 
 def main() -> int:

--- a/tests/unit/test_smoke_script_surfaces_failure_output.py
+++ b/tests/unit/test_smoke_script_surfaces_failure_output.py
@@ -1,0 +1,166 @@
+"""The PyPI artifact smoke test must print WHY the artifact failed, not just THAT it did.
+
+`subprocess.run(..., capture_output=True, check=True)` raises a `CalledProcessError` whose string
+form carries the argv and the exit status and nothing else. The captured streams hang off the
+exception object and are never printed. A smoke test built that way reports that the artifact is
+broken while withholding the artifact's own error message -- the single thing the test exists to
+obtain.
+
+Receipt: `validate-pypi-artifacts` failed on the v1.101.10 release run (30363114542). The entire
+diagnostic content of that log is::
+
+    subprocess.CalledProcessError: Command '[... 'run', '--lang', 'python', '--rewrite', ...]'
+    returned non-zero exit status 1.
+
+`tg`'s stderr was captured and discarded, so the failure was neither diagnosable from the log nor
+reproducible off it, and `publish-pypi` (which `needs:` this job) skipped -- v1.101.10 was tagged
+but never published. Three separate hypotheses were built and falsified against that log before
+anyone noticed the cause had simply been thrown away.
+
+These tests pin the helpers rather than the probe bodies: the probes change whenever a smoke step is
+added, but "a failure explains itself" is the invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_script_module() -> ModuleType:
+    root = Path(__file__).resolve().parents[2]
+    module_path = root / "scripts" / "smoke_test_pypi_artifacts.py"
+    spec = importlib.util.spec_from_file_location("smoke_test_pypi_artifacts_script", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_failing_command_prints_both_streams(capsys: pytest.CaptureFixture[str]) -> None:
+    """THE DEFECT: the streams were captured and dropped.
+
+    Both markers must appear. stdout matters as much as stderr here -- `tg` reports a refusal or an
+    incompleteness envelope on stdout, so a stderr-only report would still hide the common case.
+    """
+    module = _load_script_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        module._run_checked(
+            [
+                sys.executable,
+                "-c",
+                "import sys; print('OUT-MARKER'); print('ERR-MARKER', file=sys.stderr); "
+                "sys.exit(3)",
+            ],
+            what="a command that fails",
+        )
+
+    assert excinfo.value.code == 1, "a failed smoke step must exit non-zero"
+    captured = capsys.readouterr().err
+    assert "OUT-MARKER" in captured, "the failing command's stdout was discarded"
+    assert "ERR-MARKER" in captured, "the failing command's stderr was discarded"
+    assert "a command that fails" in captured, "the report does not say which step failed"
+    assert "3" in captured, "the report does not carry the exit status"
+
+
+def test_a_successful_command_is_silent_and_returns_its_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CONTROL ARM: without it, a helper that printed unconditionally -- or that treated every
+    command as a failure -- would satisfy the test above while making the smoke log useless.
+
+    Also pins that the completed process is returned: the plan probe asserts against `.stdout`, so
+    a helper that returned `None` on success would break the caller.
+    """
+    module = _load_script_module()
+
+    result = module._run_checked(
+        [sys.executable, "-c", "print('QUIET-MARKER')"],
+        what="a command that succeeds",
+    )
+
+    assert result.returncode == 0
+    assert "QUIET-MARKER" in result.stdout, "the completed process must carry stdout for callers"
+    assert capsys.readouterr().err == "", "a passing step must not write to the failure channel"
+
+
+def test_a_wrong_output_failure_reports_the_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """The second blindness: a bare `assert X in result.stdout` fails with no context either.
+
+    `_fail` is what the plan/apply probes use when the command SUCCEEDS but produced the wrong
+    thing -- the case a `CalledProcessError` cannot represent at all.
+    """
+    module = _load_script_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        module._fail("tg produced the wrong thing", detail="  actual: 'NOTHING-USEFUL'")
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr().err
+    assert "tg produced the wrong thing" in captured
+    assert "NOTHING-USEFUL" in captured, "the wrong output itself must reach the log"
+
+
+def test_no_probe_drives_tg_through_a_nested_interpreter() -> None:
+    """The class fix, pinned: no smoke step may run `tg` from inside a `python -c` payload.
+
+    This is the shape the v1.101.10 failure actually had, and getting here took a wrong turn worth
+    recording. The first version of this test asserted that no `subprocess.run` pairs
+    `capture_output=True` with `check=True` -- true of the fixed file, and it reported PASS. Run
+    against the pre-fix file it also reported pass: **zero** violations. The old script's offending
+    call was a string handed to `python -c`, so no call node in the file ever carried those
+    keywords. The ratchet was guarding a shape this file has never contained.
+
+    A ratchet that cannot fail on the code that caused the incident is decoration. The property
+    that actually matters is the nesting: an inner interpreter turns the child's real error into a
+    `CalledProcessError` inside the child, which the outer `check=True` re-wraps into a second
+    `CalledProcessError` naming only `python -c`. Two layers of wrapping, and the artifact's own
+    message is discarded at the first.
+
+    Verified to bite: run against `HEAD~` it flags 2 payloads.
+    """
+    root = Path(__file__).resolve().parents[2]
+    source = (root / "scripts" / "smoke_test_pypi_artifacts.py").read_text(encoding="utf-8")
+
+    tree = ast.parse(source)
+
+    # Docstrings are string constants too, and the script's docstrings QUOTE the forbidden pattern
+    # in order to explain it. Excluded structurally -- by identity of each scope's leading
+    # expression -- rather than by pattern-matching the prose, which would leave a checker that any
+    # future wording can silently re-break.
+    docstrings = set()
+    for scope in ast.walk(tree):
+        if not isinstance(
+            scope, ast.Module | ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+        ):
+            continue
+        body = getattr(scope, "body", [])
+        if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+            docstrings.add(id(body[0].value))
+
+    payloads = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+    ]
+
+    # PREMISE: the matcher really does see this file's string constants. Without it, an AST change
+    # that stopped yielding any payload would make the loop below vacuously true.
+    assert payloads, "found no string constants to check; the matcher has stopped working"
+
+    for payload in payloads:
+        assert "subprocess" not in payload, (
+            "a smoke step drives a subprocess from inside a nested interpreter payload. The "
+            "child's error becomes a CalledProcessError inside the child, and the outer call "
+            "re-wraps it -- the real message is lost. Run the command from this process via "
+            f"_run_checked() instead. Offending payload: {payload[:90]!r}"
+        )

--- a/tests/unit/test_smoke_test_pypi_artifacts.py
+++ b/tests/unit/test_smoke_test_pypi_artifacts.py
@@ -4,6 +4,8 @@ import importlib.util
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 def _load_module():
     root = Path(__file__).resolve().parents[2]
@@ -16,12 +18,26 @@ def _load_module():
 
 
 def test_should_run_smoke_install_from_local_dist(tmp_path: Path, monkeypatch):
+    """The probes now invoke `tg` directly instead of through a nested `python -c` payload.
+
+    The fake correspondingly has to ACT like tg -- emit the rewritten source on stdout, and write
+    the file under `--apply`. That is not incidental test upkeep: under the old shape the probe's
+    real work happened inside an opaque string this fake never executed, so the assertions could
+    only inspect argv. Moving the logic into the parent process is what makes the outcome
+    observable here at all.
+    """
     module = _load_module()
     calls: list[list[str]] = []
 
-    def _fake_run(cmd, check, **kwargs):
-        calls.append([str(item) for item in cmd])
-        return subprocess.CompletedProcess(cmd, 0)
+    def _fake_run(cmd, **kwargs):
+        argv = [str(item) for item in cmd]
+        calls.append(argv)
+        stdout = ""
+        if "run" in argv and "--rewrite" in argv:
+            stdout = '{"replacement_text": "lambda x, y: x + y"}'
+            if "--apply" in argv:
+                Path(argv[-1]).write_text("lambda x, y: x + y\n", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr(subprocess, "run", _fake_run)
 
@@ -33,6 +49,7 @@ def test_should_run_smoke_install_from_local_dist(tmp_path: Path, monkeypatch):
 
     assert len(calls) == 7
     expected_python = module._venv_python(tmp_path / "work" / ".pypi-smoke-venv")
+    expected_tg = str(module._venv_tg(tmp_path / "work" / ".pypi-smoke-venv"))
     assert calls[0][:3] == [module.sys.executable, "-m", "venv"]
     assert calls[1][:4] == [str(expected_python), "-m", "pip", "install"]
     assert any(dep.startswith("typer") for dep in calls[1])
@@ -48,12 +65,36 @@ def test_should_run_smoke_install_from_local_dist(tmp_path: Path, monkeypatch):
     ]
     assert calls[2][-1] == "tensor-grep==0.11.1"
     assert calls[3][1] == "-c"
-    assert calls[4][-1] == "--version"
-    assert calls[5][1] == "-c"
-    assert calls[6][1] == "-c"
-    assert "'run'" in calls[5][2]
-    assert "'run'" in calls[6][2]
-    assert "'--apply'" in calls[6][2]
+    assert calls[4] == [expected_tg, "--version"]
+
+    # The two rewrite probes: real argv on the real binary, no interpreter in between.
+    assert calls[5][:2] == [expected_tg, "run"]
+    assert "--rewrite" in calls[5] and "--apply" not in calls[5]
+    assert calls[6][:2] == [expected_tg, "run"]
+    assert "--apply" in calls[6]
+    for probe in (calls[5], calls[6]):
+        assert "-c" not in probe, "a probe is still routing through a nested interpreter"
+
+
+def test_should_fail_loudly_when_the_rewrite_plans_nothing(tmp_path: Path, monkeypatch, capsys):
+    """A tg that exits 0 with useless output must fail the smoke AND say what it printed.
+
+    This is the half a `CalledProcessError` can never express, and the half the v1.101.10 log
+    needed: the command "succeeded", so the only signal was an AssertionError with no payload.
+    """
+    module = _load_module()
+
+    def _fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="NOTHING-USEFUL", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.run_smoke_test(dist_dir=tmp_path, version="0.11.1", work_dir=tmp_path / "work")
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "NOTHING-USEFUL" in err, "the smoke failed without reporting what tg actually printed"
 
 
 def test_should_resolve_linux_tg_shim_path(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## The incident

`validate-pypi-artifacts` failed on the **v1.101.10** release run ([30363114542](https://github.com/oimiragieo/tensor-grep/actions/runs/30363114542)). `publish-pypi` `needs:` it, so it skipped — **v1.101.10 is tagged but was never published**; PyPI is still on 1.101.9.

The entire diagnostic content of that log is:

```
subprocess.CalledProcessError: Command '[... 'run', '--lang', 'python', '--rewrite', ...]'
returned non-zero exit status 1.
```

`tg` exited 1 and its stderr was captured into a `CalledProcessError` and dropped. Three hypotheses — dependency drift, the `mcp` 1.28.1 → 2.0.0 major bump visible in the dep diff, and #843's own diff — were each built and falsified against that log before it became clear **the cause had simply been thrown away**.

## Root cause of the blindness

The probes drove `tg` from inside a nested `python -c` payload:

```python
subprocess.run([python_exe, "-c", "... subprocess.run([tg, 'run', ...], capture_output=True, check=True) ..."], check=True)
```

The child's real error becomes a `CalledProcessError` **inside the child**; the outer `check=True` re-wraps that into a second one naming only `python -c`. Two layers of wrapping, and the artifact's own message is discarded at the first.

## The change

- **Run the probes from this process.** The nesting bought nothing — the inner interpreter only wrote a file and shelled out to `tg`.
- **`_run_checked()`** prints argv, exit status, stdout *and* stderr on failure. stdout matters as much as stderr: `tg` reports refusals and incompleteness envelopes there.
- **`_fail()`** covers the half a `CalledProcessError` cannot express — the command *succeeds* but prints the wrong thing, which previously surfaced as a bare `AssertionError` with no payload.

## Verification (both arms)

| Arm | Result |
|---|---|
| Full smoke, real published wheel `tensor-grep==1.101.9` | **passes** end-to-end, exit 0 |
| Forced command failure | prints `OUT-MARKER` + `ERR-MARKER`, exits 1 |
| Nesting ratchet vs. `HEAD~` | **flags 2 payloads** |
| Nesting ratchet vs. this branch | clean |

## A note on the ratchet, because it was wrong first

The first version asserted no `subprocess.run` pairs `capture_output=True` with `check=True`. True of the fixed file — and it reported **PASS against the pre-fix file too: zero violations**, because the offending call lived inside a *string*, so no call node in that file ever carried those keywords. It was guarding a shape this file has never contained. A ratchet that cannot fail on the code that caused the incident is decoration. Re-aimed at the nesting and re-verified to bite.

It also tripped on the docstrings that *quote* the forbidden pattern in order to explain it; docstrings are now excluded structurally (by identity of each scope's leading expression), not by pattern-matching prose.

## Scope

This does **not** diagnose the underlying v1.101.10 rewrite failure. That is Linux-wheel specific and does not reproduce on Windows against either 1.101.9 or current `main` (both emit `lambda x, y: x + y`, exit 0, `routing_backend: AstBackend`). This PR makes the next occurrence self-explaining instead of requiring hypothesis archaeology.

Non-releasing (`ci:`), deliberately — the publish chain is already compromised and this adds no product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
