### PR TITLE
docs(skills): land the 1.101.17 live-dogfood corrections, incl. the Slice 2 reversal

### DIFF
--- a/.claude/skills/tensor-grep-ledger/SKILL.md
+++ b/.claude/skills/tensor-grep-ledger/SKILL.md
@@ -5,8 +5,8 @@ description: Use when coordinating multiple agents on the same repo with tg ledg
 
 # tensor-grep ledger (EXPERIMENTAL, ADVISORY-tier)
 
-Verified against **tg 1.101.9** (LIVE 2026-07-28 gotcontext-saddle — Slice 1 rollup
-reconfirmed; prior 1.101.7 / 1.95.0 / 1.93.0 #706 notes still accurate).
+Verified against **tg 1.101.17** (LIVE 2026-07-28 gotcontext-saddle — Slice 1 rollup
++ Slice 2 `find` repo-visibility reconfirmed; prior 1.101.9 / 1.93.0 #706 notes for Slice 1).
 
 `tg ledger` is **ADVISORY-tier**, not MANDATORY or OPTIONAL, in the vocabulary a multi-agent-coordination
 ecosystem needs to stay legible (the same MANDATORY/OPTIONAL/ADVISORY split the `ruah` coordination
@@ -73,19 +73,22 @@ tg ledger release REPO --claim-id "$CLAIM_ID" --json
   agents' real edits collide even though the ledger itself never blocks either one.
 
 Dogfood: claim/list/release round-trip PASS from any subtree PATH under the same repo (v1.93.0/#706
-closing dogfood); record+find fresh PASS (Slice 2, unaffected by the Slice-1 fix — see below).
+closing dogfood); record+find fresh PASS including `find .` after `record core/hooks` (1.101.17).
 
-## Slice 2 — findings reuse (UNCHANGED — still literal-path-rooted, the OLD footgun survives here)
+## Slice 2 — findings reuse (repo-visible find as of 1.101.17 dogfood)
 
-**This slice did NOT get the #706 canonicalization fix.** `record`/`find` still resolve their store
-from the literal PATH argument exactly the way Slice 1 used to — a `record` at `core/hooks` and a
-`find` at `.`/repo-root are NOT guaranteed to hit the same store. Do not assume Slice 2 inherited
-Slice 1's fix; treat this as a known, still-open footgun until a matching PR closes it.
+**Live dogfood (1.101.17):** after `tg ledger record core/hooks --receipt …`,
+`tg ledger find PATH --symbol S --fresh-only` returns fresh findings for
+`PATH` in `{., core/hooks, core, $REPO_ROOT, core/skills}` — same-repo visibility,
+not limited to the literal record PATH. Prefer an explicit PATH on `record` still;
+do not assume cross-repo visibility. Older skills claiming Slice 2 is strictly
+literal-path-rooted are **stale** relative to this binary.
 
 ```bash
 tg evidence emit REPO --capsule capsule.json --query "task" --json --agent-id "$AGENT_ID" > receipt.json
 tg ledger record REPO --receipt receipt.json --artifact-kind evidence-receipt --symbol open_session --agent-id "$AGENT_ID" --json
 tg ledger find REPO --symbol open_session --artifact-kind evidence-receipt --fresh-only --json
+# also OK: tg ledger find . --symbol open_session --fresh-only --json
 ```
 
 `--artifact-kind`: `evidence-receipt` | `blast-radius` | `context-pack` | `repo-map`.
@@ -98,7 +101,7 @@ tg ledger find REPO --symbol open_session --artifact-kind evidence-receipt --fre
 | `1` | nothing matched **or** matches exist but none fresh → recompute |
 | `2` | fail-closed (missing `--symbol`, corrupt index/blob) |
 
-Dogfood: empty find exit 1 PASS; after record, find exit 0 PASS (~16s).
+Dogfood (1.101.17): after record, find at `.` / subtree / abs root → exit 0, `any_fresh: true`.
 
 ## Agent loop with ledger
 

--- a/.claude/skills/tensor-grep-prepare/SKILL.md
+++ b/.claude/skills/tensor-grep-prepare/SKILL.md
@@ -5,8 +5,8 @@ description: Use when an agent needs one-call edit readiness before changing cod
 
 # tensor-grep prepare (one-call edit readiness)
 
-Verified against **tg 1.101.9** (LIVE 2026-07-28 gotcontext-saddle; prior 1.101.7 /
-1.95.0 CLI contract / 1.92.1–1.91.0 dogfoods still representative of the core CUJ).
+Verified against **tg 1.101.17** (LIVE 2026-07-28 gotcontext-saddle; prior 1.101.9 /
+1.101.7 / 1.95.0 CLI contract still representative of the core CUJ).
 
 ## When to use
 
@@ -33,6 +33,8 @@ Dogfood:
 
 | Case | Result |
 | --- | --- |
+| `prepare … --out` (**1.101.17**) | PASS ~7s — overall 0.9, callers_count=1, file ~8KB |
+| `prepare … --claim` (**1.101.17**) | PASS ~8s — anonymous + hint; `TG_LEDGER_AGENT_ID` clears hint |
 | `prepare … --out` (**1.101.9**) | PASS ~6s — overall 0.9, callers_count=1, file ~8KB |
 | `prepare … --claim` (**1.101.9**) | PASS ~8s — submitted=true + `agent_id_hint` when anonymous |
 | `prepare core/hooks matches_trigger` (**1.101.7**) | PASS ~13s — overall 0.9, callers_count=1, claim.submitted=false |

--- a/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
+++ b/.claude/skills/tensor-grep-workspace-dogfood/SKILL.md
@@ -13,7 +13,7 @@ tg doctor --json ROOT
 tg devices
 ```
 
-## Recommended sweep (v1.101.9)
+## Recommended sweep (v1.101.17)
 
 ```bash
 cd /path/to/workspace
@@ -39,32 +39,30 @@ tg agent agent-studio/.claude/lib/routing "task" --json
 tg dogfood --root . --output /tmp/dogfood-ws.json
 ```
 
-## Latest sweep (2026-07-28, tg 1.101.9, gotcontext-saddle)
+## Latest sweep (2026-07-28, tg 1.101.17, gotcontext-saddle)
 
 | Category | Result | Notes |
 | --- | --- | --- |
-| Symbol ladder / blast / orient / map / route-test / evidence / dogfood | ✅ | `agreement_details` true; evidence `checks.digest_valid` |
-| `tg agent` scoped + root `--deadline 90` | ✅ | scoped ~12s; root ~61s rc 0 non-partial (faster vs 1.101.7) |
-| lexical + trunc hard-stop | ✅ | lexical OK; trunc now honest **conf 0.72** + ask.required (was 0.9) |
-| **`tg prepare`** / `--out` / `--claim` | ✅ | ~6–8s (faster); `agent_id_hint` |
-| ledger Slice 1 rollup + Slice 2 | ✅ | list `.` sees subtree claim; find fresh |
-| `tg find` without dense | ✅ | BM25; install-dense hint; help mentions optional MaxSim |
-| GPU | ⚠️ | `unsupported` / cpu-fallback + explicit “not GPU proof” stderr |
-| Multi-project parent unscoped | ✅ | exit 2 refuse |
-| Bare `search --json` (no PATH) | ⚠️ | still ~1s exit 1 empty, no refuse stderr |
+| Symbol ladder / blast / orient / map / route-test / evidence / dogfood | ✅ | `agreement_details`; evidence `checks.digest_valid` |
+| `tg agent` scoped + root `--deadline 90` | ✅ | scoped ~7s; root ~**47s** (faster vs 1.101.9 ~61s) |
+| lexical + trunc hard-stop | ✅ | trunc conf **0.72** + ask.required |
+| **`tg prepare`** / `--out` / `--claim` | ✅ | ~7–8s; env `TG_LEDGER_AGENT_ID` attributed |
+| ledger Slice 1 + Slice 2 find | ✅ | list rollup; **`find .` sees `record core/hooks`** (skill was stale) |
+| `tg find` without dense | ✅ | BM25 + install-dense hint |
+| GPU | ⚠️ | `unsupported` / cpu-fallback + not-proof stderr |
+| Multi-project parent unscoped | ✅ | exit 2 + JSON `incomplete_reason` |
+| Bare `search` / `search --json` (no PATH) | ⚠️ | ~2s exit 1 empty, **no** refuse stderr (text also empty now) |
 | Cold doctor daemon | ✅ | autostart hint → warm running |
 
-Artifact: `/tmp/tg-dogfood-11019.json`. Prior same-day 1.101.7: `/tmp/tg-dogfood-11017.json`.
+Artifact: `/tmp/tg-dogfood-110117.json`.
 
 ## Trend
 
 | Version | PASS | TIMEOUT | Notable |
 | --- | ---: | ---: | --- |
-| 1.91.0 | 57 | 2 | prepare + install-dense |
-| 1.92.1 | saddle ✅ | — | prepare solid; ledger PATH footgun |
-| 1.93.x–1.95.0 | fixes ship | — | ledger rollup, prepare `--out`, GPU probe honesty |
 | 1.101.7 | saddle ✅ | — | agreement_details; bare-json PATH footgun |
-| **1.101.9** | **saddle ✅** | — | faster prepare/agent; trunc conf honesty; MaxSim in find help |
+| 1.101.9 | saddle ✅ | — | faster prepare/agent; trunc conf honesty |
+| **1.101.17** | **saddle ✅** | — | Slice 2 find repo-visible; agent root ~47s; bare text also silent-empty |
 
 ## Sibling skills
 

--- a/.claude/skills/tensor-grep/SKILL.md
+++ b/.claude/skills/tensor-grep/SKILL.md
@@ -40,7 +40,7 @@ prefer the canonical path-first form.
    - `tg source REPO_PATH/src SYMBOL`
 4. Symbol navigation — prefer `src/`:
    - `tg callers REPO_PATH/src SYMBOL --deadline 15 --json`
-5. Edit readiness — **prefer `tg prepare REPO/src`** (~6s PASS on gotcontext-saddle hooks @ 1.101.9; ~27s on larger src @ 1.91.0):
+5. Edit readiness — **prefer `tg prepare REPO/src`** (~7s PASS on gotcontext-saddle hooks @ 1.101.17; ~27s on larger src @ 1.91.0):
    - `tg prepare REPO_PATH/src "task" --json`  # primary + blast floor + validation + coordination hooks
    - `tg prepare REPO_PATH/src "task" --out capsule.json --json`  # also persists the full capsule to FILE (byte-identical to stdout JSON; symlink/dangling-symlink/dir refused; feeds `tg evidence emit --capsule FILE` directly, no manual redirect)
    - `tg prepare REPO_PATH/src "task" --claim --json`  # also submit advisory ledger claim; anonymous claims stamp `coordination.claim.agent_id_hint` unless `TG_LEDGER_AGENT_ID` is set


### PR DESCRIPTION
Live dogfood on `gotcontext-saddle` against published **1.101.17**. These edits were sitting uncommitted in the working tree and would have been lost.

## The substantive change is a reversal, not a restamp

The ledger skill said:

> ## Slice 2 — findings reuse (**UNCHANGED** — still literal-path-rooted, the OLD footgun survives here)
> **This slice did NOT get the #706 canonicalization fix.** … treat this as a known, still-open footgun until a matching PR closes it.

**That matching PR is #850**, published in 1.101.16. `record core/hooks` followed by `find .` / `find core/skills` now returns fresh under the same `.git` root, confirmed by the dogfood on the shipped artifact.

The skill was actively telling agents to route around a footgun that no longer exists — worse than silence, because it costs a workaround on every call.

## Also

- version stamps → 1.101.17
- faster `agent` root path (~47s vs ~61s at 1.101.9)
- `TG_LEDGER_AGENT_ID` attribution behaviour

Separately removed `src/tensor_grep/cli/docs/` — generated codemap output left in the package source by a dogfood run. It's gitignored so it was never at risk of being committed, but it's still litter.

`test_skill_index_sync` passes. Non-releasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)