### PR TITLE
fix(search): terminate options before user positionals in the native argv builder (CWE-88)

### DIFF
--- a/src/tensor_grep/cli/main.py
+++ b/src/tensor_grep/cli/main.py
@@ -3782,10 +3782,21 @@ def _build_native_tg_search_command(
     if ndjson:
         command.append("--ndjson")
 
-    # The native binary's `search` positionals use clap allow_hyphen_values, so it
-    # already accepts dash-leading patterns/paths without an -e/-- shim; the end-of-
-    # options hardening (audit B4/#8) is applied to the external ripgrep builder, which
-    # needs it. Keep the native delegation argv stable for the parity contract.
+    # End-of-options sentinel (CWE-88 / the MCP-276 class, AGENTS.md). This builder was the
+    # "remaining tg sweep" item that AGENTS.md tracks by name, and it stayed unfixed because the
+    # comment that used to live here was FALSE: it claimed the native `search` positionals carry
+    # clap `allow_hyphen_values`. Only `-e/--regexp` does (rust_core/src/main.rs:686); `pattern`
+    # (:690-691) and `path` (:693-695) do not.
+    #
+    # Consequence without the sentinel: a dash-leading pattern is parsed by the native binary as a
+    # FLAG, so the intended path slides into pattern position and the search runs against a scope
+    # the caller never chose -- and still exits 0. Wrong scope with no error, which is the silent
+    # half and the reason this matters more than a crash would.
+    #
+    # UNCONDITIONAL, deliberately. A conditional form (emit `--` only when the pattern starts with
+    # `-`) looks equivalent and leaves exactly that silent path-promotion case exposed. Matches the
+    # sibling builders: ripgrep_backend.py's `cmd.append("--")` and mcp_server.py's.
+    command.append("--")
     command.extend([pattern, *paths])
     return command
 

--- a/tests/unit/test_cli_modes.py
+++ b/tests/unit/test_cli_modes.py
@@ -3997,6 +3997,7 @@ def test_cli_should_delegate_force_cpu_search_to_native_binary(monkeypatch):
         "-g",
         "*.log",
         "--no-ignore",
+        "--",
         "ERROR",
         ".",
     ]
@@ -4471,7 +4472,7 @@ def test_cli_should_delegate_ndjson_search_to_native_binary_and_preserve_exit_co
     result = runner.invoke(app, ["search", "ERROR", ".", "--ndjson"])
 
     assert result.exit_code == 2
-    assert seen["cmd"] == ["tg.exe", "search", "--ndjson", "ERROR", "."]
+    assert seen["cmd"] == ["tg.exe", "search", "--ndjson", "--", "ERROR", "."]
 
 
 def test_cli_should_emit_ndjson_without_native_binary(monkeypatch):
@@ -4552,7 +4553,7 @@ def test_cli_should_delegate_json_search_to_native_binary(monkeypatch):
     result = runner.invoke(app, ["search", "ERROR", ".", "--json"])
 
     assert result.exit_code == 0
-    assert seen["cmd"] == ["tg.exe", "search", "--json", "ERROR", "."]
+    assert seen["cmd"] == ["tg.exe", "search", "--json", "--", "ERROR", "."]
     assert seen["check"] is False
 
 
@@ -4592,6 +4593,7 @@ def test_cli_should_delegate_native_rg_output_flags(monkeypatch):
         "/",
         "--vimgrep",
         "--json",
+        "--",
         "ERROR",
         ".",
     ]
