### PR TITLE
docs: the signal-path law and the lockfile-canary law, plus the three-tg trap

### DIFF
--- a/.claude/skills/tensor-grep-build-and-env/SKILL.md
+++ b/.claude/skills/tensor-grep-build-and-env/SKILL.md
@@ -141,6 +141,47 @@ uv run pytest tests/unit/test_rust_core.py -q
 `RustCoreBackend().search(...)` returns real results — a stronger check than "the install didn't
 error," which can pass even when the extension silently failed to build (see Trap 8).
 
+### `uv run tg` is NOT your working tree — assert `__file__` before any behavioural claim
+
+`uv run --no-sync tg <args>` resolves `tg` from `.venv/Lib/site-packages/tensor_grep`, **not** from
+`src/`. On a box with a PATH-installed release as well, that is **three disagreeing `tg`s**, and
+nothing in the output says which one answered.
+
+Cost, measured 2026-07-28: two confidently-stated wrong conclusions in one session — a fix
+"verified" against a copy that predated it, and a phantom Python-vs-Rust divergence that was
+actually the same stale copy on both arms. The tell was there and skipped: *both arms read
+identical*, which should trigger "is my instrument loading my code?" before "I found a divergence."
+
+```bash
+# ALWAYS, before believing any measured tg behaviour:
+PYTHONPATH=src uv run --no-sync python -c "import tensor_grep.cli.main as m; print(m.__file__)"
+# must print ...\src\tensor_grep\cli\main.py -- if it says site-packages, every number is stale
+
+PYTHONPATH=src uv run --no-sync python -m tensor_grep.cli.bootstrap <args>   # not `uv run tg`
+```
+
+Use `bootstrap` rather than the console script: it is the real front door (`CliRunner` bypasses it),
+and it honours `PYTHONPATH`.
+
+### Editing `pyproject.toml` can destroy the venv mid-command
+
+`uv run --no-sync` re-syncs anyway when `pyproject.toml` changes. On Windows that sync deletes the
+venv and can then fail on `.venv/lib64` (a symlink) with `Access is denied`, leaving only
+`pyvenv.cfg` and a dangling link — every subsequent command dies with "No module named pytest".
+
+```bash
+# recover WITHOUT paying for a maturin rebuild (the Rust extension is the expensive part):
+powershell -c "(Get-Item .venv\lib64 -Force).Delete(); Remove-Item .venv -Recurse -Force"
+uv sync --no-install-project     # deps only, no cargo build
+uv pip install pytest            # dev extras are not covered by --no-install-project
+```
+
+`--no-install-project` leaves the compiled `rust_core` **absent**, so tests needing the native
+extension will fail. That is a degraded environment, not a regression: baseline any new failure by
+reverting your change and re-running before blaming it (`tests/unit/test_cli_modes.py::
+test_refs_json_deduplicates_parser_call_references` fails this way). Run a full `uv sync` when you
+need the extension back.
+
 ## Rebuilding after a Rust-side change
 
 | You changed... | Rebuild with | Typical time |

--- a/.claude/skills/tensor-grep-release-and-positioning/SKILL.md
+++ b/.claude/skills/tensor-grep-release-and-positioning/SKILL.md
@@ -274,10 +274,38 @@ Never declare a release "done" from PyPI visibility alone if the installer/updat
 ```bash
 python - << 'PY'
 import json, urllib.request
-data = json.load(urllib.request.urlopen("https://pypi.org/pypi/tensor-grep/json"))
-print(data["info"]["version"])
+# Cache-Control matters: see the trap below.
+req = urllib.request.Request("https://pypi.org/pypi/tensor-grep/json",
+                             headers={"Cache-Control": "no-cache"})
+data = json.load(urllib.request.urlopen(req))
+print("info.version:", data["info"]["version"])
+print("v1.101.14 present:", "1.101.14" in data["releases"])   # ask for YOUR version by name
 PY
 ```
