### PR TITLE
fix(ast): --apply wrote through symlinks, overwriting files outside the repo

### DIFF
--- a/rust_core/src/backend_ast.rs
+++ b/rust_core/src/backend_ast.rs
@@ -1579,7 +1579,13 @@ fn direct_write_file(file: &Path, contents: &[u8]) -> Result<()> {
     // On NTFS, in-place overwrites are journaled at the filesystem level, so after a crash readers
     // observe either the previous committed bytes or the completed overwrite rather than a half-
     // renamed temp file sequence. That trade-off matches sg's std::fs::write() behavior.
-    std::fs::write(file, contents)
+    //
+    // That trade-off is about ATOMICITY (no temp-file + rename), and it is deliberate. It is NOT
+    // a decision to follow symlinks: a bare `std::fs::write` here wrote THROUGH a git-tracked
+    // symlink to its target, so `--apply` could overwrite a file outside the repo. Matching sg's
+    // atomicity choice does not require inheriting that. The guard costs one open() flag and
+    // leaves the direct-overwrite fast path intact.
+    crate::safe_write::write_bytes_refuse_symlink(file, contents)
         .with_context(|| format!("failed to overwrite {}", file.display()))
 }
 

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::useless_conversion)]
 
 pub mod backend_ast;
-pub mod safe_write;
 pub mod backend_ast_workflow;
 pub mod backend_cpu;
 pub mod cli;
@@ -17,6 +16,7 @@ pub mod python_sidecar;
 pub mod rg_passthrough;
 pub mod routing;
 pub mod runtime_paths;
+pub mod safe_write;
 
 use crate::backend_ast::AstBackend;
 use crate::backend_cpu::CpuBackend;

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::useless_conversion)]
 
 pub mod backend_ast;
+pub mod safe_write;
 pub mod backend_ast_workflow;
 pub mod backend_cpu;
 pub mod cli;

--- a/rust_core/src/main.rs
+++ b/rust_core/src/main.rs
@@ -10916,81 +10916,13 @@ fn emit_rollback_status(summary: &ValidationRollbackSummary) {
     }
 }
 
-/// Writes `bytes` to `path`, refusing to follow a symlink/reparse point at the final path
-/// component (audit #110 Gap 1). Closes a cross-process TOCTOU: the Python front door
-/// resolves and confines the `--audit-manifest` target before invoking this native binary,
-/// but a symlink swapped into that path between the Python check and this write was
-/// previously followed by a plain `std::fs::write` -- a confined write could escape its
-/// anchor. Mirrors the confine-then-open discipline `_write_json_refuse_symlink` already
-/// uses on the Python side (`src/tensor_grep/cli/main.py`).
-///
-/// audit #115: also guards `create_checkpoint`'s metadata.json + the shared/predictable
-/// index.json write, and `restore_validation_rollback_snapshots`'s per-file restore write --
-/// the same TOCTOU class, just with the checkpoint/rollback root standing in for
-/// `--audit-manifest`'s confined target.
+/// Delegates to the single implementation in the lib crate
+/// (`tensor_grep_rs::safe_write`). It lived HERE, in the binary crate, which is why
+/// `backend_ast::direct_write_file` (lib crate) could not reach it and used a bare
+/// `std::fs::write` -- the `--apply`-writes-through-a-symlink hole. Kept as a thin alias so the
+/// existing audit-manifest / checkpoint / rollback call sites read unchanged.
 fn write_bytes_refuse_symlink(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    use std::fs::OpenOptions;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        // O_NOFOLLOW makes the open() itself fail (ELOOP) if the final path component is
-        // a symlink -- atomic, no separate check->open window.
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .custom_flags(libc::O_NOFOLLOW)
-            .open(path)
-            .with_context(|| format!("refusing to write through symlink at {}", path.display()))?;
-        file.write_all(bytes)?;
-        Ok(())
-    }
-
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
-        // Not in a dependency here (neither `windows` nor `winapi` is in Cargo.toml) -- these
-        // are the real documented values (winnt.h / fileapi.h), kept as local consts rather
-        // than pulling in a crate for two flag bits.
-        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-
-        // FILE_FLAG_OPEN_REPARSE_POINT makes CreateFile open the reparse point entry
-        // itself instead of traversing it -- so if `path` is a symlink, we open the link,
-        // not its target. Deliberately no truncate-at-open: on a real reparse point that
-        // would touch the reparse buffer before we get to check it below.
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-            .open(path)
-            .with_context(|| format!("failed to open {}", path.display()))?;
-        let attributes = file.metadata()?.file_attributes();
-        if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-            anyhow::bail!(
-                "refusing to write through symlink/reparse point at {}",
-                path.display()
-            );
-        }
-        // Confirmed a regular file (or a freshly created one) -- now safe to truncate and
-        // write, preserving create-or-overwrite semantics for a legitimate rerun.
-        file.set_len(0)?;
-        file.write_all(bytes)?;
-        Ok(())
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        if std::fs::symlink_metadata(path)
-            .map(|metadata| metadata.file_type().is_symlink())
-            .unwrap_or(false)
-        {
-            anyhow::bail!("refusing to write through symlink at {}", path.display());
-        }
-        std::fs::write(path, bytes)?;
-        Ok(())
-    }
+    tensor_grep_rs::safe_write::write_bytes_refuse_symlink(path, bytes)
 }
 
 struct AuditManifestWriteInput<'a> {

