### PR TITLE
fix(search): a bare `tg search PAT` that matched nothing now names the scope it searched

### DIFF
--- a/src/tensor_grep/cli/bootstrap.py
+++ b/src/tensor_grep/cli/bootstrap.py
@@ -576,6 +576,52 @@ def _can_delegate_to_native_tg_search(search_args: list[str]) -> bool:
     return True
 
 
+def _search_args_include_explicit_path(search_args: list[str]) -> bool:
+    """Whether the caller named a PATH, as opposed to letting it default to the cwd.
+
+    The pattern is the FIRST bare positional; any bare positional after it is a path. Flags and
+    their attached values are skipped with the same helpers the dispatch logic already uses, so a
+    value like `-g *.py` cannot be mistaken for a path.
+    """
+    positionals = 0
+    skip_next = False
+    for arg in search_args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg.startswith("-") and arg != "-":
+            if arg in _SEARCH_FLAGS_WITH_VALUES:
+                skip_next = True
+            continue
+        positionals += 1
+        if positionals > 1:
+            return True
+    return False
+
+
+def _write_defaulted_scope_note() -> None:
+    """Name the scope a zero-result search actually covered.
+
+    THE BUG THIS FIXES: a bare `tg search PAT` never reaches the Python CLI at all. `main_entry`
+    dispatches it straight to ripgrep via `_run_rg_passthrough` and re-raises rg's exit code, so a
+    no-match run returns 1 with nothing on either stream. Reported by the live dogfood on THREE
+    consecutive releases ("exit 1, empty, no refuse stderr; always pass explicit PATH"). Every
+    disclosure surface in `cli/main.py` is downstream of a branch this path never takes -- which is
+    why fixing it there had no effect, and why the fix has to live here.
+
+    Deliberately a note and exit 1, NOT the exit-2 refusal the report asked for. Exit 2 means
+    INCOMPLETE; a defaulted-scope search that ran to completion IS complete, it just answered a
+    narrower question. Refusing every bare `tg search foo` would break the ordinary invocation,
+    which works correctly. Keep the exit code honest and remove the ambiguity with words.
+    """
+    sys.stderr.write(
+        "note: no PATH was given, so the search defaulted to the current directory. "
+        "Zero matches means zero matches in THAT scope, not in the repository. "
+        "If you expected hits, re-run with an explicit PATH: tg search <pattern> <dir>\n"
+    )
+    sys.stderr.flush()
+
+
 def _search_args_include_guarded_broad_root(search_args: list[str]) -> bool:
     for arg in search_args:
         if not arg or arg == "-" or arg.startswith("-"):
@@ -1501,7 +1547,12 @@ def main_entry() -> None:
             rg_binary_path = resolve_ripgrep_binary()
             binary_name = str(rg_binary_path) if rg_binary_path else None
             if binary_name is not None:
-                raise SystemExit(_run_rg_passthrough(binary_name, passthrough_search_args))
+                exit_code = _run_rg_passthrough(binary_name, passthrough_search_args)
+                if exit_code == 1 and not _search_args_include_explicit_path(
+                    passthrough_search_args
+                ):
+                    _write_defaulted_scope_note()
+                raise SystemExit(exit_code)
 
     _run_full_cli()
 

