### PR TITLE
fix(ledger): findings were filed per-directory, so a subtree lookup silently missed them

### DIFF
--- a/src/tensor_grep/cli/ledger_store.py
+++ b/src/tensor_grep/cli/ledger_store.py
@@ -43,9 +43,24 @@ fix does not add rollup matching to release -- a release call could otherwise si
 unrelated sibling agent's claim just because it happens to share a symbol name and live under an
 ancestor scope), but when nothing matches, it now names what IS live elsewhere
 (``unmatched_reason``/``live_claims_elsewhere``) instead of a bare, indistinguishable
-``released_count: 0``. Slice 2 (``record_finding``/``find_findings`` below) deliberately keeps
-plain ``session_store._resolve_root`` -- untouched by this fix, per the same footgun it has not
-(yet) been reported for.
+``released_count: 0``.
+
+Slice 2 (``record_finding``/``find_findings`` below) originally kept plain
+``session_store._resolve_root``, deliberately, "per the same footgun it has not (yet) been
+reported for". **It has now been reported** -- twice, in the live external dogfoods of v1.101.7
+and v1.101.9 ("Slice 2 ledger still more path-literal than Slice 1"), so the condition that
+justified leaving it alone has expired and both entry points now use
+:func:`_ledger_physical_root` on the same terms as Slice 1. The symptom was the identical one
+Slice 1 was fixed for: ``record`` from the repo root and ``find`` from a subtree resolved to
+different physical indices, so the lookup returned nothing and the sibling agent recomputed an
+artifact that was already on disk -- silently, since "no finding" and "finding filed elsewhere"
+were indistinguishable. The non-git fallback is unchanged (literal path, not regressed).
+
+Findings recorded by a pre-fix binary under a subtree's own ``.tensor-grep/`` are not migrated.
+That is deliberate and safe: the findings ledger is advisory, TTL-bounded coordination state
+whose worst case on a miss is recomputation, and Slice 1 accepted the identical one-time
+invisibility when it moved. Do NOT add a migration/merge step -- reading a second index would
+reintroduce the two-root ambiguity this removes.
 
 Backend Fail-Closed Contract (AGENTS.md): a lock-acquire timeout
 (:class:`tensor_grep.cli._index_lock.IndexLockTimeoutError`), a symlink at the index
@@ -1143,7 +1158,7 @@ def record_finding(
             f"--artifact-kind must be one of {sorted(_VALID_ARTIFACT_KINDS)}, got {artifact_kind!r}"
         )
 
-    root = _resolve_root(Path(path))
+    root = _ledger_physical_root(path)
     artifact_file = Path(receipt_path).expanduser().resolve()
     artifact = _read_artifact_file(artifact_file)
 