@@ -5112,7 +5114,7 @@ def test_cli_should_delegate_explicit_gpu_device_ids_to_native_binary(monkeypatc
     result = runner.invoke(app, ["search", "ERROR", ".", "--gpu-device-ids", "3,7,7"])
 
     assert result.exit_code == 0
-    assert seen["cmd"] == ["tg.exe", "search", "--gpu-device-ids", "3,7", "ERROR", "."]
+    assert seen["cmd"] == ["tg.exe", "search", "--gpu-device-ids", "3,7", "--", "ERROR", "."]
     assert seen["check"] is False
 
 

--- a/tests/unit/test_native_argv_end_of_options.py
+++ b/tests/unit/test_native_argv_end_of_options.py
@@ -1,0 +1,135 @@
+"""The native-delegation argv builder must terminate options before user positionals.
+
+CWE-88 (argument injection), the MCP-276 threat class named in `AGENTS.md:1259` — which defines it
+with **no CLI-vs-MCP carve-out** and explicitly lists "remaining tg sweep (tracked): the other
+native-argv builders". `_build_native_tg_search_command` is one of those builders.
+
+The comment that kept it unfixed was FALSE::
+
+    # The native binary's `search` positionals use clap allow_hyphen_values, so it
+    # already accepts dash-leading patterns/paths without an -e/-- shim
+
+Only `-e/--regexp` carries `allow_hyphen_values` (`rust_core/src/main.rs:686`). The `pattern`
+(`:690-691`) and `path` (`:693-695`) positionals do not. So a dash-leading pattern is parsed by the
+native binary as a FLAG, and the intended path silently slides into pattern position — the search
+then runs against a different scope than the caller asked for and reports success. Wrong scope
+without an error is the confident-false-answer family this codebase keeps closing.
+
+The two sibling builders already do this correctly: `ripgrep_backend.py:870` and
+`mcp_server.py:1387`.
+
+THE SENTINEL IS UNCONDITIONAL, DELIBERATELY. A conditional form ("only emit `--` when the pattern
+starts with `-`") looks equivalent and is not: it leaves the ordinary multi-positional case exposed
+to path-promotion, which is the half that fails silently rather than loudly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tensor_grep.cli.main import _build_native_tg_search_command
+from tensor_grep.core.config import SearchConfig
+
+
+def _argv(pattern: str, paths: list[str], **kwargs: object) -> list[str]:
+    return _build_native_tg_search_command(
+        Path("tg.exe"),
+        pattern=pattern,
+        paths=paths,
+        config=SearchConfig(**kwargs),  # type: ignore[arg-type]
+        ndjson=False,
+    )
+
+
+def test_a_sentinel_precedes_the_user_positionals() -> None:
+    """THE DEFECT: pattern and paths were appended bare."""
+    argv = _argv("ERROR", ["."])
+
+    assert "--" in argv, "no end-of-options sentinel; a dash-leading pattern parses as a flag"
+    sentinel = argv.index("--")
+    assert argv[sentinel + 1 :] == ["ERROR", "."], (
+        "the sentinel must be the LAST thing before the user positionals, or options after it "
+        f"are themselves treated as positionals: {argv}"
+    )
+
+
+def test_a_dash_leading_pattern_stays_the_pattern() -> None:
+    """The injection case. Without the sentinel `-foo` is a flag and `.` becomes the pattern."""
+    argv = _argv("-foo", ["src"])
+
+    sentinel = argv.index("--")
+    assert argv[sentinel + 1] == "-foo", f"the dash-leading pattern was not protected: {argv}"
+    assert argv[sentinel + 2] == "src", f"the path did not stay a path: {argv}"
+
+
+def test_the_path_is_never_promoted_to_pattern_position() -> None:
+    """The SILENT half, and the reason the sentinel is unconditional.
+
+    With a dash-leading pattern eaten as a flag, the first surviving positional is the path — so
+    the search runs against a scope the caller never chose and still exits 0. There is no error to
+    notice.
+    """
+    argv = _argv("-i", ["only/this/dir"])
+    sentinel = argv.index("--")
+
+    positionals = argv[sentinel + 1 :]
+    assert positionals[0] == "-i", "pattern lost its position"
+    assert "only/this/dir" in positionals[1:], "path lost its position"
+    assert positionals.count("only/this/dir") == 1, f"path duplicated into pattern slot: {argv}"
+
+
+def test_the_sentinel_is_unconditional() -> None:
+    """CONTROL ARM: an ordinary pattern must ALSO get the sentinel.
+
+    Without this a "smart" conditional version — emit `--` only when the pattern looks dangerous —
+    passes every test above while leaving the common multi-positional case exposed. That variant is
+    forbidden by the design, and this is the assertion that forbids it.
+    """
+    for pattern in ("ERROR", "plain_word", "some.regex+"):
+        argv = _argv(pattern, ["."])
+        assert "--" in argv, f"sentinel missing for an ordinary pattern {pattern!r}: {argv}"
+
+
+def test_flags_still_precede_the_sentinel() -> None:
+    """CONTROL ARM: the fix must not push tg's own flags past the sentinel.
+
+    A sentinel emitted too early turns every subsequent tg flag into a positional — the search
+    would then treat `--json` as a path. This is the failure mode of "just append -- first".
+    """
+    argv = _argv("ERROR", ["."], json_mode=True)
+    sentinel = argv.index("--")
+
+    assert "--json" in argv[:sentinel], f"a tg flag landed after the sentinel: {argv}"
+    assert argv[sentinel + 1 :] == ["ERROR", "."]
+
+
+def test_the_false_allow_hyphen_values_comment_is_gone() -> None:
+    """The comment actively argued against the fix, so it must not survive it.
+
+    A wrong comment is worse than no comment: it is the reason this builder was skipped in the
+    original CWE-88 sweep. Pinned so a future edit cannot restore the claim.
+
+    Checks the CLAIM, not the token. The replacement comment necessarily NAMES
+    ``allow_hyphen_values`` in order to explain that the old claim was false, so a bare substring
+    check fires on the correction itself -- the quoting-vs-asserting trap, which has now bitten
+    four separate guards in this campaign. Match the assertion instead.
+    """
+    import inspect
+    import re
+
+    source = inspect.getsource(_build_native_tg_search_command)
+
+    # The false assertion, in any wrapping: positionals HAVE the attribute.
+    asserted = re.search(
+        r"positionals\s+(?:\S+\s+){0,3}(?:use|carry|have)\s+clap\s+`?allow_hyphen_values",
+        source,
+        re.IGNORECASE,
+    )
+    assert asserted is None, (
+        "the false claim that the native positionals carry clap allow_hyphen_values is back; "
+        f"only -e/--regexp does (rust_core/src/main.rs:686). Matched: {asserted!r}"
+    )
+
+    # PREMISE: the correction is still present. Without this, deleting the whole comment would
+    # satisfy the assertion above while removing the reason the sentinel exists.
+    assert "CWE-88" in source, "the sentinel lost its rationale comment"


### PR DESCRIPTION
Audit item **B2**, reclassified **up** by the plan audit.

`_build_native_tg_search_command` appended the pattern and paths as bare positionals, and stayed unfixed because the comment sitting on it was **false**:

> `# The native binary's \ positionals use clap allow_hyphen_values`

Only `-e/--regexp` carries it (`rust_core/src/main.rs:686`). `pattern` (`:690-691`) and `path` (`:693-695`) do not.

## Why CWE-88, not a correctness nit

My own plan first called this *"not the RCE class — CLI self-argv only."* `AGENTS.md:1259` defines that class with **no CLI-vs-MCP carve-out** and names *"remaining tg sweep (tracked): the other native-argv builders"* — this builder is literally that item. The downgrade licensed skipping the mandatory adversarial security gate. Corrected before any code was written.

## The silent half

With a dash-leading pattern eaten as a flag, the intended path slides into pattern position — so the search runs against **a scope the caller never chose and still exits 0**. Wrong scope, no error. That's worse than a crash, and it's why the sentinel is unconditional: the *conditional* form (emit `--` only when the pattern looks dangerous) leaves exactly this case exposed.

## TDD

Red arm verified first: `assert '--' in ['tg.exe', 'search', 'ERROR', '.']`.

Six tests, three of them control arms:

| control | what it forbids |
|---|---|
| sentinel is unconditional | a "smart" conditional variant that passes every other assertion |
| tg's flags precede it | a sentinel emitted too early, turning `--json` into a path |
| rationale comment survives | deleting the comment to satisfy the anti-claim check |

## Five argv pins updated in the same PR

Exactly as the audit predicted: `test_cli_modes.py:3991, 4474, 4555, 4587, 5115` pinned exact argv with `==` and no `--`. **The invariant is behaviour-identical, not argv-identical** — the plan's original "byte-identical argv" control arm was wrong and would have read as a regression.

## My guard tripped on itself

The replacement comment *names* `allow_hyphen_values` to explain the old claim was false, so a bare substring check fired on the correction — **fourth instance of the quoting-vs-asserting trap this campaign**. It now matches the assertion *shape*, plus a premise that the rationale is still present.

**532 tests pass.** `test_refs_json_deduplicates_parser_call_references` is deselected and **not mine** — it fails identically with this change reverted (needs the compiled `rust_core`, absent from a `--no-install-project` venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)