--- a/rust_core/src/safe_write.rs
+++ b/rust_core/src/safe_write.rs
@@ -1,0 +1,153 @@
+//! One symlink-refusing file write, shared by the binary and the lib.
+//!
+//! This guard used to live only in `main.rs` (the `tg` binary crate), so `backend_ast`'s
+//! `direct_write_file` -- which is in the LIB crate -- could not reach it and used a bare
+//! `std::fs::write`. `tg run --rewrite --apply` therefore wrote THROUGH a git-tracked symlink to
+//! its target: an ordinary mode-120000 blob pointing at `~/.ssh/config`, a sibling project's
+//! `.env`, or any absolute path redirected the rewrite out of the repo. That is the write-side
+//! twin of the read-side disclosure fixed in #847.
+//!
+//! Moved here rather than copied: two implementations of a security guard drift, and the repo's
+//! duplication lens calls that out explicitly. `main.rs` now delegates to this one.
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::Context;
+
+/// Writes `bytes` to `path`, refusing to follow a symlink/reparse point at the final path
+/// component (audit #110 Gap 1). Closes a cross-process TOCTOU: the Python front door
+/// resolves and confines the `--audit-manifest` target before invoking this native binary,
+/// but a symlink swapped into that path between the Python check and this write was
+/// previously followed by a plain `std::fs::write` -- a confined write could escape its
+/// anchor. Mirrors the confine-then-open discipline `_write_json_refuse_symlink` already
+/// uses on the Python side (`src/tensor_grep/cli/main.py`).
+///
+/// audit #115: also guards `create_checkpoint`'s metadata.json + the shared/predictable
+/// index.json write, and `restore_validation_rollback_snapshots`'s per-file restore write --
+/// the same TOCTOU class, just with the checkpoint/rollback root standing in for
+/// `--audit-manifest`'s confined target.
+pub fn write_bytes_refuse_symlink(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::fs::OpenOptions;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // O_NOFOLLOW makes the open() itself fail (ELOOP) if the final path component is
+        // a symlink -- atomic, no separate check->open window.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .with_context(|| format!("refusing to write through symlink at {}", path.display()))?;
+        file.write_all(bytes)?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+        // Not in a dependency here (neither `windows` nor `winapi` is in Cargo.toml) -- these
+        // are the real documented values (winnt.h / fileapi.h), kept as local consts rather
+        // than pulling in a crate for two flag bits.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+        // FILE_FLAG_OPEN_REPARSE_POINT makes CreateFile open the reparse point entry
+        // itself instead of traversing it -- so if `path` is a symlink, we open the link,
+        // not its target. Deliberately no truncate-at-open: on a real reparse point that
+        // would touch the reparse buffer before we get to check it below.
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        let attributes = file.metadata()?.file_attributes();
+        if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            anyhow::bail!(
+                "refusing to write through symlink/reparse point at {}",
+                path.display()
+            );
+        }
+        // Confirmed a regular file (or a freshly created one) -- now safe to truncate and
+        // write, preserving create-or-overwrite semantics for a legitimate rerun.
+        file.set_len(0)?;
+        file.write_all(bytes)?;
+        Ok(())
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        if std::fs::symlink_metadata(path)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            anyhow::bail!("refusing to write through symlink at {}", path.display());
+        }
+        std::fs::write(path, bytes)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_bytes_refuse_symlink;
+
+    /// Best-effort symlink creation. Unprivileged Windows cannot make one; skip rather than
+    /// silently pass, mirroring the Python fixture in
+    /// `tests/unit/test_scanner_skips_symlinked_files.py`.
+    fn try_symlink(target: &std::path::Path, link: &std::path::Path) -> bool {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(target, link).is_ok()
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_file(target, link).is_ok()
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = (target, link);
+            false
+        }
+    }
+
+    #[test]
+    fn refuses_to_write_through_a_symlink_and_leaves_the_target_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().join("secret.txt");
+        std::fs::write(&outside, b"SECRET_MARKER_998877\n").unwrap();
+        let link = dir.path().join("link.txt");
+        if !try_symlink(&outside, &link) {
+            eprintln!("skipping: cannot create a symlink on this host");
+            return;
+        }
+
+        let result = write_bytes_refuse_symlink(&link, b"ATTACKER\n");
+
+        assert!(result.is_err(), "writing through a symlink must be refused");
+        // The point of the guard: the TARGET must be byte-identical afterwards. Asserting only
+        // on the Err would pass for an implementation that wrote the bytes and then errored.
+        assert_eq!(
+            std::fs::read(&outside).unwrap(),
+            b"SECRET_MARKER_998877\n",
+            "the symlink target was modified despite the refusal"
+        );
+    }
+
+    #[test]
+    fn still_writes_an_ordinary_file() {
+        // CONTROL ARM: without it, a guard that refused EVERY write would satisfy the test above.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plain.txt");
+        write_bytes_refuse_symlink(&path, b"first\n").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"first\n");
+
+        // Overwrite must truncate, not leave a tail of the longer previous contents.
+        write_bytes_refuse_symlink(&path, b"second_shorter\n").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"second_shorter\n");
+    }
+}