--- a/tests/unit/test_bare_search_names_its_scope.py
+++ b/tests/unit/test_bare_search_names_its_scope.py
@@ -1,0 +1,101 @@
+"""A zero-result search the caller never scoped must name the scope it actually covered.
+
+Reported by the live dogfood on THREE consecutive releases (1.101.7, 1.101.9, 1.101.17):
+
+    bare `tg search P` and `tg search P --json` -- ~2s, exit 1, empty, no refuse stderr.
+    Always pass explicit PATH.
+
+The reason three rounds of disclosure work never touched it: **a bare search never reaches the
+Python CLI at all.** `bootstrap.main_entry` dispatches it straight to ripgrep via
+`_run_rg_passthrough` and re-raises rg's exit code, so every disclosure surface in `cli/main.py`
+sits downstream of a branch this path does not take. A fix written there had no observable effect,
+which is what finally located the real dispatch.
+
+Exit 1 is KEPT. Exit 2 means INCOMPLETE, and a defaulted-scope search that ran to completion is
+complete -- it just answered a narrower question than the caller may have meant. Refusing every
+bare `tg search foo` would break the ordinary invocation, which works correctly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tensor_grep.cli.bootstrap import (
+    _search_args_include_explicit_path,
+    _write_defaulted_scope_note,
+)
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["PAT"], False),
+        (["PAT", "."], True),
+        (["PAT", "src/"], True),
+        (["--json", "PAT"], False),
+        (["--json", "PAT", "src"], True),
+        # A flag VALUE is not a path. Without the value-flag skip, `-g *.py` would read as a
+        # second positional and silently suppress the note on a genuinely unscoped search.
+        (["-g", "*.py", "PAT"], False),
+        (["-g", "*.py", "PAT", "src"], True),
+        # `-e PAT` supplies the pattern via a flag, so there is still no bare positional path.
+        (["-e", "PAT"], False),
+    ],
+)
+def test_explicit_path_detection(args: list[str], expected: bool) -> None:
+    """The pattern is the first bare positional; a path is any bare positional after it."""
+    assert _search_args_include_explicit_path(args) is expected
+
+
+def test_the_note_names_the_scope_and_the_remedy(capsys: pytest.CaptureFixture[str]) -> None:
+    """THE DEFECT: exit 1 with zero bytes on both streams.
+
+    'Nothing matches in the repository' and 'nothing matches in whatever directory I was standing
+    in' were the same bytes on the wire.
+    """
+    _write_defaulted_scope_note()
+    err = capsys.readouterr().err
+
+    assert err, "the note produced no output at all"
+    assert "no PATH was given" in err, "the note does not say the scope was defaulted"
+    assert "current directory" in err, "the note does not name the scope actually searched"
+    assert "tg search <pattern> <dir>" in err, "the note does not give the remedy"
+
+
+def test_the_note_goes_to_stderr_not_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    """CONTROL ARM: stdout is the machine surface.
+
+    Without this, writing the note to stdout would satisfy the test above while corrupting
+    `--json` output and any downstream parser -- the exact harm this whole surface exists to
+    prevent.
+    """
+    _write_defaulted_scope_note()
+    captured = capsys.readouterr()
+
+    assert captured.out == "", "the note leaked onto stdout, where a --json consumer parses"
+    assert captured.err != ""
+
+
+def test_the_dispatch_site_gates_on_both_conditions() -> None:
+    """PREMISE, pinned by source: the note fires only on exit 1 AND no explicit path.
+
+    Pinned structurally because the call sits in `main_entry`'s dispatch, after a real subprocess
+    -- there is no way to exercise it in-process without running ripgrep. The two guards are what
+    keep it from becoming noise: without the exit-code check every successful search would print
+    it, and without the path check every scoped search would.
+    """
+    import inspect
+
+    from tensor_grep.cli import bootstrap
+
+    source = inspect.getsource(bootstrap.main_entry)
+
+    assert "_write_defaulted_scope_note()" in source, (
+        "main_entry no longer emits the defaulted-scope note; the bare-search case is silent again"
+    )
+    assert "exit_code == 1" in source, (
+        "the note is not gated on a no-match exit -- a successful search would print it too"
+    )
+    assert "_search_args_include_explicit_path" in source, (
+        "the note is not gated on the path being defaulted -- a scoped search would print it too"
+    )


### PR DESCRIPTION
Closes the dogfood's **#1 item, reported on three consecutive releases** (1.101.7, 1.101.9, 1.101.17):

> bare `tg search P` and `tg search P --json` — ~2s, exit 1, empty, no refuse stderr. Always pass explicit PATH.

## Why three rounds of disclosure work never touched it

**A bare search never reaches the Python CLI.** `bootstrap.main_entry` dispatches it straight to ripgrep via `_run_rg_passthrough` and re-raises rg's exit code, so every disclosure surface in `cli/main.py` — the refusal envelope, the incompleteness banner, the `is_empty` branch — sits downstream of a branch this path does not take.

I found that the expensive way. I first wrote the fix in `cli/main.py`, and it had **no observable effect** while tracing proved the note function *was* being invoked. That contradiction located the real dispatch: the trace ran `m.app()` directly, while the actual CLI exits inside `main_entry` long before typer runs. The main.py version was reverted rather than shipped alongside this one.

It also explains the reporter's 1.101.7 observation that *"text-mode without PATH can still print hits"* — rg streams its own output; tg contributes nothing either way.

## A considered deviation: exit 1 is kept

The report asked for an exit-2 refusal. Exit 2 means **incomplete**, and a defaulted-scope search that ran to completion *is* complete — it just answered a narrower question. Blanket-refusing every bare `tg search foo` would break the ordinary working invocation (verified: matches found, exit 0, on both a 2-file and an 801-file tree). Keep the exit code honest; remove the ambiguity with words.

## Gated on both conditions

`exit_code == 1` **and** no explicit PATH among the positionals — either guard alone turns the note into noise, and noise gets ignored.

| arm | stderr | exit |
|---|---|---|
| bare + zero matches | **note** | 1 |
| bare + WITH matches | empty | 0 |
| explicit PATH + zero | empty | 1 |

Verified end-to-end on a real 801-file tree. The path predicate skips flag values, so `-g *.py PAT` stays unscoped rather than reading `*.py` as a path — 8 parametrized cases, plus a control that the note goes to **stderr not stdout** (stdout is where a `--json` consumer parses).

169 bootstrap tests pass.

## Known remaining

The full-CLI route (`--ast` and friends, which bypass the rg passthrough) has the same gap at `main.py`'s `is_empty` branch. **Not fixed here** — I could not exercise it, and shipping an unverified second emitter beside a verified one is how a half-fix reads as complete. Tracked as task #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)