### PR TITLE
fix(deps): cap mcp below 2.0, which removed mcp.server.fastmcp and broke `tg run --rewrite`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -568,7 +568,21 @@ dependencies = [
     # >=1.27.2: CVE-2026-52870 fix (mcp 1.26.0 advisory); floor bumped, not just relocked, so a
     # fresh resolve without --upgrade-package can never silently settle back below the patched
     # version.
-    "mcp>=1.27.2",
+    #
+    # <2: mcp 2.0.0 REMOVED `mcp.server.fastmcp`, which `cli/mcp_server.py:20` imports at module
+    # scope. Because `tg run --rewrite` lazily imports `mcp_server` (ast_workflows.py:64 ->
+    # execute_rewrite_plan_json), a fresh `pip install tensor-grep` resolving 2.x makes the rewrite
+    # path die with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` -- a USER-FACING
+    # break, not just a CI one. It went unnoticed for two releases because every in-repo consumer
+    # installs from uv.lock (pinned 1.28.1); the ONLY component that resolves fresh is the PyPI
+    # smoke venv, which is exactly what caught it (release runs 30363114542, 30375308409 -- both
+    # blocked `publish-pypi`, so v1.101.10 and v1.101.11 tagged without publishing).
+    #
+    # A cap, not a port, deliberately: the cap restores publishing today, and migrating to the 2.x
+    # API is a real change that deserves its own PR and its own tests. Lifting this cap REQUIRES
+    # porting `cli/mcp_server.py` off `mcp.server.fastmcp` first -- see the guard in
+    # tests/unit/test_mcp_dependency_is_upper_bounded.py, which fails if the bound is dropped.
+    "mcp>=1.27.2,<2",
     "pathspec>=1.0.4",
     "pyyaml>=6.0",
     # opentelemetry-api only: the 6 `trace.get_tracer` call sites (cudf_backend.py,

--- a/tests/unit/test_mcp_dependency_is_upper_bounded.py
+++ b/tests/unit/test_mcp_dependency_is_upper_bounded.py
@@ -1,0 +1,90 @@
+"""`mcp` must stay upper-bounded until `cli/mcp_server.py` is ported off `mcp.server.fastmcp`.
+
+mcp 2.0.0 removed `mcp.server.fastmcp`. `cli/mcp_server.py:20` imports it at module scope, and
+`tg run --rewrite` lazily imports that module (`ast_workflows.py:64` ->
+`execute_rewrite_plan_json`), so a fresh install resolving 2.x kills the rewrite path with::
+
+    ModuleNotFoundError: No module named 'mcp.server.fastmcp'
+
+That is a USER-FACING break -- `pip install tensor-grep` today -- not merely a CI one.
+
+Why it hid for two releases: every in-repo consumer installs from `uv.lock`, which pins mcp
+1.28.1, so the whole test suite and every dev environment is immune. The ONLY component that
+resolves the dependency FRESH is the PyPI artifact smoke venv, and it is the only thing that
+caught it -- release runs 30363114542 (v1.101.10) and 30375308409 (v1.101.11), both of which
+blocked `publish-pypi` and left the version tagged but unpublished.
+
+That asymmetry is the reason this guard reads `pyproject.toml` rather than importing anything: an
+import-based check would pass under the lock forever and could never see the drift it exists to
+catch. It is a claim about the DECLARED contract, which is what a fresh installer resolves
+against.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _mcp_requirement() -> Requirement:
+    metadata = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    for raw in metadata["project"]["dependencies"]:
+        requirement = Requirement(raw)
+        if requirement.name == "mcp":
+            return requirement
+    raise AssertionError("mcp is no longer a declared dependency; update or delete this guard")
+
+
+def test_mcp_is_capped_below_2() -> None:
+    """THE DEFECT: `mcp>=1.27.2` with no upper bound resolved to 2.0.0 on a fresh install."""
+    requirement = _mcp_requirement()
+
+    assert not requirement.specifier.contains("2.0.0"), (
+        f"the declared mcp requirement ({requirement}) admits 2.0.0, which removed "
+        "`mcp.server.fastmcp` -- `tg run --rewrite` dies with ModuleNotFoundError on any fresh "
+        "install. Port cli/mcp_server.py off mcp.server.fastmcp before lifting the cap."
+    )
+
+
+def test_the_security_floor_is_not_lost_while_capping() -> None:
+    """CONTROL ARM: without it, `mcp<2` alone would satisfy the test above while silently
+    reopening CVE-2026-52870 (the mcp 1.26.0 advisory the floor was raised for).
+
+    A cap and a floor are independent claims; a change that fixes one by dropping the other is
+    the failure mode this pair exists to prevent.
+    """
+    requirement = _mcp_requirement()
+
+    assert not requirement.specifier.contains("1.26.0"), (
+        f"the declared mcp requirement ({requirement}) admits 1.26.0, which is the version "
+        "CVE-2026-52870 was patched after; the >=1.27.2 floor must survive any capping change"
+    )
+
+
+def test_the_currently_locked_version_still_satisfies_the_declared_range() -> None:
+    """PREMISE: the cap must not exclude what the lock pins.
+
+    An upper bound that contradicts `uv.lock` is the silent-downgrade trap this repo has hit
+    before (a cap unsatisfiable on a newer Python resolved the WHOLE package down with no error).
+    Reading the locked version back and asserting it is admissible catches that at test time
+    rather than at somebody's install time.
+    """
+    lock = (_PYPROJECT.parent / "uv.lock").read_text(encoding="utf-8")
+    marker = '\nname = "mcp"\nversion = "'
+    start = lock.find(marker)
+    assert start != -1, "could not find the mcp entry in uv.lock"
+    locked = lock[start + len(marker) :].split('"', 1)[0]
+
+    # PREMISE: we really parsed a version, not an empty string or a marker fragment.
+    assert Version(locked) >= Version("1.0"), f"parsed an implausible locked version: {locked!r}"
+
+    requirement = _mcp_requirement()
+    assert requirement.specifier.contains(locked), (
+        f"uv.lock pins mcp {locked}, which the declared requirement ({requirement}) excludes -- "
+        "a fresh resolve would silently move to a different version than the one tested"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -4214,7 +4214,7 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = "<8.5.0" },
     { name = "kvikio-cu12", marker = "extra == 'gpu'" },
-    { name = "mcp", specifier = ">=1.27.2" },
+    { name = "mcp", specifier = ">=1.27.2,<2" },
     { name = "model2vec", marker = "extra == 'semantic'", specifier = ">=0.5" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },


### PR DESCRIPTION
**Root cause of the PyPI publish blocker (task #16), finally in hand.**

`validate-pypi-artifacts` failed on two consecutive release runs — [30363114542](https://github.com/oimiragieo/tensor-grep/actions/runs/30363114542) (v1.101.10) and [30375308409](https://github.com/oimiragieo/tensor-grep/actions/runs/30375308409) (v1.101.11) — skipping `publish-pypi` both times. PyPI is stuck on **1.101.9** while two tags shipped without artifacts.

## The error

Visible only after #848 made the smoke print the child's stderr instead of swallowing it into a `CalledProcessError`:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
  cli/mcp_server.py:20      from mcp.server.fastmcp import FastMCP
  cli/ast_workflows.py:64   (lazy import from execute_rewrite_plan_json)
  cli/main.py:17617         execute_run(...)
```

mcp 2.0.0 removed `mcp.server.fastmcp`. `tg run --rewrite` lazily imports `mcp_server`, so **any fresh install resolving 2.x kills the rewrite path**. This is user-facing — `pip install tensor-grep` today — not just CI.

## Why it hid for two releases

Every in-repo consumer installs from `uv.lock`, which pins mcp 1.28.1. The whole test suite and every dev environment are immune. The **only** component that resolves the dependency fresh is the PyPI smoke venv — it was doing exactly its job.

## A cap, not a port — deliberately

This restores publishing today. Migrating `cli/mcp_server.py` to the mcp 2.x API is a real change that deserves its own PR and its own tests. Both the dependency comment and the guard say so, so the cap can't be lifted by accident.

## The guard

`tests/unit/test_mcp_dependency_is_upper_bounded.py` reads `pyproject.toml` rather than importing anything — an import-based check passes under the lock forever and could never see the drift it exists to catch.

| test | role |
|---|---|
| requirement must not admit 2.0.0 | **bites on `origin/main`** (verified: admits it) |
| `>=1.27.2` CVE floor must survive | control arm — "fix the cap by dropping the floor" cannot pass |
| locked version satisfies declared range | premise — catches the cap-excludes-the-lock silent-downgrade trap this repo has hit before |

## uv.lock: one line

A full `uv lock` regenerate produced **131 lines** of unrelated `platform_machine` marker churn on `cuda-pathfinder`/`pywin32` from a newer uv. Reverted — no resolved version changed, so none were shipped. Only the specifier line moves.

## Correction to my own earlier analysis

I A/B'd mcp 1.29.0 vs 2.0.0 against the same wheel and reported *"both arms pass, mcp is not the cause"*. That test was **structurally incapable** of showing this bug: on Windows the rewrite routes to `AstBackend` and never imports `mcp_server`. The dependency diff was the correct lead and I talked myself out of it with a repro that had removed the mechanism the bug lives in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)