### PR TITLE
fix(cli): imports exited 2 and orient exited 0, both printing a silent false zero

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -8951,6 +8951,28 @@ def orient(
         typer.echo(json.dumps(payload, indent=2))
         return
 
+    # `tg orient` has no exit-2 contract by design (see --deadline's help): a truncated scan still
+    # exits 0. That makes the TEXT disclosure the ONLY signal a caller gets -- and it was absent.
+    # Measured on `tg orient src/tensor_grep/cli --deadline 0.1`: exit 0, `central files (0)`, zero
+    # bytes of stderr, while the `--json` arm carried `partial: true`. An agent reading that sees a
+    # codebase with no central files and no reason to look further, which is the confident-false-zero
+    # this surface exists to prevent -- made worse here, not better, by the deliberate exit 0.
+    #
+    # Leads the payload rather than trailing it, per the disclosure-position contract.
+    if payload.get("partial") or payload.get("result_incomplete"):
+        reason = payload.get("incomplete_reason")
+        limit = payload.get("deadline_limit")
+        if not isinstance(reason, str) or not reason:
+            # `deadline_limit` is a dict of counters, not prose -- interpolating it verbatim
+            # produced a banner containing a raw `{'deadline_exceeded': True, ...}`. Read the one
+            # field a caller can act on and say it in words.
+            scanned = limit.get("files_scanned") if isinstance(limit, dict) else None
+            reason = (
+                f"the scan stopped at the --deadline after {scanned} file(s)"
+                if isinstance(scanned, int)
+                else "the scan stopped at the --deadline"
+            )
+        typer.echo(_truncation_message(reason))
     typer.echo(f"# Codebase orientation: {payload['path']}")
     typer.echo(f"central files ({len(payload['central_files'])}):")
     for cf in payload["central_files"]:
@@ -11570,6 +11592,27 @@ def _emit_symbol_command_result(
     not_found = _symbol_not_found_claim(payload, result_key)
     payload["not_found"] = not_found
     caveat, is_truncation = _annotate_result_completeness(payload, result_key=result_key)
+    # FAIL-CLOSED COUPLING between the message and the exit code below.
+    #
+    # The exit gate fires on `partial` / `result_incomplete`. The caveat above is computed by
+    # `_annotate_result_completeness` from a DIFFERENT set of signals, so a payload that arrives
+    # with `result_incomplete` ALREADY SET by the command itself produced no caveat at all.
+    # Measured on `TENSOR_GREP_MAX_PARSE_BYTES=10 tg imports <file>`: exit 2, stdout
+    # `imports=0 resolved=0 external=0 unresolved=0`, and ZERO bytes of stderr, while the `--json`
+    # arm carried `result_incomplete: true` plus the real reason. A confident false zero with no
+    # signal on the text path is precisely the failure this surface exists to prevent, and it was
+    # invisible to the never-silent ratchet because that keys on `_scan_incomplete`, which
+    # deliberately does not read `result_incomplete`.
+    #
+    # Deriving the fallback from the SAME predicate as the exit makes the two impossible to
+    # disagree by construction, rather than by two lists staying in sync. Exit behaviour is
+    # untouched -- this only guarantees an exit is never silent.
+    if caveat is None and (payload.get("partial") or payload.get("result_incomplete")):
+        reason = payload.get("incomplete_reason")
+        caveat = _truncation_message(
+            str(reason) if reason else "the result is incomplete and may be missing entries"
+        )
+        is_truncation = True
     if json_output:
         typer.echo(json.dumps(payload, indent=2))
     else:

--- a/tests/unit/test_exit_two_and_orient_are_never_silent.py
+++ b/tests/unit/test_exit_two_and_orient_are_never_silent.py
@@ -1,0 +1,145 @@
+"""An incomplete result must SAY so on the text path -- including where the exit code cannot.
+
+Two confident-false-zero bugs, both measured on the real CLI before the fix, and both invisible to
+the existing never-silent ratchet because that keys on `_scan_incomplete`, which deliberately does
+not read `result_incomplete`.
+
+A0 -- `TENSOR_GREP_MAX_PARSE_BYTES=10 tg imports <file>`::
+
+    exit 2 · stdout "imports=0 resolved=0 external=0 unresolved=0" · stderr 0 bytes
+    --json  ->  result_incomplete: true, incomplete_reason: "file exceeds the 10-byte parse cap..."
+
+  Cause: `_emit_symbol_command_result` exits on `partial or result_incomplete`, but the caveat it
+  prints comes from `_annotate_result_completeness`, computed from a DIFFERENT set of signals. A
+  payload arriving with `result_incomplete` already set by the command itself got no caveat.
+
+A1 -- `tg orient <dir> --deadline 0.1`::
+
+    exit 0 · stdout "central files (0):" · stderr 0 bytes
+    --json  ->  partial: true
+
+  `tg orient` has NO exit-2 contract by design, which makes the text disclosure the ONLY signal a
+  caller gets. It was absent, so the deliberate exit 0 made this worse rather than better.
+
+Both fixes derive the message from the SAME predicate the exit uses, so the two cannot disagree by
+construction rather than by two lists being kept in sync.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tensor_grep.cli import main as cli_main
+
+
+def _capture(payload: dict[str, Any], capsys: pytest.CaptureFixture[str]) -> str:
+    """Run the shared symbol-command emitter in text mode and return stdout."""
+    try:
+        cli_main._emit_symbol_command_result(
+            payload,
+            result_key="imports",
+            json_output=False,
+            emit_text=lambda p: print(f"imports={len(p.get('imports') or [])}"),
+        )
+    except SystemExit:
+        pass
+    except Exception as exc:  # typer.Exit is not a SystemExit subclass in every version
+        if type(exc).__name__ != "Exit":
+            raise
+    return capsys.readouterr().out
+
+
+def test_a_command_set_result_incomplete_is_disclosed(capsys: pytest.CaptureFixture[str]) -> None:
+    """THE A0 DEFECT: `result_incomplete` set by the command produced no caveat at all."""
+    out = _capture(
+        {
+            "imports": [],
+            "result_incomplete": True,
+            "incomplete_reason": "file exceeds the 10-byte parse cap (size=46)",
+        },
+        capsys,
+    )
+
+    assert "INCOMPLETE" in out.upper(), (
+        "an incomplete result printed a bare zero with no disclosure -- a confident false zero"
+    )
+    assert "parse cap" in out, "the disclosure dropped the reason the payload already carried"
+
+
+def test_the_disclosure_leads_the_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    """Position is contract: a truncation banner LEADS, it does not trail.
+
+    An agent that streams or head-truncates output must see the caveat before the numbers it
+    would otherwise trust.
+    """
+    out = _capture(
+        {"imports": [], "result_incomplete": True, "incomplete_reason": "cap hit"},
+        capsys,
+    )
+    lines = [line for line in out.splitlines() if line.strip()]
+    assert lines, "no output at all"
+    assert "INCOMPLETE" in lines[0].upper(), (
+        f"the banner does not lead; first line was {lines[0]!r}"
+    )
+
+
+def test_a_complete_result_stays_silent(capsys: pytest.CaptureFixture[str]) -> None:
+    """CONTROL ARM: without it, printing the banner unconditionally would pass every test above
+    while making every complete run cry wolf -- which is how a disclosure gets ignored."""
+    out = _capture({"imports": [{"module": "os"}]}, capsys)
+
+    assert "INCOMPLETE" not in out.upper(), "a complete result must not claim to be incomplete"
+
+
+def test_a_partial_result_is_disclosed_too(capsys: pytest.CaptureFixture[str]) -> None:
+    """The other half of the exit predicate. `--deadline` sets `partial`, a cap sets
+    `result_incomplete`; the message must follow BOTH or it re-splits from the exit."""
+    out = _capture({"imports": [], "partial": True}, capsys)
+
+    assert "INCOMPLETE" in out.upper(), "a deadline-truncated result was not disclosed"
+
+
+def test_orient_discloses_a_partial_scan() -> None:
+    """THE A1 DEFECT: orient exits 0 by design, so text was the only signal -- and it was absent.
+
+    Pinned by source, not behaviour, because orient's text path is inline in the command body and
+    the payload comes from a real repo scan; a skipped test here would prove nothing, which is
+    worse than no test. Measured before the fix on
+    `tg orient src/tensor_grep/cli --deadline 0.1`: exit 0, `central files (0)`, 0 bytes of stderr,
+    `--json` carrying `partial: true`.
+    """
+    import inspect
+
+    source = inspect.getsource(cli_main.orient)
+    text_path = source.split('typer.echo(f"# Codebase orientation')[0]
+
+    # PREMISE: we really isolated the code that runs BEFORE the payload is printed. If the header
+    # line is ever reworded, this split silently yields the whole function and the assertion below
+    # would pass for the wrong reason.
+    assert text_path != source, "could not locate orient's text header; update this guard"
+    assert "_truncation_message(" in text_path, (
+        "orient's text path emits no incompleteness banner before the payload. It has no exit-2 "
+        "contract, so this line is the ONLY signal a caller gets that the scan was cut short."
+    )
+    assert 'payload.get("partial")' in text_path, (
+        "orient's disclosure is not keyed on `partial`, the field its own --json arm sets"
+    )
+
+
+def test_the_orient_banner_never_interpolates_a_raw_dict() -> None:
+    """`deadline_limit` is a dict of counters, not prose.
+
+    The first cut interpolated it verbatim and produced a banner containing
+    `{'deadline_exceeded': True, 'files_scanned': 0, ...}`. Pinned by source because the value is
+    read inline in the command body: the emitter must not format the mapping itself.
+    """
+    import inspect
+
+    source = inspect.getsource(cli_main.orient)
+    assert "deadline_limit" in source, "orient no longer reads deadline_limit; update this guard"
+    assert 'f"the scan stopped at the --deadline ({reason})"' not in source, (
+        "orient interpolates the deadline_limit mapping straight into the banner; read the "
+        "actionable field and say it in words instead"
+    )


### PR DESCRIPTION
Fixes **A0** and **A1** from the adversarial audit. Both reproduced against the working tree before fixing — the audit measured installed `tg 1.101.9`, which is stale.

## A0 — `tg imports` exits 2 in silence

```
TENSOR_GREP_MAX_PARSE_BYTES=10 tg imports <file>
exit 2 | stdout "imports=0 resolved=0 external=0 unresolved=0" | stderr 0 bytes
--json  ->  result_incomplete: true + the real reason
```

`_emit_symbol_command_result` exits on `partial or result_incomplete`, but the caveat it prints comes from `_annotate_result_completeness`, computed from a **different** set of signals. A payload arriving with `result_incomplete` already set by the command itself got no caveat at all.

Fixed by deriving a fallback caveat from **the same predicate the exit uses**, so message and exit cannot disagree by construction rather than by two lists being kept in sync. Exit behaviour untouched.

**Not** by adding `result_incomplete` to `_scan_incomplete`, as the audit suggested. That helper's docstring says it excludes the field *deliberately* — an output cap also sets it, and including it would flip output-cap-only invocations to exit 2 and break the output-cap-stays-0 pins. The obvious fix was the wrong one.

## A1 — `tg orient` exits 0 in silence

```
tg orient <dir> --deadline 0.1
exit 0 | stdout "central files (0):" | stderr 0 bytes
--json  ->  partial: true
```

orient has **no exit-2 contract by design**, which makes the text line the *only* signal a caller gets. It was absent — so the deliberate exit 0 made this worse rather than better. Now leads the payload with a banner keyed on `partial`.

My first cut interpolated `deadline_limit` verbatim and emitted a banner containing `{'deadline_exceeded': True, ...}`. It now reads the one actionable field — *"stopped at the --deadline after 3 file(s)"* — pinned by a test.

## Verification

| check | result |
|---|---|
| both guards vs `origin/main` | **BITE** (A0 fallback absent, A1 banner absent) |
| control: complete result stays silent | passes — an unconditional banner would satisfy every other assertion while training callers to ignore it |
| control: banner must LEAD | passes |
| disclosure-family suite | 41 passed |
| `test_cli_modes.py` | 526 passed |

**Baselined, not mine:** `test_refs_json_deduplicates_parser_call_references` fails **identically with this change reverted** — a JS refs assertion that needs the compiled `rust_core` extension, absent from my rebuilt venv. Deselected for the local run, not disabled; CI has the extension.

Audit items **A1b** (broaden the ratchet by name), **A2** (MCP doc versions), **A3** (BACKLOG refresh), **B2** (native argv `--`) are not in this PR — see the follow-up tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)