@@ -1280,7 +1295,7 @@ def find_findings(
         raise LedgerUsageError("tg ledger find requires --symbol")
     resolved_symbol = symbol.strip()
 
-    root = _resolve_root(Path(path))
+    root = _ledger_physical_root(path)
     now = datetime.now(UTC)
     # Display-only prune, exactly like list_claims: expired findings are excluded from the
     # result but the index is never rewritten by a pure read (physical cleanup happens lazily

--- a/tests/unit/test_findings_ledger_is_repo_scoped.py
+++ b/tests/unit/test_findings_ledger_is_repo_scoped.py
@@ -1,0 +1,132 @@
+"""Slice 2 of the ledger must resolve to the same physical index from any subtree of a repo.
+
+Slice 1 (claims) was fixed for the "PATH-scope footgun" in v1.92.1: `claim core/hooks` and
+`list .` each resolved to a DIFFERENT physical directory, so a claim filed from one subtree was
+invisible from another within the SAME repository, with no error and no signal.
+
+Slice 2 (`record_finding` / `find_findings`) was left on the literal
+`session_store._resolve_root`, and the module docstring said so explicitly -- "per the same
+footgun it has not (yet) been reported for". It has now been reported, twice, in the live external
+dogfoods of v1.101.7 and v1.101.9 ("Slice 2 ledger still more path-literal than Slice 1").
+
+The consequence is worse here than for claims. A findings miss is SILENT and self-justifying: the
+caller asked "has anyone computed this?", got "no", and recomputed -- which is exactly what it
+would do if the answer were legitimately no. "Nothing recorded" and "recorded under a different
+root" are indistinguishable at the call site, so the coordination pillar degrades to zero reuse
+without ever reporting a fault.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tensor_grep.cli.ledger_store import find_findings, record_finding
+
+
+def _repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A git repo with a nested subtree. Returns (repo_root, subtree)."""
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    sub = root / "core" / "hooks"
+    sub.mkdir(parents=True)
+    (root / "a.py").write_text("def target():\n    pass\n", encoding="utf-8")
+
+    # PREMISE: the two paths really are distinct directories, so a literal-root implementation
+    # genuinely would resolve them differently. Without this the test could pass on a fluke of
+    # tmp_path layout.
+    assert root.resolve() != sub.resolve()
+    return root, sub
+
+
+def _receipt(tmp_path: Path, name: str = "receipt.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps({"summary": "precomputed", "items": [1, 2, 3]}), encoding="utf-8")
+    return path
+
+
+def _record(where: Path, receipt: Path, symbol: str = "target") -> dict:
+    return record_finding(
+        str(where),
+        symbol=symbol,
+        artifact_kind="blast-radius",
+        receipt_path=str(receipt),
+    )
+
+
+def test_a_finding_recorded_at_the_root_is_found_from_a_subtree(tmp_path: Path) -> None:
+    """THE DEFECT: the subtree lookup resolved to its own index and returned nothing."""
+    root, sub = _repo(tmp_path)
+    _record(root, _receipt(tmp_path))
+
+    result = find_findings(str(sub), symbol="target")
+
+    assert result["count"] == 1, (
+        "a finding recorded at the repo root is invisible from a subtree of the same repo -- "
+        "the sibling agent recomputes an artifact that is already on disk"
+    )
+
+
+def test_a_finding_recorded_in_a_subtree_is_found_from_the_root(tmp_path: Path) -> None:
+    """The other direction. Both must unify, or the fix is half a fix."""
+    root, sub = _repo(tmp_path)
+    _record(sub, _receipt(tmp_path))
+
+    result = find_findings(str(root), symbol="target")
+
+    assert result["count"] == 1, "a finding recorded in a subtree is invisible from the repo root"
+
+
+def test_two_different_repos_still_do_not_share_findings(tmp_path: Path) -> None:
+    """CONTROL ARM: without it, "resolve everything to one global index" would satisfy both tests
+    above while destroying isolation between unrelated repositories.
+
+    This is the assertion that makes the two above mean something -- it pins that the unification
+    is bounded by the `.git` boundary rather than being unconditional.
+    """
+    root_a, _ = _repo(tmp_path / "one")
+    root_b, _ = _repo(tmp_path / "two")
+    _record(root_a, _receipt(tmp_path))
+
+    assert find_findings(str(root_a), symbol="target")["count"] == 1, "premise: A really recorded"
+    assert find_findings(str(root_b), symbol="target")["count"] == 0, (
+        "a finding from an unrelated repository leaked across the .git boundary"
+    )
+
+
+def test_a_non_git_directory_keeps_literal_path_behaviour(tmp_path: Path) -> None:
+    """The documented fallback: with no `.git` ancestor there is no repo boundary to canonicalize
+    to, so resolution stays literal. Pinned so a later "always walk up" change has to argue with
+    it -- walking past a non-git directory would start merging unrelated working directories.
+    """
+    plain = tmp_path / "plain"
+    nested = plain / "nested"
+    nested.mkdir(parents=True)
+
+    _record(plain, _receipt(tmp_path))
+
+    assert find_findings(str(plain), symbol="target")["count"] == 1, "premise: it recorded"
+    assert find_findings(str(nested), symbol="target")["count"] == 0, (
+        "a non-git directory must keep literal-path behaviour; unifying here would merge "
+        "unrelated working directories that happen to share a parent"
+    )
+
+
+@pytest.mark.parametrize("start", ["root", "sub"])
+def test_the_index_lives_at_the_repo_root_regardless_of_where_record_ran(
+    tmp_path: Path, start: str
+) -> None:
+    """Storage location, not just lookup: exactly one physical index, at the repo root.
+
+    Asserting only on `find` would pass for an implementation that wrote two indices and then
+    read both -- which reintroduces the two-root ambiguity instead of removing it.
+    """
+    root, sub = _repo(tmp_path)
+    _record(root if start == "root" else sub, _receipt(tmp_path))
+
+    indices = sorted(p.relative_to(root).as_posix() for p in root.rglob(".tensor-grep"))
+    assert indices == [".tensor-grep"], (
+        f"expected exactly one ledger directory, at the repo root; found {indices}"
+    )


### PR DESCRIPTION
Closes the second half of the PATH-scope footgun. Backlog task #14; reported in the live external dogfoods of **v1.101.7 and v1.101.9**.

## The defect

Slice 1 (claims) was fixed in v1.92.1 — `claim core/hooks` and `list .` resolved to different physical directories, so a claim filed from one subtree was invisible from another in the same repo. Slice 2 (`record_finding`/`find_findings`) was deliberately left on the literal `session_store._resolve_root`, and `ledger_store.py` said why:

> Slice 2 … deliberately keeps plain `session_store._resolve_root` — untouched by this fix, **per the same footgun it has not (yet) been reported for.**

It has now been reported, twice. The stated precondition for leaving it alone has expired, so both entry points move to `_ledger_physical_root` on Slice 1's terms.

## Why this one is worse than the claims case

A findings miss is **silent and self-justifying**. The caller asks "has anyone computed this?", gets "no", and recomputes — which is exactly what it would do if the answer were legitimately no. *Nothing recorded* and *recorded under a different root* are indistinguishable at the call site, so the reuse pillar degrades to zero without ever reporting a fault.

## Measured, with a control arm

| arm | record at root, find from `core/hooks` |
|---|---|
| pre-fix | `count == 0` — `assert 0 == 1` |
| post-fix | `count == 1` |

Verified by reverting the source hunk and re-running the tests, per the guard rule in #849.

## Bounded, not unconditional

Three pins so the unification cannot quietly become "one global index":

- two unrelated repos still do **not** share findings (`.git` boundary holds)
- a non-git directory keeps literal-path behaviour
- exactly **one** `.tensor-grep` directory exists after recording from either location — asserting only on `find` would pass for an implementation that wrote two indices and read both, reintroducing the ambiguity instead of removing it

## Migration

Pre-fix findings under a subtree's own `.tensor-grep` are **not** migrated. Deliberate and safe: the ledger is advisory, TTL-bounded state whose worst case on a miss is recomputation, and Slice 1 accepted the identical one-time invisibility. The docstring now records that a migration/merge step must **not** be added — reading a second index would reintroduce the two-root ambiguity this removes.

178 ledger/findings tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)