### PR DESCRIPTION
Closes task #18. Found by an external audit (finding S2), independently confirmed against this tree before acting.

## The defect

`backend_ast::direct_write_file` used a bare `std::fs::write`, so `tg run --rewrite --apply` on a repo containing a **git-tracked symlink** — an ordinary mode-120000 blob, nothing exotic — wrote *through* the link to its target. `config.py -> ~/.ssh/config`, a sibling project's `.env`, or any absolute path redirected the rewrite out of the repo.

This is the **write-side twin** of the read-side disclosure fixed in #847, and worse: that one leaked bytes out, this one overwrites bytes in.

## Root cause is a crate boundary

The guard already existed. `write_bytes_refuse_symlink` is used by the audit-manifest, checkpoint and rollback paths — but it lived in `main.rs`, the **binary** crate, while `backend_ast` is in the **lib** crate. It was unreachable from the one place that needed it most.

Moved to `tensor_grep_rs::safe_write`, used from both. **Moved, not copied** — two implementations of a security guard drift, and the repo's duplication lens calls that out. `main.rs` now delegates in two lines, so there is exactly one implementation.

## The receipt is preserved, not deleted

The call-site comment says the direct overwrite "matches sg's `std::fs::write()` behavior". That trade-off is about **atomicity** — no temp-file + rename, for Windows rewrite throughput — and it is deliberate and untouched. It was never a decision to follow symlinks. The comment is kept and extended to say so, so the next reader doesn't re-litigate the atomicity choice or mistake this for a revert of it.

## Tests

- refuses the write **and** asserts the symlink target is byte-identical afterwards — asserting only on the `Err` would pass for an implementation that wrote the bytes *and then* errored
- **control arm**: an ordinary file is still written, and an overwrite truncates — a guard that refused every write would satisfy the first test
- skips rather than silently passing where symlink creation needs privilege, mirroring `tests/unit/test_scanner_skips_symlinked_files.py`

## Verification status — stated plainly

**Not compiled locally.** A cargo build of `rust_core` is CPU-heavy (LTO) and this desktop is off-limits for it, so CI's six `test-rust-core` legs plus `cargo clippy -- -D warnings` are the arbiter here, per this repo's own "the CI run is the merge arbiter, never the local gate" rule. `rustfmt --check` is clean on all four files. I checked for orphaned imports by hand after removing the 76-line body from `main.rs` (`io::Write` still has 10 users; the remaining `OpenOptions` is fully qualified, not an import).

If CI reddens, that is the expected place for it to surface — do not merge on my say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)