+
+**TRAP — `info.version` is CDN-cached and lies for a window after a publish.** Twice on 2026-07-28
+a post-release probe read the PREVIOUS version and was one sentence away from being reported as
+"the release did not publish", while `publish-pypi` and `publish-success-gate` were both green and
+the tag existed. A 60-second settle delay was **not** enough.
+
+Two independent fixes, use both:
+
+1. Send `Cache-Control: no-cache` on the request.
+2. Ask the `releases` **map** for the exact version you expect (`"1.101.14" in data["releases"]`)
+   rather than reading `info.version`. A membership test on a specific key is a different question
+   than "what is latest", and it does not depend on the summary field being fresh.
+
+Cross-check against the tag and the job conclusion — three signals, not one:
+
+```bash
+git fetch -q origin --tags && git tag --sort=-v:refname | head -3
+gh run view <run-id> --json jobs \
+  --jq '.jobs[]|select(.name|test("publish-pypi|publish-success"))|"\(.name): \(.conclusion)"'
+```
+
+This is the same class as everything else in this file: **a stale read and a real failure are
+indistinguishable in the output**, so the probe needs a second, independently-sourced signal before
+you act on a negative.
 
 Then run the Docker dogfood harness (`scripts/dogfood/README.md`) — it installs the *published*
 package into a clean container and drives the *real* `tg` binary (not `CliRunner`, which bypasses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -908,6 +908,76 @@ This is the CI-probe twin of the false-zero law: there, an instrument returns EM
 reads as a clean bill; here, an instrument returns a REASON-LESS failure and the exit status reads as
 a diagnosis.
 
+### Trace the SIGNAL PATH to the instrument before believing a negative
+
+The parent pattern behind the false-zero law, the both-arms law, and the setup-lies law. Those name
+symptoms; this names the cause: **a negative result has two indistinguishable explanations — the
+phenomenon is absent, or the signal never reached the probe.** Nothing in the output separates them,
+and confidence is highest exactly when the probe is your own, because you know what you *intended*
+it to measure.
+
+Six wrong conclusions in one session (2026-07-28), every one the same failure — the instrument
+silently lacked REACH:
+
+| instrument | the hop it could not reach | the false conclusion |
+|---|---|---|
+| CI log of the failing smoke | `capture_output=True` discarded the child's stderr | 3 hypotheses "tested" against a log with no cause in it |
+| a newly written ratchet | the offending call lived in a STRING, not a call node | "guard added" — 0 violations on the code that caused the incident |
+| `uv run --no-sync tg` | resolves `.venv/site-packages`, not `src/` | two separate wrong verdicts, one of them a phantom Python-vs-Rust divergence |
+| an mcp 1.x-vs-2.0 A/B | on Windows the rewrite routes to `AstBackend` and never imports `mcp_server` | "mcp is not the cause" — it **was** the cause |
+| an external audit's `git status` | WSL git over a `core.autocrlf=true` Windows checkout | "338-file dirty tree", P0, *discard it* (destructive) |
+| `rustfmt --check <3 files>` | the change edited 4 | "format clean" → CI red |
+
+**The rule: name every hop the phenomenon must travel to reach your probe, and verify each one.**
+
+```
+mcp 2.0 breaks tg  ⇒  pattern parsed → command routed → backend selected → mcp_server imported
+                                                        ^^^^^^^^^^^^^^^^ Windows exits here
+```
+
+Hop 3 was never checked, so hop 4 could not fire, so the probe was structurally incapable of a
+positive. One `print(routing_backend)` would have shown it.
+
+Cheapest checks first:
+
+- **Does the probe load MY code?** `PYTHONPATH=src` **and** assert `module.__file__`. Never
+  `uv run tg` for a behavioural claim — a dev box can carry three disagreeing `tg`s (PATH-installed,
+  `.venv` site-packages, `src/`).
+- **Can the probe return non-zero at all?** Run it against the pre-fix revision and require a
+  non-zero count (see Form 1 applied to guards, above).
+- **Did the failing path actually execute?** Print the branch/route taken, not just the result.
+- **Is the probe's scope the whole change?** A gate is only as wide as the file list you hand it.
+- **Whose environment produced this snapshot?** A WSL git over a Windows checkout, a stale branch, a
+  clean clone — each yields a confident number about a tree nobody is working on.
+
+**Corollary, and the one that cost the most: a simplification that removes the mechanism can never
+discriminate.** The mcp A/B was a *correct* experiment on the wrong path. When a repro is simpler
+than the failing scenario, ask which hop the simplification deleted — and if the answer is "the one
+the bug lives in", the result is not evidence in either direction.
+
+### A lockfile immunises everyone except the canary
+
+`mcp` 2.0.0 removed `mcp.server.fastmcp`, which `cli/mcp_server.py` imports at module scope and
+`tg run --rewrite` reaches lazily. Any fresh `pip install tensor-grep` broke the rewrite path. It
+blocked `publish-pypi` on two consecutive releases — v1.101.10 and v1.101.11 tagged and never
+published — against a declared `mcp>=1.27.2` with no upper bound.
+
+Nobody saw it because **every in-repo consumer installs from `uv.lock`** (pinned 1.28.1): the full
+suite, every dev environment, and every CI leg were immune *by construction*. The only component
+that resolves fresh is the PyPI artifact smoke venv. One canary, firing correctly twice while it was
+treated as the problem.
+
+- **A lockfile is a blindfold as well as a seatbelt.** It guarantees your tests cannot observe what a
+  new user gets. Know which component resolves fresh — its failures are user-facing by definition.
+- **When only the fresh-resolve component fails, suspect the DECLARED constraint, not the
+  component.**
+- **Cap majors on anything imported by submodule path.** `from x.y.z import W` is a promise about
+  another project's internal layout; a major bump is entitled to break it.
+- **Guard the cap by reading `pyproject.toml`, not by importing** — an import-based check passes
+  under the lock forever. Pair it with a control arm (the CVE floor survives the cap) and a premise
+  (the locked version satisfies the range; a cap excluding the lock is the silent-downgrade trap).
+- **A cap is not a port.** Say so in the comment *and* the guard, or someone lifts it to "clean up".
+
 **MAINTENANCE: this family is MIRRORED, so adding a form is a TWO-FILE EDIT, always.** This section
 is canonical; `tensor-grep-validation-and-qa`'s Part 0 carries the same family for cheap-session
 readers. Grep BOTH files for the next number before assigning it, and update the mirror in the same


### PR DESCRIPTION
Retention for the 2026-07-28 session. Two laws into `AGENTS.md`, one trap into the build-and-env skill — all three earned by wrong conclusions stated confidently during this session.

### 1. Trace the signal path to the instrument

The **parent** pattern behind the false-zero, both-arms and setup-lies laws. Those name symptoms; this names the cause: a negative result has two indistinguishable explanations — *the phenomenon is absent*, or *the signal never reached the probe*. Six instances in one session, tabulated with the hop each instrument could not reach.

The corollary that cost the most: **a simplification that removes the mechanism can never discriminate.** An mcp 1.x-vs-2.0 A/B "ruled out" the true cause because on Windows the rewrite routes to `AstBackend` and never imports `mcp_server` — a correct experiment on the wrong path.

### 2. A lockfile immunises everyone except the canary

Every in-repo consumer installs from `uv.lock`, so the entire suite was immune to the mcp 2.0 break *by construction*. The only component resolving fresh — the PyPI smoke venv — was the sole detector. It fired correctly twice while being treated as the problem, and two releases tagged without publishing.

### 3. `uv run tg` is not your working tree

It resolves `.venv/site-packages`, not `src/`. With a PATH-installed release as well, that's three disagreeing binaries and nothing says which answered. Adds the assert-`__file__` recipe, the `bootstrap` invocation, and the Windows venv-destruction recovery (editing `pyproject.toml` triggers a re-sync that can die on the `lib64` symlink) — including the caveat that `--no-install-project` leaves `rust_core` absent, so a new failure must be **baselined** before it's blamed.

`test_skill_index_sync` passes; `AGENTS.md` is ruff-format clean. Non-releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)